### PR TITLE
feat(#100): wire 19 role files into workflows, skills, and CLAUDE.md

### DIFF
--- a/.claude/rules/role-triggers.md
+++ b/.claude/rules/role-triggers.md
@@ -1,0 +1,107 @@
+# Role Triggers — When to Activate Which Role
+
+ApexStack ships **19 role definitions** in `roles/{department}/`. They are not all loaded into every session (context efficiency — 19 files × ~120 lines averages out to ~22k tokens, most of which are idle during any given task). Instead, a role is **activated** when a specific condition is met: you read the role file, adopt its identity, responsibilities, and constraints for the duration of the task, then hand off to the next role in the chain.
+
+## Activation Table
+
+| Role | File | Activate when… |
+|------|------|----------------|
+| **Head of Engineering** | `roles/engineering/head-of-engineering.md` | Architecture review requested · new tech stack addition · cross-project engineering call · escalation from a Tech Lead |
+| **Tech Lead** | `roles/engineering/tech-lead.md` | Technical design for a new feature · planning phase in SDLC · code review approval gate · implementation task breakdown |
+| **Backend Engineer** | `roles/engineering/backend-engineer.md` | Implementation phase on backend code (domain / application / infrastructure layers) · API work · database schema changes |
+| **Frontend Engineer** | `roles/engineering/frontend-engineer.md` | Implementation phase on UI code · component work · design-system integration · accessibility review |
+| **QA Engineer** | `roles/engineering/qa-engineer.md` | **Ticket enters QA state after merge** · acceptance-criteria verification · bug triage · regression testing |
+| **Platform Engineer** | `roles/engineering/platform-engineer.md` | CI/CD pipeline changes · developer tooling · infrastructure-as-code work · golden-path templates |
+| **SRE** | `roles/engineering/sre.md` | Production incident · SLO breach · monitoring / alerting work · on-call rotation |
+| **Head of Product** | `roles/product/head-of-product.md` | Roadmap prioritization · feasibility call · strategic product decision · resource allocation across products |
+| **Product Manager** | `roles/product/product-manager.md` | PRD creation · user-story breakdown · acceptance-criteria authoring · sprint planning |
+| **Product Analyst** | `roles/product/product-analyst.md` | Market research · competitive analysis · metric investigation · data-driven product call |
+| **Head of Design** | `roles/design/head-of-design.md` | Design-system changes · UX principles decision · cross-project visual standards |
+| **UI Designer** | `roles/design/ui-designer.md` | Visual design · component specifications · design tokens · pixel-level work |
+| **UX Designer** | `roles/design/ux-designer.md` | User flows · information architecture · usability review · wireframing |
+| **Head of Security** | `roles/security/head-of-security.md` | Security strategy · threat model · compliance call · cross-project security architecture |
+| **Security Auditor** | `roles/security/security-auditor.md` | **PR touches auth / crypto / user data / secrets** · SAST findings · OWASP review · dependency vulnerability |
+| **Penetration Tester** | `roles/security/penetration-tester.md` | Active testing · exploit discovery · API security review · pre-release security sign-off |
+| **Head of Data** | `roles/data/head-of-data.md` | Analytics strategy · data governance · reporting architecture · cross-project data modelling |
+| **Data Analyst** | `roles/data/data-analyst.md` | SQL queries · dashboards · A/B-test analysis · metric investigation |
+| **Data Engineer** | `roles/data/data-engineer.md` | ETL pipelines · data modelling · data-quality work · warehouse schema changes |
+
+## Activation Protocol
+
+When a trigger condition is met:
+
+1. **Read the role file**: `@roles/{department}/{role}.md`
+2. **Adopt the role's identity** — responsibilities, CAN / CANNOT constraints, interfaces
+3. **Follow the handoff rules** defined in the role file — who you receive from, who you deliver to
+4. **Stay in the role** until the task completes or a different trigger activates a different role
+
+A single conversation can move through multiple roles. The SDLC for one feature typically chains:
+
+```
+Head of Product → Product Manager → Head of Design / UX Designer / UI Designer
+  → Tech Lead → Backend Engineer / Frontend Engineer
+    → [Security Auditor if PR touches auth]
+      → QA Engineer → Platform Engineer / SRE
+```
+
+Each handoff is explicit. The handing-off role delivers the artefact defined in its role file (PRD, tech design, PR, test plan, etc.); the receiving role reads it and moves forward.
+
+## Trigger Types
+
+**Auto-activation** — a role should activate automatically when its condition is detected in conversation context:
+
+| Signal | Activate |
+|--------|----------|
+| Ticket moved to `qa` label | QA Engineer |
+| PR diff touches `**/auth/**`, `**/crypto/**`, `**/secrets/**`, `.env*` | Security Auditor |
+| PR diff touches `.github/workflows/**`, `golden-paths/pipelines/**` | Platform Engineer |
+| PR diff touches `docs/agdr/**` or adds a new dependency | Tech Lead |
+| Production incident / SLO breach mentioned | SRE |
+| New PRD or spec being drafted | Product Manager |
+| Roadmap question or prioritization call | Head of Product |
+| User flow / wireframe / IA question | UX Designer |
+| Component spec / design tokens question | UI Designer |
+| Cross-project strategy question | The relevant Head of _ role |
+
+**Prompted activation** — the user explicitly asks for a role:
+
+```
+"Act as the QA Engineer and verify ticket #42"
+"Put on your Tech Lead hat and review this PR"
+"As the Security Auditor, check this PR for OWASP issues"
+```
+
+Both forms result in the role file being read and the role being embodied for the task.
+
+## Role Boundaries
+
+Every role file defines CAN / CANNOT lists. When active in a role, respect those boundaries strictly:
+
+- A Backend Engineer **cannot** add new technologies without Tech Lead approval
+- A Tech Lead **cannot** override Head of Engineering decisions
+- A QA Engineer **cannot** approve code merges (only comment)
+- A Product Manager **cannot** make technical architecture calls
+
+When you hit a CANNOT, hand off to the role that can.
+
+## Handoff Artefacts
+
+Roles deliver concrete artefacts at each handoff point. These are the contracts between roles — if the artefact isn't ready, the next role can't start.
+
+| From → To | Artefact |
+|-----------|----------|
+| Product Manager → Tech Lead | Approved PRD with acceptance criteria |
+| Head of Design → UX/UI Designer | Design system tokens + principles |
+| UX Designer → UI Designer | User flows + wireframes |
+| UI Designer → Frontend Engineer | Component specs + design tokens |
+| Tech Lead → Backend / Frontend Engineer | Technical design + task breakdown |
+| Backend / Frontend Engineer → QA Engineer | Testable build + PR |
+| Security Auditor → Tech Lead | Security findings + required fixes |
+| QA Engineer → Product Manager | AC verification sign-off |
+| Platform Engineer → SRE | Production deployment + runbook |
+
+## Aspirational → Real
+
+Before this rule existed, the 19 role files were passive markdown docs — no trigger, no activation, no automatic reference from workflows or skills. A user had to manually say *"please read `roles/engineering/qa-engineer.md` and act as the QA Engineer"* for anything to happen.
+
+This file closes that gap. When in a Claude Code session under apexstack, the trigger table drives which role activates, and the workflow and skill files now explicitly reference the role files at every phase boundary. Roles are now **first-class participants** in the SDLC, not reference material.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -10,6 +10,17 @@ allowed-tools: Bash, Read, Grep, Glob
 
 Review a pull request for quality, security, and adherence to standards.
 
+## Activated agent + role
+
+When `/code-review` runs:
+
+1. **Primary reviewer**: the **Code Reviewer agent (Rex)** at [`.claude/agents/code-reviewer.md`](../../agents/code-reviewer.md) — runs on every commit, owns the automated first-pass review.
+2. **Human approval gate**: the **[Tech Lead](../../../roles/engineering/tech-lead.md)** — activates to sign off on architecture, design patterns, and team conventions that Rex can't judge from code alone.
+3. **Conditional Security Auditor**: if the diff touches `**/auth/**`, `**/crypto/**`, `**/secrets/**`, `.env*`, or similar, the **[Security Auditor](../../../roles/security/security-auditor.md)** also activates and must sign off before merge. Consider chaining `/security-review` for the deeper pass.
+4. **Conditional UI Designer**: if the diff touches visible UI, the **[UI Designer](../../../roles/design/ui-designer.md)** activates for design review.
+
+See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the full activation protocol.
+
 ## Usage
 
 ```

--- a/.claude/skills/decide/SKILL.md
+++ b/.claude/skills/decide/SKILL.md
@@ -9,6 +9,14 @@ argument-hint: "<what you're deciding>"
 
 Forces structured decision-making and creates an auditable Agent Decision Record (AgDR).
 
+## Activated role
+
+When `/decide` runs, activate the **[Tech Lead](../../../roles/engineering/tech-lead.md)** role — they own technical decisions within their domain. For decisions that cross the architecture-review threshold (new service, new tech stack, new external integration, major data model change), escalate to the **[Head of Engineering](../../../roles/engineering/head-of-engineering.md)** before creating the AgDR.
+
+If the decision touches auth / crypto / secrets / PII, also involve the **[Security Auditor](../../../roles/security/security-auditor.md)** for sign-off on the security implications before finalising the choice.
+
+See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the full activation protocol.
+
 ## Process
 
 ### 1. Parse the Decision Topic

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -9,6 +9,12 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 
 Manage the product roadmap as a single durable file. The skill is intentionally low-ceremony: a roadmap is a markdown file with milestones, each containing a table of items. `/roadmap` reads it, edits it, and renders it.
 
+## Activated role
+
+When `/roadmap` runs, activate the **[Head of Product](../../../roles/product/head-of-product.md)** role — they own roadmap prioritisation, strategic sequencing, and milestone decisions. For adding a specific item with a PRD, chain to `/write-spec` which activates the [Product Manager](../../../roles/product/product-manager.md) instead. For items that require data-driven reprioritisation, involve the [Product Analyst](../../../roles/product/product-analyst.md).
+
+See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the full activation protocol.
+
 ## Usage
 
 ```

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -10,6 +10,17 @@ allowed-tools: Bash, Read, Grep, Glob
 
 Review a pull request specifically for security vulnerabilities and best practices.
 
+## Activated agent + role
+
+When `/security-review` runs:
+
+1. **Primary reviewer**: the **Security Reviewer agent (Shield)** at [`.claude/agents/security-reviewer.md`](../../agents/security-reviewer.md) — runs the automated security checklist.
+2. **Human approval gate**: the **[Security Auditor](../../../roles/security/security-auditor.md)** role — activates on any PR that touches auth / crypto / secrets / user data / PII, or when `/security-review` is explicitly invoked.
+3. **Escalation for strategic calls**: the **[Head of Security](../../../roles/security/head-of-security.md)** — threat modelling, compliance decisions, or novel attack surfaces.
+4. **For active testing**: the **[Penetration Tester](../../../roles/security/penetration-tester.md)** — exploit discovery, API security review, pre-release security sign-off.
+
+See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the full activation protocol.
+
 ## Usage
 
 ```

--- a/.claude/skills/write-spec/SKILL.md
+++ b/.claude/skills/write-spec/SKILL.md
@@ -8,6 +8,14 @@ argument-hint: "<feature or problem statement>"
 
 Write a feature specification or product requirements document (PRD).
 
+## Activated role
+
+When `/write-spec` runs, activate the **[Product Manager](../../../roles/product/product-manager.md)** role — they own PRD creation, user stories, and acceptance criteria. For roadmap-level prioritisation calls, escalate to the **[Head of Product](../../../roles/product/head-of-product.md)**.
+
+Design-heavy features should also involve the **[UX Designer](../../../roles/design/ux-designer.md)** (for user flows) and the **[UI Designer](../../../roles/design/ui-designer.md)** (for component specs) once the PRD has a problem statement. Technical feasibility review happens at the Tech Design phase, not here — the `/write-spec` output hands off to the [Tech Lead](../../../roles/engineering/tech-lead.md) who activates for Phase 2.
+
+See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the full activation protocol.
+
 ## Usage
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,20 @@ Role definitions live in `roles/`. Each role defines:
 | Security | Head of Security, Security Auditor, Pen Tester | `roles/security/` |
 | Data | Head of Data, Data Analyst, Data Engineer | `roles/data/` |
 
-When asked to act as a role, read the corresponding role file and follow its guidelines.
+### Activation — roles are first-class participants, not reference docs
+
+Roles activate **on specific conditions**. The full trigger table lives in `@.claude/rules/role-triggers.md` (imported below). The short version:
+
+- **Auto-activation** — certain signals fire a role automatically. Examples: ticket moves to `qa` label → QA Engineer; PR diff touches `**/auth/**` → Security Auditor; production incident → SRE; new PRD drafted → Product Manager.
+- **Prompted activation** — the user can explicitly activate any role: *"act as the QA Engineer for ticket #42"*, *"put on your Tech Lead hat"*, etc.
+
+When a role activates:
+1. Read the file at `roles/{department}/{role}.md`
+2. Adopt the role's identity, responsibilities, CAN / CANNOT boundaries
+3. Follow the handoff rules in the role file — who you receive from, who you deliver to
+4. Stay in the role until the task completes or a different trigger activates a different role
+
+Full trigger table and handoff artefacts: @.claude/rules/role-triggers.md
 
 ---
 

--- a/workflows/code-review.md
+++ b/workflows/code-review.md
@@ -6,11 +6,16 @@ Ensure code quality, share knowledge, and catch issues before they reach product
 
 ## Roles
 
-| Role | Responsibility |
-|------|----------------|
-| **Author** | Creates PR, responds to feedback |
-| **Reviewer** | Reviews code, provides feedback |
-| **Approver** | Tech Lead or Senior who gives final approval |
+Code review is a **role-activated** workflow. The roles below activate automatically when a PR is opened, per [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md).
+
+| Role | Responsibility | Role file |
+|------|----------------|-----------|
+| **Author** | Creates PR, responds to feedback. The engineer who wrote the code: [Backend Engineer](../roles/engineering/backend-engineer.md) or [Frontend Engineer](../roles/engineering/frontend-engineer.md). | `roles/engineering/{backend,frontend}-engineer.md` |
+| **Code Reviewer agent (Rex)** | Automated first-pass review on every commit. Checks architecture, tests, security, AgDR, glossary. | `.claude/agents/code-reviewer.md` |
+| **Tech Lead reviewer** | Human approval gate. Signs off on architecture, design patterns, team conventions. | [`roles/engineering/tech-lead.md`](../roles/engineering/tech-lead.md) |
+| **Security Auditor** (conditional) | Activates when the PR diff touches `**/auth/**`, `**/crypto/**`, `**/secrets/**`, `.env*`, or similar. | [`roles/security/security-auditor.md`](../roles/security/security-auditor.md) |
+| **UI Designer** (conditional) | Activates when the PR diff touches UI components, design tokens, or visible layout. | [`roles/design/ui-designer.md`](../roles/design/ui-designer.md) |
+| **QA Engineer** | Not a reviewer — takes over at the QA phase after merge to verify acceptance criteria. | [`roles/engineering/qa-engineer.md`](../roles/engineering/qa-engineer.md) |
 
 ---
 

--- a/workflows/deployment.md
+++ b/workflows/deployment.md
@@ -2,6 +2,19 @@
 
 How code moves from development to production.
 
+## Roles
+
+Deployment is a **role-activated** workflow. Roles activate automatically per [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md).
+
+| Stage | Primary role | Trigger |
+|-------|--------------|---------|
+| CI/CD pipeline design and maintenance | [Platform Engineer](../roles/engineering/platform-engineer.md) | CI/CD config changes, pipeline failures, golden-path updates |
+| Staging deployment | [Platform Engineer](../roles/engineering/platform-engineer.md) | Push to `main` auto-triggers |
+| Production promotion gate | [Platform Engineer](../roles/engineering/platform-engineer.md) + [Head of Engineering](../roles/engineering/head-of-engineering.md) sign-off for risky changes | Manual after QA sign-off |
+| Incident response / rollback | [SRE](../roles/engineering/sre.md) | SLO breach, error-rate spike, P1 incident |
+| Post-deploy monitoring (first 24-48h) | [SRE](../roles/engineering/sre.md) | Production deploy completed |
+| Security review gate (if required) | [Security Auditor](../roles/security/security-auditor.md) | Auth / crypto / secrets / PII in the diff |
+
 ---
 
 ## Deployment Flow

--- a/workflows/sdlc.md
+++ b/workflows/sdlc.md
@@ -14,6 +14,10 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 
 ## Phase 1: Planning
 
+> **Primary role**: [Tech Lead](../roles/engineering/tech-lead.md) · **Supporting**: [Product Manager](../roles/product/product-manager.md), [Head of Engineering](../roles/engineering/head-of-engineering.md) · **Trigger**: new feature enters the sprint with an approved PRD
+>
+> Read the Tech Lead role file and adopt it before starting this phase. See [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md) for the full activation protocol.
+
 ### Entry Criteria
 - Approved PRD from Product
 - Design review complete (if UI involved)
@@ -37,6 +41,8 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 ---
 
 ## Phase 2: Technical Design
+
+> **Primary role**: [Tech Lead](../roles/engineering/tech-lead.md) · **Escalation**: [Head of Engineering](../roles/engineering/head-of-engineering.md) (architecture review) · **Supporting**: [UX Designer](../roles/design/ux-designer.md), [UI Designer](../roles/design/ui-designer.md) (if UI involved)
 
 ### Entry Criteria
 - Feature in sprint
@@ -66,6 +72,10 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 ---
 
 ## Phase 3: Build
+
+> **Primary roles**: [Backend Engineer](../roles/engineering/backend-engineer.md), [Frontend Engineer](../roles/engineering/frontend-engineer.md) · **Coordinator**: [Tech Lead](../roles/engineering/tech-lead.md) · **Trigger**: technical design approved, tasks assigned
+>
+> The engineer implementing the task activates the matching role. Cross-stack tickets may chain Backend → Frontend (or vice-versa) via an explicit handoff.
 
 ### Entry Criteria
 - Technical design approved
@@ -132,6 +142,10 @@ RIGHT:
 
 ## Phase 4: Code Review
 
+> **Primary role**: [Tech Lead](../roles/engineering/tech-lead.md) · **Automated reviewer**: Code Reviewer agent (Rex) via `/code-review` · **Security gate** (if PR touches auth / crypto / secrets / user data): [Security Auditor](../roles/security/security-auditor.md) · **Design gate** (if PR touches UI): [UI Designer](../roles/design/ui-designer.md)
+>
+> Rex reviews every commit automatically. Human reviewers (Tech Lead, Security Auditor, UI Designer) activate on the triggers above. All reviews must match the commit SHA being merged.
+
 ### Entry Criteria
 - PR submitted
 - CI checks passing
@@ -162,6 +176,10 @@ RIGHT:
 ---
 
 ## Phase 5: QA Verification (MANDATORY)
+
+> **Primary role**: [QA Engineer](../roles/engineering/qa-engineer.md) · **Trigger**: merged PR → ticket moves to `qa` label (NOT auto-closed) · **Handoff from**: [Backend](../roles/engineering/backend-engineer.md) / [Frontend Engineer](../roles/engineering/frontend-engineer.md) (testable build on staging) · **Handoff to**: [Product Manager](../roles/product/product-manager.md) (AC sign-off) → Done
+>
+> This is the **mandatory gate** — merged code is never Done until the QA Engineer has verified every acceptance criterion. Auto-closing via `Closes #XX` is intentionally overridden with `Refs #XX` + the `qa` label when QA verification is required.
 
 ### Entry Criteria
 - PR approved and merged
@@ -198,6 +216,8 @@ In Progress --> In Review --> QA --> Done
 
 ## Phase 6: Deploy
 
+> **Primary role**: [Platform Engineer](../roles/engineering/platform-engineer.md) · **Support**: [SRE](../roles/engineering/sre.md) (runbook + rollback plan) · **Trigger**: QA sign-off complete, staging validated
+
 ### Entry Criteria
 - Tests passed
 - QA sign-off
@@ -218,6 +238,8 @@ In Progress --> In Review --> QA --> Done
 ---
 
 ## Phase 7: Monitor
+
+> **Primary role**: [SRE](../roles/engineering/sre.md) · **Escalation**: [Head of Engineering](../roles/engineering/head-of-engineering.md) on sustained incident · **Trigger**: deployment to production, first 24-48h watch window
 
 ### Entry Criteria
 - Deployed to production
@@ -243,12 +265,14 @@ In Progress --> In Review --> QA --> Done
 
 ## Roles Summary
 
-| Phase | Primary | Support |
-|-------|---------|---------|
-| Planning | Tech Lead | Product, Engineers |
-| Design | Tech Lead | Head of Engineering |
-| Build | Engineers | Tech Lead |
-| Review | Tech Lead | Peers, Design |
-| QA | QA Engineer | Engineers |
-| Deploy | Platform/CI | Tech Lead |
-| Monitor | SRE | Engineers |
+Every phase has a primary role that activates automatically when the phase starts. Full trigger table: [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md).
+
+| Phase | Primary role | Supporting roles |
+|-------|--------------|------------------|
+| Planning | [Tech Lead](../roles/engineering/tech-lead.md) | [Product Manager](../roles/product/product-manager.md), Engineers |
+| Technical Design | [Tech Lead](../roles/engineering/tech-lead.md) | [Head of Engineering](../roles/engineering/head-of-engineering.md) (escalation), [UX Designer](../roles/design/ux-designer.md) / [UI Designer](../roles/design/ui-designer.md) |
+| Build | [Backend Engineer](../roles/engineering/backend-engineer.md) / [Frontend Engineer](../roles/engineering/frontend-engineer.md) | [Tech Lead](../roles/engineering/tech-lead.md) |
+| Code Review | [Tech Lead](../roles/engineering/tech-lead.md) + Rex | [Security Auditor](../roles/security/security-auditor.md) (if auth), [UI Designer](../roles/design/ui-designer.md) (if UI) |
+| QA | [QA Engineer](../roles/engineering/qa-engineer.md) | Engineers (bug fixes) |
+| Deploy | [Platform Engineer](../roles/engineering/platform-engineer.md) | [SRE](../roles/engineering/sre.md) |
+| Monitor | [SRE](../roles/engineering/sre.md) | [Head of Engineering](../roles/engineering/head-of-engineering.md) (escalation) |


### PR DESCRIPTION
## Summary

PR 4 of the positioning epic (`me2resh/apexscript-org#100`). Closes the biggest gap the PR #1 Rex audit flagged: **all 19 role files exist and are well-specified, but nothing in the running system references them**. Before this PR, a user had to manually say *"please read `roles/engineering/qa-engineer.md` and act as the QA Engineer"* for a role to activate. After this PR, roles are first-class participants in the SDLC — they activate on explicit conditions, workflows and skills reference them by file path, and a single new rule (`role-triggers.md`) is loaded into every session to drive activation.

This is also the PR that **makes the aspirational role lines in the hero lifecycle demo real**. The `Tech Lead role: planning`, `Backend Engineer role: implementing`, and `QA Engineer role: verifying` lines in the animation now correspond to actual activation protocol.

## What changed — 10 files

### NEW — `.claude/rules/role-triggers.md` (~107 lines)
The activation rule. Always loaded via CLAUDE.md's `@import`. Contains:
- **Activation table** for all 19 roles — department, file path, 2-4 concrete activation conditions per role
- **Activation protocol** — read the file, adopt the identity, follow handoff rules, stay until task completes
- **Auto-activation signals** (10 conditions → role mapping) — ticket label, PR path match, incident, PRD draft, etc.
- **Prompted activation** examples — *"act as the QA Engineer for #42"*
- **Role boundary enforcement** — CAN/CANNOT is strict, hand off when you hit a CANNOT
- **Handoff artefacts table** — the contracts between roles (PRD, tech design, testable build, security findings, AC sign-off)

### `CLAUDE.md`
- Adds an "Activation" subsection under ROLES explaining the model in three short paragraphs
- New `@.claude/rules/role-triggers.md` import at the end of the subsection

### `workflows/sdlc.md` — each phase gets a "Primary role" header
| Phase | Primary | Supporting / Conditional |
|---|---|---|
| 1. Planning | Tech Lead | Product Manager, Head of Eng (escalation) |
| 2. Tech Design | Tech Lead | Head of Eng, UX/UI Designer |
| 3. Build | Backend / Frontend Engineer | Tech Lead (coordinator) |
| 4. Code Review | Tech Lead + Rex | Security Auditor (if auth diff), UI Designer (if UI diff) |
| 5. **QA** | **QA Engineer** | Engineers (bug fixes) — **MANDATORY gate** |
| 6. Deploy | Platform Engineer | SRE |
| 7. Monitor | SRE | Head of Eng (escalation) |

The "Roles Summary" table at the bottom is rewritten with every role name as a markdown link to its file.

### `workflows/code-review.md` — Roles table expanded
- Author column names the actual Backend / Frontend Engineer roles
- Rex called out as the automated first-pass reviewer
- Tech Lead is the human approval gate with a link to the role file
- Conditional Security Auditor row (PR touches auth / crypto / secrets / user data)
- Conditional UI Designer row (PR touches visible UI)
- QA Engineer explicitly called out as **not** a reviewer — they take over at the QA phase, a common misconception about merge approval

### `workflows/deployment.md` — new Roles table at the top
Maps each deployment stage to its activating role:
- CI/CD pipeline maintenance → Platform Engineer
- Staging deployment → Platform Engineer
- Production promotion gate → Platform Engineer + Head of Engineering (for risky changes)
- Incident response / rollback → SRE
- Post-deploy monitoring (first 24-48h) → SRE
- Security review gate → Security Auditor (if required)

### 5 skill files — each gets an "Activated role" section between the intro and the process

| Skill | Activated role(s) |
|---|---|
| `/decide` | Tech Lead (+ Head of Eng at arch-review threshold, Security Auditor if decision touches auth/secrets) |
| `/write-spec` | Product Manager (+ Head of Product escalation, UX/UI Designer for design-heavy features, hands off to Tech Lead at Tech Design phase) |
| `/code-review` | Rex + Tech Lead (+ conditional Security Auditor, conditional UI Designer) |
| `/security-review` | Shield + Security Auditor (+ Head of Security for strategic calls, Penetration Tester for active testing) |
| `/roadmap` | Head of Product (+ Product Analyst for data-driven reprioritisation) |

## What's NOT in this PR (intentional scope discipline)

- **The 19 role files themselves are untouched.** The audit confirmed their content was already good — clear CAN/CANNOT, interfaces, handoffs, no dangling references. This PR is integration, not rewrite.
- **Skills without role activation**: `/inbox`, `/status`, `/tasks`, `/projects`, `/idea`, `/handover`, `/audit-deps`, `/stakeholder-update`. These are portfolio / CEO-facing or the role is implicit from task context — forcing a role activation section would be noise.
- **No new roles added.** The roster stays at 19.
- **`role-triggers.md` is imported ONCE** — from CLAUDE.md. Individual workflows and skills reference it by relative path but don't re-import. Keeps the context footprint lean.

## Token budget

- `role-triggers.md` is ~107 lines (~1.3k tokens). Loaded once per session via the CLAUDE.md `@import`.
- The 19 full role files are **NOT** pre-loaded — they're read on demand when their trigger fires. Saves ~22k tokens that would otherwise sit idle in every session regardless of task.
- Activation is explicit: Claude reads the trigger table, matches the current context, then reads the specific role file needed. No waste.

## Multi-project neutrality

```
grep -iE "flat-?mate|curios|sharp ?pick|movetwo|yumyum" \
  .claude/rules/role-triggers.md \
  CLAUDE.md \
  workflows/*.md \
  .claude/skills/{decide,write-spec,code-review,security-review,roadmap}/SKILL.md
# → 0 hits
```

All file paths use `roles/{department}/{role}.md` and `.claude/rules/role-triggers.md`. No org-specific references.

## Glossary

| Term | Definition |
|------|------------|
| Role activation | The moment Claude reads a specific role file and adopts its identity, responsibilities, and CAN/CANNOT boundaries for the duration of the current task |
| Auto-activation | Role activation triggered by a signal in conversation context (e.g. "PR diff touches `**/auth/**`" → Security Auditor activates) without explicit user prompt |
| Prompted activation | Role activation triggered by explicit user request (*"act as the QA Engineer"*) |
| Trigger table | The core table in `role-triggers.md` mapping 19 roles to the conditions that should fire them |
| Handoff artefact | The concrete output one role delivers to the next role in the SDLC chain (PRD, tech design, testable build, AC sign-off, etc.) — the contract between roles |
| CAN / CANNOT boundary | The explicit list in each role file of what the role is allowed to do and what requires handing off to a different role |
| Role chain | The typical sequence of roles that own a feature end-to-end: Product → Design → Tech Lead → Engineer → QA → Platform → SRE |
| Aspirational → real | The shift this PR delivers: the "role active" lines in the hero lifecycle demo were preview copy; they now correspond to a concrete activation protocol that actually fires |

## Test plan

- [ ] `cat .claude/rules/role-triggers.md` reads coherently end-to-end
- [ ] `cat CLAUDE.md | grep -A2 "role-triggers"` shows the import line in the ROLES section
- [ ] `grep -c "role-triggers" workflows/*.md .claude/skills/*/SKILL.md CLAUDE.md` returns a positive count across all 9 files
- [ ] Open `workflows/sdlc.md` and confirm every phase has a "Primary role" blockquote at the top
- [ ] Open `workflows/code-review.md` and confirm the Roles table has linked role files
- [ ] Open `workflows/deployment.md` and confirm the new Roles table at the top
- [ ] Open each of the 5 edited skill files and confirm the "Activated role" section exists between the intro and the Usage / Process section
- [ ] `grep -iE "flat-?mate|curios|sharp ?pick|movetwo|yumyum" .claude/rules/role-triggers.md CLAUDE.md workflows/*.md .claude/skills/*/SKILL.md` returns 0 hits
- [ ] Dogfood smoke test: in a fresh Claude Code session inside apexstack, paste "act as the QA Engineer and verify ticket #42" — Claude should read `roles/engineering/qa-engineer.md` and respond in character. (Requires a real ticket #42, so this is a manual step.)
- [ ] Rex review

Refs me2resh/apexscript-org#100

🤖 Generated with [Claude Code](https://claude.com/claude-code)