### PR TITLE
feat(#100): animated /idea shell demo in the hero

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -346,6 +346,105 @@ a:hover { color: var(--accent); }
   .cta__sep { display: none; }
 }
 
+/* ============================================================
+   shell demo — animated /idea walkthrough in the hero
+   ============================================================ */
+
+.shell-demo {
+  max-width: 780px;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  margin: 0 0 2rem 0;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.6;
+  position: relative;
+  overflow: hidden;
+}
+.shell-demo__chrome {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.85rem;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper-3);
+}
+.shell-demo__dots {
+  display: inline-flex;
+  gap: 0.35rem;
+}
+.shell-demo__dot {
+  display: inline-block;
+  width: 0.6rem;
+  height: 0.6rem;
+  border: 1px solid var(--ink-faint);
+}
+.shell-demo__dot.is-warn {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+.shell-demo__title {
+  font-size: 11px;
+  color: var(--ink-faint);
+  letter-spacing: 0.03em;
+  text-transform: lowercase;
+}
+.shell-demo__replay {
+  display: none;
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid var(--rule-faint);
+  color: var(--ink-faint);
+  font-family: inherit;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.6rem;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.shell-demo__replay:hover,
+.shell-demo__replay:focus-visible {
+  color: var(--ink);
+  border-color: var(--ink);
+}
+.shell-demo__body {
+  padding: 1rem 1.25rem 1.15rem;
+  min-height: 15.5rem;
+  color: var(--ink);
+  word-break: break-word;
+}
+.shell-demo__body .line {
+  display: block;
+  min-height: 1.6em;
+  white-space: pre-wrap;
+}
+.shell-demo__body .prompt {
+  color: var(--ink-faint);
+  user-select: none;
+}
+.shell-demo__body .cmd {
+  color: var(--ink);
+  font-weight: 600;
+}
+.shell-demo__body .cmd .prompt {
+  color: var(--accent);
+}
+.shell-demo__body .sys {
+  color: var(--ink-soft);
+}
+.shell-demo__body .you {
+  color: var(--ink);
+}
+.shell-demo__body .ok {
+  color: var(--accent);
+  font-weight: 600;
+  margin-top: 0.45rem;
+}
+.shell-demo__body .muted {
+  color: var(--ink-faint);
+}
+
 .hero__metrics {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -953,6 +1052,31 @@ footer.foot {
       <a href="https://github.com/me2resh/apexstack" class="cta cta--primary" target="_blank" rel="noopener">★ Star on GitHub</a>
       <span class="cta__sep" aria-hidden="true">·</span>
       <a href="#install" class="cta cta--ghost">or install it now ↓</a>
+    </div>
+
+    <div class="shell-demo rise rise-4" id="shell-demo" aria-label="Demo of the /idea slash command running in Claude Code">
+      <div class="shell-demo__chrome" aria-hidden="true">
+        <span class="shell-demo__dots">
+          <span class="shell-demo__dot"></span>
+          <span class="shell-demo__dot"></span>
+          <span class="shell-demo__dot is-warn"></span>
+        </span>
+        <span class="shell-demo__title">claude code — apexstack — /idea</span>
+        <button type="button" class="shell-demo__replay" id="shell-demo-replay" aria-label="Replay the demo">replay ↻</button>
+      </div>
+      <div class="shell-demo__body" id="shell-demo-body">
+        <div class="line cmd"><span class="prompt">$ </span>/idea Usage-based pricing for creators</div>
+        <div class="line sys">Category? (1) New Product (2) Feature (3) Internal Tool (4) Process</div>
+        <div class="line you"><span class="prompt">&gt; </span>2</div>
+        <div class="line sys">Description? (one line)</div>
+        <div class="line you"><span class="prompt">&gt; </span>Let creators tier paid access by usage instead of seat count</div>
+        <div class="line sys">Create GitHub Issue in your-org/example-app? (y/n)</div>
+        <div class="line you"><span class="prompt">&gt; </span>y</div>
+        <div class="line ok">✓ Captured: IDEA-025 — Usage-based pricing for creators</div>
+        <div class="line muted">&nbsp;&nbsp;Backlog:&nbsp;&nbsp;projects/ideas-backlog.md</div>
+        <div class="line muted">&nbsp;&nbsp;Tracking: your-org/example-app#31</div>
+        <div class="line muted">&nbsp;&nbsp;Next:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;triage, then /write-spec</div>
+      </div>
     </div>
 
     <div class="install rise rise-4" id="install-block">
@@ -1571,6 +1695,108 @@ echo '@~/.apexstack/CLAUDE.md' &gt;&gt; CLAUDE.md
       btn.textContent = prev;
     }, 1600);
   }
+})();
+
+// ---- /idea shell animation ----
+(function () {
+  var body = document.getElementById('shell-demo-body');
+  var replay = document.getElementById('shell-demo-replay');
+  if (!body) return;
+
+  // Respect prefers-reduced-motion: keep the pre-rendered static demo, skip the typewriter
+  if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    return;
+  }
+
+  // Script: [type, text, delayAfterMs, typeSpeedMs (0 = instant)]
+  var script = [
+    ['cmd',   '/idea Usage-based pricing for creators',                             900, 40],
+    ['sys',   'Category? (1) New Product (2) Feature (3) Internal Tool (4) Process', 420, 0],
+    ['you',   '2',                                                                   650, 140],
+    ['sys',   'Description? (one line)',                                             420, 0],
+    ['you',   'Let creators tier paid access by usage instead of seat count',        900, 32],
+    ['sys',   'Create GitHub Issue in your-org/example-app? (y/n)',                  420, 0],
+    ['you',   'y',                                                                   700, 180],
+    ['ok',    '\u2713 Captured: IDEA-025 — Usage-based pricing for creators',        360, 0],
+    ['muted', '  Backlog:  projects/ideas-backlog.md',                               360, 0],
+    ['muted', '  Tracking: your-org/example-app#31',                                 360, 0],
+    ['muted', '  Next:     triage, then /write-spec',                                  0, 0]
+  ];
+
+  var timeouts = [];
+
+  function clearTimeouts() {
+    timeouts.forEach(function (t) { clearTimeout(t); });
+    timeouts = [];
+  }
+
+  function typeInto(target, text, speed, done) {
+    if (speed === 0) {
+      target.textContent = text;
+      done();
+      return;
+    }
+    var i = 0;
+    function step() {
+      if (i <= text.length) {
+        target.textContent = text.slice(0, i);
+        i++;
+        timeouts.push(setTimeout(step, speed + (Math.random() * 30 - 15)));
+      } else {
+        done();
+      }
+    }
+    step();
+  }
+
+  function play() {
+    clearTimeouts();
+    body.innerHTML = '';
+    var i = 0;
+
+    function next() {
+      if (i >= script.length) return;
+      var entry = script[i];
+      var type = entry[0];
+      var text = entry[1];
+      var delayAfter = entry[2];
+      var speed = entry[3];
+
+      var line = document.createElement('div');
+      line.className = 'line ' + type;
+      body.appendChild(line);
+
+      if (type === 'cmd' || type === 'you') {
+        var prompt = document.createElement('span');
+        prompt.className = 'prompt';
+        prompt.textContent = type === 'cmd' ? '$ ' : '> ';
+        line.appendChild(prompt);
+        var inner = document.createElement('span');
+        line.appendChild(inner);
+        typeInto(inner, text, speed, function () {
+          i++;
+          timeouts.push(setTimeout(next, delayAfter));
+        });
+      } else {
+        line.textContent = text;
+        i++;
+        timeouts.push(setTimeout(next, delayAfter));
+      }
+    }
+
+    next();
+  }
+
+  // Reveal the replay button (hidden by default so no-JS users don't see a dead button)
+  if (replay) {
+    replay.style.display = 'inline-block';
+    replay.addEventListener('click', function () {
+      play();
+    });
+  }
+
+  // Start after a short beat so the rise-4 fade-in has time to breathe
+  timeouts.push(setTimeout(play, 900));
 })();
 </script>
 


