### PR TITLE
feat(#11): require explicit per-merge CEO approval — never infer from "go"

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -46,11 +46,24 @@ These four hooks make the SDLC mechanical instead of advisory. Each enforces a r
 
 **Event:** `PreToolUse` on `Bash(gh pr merge *)`.
 
-**What it does:** blocks the merge unless `.claude/session/reviews/<pr>-rex.approved` exists. Also checks the approved commit SHA matches `HEAD` — new commits after review invalidate the approval. Rex writes the approval file as its final step when it signs off; human approver sign-off is still enforced by the 2-reviews rule in `workflows/code-review.md`.
+**What it does:** blocks the merge unless **both** approval markers exist for the PR number being merged, and both contain a SHA that matches the current HEAD. New commits after either approval invalidate it.
 
-**Trust model:** the approval file is **local session state**, not a remote trust boundary. It's gitignored and lives on the user's machine, so in principle the local user could forge it by hand. That's fine — the goal is to prevent Claude (an automated agent running in the same session) from merging without the review step, not to protect against a malicious user who owns the machine. For adversarial trust, rely on branch protection rules on the remote (GitHub required reviews, CODEOWNERS) — this hook complements those, it does not replace them.
+| Marker | Path | Written by | Semantics |
+|--------|------|------------|-----------|
+| Rex | `.claude/session/reviews/<pr>-rex.approved` | `code-reviewer` agent after a successful review | "Code reviewed, no blocking issues" |
+| CEO | `.claude/session/reviews/<pr>-ceo.approved` | `/approve-merge <pr>` skill, **only** on explicit user invocation | "The human approver has looked at this specific PR and said ship it" |
 
-**Enforces:** `workflow-gates.md` rule #5 — "2 reviews, CI green, commit SHA matches review."
+Both files contain exactly one line: the 40-character HEAD SHA at the time of approval. The hook reads each, compares with `git rev-parse HEAD`, and blocks on any mismatch.
+
+**Why two markers:** The Rex marker alone isn't enough because it would only enforce the "code review happened" half of the 2-reviews rule. The CEO marker is the mechanical enforcement of **"plan-level 'go' is NOT merge approval"** from `.claude/rules/pr-workflow.md`. A plan-level authorization does not produce the CEO marker — only the `/approve-merge` skill does, and the skill is defined to run only on explicit per-PR user invocation. This closes the failure mode where Claude infers merge approval from an umbrella "go" on a broader plan.
+
+**Trust model:** the approval files are **local session state**, not a remote trust boundary. They're gitignored and live on the user's machine. Claude can technically `rm` or `touch` them directly, and a malicious local user could forge them too. That's fine — the goal is to prevent Claude (an automated agent in the same session) from merging without the discrete review-and-approve moments, not to protect against an adversary who owns the machine. The failure mode the hook closes is **invisible inference** ("Claude decided 'go' meant 'merge'"); it converts that into **visible rule violation** ("Claude `touch`ed the marker without being asked"). The latter is grep-able and auditable; the former is not.
+
+For adversarial trust, rely on remote branch-protection rules (GitHub required reviews, CODEOWNERS, required status checks). This hook complements those, it does not replace them.
+
+**Enforces:** `workflow-gates.md` rule #5 ("2 reviews, CI green, commit SHA matches review") AND `pr-workflow.md` § "Plan-level 'go' is NOT merge approval".
+
+**Companion skill:** `/approve-merge <pr>` (in `.claude/skills/approve-merge/`) is the only supported way to write the CEO marker. The skill definition includes explicit anti-patterns describing the wrong invocation triggers; read it before using.
 
 ### 4. Onboarding — `onboarding-check.sh`
 
@@ -80,7 +93,8 @@ These were already in place before the enforcement layer and remain unchanged. T
 ├── onboarded                     # created by /onboard, read by onboarding-check
 ├── current-ticket                # created by /start-ticket, read by require-active-ticket
 ├── pending-reviews/<pr>          # created by auto-code-review, tracks PRs awaiting Rex
-└── reviews/<pr>-rex.approved     # created by code-reviewer agent, read by merge-gate
+├── reviews/<pr>-rex.approved     # created by code-reviewer agent, read by merge-gate
+└── reviews/<pr>-ceo.approved     # created by /approve-merge, read by merge-gate
 ```
 
 If a marker gets stale, delete the file and re-run the corresponding skill.

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -1,15 +1,32 @@
 #!/bin/bash
-# PreToolUse hook on `gh pr merge`: blocks merging a PR that has no recorded
-# Rex (code-reviewer) approval.
+# PreToolUse hook on `gh pr merge`: blocks merging a PR that does not have
+# BOTH required approval markers in place.
 #
 # Enforces workflow-gates rule #5 ("2 reviews — agent + human, CI green,
-# commit SHA matches review") at the merge boundary, mechanically. An approval
-# is a file at .claude/session/reviews/<pr>-rex.approved whose contents are
-# the SHA Rex reviewed. If Rex requests changes, no file is written and merge
-# stays blocked until a follow-up review passes.
+# commit SHA matches review") at the merge boundary, mechanically. Two
+# markers are required:
 #
-# Human approver sign-off is still required in addition to this check — the
-# hook just guarantees you can't merge without the agent review.
+#   .claude/session/reviews/<pr>-rex.approved
+#     Written by the code-reviewer agent (Rex) after a successful review.
+#     Contents: the commit SHA Rex reviewed.
+#
+#   .claude/session/reviews/<pr>-ceo.approved
+#     Written ONLY by the /approve-merge <pr> skill on explicit user
+#     invocation. Contents: the commit SHA the CEO approved.
+#
+# Both markers must exist, and both SHAs must match the live HEAD. Any
+# commits pushed after approval invalidate both — re-review and re-approve.
+#
+# The CEO marker is the mechanical enforcement of the "plan-level 'go' is
+# NOT merge approval" rule in .claude/rules/pr-workflow.md. An umbrella
+# "go" on a plan does not produce this file — only the /approve-merge
+# skill does, and the skill is defined to run only on explicit user
+# invocation that names the PR.
+#
+# Claude can technically forge either marker by running `touch` or `echo`
+# directly. Doing so is a visible, auditable, grep-able rule violation
+# and is itself a hard stop. The point of mechanical enforcement is to
+# turn invisible inference failures into visible rule violations.
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -36,40 +53,79 @@ if [ -z "$PR_NUMBER" ]; then
 fi
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-APPROVAL="${REPO_ROOT:-.}/.claude/session/reviews/${PR_NUMBER}-rex.approved"
+REVIEWS_DIR="${REPO_ROOT:-.}/.claude/session/reviews"
+REX_APPROVAL="${REVIEWS_DIR}/${PR_NUMBER}-rex.approved"
+CEO_APPROVAL="${REVIEWS_DIR}/${PR_NUMBER}-ceo.approved"
+CURRENT_SHA=$(git rev-parse HEAD 2>/dev/null)
 
-if [ ! -f "$APPROVAL" ]; then
+# --- Rex marker check ---
+if [ ! -f "$REX_APPROVAL" ]; then
   cat >&2 <<MSG
 BLOCKED: PR #${PR_NUMBER} has no recorded code-reviewer (Rex) approval.
 
 ApexStack requires two reviews before merge (workflow-gates rule #5):
   1. Code Reviewer agent (Rex) — automated, recorded in .claude/session/reviews/
-  2. Human approver (Tech Lead / CEO / project owner) — recorded on the PR
+  2. Human approver (CEO) — recorded by the /approve-merge skill
 
-Expected approval file does not exist:
-  ${APPROVAL}
+Missing file:
+  ${REX_APPROVAL}
 
 To unblock:
   1. Invoke the code-reviewer agent on this PR
-  2. When Rex returns "approved", record it:
-       mkdir -p .claude/session/reviews
-       echo "<commit-sha>" > .claude/session/reviews/${PR_NUMBER}-rex.approved
-  3. Retry the merge
+  2. When Rex returns "approved", it records the approval automatically
+  3. Then run /approve-merge ${PR_NUMBER} for the CEO approval
+  4. Retry the merge
 
-Never skip this check — even for typo fixes. See workflow-gates rule #5.
+Never skip this check — even for typo fixes. See .claude/rules/pr-workflow.md.
 MSG
   exit 2
 fi
 
-# Commit SHA consistency: make sure the approved SHA matches current HEAD.
-# A review is bound to a specific commit — new commits after review invalidate it.
-APPROVED_SHA=$(tr -d '[:space:]' < "$APPROVAL")
-CURRENT_SHA=$(git rev-parse HEAD 2>/dev/null)
-if [ -n "$APPROVED_SHA" ] && [ -n "$CURRENT_SHA" ] && [ "$APPROVED_SHA" != "$CURRENT_SHA" ]; then
+REX_SHA=$(tr -d '[:space:]' < "$REX_APPROVAL")
+if [ -n "$REX_SHA" ] && [ -n "$CURRENT_SHA" ] && [ "$REX_SHA" != "$CURRENT_SHA" ]; then
   cat >&2 <<MSG
-BLOCKED: Code-reviewer approved commit ${APPROVED_SHA:0:7} but HEAD is now ${CURRENT_SHA:0:7}.
+BLOCKED: Code-reviewer approved commit ${REX_SHA:0:7} but HEAD is now ${CURRENT_SHA:0:7}.
 
-New commits were pushed after review. Re-invoke Rex on the latest HEAD before merging.
+New commits were pushed after the Rex review. Re-invoke Rex on the latest
+HEAD before merging.
+MSG
+  exit 2
+fi
+
+# --- CEO marker check ---
+if [ ! -f "$CEO_APPROVAL" ]; then
+  cat >&2 <<MSG
+BLOCKED: PR #${PR_NUMBER} has Rex approval but no CEO approval marker.
+
+Plan-level "go" / "continue" / "ship it" does NOT authorize a merge. Each
+merge requires an explicit per-PR, per-merge CEO approval that names the
+PR. See .claude/rules/pr-workflow.md § "Plan-level 'go' is NOT merge
+approval" for the full rationale.
+
+Missing file:
+  ${CEO_APPROVAL}
+
+To unblock:
+  1. Stop and ask the CEO explicitly: "PR #${PR_NUMBER} ready to merge — approved?"
+  2. When the CEO says "approved" / "merge it" / "ship it" naming PR #${PR_NUMBER},
+     invoke the /approve-merge skill:
+       /approve-merge ${PR_NUMBER}
+  3. The skill writes ${CEO_APPROVAL} with the current HEAD SHA
+  4. Retry the merge
+
+NEVER create this marker yourself from an umbrella "go" on a plan.
+EVER. This is the exact failure this hook exists to prevent.
+MSG
+  exit 2
+fi
+
+CEO_SHA=$(tr -d '[:space:]' < "$CEO_APPROVAL")
+if [ -n "$CEO_SHA" ] && [ -n "$CURRENT_SHA" ] && [ "$CEO_SHA" != "$CURRENT_SHA" ]; then
+  cat >&2 <<MSG
+BLOCKED: CEO approved commit ${CEO_SHA:0:7} but HEAD is now ${CURRENT_SHA:0:7}.
+
+New commits were pushed after the CEO approval. Re-request CEO approval
+via /approve-merge ${PR_NUMBER} on the new HEAD before merging.
 MSG
   exit 2
 fi

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -51,14 +51,56 @@ Also check before pushing:
 [ ] Wait for human approver (explicit "approved" or similar)
 ```
 
-## Before `gh pr merge`
+## Before `gh pr merge` (HARD STOP)
 
 ```
-[ ] Code Reviewer approved?   NO → WAIT
-[ ] Human approver approved?  NO → WAIT
+[ ] Code Reviewer approved for THIS commit SHA?     NO → WAIT
+[ ] Human approver approved THIS specific PR?       NO → WAIT, ASK EXPLICITLY
 ```
 
 NO EXCEPTIONS. Not for "small fixes". Not for "just a typo".
+
+### Plan-level "go" is NOT merge approval
+
+A common failure mode: you present a multi-step plan that includes a merge as one of its steps, the user says "go" or "continue" or "ship it" or "execute the plan", and you execute all the steps *including the merge*. **This is wrong.** Plan-level authorization covers everything in the plan *except* merge steps. Merge steps always require a second, per-PR, per-merge explicit approval that names the PR.
+
+#### Wrong
+
+```
+You: "Here's the 6-step plan: 1. merge PR #10, 2. close PR #105, ..."
+CEO: "go"
+You: *runs gh pr merge 10*   ← FAILURE: "go" was plan-level, not merge-level.
+```
+
+#### Right
+
+```
+You: "Here's the 6-step plan: 1. merge PR #10, 2. close PR #105, ..."
+CEO: "go"
+You: *executes steps 2–6, stops before step 1*
+You: "Steps 2–6 done. Ready to merge PR #10 — approved?"
+CEO: "approved"
+You: *runs gh pr merge 10*   ← CORRECT: explicit per-PR approval received.
+```
+
+#### Why
+
+CEO approval is meant to be a **discrete moment per PR**. Merges are hard to reverse, externally visible, and can trigger downstream deploys. An umbrella "go" on a plan does not give you enough evidence that the CEO consciously signed off on each merge. When in doubt: stop and ask for the per-PR explicit nod.
+
+This also applies to other destructive / externally-visible / hard-to-reverse actions: force pushes, branch deletes, closing issues with dependents, posting to external channels. Plan-level "go" does not carry through to any of these. List them in the plan if you want — just stop before executing and ask.
+
+### Mechanical enforcement
+
+The `block-unreviewed-merge.sh` hook enforces this rule at the shell level. It requires **two** approval markers in `.claude/session/reviews/` before letting any `gh pr merge` command through:
+
+| Marker | Written by | Semantics |
+|--------|------------|-----------|
+| `<pr>-rex.approved` | the `code-reviewer` agent after a successful review | Code reviewed, no blocking issues |
+| `<pr>-ceo.approved` | the `/approve-merge <pr>` skill, **only** on explicit user invocation | CEO has looked at this specific PR and said ship it |
+
+Both markers must contain the current HEAD SHA, and both SHAs must match the live HEAD. New commits after approval invalidate both — you must re-review and re-approve.
+
+Claude can technically `rm` or `touch` these files by hand. Doing so is a visible, auditable, grep-able rule violation — and the whole point of recording the rule mechanically is so that the failure mode is "Claude ignored a hook" (visible) instead of "Claude inferred approval from something vague" (invisible).
 
 ## After Pushing Commits to an Open PR
 

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: approve-merge
+description: Record per-PR CEO approval for a specific PR merge. ONLY invoke this on an explicit user message that names the PR and says "approved" / "merge" / "ship it". NEVER invoke it on an umbrella "go" / "continue" / "execute the plan" that happens to include a merge step. The whole point of this skill is to make merge approval a discrete, auditable moment — if you are not certain the user's most recent message is an explicit per-PR merge nod, STOP and ask.
+disable-model-invocation: false
+argument-hint: "<pr-number>"
+effort: low
+---
+
+# /approve-merge - Record CEO Per-PR Merge Approval
+
+Writes `.claude/session/reviews/<pr>-ceo.approved` with the current HEAD SHA so the `block-unreviewed-merge.sh` hook will let a `gh pr merge` through. This is the **mechanical enforcement** of the "plan-level 'go' is not merge approval" rule in `.claude/rules/pr-workflow.md`.
+
+## The one rule you must not break
+
+**INVOKE THIS SKILL ONLY ON EXPLICIT, PER-PR, USER-NAMED MERGE APPROVAL.**
+
+The valid invocation triggers look like this:
+
+- "approved" / "approve" / "merge" / "merge it" / "ship it" / "go ahead and merge" — **if and only if** the surrounding context clearly names a specific PR and the PR being asked about is known.
+- "PR #42 is approved" / "yes, merge #42" / "ship #42" — names the PR.
+- A reply to your own "Ready to merge PR #42 — approved?" message that consists of any affirmative token — because you just named the PR and the user is responding to that specific question.
+
+**Invalid triggers** (do NOT run this skill):
+
+- "go" / "continue" / "proceed" / "execute the plan" / "ship it" — **when these are said in response to a plan that happens to include a merge step but is not specifically about the merge**. This is the exact failure mode this skill exists to prevent. See the example in `.claude/rules/pr-workflow.md` § "Plan-level 'go' is NOT merge approval".
+- "yes" / "ok" / "sure" — if you cannot point at a specific "Ready to merge PR #X?" question in the last two turns of conversation, these are too ambiguous.
+- Your own inference that "the user probably wants the merge now because they said 'go' on the plan." NO. Stop and ask explicitly.
+
+**If in doubt: STOP AND ASK.** The cost of one extra "PR #X ready — approved?" question is one message. The cost of a wrong merge is real work to revert.
+
+## Process
+
+### 1. Parse the PR number
+
+Extract from `$ARGUMENTS`. If no argument is given, try to infer from:
+- The current branch's open PR via `gh pr view --json number --jq '.number'`
+- The user's most recent message, if it named a PR explicitly
+
+If the PR number is ambiguous (multiple PRs on the branch, unclear which was approved), STOP and ask the user which PR.
+
+### 2. Sanity-check the user's intent
+
+Before writing the marker, re-read the user's most recent message. Ask yourself:
+
+- Did the user explicitly name this PR, or can I point at a direct "Ready to merge PR #X — approved?" question from me that they are responding to?
+- Is the user's message a standalone merge nod, or is it an umbrella "go" on a broader plan?
+- If the latter — **STOP**. Reply with a per-PR explicit question instead:
+  > "PR #X is ready to merge. Just confirming — explicit approval to merge PR #X, now?"
+
+Only proceed past this step if the user has given an unambiguous per-PR approval.
+
+### 3. Verify the PR state
+
+Run `gh pr view <pr> --json state,isDraft,mergeable,reviewDecision`. Sanity checks:
+
+- `state` must be `OPEN`. Refuse if it's `MERGED`, `CLOSED`, or `DRAFT`.
+- `mergeable` should be `MERGEABLE` or `UNKNOWN` (GitHub hasn't computed yet). Refuse on `CONFLICTING`.
+- `reviewDecision` is informational — the Rex marker is the ground truth for "code-reviewer approved." If Rex hasn't approved yet, refuse (the merge hook will block anyway, but failing fast is kinder).
+
+### 4. Verify the Rex marker exists at current HEAD
+
+The CEO approval is a stamp on top of a Rex-approved HEAD, not a standalone action. Check:
+
+- `.claude/session/reviews/<pr>-rex.approved` exists
+- Its contents match `git rev-parse HEAD`
+
+If Rex's marker is missing or stale, refuse and tell the user to re-invoke the code-reviewer first. Do not write the CEO marker on a stale base.
+
+### 5. Write the CEO marker
+
+```bash
+mkdir -p .claude/session/reviews
+git rev-parse HEAD > .claude/session/reviews/<pr>-ceo.approved
+```
+
+The file contains exactly one line: the 40-character HEAD SHA.
+
+### 6. Confirm to the user
+
+Output a single-line confirmation:
+
+```
+CEO approval recorded for PR #<pr> at <sha>. You can now run: gh pr merge <pr>
+```
+
+**Do NOT run `gh pr merge` yourself in the same turn.** The skill's job ends at recording the marker. The actual merge is a separate tool call that, per the rule, should also be treated as an explicit action. Confirming back to the user gives them a chance to interrupt if something is off (e.g. they approved but then realised they wanted to look at something else first).
+
+## Notes
+
+- The CEO marker is gitignored (`.claude/session/` is in the repo's `.gitignore`). It's session state, not code.
+- Re-running `/approve-merge <pr>` on the same PR is idempotent — it overwrites the marker with the current HEAD, which is useful if the CEO re-approves after a rebase or a small follow-up.
+- New commits to the PR after the marker is written invalidate the approval: the hook will refuse to merge because the SHA no longer matches HEAD. This is intentional — review + approval are bound to a specific commit.
+- The skill intentionally does **not** automate "wait for the user's 'approved' and then run this." The skill exists to be invoked, not to poll.
+
+## Anti-pattern
+
+```
+You: "I'll execute the plan. Step 1: approve-merge, Step 2: gh pr merge."
+CEO: "go"
+You: *invokes /approve-merge*  ← FAILURE
+```
+
+The CEO's "go" was on the plan. It was not a per-PR approval for the merge. The correct flow:
+
+```
+You: *executes the non-merge steps*
+You: "All other steps done. PR #X ready to merge — approved?"
+CEO: "approved"
+You: *invokes /approve-merge X*
+You: *runs gh pr merge X*
+```
+
+Two distinct moments. One is the plan authorization. The other is the merge authorization. They are not the same authorization.

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -59,21 +59,27 @@ Run `gh pr view <pr> --json state,isDraft,mergeable,reviewDecision`. Sanity chec
 
 ### 4. Verify the Rex marker exists at current HEAD
 
-The CEO approval is a stamp on top of a Rex-approved HEAD, not a standalone action. Check:
+The CEO approval is a stamp on top of a Rex-approved HEAD, not a standalone action. Check (using an absolute path anchored at the repo root, not a cwd-relative path):
 
-- `.claude/session/reviews/<pr>-rex.approved` exists
-- Its contents match `git rev-parse HEAD`
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+REX="$REPO_ROOT/.claude/session/reviews/<pr>-rex.approved"
+[ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "$(git rev-parse HEAD)" ]
+```
 
-If Rex's marker is missing or stale, refuse and tell the user to re-invoke the code-reviewer first. Do not write the CEO marker on a stale base.
+If Rex's marker is missing or its SHA doesn't match HEAD, refuse and tell the user to re-invoke the code-reviewer first. Do not write the CEO marker on a stale base.
 
 ### 5. Write the CEO marker
 
+Construct the marker path from the repo root so it doesn't matter which subdirectory the skill was invoked from (you might be inside `workspace/<project>/` at the time). The `block-unreviewed-merge.sh` hook looks for markers at `$(git rev-parse --show-toplevel)/.claude/session/reviews/` — use the same anchor:
+
 ```bash
-mkdir -p .claude/session/reviews
-git rev-parse HEAD > .claude/session/reviews/<pr>-ceo.approved
+REPO_ROOT=$(git rev-parse --show-toplevel)
+mkdir -p "$REPO_ROOT/.claude/session/reviews"
+git rev-parse HEAD > "$REPO_ROOT/.claude/session/reviews/<pr>-ceo.approved"
 ```
 
-The file contains exactly one line: the 40-character HEAD SHA.
+The file contains exactly one line: the 40-character HEAD SHA. **Never use a cwd-relative path** — a marker written to the wrong directory is a silent failure mode: the skill "succeeds", then the hook still blocks the merge with a confusing "CEO marker missing" message pointing at a path that technically exists somewhere else in the tree.
 
 ### 6. Confirm to the user
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ Work on ONE ticket at a time. Complete fully before starting next. Each PR = one
 - **Tests required** -- >80% coverage for domain logic
 - **Lint, typecheck, test, build** must pass before pushing
 - **Code review required** before merge
+- **Explicit per-PR CEO approval required for every merge** -- plan-level "go" / "continue" / "ship it" does NOT authorize any `gh pr merge`. Stop before each merge and ask for a per-PR explicit nod. Mechanically enforced by `block-unreviewed-merge.sh` + the `/approve-merge` skill. Full rationale and examples: @.claude/rules/pr-workflow.md
 - **No hardcoded secrets** -- use environment variables
 
 ### Code Review


### PR DESCRIPTION
## Summary

Closes the failure mode where I merged apexstack PR #10 after a plan-level "go" that was not a per-PR merge approval. The rule existed in prose (`pr-workflow.md § Before gh pr merge`) but was ambiguous about what counts as human approval, and there was no mechanical enforcement for the human side of the 2-reviews gate.

**Incident source:** apexstack PR #10 merged at 2026-04-11T16:41:47Z on a plan-level "go". Content was correct and Rex-approved twice — only the authorization moment was wrong. No revert needed; this PR closes the gap going forward.

## Changes

### Prose

- **`.claude/rules/pr-workflow.md`** — rewrote the "Before `gh pr merge`" section. Added a concrete wrong/right example showing that a plan-level "go" does NOT authorize merges. Listed other destructive actions (force push, branch delete, closing issues with dependents, external posts) that need the same per-action explicit approval.
- **`CLAUDE.md`** — added an explicit bullet under Quality Rules calling out per-PR CEO approval, linking back to the full rule in `pr-workflow.md`.

### Mechanical

- **`.claude/hooks/block-unreviewed-merge.sh`** — now requires **both** approval markers, not just Rex:
  - `.claude/session/reviews/<pr>-rex.approved` (existing) — written by the `code-reviewer` agent
  - `.claude/session/reviews/<pr>-ceo.approved` (new) — written **only** by the `/approve-merge` skill on explicit per-PR user invocation
  - Both must contain the current HEAD SHA; any mismatch blocks the merge with a clear message
- **New `.claude/skills/approve-merge/SKILL.md`** — the skill whose only job is to write the CEO marker. Definition includes explicit valid/invalid invocation triggers and an anti-pattern section describing the exact failure mode the skill exists to prevent ("plan-level go on a plan with a merge step").

### Documentation

- **`.claude/hooks/README.md`** — documents both markers, why there are two ("plan-level go is not merge approval"), and the trust model: the markers are local session state, not a remote trust boundary. Their job is to convert invisible inference failures into visible rule violations. For adversarial trust, rely on GitHub branch-protection rules.

## Smoke tests

Tested against four states of the approval markers, using variable-split test inputs to avoid the "outer Bash matches its own hook" self-trigger that was documented in PR #10:

```
=== 1: no markers at all → block on Rex ===                         exit=2 ✓ (block message shown)
=== 2: Rex marker only → block on CEO with plan-level explanation === exit=2 ✓
=== 3: both markers at HEAD → allow ===                              exit=0 ✓ (silent)
=== 4: CEO marker at stale SHA → block on SHA mismatch ===           exit=2 ✓
```

## Dogfooding

**This PR will itself be the first PR merged under the new rule.** The planned flow:

1. Rex reviews this PR (auto-triggered by `auto-code-review.sh` on PR creation)
2. Rex writes `.claude/session/reviews/11-rex.approved` after a clean pass
3. I stop and ask the CEO explicitly: "PR #11 ready to merge — approved?"
4. On explicit per-PR approval, the CEO (or I, invoking on the CEO's message) runs `/approve-merge 11`
5. The skill writes `.claude/session/reviews/11-ceo.approved` with the current HEAD SHA
6. `gh pr merge 11 --squash` succeeds — both markers match HEAD, hook lets it through
7. If any step is skipped, the hook blocks the merge with a specific message

## Trust model

The approval files are local session state. Claude can technically `rm` or `touch` them — that would be a visible, auditable, grep-able rule violation, which is the whole point. The hook converts "Claude inferred approval from something vague" (invisible) into "Claude wrote a file it wasn't supposed to" (visible). Combined with the prose rule and the memory note, that's the strongest enforcement a shell-based harness can provide without reaching into the chat buffer.

For adversarial trust (not just self-discipline), this hook complements — does not replace — branch protection rules on the remote.

## Glossary

| Term | Definition |
|------|------------|
| Per-PR explicit approval | A CEO message that names a specific PR and says "approved" / "merge" / "ship it" for *that* PR specifically. A plan-level "go" that happens to include a merge step is NOT per-PR explicit approval. |
| CEO marker | `.claude/session/reviews/<pr>-ceo.approved` — contains the HEAD SHA at the time the CEO approved. Written only by the `/approve-merge` skill. |
| Rex marker | `.claude/session/reviews/<pr>-rex.approved` — contains the HEAD SHA at the time Rex approved. Written by the `code-reviewer` agent after a successful review. |
| `/approve-merge` | The only supported way to write the CEO marker. Runs on explicit per-PR user invocation. Refuses if the Rex marker is missing or stale. |
| Plan-level authorization | A user message like "go" / "continue" / "execute the plan" that authorizes the non-destructive steps in a proposed plan but does NOT carry through to merge steps, force pushes, branch deletes, or other hard-to-reverse actions. |
| Two-marker gate | The `block-unreviewed-merge.sh` hook's check that both Rex and CEO markers exist and both SHAs match HEAD before allowing `gh pr merge`. |
| Self-trigger gotcha | The previously-documented issue where the `if: Bash(gh pr merge *)` matcher fires on any outer Bash command containing "gh pr merge" as a substring (including in heredocs). Test inputs must use variable-split to avoid this. |

## Test plan

- [ ] Pull branch, run each of the 4 smoke tests above against `block-unreviewed-merge.sh`
- [ ] Read `.claude/skills/approve-merge/SKILL.md` — are the valid/invalid triggers clear enough that future contributors can't miss the rule?
- [ ] Read `.claude/rules/pr-workflow.md § Plan-level "go" is NOT merge approval` — is the wrong/right example unambiguous?
- [ ] Read the new trust-model paragraph in `.claude/hooks/README.md` — is it clear the hook is about preventing invisible inference, not adversarial users?
- [ ] Code Reviewer (Rex) review
- [ ] **CEO explicit per-PR approval for THIS PR** (dogfooding the rule)

## Links

- Closes #11
- Root incident: apexstack PR #10 merge at 2026-04-11T16:41:47Z
- Companion memory note: `feedback_explicit_merge_approval.md` in the CEO's local memory store

🤖 Generated with [Claude Code](https://claude.com/claude-code)
