### PR TITLE
feat(#101): /handover auto-append + /idea polish (audit-flagged gaps)

### DIFF
--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -174,7 +174,8 @@ Write `projects/<name>/handover-assessment.md`:
 - [ ] `golden-paths/pipelines/pr-title-check.yml`
 
 ### Registry entry
-Multi-project is the default mode, so add this to `apexstack.projects.yaml` at the ops-repo root:
+
+The entry that will be appended to `apexstack.projects.yaml` at the root of the ops repo (see step 6 — the skill does this append for you, with confirmation):
 
 ```yaml
 - name: {name}
@@ -183,43 +184,153 @@ Multi-project is the default mode, so add this to `apexstack.projects.yaml` at t
   docs: projects/{name}
   status: handover
   roles:
-    - tech-lead
-    - backend-engineer
+    {dynamically derived from the tech stack + CI config — see
+     "Deriving applicable roles" below}
 ```
+
+**Deriving applicable roles**: don't hard-code `[tech-lead, backend-engineer]`. Look at the tech stack from step 3:
+
+| Signal | Add role |
+|--------|----------|
+| Any backend code (package.json with server deps, pyproject.toml, etc.) | `backend-engineer` |
+| Any UI code (React/Vue/Svelte, `src/components/`, CSS modules) | `frontend-engineer` |
+| CI config detected (`.github/workflows/`, `.gitlab-ci.yml`, etc.) | `platform-engineer` |
+| Production deployment evidence (Dockerfile, Terraform, AWS/GCP/Azure SDK) | `sre` |
+| Auth / crypto / secrets in the diff | `security-auditor` |
+| Always | `tech-lead` |
+
+For a typical handover you'll end up with 3-5 roles in the list.
 
 ## Next Steps
 
-1. {first concrete action — usually "run /audit-deps and triage criticals"}
-2. {second action — usually "open issues for each Quality Risk above"}
-3. {third action — usually "merge the CI templates as the first PR under ApexStack"}
-4. {…}
+Derived dynamically from the Quality Risks found in this assessment. Don't emit generic placeholders — emit specific actions.
+
+Mapping table:
+
+| Risk found | Next step entry |
+|------------|-----------------|
+| ≥ 1 CVE in deps (any severity) | `1. /audit-deps {name} — triage the {severity} {package} CVE before any new feature work` |
+| Failing tests | `2. Fix the {N} failing tests in {module} before merging new PRs (baseline must be green)` |
+| No observability (no Sentry/Datadog/CloudWatch/etc.) | `3. /decide on observability ({two most common options for this stack})` |
+| Stale CI (no runs in > 30 days) | `4. Re-enable CI on this repo — copy in golden-paths/pipelines/ci.yml` |
+| Test coverage unknown | `5. Set up test coverage reporting (vitest/jest coverage config) before the first feature` |
+| ≥ 10 open issues | `6. Triage the issue backlog with the previous owner before taking ownership` |
+| Missing README or onboarding doc | `7. Write a minimum-viable README (what the project does, how to run it locally, where it deploys)` |
+
+If no risks match a row, omit that row. If fewer than 3 actions come out, add:
+
+- `{next} /code-review the most-recent PR on this repo as Rex to calibrate review standards`
+- `{next} Stakeholder sync with the previous owner to cover context the static read couldn't surface`
+
+## Post-Handover Checklist
+
+Also derived from the risks found. Tailor to the specific repo — don't emit generic items.
+
+- [ ] Review this assessment with the previous owner
+- [ ] {top quality risk} — close before the first feature PR
+- [ ] {second quality risk} — scheduled in the first 2 weeks
+- [ ] Add `{name}` to the weekly `/stakeholder-update` rollup
+- [ ] Onboard the roles listed above into the team's on-call / review rotation
+- [ ] Set up a test coverage baseline (run `npm test -- --coverage` or equivalent and commit the threshold)
+- [ ] Run `/audit-deps {name}` monthly for the next 3 months
 
 ## Open Questions
 - {anything you couldn't determine from a static read}
 ```
 
-### 6. Return a summary
+### 6. Append to the portfolio registry
+
+**Don't just print the snippet** — offer to append it automatically:
+
+```
+Ready to add {name} to apexstack.projects.yaml? (y/n)
+> y
+```
+
+If yes:
+
+1. **Locate the registry**: `apexstack.projects.yaml` at the root of the ops repo. If missing, first copy from `apexstack.projects.yaml.example` and show the user a warning: `⚠ Registry didn't exist — created from .example. You may need to fill in other projects.`
+
+2. **Append the entry**. Use `yq` if available for a safe YAML edit, otherwise append as plain text with careful indentation:
+
+   ```bash
+   # Prefer yq for correctness
+   if command -v yq >/dev/null 2>&1; then
+     yq eval -i '.projects += [{"name": "{name}", "repo": "{owner/name}", "workspace": "workspace/{name}", "docs": "projects/{name}", "status": "handover", "roles": [{roles}]}]' apexstack.projects.yaml
+   else
+     # Fallback: plain text append
+     cat >> apexstack.projects.yaml <<'YAML'
+     - name: {name}
+       repo: {owner/name}
+       workspace: workspace/{name}
+       docs: projects/{name}
+       status: handover
+       roles:
+         - tech-lead
+         - backend-engineer
+   YAML
+   fi
+   ```
+
+3. **Validate the result**:
+
+   ```bash
+   # Prefer yq or python -c 'import yaml; yaml.safe_load(open("apexstack.projects.yaml"))'
+   yq eval '.' apexstack.projects.yaml >/dev/null 2>&1 \
+     || python3 -c 'import sys, yaml; yaml.safe_load(open("apexstack.projects.yaml"))' 2>&1
+   ```
+
+   If validation fails: **restore the previous version** from a backup made before the write, print the parse error, and tell the user to fix it manually. Never leave the registry in a broken state.
+
+4. **Confirm to the user**:
+
+   ```
+   ✓ Added {name} to apexstack.projects.yaml
+     status: handover
+     roles: {the derived list}
+   ```
+
+If the user says `n` at the prompt, print the snippet they'd need to copy manually and continue to step 7 without writing anything:
+
+```
+Skipping the auto-append. If you want to add it later, copy this into apexstack.projects.yaml:
+
+  - name: {name}
+    repo: {owner/name}
+    workspace: workspace/{name}
+    docs: projects/{name}
+    status: handover
+    roles: {derived list}
+```
+
+### 7. Return a summary
 
 ```
 Handover assessment written: projects/{name}/handover-assessment.md
+Registry updated: apexstack.projects.yaml ({added | skipped})
 
 Tech stack: {one-liner}
 Build: {ok / failed}
-Risks: {N items}
-Next steps: {first 2}
-
-Recommended status in registry: handover
+Risks: {N items} ({highest severity})
+Roles activated: {comma-separated}
+Top 3 next steps:
+  1. {first dynamic step}
+  2. {second dynamic step}
+  3. {third dynamic step}
 ```
 
 ## Rules
 
-1. **Read-only by default** — never modify the target repo without explicit permission.
+1. **Read-only against the target repo** — never modify the target repo without explicit permission. (The ops repo IS modified — you append to the registry and create the assessment file — but that's the point.)
 2. **Honest assessment** — if a build fails, say so. Don't paper over problems.
 3. **Always seed `projects/<name>/`** — even if minimal.
-4. **Always include the registry snippet** — multi-project is the default, so the user almost certainly wants the registry entry right away.
-5. **Never auto-clone** — ask for the path.
-6. **Never store secrets** — if `.env` is found, list its presence but never read its contents.
-7. **Status starts at `handover`** — moves to `active` only after the integration plan is executed.
+4. **Auto-append to the registry** (with confirmation) — don't leave the user to copy-paste a snippet. Propose the append, validate the resulting YAML, roll back on failure.
+5. **Derive roles from the stack** — don't hard-code `[tech-lead, backend-engineer]`. The roles list depends on the actual tech stack, CI config, and security surface detected in step 3.
+6. **Derive next steps from the risks** — don't emit generic placeholders. Every "Next Step" must correspond to a specific finding from the Quality Risks section of the assessment.
+7. **Never auto-clone** — ask for the path.
+8. **Never store secrets** — if `.env` is found, list its presence but never read its contents.
+9. **Status starts at `handover`** — moves to `active` only after the integration plan is executed.
+10. **Never break the registry** — if the YAML append breaks the file, restore the previous version and ask the user to edit manually.
 
 ## When to use this
 

--- a/.claude/skills/idea/SKILL.md
+++ b/.claude/skills/idea/SKILL.md
@@ -37,11 +37,55 @@ What's the idea? Give me a short title (1 line).
 
 Ask conversationally (one question at a time, don't batch):
 
-- **Category**: New Product / Feature / Internal Tool / Process
-- **Submitter**: who's proposing it (default to current git user)
-- **One-line description**: what would it do? Who's it for?
+**Category** — must be one of four values. Present numbered options and **re-prompt on invalid input**:
+
+```
+Category?
+  1. New Product
+  2. Feature
+  3. Internal Tool
+  4. Process
+>
+```
+
+Accept `1`, `2`, `3`, `4` or the corresponding word (case-insensitive). On anything else, say `Please pick 1-4 or type the category name.` and re-ask. Loop until valid — do **not** silently accept garbage.
+
+**Submitter** — who's proposing it. Default to the current git user (`git config user.name`). If the user wants to override, accept their input as-is.
+
+**One-line description** — what would it do? Who's it for? If empty, re-prompt: `Give me one sentence about what this idea does.` Loop until non-empty.
 
 Don't go deeper than that — this is a lightweight capture, not a spec.
+
+### 3. Check for duplicates
+
+Before computing an ID or appending anything, fuzzy-match the title against existing backlog entries:
+
+```bash
+# Normalise a title: lowercase, strip punctuation, collapse whitespace
+normalise() { echo "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:punct:]' | tr -s ' '; }
+
+# Extract existing titles from the backlog table
+grep -E '^\| IDEA-[0-9]+ \|' projects/ideas-backlog.md 2>/dev/null \
+  | awk -F'|' '{print $3}' \
+  | sed 's/^ *//;s/ *$//'
+```
+
+Compare the normalised new title against every normalised existing title using a simple token-overlap heuristic: if ≥ 80% of the words in the shorter title appear in the longer one, flag as a potential duplicate.
+
+If a potential match is found:
+
+```
+⚠ Similar idea already in the backlog:
+  IDEA-025 — {existing title} (status: {status})
+
+Is this a duplicate? (y = skip, n = add anyway)
+>
+```
+
+- `y` → skip the append, return without logging anything new, suggest `/write-spec IDEA-025` if the user wants to work on the existing idea
+- `n` → continue to step 4
+
+If no match is found, continue silently to step 4.
 
 ### 4. Compute the next ID
 
@@ -79,6 +123,8 @@ After the entry is appended, ask:
 Would you like me to create a tracking GitHub Issue for IDEA-NNN? (y/n)
 ```
 
+If the user says no, skip this step entirely — the backlog entry is already saved, and that's enough.
+
 If yes, create one with the `enhancement` and `idea` labels (creating the labels if needed):
 
 ```bash
@@ -104,7 +150,29 @@ EOF
   --label "idea,needs-triage"
 ```
 
-If the issue is created, append the issue URL to the backlog row's Description column as `(GH#NN)`.
+**Error handling** — if `gh issue create` fails for any reason (missing auth, labels don't exist, network error, rate limit), catch the error and fall back gracefully:
+
+```
+⚠ Couldn't create the tracking issue: {reason}
+  The idea is still saved in projects/ideas-backlog.md as IDEA-NNN.
+
+  Try again? (y = retry, n = skip, gh = show the gh error for debugging)
+>
+```
+
+Common failure modes and what to do:
+
+| Failure | Action |
+|---------|--------|
+| `could not resolve repository` | Ask the user which repo to file the issue in; the backlog entry was already saved |
+| `missing scope: issues:write` | Tell the user to run `gh auth refresh -s issues` and offer to retry |
+| `label "idea" not found` | Create the label first (`gh label create idea`) then retry |
+| `HTTP 403 rate-limited` | Offer to retry after a short wait |
+| Any other error | Show the raw `gh` output, skip the tracking issue, keep the backlog entry |
+
+The guiding principle: **the backlog entry is the primary artefact; the tracking issue is a bonus**. Never lose the backlog entry because the GitHub Issue creation failed.
+
+If the issue is created successfully, append the issue URL to the backlog row's Description column as `(GH#NN)`.
 
 ## Output
 
@@ -124,8 +192,11 @@ Next: triage with the team, then `/write-spec` if it survives.
 3. **One row per idea** — never edit existing rows from this skill; new ideas always append.
 4. **Status starts at NEW** — triage changes it later.
 5. **Single backlog** — every idea goes into `projects/ideas-backlog.md` at the root of the ops repo; triage assigns it to a project later.
-6. **Don't create the issue silently** — always ask first.
-7. **Never delete** — superseded ideas get status `SUPERSEDED`, not removal.
+6. **Validate before accepting** — category must be 1-4; description must be non-empty. Loop until valid; never silently accept garbage.
+7. **Dedup before appending** — fuzzy-match the title against existing entries; flag and confirm before creating a second entry for the same idea.
+8. **The backlog is the primary artefact** — if the tracking issue fails to create, the backlog entry still stands. Never lose data because GitHub was flaky.
+9. **Don't create the issue silently** — always ask first.
+10. **Never delete** — superseded ideas get status `SUPERSEDED`, not removal.
 
 ## Status values
 


### PR DESCRIPTION
## Summary

**Closes the apexstack positioning epic.** The Explore agent audit back in PR #1 flagged specific gaps in `/handover` and `/idea` that were deferred through PRs #4-#8 because they're independent of the positioning work. This PR closes them, and closes `me2resh/apexscript-org#101` + the umbrella epic `me2resh/apexscript-org#100`.

Two files changed: `.claude/skills/handover/SKILL.md` (+145/-11) and `.claude/skills/idea/SKILL.md` (+83/-8). Net `+205/-23`.

## `/handover` — 3 audit gaps + 1 bonus

### 1. Auto-append to the portfolio registry (CRITICAL)

**Before**: the skill generated a YAML snippet and told the user *"add this to `apexstack.projects.yaml`"*. Users forgot, miscopied, or broke the YAML indentation.

**After**: new **step 6** prompts `Ready to add {name} to apexstack.projects.yaml? (y/n)`. On `y`, the skill:
- Locates the registry at the ops-repo root (creates from `.example` if missing, with a warning)
- Appends the entry via `yq` if available, otherwise plain-text append with careful indentation
- Validates the result by parsing the YAML (`yq` or `python3 -c 'yaml.safe_load'`)
- **Rolls back on failure** — never leaves the registry broken
- Confirms the append to the user with the derived roles list

On `n`, prints the snippet for manual copy-paste and continues without writing.

### 2. Dynamic "Next Steps" derived from risks found

**Before**: generic placeholders like `{first concrete action — usually "run /audit-deps and triage criticals"}`. Embarrassing.

**After**: a mapping table in the skill spec defines the derivation:

| Risk found | Next step entry |
|---|---|
| ≥ 1 CVE in deps | `/audit-deps {name} — triage the {severity} {package} CVE before any new feature work` |
| Failing tests | `Fix the {N} failing tests in {module} before merging new PRs (baseline must be green)` |
| No observability | `/decide on observability ({two most common options for this stack})` |
| Stale CI (> 30 days) | `Re-enable CI — copy in golden-paths/pipelines/ci.yml` |
| Coverage unknown | `Set up test coverage reporting` |
| > 10 open issues | `Triage the issue backlog with the previous owner before taking ownership` |
| Missing README | `Write a minimum-viable README` |

If fewer than 3 risk-derived actions come out, fills in with generic calibration steps.

### 3. Post-handover checklist

**Before**: no checklist. User had to remember what to do next.

**After**: new section at the bottom of the assessment template, tailored to the specific risks. Items like:
- Review this assessment with the previous owner
- Close {top risk} before the first feature PR
- Add {name} to the weekly `/stakeholder-update` rollup
- Set up a test coverage baseline
- Run `/audit-deps {name}` monthly for the next 3 months

### Bonus: derive the role list dynamically

**Before**: hard-coded `[tech-lead, backend-engineer]` in the template.

**After**: mapping table in the spec:

| Signal | Add role |
|--------|----------|
| Backend deps (package.json server deps, pyproject.toml, etc.) | `backend-engineer` |
| UI code (React/Vue/Svelte, `src/components/`, CSS modules) | `frontend-engineer` |
| CI config detected | `platform-engineer` |
| Production deployment evidence (Dockerfile, Terraform, cloud SDK) | `sre` |
| Auth / crypto / secrets in the diff | `security-auditor` |
| Always | `tech-lead` |

A typical handover ends up with 3-5 roles in the registry entry.

## `/idea` — 3 audit gaps + 1 numbering bug

### 1. Input validation for category

**Before**: the prompt asked for category but silently accepted anything. A user typing `foo` got `Category: foo` in the backlog.

**After**: explicit 1/2/3/4 prompt. Accepts either the number or the word (case-insensitive). **Re-prompts on invalid input** with `Please pick 1-4 or type the category name.` Loops until valid. Same treatment for the description field — re-prompt if empty.

### 2. Dedup check before appending (new step 3)

**Before**: no check. Users submitted the same idea twice and got two entries.

**After**: simple token-overlap heuristic. Normalise both titles (lowercase, strip punctuation), compare with a threshold (≥ 80% of the words in the shorter title appear in the longer one).

Match found → prompt:

```
⚠ Similar idea already in the backlog:
  IDEA-025 — {existing title} (status: {status})

Is this a duplicate? (y = skip, n = add anyway)
```

On `y`: skip the append, suggest `/write-spec IDEA-025`. On `n`: continue.

### 3. Error handling for `gh issue create`

**Before**: if the tracking issue creation failed, the idea was half-saved or errored out.

**After**:

```
⚠ Couldn't create the tracking issue: {reason}
  The idea is still saved in projects/ideas-backlog.md as IDEA-NNN.

  Try again? (y = retry, n = skip, gh = show the gh error for debugging)
```

With a failure-modes table: missing auth scope, label not found, rate limit, network error — each has a specific recovery path.

**Guiding principle (now rule #8)**: *the backlog entry is the primary artefact; the tracking issue is a bonus*. Never lose the backlog entry because GitHub was flaky.

### 4. Section numbering bug fixed

The old file had steps 1, 2, 4, 5, 6 — step 3 was missing because an earlier refactor deleted it without renumbering. With the new dedup step slotted in at 3, the sequence is 1, 2, 3, 4, 5, 6 again.

## Rules sections updated

- **`/handover`**: rule 4 is now "Auto-append to the registry (with confirmation)"; rule 5 is "Derive roles from the stack"; rule 6 is "Derive next steps from the risks"; rule 10 is "Never break the registry".
- **`/idea`**: rule 6 is "Validate before accepting"; rule 7 is "Dedup before appending"; rule 8 is "The backlog is the primary artefact".

## What's NOT in this PR

- The tabbed terminal animation (`me2resh/apexscript-org#102`) — separate ticket, not part of the epic closure
- Any changes to skill frontmatter
- Any changes to `/handover`'s overall assessment output format beyond the Next Steps and Post-Handover Checklist sections
- Any changes to `/idea`'s backlog file format or ID scheme
- No changes to any other skill, workflow, or role file

## Multi-project neutrality

```
grep -iE "flat-?mate|curios|sharp ?pick|movetwo|yumyum" .claude/skills/handover/SKILL.md .claude/skills/idea/SKILL.md
→ 0 hits
```

## Glossary

| Term | Definition |
|------|------------|
| Portfolio registry | `apexstack.projects.yaml` at the root of the ops repo. Source of truth for which projects ApexStack manages. |
| Handover assessment | The structured markdown file at `projects/<name>/handover-assessment.md` that `/handover` produces — tech stack, risks, integration plan, next steps |
| Registry entry | A YAML object in `apexstack.projects.yaml` representing one managed project (name, repo, workspace, docs, status, roles) |
| Dynamic next steps | Next-step entries derived from the specific risks the assessment found, not a generic placeholder list |
| Post-handover checklist | A tailored checklist at the bottom of the assessment, also derived from the risks |
| Derived roles list | The `roles:` array in a registry entry — computed from the detected tech stack, CI config, and security surface, not hard-coded |
| Token-overlap dedup | The simple fuzzy-match heuristic used by `/idea` to detect duplicate ideas — normalise titles, compare word overlap against a threshold |
| Primary artefact principle | The guiding rule that `/idea`'s backlog entry is the essential output and the tracking issue is a bonus — never lose the backlog because GitHub was flaky |

## Test plan

- [ ] Create a test repo locally and run `/handover test-repo ~/tmp/test-repo` — verify it prompts for the registry append and actually writes the YAML
- [ ] Break the test repo's package.json on purpose, run `/handover` again, verify the Next Steps include the failing-test item
- [ ] Run `/idea` with an invalid category (e.g. `foo`) — verify the skill re-prompts instead of accepting it
- [ ] Run `/idea` twice with the same title — verify the second invocation flags the duplicate
- [ ] Disconnect the network (or use `GH_TOKEN=""`) and run `/idea` with the tracking-issue option — verify the backlog entry still saves and the user gets a clear retry/skip prompt
- [ ] `grep -iE "flat-?mate|curios|sharp ?pick|movetwo|yumyum" .claude/skills/handover/SKILL.md .claude/skills/idea/SKILL.md` → 0 hits
- [ ] Rex review

Closes me2resh/apexscript-org#101
Closes me2resh/apexscript-org#100

🤖 Generated with [Claude Code](https://claude.com/claude-code)