### PR DESCRIPTION
## Summary

PR 3 of the apexstack positioning epic (`me2resh/apexscript-org#100`). Adds an animated shell window showing a real `/idea` invocation end-to-end, placed in the hero between the CTA block and the install command so readers see proof of what the stack feels like before they commit to cloning.

You picked `/idea` (over `/handover` or the full ticket flow) because it's relatable, lightweight, and demonstrates the multi-project story: the demo creates `IDEA-025`, stores it in the shared `projects/ideas-backlog.md`, and files a tracking issue against `your-org/example-app` — all three surfaces the copy above promises.

## The demo script (~11 seconds, typewriter timing)

```
$ /idea Usage-based pricing for creators
Category? (1) New Product (2) Feature (3) Internal Tool (4) Process
> 2
Description? (one line)
> Let creators tier paid access by usage instead of seat count
Create GitHub Issue in your-org/example-app? (y/n)
> y
✓ Captured: IDEA-025 — Usage-based pricing for creators
  Backlog:  projects/ideas-backlog.md
  Tracking: your-org/example-app#31
  Next:     triage, then /write-spec
```

**Multi-project neutrality**: no real project names leak — placeholder is `your-org/example-app`, matching the `apexstack.projects.yaml.example` registry convention the rest of the repo already uses.

## Implementation

**HTML** — new `.shell-demo` block in the hero (after `.hero__cta`, before `.install`), with:
- Chrome bar: three brutalist dots (two outline, one filled with accent colour), a title `claude code — apexstack — /idea`, and a replay button
- Body: pre-rendered static content listing the full transcript — so the demo is readable even with JS disabled or `prefers-reduced-motion: reduce`

