### PR TITLE
docs(#100): positioning rewrite — "where projects get forged"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# ApexStack -- AI-Native Development Stack
+# ApexStack -- A Multi-Project Forge for Claude Code
 
-You are the **Chief of Staff** for this software team. Your job is to ensure processes are followed, quality is maintained, and work moves efficiently from idea to production.
+You are the **Chief of Staff** running a portfolio of projects inside apexstack. You don't add apexstack to a project — projects get forged *inside* it. Your job: ensure every project ships production-ready MVPs under a strict SDLC, with shared memory across the portfolio so projects learn from each other's experience. Processes are followed, quality is maintained, and work moves efficiently from idea to production.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # ApexStack
 
-**A complete AI-native software development stack for Claude Code.**
+**Where projects get forged.**
 
-ApexStack packages a production-tested development workflow into a reusable stack that any team can adopt. It provides role definitions, workflow processes, document templates, and Claude Code configuration that turns your AI assistant into a structured Chief of Staff for your engineering org.
+A multi-project ops repo where your projects reference each other, learn from shared experience, and ship production-ready under a strict SDLC. Built for founders and technical leads running 2–5 products at once.
 
-Inspired by [gstacks.org](https://gstacks.org/) -- but purpose-built for software teams using Claude Code.
+You don't *add* apexstack to a project — projects get forged *inside* it. One ops repo. Every product. Shared memory. Strict gates. Production-ready MVPs.
+
+Claude Code is the default driver, but the rules, hooks, and templates are plain markdown and shell. Swap the AI. Keep the forge. No SaaS. No lock-in.
+
+Inspired by [gstacks.org](https://gstacks.org/) — but purpose-built for software teams running more than one product at a time.
 
 ## What's Inside
 
@@ -144,6 +148,23 @@ echo "@.apexstack/CLAUDE.md" >> CLAUDE.md
 ```
 
 Skip step 4 entirely — there's no registry. The same skills scope to the current repo. Roadmap lives at `ROADMAP.md`, ideas at `IDEAS.md`. See [`docs/multi-project.md`](docs/multi-project.md) for the full comparison.
+
+### Global install (alternative)
+
+If you run **several** ops repos (a founder with a couple of orgs, a consultant with multiple clients), clone apexstack **once** globally and reference it from every ops repo instead of cloning into each. One place to upgrade, one place to patch.
+
+```bash
+# one time, globally
+git clone https://github.com/me2resh/apexstack.git ~/.apexstack
+
+# in each ops repo (replaces steps 1 and 2 of the default flow)
+ln -s ~/.apexstack/.claude .claude
+echo '@~/.apexstack/CLAUDE.md' >> CLAUDE.md
+
+# steps 3, 4, 5, 6 are the same as the default flow
+```
+
+**Tradeoff**: the symlinks point at an absolute path in your home directory, so moving `~/.apexstack/` breaks the link. Not a good fit if you sync dotfiles across machines with different home paths.
 
 ## Why ApexStack?
 

--- a/site/index.html
+++ b/site/index.html
@@ -301,6 +301,47 @@ a:hover { color: var(--accent); }
   margin-bottom: 2.5rem;
 }
 
+.hero__cta {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+.cta {
+  display: inline-block;
+  font-family: inherit;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.85rem 1.5rem;
+  border: 1px solid var(--rule);
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.cta--primary {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+  font-weight: 700;
+}
+.cta--primary:hover {
+  background: var(--accent);
+  color: var(--paper);
+  border-color: var(--accent);
+}
+.cta--ghost {
+  color: var(--ink-soft);
+  border: none;
+  padding: 0.85rem 0.25rem;
+}
+.cta--ghost:hover {
+  color: var(--accent);
+}
+.cta__sep {
+  color: var(--ink-ghost);
+  user-select: none;
+}
+
 .hero__metrics {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -891,27 +932,33 @@ footer.foot {
 
     <div class="hero__eyebrow rise rise-1">
       <span class="pill">apexstack v0.1</span>
-      <span>open source · MIT · plain markdown · zero dependencies</span>
+      <span>open source · MIT · for founders forging multiple products</span>
     </div>
 
-    <h1 class="hero__title rise rise-2">apexstack</h1>
+    <h1 class="hero__title rise rise-2">Where projects get forged.</h1>
 
     <p class="hero__tagline rise rise-3">
-      An opinionated stack for <span class="uline">Claude Code</span>. Roles, workflows, hooks, agents, slash commands, and CI pipelines — packaged so your AI can act like a structured chief of staff for your engineering org.
+      The multi-project ops repo where your projects reference each other, learn from shared experience, and ship production-ready under a strict SDLC.
     </p>
 
     <p class="hero__sub rise rise-3">
-      Drop into any project. Configure with one YAML file. Get a Code Reviewer agent that enforces glossaries, hooks that block <code>git add -A</code>, slash commands like <code>/decide</code> and <code>/code-review</code>, and CI workflows ready to copy into <code>.github/workflows/</code>. No SaaS. No lock-in. Just markdown and shell scripts.
+      You don't <em>add</em> apexstack to a project — projects get forged <em>inside</em> it. One ops repo. Every product. Shared memory. Strict gates. Production-ready MVPs. Claude Code is the default driver, but the rules, hooks, and templates are plain markdown and shell. Swap the AI. Keep the forge.
     </p>
+
+    <div class="hero__cta rise rise-4">
+      <a href="https://github.com/me2resh/apexstack" class="cta cta--primary" target="_blank" rel="noopener">★ Star on GitHub</a>
+      <span class="cta__sep" aria-hidden="true">·</span>
+      <a href="#install" class="cta cta--ghost">or install it now ↓</a>
+    </div>
 
     <div class="install rise rise-4" id="install-block">
       <span class="install__prompt">$</span>
-      <code class="install__cmd" id="install-cmd">git clone https://github.com/me2resh/apexstack.git ~/.apexstack</code>
+      <code class="install__cmd" id="install-cmd">git clone https://github.com/me2resh/apexstack.git .apexstack</code>
       <button type="button" class="install__copy" id="install-copy" aria-label="Copy install command">copy</button>
     </div>
 
     <p class="install__caveat rise rise-4">
-      Then symlink <code>~/.apexstack/.claude</code> to your project root, point your <code>CLAUDE.md</code> at <code>@~/.apexstack/CLAUDE.md</code>, and you're done. Full steps in <a href="#install" class="uline">install</a> below.
+      Run from your ops repo — the one you'll use to govern every product. Five more steps in <a href="#install" class="uline">install</a> below. No magic. No build. No SaaS. Prefer a single global copy shared across every ops repo? <a href="#install-global" class="uline">That's also supported</a>.
     </p>
 
     <div class="hero__metrics rise rise-5" aria-label="What you get">
@@ -1378,6 +1425,21 @@ $EDITOR apexstack.projects.yaml  <span class="cm"># list your repos</span></pre>
       <pre class="step__code"><span class="cm"># in onboarding.yaml</span>
 apexstack:
   mode: <span class="acc">single-project</span></pre>
+    </article>
+
+    <article class="step" id="install-global" style="grid-column: 1 / -1;">
+      <div class="step__num">alternative — global install</div>
+      <h3 class="step__title">If you run several ops repos</h3>
+      <p class="step__desc">The six-step default clones apexstack into each ops repo at <code>.apexstack/</code>. That's the right call for most people — upgrades are per-repo, nothing is shared across machines. If you run <em>several</em> ops repos (a founder with a couple of orgs, a consultant with multiple clients), clone apexstack <em>once</em> globally and reference it from every ops repo. One place to upgrade, one place to patch.</p>
+      <p class="step__desc"><strong>Tradeoff</strong>: the symlinks point at an absolute path in your home directory, so moving <code>~/.apexstack/</code> breaks the link. Not a good fit if you sync dotfiles across machines with different home paths.</p>
+      <pre class="step__code"><span class="cm"># one time, globally</span>
+git clone https://github.com/me2resh/apexstack.git ~/.apexstack
+
+<span class="cm"># in each ops repo (replaces steps 01 and 02 of the default flow)</span>
+ln -s ~/.apexstack/.claude .claude
+echo '@~/.apexstack/CLAUDE.md' &gt;&gt; CLAUDE.md
+
+<span class="cm"># steps 03, 04, 05, 06 are the same as the default flow</span></pre>
     </article>
 
   </div>

--- a/site/index.html
+++ b/site/index.html
@@ -236,12 +236,13 @@ a:hover { color: var(--accent); }
 @keyframes blink { 50% { opacity: 0; } }
 
 .hero__tagline {
-  font-size: clamp(1rem, 1.6vw, 1.25rem);
-  font-weight: 500;
+  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  font-weight: 600;
   color: var(--ink);
   max-width: 60ch;
-  line-height: 1.5;
+  line-height: 1.25;
   margin-bottom: 1rem;
+  letter-spacing: -0.015em;
 }
 
 .hero__sub {
@@ -938,14 +939,14 @@ footer.foot {
       <span>open source · MIT · for founders forging multiple products</span>
     </div>
 
-    <h1 class="hero__title rise rise-2">Where projects get forged.</h1>
+    <h1 class="hero__title rise rise-2">apexstack</h1>
 
     <p class="hero__tagline rise rise-3">
-      The multi-project ops repo where your projects reference each other, learn from shared experience, and ship production-ready under a strict SDLC.
+      Where projects get forged.
     </p>
 
     <p class="hero__sub rise rise-3">
-      You don't <em>add</em> apexstack to a project — projects get forged <em>inside</em> it. One ops repo. Every product. Shared memory. Strict gates. Production-ready MVPs. Claude Code is the default driver, but the rules, hooks, and templates are plain markdown and shell. Swap the AI. Keep the forge.
+      The multi-project ops repo where your projects reference each other, learn from shared experience, and ship production-ready under a strict SDLC. You don't <em>add</em> apexstack to a project — projects get forged <em>inside</em> it. One ops repo. Every product. Shared memory. Strict gates. Production-ready MVPs. Claude Code is the default driver, but the rules, hooks, and templates are plain markdown and shell. Swap the AI. Keep the forge.
     </p>
 
     <div class="hero__cta rise rise-4">

--- a/site/index.html
+++ b/site/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>ApexStack — an opinionated stack for Claude Code</title>
-<meta name="description" content="ApexStack packages roles, workflows, hooks, agents, slash commands, and CI pipelines into one drop-in stack for Claude Code. Open source. Plain markdown. No lock-in.">
+<title>ApexStack — where projects get forged</title>
+<meta name="description" content="ApexStack is a multi-project ops repo where your projects reference each other, learn from shared experience, and ship production-ready under a strict SDLC. Built for founders running 2–5 products at once. Open source. Claude Code native, but plain markdown underneath.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet">
@@ -340,6 +340,9 @@ a:hover { color: var(--accent); }
 .cta__sep {
   color: var(--ink-ghost);
   user-select: none;
+}
+@media (max-width: 520px) {
+  .cta__sep { display: none; }
 }
 
 .hero__metrics {
@@ -958,7 +961,7 @@ footer.foot {
     </div>
 
     <p class="install__caveat rise rise-4">
-      Run from your ops repo — the one you'll use to govern every product. Five more steps in <a href="#install" class="uline">install</a> below. No magic. No build. No SaaS. Prefer a single global copy shared across every ops repo? <a href="#install-global" class="uline">That's also supported</a>.
+      Run from your ops repo — the one you'll use to govern every product. Full walkthrough in <a href="#install" class="uline">install</a> below. No magic. No build. No SaaS. Prefer a single global copy shared across every ops repo? <a href="#install-global" class="uline">That's also supported</a>.
     </p>
 
     <div class="hero__metrics rise rise-5" aria-label="What you get">


### PR DESCRIPTION
## Summary

PR 1 of 5 for the apexstack positioning epic (`me2resh/apexscript-org#100`). Reframes apexstack from "an opinionated stack for Claude Code" to **"a multi-project ops repo where projects get forged."** Targets the solo founder / technical CEO running 2–5 products and drowning in context-switching.

This PR only touches copy and the hero CTA. No new features, no roles work, no skill fixes — those land in PRs 2–5 per the epic.

## Audience discovery (per the new UX rule)

Captured in the epic issue; summarised here:

- **Primary persona**: solo founder / technical CEO running 2–5 products, drowning in context-switching
- **Conversion goal**: (1) star the repo, (2) `git clone` to try it locally
- **Objections to overcome**: "too Claude Code specific" and "too opinionated"
- **Tone**: punchy and confident, short sentences, strong verbs
- **Forge metaphor**: literal — use the word "forge"

## Three open aha-moment candidates — pick one in review

You said A2 ("not sure") — I drafted four H1 options below. Picked option 1 as the working default in this PR; swap to any of the others in a follow-up commit if you prefer.

| # | H1 | Tagline | Vibe |
|---|----|---------|------|
| **1 (shipped)** | "Where projects get forged." | "The multi-project ops repo where your projects reference each other, learn from shared experience, and ship production-ready under a strict SDLC." | Quiet-confident, stays close to your exact phrasing |
| 2 | "Forge your portfolio." | "One ops repo. Every product. Shared memory. Strict SDLC. Production-ready MVPs — from a founder juggling 2–5 products at once." | Imperative, punchier, more SaaS-ad |
| 3 | "One forge. Every project." | "The multi-project setup where your portfolio learns from itself. Strict SDLC, shared memory, and production-ready MVPs — the Claude-Code-native default, but the forge is plain markdown." | Two-sentence punch, leans into "one" × "every" parallelism |
| 4 | "Stop duct-taping 5 CLAUDE.mds." | "ApexStack is the multi-project forge for founders running 2–5 products. One ops repo. Shared memory. Strict SDLC. Production-ready MVPs." | Problem-first, pain-named, most ad-like |

## What changed

### `site/index.html` hero
- Eyebrow: `"plain markdown · zero dependencies"` → `"for founders forging multiple products"`
- H1: `"apexstack"` → `"Where projects get forged."`
- Tagline: rewritten to lead with the multi-project + forge framing + strict SDLC
- Subhead: rewritten. New structure: framing (`you don't add, you forge inside`) → promise (`one ops repo, every product, shared memory, strict gates, production-ready MVPs`) → objection handling (`Claude Code is the default driver, but the rules/hooks/templates are plain markdown and shell — swap the AI, keep the forge`)
- **NEW `hero__cta` block**: `[★ Star on GitHub] · [or install it now ↓]`. Star is primary (filled ink → accent on hover), install link is ghost (text-only, accent on hover)
- Install command: `~/.apexstack` → `.apexstack` (fix — the brief was pointing at a broken home-dir pattern per the audit)
- Install caveat: rewritten to point at the six-step install + the new global-install alternative

### `site/index.html` CSS
Added `.hero__cta`, `.cta`, `.cta--primary`, `.cta--ghost`, `.cta__sep` to the existing terminal-brutalism style block. Sharp corners, hairline borders, no gradients. ~40 lines.

### `site/index.html` install section (`05 / INSTALL`)
- Kept the six-step per-ops-repo walkthrough unchanged (canonical path)
- Kept the single-project opt-out at the end
- **NEW**: "alternative — global install" step (anchor `#install-global`) for users running several ops repos. Documents the tradeoff (absolute paths in symlinks).

### `README.md`
- Hero rewritten end-to-end to match the site
- Added "Global install (alternative)" section after "Single-project install (opt-out)"
- gstacks.org attribution reworded

### `CLAUDE.md`
- Title: `"AI-Native Development Stack"` → `"A Multi-Project Forge for Claude Code"`
- First paragraph expanded with the forge framing and the `"projects get forged inside it, not added to it"` phrasing. The operational instructions below it are untouched so the rest of the file still drives Claude correctly.

## What's NOT in this PR (tracked in the epic)

| Item | Tracked as |
|------|------------|
| Commands sub-page explaining each skill | PR 2 |
| Hero shell animation (CSS + JS typewriter) | PR 3 (depends on PR 2 — the command shown in the animation will be picked from the sub-page) |
| Roles integration (CLAUDE.md imports, `role-triggers.md` rule, workflow threading) | PR 4 — the audit flagged **all 19 roles are completely disconnected from the running system**, so this will be its own PR |
| `/handover` auto-append to registry + `/idea` polish | PR 5 |
| Anvil / metalwork SVG iconography | holding off on visuals until copy is locked |
| AgDR backfill | explicitly skipped per earlier CEO call |

## Glossary

| Term | Definition |
|------|------------|
| Forge | The central metaphor — apexstack is the workbench where multiple products get shaped, not a tool you bolt onto an existing codebase. "Projects get forged inside it." |
| Ops repo | The repo where apexstack lives and where Claude Code runs from. Holds shared rules/skills/hooks + the portfolio registry + per-project planning docs. Different from the project code repos it governs. |
| Shared memory | The fact that decisions, learnings, and AgDRs in one project are visible to every other project in the ops repo. The opposite of "re-explain the stack in every project's CLAUDE.md". |
| Default driver | Claude Code is the default AI that reads the stack, but the rules/hooks/templates are plain markdown and shell scripts — portable to other AI tools if/when they arrive. |
| Aha moment | The single sentence or image that makes a reader stop scrolling and say "oh, this is the thing I need". Four candidates above, option 1 shipped. |
| `hero__cta` | New CSS block in the hero that holds the primary (★ Star) and secondary (install link) call-to-action buttons |
| Global install | Alternative install pattern: clone apexstack once at `~/.apexstack/` and reference from every ops repo via symlinks. Good for founders running multiple orgs. |

## Test plan

- [ ] `cd projects/hava/mockups/ && python3 -m http.server 8000` — wait, wrong repo. Run `python3 -m http.server 8000` inside `site/` in the apexstack repo
- [ ] Open `http://localhost:8000` in a browser, confirm the hero reads "Where projects get forged." and the CTA buttons are visible above the install block
- [ ] Click "★ Star on GitHub" — opens the GitHub repo
- [ ] Click "or install it now ↓" — scrolls to `#install` section
- [ ] Click the install caveat's `#install-global` link — scrolls to the new global-install step
- [ ] Inspect CSS in devtools, confirm `.cta--primary` has `background: var(--ink)` and hover → `var(--accent)`
- [ ] Dark-mode check (`prefers-color-scheme: dark`) — CTA should still be readable
- [ ] `grep -n "~/.apexstack" site/index.html` — should only hit the new global-install step, NOT the hero install block
- [ ] `grep -n "opinionated stack for Claude Code" site/index.html README.md CLAUDE.md` — should return zero hits (old tagline gone)
- [ ] README.md renders cleanly on GitHub (preview the PR)
- [ ] Rex review

Refs me2resh/apexscript-org#100

🤖 Generated with [Claude Code](https://claude.com/claude-code)