### PR TITLE
feat(#14): ticket-vocabulary rule + verify-issue-exists backstops

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -71,9 +71,47 @@ For adversarial trust, rely on remote branch-protection rules (GitHub required r
 
 **What it does:** on every new session, if `.claude/session/onboarded` is missing, injects a reminder telling Claude to run `/onboard` with the user before doing work. The `/onboard` skill asks the day-one discovery questions (project identity, tracker, required checks, reviewers, UI, deploy targets, sensitive topics) and writes the marker plus `.claude/project-config.json`.
 
+## The Ticket-Vocabulary Backstops
+
+These two hooks are the mechanical backstop for the rule in `.claude/rules/ticket-vocabulary.md` — "`Ticket`, `#N`, and dependency notation refer ONLY to real GitHub issues". The rule itself is self-discipline; these hooks catch the downstream symptom (a fabricated `#N` that slipped into a durable artifact).
+
+### 5. PR-title issue verification — `validate-pr-create.sh` (extended)
+
+**Event:** `PreToolUse` on `Bash(gh pr create *)`.
+
+**What it does:** after the existing title-format / glossary / branch-ID checks, extracts the issue number from the PR title (e.g. `14` from `feat(#14): …`) and runs `gh issue view <N> --repo <tracker>` to verify it exists. Blocks PR creation with a clear message if the issue is missing.
+
+**Tracker repo resolution:**
+1. First tries `.tracker_repo` in `.claude/project-config.json` if present
+2. Falls back to parsing the `origin` remote (`owner/repo` from SSH or HTTPS URL)
+
+**Why:** catches the case where Claude built a plan using `Ticket N` vocabulary, forgot to create the real issue, and then went straight to `gh pr create --title "feat(#N): …"`. The title is the moment the fabrication becomes durable. This hook refuses to let that happen.
+
+### 6. Commit-message ref verification — `verify-commit-refs.sh` (new)
+
+**Event:** `PreToolUse` on `Bash(git commit *)`.
+
+**What it does:** parses the commit message from `-m "..."`, `-m '...'`, or `-F <file>` args and scans for issue references matching any of:
+
+- `Closes #N` / `Close #N` / `Closed #N`
+- `Fixes #N` / `Fix #N` / `Fixed #N`
+- `Resolves #N` / `Resolve #N` / `Resolved #N`
+- `Refs #N` / `Ref #N` / `References #N`
+- `Related to #N`
+
+Each referenced number is verified against the tracker repo via `gh issue view`. Blocks the commit if any reference doesn't resolve.
+
+**Limitation:** interactive commits (no `-m` / `-F`) are skipped. Parsing `.git/COMMIT_EDITMSG` before git's own validation would race, and Claude rarely uses the interactive path anyway. Accepted gap — in practice Claude almost always uses `-m` with a HEREDOC.
+
+**Why:** same root as validate-pr-create.sh — commit messages are the other main path where a fabricated `#N` becomes durable. `git log` + `git blame` + GitHub's auto-linking all lean on these references, so wrong ones pollute the permanent record.
+
+### Both hooks are backstops, not primary fixes
+
+The primary fix for the vocabulary-collision failure mode is the **rule** in `.claude/rules/ticket-vocabulary.md`. Read it. The hooks catch downstream symptoms at the moment of durable commitment (PR title, commit message). They cannot see prose output — so the vocabulary rule has to come first, and these hooks are the grep-able artifact trail when the rule fails.
+
 ## Pre-existing Hooks
 
-These were already in place before the enforcement layer and remain unchanged. The ticket-first + merge-gate + auto-review hooks layer on top; nothing below is regressed.
+These were already in place before the enforcement layer and remain unchanged (except `validate-pr-create.sh` which was extended in GH-14 — see above). The newer hooks layer on top; nothing below is regressed.
 
 | Hook | Event | Purpose |
 |------|-------|---------|
@@ -82,7 +120,7 @@ These were already in place before the enforcement layer and remain unchanged. T
 | `validate-branch-name.sh` | PreToolUse / Bash | Warns on non-conforming branch names before push |
 | `check-secrets.sh` | PreToolUse / Bash | Scans commits for hardcoded secrets |
 | `pre-push-gate.sh` | PreToolUse / Bash | Reminds to run lint / typecheck / test / build |
-| `validate-pr-create.sh` | PreToolUse / Bash | Checks PR title format, glossary, branch ID |
+| `validate-pr-create.sh` | PreToolUse / Bash | Checks PR title format, glossary, branch ID, **and verifies the title's issue number exists (extended in GH-14)** |
 
 ## Session State Directory
 

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -3,6 +3,9 @@
 # - PR title matches format: type(TICKET): description
 # - PR body contains a Glossary section
 # - Branch has a ticket ID
+# - The ticket referenced in the title actually exists in the tracker repo
+#   (backstop for the ticket-vocabulary rule — catches fabricated #N that
+#   slipped through prose into a PR title)
 #
 # Customize the ticket pattern below if your team uses a different scheme.
 
@@ -30,9 +33,51 @@ fi
 # Accepts: type(<UPPERCASE-PREFIX 2-10 chars>-<digits>): … or type(#<digits>): …
 # Note: this pattern is intentionally aligned with the pr-title-check.yml
 # CI workflow regex so anything that passes this hook also passes CI.
+TICKET_REF=""
 if [ -n "$TITLE" ]; then
   if ! echo "$TITLE" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\(([A-Z]{2,10}-[0-9]+|#[0-9]+)\):'; then
     ERRORS="${ERRORS}PR title '$TITLE' doesn't match format: type(TICKET-ID): description\n"
+  else
+    # Extract the ticket reference so we can verify it exists
+    TICKET_REF=$(echo "$TITLE" | sed -nE 's/^[a-z]+\(([^)]+)\):.*/\1/p')
+  fi
+fi
+
+# Verify the ticket in the title actually exists in the tracker repo
+# (backstop for ticket-vocabulary.md — catches fabricated #N in PR titles)
+if [ -n "$TICKET_REF" ]; then
+  # Extract digits from the ref (works for both #N and PREFIX-N)
+  TICKET_NUM=$(echo "$TICKET_REF" | grep -oE '[0-9]+$')
+
+  # Resolve tracker repo: prefer .claude/project-config.json, fall back to origin
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+  TRACKER_REPO=""
+  if [ -f "${REPO_ROOT}/.claude/project-config.json" ]; then
+    TRACKER_REPO=$(jq -r '.tracker_repo // empty' "${REPO_ROOT}/.claude/project-config.json" 2>/dev/null)
+  fi
+  if [ -z "$TRACKER_REPO" ]; then
+    # Parse owner/repo from origin remote
+    ORIGIN_URL=$(git remote get-url origin 2>/dev/null)
+    TRACKER_REPO=$(echo "$ORIGIN_URL" | sed -nE 's|.*[:/]([^/:]+/[^/]+)\.git$|\1|p; s|.*[:/]([^/:]+/[^/]+)$|\1|p' | head -1)
+  fi
+
+  if [ -n "$TICKET_NUM" ] && [ -n "$TRACKER_REPO" ]; then
+    if ! gh issue view "$TICKET_NUM" --repo "$TRACKER_REPO" --json state >/dev/null 2>&1; then
+      cat >&2 <<MSG
+BLOCKED: PR title references ${TICKET_REF} but issue #${TICKET_NUM} does not
+exist in ${TRACKER_REPO}.
+
+This is the failure mode the ticket-vocabulary rule exists to prevent — do NOT
+use tracker notation (#N) for plan items that have no real issue behind them.
+See .claude/rules/ticket-vocabulary.md § "The rule".
+
+If you intended to create the PR for a real ticket, verify the number.
+If you were about to file work that has no ticket yet, create one first:
+  gh issue create --repo ${TRACKER_REPO} --title "..."
+and use the returned number in your PR title.
+MSG
+      exit 2
+    fi
   fi
 fi
 

--- a/.claude/hooks/verify-commit-refs.sh
+++ b/.claude/hooks/verify-commit-refs.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# PreToolUse hook on `git commit -m / -F`: scans the commit message for
+# issue references (Closes #N, Refs #N, Fixes #N, Resolves #N, Related to #N)
+# and blocks the commit if any reference points at an issue that doesn't
+# exist in the tracker repo.
+#
+# Backstop for the ticket-vocabulary rule (.claude/rules/ticket-vocabulary.md).
+# The primary enforcement is self-discipline: never use tracker notation for
+# plan items that have no real issue behind them. This hook catches the
+# downstream symptom — a fabricated #N that made it into a commit message
+# on its way to becoming durable history.
+#
+# Interactive commits (no -m / -F) are NOT checked. Parsing .git/COMMIT_EDITMSG
+# before the editor opens would race with git's own validation, and Claude
+# rarely uses the interactive path anyway. Accepted gap.
+#
+# Tracker repo resolves in this order:
+#   1. .claude/project-config.json `.tracker_repo`
+#   2. origin remote (parsed from `git remote get-url origin`)
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Only check on git commit
+if ! echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
+  exit 0
+fi
+
+# Extract the commit message. Try -m "..." / -m '...' / -m $'...' first.
+# Then try -F <file> / --file <file>. If neither, assume interactive — skip.
+MSG=""
+
+# -m 'single quoted'
+MSG=$(echo "$COMMAND" | sed -nE "s/.*-m[[:space:]]+'([^']*)'.*/\1/p" | head -1)
+
+# -m "double quoted" (handle backslash-escaped quotes inside)
+if [ -z "$MSG" ]; then
+  MSG=$(echo "$COMMAND" | sed -nE 's/.*-m[[:space:]]+"([^"]*)".*/\1/p' | head -1)
+fi
+
+# -F <file> / --file <file>
+if [ -z "$MSG" ]; then
+  MSG_FILE=$(echo "$COMMAND" | sed -nE 's/.*(-F|--file)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
+  if [ -n "$MSG_FILE" ] && [ -f "$MSG_FILE" ]; then
+    MSG=$(cat "$MSG_FILE")
+  fi
+fi
+
+# No message found → interactive commit or parse failure. Skip.
+if [ -z "$MSG" ]; then
+  exit 0
+fi
+
+# Extract issue references. Patterns matched (case-insensitive):
+#   Closes #N / Close #N / Closed #N
+#   Fixes #N / Fix #N / Fixed #N
+#   Resolves #N / Resolve #N / Resolved #N
+#   Refs #N / Ref #N / References #N / Related to #N
+# One reference per line is the common pattern; multiples in one line also work.
+REFS=$(echo "$MSG" | grep -oEi '\b(close[sd]?|fix(e[sd])?|resolve[sd]?|ref(s|erences)?|related to)[[:space:]]+#[0-9]+' | grep -oE '#[0-9]+' | sort -u)
+
+if [ -z "$REFS" ]; then
+  exit 0
+fi
+
+# Resolve tracker repo
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+TRACKER_REPO=""
+if [ -f "${REPO_ROOT}/.claude/project-config.json" ]; then
+  TRACKER_REPO=$(jq -r '.tracker_repo // empty' "${REPO_ROOT}/.claude/project-config.json" 2>/dev/null)
+fi
+if [ -z "$TRACKER_REPO" ]; then
+  ORIGIN_URL=$(git remote get-url origin 2>/dev/null)
+  TRACKER_REPO=$(echo "$ORIGIN_URL" | sed -nE 's|.*[:/]([^/:]+/[^/]+)\.git$|\1|p; s|.*[:/]([^/:]+/[^/]+)$|\1|p' | head -1)
+fi
+
+if [ -z "$TRACKER_REPO" ]; then
+  echo "WARN: verify-commit-refs.sh could not resolve tracker repo. Skipping." >&2
+  exit 0
+fi
+
+# Verify each referenced issue exists
+MISSING=""
+for REF in $REFS; do
+  NUM=$(echo "$REF" | tr -d '#')
+  if ! gh issue view "$NUM" --repo "$TRACKER_REPO" --json state >/dev/null 2>&1; then
+    MISSING="${MISSING}${REF} "
+  fi
+done
+
+if [ -n "$MISSING" ]; then
+  cat >&2 <<MSG
+BLOCKED: Commit message references issues that do not exist in ${TRACKER_REPO}:
+  ${MISSING}
+
+This is the failure mode the ticket-vocabulary rule exists to prevent — do NOT
+use tracker notation (Closes #N, Refs #N, etc.) for plan items that have no
+real issue behind them. See .claude/rules/ticket-vocabulary.md.
+
+If you intended to reference a real issue, verify the number(s).
+If you were about to commit work that has no ticket yet, create one first:
+  gh issue create --repo ${TRACKER_REPO} --title "..."
+and use the returned number in your commit message.
+
+If the reference is truly informational (cross-repo link that can't be verified
+with \`gh issue view\`), write it as a plain URL instead of #N notation.
+MSG
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/verify-commit-refs.sh
+++ b/.claude/hooks/verify-commit-refs.sh
@@ -30,21 +30,37 @@ if ! echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
   exit 0
 fi
 
-# Extract the commit message. Try -m "..." / -m '...' / -m $'...' first.
-# Then try -F <file> / --file <file>. If neither, assume interactive — skip.
+# Extract the commit message. Try -m "..." / -m '...' first, then -F <file>.
+# If neither is present, assume interactive commit — skip.
+#
+# IMPORTANT: Claude and humans both commonly use multi-line -m arguments via
+# HEREDOC substitution like `git commit -m "$(cat <<EOF ... EOF)"`, which means
+# the literal -m value spans multiple lines in the command string. `sed -nE`
+# processes stdin line-by-line by default, so a regex like `-m "([^"]*)"`
+# cannot span lines and silently fails to match.
+#
+# Fix: flatten the command string with `tr '\n' ' '` before sed processing.
+# The message then parses as a single logical line. The ref-pattern grep
+# below doesn't care about line breaks either way.
+#
+# Without this flattening, the hook was INERT for any multi-line commit —
+# which is the default shape for Claude-generated commits. Confirmed via
+# smoke test before the fix.
+COMMAND_FLAT=$(echo "$COMMAND" | tr '\n' ' ')
+
 MSG=""
 
 # -m 'single quoted'
-MSG=$(echo "$COMMAND" | sed -nE "s/.*-m[[:space:]]+'([^']*)'.*/\1/p" | head -1)
+MSG=$(echo "$COMMAND_FLAT" | sed -nE "s/.*-m[[:space:]]+'([^']*)'.*/\1/p" | head -1)
 
-# -m "double quoted" (handle backslash-escaped quotes inside)
+# -m "double quoted"
 if [ -z "$MSG" ]; then
-  MSG=$(echo "$COMMAND" | sed -nE 's/.*-m[[:space:]]+"([^"]*)".*/\1/p' | head -1)
+  MSG=$(echo "$COMMAND_FLAT" | sed -nE 's/.*-m[[:space:]]+"([^"]*)".*/\1/p' | head -1)
 fi
 
 # -F <file> / --file <file>
 if [ -z "$MSG" ]; then
-  MSG_FILE=$(echo "$COMMAND" | sed -nE 's/.*(-F|--file)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
+  MSG_FILE=$(echo "$COMMAND_FLAT" | sed -nE 's/.*(-F|--file)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
   if [ -n "$MSG_FILE" ] && [ -f "$MSG_FILE" ]; then
     MSG=$(cat "$MSG_FILE")
   fi

--- a/.claude/rules/ticket-vocabulary.md
+++ b/.claude/rules/ticket-vocabulary.md
@@ -1,0 +1,117 @@
+# Ticket Vocabulary — Reserved Terms
+
+Tracker vocabulary is **reserved for real GitHub issues**, never for in-conversation planning. This rule exists to prevent the "vocabulary collision" failure mode where Claude's internal plan decomposition wears tracker clothing and the user reasonably reads it as tracker state.
+
+## The rule
+
+**`Ticket`, `#N`, and dependency notation (`blocked by #N`, `depends on #N`, `refs #N`, `closes #N`) refer ONLY to real GitHub issues that exist in a tracker and can be fetched with `gh issue view`.**
+
+Do not use any of these terms for:
+
+- Plan items you just thought of
+- Work breakdowns presented in conversation
+- Proposed decompositions that the user hasn't agreed to ship to a tracker yet
+- Examples, hypotheticals, or design sketches
+
+When you need to decompose work *in conversation* without committing it to a tracker, use one of these **safe vocabularies** instead:
+
+| Safe | Why it's safe |
+|------|---------------|
+| `Step 1`, `Step 2`, … | Obviously sequential prose, not a tracker unit |
+| `Item A`, `Item B`, … | Lettered, clearly a list convention |
+| `Task 1`, `Task 2`, … | Generic work unit, not tracker-specific |
+| Plain bullets or numbered lists | Zero tracker semantics |
+| `Phase 1 — X`, `Phase 2 — Y`, … | Sequencing language |
+
+**Never:**
+
+- `Ticket 1: X` / `Ticket 2: Y`
+- `#1`, `#2`, … (when referring to plan items, not real issues)
+- `blocked by #1` (when #1 is a plan item, not a real issue)
+
+The problem is not the number 1. The problem is the combination of the word "Ticket" *and* the `#N` notation *and* dependency arrows, which together paint tracker state on top of prose. Any one of those alone is usually fine; together they fabricate a tracker view.
+
+## The boundary-crossing rule
+
+If your plan includes items that need **tracker properties** — blocking relationships that persist across sessions, assignment to a specific owner, QA state transitions, cross-session tracking, merge-time auto-closing — then that's the moment to **stop planning in prose and call `gh issue create` for each**.
+
+You cannot present a plan as a tracker view of work that is not in the tracker. Call the tool or call it planning. There is no middle ground.
+
+### The checkpoint
+
+Any time you catch yourself about to type `Ticket N:` or `#N` or `blocked by #N` in a plan response, STOP and ask:
+
+1. **Does this reference an issue that already exists in a tracker?** If yes, you already fetched or created it — fine to use tracker notation. Otherwise:
+2. **Does this plan item need tracker properties?** If yes, run `gh issue create` now for each item that needs one, collect the real numbers, and use those in your response. Otherwise:
+3. **Rewrite with safe vocabulary** (`Step N`, `Item A`, plain bullets).
+
+The cost of asking the user "do you want me to create these as real issues first?" is one message. The cost of a fabricated tracker view that the user takes as real is much higher — they act on it, assign people, plan sprints, and only discover later that none of the tickets exist.
+
+## Anti-pattern (2026-04-11 incident)
+
+This is the exact output shape that triggered this rule. A friend of the CEO ran ApexStack on an email-processor backlog and saw:
+
+```
+Ticket 1: Test Infrastructure Setup
+Ticket 2: Replace Email Processor Stubs › blocked by #1
+Ticket 3: Email Scheduler Tests › blocked by #1, #2
+Ticket 4: Fix Email Sender Stubs › blocked by #1
+Ticket 5: CSV Importer Integration Tests › blocked by #1
+Ticket 6: CI Pipeline › blocked by #1
+Ticket 7: Webhook + Cron Route Tests › blocked by #1, #5
+Ticket 8: Public API Route Tests › blocked by #1, #5
+Ticket 9: Phone + Background Processor Tests › blocked by #1
+Ticket 10: AI Mock Tests for CI › blocked by #1
+```
+
+The user reasonably assumed these were real GitHub issues and asked "where did it create them?" The agent admitted: nowhere. They didn't exist. It was the agent's internal plan decomposition wearing tracker vocabulary. Even when the user said "follow SDLC", the agent kept regenerating similar output because it had no separate dialect for "plan" vs "tracker view".
+
+### Corrected version (same content, safe vocabulary)
+
+```
+Here's a proposed breakdown for the email-processor backlog. **None of
+these exist as GitHub issues yet** — tell me which ones to create as
+real tickets and I'll run `gh issue create` for each.
+
+Step 1 — Test Infrastructure Setup (foundation for everything below)
+Step 2 — Replace Email Processor Stubs (needs Step 1 done first)
+Step 3 — Email Scheduler Tests (needs Steps 1 and 2)
+Step 4 — Fix Email Sender Stubs (needs Step 1)
+Step 5 — CSV Importer Integration Tests (needs Step 1)
+Step 6 — CI Pipeline (needs Step 1)
+Step 7 — Webhook + Cron Route Tests (needs Steps 1 and 5)
+Step 8 — Public API Route Tests (needs Steps 1 and 5)
+Step 9 — Phone + Background Processor Tests (needs Step 1)
+Step 10 — AI Mock Tests for CI (needs Step 1)
+
+Want me to create GitHub issues for all 10, or only a subset? Once I
+have real issue numbers, I'll re-post the plan using #N notation so you
+can link and track.
+```
+
+Differences from the anti-pattern:
+
+1. `Step N` instead of `Ticket N` — clearly a prose decomposition, not a tracker list
+2. "needs Step N" instead of "blocked by #N" — prose dependency, not tracker semantics
+3. **Explicit disclaimer** at the top: "None of these exist as GitHub issues yet"
+4. **Explicit checkpoint** at the bottom: asks the user whether to cross the boundary into real issues
+5. **Commits to re-posting with real `#N`** once the tickets exist
+
+The corrected version is slightly longer but removes the ambiguity entirely. The user cannot mistake it for tracker state.
+
+## Backstop enforcement
+
+This rule is primarily self-discipline. It is also backed up by two mechanical hooks that catch the downstream symptoms if the rule fails:
+
+| Hook | Event | What it catches |
+|------|-------|-----------------|
+| `validate-pr-create.sh` | `PreToolUse` on `gh pr create` | PR titles that reference an issue number which doesn't exist in the tracker repo |
+| `verify-commit-refs.sh` | `PreToolUse` on `git commit -m / -F` | Commit messages with `Closes #N` / `Refs #N` / `Fixes #N` / `Resolves #N` pointing at issues that don't exist |
+
+Both hooks block at the moment the fabricated reference would be committed to a durable artifact (PR title, commit message). They cannot see conversation prose — that's why the rule comes first and the hooks are labeled **backstops**, not the primary fix.
+
+## Why not lint Claude's prose output?
+
+Considered and rejected. Hooks run on tool calls, not on assistant text output. The only way to catch a fabricated `#N` in prose would be a self-discipline check Claude runs at the end of every response — which is exactly the failure mode this rule is trying to prevent. If Claude could reliably remember to check itself, the vocabulary collision wouldn't happen in the first place.
+
+For adversarial trust beyond self-discipline, rely on GitHub branch protection, CODEOWNERS, and required status checks — those are a separate layer this rule does not replace.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,6 +46,11 @@
           },
           {
             "type": "command",
+            "if": "Bash(git commit *)",
+            "command": ".claude/hooks/verify-commit-refs.sh"
+          },
+          {
+            "type": "command",
             "if": "Bash(git push *)",
             "command": ".claude/hooks/pre-push-gate.sh"
           },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Work on ONE ticket at a time. Complete fully before starting next. Each PR = one
 - **Lint, typecheck, test, build** must pass before pushing
 - **Code review required** before merge
 - **Explicit per-PR CEO approval required for every merge** -- plan-level "go" / "continue" / "ship it" does NOT authorize any `gh pr merge`. Stop before each merge and ask for a per-PR explicit nod. Mechanically enforced by `block-unreviewed-merge.sh` + the `/approve-merge` skill. Full rationale and examples: @.claude/rules/pr-workflow.md
+- **Tracker vocabulary is reserved** -- the words `Ticket`, `#N`, and dependency notation (`blocked by #N`, `depends on #N`) refer ONLY to real GitHub issues that exist in a tracker. Never apply them to in-conversation plan items. When decomposing work in chat, use `Step N` / `Item N` / plain bullets. Crossing the boundary from "plan item" to "tracker item" requires an explicit `gh issue create`. Full rule and anti-pattern example: @.claude/rules/ticket-vocabulary.md
 - **No hardcoded secrets** -- use environment variables
 
 ### Code Review


### PR DESCRIPTION
## Summary

Closes the **vocabulary-collision** failure mode where Claude's internal plan decomposition wears tracker clothing and the user reasonably reads it as tracker state. Root cause identified on 2026-04-11 after a friend of the CEO hit it on a real project: the agent presented a 10-item "Ticket N ... blocked by #M" plan in chat, none of which existed on GitHub, and the user thought they were real issues.

The fix is primarily a **rule** (`.claude/rules/ticket-vocabulary.md`) that reserves tracker vocabulary for real issues only, backed by two mechanical **backstops** that catch the downstream symptom when the rule fails.

## Side-by-side repro (the exact 2026-04-11 shape)

**Before this PR — what actually shipped to the user:**

```
Ticket 1: Test Infrastructure Setup
Ticket 2: Replace Email Processor Stubs > blocked by #1
Ticket 3: Email Scheduler Tests > blocked by #1, #2
Ticket 4: Fix Email Sender Stubs > blocked by #1
Ticket 5: CSV Importer Integration Tests > blocked by #1
Ticket 6: CI Pipeline > blocked by #1
Ticket 7: Webhook + Cron Route Tests > blocked by #1, #5
Ticket 8: Public API Route Tests > blocked by #1, #5
Ticket 9: Phone + Background Processor Tests > blocked by #1
Ticket 10: AI Mock Tests for CI > blocked by #1
```

**After this PR — same content, safe vocabulary + explicit boundary:**

```
Here's a proposed breakdown for the email-processor backlog. None of
these exist as GitHub issues yet - tell me which ones to create as
real tickets and I'll run `gh issue create` for each.

Step 1 - Test Infrastructure Setup (foundation for everything below)
Step 2 - Replace Email Processor Stubs (needs Step 1 done first)
Step 3 - Email Scheduler Tests (needs Steps 1 and 2)
...
Step 10 - AI Mock Tests for CI (needs Step 1)

Want me to create GitHub issues for all 10, or only a subset? Once I
have real issue numbers, I'll re-post the plan using #N notation.
```

Differences: `Step N` instead of `Ticket N`, "needs Step N" instead of "blocked by #N", explicit disclaimer that nothing exists yet, explicit checkpoint asking whether to cross the boundary into real issues.

## Changes

### New rule (primary)

- **`.claude/rules/ticket-vocabulary.md`** — reserves `Ticket`, `#N`, and dependency notation (`blocked by #N`, `depends on #N`, `refs #N`, `closes #N`) for real GitHub issues only. Prescribes safe vocabulary for in-conversation planning (`Step N`, `Item A`, plain bullets, phases). Includes a boundary-crossing rule: if plan items need tracker properties, STOP and run `gh issue create` before presenting. Contains the 2026-04-11 anti-pattern verbatim and a corrected version side-by-side.
- **`CLAUDE.md`** — new bullet under Quality Rules linking the vocabulary rule, placed next to the per-PR merge approval bullet. Both are "don't fake process state" rules.

### Mechanical backstops (secondary)

- **`.claude/hooks/validate-pr-create.sh`** — extended. After the existing title-format / glossary / branch-ID checks, extracts the issue number from the PR title (e.g. `14` from `feat(#14): ...`) and runs `gh issue view <N> --repo <tracker>` to verify it exists. Blocks PR creation with a clear message if the referenced issue is missing. Tracker repo resolves from `.claude/project-config.json` first, falls back to the origin remote parsed from `git remote get-url origin`.
- **`.claude/hooks/verify-commit-refs.sh`** (new) — `PreToolUse` on `Bash(git commit *)`. Parses the commit message from `-m "..."`, `-m '...'`, or `-F <file>` args. Scans for `Closes #N`, `Fixes #N`, `Resolves #N`, `Refs #N`, `Related to #N` patterns and verifies each against the tracker repo. Blocks the commit if any reference doesn't resolve. Interactive commits (no `-m`/`-F`) are silently skipped — accepted gap, Claude rarely uses that path.
- **`.claude/settings.json`** — registers the new hook under the existing `Bash(git commit *)` matcher, right after `check-secrets.sh`. Pre-existing Rex/CEO merge-gate block untouched.

### Documentation

- **`.claude/hooks/README.md`** — new "Ticket-Vocabulary Backstops" section documenting both hooks with tracker-repo resolution rules, the `-m`/`-F` parsing limitation, and an explicit note that these are **backstops**, not the primary fix. Pre-existing hooks table notes that `validate-pr-create.sh` was extended in this ticket.

## Smoke tests

All 7 passed locally, using variable-split test inputs to avoid the self-trigger gotcha documented in the hooks README:

```
=== 1: settings.json jq parse ===                                       valid ✓
=== 2: validate-pr-create allows real #11 in title ===                   exit=0 ✓
=== 3: validate-pr-create blocks fake #999999 in title ===               exit=2 ✓ (block message)
=== 4: verify-commit-refs allows real #11 in -m message ===              exit=0 ✓
=== 5: verify-commit-refs blocks fake #999999 in -m message ===          exit=2 ✓ (block message)
=== 6: verify-commit-refs skips interactive commit (no -m/-F) ===         exit=0 ✓
=== 7: verify-commit-refs allows no-ref messages silently ===             exit=0 ✓
```

One real-life dogfooding moment: the commit for this PR has `Closes #14` in its body, and `verify-commit-refs.sh` fired on that commit. Because #14 exists in this repo, the hook silently allowed the commit through. First real-world use, working as designed.

## Why the rule comes first

The hooks catch **downstream symptoms** — a fabricated `#N` that made it into a PR title or commit message. They cannot inspect Claude's prose output (hooks only see tool calls). So:

1. The vocabulary rule has to come first as self-discipline
2. The hooks are the grep-able artifact trail that closes the loop at the moment fabrication becomes durable
3. The "lint Claude's prose output for #N patterns before sending" idea was considered and rejected — it would require Claude to reliably remember to check itself, which is exactly the failure mode this ticket exists to prevent

For adversarial trust beyond self-discipline, rely on GitHub branch protection, CODEOWNERS, and required status checks — the hooks don't replace that layer, only complement it.

## Glossary

| Term | Definition |
|------|------------|
| Tracker vocabulary | The words `Ticket`, `#N`, and dependency notation (`blocked by #N`, `depends on #N`, `refs #N`, `closes #N`) that refer to GitHub issues. Reserved for real issues only by this PR. |
| Plan vocabulary | Safe alternatives for in-conversation decomposition: `Step N`, `Item A`, `Task 1`, plain bullets, `Phase N`. Obviously not tracker state. |
| Vocabulary collision | The failure mode where Claude uses tracker vocabulary for internal plan items because it has no separate dialect, and the user reads the output as tracker state. Named and fixed by this PR. |
| Boundary-crossing rule | "If plan items need tracker properties, STOP and run `gh issue create` before presenting." The moment a plan becomes a tracker view. |
| Backstop hook | A hook that catches a downstream symptom of a rule violation (e.g. a fabricated `#N` in a PR title). Labeled as such to distinguish from primary enforcement. |
| Tracker repo resolution | The order in which the hooks resolve which repo to query: (1) `.claude/project-config.json .tracker_repo`, (2) origin remote via `git remote get-url origin`. |
| Self-trigger gotcha | Previously documented issue where `if: Bash(gh pr merge *)` / `Bash(gh pr create *)` matchers fire on any outer Bash command containing the literal string (e.g. in a heredoc). Test inputs must use variable-split to avoid this. |

## Test plan

- [ ] Pull branch, run the 7 smoke tests above locally
- [ ] Read `.claude/rules/ticket-vocabulary.md` — is the rule unambiguous, and does the anti-pattern example match the 2026-04-11 failure shape?
- [ ] Read the new "Ticket-Vocabulary Backstops" section of `.claude/hooks/README.md` — clear that the hooks are backstops, not primary fixes?
- [ ] Code Reviewer (Rex) review
- [ ] **Explicit per-PR CEO approval for this PR** (per the rule merged in #11)

## Links

- Closes #14
- Root-cause rule merged alongside: #11 (explicit per-merge approval) — commit `646302e`
- Sibling follow-ups still open: #13 (CLAUDE.md rule audit), #15 (`.claude/` duplication cleanup), plus the 3 deferred nice-to-haves from #12 not yet ticketed
- Source incident: sibling project test run, 2026-04-11
- Diagnostic reframing from "fabrication" to "vocabulary collision": CEO observation, 2026-04-11 post-merge of #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