**CSS** — new `.shell-demo*` rules slotted between `.cta__sep` and `.hero__metrics`:
- Shell window matches the existing terminal-brutalism aesthetic: sharp corners, hairline borders, paper-2 background, accent colour for the filled dot and the `$` prompt
- Line types: `cmd` (bold ink), `sys` (muted ink-soft), `you` (ink), `ok` (accent + bold), `muted` (ink-faint)
- Prompt colouring: `$` is accent, `>` is ink-faint (user input marker vs system prompt)
- Replay button: hidden by default via `display: none`, JS reveals it
- Respects `prefers-color-scheme: dark` because every variable it uses already flips

**JavaScript** — ~90-line IIFE appended to the existing end-of-body script tag (not a new `<script>`):
- Typewriter effect with per-character delay + ±15ms jitter so it feels human
- Per-line `delayAfterMs` so system prompts appear instantly but pause before the next line
- `cmd` lines get a `$ ` prompt prepended; `you` lines get a `> ` prompt; everything else prints plain
- Clears the body on play/replay to avoid artefacts
- **Reduced-motion path**: if `window.matchMedia('(prefers-reduced-motion: reduce)').matches`, the IIFE exits immediately without animating. The pre-rendered static HTML stays in place and the replay button stays hidden (nothing to replay). No forced wait.
- **No-JS path**: the static HTML is fully readable with CSS only; the replay button is `display: none` until JS reveals it, so no dead button.

## Placement rationale

| Epic field | Picked | This PR |
|---|---|---|
| **C1 — which command** | `/idea` (user decided just now) | Script covers the full `/idea` flow: title, category, description, tracking issue |
| **C2 — tech** | CSS + small JS (from earlier UX discovery) | ~90 lines of vanilla JS, inline, no build step |
| **C3 — placement** | Hero (from earlier UX discovery) | Between `.hero__cta` and `.install`, so the funnel reads: pitch → CTA → proof → install → caveat → metrics |

## Accessibility

- `aria-label` on the shell-demo wrapper describes what it is
- `aria-hidden` on the decorative chrome dots
- Replay button has `aria-label="Replay the demo"` and `type="button"`
- `prefers-reduced-motion` fully respected (no animation, no forced delay, no replay loop, button hidden)
- Static pre-rendered content is a functional fallback — demo is readable even with JS disabled
- All colours inherit from existing CSS variables so dark mode works without further work

## Glossary

| Term | Definition |
|------|------------|
| Shell demo | The new animated terminal window in the hero showing `/idea` running end-to-end |
| Chrome bar | The top of a shell window — three dots + title. Purely decorative, `aria-hidden`. |
| Typewriter effect | JS that appends characters one at a time to an element, simulating someone typing |
| Jitter | Small random variation (±15ms) added to the per-character delay so the typing looks human, not mechanical |
| Reduced-motion path | The branch of the JS that runs when the user has `prefers-reduced-motion: reduce` — it exits immediately without animating |
| `your-org/example-app` | The canonical placeholder repo name used throughout apexstack, from `apexstack.projects.yaml.example`. Used here so no real project leaks. |
| IDEA-025 | Example idea ID in the demo, zero-padded to 3 digits per the `/idea` skill rules |
| `/write-spec` | The next skill in the idea lifecycle — triage an IDEA-NNN, then `/write-spec` produces a PRD if it survives |

## Test plan

- [ ] Open the site locally: `cd site && python3 -m http.server 8000`
- [ ] Visit `http://localhost:8000` — hero shows the shell demo between the CTA buttons and the install command
- [ ] Demo auto-plays after ~900ms — `$ /idea ...` types out character by character, then the system responses appear, then the final output types out
- [ ] Total runtime ~10-11 seconds
- [ ] Click the replay button (top-right of the chrome bar) — demo clears and replays
- [ ] Hover state: replay button border/text darken to `var(--ink)`
- [ ] Dark mode (`prefers-color-scheme: dark`): colours flip correctly, demo still legible
- [ ] `prefers-reduced-motion: reduce` (toggle in browser devtools): demo shows the full static transcript immediately, replay button is hidden, no typing animation
- [ ] Disable JS in devtools: demo shows the full static transcript, no replay button
- [ ] Verify no real project names leak: `grep -iE "flat-?mate|curios|sharp ?pick|movetwo|yumyum" site/index.html` returns 0 hits
- [ ] Verify hero layout doesn't break on narrow screens (try 375px width)
- [ ] Rex review

## What's NOT in this PR (tracked in the epic)

| Item | Tracked as |
|------|------------|
| Commands sub-page | Intentionally skipped per CEO call — the animation target was picked without needing the reference page first |
| Roles integration (19 role imports + triggers + workflow threading) | PR 4 — the biggest audit finding, own PR |
| `/handover` auto-append to registry + `/idea` polish | PR 5 |
| Anvil/metalwork iconography | Still deferred; copy is locked now but visual treatment is its own decision |

Refs me2resh/apexscript-org#100

🤖 Generated with [Claude Code](https://claude.com/claude-code)