### PR TITLE
fix(#99): post-merge cleanup from PR #1 Rex review

### DIFF
--- a/.claude/skills/projects/SKILL.md
+++ b/.claude/skills/projects/SKILL.md
@@ -26,32 +26,10 @@ grep -E '^\s*mode:\s*' onboarding.yaml 2>/dev/null | head -1
 
 | Value | Behaviour |
 |-------|-----------|
-| `mode: single-project` (or missing — this is the default) | Show only the current repo |
-| `mode: multi-project` | Read `apexstack.projects.yaml` and show every project listed |
+| `mode: multi-project` (or missing — this is the default) | Read `apexstack.projects.yaml` and show every project listed |
+| `mode: single-project` | Show only the current repo |
 
-## Single-project mode (the default)
-
-In single-project mode, there's only one project — the repo Claude Code is running in. Output:
-
-```
-Project: {repo name from `git remote get-url origin`}
-Branch:  {git rev-parse --abbrev-ref HEAD}
-Status:  active
-Open PRs:    {gh pr list --state open --json number | jq length}
-Open Issues: {gh issue list --state open --json number | jq length}
-Last commit: {git log -1 --format='%h %ai %s'}
-Uncommitted: {git status --porcelain | wc -l} files
-```
-
-If the user wants the full registry view, suggest:
-
-```
-You're in single-project mode. To manage multiple projects, set
-`apexstack.mode: multi-project` in onboarding.yaml and create
-apexstack.projects.yaml at the root.
-```
-
-## Multi-project mode
+## Multi-project mode (the default)
 
 In multi-project mode, read `apexstack.projects.yaml`:
 
@@ -83,6 +61,29 @@ fi
 # Always go to GitHub for PRs / issues (project of record)
 PRS=$(gh -R {repo} pr list --state open --json number --jq 'length')
 ISSUES=$(gh -R {repo} issue list --state open --json number --jq 'length')
+```
+
+## Single-project mode (opt-in)
+
+In single-project mode, there's only one project — the repo Claude Code is running in. Output:
+
+```
+Project: {repo name from `git remote get-url origin`}
+Branch:  {git rev-parse --abbrev-ref HEAD}
+Status:  active
+Open PRs:    {gh pr list --state open --json number | jq length}
+Open Issues: {gh issue list --state open --json number | jq length}
+Last commit: {git log -1 --format='%h %ai %s'}
+Uncommitted: {git status --porcelain | wc -l} files
+```
+
+If the user wants the full registry view, suggest:
+
+```
+You're in single-project mode (opt-in). To manage multiple projects,
+remove the `apexstack.mode: single-project` line from onboarding.yaml
+to switch back to the default multi-project mode, and create
+apexstack.projects.yaml at the root.
 ```
 
 ## Output format (multi-project)

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Skip step 4 entirely — there's no registry. The same skills scope to the curre
 
 ## Roles
 
-ApexStack includes 20 software development roles across 5 departments:
+ApexStack includes 19 software development roles across 5 departments:
 
 ### Engineering (7 roles)
 - **Head of Engineering** -- Technical strategy, architecture standards, quality

--- a/apexstack.projects.yaml.example
+++ b/apexstack.projects.yaml.example
@@ -3,24 +3,23 @@
 # =============================================================================
 #
 # Place this file at the root of your **ops repo** (the repo where you run
-# Claude Code from when you want to manage multiple projects as one
-# organisation). Rename it from `.example` to `apexstack.projects.yaml` once
-# you've filled it in.
+# Claude Code from to manage multiple projects as one organisation). Rename
+# it from `.example` to `apexstack.projects.yaml` once you've filled it in.
 #
-# This file enables MULTI-PROJECT MODE. Skills like /projects, /inbox,
-# /status, /tasks, and /stakeholder-update will then aggregate across every
-# project listed below instead of looking only at the current repo.
+# This file is the registry for ApexStack's default mode: MULTI-PROJECT MODE.
+# Skills like /projects, /inbox, /status, /tasks, and /stakeholder-update
+# aggregate across every project listed below. Most engineering orgs have
+# more than one repo, so this is the right default — even a "single product"
+# team usually has an app repo + infra + a marketing site.
 #
-# To enable multi-project mode you also need to set
+# Multi-project mode is enabled by default in `onboarding.yaml`:
 #
 #     apexstack:
-#       mode: multi-project
+#       mode: multi-project   # default
 #
-# at the top of `onboarding.yaml`.
-#
-# Single-project mode is the default — if this file does not exist, ApexStack
-# treats the current directory as a single managed project and ignores the
-# registry concept entirely.
+# Single-project mode is the opt-in for the simple "I have one repo" case.
+# Set `apexstack.mode: single-project` in `onboarding.yaml` to disable the
+# registry and treat the current directory as a single managed project.
 #
 
 # Schema version. Bump if breaking changes are introduced.

--- a/golden-paths/pipelines/ci.yml
+++ b/golden-paths/pipelines/ci.yml
@@ -90,7 +90,7 @@ jobs:
           fi
 
   # =============================================
-  # SENTINEL — Security Scanning
+  # SHIELD — Security Scanning
   # =============================================
   security:
     name: "🛡️ Shield: Security"

--- a/projects/README.md
+++ b/projects/README.md
@@ -6,7 +6,7 @@ This directory holds **ApexStack-managed documentation** for each project ApexSt
 - Belong to the operating model rather than the codebase
 - Need to exist before the project even has its own repo (e.g. handover assessments)
 
-In **single-project mode** (the default), this directory is optional — you can keep your roadmap, ideas, and notes at the project root instead. In **multi-project mode**, this directory is the canonical place for per-project ApexStack docs in the ops repo.
+In **multi-project mode** (the default), this directory is the canonical place for per-project ApexStack docs in the ops repo. In **single-project mode** (opt-in), this directory is optional — you can keep your roadmap, ideas, and notes at the project root instead.
 
 ## Layout
 

--- a/site/index.html
+++ b/site/index.html
@@ -953,7 +953,7 @@ footer.foot {
     <div class="tree__inner">
       <div class="tree__head">
         <span>$ tree apexstack</span>
-        <span class="files">79 files · the runnable + portfolio layers added in v0.1</span>
+        <span class="files">the runnable + portfolio layers added in v0.1</span>
       </div>
       <div class="tree__body"><span class="dir">apexstack/</span>
 <span class="branch">├──</span> <span class="lf">CLAUDE.md</span>              <span class="nf"># Stack entry point — Claude Code reads this first</span>

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -1,6 +1,6 @@
 # `workspace/` — Live Project Clones
 
-This directory holds **live working copies** of projects that ApexStack manages. It only matters in **multi-project mode** — in single-project mode (the default) you can ignore it.
+This directory holds **live working copies** of projects that ApexStack manages. It's part of the default layout. In single-project mode (the opt-in for one-repo teams) you can ignore it.
 
 ## The two modes
 
@@ -8,13 +8,24 @@ ApexStack supports two operating modes, set in `onboarding.yaml`:
 
 ```yaml
 apexstack:
-  mode: single-project   # default
-  # mode: multi-project  # opt-in
+  mode: multi-project    # default
+  # mode: single-project # opt-in
 ```
 
-### Single-project mode (default)
+### Multi-project mode (the default)
 
-ApexStack is checked out into your project's repo (or kept globally at `~/.apexstack/`), and the rules and skills apply to that one repo. There is no `workspace/` directory you need to care about. Your code is just... your code, in its own repo. This is the right choice for solo developers and teams managing one product.
+When you manage **multiple repos as one organisation** (e.g. a CTO running an ops repo across 3–10 products), ApexStack aggregates across all of them. Skills like `/projects`, `/inbox`, `/status`, and `/tasks` iterate over a registry instead of looking at one repo. Most engineering orgs have more than one repo, so this is the right default — even a "single product" team usually has an app + infra + a marketing site.
+
+How the default works:
+
+1. `apexstack.mode` is read from `onboarding.yaml`; missing or `multi-project` → multi-project mode
+2. `apexstack.projects.yaml` at the root of your **ops repo** holds the registry (see `apexstack.projects.yaml.example` for the schema)
+3. Optionally clone each managed repo into `workspace/<name>/` (live working copies)
+4. Add per-project docs under `projects/<name>/`
+
+### Single-project mode (opt-in)
+
+ApexStack is checked out into your project's repo (or kept globally at `~/.apexstack/`), and the rules and skills apply to that one repo. There is no `workspace/` directory you need to care about. Your code is just... your code, in its own repo. This is the right choice for solo developers and teams with exactly one product.
 
 ```
 your-app/
@@ -25,16 +36,7 @@ your-app/
 └── ROADMAP.md              ← single-project roadmap lives at the root
 ```
 
-### Multi-project mode (opt-in)
-
-When you manage **multiple repos as one organisation** (e.g. a CTO running an ops repo across 3–10 products), ApexStack can aggregate across all of them. Skills like `/projects`, `/inbox`, `/status`, and `/tasks` then iterate over a registry instead of looking at one repo.
-
-To turn it on:
-
-1. Set `apexstack.mode: multi-project` in `onboarding.yaml`
-2. Create `apexstack.projects.yaml` at the root of your **ops repo** (the one Claude Code is running in) — see `apexstack.projects.yaml.example` for the schema
-3. Optionally clone each managed repo into `workspace/<name>/` (live working copies)
-4. Add per-project docs under `projects/<name>/`
+To opt in: set `apexstack.mode: single-project` in `onboarding.yaml`.
 
 ## Directory layout under multi-project mode
 


### PR DESCRIPTION
## Summary

Post-merge cleanup after Rex's re-review of PR #1 (merged 2026-04-08 as `3de84fa`). Four blockers and one nit — all small, all correctness fixes, no scope creep.

This PR is tracked in the **apexscript-org** issue tracker (the ApexStack ops repo) per the narrow exception that apexstack's coordination tickets live in apexscript-org. The fix PR itself lives here in `me2resh/apexstack`. The `Closes` keyword below uses the cross-repo form.

## N1 — Default-mode contradiction (CRITICAL) — 4 files

Four files claimed single-project was the default, contradicting `CLAUDE.md`, `README.md`, `onboarding.yaml`, `docs/multi-project.md`, `site/index.html`, and 7 of 8 new skills (which all say **multi-project is the default**). The commit message for `ba892bc` literally said "multi-project mode (default)". These four were the stragglers and now align:

- `apexstack.projects.yaml.example` — header comment rewritten to say this file is the registry for the default multi-project mode; single-project is the opt-in
- `workspace/README.md` — section order swapped (multi-project first as the default, single-project second as opt-in), intro paragraph reworded, mode comments in the onboarding.yaml snippet flipped
- `projects/README.md` — opening paragraph flipped so multi-project is described as the default
- `.claude/skills/projects/SKILL.md` — mode detection table row order flipped (`mode: multi-project` "or missing" is now default), sections swapped so multi-project comes first, single-project moved below as opt-in, the "flip back" prompt reworded

## N2 — Roles count — 1 file

- `README.md:166` — "20 software development roles" → **19**. Actual: 7 Engineering + 3 Product + 3 Design + 3 Security + 3 Data = 19. The tree in `site/index.html` at line ~964 already correctly said 19.

## N3 — Site file count — 1 file

- `site/index.html:956` — dropped the `79 files · ` prefix from the tree header line. The descriptive tagline "the runnable + portfolio layers added in v0.1" stays. Rather than updating 79 → 76 and having to update it again next time a file lands, killing the number outright is the long-term fix.

## Stale SENTINEL comment — 1 file

- `golden-paths/pipelines/ci.yml:93` — the security section comment said `# SENTINEL — Security Scanning` but the job itself is named `"🛡️ Shield: Security"` (the Sentinel→Shield rename landed in PR #1). One-line comment fix to match.

## What's NOT in this PR

- **N4** (PR #1 body says "5 skills" + Sentinel/Scout in glossary) — GitHub PR bodies are immutable after merge, so this is recorded in the tracking issue as NOT FIXABLE.
- **Retroactive AgDRs** (hooks-vs-MCP, agent selection, site aesthetic) — intentionally skipped per the CEO's call. v0.1 doesn't need them backfilled.
- **Review-noise cleanup** on PR #1 — tracked separately; this PR's diff stays focused on the code fixes.

## Glossary

| Term | Definition |
|------|------------|
| Default mode | ApexStack's out-of-the-box behaviour — **multi-project** — where the tool lives in an "ops repo" and governs a portfolio of repos via `apexstack.projects.yaml` |
| Opt-in mode | `single-project` — the alternative, enabled by setting `apexstack.mode: single-project` in `onboarding.yaml`, for teams governing exactly one repo |
| Registry | `apexstack.projects.yaml` — the list of projects ApexStack manages in multi-project mode |
| Ops repo | The repo where Claude Code + ApexStack + the registry live. Holds shared rules/skills/hooks and per-project docs, governs code repos that live elsewhere. |
| Live working copy | A `git clone`d project under `workspace/<name>/`, used when you want local git operations on a managed project. Gitignored in the ops repo. |
| N1 / N2 / N3 / N4 | The new blockers Rex flagged in the re-review of `ba892bc`, numbered sequentially to distinguish from the first review's B1-B6 |
| `# SHIELD` | The ApexStack security agent identity (formerly "Sentinel" before the PR #1 rename) — the CI comment now matches the shipped agent name |
| Cross-repo `Closes` | GitHub keyword `Closes owner/repo#N` — closes an issue in a different repo when a PR merges. Used here so a PR on `me2resh/apexstack` closes an issue on `me2resh/apexscript-org`. |

## Test plan

- [ ] `grep -n "20 software development roles" README.md` returns no hits
- [ ] `grep -n "79 files" site/index.html` returns no hits
- [ ] `grep -n "SENTINEL" golden-paths/pipelines/ci.yml` returns no hits
- [ ] `grep -rE "single-project.{0,20}default" apexstack.projects.yaml.example workspace/README.md projects/README.md .claude/skills/projects/SKILL.md` returns no hits where single-project is labelled default (only opt-in)
- [ ] `cat docs/multi-project.md` still reads coherently against the rest of the PR — no NEW contradictions introduced
- [ ] Rex re-review

Closes me2resh/apexscript-org#99

🤖 Generated with [Claude Code](https://claude.com/claude-code)