### PR TITLE
refactor(#100): multi-project only + fork-first install

### DIFF
--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -27,7 +27,7 @@ The assessment is always written to:
 projects/<name>/handover-assessment.md
 ```
 
-In multi-project mode (the default), this folder lives in the ops repo, alongside the rest of `projects/`. In single-project mode, it lives inside the current repo.
+The folder lives in the ops repo (your fork of apexstack), alongside the rest of `projects/`.
 
 If `projects/<name>/` doesn't exist, create it. Also seed a `projects/<name>/README.md` stub if missing — see `projects/README.md` for the convention.
 

--- a/.claude/skills/idea/SKILL.md
+++ b/.claude/skills/idea/SKILL.md
@@ -123,7 +123,7 @@ Next: triage with the team, then `/write-spec` if it survives.
 2. **Always assign an ID** — `IDEA-NNN`, zero-padded to 3 digits.
 3. **One row per idea** — never edit existing rows from this skill; new ideas always append.
 4. **Status starts at NEW** — triage changes it later.
-5. **Mode-aware** — detect `apexstack.mode` and write to the right file.
+5. **Single backlog** — every idea goes into `projects/ideas-backlog.md` at the root of the ops repo; triage assigns it to a project later.
 6. **Don't create the issue silently** — always ask first.
 7. **Never delete** — superseded ideas get status `SUPERSEDED`, not removal.
 

--- a/.claude/skills/idea/SKILL.md
+++ b/.claude/skills/idea/SKILL.md
@@ -19,16 +19,9 @@ Capture a new product, feature, or internal-tool idea so it lands somewhere dura
 
 ## Where the entry goes
 
-ApexStack supports two modes (configured in `onboarding.yaml` under `apexstack.mode`):
+Every idea lands in `projects/ideas-backlog.md` at the root of your ops repo (your fork of apexstack). One shared backlog for every project — triage decides which project ends up owning a given idea.
 
-| Mode | Backlog file |
-|------|--------------|
-| **multi-project mode** (default) | `projects/ideas-backlog.md` at the ops repo root |
-| **single-project mode** | `IDEAS.md` at the project root |
-
-In multi-project mode (the default), the idea sits at the ops-repo level so it can later be assigned to whichever project ends up owning it. In single-project mode, the idea is local to the one repo.
-
-If neither file exists yet, create it with a header and a table.
+If the file doesn't exist yet, create it with a header and a table.
 
 ## Process
 
@@ -40,17 +33,7 @@ Take the title from `$ARGUMENTS`. If empty, ask:
 What's the idea? Give me a short title (1 line).
 ```
 
-### 2. Detect the mode
-
-```bash
-# Check onboarding.yaml for mode
-grep -E '^\s*mode:\s*' onboarding.yaml 2>/dev/null | head -1
-```
-
-If `mode: single-project` -> use `IDEAS.md`.
-Otherwise (default, missing key, or `mode: multi-project`) -> use `projects/ideas-backlog.md`.
-
-### 3. Gather metadata
+### 2. Gather metadata
 
 Ask conversationally (one question at a time, don't batch):
 

--- a/.claude/skills/inbox/SKILL.md
+++ b/.claude/skills/inbox/SKILL.md
@@ -155,7 +155,7 @@ If everything is empty:
 
 1. **Read-only** — never close, comment, or assign anything from this skill
 2. **Always sort by recency within each section** — newest updates first
-3. **Multi-project mode iterates the registry** — never shell out to "all repos in the org"; only managed ones count
+3. **Registry-scoped** — only projects listed in `apexstack.projects.yaml` count; never shell out to "all repos in the org"
 4. **Skip empty sections** — don't print headers with `(0)`
 5. **Never error on a single project** — if one repo is unreachable, mark it `?` and continue
 6. **Always include URLs** — every row needs a clickable link

--- a/.claude/skills/inbox/SKILL.md
+++ b/.claude/skills/inbox/SKILL.md
@@ -16,16 +16,9 @@ Aggregates everything that's currently waiting on **you** across the projects Ap
 /inbox --since 24h
 ```
 
-## Mode detection
+## Scope
 
-```bash
-grep -E '^\s*mode:\s*' onboarding.yaml 2>/dev/null | head -1
-```
-
-| Mode | Scope |
-|------|-------|
-| `multi-project` (default) | Every project in `apexstack.projects.yaml` |
-| `single-project` | Current repo only |
+`/inbox` iterates every project in `apexstack.projects.yaml` at the root of your ops repo (your fork of apexstack). If the registry doesn't exist, print a clear error pointing at `docs/multi-project.md`.
 
 ## What goes in the inbox
 
@@ -40,7 +33,7 @@ gh pr list \
   --limit 50
 ```
 
-In multi-project mode, run this per `repo:` from the registry (or use `--search "user:your-org"` if you have an org).
+Run this per `repo:` from the registry (or use `--search "user:your-org"` if you have an org).
 
 ### 2. PRs you authored that have changes requested
 
@@ -104,11 +97,11 @@ gh issue list --label blocked --state open \
   --json number,title,url,labels
 ```
 
-(Per project in multi-project mode.)
+(Run per project from the registry.)
 
 ## Output format
 
-Group everything under headings, project-prefixed in multi-project mode:
+Group everything under headings, project-prefixed:
 
 ```
 INBOX — 2026-04-06 09:14

--- a/.claude/skills/projects/SKILL.md
+++ b/.claude/skills/projects/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # /projects — List Managed Projects
 
-Show every project ApexStack is managing, with a one-line health snapshot. The behaviour depends on which mode you're in.
+Show every project ApexStack is managing, with a one-line health snapshot. Reads `apexstack.projects.yaml` at the root of the ops repo (your fork of apexstack) and iterates the registry.
 
 ## Usage
 
@@ -16,22 +16,9 @@ Show every project ApexStack is managing, with a one-line health snapshot. The b
 /projects --json
 ```
 
-## Mode detection
+## Behaviour
 
-ApexStack reads `onboarding.yaml` to decide:
-
-```bash
-grep -E '^\s*mode:\s*' onboarding.yaml 2>/dev/null | head -1
-```
-
-| Value | Behaviour |
-|-------|-----------|
-| `mode: multi-project` (or missing — this is the default) | Read `apexstack.projects.yaml` and show every project listed |
-| `mode: single-project` | Show only the current repo |
-
-## Multi-project mode (the default)
-
-In multi-project mode, read `apexstack.projects.yaml`:
+Read `apexstack.projects.yaml`:
 
 ```yaml
 version: 1
@@ -63,30 +50,9 @@ PRS=$(gh -R {repo} pr list --state open --json number --jq 'length')
 ISSUES=$(gh -R {repo} issue list --state open --json number --jq 'length')
 ```
 
-## Single-project mode (opt-in)
+If `apexstack.projects.yaml` doesn't exist at the ops-repo root, print a clear error pointing the user at `apexstack.projects.yaml.example` and `docs/multi-project.md` for the setup guide.
 
-In single-project mode, there's only one project — the repo Claude Code is running in. Output:
-
-```
-Project: {repo name from `git remote get-url origin`}
-Branch:  {git rev-parse --abbrev-ref HEAD}
-Status:  active
-Open PRs:    {gh pr list --state open --json number | jq length}
-Open Issues: {gh issue list --state open --json number | jq length}
-Last commit: {git log -1 --format='%h %ai %s'}
-Uncommitted: {git status --porcelain | wc -l} files
-```
-
-If the user wants the full registry view, suggest:
-
-```
-You're in single-project mode (opt-in). To manage multiple projects,
-remove the `apexstack.mode: single-project` line from onboarding.yaml
-to switch back to the default multi-project mode, and create
-apexstack.projects.yaml at the root.
-```
-
-## Output format (multi-project)
+## Output format
 
 A markdown table:
 
@@ -132,7 +98,7 @@ And, if relevant, flag rows that need attention:
 
 ## Rules
 
-1. **Mode-aware** — single-project shows one row, multi-project shows N
+1. **Registry-driven** — the registry is the source of truth; no discovery fallback
 2. **Source of truth for PRs/issues = GitHub** — never read from a stale local file
 3. **Source of truth for branch state = local workspace** — `gh` doesn't know about your dirty files
 4. **Don't silently fail on a missing project** — show the row, mark the gap
@@ -142,6 +108,6 @@ And, if relevant, flag rows that need attention:
 ## Related skills
 
 - `/inbox` — same registry, but filtered to "needs your attention"
-- `/status` — single-project deep dive (current branch, recent commits)
+- `/status` — per-project deep dive (current branch, recent commits)
 - `/tasks` — actionable list with URLs
 - `/handover` — onboard a new repo into the registry

--- a/.claude/skills/projects/SKILL.md
+++ b/.claude/skills/projects/SKILL.md
@@ -91,7 +91,7 @@ And, if relevant, flag rows that need attention:
 
 | Condition | Behaviour |
 |-----------|-----------|
-| Multi-project mode but no `apexstack.projects.yaml` | Print a clear error and a sample registry to copy |
+| No `apexstack.projects.yaml` at the ops-repo root | Print a clear error and a sample registry to copy |
 | Project listed but workspace path missing | Show row with `(not cloned)` — don't fail |
 | `gh` not authenticated | Show row with `?` for PRs/issues — don't fail |
 | `repo` field looks invalid | Skip with a warning, continue with the rest |

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -178,7 +178,7 @@ Owner: @octocat
 3. **Done is append-only** — items move to Done, never out of it
 4. **Update `Last updated`** on every write
 5. **Confirm destructive ops** — `remove`, `reorder` ask first
-6. **Mode-aware** — write to `ROADMAP.md` (single) or `projects/<name>/roadmap.md` (multi)
+6. **One roadmap per project** — always write to `projects/<name>/roadmap.md` in the ops repo
 7. **Don't auto-create issues unless asked** — `--with-issues` is opt-in
 8. **Preserve markdown formatting** — don't reflow rows or change column widths unnecessarily
 

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -27,12 +27,7 @@ See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the ful
 
 ## File location
 
-| Mode | File |
-|------|------|
-| **multi-project mode** (default) | `projects/<name>/roadmap.md`, where `<name>` is either passed via `--project` or the current working directory |
-| **single-project mode** | `ROADMAP.md` at the project root |
-
-In multi-project mode (the default), without `--project`, the skill asks which project's roadmap to operate on, listing the registry.
+Every roadmap lives at `projects/<name>/roadmap.md` inside your ops repo, where `<name>` matches an entry in `apexstack.projects.yaml`. Without `--project`, the skill asks which project's roadmap to operate on, listing the registry.
 
 ## File format
 

--- a/.claude/skills/stakeholder-update/SKILL.md
+++ b/.claude/skills/stakeholder-update/SKILL.md
@@ -18,16 +18,9 @@ Synthesises recent activity into a stakeholder-facing update. The skill is audie
 /stakeholder-update weekly --project example-app
 ```
 
-## Mode detection
+## Scope
 
-```bash
-grep -E '^\s*mode:\s*' onboarding.yaml 2>/dev/null | head -1
-```
-
-| Mode | Scope |
-|------|-------|
-| `multi-project` (default) | Aggregated across all projects in the registry, unless `--project` is given |
-| `single-project` | Current repo |
+Aggregated across every project in `apexstack.projects.yaml` (the registry at the root of your ops repo), unless `--project <name>` is passed to scope to one.
 
 ## Inputs
 
@@ -38,10 +31,10 @@ The skill pulls from:
 | `gh pr list --state merged --search "merged:>=<since>"` | What shipped |
 | `gh issue list --state closed --search "closed:>=<since>"` | What got resolved |
 | `git log --since=<since> --oneline` | Commit volume / themes |
-| `docs/agdr/AgDR-*.md` (in this period) | Decisions made |
-| `ROADMAP.md` or `projects/<name>/roadmap.md` | Strategic direction |
+| `docs/agdr/AgDR-*.md` (in this period, inside each project) | Decisions made |
+| `projects/<name>/roadmap.md` | Strategic direction |
 | `gh pr list --state open` | What's in flight |
-| `IDEAS.md` or `projects/ideas-backlog.md` | Ideas captured |
+| `projects/ideas-backlog.md` | Ideas captured |
 
 `<since>` is computed from the update type:
 
@@ -194,15 +187,15 @@ The skill pulls from:
 
 1. Parse the update type from `$ARGUMENTS` (default: `weekly`)
 2. Compute `<since>` based on type
-3. Detect mode and decide the project scope
+3. Read the registry; resolve `--project` if passed, otherwise iterate all projects
 4. Pull all inputs in parallel
 5. Synthesise the update using the matching template
-6. Print to stdout, **and** offer to write it to `projects/<name>/updates/{type}-{YYYY-MM-DD}.md` (or `updates/{type}-{YYYY-MM-DD}.md` in single-project mode)
+6. Print to stdout, **and** offer to write it to `projects/<name>/updates/{type}-{YYYY-MM-DD}.md`
 7. Offer to post to the team's communication channel (Slack/Discord) — only as a follow-up suggestion, never automatic
 
-## Multi-project rollup
+## Portfolio rollup
 
-In multi-project mode without `--project`, generate one section per project, prefixed with the project name and bounded by separators. Add a portfolio summary at the top:
+Without `--project`, generate one section per project, prefixed with the project name and bounded by separators. Add a portfolio summary at the top:
 
 ```
 PORTFOLIO ROLLUP — Week of 2026-04-06
@@ -233,7 +226,7 @@ marketing-site — Weekly
 4. **Use real PR/issue numbers** — every claim links to evidence
 5. **AgDRs are first-class** — decisions belong in updates, not just code
 6. **Don't auto-publish** — write the file, suggest the channel, but never post on the user's behalf
-7. **Mode-aware** — single-project = one section, multi-project = portfolio rollup
+7. **Scope-aware** — one section per project, portfolio rollup when no `--project` flag
 8. **Tone matches type** — terse (weekly), narrative (monthly), celebratory (launch)
 
 ## Related skills

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -16,16 +16,9 @@ A focused "where am I" view. Where `/inbox` shows what's waiting on you and `/pr
 /status --verbose
 ```
 
-## Mode detection
+## Scope
 
-```bash
-grep -E '^\s*mode:\s*' onboarding.yaml 2>/dev/null | head -1
-```
-
-| Mode | Behaviour |
-|------|-----------|
-| `multi-project` (default) | Show every project in `apexstack.projects.yaml`, or one if `--project` is given |
-| `single-project` | Show the current repo only |
+Iterates every project in `apexstack.projects.yaml` (the registry at the root of your ops repo), or a single project if `--project <name>` is passed.
 
 ## What it shows
 

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -124,9 +124,9 @@ Surface anything unusual:
 - More than 20 dirty files (probably forgot to commit)
 - Branch is more than 5 commits behind `origin/main` (rebase recommended)
 
-## Multi-project mode
+## Portfolio output
 
-In multi-project mode, run sections A–D for each project in the registry. Use a per-project header:
+Run sections A–D for each project in the registry. Use a per-project header:
 
 ```
 ═══════════════════════════════════════
@@ -160,9 +160,7 @@ If a project's workspace isn't cloned locally, show GitHub data only and mark gi
 - All AgDRs from the last 30 days
 - CI run history for the current branch
 
-## Output format
-
-Single-project mode default:
+## Output format (one-project view with `--project <name>`)
 
 ```
 STATUS — example-app — 2026-04-06 09:14

--- a/.claude/skills/tasks/SKILL.md
+++ b/.claude/skills/tasks/SKILL.md
@@ -17,16 +17,9 @@ A single ordered list of "things to click on right now". Where `/inbox` groups i
 /tasks --markdown
 ```
 
-## Mode detection
+## Scope
 
-```bash
-grep -E '^\s*mode:\s*' onboarding.yaml 2>/dev/null | head -1
-```
-
-| Mode | Scope |
-|------|-------|
-| `multi-project` (default) | Every project in `apexstack.projects.yaml` |
-| `single-project` | Current repo only |
+Iterates every project in `apexstack.projects.yaml` (the registry at the root of your ops repo).
 
 ## Where tasks come from
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | What | Where |
 |------|-------|
 | Company Config | `onboarding.yaml` |
-| **Project registry** (multi-project) | `apexstack.projects.yaml` |
+| **Portfolio registry** | `apexstack.projects.yaml` |
 | Role Definitions | `roles/` |
 | Workflows | `workflows/` |
 | Templates | `templates/` |
@@ -220,11 +220,11 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Agents | `.claude/agents/` |
 | Skills (13 slash commands) | `.claude/skills/` |
 | Hook wiring | `.claude/settings.json` |
-| **Per-project docs** (multi-project) | `projects/<name>/` |
-| **Live working copies** (multi-project) | `workspace/<name>/` |
+| **Per-project docs** | `projects/<name>/` |
+| **Live working copies** (gitignored) | `workspace/<name>/` |
 | CI pipelines | `golden-paths/pipelines/` |
 | Getting Started | `docs/getting-started.md` |
-| Multi-project guide | `docs/multi-project.md` |
+| Full setup guide | `docs/multi-project.md` |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,21 +7,17 @@ You are the **Chief of Staff** running a portfolio of projects inside apexstack.
 ## SETUP
 
 1. Read `onboarding.yaml` for company-specific configuration
-2. Read `apexstack.mode` — **multi-project is the default**; the value is `multi-project` unless explicitly set to `single-project`
-3. In **multi-project mode**, also read `apexstack.projects.yaml` (the portfolio registry) so you know which repos are under management
-4. Understand the team structure and roles
-5. Apply the workflows and standards defined in this stack
+2. Read `apexstack.projects.yaml` — the portfolio registry listing every repo under management
+3. Understand the team structure and roles
+4. Apply the workflows and standards defined in this stack
 
-## OPERATING MODE
+## PORTFOLIO MODEL
 
-ApexStack supports two modes set in `onboarding.yaml`:
+ApexStack governs a portfolio of repos as one organisation. The repo this `CLAUDE.md` lives in is your **ops repo** — a fork of `me2resh/apexstack` cloned into your organisation (optionally renamed to `your-org/ops` or similar). The registry file `apexstack.projects.yaml` at the ops-repo root lists every project under management. Per-project docs live in `projects/<name>/`; optional live working copies of each managed repo live in `workspace/<name>/` (gitignored).
 
-| Mode | Behaviour |
-|------|-----------|
-| **`multi-project`** (default) | ApexStack lives in an "ops repo" and governs a portfolio of repos via `apexstack.projects.yaml`. Skills like `/projects`, `/inbox`, `/status`, `/tasks` aggregate across the registry. |
-| `single-project` | ApexStack governs the one repo it lives in. Same skills scope to the current repo only. Use this only when you genuinely have one repo. |
+Skills like `/projects`, `/inbox`, `/status`, `/tasks`, and `/stakeholder-update` aggregate across the registry. Even if you only have one repo to govern, you still fork apexstack and register that single repo — the skills work the same way, and future projects plug into the same registry.
 
-Full guide: @docs/multi-project.md
+Full setup guide: @docs/multi-project.md
 
 ---
 
@@ -181,7 +177,7 @@ ApexStack ships with a `.claude/` directory containing the Claude Code primitive
 | `/write-spec` | Generate a PRD or feature spec from a problem statement |
 | `/idea` | Capture a new product idea to the backlog |
 | `/handover` | Onboard an external repo into ApexStack management |
-| `/projects` | List all managed projects with status (multi-project) or current repo (single-project) |
+| `/projects` | List all managed projects from the registry with status |
 | `/inbox` | Items needing your attention — PRs, issues, comments, blockers |
 | `/status` | Current snapshot — git, CI, in-progress work |
 | `/tasks` | Actionable task list with direct URLs, prioritised |

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ apexstack/
 │   ├── agents/            # Sub-agents: Code Reviewer (Rex), Security Reviewer (Shield), Dependency Auditor (Guardian), PR Manager, Ticket Manager
 │   └── skills/            # 13 slash commands: /decide, /code-review, /security-review, /audit-deps, /write-spec, /idea, /handover, /projects, /inbox, /status, /tasks, /roadmap, /stakeholder-update
 │
-├── workspace/             # Live local clones (multi-project mode) — gitignored
-├── projects/              # Per-project committed docs (multi-project mode)
+├── workspace/             # Live local clones of managed projects — gitignored
+├── projects/              # Per-project committed docs (README, roadmap, AgDRs, updates)
 ├── apexstack.projects.yaml.example  # Portfolio registry template
 │
 ├── golden-paths/          # Reusable infra & ops templates
@@ -53,76 +53,69 @@ apexstack/
 │
 ├── docs/                  # Documentation
 │   ├── getting-started.md # Setup guide
-│   └── multi-project.md   # Full guide to multi-project mode
+│   └── multi-project.md   # Full setup guide (fork flow, directory layout, daily workflow, FAQ)
 │
 └── site/                  # Landing page
     └── index.html
 ```
 
-## Operating modes
+## Quick Start — fork and go
 
-ApexStack supports two modes, set in `onboarding.yaml`:
+ApexStack governs a **portfolio of repos** as one organisation. You fork apexstack, clone the fork, treat it as your "ops repo", and register every project you want under management. No `.apexstack/` symlinks, no nested installs — the fork IS the ops repo.
 
-| Mode | Default? | Use when |
-|------|:---:|------|
-| **`multi-project`** | ✅ default | You manage two or more repos as one organisation. ApexStack lives in an "ops repo" with a portfolio registry (`apexstack.projects.yaml`). Skills like `/projects`, `/inbox`, `/status`, `/tasks` aggregate across the registry. |
-| `single-project` | opt-in | You manage exactly one repo and don't see that changing. ApexStack lives inside that one repo. The same skills scope to the current repo. |
+### 1. Star + Fork on GitHub
 
-Full guide: [`docs/multi-project.md`](docs/multi-project.md).
+Visit [`github.com/me2resh/apexstack`](https://github.com/me2resh/apexstack), **Star** it, then **Fork** it into your org. You can keep the fork named `apexstack` or rename to something that fits your naming convention (`your-org/ops`, `your-org/apex`, etc.).
 
-## Quick Start (multi-project — the default)
-
-### 1. Clone ApexStack into your ops repo
-
-The "ops repo" is the repo where you'll run Claude Code from to manage your portfolio. Common choices: a dedicated `your-org/ops` repo, or an existing internal-tools / playbook repo.
+### 2. Clone your fork locally
 
 ```bash
-# from your ops repo
-git clone https://github.com/me2resh/apexstack.git .apexstack
+gh repo clone your-org/apexstack
+cd apexstack
 ```
 
-### 2. Symlink the runnable layer
-
-Claude Code only looks for hooks, agents, skills, and `settings.json` at `.claude/`. Symlink so apexstack updates stay in sync:
+Or with plain git:
 
 ```bash
-# in your ops repo root
-ln -s .apexstack/.claude .claude
+git clone https://github.com/your-org/apexstack.git
+cd apexstack
 ```
 
-### 3. Configure
-
-Edit `.apexstack/onboarding.yaml`:
-
-```yaml
-apexstack:
-  mode: multi-project   # default — leave as is
-
-company:
-  name: "Your Company"
-  mission: "What you're building and why"
-
-team:
-  - name: "Alice"
-    role: "tech-lead"
-```
-
-### 4. List your projects
+### 3. Add `upstream` for future updates
 
 ```bash
-# in your ops repo root
-cp .apexstack/apexstack.projects.yaml.example apexstack.projects.yaml
+git remote add upstream https://github.com/me2resh/apexstack.git
+```
+
+Later, `git fetch upstream && git merge upstream/main` pulls the latest apexstack improvements into your fork.
+
+### 4. Fill in `onboarding.yaml`
+
+```bash
+$EDITOR onboarding.yaml
+```
+
+Set company, team, tech stack, quality bar. Defaults are sensible — change what matters for your team.
+
+### 5. Create the portfolio registry
+
+```bash
+cp apexstack.projects.yaml.example apexstack.projects.yaml
 $EDITOR apexstack.projects.yaml   # list every repo you manage
 ```
 
-### 5. Wire CLAUDE.md
+The minimal entry is:
 
-In your ops repo's `CLAUDE.md`:
-
-```markdown
-# Development Stack
-@.apexstack/CLAUDE.md
+```yaml
+version: 1
+projects:
+  - name: example-app
+    repo: your-org/example-app
+    docs: projects/example-app
+    status: active
 ```
+
+Even if you have just one repo, register it — the skills are happier with one registered project than with a dangling "assume the current directory" fallback.
 
 ### 6. Start working
 
@@ -133,40 +126,9 @@ In your ops repo's `CLAUDE.md`:
 /decide            # make a technical decision (creates an AgDR)
 ```
 
-The hooks fire on every `git` / `gh` command, the cross-project skills aggregate across the registry, and the Code Reviewer agent can be invoked with `/code-review <pr>`.
+The hooks fire on every `git` / `gh` command, the portfolio skills aggregate across the registry, and the Code Reviewer agent can be invoked with `/code-review <pr>`.
 
----
-
-### Single-project install (opt-out)
-
-If you only have one repo, install directly into it instead of an ops repo:
-
-```bash
-# in your one project repo
-git clone https://github.com/me2resh/apexstack.git .apexstack
-ln -s .apexstack/.claude .claude
-$EDITOR .apexstack/onboarding.yaml   # set apexstack.mode: single-project
-echo "@.apexstack/CLAUDE.md" >> CLAUDE.md
-```
-
-Skip step 4 entirely — there's no registry. The same skills scope to the current repo. Roadmap lives at `ROADMAP.md`, ideas at `IDEAS.md`. See [`docs/multi-project.md`](docs/multi-project.md) for the full comparison.
-
-### Global install (alternative)
-
-If you run **several** ops repos (a founder with a couple of orgs, a consultant with multiple clients), clone apexstack **once** globally and reference it from every ops repo instead of cloning into each. One place to upgrade, one place to patch.
-
-```bash
-# one time, globally
-git clone https://github.com/me2resh/apexstack.git ~/.apexstack
-
-# in each ops repo (replaces steps 1 and 2 of the default flow)
-ln -s ~/.apexstack/.claude .claude
-echo '@~/.apexstack/CLAUDE.md' >> CLAUDE.md
-
-# steps 3, 4, 5, 6 are the same as the default flow
-```
-
-**Tradeoff**: the symlinks point at an absolute path in your home directory, so moving `~/.apexstack/` breaks the link. Not a good fit if you sync dotfiles across machines with different home paths.
+Full setup guide with directory layout, daily workflow, and FAQ: [`docs/multi-project.md`](docs/multi-project.md).
 
 ## Why ApexStack?
 

--- a/apexstack.projects.yaml.example
+++ b/apexstack.projects.yaml.example
@@ -1,25 +1,19 @@
 # =============================================================================
-# ApexStack Multi-Project Registry
+# ApexStack Portfolio Registry
 # =============================================================================
 #
-# Place this file at the root of your **ops repo** (the repo where you run
-# Claude Code from to manage multiple projects as one organisation). Rename
-# it from `.example` to `apexstack.projects.yaml` once you've filled it in.
+# Place this file at the root of your **ops repo** — the fork of apexstack
+# you cloned to govern your portfolio of projects. Rename this file from
+# `.example` to `apexstack.projects.yaml` once you've filled it in.
 #
-# This file is the registry for ApexStack's default mode: MULTI-PROJECT MODE.
 # Skills like /projects, /inbox, /status, /tasks, and /stakeholder-update
 # aggregate across every project listed below. Most engineering orgs have
-# more than one repo, so this is the right default — even a "single product"
-# team usually has an app repo + infra + a marketing site.
+# more than one repo — even a "single product" team usually has an app repo
+# + infra + a marketing site.
 #
-# Multi-project mode is enabled by default in `onboarding.yaml`:
-#
-#     apexstack:
-#       mode: multi-project   # default
-#
-# Single-project mode is the opt-in for the simple "I have one repo" case.
-# Set `apexstack.mode: single-project` in `onboarding.yaml` to disable the
-# registry and treat the current directory as a single managed project.
+# If you have exactly one repo, register it here as your single entry and
+# every skill still works. There is no single-project fallback mode; the
+# registry is the source of truth for what ApexStack manages.
 #
 
 # Schema version. Bump if breaking changes are introduced.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,37 +1,45 @@
 # Getting Started with ApexStack
 
-This guide walks you through adopting ApexStack for your team.
+Short version of the setup flow. For the full walkthrough (directory layout, daily workflow, upgrade path, FAQ) see [`multi-project.md`](multi-project.md).
 
 ---
 
 ## Prerequisites
 
-- A GitHub repository for your project
+- A GitHub account and an org you can fork into
 - [Claude Code](https://claude.com/claude-code) installed
-- Basic familiarity with Claude Code's CLAUDE.md system
+- [GitHub CLI (`gh`)](https://cli.github.com) installed (optional but recommended)
+- Basic familiarity with Claude Code's `CLAUDE.md` system
 
 ---
 
-## Step 1: Add ApexStack to Your Project
+## Step 1: Fork apexstack on GitHub
 
-### Option A: Copy into your repo
+Your ops repo **is** a fork of apexstack. One repo, no nested installs.
 
-```bash
-# Clone ApexStack
-git clone https://github.com/me2resh/apexstack.git /tmp/apexstack
+Visit [`github.com/me2resh/apexstack`](https://github.com/me2resh/apexstack), **Star** it, then **Fork** it into your org. Rename the fork if you want (`your-org/ops`, `your-org/apex`, or keep it as `apexstack` — GitHub handles the rename cleanly).
 
-# Copy into your project (as a hidden directory)
-cp -r /tmp/apexstack your-project/.apexstack/
-
-# Or copy into a visible directory
-cp -r /tmp/apexstack your-project/apexstack/
-```
-
-### Option B: Git submodule
+Then clone your fork locally:
 
 ```bash
-git submodule add https://github.com/me2resh/apexstack.git .apexstack
+gh repo fork me2resh/apexstack --clone
+cd apexstack
 ```
+
+Or with plain git:
+
+```bash
+git clone https://github.com/your-org/apexstack.git
+cd apexstack
+```
+
+Add the upstream remote so you can pull future updates:
+
+```bash
+git remote add upstream https://github.com/me2resh/apexstack.git
+```
+
+Later, `git fetch upstream && git merge upstream/main` pulls the latest apexstack improvements into your fork.
 
 ---
 
@@ -64,21 +72,29 @@ tech_stack:
 
 ---
 
-## Step 3: Connect to Claude Code
+## Step 3: Create the portfolio registry
 
-Add a reference to ApexStack in your project's `CLAUDE.md`:
+Copy the example registry and list every repo you want under management:
 
-```markdown
-# My Project
-
-## Development Stack
-@.apexstack/CLAUDE.md
-
-## Project-Specific Rules
-[Your additional rules here]
+```bash
+cp apexstack.projects.yaml.example apexstack.projects.yaml
+$EDITOR apexstack.projects.yaml
 ```
 
-This tells Claude Code to read the ApexStack configuration alongside your project rules.
+The minimal entry is:
+
+```yaml
+version: 1
+projects:
+  - name: example-app
+    repo: your-org/example-app
+    docs: projects/example-app
+    status: active
+```
+
+Even if you have just one repo, register it — the skills work the same whether you have 1 or 20.
+
+The `CLAUDE.md` at the root of your fork is the stack entry point. Claude Code reads it automatically when you start a session inside the fork — no additional wiring needed.
 
 ---
 
@@ -178,10 +194,7 @@ After setup, Claude Code will:
 
 ### Claude Code doesn't seem to know about the stack
 
-Make sure your `CLAUDE.md` references the stack:
-```markdown
-@.apexstack/CLAUDE.md
-```
+Make sure you're running Claude Code from inside your fork of apexstack (the ops repo). Claude Code reads `CLAUDE.md` automatically from the working directory's root — if you're one level deep (e.g. inside `workspace/<project>/`) it picks up the project's own `CLAUDE.md` instead.
 
 ### Roles aren't being applied correctly
 

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -1,74 +1,91 @@
-# Multi-Project Mode
+# ApexStack Setup
 
-ApexStack supports two operating modes. **Multi-project mode is the default**: ApexStack lives in an "ops repo" and governs a portfolio of repos as one organisation. **Single-project mode** is opt-in for the simple case: ApexStack lives inside one repo and governs that repo only. This document covers the multi-project mode in depth — the setup, the registry, the daily workflow, and how to opt back to single-project if you need to.
+ApexStack governs a **portfolio of repos as one organisation**. You fork apexstack, clone the fork, treat it as your "ops repo", and register every project you want under management. This document is the full setup guide: the fork flow, the directory layout, the daily workflow, and the FAQ.
+
+> There is no single-project fallback mode. Even if you have exactly one repo, you still fork apexstack and register that one repo. Future projects plug into the same registry.
 
 ---
 
 ## TL;DR
 
-| | Multi-project (default) | Single-project (opt-in) |
-|---|---|---|
-| **Number of repos governed** | many | 1 |
-| **Where ApexStack lives** | In a separate "ops repo" | Inside the one project repo |
-| **Roadmap location** | `projects/<name>/roadmap.md` per project | `ROADMAP.md` at project root |
-| **Ideas location** | `projects/ideas-backlog.md` (shared) | `IDEAS.md` at project root |
-| **Registry file** | `apexstack.projects.yaml` | None |
-| **`/projects` shows** | All projects in the registry | The current repo |
-| **`/inbox` shows** | Items across the whole registry | Items in the current repo |
-| **Set in `onboarding.yaml`** | `apexstack.mode: multi-project` (default) | `apexstack.mode: single-project` |
-| **Best for** | CTO / engineering lead / Chief of Staff with a portfolio | Solo dev, one-product teams |
+| | ApexStack |
+|---|---|
+| **What you install** | A fork of `me2resh/apexstack`, cloned locally. No `.apexstack/` symlinks, no nested installs. |
+| **What governs the portfolio** | `apexstack.projects.yaml` at the root of your fork |
+| **Where per-project docs live** | `projects/<name>/` inside your fork, committed |
+| **Where live working copies live** | `workspace/<name>/` inside your fork, gitignored |
+| **Where the registry, roadmap, ideas, updates live** | All inside your fork, alongside the apexstack primitives |
+| **How upgrades flow** | `git pull upstream main` from `me2resh/apexstack` |
+| **Best for** | CTOs, engineering leads, Chief-of-Staff roles managing 2+ repos (or 1 repo with intent to grow) |
 
 ---
 
-## Why multi-project is the default
+## Why fork instead of clone?
 
-Most engineering orgs have more than one repo. Even a "single product" team usually has at least an app repo + an infra repo + a marketing site + maybe a CLI or extension. ApexStack is built around managing that portfolio coherently — one ops repo, one registry, one set of skills that aggregate across everything.
+Earlier versions of apexstack told you to clone the repo into a hidden `.apexstack/` directory inside a separate ops repo and symlink the `.claude/` folder. That pattern worked but it had three problems:
 
-If you actually have **exactly one repo** to govern, single-project mode is the right call — it's simpler and avoids the registry overhead. Set `apexstack.mode: single-project` in `onboarding.yaml` and the same skills scope to the current repo.
+1. **Brand invisibility** — `.apexstack/` is a dotfile, hidden from `ls` and GitHub views. Nobody knew you were using apexstack.
+2. **Two repos to maintain** — your ops repo plus the nested clone. Upgrades meant `git pull` in `.apexstack/`, which felt off-piste.
+3. **Symlink fragility** — the `.claude/` symlink broke on dotfile sync tools and Windows setups.
 
----
+Forking solves all three:
 
-## When to switch to single-project mode
-
-Switch to single-project (opt out of multi-project) when **all** of these are true:
-
-1. You manage **exactly one** repo
-2. You don't see that changing in the foreseeable future
-3. You want zero registry overhead
-
-Multi-project mode is otherwise the right default — even if you only have two repos, the registry is one tiny YAML file and the cross-repo skills (`/projects`, `/inbox`, `/status`, `/tasks`) are immediately useful.
+1. **The fork stays named** (keep it as `your-org/apexstack`, or rename to `your-org/ops` — your call)
+2. **One repo to maintain** — the fork IS the ops repo
+3. **Upgrades via the normal fork workflow** — `git pull upstream main`, resolve conflicts, done
 
 ---
 
-## Setup
+## Setup — 6 steps, ~5 minutes
 
-### 1. Pick the ops repo
+### 1. Fork on GitHub
 
-Decide which repo will be your **ops repo**. Common choices:
+Visit [`github.com/me2resh/apexstack`](https://github.com/me2resh/apexstack) and click **Fork** (top right). Star it while you're there.
 
-- A new dedicated repo (e.g. `your-org/ops`)
-- An existing internal-tools repo
-- A `meta` repo that already holds your team's playbooks
+The fork lands in your org. You can keep the name as `apexstack` or rename to something that fits your naming convention (`your-org/ops`, `your-org/apex`, `your-org/cos` for Chief-of-Staff — whatever suits).
 
-The ops repo holds:
+### 2. Clone your fork locally
 
-- The ApexStack rules, skills, and hooks (`.claude/`)
-- The registry (`apexstack.projects.yaml`)
-- Per-project docs (`projects/<name>/`)
-- Optionally, live clones of each managed repo (`workspace/<name>/`)
+Using the GitHub CLI:
 
-### 2. Switch the mode
-
-In `onboarding.yaml`, set:
-
-```yaml
-apexstack:
-  mode: multi-project
+```bash
+gh repo clone your-org/apexstack
+cd apexstack
 ```
 
-### 3. Create the registry
+Or plain git:
 
-Copy `apexstack.projects.yaml.example` to `apexstack.projects.yaml` and edit it. The minimal entry is:
+```bash
+git clone https://github.com/your-org/apexstack.git
+cd apexstack
+```
+
+### 3. Add `upstream` for future updates
+
+```bash
+git remote add upstream https://github.com/me2resh/apexstack.git
+```
+
+Now `git fetch upstream` will pull the latest apexstack changes whenever you want to upgrade, and `git merge upstream/main` brings them into your fork.
+
+### 4. Fill in `onboarding.yaml`
+
+Edit the file at the repo root. Set company, team, tech stack, quality bar. Defaults are sensible — change what matters for your team.
+
+```bash
+$EDITOR onboarding.yaml
+```
+
+### 5. Create the registry
+
+Copy the example and list every repo you want under management:
+
+```bash
+cp apexstack.projects.yaml.example apexstack.projects.yaml
+$EDITOR apexstack.projects.yaml
+```
+
+The minimal entry is:
 
 ```yaml
 version: 1
@@ -79,9 +96,9 @@ projects:
     status: active
 ```
 
-You can add `workspace`, `roles`, `tier`, `tags`, and `ticket_prefix` later.
+Add `workspace`, `roles`, `tier`, `tags`, and `ticket_prefix` later as you need them. Even if you have just one repo right now, register it — the skills are happier with one registered project than with a dangling "assume the current directory" fallback.
 
-### 4. Seed `projects/<name>/`
+### 6. Seed per-project docs
 
 For each project in the registry, create the docs folder:
 
@@ -91,25 +108,21 @@ projects/example-app/
 └── roadmap.md     ← project-specific roadmap (optional)
 ```
 
-You can run `/handover example-app` to auto-generate a `handover-assessment.md` and seed the README.
-
-### 5. (Optional) Clone the live working copy
+Or run `/handover example-app` and the skill will generate a real assessment and seed the README. Then optionally clone the live working copy:
 
 ```bash
 git clone github.com/your-org/example-app workspace/example-app
 ```
 
-Add `workspace/*/` to the ops repo's `.gitignore` — live clones have their own remotes and shouldn't be double-tracked.
+`workspace/*/` is already gitignored in apexstack, so the nested clone won't be double-tracked.
 
-### 6. Verify
-
-Run:
+### Verify
 
 ```
 /projects
 ```
 
-You should see a table with one row per project from the registry. Then:
+You should see one row per registered project. Then:
 
 ```
 /inbox
@@ -117,17 +130,36 @@ You should see a table with one row per project from the registry. Then:
 /tasks
 ```
 
-Each should aggregate across all the projects you've registered.
+Each aggregates across every registered project. You're live.
 
 ---
 
 ## Directory layout
 
 ```
-my-ops-repo/
+your-org/apexstack/                ← your fork, cloned locally (the "ops repo")
+├── CLAUDE.md                      ← entry point Claude Code reads first
+├── onboarding.yaml                ← company + team + stack config
+├── apexstack.projects.yaml        ← the portfolio registry
+│
 ├── .claude/                       ← shared rules, skills, hooks, agents
-├── apexstack.projects.yaml        ← the registry (multi-project mode marker)
-├── onboarding.yaml                ← apexstack.mode: multi-project
+│   ├── rules/
+│   ├── skills/
+│   ├── hooks/
+│   ├── agents/
+│   └── settings.json
+│
+├── roles/                         ← 19 role definitions, upstream from apexstack
+│   ├── engineering/
+│   ├── product/
+│   ├── design/
+│   ├── security/
+│   └── data/
+│
+├── workflows/                     ← SDLC, code review, deployment
+├── templates/                     ← PRD, tech design, ADR, AgDR
+├── golden-paths/                  ← reusable CI pipelines
+├── site/                          ← the apexstack landing page (feel free to delete or replace)
 │
 ├── workspace/                     ← LIVE WORKING COPIES (gitignored)
 │   ├── README.md
@@ -142,10 +174,7 @@ my-ops-repo/
 │   │   ├── README.md
 │   │   ├── roadmap.md
 │   │   ├── handover-assessment.md
-│   │   ├── updates/
-│   │   │   ├── weekly-2026-04-06.md
-│   │   │   └── monthly-2026-03.md
-│   │   └── notes/
+│   │   └── updates/
 │   ├── billing-api/
 │   └── marketing-site/
 │
@@ -155,144 +184,125 @@ my-ops-repo/
 
 The split between `workspace/` and `projects/` is deliberate:
 
-- **`workspace/<name>/`** is where you do code work. It's a real git clone of the project. Branches, PRs, and CI happen here. **Don't commit it to the ops repo** — it has its own remote.
-- **`projects/<name>/`** is where ApexStack docs about the project live. It's part of the ops repo. Roadmaps, handover assessments, stakeholder updates all live here.
+- **`workspace/<name>/`** is where you do code work. It's a real git clone of the project. Branches, PRs, and CI happen there. **It's gitignored in your fork** — each project has its own remote.
+- **`projects/<name>/`** is where ApexStack docs about the project live. It's committed to your fork alongside the registry. Roadmaps, handover assessments, stakeholder updates all live here.
 
-The test for "where does this doc go?" is **"would I want this to follow the code if the project was spun out tomorrow?"** If yes → put it in the project's own repo (i.e. inside `workspace/<name>/`). If no → put it in `projects/<name>/`.
-
----
-
-## How skills behave in multi-project mode
-
-Every skill that's portfolio-aware reads `apexstack.mode` first. If it's `multi-project`, the skill iterates the registry instead of acting on the current repo.
-
-| Skill | Single-project behaviour | Multi-project behaviour |
-|-------|--------------------------|-------------------------|
-| `/projects` | Shows current repo as one row | Reads registry, shows N rows |
-| `/status` | Git + PRs + issues for current repo | Same, per project, separated by headers |
-| `/inbox` | PRs/issues/comments for current repo | Aggregated across all projects |
-| `/tasks` | Actionable list for current repo | Aggregated, scored, and sorted across projects |
-| `/idea` | Appends to `IDEAS.md` | Appends to `projects/ideas-backlog.md` |
-| `/roadmap` | Reads `ROADMAP.md` | Reads `projects/<name>/roadmap.md`; asks which project if ambiguous |
-| `/stakeholder-update` | One project's update | Portfolio rollup with a section per project |
-| `/handover` | Writes to `projects/<name>/handover-assessment.md` (creates the folder) | Same, plus suggests adding the project to the registry |
-
-Skills that aren't portfolio-aware (`/decide`, `/write-spec`, `/code-review`, `/security-review`, `/audit-deps`) work the same in both modes — they always operate on the current working directory.
+The test for *"where does this doc go?"* is **"would I want this to follow the code if the project was spun out tomorrow?"** If yes → put it in the project's own repo (i.e. inside `workspace/<name>/docs/`). If no → put it in `projects/<name>/` in your fork.
 
 ---
 
-## Migrating from single → multi
+## How skills behave
 
-You don't have to migrate everything at once. The recommended order:
+Every portfolio skill reads `apexstack.projects.yaml` and iterates the registry.
 
-### Step 1 — Flip the mode
+| Skill | Behaviour |
+|-------|-----------|
+| `/projects` | Reads the registry, shows one row per project with status, branch, open PRs, open issues |
+| `/status` | Same as `/projects` but with git + CI snapshots per project, separated by headers |
+| `/inbox` | Aggregates PRs, issues, and comments needing your attention across every registered project |
+| `/tasks` | Aggregated, scored, and sorted task list across the portfolio |
+| `/idea` | Appends to `projects/ideas-backlog.md` at the fork root (one shared backlog for all projects) |
+| `/roadmap` | Reads `projects/<name>/roadmap.md`; asks which project if ambiguous |
+| `/stakeholder-update` | Portfolio rollup with a section per project |
+| `/handover` | Writes to `projects/<name>/handover-assessment.md` and appends the project to the registry |
 
-Edit `onboarding.yaml`:
+Skills that aren't portfolio-aware (`/decide`, `/write-spec`, `/code-review`, `/security-review`, `/audit-deps`) operate on the current working directory — `cd workspace/<name>/` first if you want them to run against a specific project's code.
 
-```yaml
-apexstack:
-  mode: multi-project
-```
+---
 
-Skills will start looking for `apexstack.projects.yaml`. If it doesn't exist yet, they'll print a clear error pointing you at the example file.
+## Daily workflow
 
-### Step 2 — Create the registry with one project
+A typical morning as a CTO / Chief of Staff using apexstack:
 
-Start with **just one project** — the repo you're already in:
+1. **`cd ~/apexstack`** — into your fork
+2. **`/inbox`** — see everything waiting on you across every managed project
+3. **`/status`** — snapshot of git + CI health for each project
+4. Pick a ticket, **`cd workspace/<project>/`**, pick up the ticket as the appropriate role (see [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md))
+5. Work the ticket — the role file drives behaviour, the lifecycle demo in the hero of the landing site walks through the full flow
+6. Back at the fork root, **`/stakeholder-update weekly`** on Fridays to generate the summary
 
-```yaml
-version: 1
-projects:
-  - name: my-current-app
-    repo: your-org/my-current-app
-    workspace: .              # the current directory IS this project
-    docs: projects/my-current-app
-    status: active
-```
+---
 
-This is the smallest viable multi-project setup: one project, one row.
+## Upgrades — pulling from upstream
 
-### Step 3 — Move existing docs
-
-Move your existing single-project docs into `projects/my-current-app/`:
+Every few weeks, pull the latest apexstack improvements into your fork:
 
 ```bash
-mv ROADMAP.md projects/my-current-app/roadmap.md
-mv IDEAS.md projects/ideas-backlog.md   # ideas become shared
+cd ~/apexstack
+
+# Get the latest upstream changes
+git fetch upstream
+
+# See what's new
+git log --oneline HEAD..upstream/main
+
+# Merge them in
+git merge upstream/main
+
+# Resolve any conflicts (usually in files you haven't customised — role files, workflow files, CLAUDE.md imports)
+# Commit the merge
+git push origin main
 ```
 
-(Keep the originals as redirect stubs if you want a transition period.)
+Files you're most likely to customise:
 
-### Step 4 — Add a second project
+- `onboarding.yaml` — always yours, never upstream
+- `apexstack.projects.yaml` — always yours
+- `projects/<name>/` — always yours
+- `site/index.html` — delete or replace with your own landing page
+- Role files in `roles/` — usually upstream, but feel free to edit for your team's voice
 
-Once step 3 is working, add another project to the registry:
+Files that stay close to upstream (merge cleanly most of the time):
 
-```yaml
-- name: marketing-site
-  repo: your-org/marketing-site
-  docs: projects/marketing-site
-  status: active
-```
-
-Run `/handover marketing-site` to generate the handover assessment and seed the README. Add `workspace/marketing-site/` if you want a local clone.
-
-### Step 5 — Repeat
-
-Add more projects as you bring them under management. There's no limit, but the registry gets unwieldy past ~15 projects — at that point consider splitting into multiple ops repos by domain.
-
----
-
-## Going back: multi → single
-
-You can revert at any time:
-
-1. Set `apexstack.mode: single-project` in `onboarding.yaml`
-2. Decide which project the ops repo "is" — usually the one whose docs were richest
-3. Move that project's docs back to the root (`projects/<name>/roadmap.md` → `ROADMAP.md`)
-4. Delete `apexstack.projects.yaml` (or keep it as a backup)
-5. The other projects keep working independently — they just stop being aggregated
-
-Nothing is destructive. The other projects' docs in `projects/` aren't deleted; they just stop being read by the portfolio skills.
+- `.claude/hooks/` — shell scripts
+- `.claude/rules/` — modular rule files
+- `.claude/agents/` — sub-agent definitions
+- `workflows/` — SDLC, code review, deployment
+- `templates/` — PRD, tech design, ADR, AgDR
+- `golden-paths/` — reusable CI pipelines
 
 ---
 
 ## Trade-offs
 
-### Pros of multi-project mode
+### Pros of the fork-as-ops-repo model
 
-- **One inbox**: `/inbox` shows everything waiting on you across the whole portfolio in 1 second
-- **Portfolio visibility**: `/projects` is the dashboard a CTO actually uses
-- **Cross-project docs have a home**: stakeholder updates, handover assessments, multi-quarter roadmaps belong somewhere durable
-- **Consistent governance**: same rules, same hooks, same skills apply to every project — no drift
-- **Onboarding new repos is a documented process**: `/handover` produces a real artefact
+- **One repo to rule them all** — the fork IS the ops repo. No nested installs, no symlinks.
+- **Brand visible** — if you keep the fork named `apexstack`, anyone looking at your org sees you're running the stack.
+- **Upgrades are standard git** — `git pull upstream main`. No proprietary upgrade tool.
+- **One inbox** — `/inbox` shows everything across the portfolio in ~1 second
+- **Cross-project docs have a home** — stakeholder updates, handover assessments, multi-quarter roadmaps live in `projects/`
+- **Consistent governance** — same rules, hooks, skills apply to every project automatically
 
-### Cons of multi-project mode
+### Cons
 
-- **More moving parts**: a registry file, two directory conventions, mode-aware skills
-- **Registry drift**: if a project changes name or moves repos, you have to update the registry by hand
-- **Two layers of git**: the ops repo has its own git history, and each `workspace/<name>/` has its own — easy to confuse
-- **Not magical**: there's no auto-discovery of repos in your GitHub org. You have to register each one explicitly. (This is on purpose — implicit discovery would be unsafe.)
-- **Gitignore discipline required**: forgetting to gitignore `workspace/*/` will make your ops repo huge fast
-
-### When the trade-off is worth it
-
-Roughly: if you spend more than 10 hours/week coordinating across multiple repos, multi-project mode pays for itself. Below that, single-project mode is almost always better.
+- **Registry drift** — if a project changes name or moves repos, you update the registry by hand
+- **Two layers of git** — your fork has history, and each `workspace/<name>/` has its own — easy to confuse which one you're committing into
+- **Not magical** — no auto-discovery of repos in your GitHub org. You register each one explicitly. (Deliberate — implicit discovery would be unsafe.)
+- **Gitignore discipline required** — `workspace/*/` is gitignored upstream, but if you accidentally add a working copy with `git add -f` you'll regret it fast
+- **Conflict resolution on upgrade** — merging upstream occasionally creates conflicts in files you've customised. Usually small, but not zero.
 
 ---
 
 ## FAQ
 
-**Can I have two ops repos?** Yes. Some teams split by domain (e.g. one ops repo for product, one for platform). Each ops repo is independent.
+**Can I have two ops repos?** Yes. Some teams split by domain (e.g. one ops repo for product, one for platform). Each ops repo is an independent fork of apexstack with its own registry.
 
 **Can a project be in two registries?** Technically yes, but don't. It defeats the "single source of truth" benefit and creates conflicts in `projects/<name>/`. Pick one ops repo per project.
 
-**Do I need to clone every project locally?** No. The `workspace` field is optional. Skills will use GitHub-only data and mark git fields as `(not cloned)` for projects without a local clone.
+**Do I need to clone every project locally?** No. The `workspace` field in the registry is optional. Skills will use GitHub-only data and mark git fields as `(not cloned)` for projects without a local clone.
 
-**Does `/decide` write AgDRs to the ops repo or the project repo?** The project repo. AgDRs are tied to commits, so they live with the code. `/decide` always writes to `{cwd}/docs/agdr/`, which means you need to `cd workspace/<name>/` first.
+**Does `/decide` write AgDRs to the fork or the project repo?** The project repo. AgDRs are tied to commits, so they live with the code. `/decide` always writes to `{cwd}/docs/agdr/`, which means you need to `cd workspace/<name>/` first.
 
 **Does the registry support globs?** No. It's an explicit list. If you want all repos in an org, use `gh repo list` to generate the file once and commit the result — but you should still curate it.
 
 **Can I use this with Linear / Jira / etc.?** Yes. Set `ticket_prefix` per project in the registry. Skills that read tickets will use the right prefix per project.
+
+**What if I only have one repo?** Fork apexstack anyway and register that one repo. The skills work the same way. When you add a second project, just append to the registry — no migration, no re-setup.
+
+**Can I delete the landing page (`site/`)?** Yes — it's the apexstack marketing site. Feel free to delete, replace, or leave it in place. It doesn't affect the rest of the stack.
+
+**Can I rename my fork?** Yes. GitHub handles rename redirects cleanly. Your local clone will need `git remote set-url origin` after the rename.
 
 ---
 
@@ -301,7 +311,7 @@ Roughly: if you spend more than 10 hours/week coordinating across multiple repos
 - `apexstack.projects.yaml.example` — the registry schema
 - `workspace/README.md` — the live working copies convention
 - `projects/README.md` — the per-project docs convention
-- `onboarding.yaml` — where you set the mode
+- `onboarding.yaml` — company + team + stack config
+- `.claude/rules/role-triggers.md` — when to activate which role
 - `.claude/skills/projects/SKILL.md` — the `/projects` skill spec
-- `.claude/skills/inbox/SKILL.md` — the `/inbox` skill spec
 - `.claude/skills/handover/SKILL.md` — the `/handover` skill spec

--- a/golden-paths/pipelines/README.md
+++ b/golden-paths/pipelines/README.md
@@ -18,25 +18,25 @@ Reusable GitHub Actions workflows that integrate ApexStack's automated agents in
 
 ## Quick Start
 
+These pipelines live inside your fork of apexstack (the ops repo) at `golden-paths/pipelines/`. To use them in a managed project, copy them into that project's own `.github/workflows/` directory.
+
 ### Option 1: Copy individual pipelines
 
-Copy only the pipelines you need to your project:
-
 ```bash
-# From your project root
+# From your managed project's root (e.g. inside workspace/example-app/)
 mkdir -p .github/workflows
 
-# Copy specific pipelines
-cp .apexstack/golden-paths/pipelines/security.yml .github/workflows/
-cp .apexstack/golden-paths/pipelines/code-quality.yml .github/workflows/
+# Copy specific pipelines from your ops repo
+cp ~/apexstack/golden-paths/pipelines/security.yml .github/workflows/
+cp ~/apexstack/golden-paths/pipelines/code-quality.yml .github/workflows/
 ```
+
+(Adjust `~/apexstack` to wherever you cloned your fork.)
 
 ### Option 2: Use the combined pipeline
 
-Copy the all-in-one CI pipeline:
-
 ```bash
-cp .apexstack/golden-paths/pipelines/ci.yml .github/workflows/
+cp ~/apexstack/golden-paths/pipelines/ci.yml .github/workflows/
 ```
 
 ---

--- a/onboarding.yaml
+++ b/onboarding.yaml
@@ -10,34 +10,20 @@
 #
 
 # -----------------------------------------------------------------------------
-# ApexStack Mode
+# ApexStack Setup
 # -----------------------------------------------------------------------------
-# ApexStack supports two operating modes:
+# ApexStack governs a PORTFOLIO of repos as one organisation. The repo this
+# file lives in is your "ops repo" — ApexStack itself, forked from
+# me2resh/apexstack. A registry file (apexstack.projects.yaml) lists every
+# managed project. Skills like /projects, /inbox, /status, /tasks aggregate
+# across the registry. Per-project docs live in projects/<name>/, and live
+# working copies (optional) live in workspace/<name>/.
 #
-#   multi-project (DEFAULT)
-#     ApexStack governs MULTIPLE repos as one organisation. The current repo
-#     is treated as the "ops repo" and a registry file
-#     (apexstack.projects.yaml) lists every managed project. Skills like
-#     /projects, /inbox, /status, /tasks aggregate across the registry by
-#     default. Per-project docs live in projects/<name>/, and live working
-#     copies (optional) live in workspace/<name>/.
-#     Best for CTOs, engineering leads, and Chief-of-Staff roles managing a
-#     portfolio of repos. This is the default because most teams have more
-#     than one repo to look after, and ApexStack is designed for that case.
+# Built for CTOs, engineering leads, and Chief-of-Staff roles managing a
+# portfolio of 2+ repos. If you have exactly one repo, you can still fork
+# apexstack and register a single project — the skills work the same way.
 #
-#   single-project
-#     ApexStack governs ONE repo — the one this file lives in. Skills like
-#     /projects, /status, and /inbox scope to the current repo only. The
-#     roadmap lives at ROADMAP.md, ideas at IDEAS.md, and there is no
-#     workspace/ or projects/ directory. Best for solo developers and teams
-#     with exactly one product. Set explicitly to opt out of multi-project.
-#
-# See docs/multi-project.md for the full guide. To switch from one mode to
-# the other, edit the value below — no migration tool needed, the skills
-# detect the mode at invocation.
-#
-apexstack:
-  mode: multi-project   # or: single-project
+# See docs/setup.md for the full guide.
 
 # -----------------------------------------------------------------------------
 # Company Information

--- a/projects/README.md
+++ b/projects/README.md
@@ -15,7 +15,7 @@ Each managed project gets its own subdirectory:
 ```
 projects/
 ├── README.md                       ← you are here
-├── ideas-backlog.md                ← shared ideas backlog (multi-project mode)
+├── ideas-backlog.md                ← shared ideas backlog
 │
 ├── example-app/
 │   ├── README.md                   ← project overview, owners, links

--- a/projects/README.md
+++ b/projects/README.md
@@ -6,7 +6,7 @@ This directory holds **ApexStack-managed documentation** for each project ApexSt
 - Belong to the operating model rather than the codebase
 - Need to exist before the project even has its own repo (e.g. handover assessments)
 
-In **multi-project mode** (the default), this directory is the canonical place for per-project ApexStack docs in the ops repo. In **single-project mode** (opt-in), this directory is optional — you can keep your roadmap, ideas, and notes at the project root instead.
+This directory is the canonical place for per-project ApexStack docs in your ops repo. Your ops repo is a fork of `me2resh/apexstack` — see [`docs/multi-project.md`](../docs/multi-project.md) for the full setup guide.
 
 ## Layout
 
@@ -100,29 +100,14 @@ Every `projects/<name>/README.md` should answer:
 | Project paused | Don't delete the folder — flip `status: paused` in the registry and the README |
 | Project archived | Move to `projects/_archive/<name>/` and update the registry |
 
-## Single-project mode
-
-In single-project mode, this directory typically isn't used. Your project's docs live at the **root of the project repo**:
-
-```
-your-app/
-├── ROADMAP.md
-├── IDEAS.md
-├── docs/
-│   └── agdr/
-└── ...
-```
-
-You only need `projects/` when you flip to multi-project mode and want a clean separation between project code and ops-level docs.
-
 ## Skills that read or write here
 
 | Skill | Behaviour |
 |-------|-----------|
 | `/handover` | Creates `projects/<name>/handover-assessment.md` and seeds the README |
-| `/roadmap` | Reads/writes `projects/<name>/roadmap.md` (multi-project) or `ROADMAP.md` (single) |
-| `/idea` | Appends to `projects/ideas-backlog.md` (multi) or `IDEAS.md` (single) |
-| `/stakeholder-update` | Writes to `projects/<name>/updates/` (multi) or `updates/` (single) |
+| `/roadmap` | Reads/writes `projects/<name>/roadmap.md` |
+| `/idea` | Appends to `projects/ideas-backlog.md` — one shared backlog for every project |
+| `/stakeholder-update` | Writes to `projects/<name>/updates/` |
 | `/projects` | Reads each project README for the table view |
 | `/status` | Reads roadmap and updates folder for context |
 

--- a/site/index.html
+++ b/site/index.html
@@ -1729,7 +1729,7 @@ $EDITOR apexstack.projects.yaml  <span class="cm"># list your repos</span></pre>
     <div>
       <h2>Stop reinventing<br>the same <span class="acc">processes</span>.</h2>
       <p>
-        ApexStack is one git clone, one symlink, and one config file away.
+        ApexStack is one fork, one clone, and one config file away.
         It's MIT licensed, plain markdown, and edits are encouraged.
         If you change your mind, you delete the directory and you're back where you started.
       </p>

--- a/site/index.html
+++ b/site/index.html
@@ -707,6 +707,40 @@ a:hover { color: var(--accent); }
   font-weight: 600;
 }
 
+/* wide variant — 2-column internal layout so the card fills the grid row
+   it spans (used for layer 05 since it's the only full-width card) */
+.layer--wide {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  column-gap: 3rem;
+  row-gap: 0.75rem;
+  align-items: start;
+}
+.layer--wide .layer__num { grid-column: 1 / -1; }
+.layer--wide .layer__title { grid-column: 1; grid-row: 2; }
+.layer--wide .layer__desc {
+  grid-column: 1;
+  grid-row: 3;
+  max-width: none;
+  margin-bottom: 0;
+}
+.layer--wide .layer__list {
+  grid-column: 2;
+  grid-row: 2 / span 2;
+  align-self: start;
+}
+.layer--wide .layer__list li {
+  grid-template-columns: 24ch 1fr;
+}
+@media (max-width: 900px) {
+  .layer--wide {
+    grid-template-columns: 1fr;
+  }
+  .layer--wide .layer__title { grid-row: auto; }
+  .layer--wide .layer__desc { grid-row: auto; }
+  .layer--wide .layer__list { grid-column: 1; grid-row: auto; margin-top: 1.25rem; }
+}
+
 /* ============================================================
    show, don't tell — example demos
    ============================================================ */
@@ -1099,9 +1133,9 @@ footer.foot {
     </p>
 
     <div class="hero__cta rise rise-4">
-      <a href="https://github.com/me2resh/apexstack" class="cta cta--primary" target="_blank" rel="noopener">★ Star on GitHub</a>
+      <a href="https://github.com/me2resh/apexstack" class="cta cta--primary" target="_blank" rel="noopener">★ Star &nbsp;·&nbsp; ⑂ Fork on GitHub</a>
       <span class="cta__sep" aria-hidden="true">·</span>
-      <a href="#install" class="cta cta--ghost">or install it now ↓</a>
+      <a href="#install" class="cta cta--ghost">or see the install steps ↓</a>
     </div>
 
     <div class="shell-demo shell-demo--tall rise rise-4" id="shell-lifecycle" aria-label="Demo of a full ticket lifecycle in apexstack, from inbox pickup to QA sign-off">
@@ -1175,12 +1209,12 @@ footer.foot {
 
     <div class="install rise rise-4" id="install-block">
       <span class="install__prompt">$</span>
-      <code class="install__cmd" id="install-cmd">git clone https://github.com/me2resh/apexstack.git .apexstack</code>
+      <code class="install__cmd" id="install-cmd">gh repo fork me2resh/apexstack --clone</code>
       <button type="button" class="install__copy" id="install-copy" aria-label="Copy install command">copy</button>
     </div>
 
     <p class="install__caveat rise rise-4">
-      Run from your ops repo — the one you'll use to govern every product. Full walkthrough in <a href="#install" class="uline">install</a> below. No magic. No build. No SaaS. Prefer a single global copy shared across every ops repo? <a href="#install-global" class="uline">That's also supported</a>.
+      One command forks apexstack into your org and clones the fork locally. The fork <strong>is</strong> your ops repo — no nested installs, no symlinks. Full walkthrough in <a href="#install" class="uline">install</a> below. No magic. No build. No SaaS. Rename the fork to <code>your-org/ops</code> if you prefer — GitHub handles the rename cleanly.
     </p>
 
     <div class="hero__metrics rise rise-5" aria-label="What you get">
@@ -1197,8 +1231,8 @@ footer.foot {
         <span>CI pipelines</span>
       </div>
       <div class="hero__metric">
-        <strong>2</strong>
-        <span>Operating modes (single &amp; multi-project)</span>
+        <strong>1</strong>
+        <span>Fork · your ops repo in one command</span>
       </div>
     </div>
 
@@ -1289,10 +1323,10 @@ footer.foot {
 <span class="branch">│       ├──</span> <span class="lf">roadmap/SKILL.md</span>         <span class="nf"># /roadmap — update or create the product roadmap</span>
 <span class="branch">│       └──</span> <span class="lf">stakeholder-update/SKILL.md</span> <span class="nf"># /stakeholder-update — weekly/monthly/launch</span>
 <span class="branch">│</span>
-<span class="branch">├──</span> <span class="dir new">workspace/</span>             <span class="nf"># <span class="new">[NEW]</span> Live local clones (gitignored) — multi-project mode</span>
+<span class="branch">├──</span> <span class="dir new">workspace/</span>             <span class="nf"># <span class="new">[NEW]</span> Live local clones of managed projects (gitignored)</span>
 <span class="branch">│   └──</span> <span class="lf">README.md</span>          <span class="nf"># Convention: workspace/&lt;name&gt;/ holds each repo's working copy</span>
 <span class="branch">│</span>
-<span class="branch">├──</span> <span class="dir new">projects/</span>              <span class="nf"># <span class="new">[NEW]</span> Per-project committed docs — multi-project mode</span>
+<span class="branch">├──</span> <span class="dir new">projects/</span>              <span class="nf"># <span class="new">[NEW]</span> Per-project committed docs (README, roadmap, AgDRs, updates)</span>
 <span class="branch">│   ├──</span> <span class="lf">README.md</span>          <span class="nf"># Convention: projects/&lt;name&gt;/ holds README, roadmap, AgDRs, handover</span>
 <span class="branch">│   └──</span> <span class="lf">ideas-backlog.md</span>   <span class="nf"># Shared idea backlog (created by /idea on first use)</span>
 <span class="branch">│</span>
@@ -1311,7 +1345,7 @@ footer.foot {
 <span class="branch">│</span>
 <span class="branch">├──</span> <span class="dir">docs/</span>
 <span class="branch">│   ├──</span> <span class="lf">getting-started.md</span>
-<span class="branch">│   └──</span> <span class="lf new">multi-project.md</span>     <span class="nf"># <span class="new">[NEW]</span> Full guide to multi-project mode</span>
+<span class="branch">│   └──</span> <span class="lf new">multi-project.md</span>     <span class="nf"># <span class="new">[NEW]</span> Full setup guide — fork flow, daily workflow, FAQ</span>
 <span class="branch">│</span>
 <span class="branch">└──</span> <span class="dir">site/</span>                  <span class="nf"># this page</span>
     <span class="branch">└──</span> <span class="lf">index.html</span>
@@ -1330,7 +1364,7 @@ footer.foot {
     <span class="section__num">02 / LAYERS</span>
     <h2 class="section__title">Five layers, one stack</h2>
     <p class="section__lede">
-      ApexStack is built around managing a <em>portfolio</em> of projects, not a single repo. Five layers stack together: roles, workflows + templates, hooks + rules, agents + skills, and the workspace itself — a registry of every repo under your org's care. Single-project mode still works for the simple case, but the default is multi-project.
+      ApexStack is built around managing a <em>portfolio</em> of projects, not a single repo. Five layers stack together: roles, workflows + templates, hooks + rules, agents + skills, and the workspace itself — a registry of every repo under your org's care. There's no single-project fallback; even if you only have one repo to manage, you register it and every layer works the same.
     </p>
   </div>
 
@@ -1392,18 +1426,17 @@ footer.foot {
       </ul>
     </article>
 
-    <article class="layer" style="grid-column: 1 / -1;">
-      <div class="layer__num">05 — workspace · multi-project by default <span class="new">NEW</span></div>
+    <article class="layer layer--wide" style="grid-column: 1 / -1;">
+      <div class="layer__num">05 — workspace · portfolio registry <span class="new">NEW</span></div>
       <h3 class="layer__title">A portfolio, not a single repo</h3>
       <p class="layer__desc">
-        ApexStack treats your engineering org as a portfolio of projects, not a single codebase. The default install creates an <strong>ops repo</strong> with an <code>apexstack.projects.yaml</code> registry listing every repo you manage — and every skill that operates on tickets, PRs, issues, status, or roadmap (<code>/projects</code>, <code>/inbox</code>, <code>/status</code>, <code>/tasks</code>, <code>/handover</code>) aggregates across the registry by default. If you only have one repo, ApexStack still works — set <code>mode: single-project</code> in <code>onboarding.yaml</code> and the same skills scope to the current repo. <code>workspace/&lt;name&gt;/</code> holds live local clones; <code>projects/&lt;name&gt;/</code> holds the long-lived committed docs.
+        Your ops repo is a <strong>fork of apexstack</strong>. At its root sits <code>apexstack.projects.yaml</code> — the registry that lists every project under management. Every portfolio skill (<code>/projects</code>, <code>/inbox</code>, <code>/status</code>, <code>/tasks</code>, <code>/handover</code>, <code>/stakeholder-update</code>) aggregates across the registry. <code>projects/&lt;name&gt;/</code> holds committed per-project docs; <code>workspace/&lt;name&gt;/</code> (gitignored) holds live local clones.
       </p>
-      <ul class="layer__list" style="grid-template-columns: 22ch 1fr;">
-        <li><code>onboarding.yaml</code><span><code>apexstack.mode: multi-project</code> (default) or <code>single-project</code></span></li>
-        <li><code>apexstack.projects.yaml</code><span>the portfolio registry — name, repo, workspace path, docs path, status, applicable roles</span></li>
-        <li><code>workspace/&lt;name&gt;/</code><span>live local clones, gitignored — your daily working copies</span></li>
-        <li><code>projects/&lt;name&gt;/</code><span>committed per-project docs (README, roadmap, AgDRs, handover assessments, stakeholder updates)</span></li>
-        <li><code>docs/multi-project.md</code><span>full guide — registry schema, daily workflow, migration from single-project</span></li>
+      <ul class="layer__list">
+        <li><code>apexstack.projects.yaml</code><span>registry — name, repo, workspace path, docs path, status, roles</span></li>
+        <li><code>projects/&lt;name&gt;/</code><span>committed docs per project (README, roadmap, AgDRs, updates)</span></li>
+        <li><code>workspace/&lt;name&gt;/</code><span>gitignored local clones — your daily working copies</span></li>
+        <li><code>docs/multi-project.md</code><span>full setup guide — fork flow, daily workflow, FAQ</span></li>
       </ul>
     </article>
 
@@ -1582,90 +1615,62 @@ Branch: feature/GH-42-add-csv-export
 
   <div class="section__head">
     <span class="section__num">05 / INSTALL</span>
-    <h2 class="section__title">Set up your portfolio in six steps</h2>
+    <h2 class="section__title">Fork, clone, register — five steps</h2>
     <p class="section__lede">
-      ApexStack defaults to multi-project mode — one ops repo, one registry, every managed project listed inside it. Single-project mode (one repo only) is a one-line opt-out at the end if that's what you actually need.
+      Your ops repo is a fork of apexstack. The fork <strong>is</strong> your ops repo — no nested installs, no symlinks, no separate folder to maintain. Star + fork on GitHub, clone the fork, fill in the registry, start working.
     </p>
   </div>
 
   <div class="steps">
 
     <article class="step">
-      <div class="step__num">01 — clone</div>
-      <h3 class="step__title">Clone ApexStack into your ops repo</h3>
-      <p class="step__desc">The <em>ops repo</em> is where ApexStack lives — typically a dedicated repo like <code>your-org/ops</code>, or an existing internal-tools repo. ApexStack itself sits at <code>.apexstack/</code> inside it.</p>
-      <pre class="step__code"><span class="cm"># in your ops repo (or create one)</span>
-git clone https://github.com/me2resh/apexstack.git \
-  .apexstack</pre>
+      <div class="step__num">01 — star + fork</div>
+      <h3 class="step__title">Fork apexstack on GitHub</h3>
+      <p class="step__desc">Visit <a href="https://github.com/me2resh/apexstack" class="uline" target="_blank" rel="noopener">github.com/me2resh/apexstack</a>, click <strong>Star</strong>, then <strong>Fork</strong>. Rename the fork if you want — <code>your-org/ops</code> or <code>your-org/apex</code> both work. GitHub handles the rename cleanly.</p>
+      <pre class="step__code"><span class="cm"># one command via the GitHub CLI — forks and clones in one step</span>
+gh repo fork me2resh/apexstack --clone
+cd apexstack</pre>
     </article>
 
     <article class="step">
-      <div class="step__num">02 — expose .claude/</div>
-      <h3 class="step__title">Symlink the runnable layer</h3>
-      <p class="step__desc">Claude Code looks for hooks, agents, skills, and <code>settings.json</code> at <code>.claude/</code>. Symlink so updates in apexstack stay in sync.</p>
-      <pre class="step__code"><span class="cm"># in your ops repo root</span>
-ln -s <span class="acc">.apexstack/.claude</span> .claude</pre>
+      <div class="step__num">02 — upstream remote</div>
+      <h3 class="step__title">Track upstream for updates</h3>
+      <p class="step__desc">Add the upstream remote so you can pull future apexstack improvements into your fork with a normal git merge. No proprietary upgrade tool.</p>
+      <pre class="step__code"><span class="cm"># in your fork</span>
+git remote add upstream \
+  https://github.com/me2resh/apexstack.git
+
+<span class="cm"># later, to pull updates:</span>
+git fetch upstream &amp;&amp; git merge upstream/main</pre>
     </article>
 
     <article class="step">
       <div class="step__num">03 — configure</div>
       <h3 class="step__title">Fill in onboarding.yaml</h3>
-      <p class="step__desc">Tell ApexStack about your team — roles, tech stack, quality bar. The default mode is <code>multi-project</code>; leave it as is unless you only have one repo.</p>
-      <pre class="step__code"><span class="cm"># defaults are sane — edit in place</span>
-$EDITOR .apexstack/onboarding.yaml</pre>
+      <p class="step__desc">Tell ApexStack about your team — company, roles, tech stack, quality bar. Defaults are sensible; edit what matters.</p>
+      <pre class="step__code"><span class="cm"># in your fork root</span>
+$EDITOR onboarding.yaml</pre>
     </article>
 
     <article class="step">
       <div class="step__num">04 — list your projects</div>
-      <h3 class="step__title">Create the registry</h3>
-      <p class="step__desc">Copy the example registry and list every repo you want under ApexStack management. One YAML entry per project — name, repo, status, applicable roles. The cross-project skills (<code>/projects</code>, <code>/inbox</code>, <code>/status</code>, <code>/tasks</code>) read from this file.</p>
-      <pre class="step__code"><span class="cm"># in your ops repo root</span>
-cp .apexstack/apexstack.projects.yaml.example \
+      <h3 class="step__title">Create the portfolio registry</h3>
+      <p class="step__desc">Copy the example registry and list every repo you want under ApexStack management. Even one project counts — the skills work the same whether you have 1 or 20. Add more as you bring them under management.</p>
+      <pre class="step__code"><span class="cm"># in your fork root</span>
+cp apexstack.projects.yaml.example \
    apexstack.projects.yaml
 $EDITOR apexstack.projects.yaml  <span class="cm"># list your repos</span></pre>
     </article>
 
     <article class="step">
-      <div class="step__num">05 — wire CLAUDE.md</div>
-      <h3 class="step__title">Point your CLAUDE.md at the stack</h3>
-      <p class="step__desc">A single <code>@-import</code> line in your ops repo's <code>CLAUDE.md</code> pulls in the entire stack — rules, role definitions, workflows, templates, and the multi-project skill set.</p>
-      <pre class="step__code"><span class="cm"># in your ops repo CLAUDE.md</span>
-<span class="acc">@.apexstack/CLAUDE.md</span></pre>
-    </article>
-
-    <article class="step">
-      <div class="step__num">06 — start working</div>
+      <div class="step__num">05 — start working</div>
       <h3 class="step__title">Try a portfolio command</h3>
-      <p class="step__desc">In any Claude Code session inside the ops repo, the cross-project skills are immediately available. Hooks fire on every Bash call. Done.</p>
-      <pre class="step__code"><span class="cm"># in claude code, from the ops repo</span>
+      <p class="step__desc">Open Claude Code in your fork. The portfolio skills, hooks, agents, and rules are all loaded automatically — no symlinks, no wiring. The <code>CLAUDE.md</code> at the fork root is the entry point Claude Code reads first.</p>
+      <pre class="step__code"><span class="cm"># in claude code, from the fork root</span>
 <span class="acc">/projects</span>          <span class="cm"># list every managed project + status</span>
 <span class="acc">/inbox</span>             <span class="cm"># PRs, issues, comments needing your eyes</span>
 <span class="acc">/status</span>            <span class="cm"># git + CI snapshot per project</span>
 <span class="acc">/decide</span> migrate billing to Stripe</pre>
-    </article>
-
-    <article class="step" style="grid-column: 1 / -1;">
-      <div class="step__num">opt-out — single-project mode</div>
-      <h3 class="step__title">If you actually have just one repo</h3>
-      <p class="step__desc">Skip step 04 entirely (no registry needed) and set <code>apexstack.mode: single-project</code> in <code>onboarding.yaml</code>. ApexStack lives directly inside that one repo, not a separate ops repo. The same skills scope to the current repo, the roadmap lives at <code>ROADMAP.md</code>, ideas at <code>IDEAS.md</code>. Everything else is identical.</p>
-      <pre class="step__code"><span class="cm"># in onboarding.yaml</span>
-apexstack:
-  mode: <span class="acc">single-project</span></pre>
-    </article>
-
-    <article class="step" id="install-global" style="grid-column: 1 / -1;">
-      <div class="step__num">alternative — global install</div>
-      <h3 class="step__title">If you run several ops repos</h3>
-      <p class="step__desc">The six-step default clones apexstack into each ops repo at <code>.apexstack/</code>. That's the right call for most people — upgrades are per-repo, nothing is shared across machines. If you run <em>several</em> ops repos (a founder with a couple of orgs, a consultant with multiple clients), clone apexstack <em>once</em> globally and reference it from every ops repo. One place to upgrade, one place to patch.</p>
-      <p class="step__desc"><strong>Tradeoff</strong>: the symlinks point at an absolute path in your home directory, so moving <code>~/.apexstack/</code> breaks the link. Not a good fit if you sync dotfiles across machines with different home paths.</p>
-      <pre class="step__code"><span class="cm"># one time, globally</span>
-git clone https://github.com/me2resh/apexstack.git ~/.apexstack
-
-<span class="cm"># in each ops repo (replaces steps 01 and 02 of the default flow)</span>
-ln -s ~/.apexstack/.claude .claude
-echo '@~/.apexstack/CLAUDE.md' &gt;&gt; CLAUDE.md
-
-<span class="cm"># steps 03, 04, 05, 06 are the same as the default flow</span></pre>
     </article>
 
   </div>

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -1,50 +1,21 @@
 # `workspace/` — Live Project Clones
 
-This directory holds **live working copies** of projects that ApexStack manages. It's part of the default layout. In single-project mode (the opt-in for one-repo teams) you can ignore it.
+This directory holds **live working copies** of projects that ApexStack manages. It's where code work happens: branches, commits, PRs, CI. Everything under `workspace/*/` is gitignored — each managed project has its own remote and is cloned into this folder independently.
 
-## The two modes
+## How it works
 
-ApexStack supports two operating modes, set in `onboarding.yaml`:
+1. Your ops repo is a fork of `me2resh/apexstack` (see [`docs/multi-project.md`](../docs/multi-project.md) for the full setup)
+2. `apexstack.projects.yaml` at the root of your fork lists every project under management
+3. For each project you want a local working copy of, `git clone` it into `workspace/<name>/` — the name should match the registry entry
+4. ApexStack skills that need local git data (e.g. `/status` showing dirty files) will look here
 
-```yaml
-apexstack:
-  mode: multi-project    # default
-  # mode: single-project # opt-in
-```
-
-### Multi-project mode (the default)
-
-When you manage **multiple repos as one organisation** (e.g. a CTO running an ops repo across 3–10 products), ApexStack aggregates across all of them. Skills like `/projects`, `/inbox`, `/status`, and `/tasks` iterate over a registry instead of looking at one repo. Most engineering orgs have more than one repo, so this is the right default — even a "single product" team usually has an app + infra + a marketing site.
-
-How the default works:
-
-1. `apexstack.mode` is read from `onboarding.yaml`; missing or `multi-project` → multi-project mode
-2. `apexstack.projects.yaml` at the root of your **ops repo** holds the registry (see `apexstack.projects.yaml.example` for the schema)
-3. Optionally clone each managed repo into `workspace/<name>/` (live working copies)
-4. Add per-project docs under `projects/<name>/`
-
-### Single-project mode (opt-in)
-
-ApexStack is checked out into your project's repo (or kept globally at `~/.apexstack/`), and the rules and skills apply to that one repo. There is no `workspace/` directory you need to care about. Your code is just... your code, in its own repo. This is the right choice for solo developers and teams with exactly one product.
+## Directory layout
 
 ```
-your-app/
-├── .claude/                ← rules, skills, hooks (from ApexStack)
-├── src/
-├── tests/
-├── package.json
-└── ROADMAP.md              ← single-project roadmap lives at the root
-```
-
-To opt in: set `apexstack.mode: single-project` in `onboarding.yaml`.
-
-## Directory layout under multi-project mode
-
-```
-my-ops-repo/
+your-org/apexstack/                ← your fork of apexstack, cloned locally (the "ops repo")
 ├── .claude/                       ← shared rules, skills, hooks
 ├── apexstack.projects.yaml        ← the registry (which projects ApexStack manages)
-├── onboarding.yaml                ← apexstack.mode: multi-project
+├── onboarding.yaml                ← company, team, tech stack
 │
 ├── workspace/                     ← LIVE WORKING COPIES (this directory)
 │   ├── README.md                  ← you are here
@@ -65,7 +36,7 @@ my-ops-repo/
 │       └── ...
 │
 └── docs/
-    └── multi-project.md           ← in-depth guide
+    └── multi-project.md           ← full setup guide
 ```
 
 ## Why two parallel directories?
@@ -92,7 +63,7 @@ workspace/*/
 
 ## Running skills against the workspace
 
-Most skills auto-detect mode and iterate the registry:
+Portfolio skills iterate the registry; project-specific ones use the current working directory.
 
 ```
 /projects                  # all managed projects
@@ -108,16 +79,4 @@ Most skills auto-detect mode and iterate the registry:
 /stakeholder-update weekly --project example-app
 ```
 
-To work on a specific project's code, `cd workspace/<name>` first — that puts your shell inside the real repo where branches, PRs, and CI live.
-
-## Migrating from single → multi
-
-See `docs/multi-project.md` for the full guide. The short version:
-
-1. Set `apexstack.mode: multi-project`
-2. Create `apexstack.projects.yaml`
-3. Move your existing roadmap from `ROADMAP.md` to `projects/<current-project>/roadmap.md`
-4. Move ideas from `IDEAS.md` to `projects/ideas-backlog.md`
-5. (Optional) Clone other repos into `workspace/`
-
-You can always go back: just remove the registry and flip `mode` back to `single-project`.
+To work on a specific project's code, `cd workspace/<name>` first — that puts your shell inside the real repo where branches, PRs, and CI live. Skills like `/decide`, `/code-review`, and `/security-review` operate on whatever working directory you're in.


### PR DESCRIPTION
## Summary

Two strategic direction changes rolled into one PR because they're deeply coupled — removing single-project mode changes the install flow, and the fork-first install changes every doc that talked about cloning into `.apexstack/`.

**1. Drop single-project mode entirely.** No more dual-mode conditional branches in skills, no more `apexstack.mode` field in onboarding.yaml, no more "single-project opt-out" in the docs. Multi-project is the only model. Users with exactly one repo fork apexstack and register that one repo.

**2. Fork-first install.** Your ops repo IS a fork of apexstack, not a separate repo with `.apexstack/` cloned inside it. One repo. No nested installs, no symlinks. Upgrades flow via `git fetch upstream && git merge upstream/main`. Users can optionally rename the fork to `your-org/ops` or similar (per Q2.b).

## The 5-step install (was 6 + 2 opt-outs)

| # | Step |
|---|---|
| 01 | ⭐ Star + ⑂ Fork on GitHub (`gh repo fork me2resh/apexstack --clone`) |
| 02 | Add `upstream` remote for future updates |
| 03 | Fill in `onboarding.yaml` |
| 04 | Create the portfolio registry (`apexstack.projects.yaml`) |
| 05 | Start working — `/projects`, `/inbox`, `/status`, `/decide` |

Gone: the "symlink runnable layer" step (no symlink needed), the "wire CLAUDE.md with @-import" step (CLAUDE.md is at the fork root), the "single-project opt-out" step, the "global install alternative" step.

## Files touched — 16

| Area | Files |
|------|-------|
| **Config** | `onboarding.yaml`, `apexstack.projects.yaml.example` |
| **Docs** | `CLAUDE.md`, `README.md`, `docs/multi-project.md` (full rewrite), `workspace/README.md`, `projects/README.md` |
| **Skills** (8 mode-detecting) | `handover`, `idea`, `inbox`, `projects`, `roadmap`, `stakeholder-update`, `status`, `tasks` |
| **Site** | `site/index.html` (hero CTA, install block, install caveat, metric #4, tree comments, layers lede, Layer 05, SECTION 05 / INSTALL) |

## Side effects (positive)

**Layers section UX bug from your screenshot is fixed.** The old Layer 05 had "content only fills left 1/3, right 2/3 empty" because it spanned full width but its content was still constrained. Rewriting it shorter (single-project content removed) plus a new `.layer--wide` CSS variant with a 2-column internal grid means the card now fills its full width naturally — description on the left, registry file list on the right.

**Hero metric #4 changed from "2 Operating modes" to "1 Fork · your ops repo in one command"** — celebrates the simplification instead of the dropped complexity.

## Intentional leftovers

Two "single-project" strings remain, both **intentional negation disclaimers** that tell anyone searching for the old concept: *"there is no single-project fallback"*:

1. `docs/multi-project.md:5` — "There is no single-project fallback mode. Even if you have exactly one repo, you still fork apexstack and register that one repo."
2. `site/index.html:1367` (Layers section lede) — "There's no single-project fallback; even if you only have one repo to manage, you register it and every layer works the same."

These are not a regression — they're the anti-signpost that prevents confusion for anyone coming from the old docs.

## Not in scope (explicitly untouched)

- The lifecycle demo script in the hero (doesn't reference install or mode)
- Role files in `roles/` (no mode refs)
- Workflow files (`sdlc.md`, `code-review.md`, `deployment.md`) — no mode refs
- `.claude/agents/` — no mode refs
- `.claude/hooks/` — no mode refs
- The tabbed terminal animation (paused; you asked for that earlier and I had a branch started, but this refactor supersedes it — the tabbed terminal can come as a follow-up PR once the positioning is stable)

## Answers to the clarifying questions

- **Q1.a** ✓ The fork IS the ops repo. No nesting.
- **Q2.b** ✓ Rename is optional; docs describe it that way (you chose this even though it loses some brand retention — went with your call, not my recommendation)
- **Q3.c** ✓ Single button in the hero linking to the repo page where both star + fork are available
- **Q4.a** ✓ One big PR

## Verification

```
grep -rn "single-project" --include="*.md" --include="*.yaml" --include="*.html" --include="*.sh"
→ 2 hits (both intentional negation disclaimers)

grep -rn "mode:" --include="*.md" --include="*.yaml" --include="*.html"
→ 0 hits

grep -iE "flat-?mate|curios|sharp ?pick|movetwo|yumyum" on all 16 changed files
→ 0 hits (multi-project neutrality preserved)
```

## Glossary

| Term | Definition |
|------|------------|
| Ops repo | Your fork of apexstack. The fork IS the ops repo — no nested installs, no separate repo. |
| Upstream | The canonical `me2resh/apexstack` repo. Added as a git remote in step 02 so `git fetch upstream && git merge upstream/main` pulls updates into your fork. |
| Portfolio registry | `apexstack.projects.yaml` at the root of your fork. Lists every project under management. Single source of truth. |
| Multi-project neutrality | The property that the stack doesn't leak real project names (flat-mate, curios-dog, sharppick, movetwo, yumyum) into examples or copy. All examples use `your-org/example-app` or similar placeholders. |
| Layer 05 | The "workspace · portfolio registry" card in the SECTION 02 / LAYERS grid. It's the card that used to have the UX bug (full-width but content constrained to left third). Now uses `.layer--wide` with a 2-column internal grid. |
| `.layer--wide` | New CSS variant that gives a `.layer` card a 2-column internal grid (title+description left, list right) so full-width cards fill their width naturally. |
| Fork-first install | The new install model: fork apexstack on GitHub, clone the fork, treat it as your ops repo. Replaces the old "clone into `.apexstack/` + symlink" pattern. |
| Intentional negation disclaimer | A sentence that mentions a dropped concept specifically to redirect anyone searching for it: "There is no X fallback — do Y instead." Good SEO, good UX. |

## Test plan

- [ ] `cd site && python3 -m http.server 8000` — open `http://localhost:8000`
- [ ] Hero CTA reads `★ Star · ⑂ Fork on GitHub` (single button) and clicking opens the GitHub repo page
- [ ] Hero install block shows `gh repo fork me2resh/apexstack --clone`
- [ ] Hero metrics show the new "1 Fork · your ops repo in one command" metric
- [ ] Layers section: Layer 05 fills the full width with a 2-column internal layout (description left, list right) — no more "content only in left third"
- [ ] At 900px viewport width or narrower, Layer 05 stacks to single column
- [ ] SECTION 05 / INSTALL shows 5 steps (not 6 + 2 opt-outs)
- [ ] Step 01 shows the `gh repo fork` command
- [ ] Step 02 shows the upstream remote setup
- [ ] Dark mode preserves the new layout
- [ ] Reduced motion still respected (no regressions to the lifecycle demo)
- [ ] `grep -rn "single-project"` returns only the 2 intentional disclaimers
- [ ] `grep -rn "mode:"` returns 0 hits
- [ ] README renders cleanly on GitHub
- [ ] docs/multi-project.md reads end-to-end without referring to single-project mode as a live option
- [ ] Rex review

Refs me2resh/apexscript-org#100

🤖 Generated with [Claude Code](https://claude.com/claude-code)