### PR TITLE
feat(#13): rule-audit hooks — AgDR-for-arch, design review, red-CI, commit-format

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -109,6 +109,115 @@ Each referenced number is verified against the tracker repo via `gh issue view`.
 
 The primary fix for the vocabulary-collision failure mode is the **rule** in `.claude/rules/ticket-vocabulary.md`. Read it. The hooks catch downstream symptoms at the moment of durable commitment (PR title, commit message). They cannot see prose output — so the vocabulary rule has to come first, and these hooks are the grep-able artifact trail when the rule fails.
 
+## The Rule-Mechanization Hooks (GH-13)
+
+Four more hooks added by the rule-audit ticket ([#13](https://github.com/me2resh/apexstack/issues/13)) and recorded in [`docs/agdr/AgDR-0001-rule-mechanization-hooks.md`](../../docs/agdr/AgDR-0001-rule-mechanization-hooks.md). Each closes a specific "prose rule the model drops under pressure" gap that the audit surfaced.
+
+### 7. AgDR-for-arch-changes — `require-agdr-for-arch-changes.sh`
+
+**Event:** `PreToolUse` on `Bash(git commit *)`.
+
+**What it does:** parses the commit message and the staged diff. If any staged file matches the architecture path list, requires **either** (a) a new AgDR file staged alongside (`docs/agdr/AgDR-NNNN-*.md`), **or** (b) an AgDR reference in the commit message (`AgDR-NNNN` or `docs/agdr/AgDR-`). Blocks the commit otherwise.
+
+**Default architecture paths** (regex):
+
+```
+infrastructure/           # terraform, pulumi, cdk, cfn layouts
+\.tf$ / \.tfvars$         # terraform files
+^terraform/
+^docker-compose.*\.ya?ml$ # container orchestration
+^Dockerfile               # dockerfiles
+^\.github/workflows/      # CI/CD pipeline changes
+```
+
+**Customize:** set `.architecture_paths` in `.claude/project-config.json` to a JSON array of regex patterns. The default list is deliberately narrow — see AgDR-0001 for why dependency manifests (`package.json`, `go.mod`) and API schemas are explicitly excluded.
+
+**Enforces:** `.claude/rules/agdr-decisions.md § Enforcement` — specifically the line "Pre-commit hook warns if architecture files changed without an AgDR reference", which was prose-only until this hook shipped.
+
+### 8. Design-review-for-UI merge gate — `require-design-review-for-ui.sh`
+
+**Event:** `PreToolUse` on `Bash(gh pr merge *)`.
+
+**What it does:** if the PR's diff touches any UI file, requires a design-approval marker at `.claude/session/reviews/<pr>-design.approved` with a SHA matching HEAD. Non-UI PRs bypass silently.
+
+**Default UI paths** (regex):
+
+```
+\.tsx$                    # React (TSX only, NOT plain .ts)
+\.jsx$                    # React (JSX only, NOT plain .js)
+\.vue$
+\.svelte$
+\.css$ / \.scss$ / \.sass$ / \.less$
+design-tokens
+```
+
+**Critical note:** `.tsx`/`.jsx` are matched **exactly**, not as `.tsx?` / `.jsx?`. The original draft had the regex-optional form, which also matched plain `.ts` and `.js` files — caught in smoke testing and fixed before merge. Server-side TypeScript/JavaScript should never trigger a design gate.
+
+**Customize:** `.ui_paths` in `.claude/project-config.json`.
+
+**Marker writing:** there is no `/approve-design` skill yet; the design reviewer (or UI Designer role) writes the marker manually:
+
+```bash
+mkdir -p .claude/session/reviews
+git rev-parse HEAD > .claude/session/reviews/<pr>-design.approved
+```
+
+For projects that deliberately skip design review (admin tools, internal dashboards), `touch .claude/session/reviews/<pr>-design.approved` is a visible, auditable "we decided to skip" artifact rather than an invisible omission. Future ticket: add a `/skip-design-review` skill that records the reason alongside the marker.
+
+**Enforces:** `.claude/rules/pr-quality.md § "Design Review (UI Changes)"` and `workflows/code-review.md § "UI Designer (conditional)"` — both prose-only until this hook shipped.
+
+### 9. No-red-CI merge gate — `block-merge-on-red-ci.sh`
+
+**Event:** `PreToolUse` on `Bash(gh pr merge *)`.
+
+**What it does:** runs `gh pr checks <pr>` on the target PR and blocks if any check is failing, cancelled, timed out, pending, or in-progress.
+
+**State handling:**
+
+| State | Behavior |
+|-------|----------|
+| All green | Allow |
+| Any failing / cancelled / timed out | **Block** with the check output in the error message |
+| Any pending / in-progress / queued | **Block** (pending is not green; wait for CI to finish, then retry) |
+| "No checks reported" (no CI configured) | Allow with a NOTE to stderr — legitimate state for early apexstack forks |
+
+**Enforces:** `.claude/rules/pr-quality.md § "No Red CI Before Merge"` — "Never merge with red CI, even if the failure is pre-existing or unrelated." Was prose-only.
+
+### 10. Commit-format validator — `validate-commit-format.sh`
+
+**Event:** `PreToolUse` on `Bash(git commit *)`.
+
+**What it does:** parses the commit message from `-m` or `-F` args (multi-line safe, same pattern as `verify-commit-refs.sh`) and validates the subject line against:
+
+```
+^(feat|fix|refactor|test|docs|chore|style|perf|build|ci|revert)(\([^)]+\))?:[[:space:]]+.+
+```
+
+Accepts `type: subject` and `type(scope): subject`. Rejects subjects without a valid type prefix.
+
+**Why this list of types:** identical to the PR-title type list in `git-conventions.md`, plus `revert` which PR titles allow. Keeping the commit-type list aligned with the PR-title list prevents "commit passes but PR title using the same type fails" asymmetry.
+
+**Interactive commits (no `-m` / `-F`)** are skipped — accepted gap, matches sibling hooks' policy.
+
+**Enforces:** `.claude/rules/git-conventions.md § "Commit Message Format"` — was prose-only.
+
+## Settings Ordering Note
+
+The new hooks are registered in `.claude/settings.json` alongside the existing ones on the same `Bash(git commit *)` / `Bash(gh pr merge *)` matchers. The Claude Code harness runs all matching hooks sequentially, and **any exit-2 blocks the tool call**. Order of registration within a matcher block is execution order. Current order (GH-13 additions shown in **bold**):
+
+**On `git commit`:**
+1. `check-secrets.sh`
+2. `verify-commit-refs.sh`
+3. **`validate-commit-format.sh`**
+4. **`require-agdr-for-arch-changes.sh`**
+
+**On `gh pr merge`:**
+1. `block-unreviewed-merge.sh` (Rex + CEO markers)
+2. **`require-design-review-for-ui.sh`**
+3. **`block-merge-on-red-ci.sh`**
+
+The ordering is deliberate: cheap local checks first, expensive remote checks (`gh pr checks`) last, so that a merge already blocked by Rex/CEO/design markers doesn't pay the network cost.
+
 ## Pre-existing Hooks
 
 These were already in place before the enforcement layer and remain unchanged (except `validate-pr-create.sh` which was extended in GH-14 — see above). The newer hooks layer on top; nothing below is regressed.
@@ -117,10 +226,10 @@ These were already in place before the enforcement layer and remain unchanged (e
 |------|-------|---------|
 | `block-git-add-all.sh` | PreToolUse / Bash | Blocks `git add -A / . / --all` |
 | `block-main-push.sh` | PreToolUse / Bash | Blocks pushing to `main` / `master` |
-| `validate-branch-name.sh` | PreToolUse / Bash | Warns on non-conforming branch names before push |
+| `validate-branch-name.sh` | PreToolUse / Bash | **Warns** on non-conforming branch names before push (warning-only; warning→blocker upgrade deferred to a follow-up ticket — breaking change) |
 | `check-secrets.sh` | PreToolUse / Bash | Scans commits for hardcoded secrets |
 | `pre-push-gate.sh` | PreToolUse / Bash | Reminds to run lint / typecheck / test / build |
-| `validate-pr-create.sh` | PreToolUse / Bash | Checks PR title format, glossary, branch ID, **and verifies the title's issue number exists (extended in GH-14)** |
+| `validate-pr-create.sh` | PreToolUse / Bash | **Warns** on title format / glossary / branch ID. **Blocks** when the title's issue number doesn't exist in the tracker (extended in GH-14). Warning→blocker upgrade for the format checks deferred. |
 
 ## Session State Directory
 

--- a/.claude/hooks/block-merge-on-red-ci.sh
+++ b/.claude/hooks/block-merge-on-red-ci.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# PreToolUse hook on `gh pr merge`: blocks the merge if any required CI
+# check is failing, pending, or cancelled.
+#
+# Enforces .claude/rules/pr-quality.md § "No Red CI Before Merge" —
+# "Never merge with red CI - even if the failure is pre-existing or
+# unrelated. Fix the pre-existing issue first (separate commit), rebase
+# the PR so all checks are green, and only then merge." Was prose-only
+# until this hook shipped.
+#
+# Uses `gh pr checks <pr>` which returns one line per check with status.
+# Exit codes:
+#   0 = all checks passed (and none required are missing)
+#   1 = at least one check failed, was cancelled, or skipped
+#   8 = no checks at all
+#
+# The hook allows:
+#   - exit 0 (all green)
+#   - exit 8 if the repo has no CI (gh pr checks returns "no checks" — allow)
+# Blocks:
+#   - exit 1 (red CI)
+#   - any check with state FAILURE | CANCELLED | TIMED_OUT
+#
+# Pending checks (IN_PROGRESS | QUEUED): BLOCKED. The rule says all checks
+# must be green; pending is not green. Wait for CI to finish, then retry.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+merge\b'; then
+  exit 0
+fi
+
+# Extract PR number (same approach as the other merge-gate hooks)
+PR_NUMBER=$(echo "$COMMAND" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*' | grep -oE '[0-9]+' | head -1)
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null)
+fi
+
+if [ -z "$PR_NUMBER" ]; then
+  # Another hook will handle "no PR number" — skip
+  exit 0
+fi
+
+# Query checks. gh pr checks returns text output; we check both the exit code
+# and a "no checks reported" substring — the latter is how gh reports the
+# genuinely-unchecked case regardless of exit code version.
+CHECKS_OUTPUT=$(gh pr checks "$PR_NUMBER" 2>&1)
+CHECKS_RC=$?
+
+# "no checks reported on the 'X' branch" — legitimate no-CI state. Allow.
+# Projects without CI (or branches without the expected workflow wiring)
+# hit this path. Log a single-line note so the user knows the gate was a no-op.
+if echo "$CHECKS_OUTPUT" | grep -q "no checks reported"; then
+  echo "NOTE: PR #${PR_NUMBER} has no CI checks configured. Merge-on-red-CI gate is a no-op for this PR." >&2
+  exit 0
+fi
+
+if [ "$CHECKS_RC" = "0" ]; then
+  # All green — allow
+  exit 0
+fi
+
+# Red CI (exit 1) or unknown non-zero. Build a readable report.
+FAILED_COUNT=$(echo "$CHECKS_OUTPUT" | grep -c -E '^(fail|FAIL|✗|X)' 2>/dev/null || echo 0)
+PENDING_COUNT=$(echo "$CHECKS_OUTPUT" | grep -c -E '^(pending|PENDING|\*|-)' 2>/dev/null || echo 0)
+
+cat >&2 <<MSG
+BLOCKED: PR #${PR_NUMBER} has red CI. Cannot merge.
+
+\`gh pr checks ${PR_NUMBER}\` reported failures or pending checks:
+
+$(echo "$CHECKS_OUTPUT" | head -30 | sed 's/^/  /')
+
+ApexStack rule (.claude/rules/pr-quality.md § "No Red CI Before Merge"):
+
+  "Never merge with red CI — even if the failure is pre-existing or
+  unrelated. Fix the pre-existing issue first (separate commit), rebase
+  the PR so all checks are green, and only then merge."
+
+To unblock:
+
+  1. Look at the failing check logs: \`gh pr checks ${PR_NUMBER} --watch\`
+     or click through from https://github.com/{owner}/{repo}/pull/${PR_NUMBER}
+  2. If the failure is in YOUR change, fix it and push
+  3. If the failure is PRE-EXISTING (CI was already red on main), fix the
+     pre-existing issue in a separate commit on this branch, then retry
+  4. If checks are PENDING, wait for them to finish, then retry
+  5. Re-invoke Rex after any new commit (re-review required)
+  6. Retry \`gh pr merge ${PR_NUMBER}\`
+
+No exceptions. Not even for "unrelated" failures. Red CI stays red until
+someone fixes it — that's the whole point of the rule.
+MSG
+exit 2

--- a/.claude/hooks/require-agdr-for-arch-changes.sh
+++ b/.claude/hooks/require-agdr-for-arch-changes.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# PreToolUse hook on `git commit`: when the staged diff touches architecture
+# files, require either:
+#   (a) an AgDR reference in the commit message (AgDR-NNNN / docs/agdr/AgDR-…), OR
+#   (b) a new AgDR file in the staged changes (docs/agdr/AgDR-NNNN-*.md)
+#
+# Enforces .claude/rules/agdr-decisions.md § "Pre-commit hook warns if
+# architecture files changed without an AgDR reference" — which was prose-only
+# until this hook shipped.
+#
+# What counts as "architecture":
+#   - infrastructure/**              (terraform, pulumi, cdk, cfn)
+#   - *.tf, *.tfvars                 (terraform)
+#   - docker-compose*.yml, Dockerfile* (container orchestration)
+#   - .github/workflows/**           (CI/CD pipeline changes)
+#
+# Deliberately NARROW. Dependency bumps (package.json, go.mod, etc.) and API
+# schema changes are NOT included — too noisy, not all changes need an AgDR.
+# Projects that want a broader list can override via
+# .claude/project-config.json `.architecture_paths` (a JSON array of globs).
+#
+# Multi-line -m messages are handled the same way as verify-commit-refs.sh:
+# flatten newlines before sed parsing.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+if ! echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
+  exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# Get staged files. If nothing is staged, let git commit fail on its own terms.
+STAGED=$(git diff --cached --name-only 2>/dev/null)
+if [ -z "$STAGED" ]; then
+  exit 0
+fi
+
+# Default architecture path patterns. Projects can override via project-config.
+ARCH_GLOBS='infrastructure/
+\.tf$
+\.tfvars$
+^terraform/
+^docker-compose.*\.ya?ml$
+^Dockerfile
+^\.github/workflows/'
+
+# Allow project-config to override
+if [ -f "${REPO_ROOT}/.claude/project-config.json" ]; then
+  CUSTOM=$(jq -r '.architecture_paths // [] | join("|")' "${REPO_ROOT}/.claude/project-config.json" 2>/dev/null)
+  if [ -n "$CUSTOM" ] && [ "$CUSTOM" != "null" ]; then
+    ARCH_GLOBS="$CUSTOM"
+  fi
+fi
+
+# Find any staged file that matches an architecture pattern
+TOUCHED_ARCH=""
+while IFS= read -r FILE; do
+  [ -z "$FILE" ] && continue
+  while IFS= read -r PATTERN; do
+    [ -z "$PATTERN" ] && continue
+    if echo "$FILE" | grep -qE "$PATTERN"; then
+      TOUCHED_ARCH="${TOUCHED_ARCH}${FILE} "
+      break
+    fi
+  done <<< "$ARCH_GLOBS"
+done <<< "$STAGED"
+
+if [ -z "$TOUCHED_ARCH" ]; then
+  # No arch files in this commit — nothing to enforce
+  exit 0
+fi
+
+# An AgDR is required. Check two paths:
+#   (1) The staged files include a new AgDR at docs/agdr/AgDR-*.md
+#   (2) The commit message references an existing AgDR
+
+# (1) New AgDR file in staged changes?
+if echo "$STAGED" | grep -qE '^docs/agdr/AgDR-[0-9]+-.*\.md$'; then
+  exit 0
+fi
+
+# (2) AgDR reference in commit message?
+# Extract the message using the multi-line-safe pattern (flatten first).
+COMMAND_FLAT=$(echo "$COMMAND" | tr '\n' ' ')
+MSG=""
+MSG=$(echo "$COMMAND_FLAT" | sed -nE "s/.*-m[[:space:]]+'([^']*)'.*/\1/p" | head -1)
+if [ -z "$MSG" ]; then
+  MSG=$(echo "$COMMAND_FLAT" | sed -nE 's/.*-m[[:space:]]+"([^"]*)".*/\1/p' | head -1)
+fi
+if [ -z "$MSG" ]; then
+  MSG_FILE=$(echo "$COMMAND_FLAT" | sed -nE 's/.*(-F|--file)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
+  if [ -n "$MSG_FILE" ] && [ -f "$MSG_FILE" ]; then
+    MSG=$(cat "$MSG_FILE")
+  fi
+fi
+
+if [ -z "$MSG" ]; then
+  # Interactive commit — skip (matches verify-commit-refs.sh policy)
+  exit 0
+fi
+
+if echo "$MSG" | grep -qE 'AgDR-[0-9]+|docs/agdr/AgDR-'; then
+  exit 0
+fi
+
+# No AgDR reference and no new AgDR file — block
+cat >&2 <<MSG_END
+BLOCKED: Commit touches architecture files but has no AgDR reference.
+
+Architecture files in this commit:
+$(echo "$TOUCHED_ARCH" | tr ' ' '\n' | sed 's/^/  /' | grep -v '^  $')
+
+ApexStack requires an Agent Decision Record (AgDR) for architectural
+changes — see .claude/rules/agdr-decisions.md § Enforcement. Every
+decision that has trade-offs (infrastructure layout, CI/CD design,
+deployment strategy, container topology) must be recorded so future
+maintainers can understand why this was chosen over alternatives.
+
+To unblock:
+
+  1. Run the /decide skill to walk through the decision and generate
+     an AgDR file at docs/agdr/AgDR-NNNN-{slug}.md
+  2. Either:
+       - Stage the new AgDR file alongside this commit: git add docs/agdr/AgDR-NNNN-*.md
+       OR
+       - Reference an existing AgDR in the commit message:
+           "... decided by AgDR-0042"
+  3. Retry the commit
+
+If the change is TRULY trivial (cosmetic rename, comment fix, whitespace),
+amend the commit message to cite the parent ticket explicitly and add
+"no AgDR needed: trivial refactor" — and the hook will still block, but
+that's the signal to create a minimal AgDR rather than bypass the rule.
+
+Customize which paths count as "architecture" via
+.claude/project-config.json \`.architecture_paths\` (JSON array of regex patterns).
+MSG_END
+exit 2

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# PreToolUse hook on `gh pr merge`: when the PR's diff touches UI files,
+# require a design approval marker at .claude/session/reviews/<pr>-design.approved
+# (with a matching HEAD SHA) before letting the merge through.
+#
+# Enforces .claude/rules/pr-quality.md § "Design Review" and
+# workflows/code-review.md § "UI Designer (conditional)" — which were
+# prose-only until this hook shipped.
+#
+# What counts as "UI":
+#   - *.tsx, *.jsx (React)
+#   - *.vue (Vue)
+#   - *.svelte (Svelte)
+#   - *.css, *.scss, *.sass, *.less (styles)
+#   - design-tokens.* (design systems)
+#
+# Projects that want a broader/narrower list can override via
+# .claude/project-config.json `.ui_paths` (JSON array of regex patterns).
+#
+# How the marker gets written: the design-reviewer records approval by
+# writing the marker file. There is no /approve-design skill yet — the
+# design reviewer writes the file manually or via a (future) skill.
+#
+# Trust model: same as other markers. Local session state, gitignored,
+# converts invisible inference ("ah, the UI change looked fine") into
+# visible file existence. For adversarial trust, use CODEOWNERS.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+merge\b'; then
+  exit 0
+fi
+
+# Extract PR number (same approach as block-unreviewed-merge.sh)
+PR_NUMBER=$(echo "$COMMAND" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*' | grep -oE '[0-9]+' | head -1)
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null)
+fi
+
+if [ -z "$PR_NUMBER" ]; then
+  # Let block-unreviewed-merge.sh handle the "no PR number" error — we skip
+  exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+
+# Default UI path patterns (regex). Note: .tsx$ / .jsx$ are EXACT — they must
+# not match plain .ts / .js, which are often backend/server files. The
+# original draft had \.tsx?$ which matched .ts too; caught in smoke test.
+UI_GLOBS='\.tsx$
+\.jsx$
+\.vue$
+\.svelte$
+\.css$
+\.scss$
+\.sass$
+\.less$
+design-tokens'
+
+# Allow project-config to override
+if [ -n "$REPO_ROOT" ] && [ -f "${REPO_ROOT}/.claude/project-config.json" ]; then
+  CUSTOM=$(jq -r '.ui_paths // [] | join("|")' "${REPO_ROOT}/.claude/project-config.json" 2>/dev/null)
+  if [ -n "$CUSTOM" ] && [ "$CUSTOM" != "null" ]; then
+    UI_GLOBS="$CUSTOM"
+  fi
+fi
+
+# Get the PR's changed files
+CHANGED=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null)
+if [ -z "$CHANGED" ]; then
+  # Couldn't determine files — skip rather than false-positive
+  exit 0
+fi
+
+TOUCHED_UI=""
+while IFS= read -r FILE; do
+  [ -z "$FILE" ] && continue
+  while IFS= read -r PATTERN; do
+    [ -z "$PATTERN" ] && continue
+    if echo "$FILE" | grep -qE "$PATTERN"; then
+      TOUCHED_UI="${TOUCHED_UI}${FILE} "
+      break
+    fi
+  done <<< "$UI_GLOBS"
+done <<< "$CHANGED"
+
+if [ -z "$TOUCHED_UI" ]; then
+  # Not a UI PR — nothing to enforce, merge-gate will continue
+  exit 0
+fi
+
+# UI PR detected — require a design approval marker
+APPROVAL="${REPO_ROOT:-.}/.claude/session/reviews/${PR_NUMBER}-design.approved"
+
+if [ ! -f "$APPROVAL" ]; then
+  cat >&2 <<MSG
+BLOCKED: PR #${PR_NUMBER} touches UI files but has no design-review approval marker.
+
+UI files in this diff:
+$(echo "$TOUCHED_UI" | tr ' ' '\n' | sed 's/^/  /' | grep -v '^  $' | head -20)
+
+ApexStack requires a design review on any PR that touches user-facing UI —
+see .claude/rules/pr-quality.md § "Design Review (UI Changes)" and
+workflows/code-review.md § "UI Designer (conditional)".
+
+The expected approval file does not exist:
+  ${APPROVAL}
+
+To unblock:
+
+  1. Invoke the UI Designer role (or a human designer) to review the UI changes
+  2. When the designer approves, record it with the current HEAD SHA:
+       mkdir -p .claude/session/reviews
+       git rev-parse HEAD > .claude/session/reviews/${PR_NUMBER}-design.approved
+  3. Retry the merge
+
+To customize which file patterns count as "UI", set
+\`.ui_paths\` in .claude/project-config.json (JSON array of regex patterns).
+
+For projects that deliberately ship UI without design review (e.g. admin tools,
+internal dashboards), touch the marker file manually — that's a visible,
+auditable "we decided to skip design review" artifact rather than an
+invisible omission.
+MSG
+  exit 2
+fi
+
+# SHA consistency check
+APPROVED_SHA=$(tr -d '[:space:]' < "$APPROVAL")
+CURRENT_SHA=$(git rev-parse HEAD 2>/dev/null)
+if [ -n "$APPROVED_SHA" ] && [ -n "$CURRENT_SHA" ] && [ "$APPROVED_SHA" != "$CURRENT_SHA" ]; then
+  cat >&2 <<MSG
+BLOCKED: Design review approved commit ${APPROVED_SHA:0:7} but HEAD is now ${CURRENT_SHA:0:7}.
+
+New commits were pushed after the design review. Re-request design review
+on the latest HEAD before merging.
+MSG
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# PreToolUse hook on `git commit`: validates the commit message subject line
+# against the conventional commit format defined in
+# .claude/rules/git-conventions.md:
+#
+#   type: subject
+#
+# Where type is one of: feat, fix, refactor, test, docs, chore, style, perf
+#
+# Note: the PR *title* format is `type(TICKET): description` (with scope in
+# parens) — that's enforced by validate-pr-create.sh. Commit messages use
+# the simpler `type: subject` form without the scope because commits often
+# don't correspond 1:1 to tickets.
+#
+# Multi-line -m messages are handled by flattening newlines before parsing
+# (same pattern as verify-commit-refs.sh). Interactive commits (no -m / -F)
+# are skipped.
+#
+# ApexStack also accepts the scoped form `type(scope): subject` as a valid
+# superset — if a project wants to use scopes in commits, that's fine, but
+# the scope is not required.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+if ! echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
+  exit 0
+fi
+
+# Extract commit message (multi-line safe)
+COMMAND_FLAT=$(echo "$COMMAND" | tr '\n' ' ')
+MSG=""
+MSG=$(echo "$COMMAND_FLAT" | sed -nE "s/.*-m[[:space:]]+'([^']*)'.*/\1/p" | head -1)
+if [ -z "$MSG" ]; then
+  MSG=$(echo "$COMMAND_FLAT" | sed -nE 's/.*-m[[:space:]]+"([^"]*)".*/\1/p' | head -1)
+fi
+if [ -z "$MSG" ]; then
+  MSG_FILE=$(echo "$COMMAND_FLAT" | sed -nE 's/.*(-F|--file)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
+  if [ -n "$MSG_FILE" ] && [ -f "$MSG_FILE" ]; then
+    MSG=$(cat "$MSG_FILE")
+  fi
+fi
+
+if [ -z "$MSG" ]; then
+  # Interactive commit — skip (accepted gap, matches sibling hooks)
+  exit 0
+fi
+
+# Get the first line of the message (the subject)
+SUBJECT=$(echo "$MSG" | head -1)
+
+if [ -z "$SUBJECT" ]; then
+  exit 0
+fi
+
+# Validate:
+#   type: subject         (no scope)
+#   type(scope): subject  (with scope — superset)
+#
+# Types per .claude/rules/git-conventions.md:
+#   feat, fix, refactor, test, docs, chore, style, perf
+#
+# ApexStack also accepts (build, ci, revert) since those types appear in the
+# PR-title regex in git-conventions.md — staying consistent prevents commit
+# messages from being valid in PR titles but not commits.
+TYPE_REGEX='^(feat|fix|refactor|test|docs|chore|style|perf|build|ci|revert)(\([^)]+\))?:[[:space:]]+.+'
+
+if ! echo "$SUBJECT" | grep -qE "$TYPE_REGEX"; then
+  cat >&2 <<MSG_END
+BLOCKED: Commit subject doesn't match the conventional commit format.
+
+Subject was:
+  ${SUBJECT}
+
+Expected format (from .claude/rules/git-conventions.md):
+  type: subject
+  type(scope): subject
+
+Where type is one of:
+  feat, fix, refactor, test, docs, chore, style, perf, build, ci, revert
+
+Examples:
+  feat: add user avatar upload
+  fix(auth): handle expired refresh tokens
+  refactor: split order service into read/write sides
+  docs(#42): update deployment runbook
+
+The scope in parens is optional for commits (but REQUIRED for PR titles
+with a ticket reference — that's enforced by validate-pr-create.sh).
+
+To unblock:
+  1. Amend the commit: git commit --amend -m "type: your subject"
+  2. Or write a new commit with a conforming subject
+
+If you think this rule is too strict for your project, customize the type
+list in .claude/hooks/validate-commit-format.sh or file a ticket to add
+\`.commit_types\` as a project-config option.
+MSG_END
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,16 @@
           },
           {
             "type": "command",
+            "if": "Bash(git commit *)",
+            "command": ".claude/hooks/validate-commit-format.sh"
+          },
+          {
+            "type": "command",
+            "if": "Bash(git commit *)",
+            "command": ".claude/hooks/require-agdr-for-arch-changes.sh"
+          },
+          {
+            "type": "command",
             "if": "Bash(git push *)",
             "command": ".claude/hooks/pre-push-gate.sh"
           },
@@ -63,6 +73,16 @@
             "type": "command",
             "if": "Bash(gh pr merge *)",
             "command": ".claude/hooks/block-unreviewed-merge.sh"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh pr merge *)",
+            "command": ".claude/hooks/require-design-review-for-ui.sh"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh pr merge *)",
+            "command": ".claude/hooks/block-merge-on-red-ci.sh"
           }
         ]
       }

--- a/docs/agdr/AgDR-0001-rule-mechanization-hooks.md
+++ b/docs/agdr/AgDR-0001-rule-mechanization-hooks.md
@@ -1,0 +1,165 @@
+---
+id: AgDR-0001
+timestamp: 2026-04-11T18:50:00Z
+agent: atlas
+model: claude-opus-4-6
+trigger: user-prompt
+status: executed
+ticket: me2resh/apexstack#13
+---
+
+# Rule mechanization — which four hooks to ship and what thresholds they enforce
+
+> In the context of auditing the apexstack CLAUDE.md and rule files after three sibling incidents exposed "prose rules the model drops under pressure", facing the choice of which MUST rules to mechanize and which to leave explicitly advisory, I decided to ship four new hooks (`require-agdr-for-arch-changes`, `require-design-review-for-ui`, `block-merge-on-red-ci`, `validate-commit-format`) with narrow default path lists and project-config overrides, accepting that some MUSTs (>80% coverage, "no bare any", "one ticket at a time") stay prose because they are either too project-specific or genuinely not mechanizable in a shell harness.
+
+## Context
+
+Three sibling incidents in the same session (2026-04-11) all traced back to the same root cause: rules written as prose in `CLAUDE.md` / `.claude/rules/*.md` / `workflows/*.md` are advice the model drops under pressure.
+
+- **Incident 1** — plan-level "go" was inferred as merge approval. Fixed in [#11](https://github.com/me2resh/apexstack/issues/11) / commit `646302e`: explicit per-merge CEO approval rule, two-marker merge gate, `/approve-merge` skill.
+- **Incident 2** — agent presented a fabricated 10-ticket tree in chat using tracker vocabulary. Fixed in [#14](https://github.com/me2resh/apexstack/issues/14) / commit `d0a2128`: ticket-vocabulary rule + verify-issue-exists backstops.
+- **Incident 3** — general audit. Multiple MUSTs in the rules remained unenforced by hooks. This ticket (#13).
+
+The audit found that the apexstack rules/workflows files contain ~15 MUST-type statements. About 10 are already mechanized (from the enforcement work merged earlier this session plus the pre-existing six hooks). Of the remainder, some are mechanizable and some are not.
+
+## Options Considered
+
+### Option A — ship all mechanizable rules as hooks, immediately, with broad defaults
+
+Everything that *could* be a hook becomes one. Design rules touch any UI file extension, architecture rules touch any infrastructure-adjacent path, commit-format enforces strict types, PR-body glossary becomes a blocker, etc.
+
+**Pros:** maximum mechanical enforcement, minimum prose leakage, clearest message that "if it's a rule, it's a hook."
+
+**Cons:** broad defaults fire false positives constantly (server `.ts` treated as UI, `package.json` bump treated as architecture, etc.). Users burn out on false alarms and disable hooks. Worse-than-status-quo outcome.
+
+### Option B — ship only the rules with clean mechanization and narrow defaults, leave the rest explicitly advisory
+
+Four hooks with narrow, project-configurable path lists:
+
+- `require-agdr-for-arch-changes.sh` — fires on `git commit` when the staged diff touches `infrastructure/`, `*.tf`, `docker-compose*.yml`, `Dockerfile*`, or `.github/workflows/`. Requires an AgDR reference in the commit message or a new AgDR file staged alongside. Narrow enough that false positives are rare.
+- `require-design-review-for-ui.sh` — fires on `gh pr merge` when the PR diff touches `.tsx`, `.jsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`, or `design-tokens*`. Requires a design approval marker. **Deliberately excludes `.ts` and `.js`** — those are server-side TypeScript/JavaScript much more often than UI, and catching them would create false positives on every backend PR.
+- `block-merge-on-red-ci.sh` — fires on `gh pr merge`, runs `gh pr checks` on the target PR, blocks on any failing/pending check. Allows the "no checks configured" case (some projects don't have CI) with a NOTE.
+- `validate-commit-format.sh` — fires on `git commit`, checks that the subject matches `type: subject` or `type(scope): subject` with type from `{feat, fix, refactor, test, docs, chore, style, perf, build, ci, revert}`. Matches the PR-title type list in `git-conventions.md`.
+
+Each hook has default path lists that can be overridden via `.claude/project-config.json` (`architecture_paths`, `ui_paths` — `commit_types` is a future extension if a project wants a stricter or looser type list).
+
+**Pros:** low false-positive rate by construction. Projects can tighten the defaults if they want broader coverage. The rules that *can't* be mechanized cleanly are explicit about that — they stay prose and the audit doc (follow-up) will label them.
+
+**Cons:** some MUSTs remain advisory (>80% coverage, typing rules, one-ticket-at-a-time), which means the "every MUST is a hook" goal isn't fully met. Acceptable because the alternative is worse-than-prose (hook spam that gets disabled).
+
+### Option C — split each hook into its own PR
+
+One PR per hook, each with its own Rex review cycle and CEO approval.
+
+**Pros:** smaller reviews, easier to revert individual hooks.
+
+**Cons:** four round trips instead of one, cross-PR coupling via `settings.json`, audit doc can't land until all hooks merge, 4x the CEO-approval-moment overhead.
+
+## Decision
+
+**Chosen: Option B** — ship the four hooks in one PR with narrow defaults and project-config overrides.
+
+**Why:**
+
+1. The audit's core finding is "mechanize the ones you can without creating false-positive spam." Option A loses that by being too broad. Option C fragments the work.
+2. Narrow defaults + config overrides is the right shape because apexstack is a forkable framework. The defaults should be safe-for-everyone; each fork tightens/loosens to match its own tech stack.
+3. All four hooks share infrastructure (`settings.json` wiring, `.claude/hooks/README.md` section, multi-line `-m` parsing from the verify-commit-refs fix in #14). Shipping as one PR avoids duplicating that machinery across four PRs.
+4. One PR = one Rex cycle = one CEO approval moment. Current session throughput is the binding constraint, not review-surface width.
+
+## Rules explicitly staying advisory (not mechanized by this ticket)
+
+These were considered for mechanization and deliberately left as prose, with a plan to label them explicitly in the follow-up audit doc:
+
+- **`>80% coverage for domain logic`** — project-specific. Coverage reports live in each project's CI, not the framework. A framework-level hook would need to know the project's coverage tool, output format, and thresholds. Too brittle. Stays advisory; each project enforces in its own CI.
+- **`No bare any types without justification`** — lint-level concern. Needs static analysis, not a shell hook. Belongs in each project's ESLint/tsconfig, not the framework.
+- **`Domain layer has no external dependencies`** — architectural, needs import-graph analysis. Same answer: lint-level, per-project.
+- **`One ticket at a time`** — behavioral, hard to detect mechanically. The closest proxy would be "block `gh pr create` if there's already an open PR on this branch's parent issue", but that's complex for marginal value. Stays prose.
+- **`Testing pyramid 70/20/10`** — advisory metric, not a threshold. Not mechanizable.
+- **Trigger patterns for role activation (`role-triggers.md`)** — context-aware activation, language-level matching. Not mechanizable in shell hooks.
+- **`/decide` trigger patterns ("when you say 'I'll use X' → stop")** — self-discipline on prose output. Same class as the rejected "lint Claude's chat output" idea in #14.
+
+The follow-up audit doc (`docs/rule-audit.md`, separate ticket) will list these explicitly with "advisory, see reason X" labels.
+
+## Threshold decisions (the actual content of this AgDR)
+
+### Architecture paths (`require-agdr-for-arch-changes.sh`)
+
+Default regex patterns:
+
+```
+infrastructure/
+\.tf$
+\.tfvars$
+^terraform/
+^docker-compose.*\.ya?ml$
+^Dockerfile
+^\.github/workflows/
+```
+
+**Deliberately excluded:**
+
+- `package.json`, `go.mod`, `requirements.txt`, etc. — dependency bumps are too frequent and too small for an AgDR each. Projects that care about this can override `architecture_paths` to add them.
+- `openapi.yaml`, `*.graphql` — API schemas might deserve AgDRs, but not every schema tweak. Too noisy as a default.
+- `src/domain/**/entities/` — architectural in DDD projects, but the path is project-specific and would false-positive everywhere that uses a different layout.
+
+### UI paths (`require-design-review-for-ui.sh`)
+
+Default regex patterns:
+
+```
+\.tsx$
+\.jsx$
+\.vue$
+\.svelte$
+\.css$
+\.scss$
+\.sass$
+\.less$
+design-tokens
+```
+
+**Deliberately excluded:**
+
+- `\.ts$`, `\.js$` — the original draft had `\.tsx?$` and `\.jsx?$` which matched plain `.ts` and `.js`. Caught in smoke test. Plain `.ts`/`.js` are much more often server/build code than UI. Forking the pattern would have caused false positives on every backend PR.
+- HTML files — Next.js / Vue projects don't have plain `.html` often; static sites might. Not a default.
+- Image files — bitmap changes are visual but don't need a *designer's* review in most teams. Content concern, not design.
+
+### Commit message types (`validate-commit-format.sh`)
+
+Accepted types: `feat, fix, refactor, test, docs, chore, style, perf, build, ci, revert`.
+
+This is the same list used in the PR-title regex in `git-conventions.md` (plus `revert` which PR titles allow via the existing regex). Keeping the commit list aligned with the PR list prevents the "commit passes validation but PR title using the same type fails" asymmetry.
+
+### Red-CI check semantics (`block-merge-on-red-ci.sh`)
+
+- **Green** → allow
+- **Red** (any fail/cancelled/timeout) → block
+- **Pending / in-progress** → block (the rule says "no red CI", and pending is not green)
+- **No checks configured** (`"no checks reported"` text from `gh pr checks`) → allow with a NOTE (legitimate state for repos without CI; common in early apexstack forks)
+
+## Consequences
+
+**Positive:**
+
+- Four previously-unenforced rules from `agdr-decisions.md`, `pr-quality.md`, and `git-conventions.md` are now mechanical.
+- Claude (or any user of apexstack) will hit a hard-stop at commit/merge time if they try to bypass these rules.
+- Design decisions for the hooks are documented in one place (this AgDR) so future contributors understand why the defaults are narrow and how to widen them via project-config.
+
+**Negative / tradeoffs:**
+
+- The hooks won't catch rules that can't be mechanized in a shell harness. Those stay advisory and depend on self-discipline, same as `ticket-vocabulary.md` from #14.
+- Narrow defaults mean some projects will need to customize `project-config.json` to get full coverage. The alternative — broad defaults — was rejected as worse.
+- New dependency on `gh pr checks` in `block-merge-on-red-ci.sh`. Assumed already present; apexstack already depends on `gh` throughout.
+
+**Follow-ups captured:**
+
+- **docs/rule-audit.md** — the full audit table listing every MUST and whether it's mechanized / advisory / deferred. Separate ticket.
+- **Warning → blocker upgrade** for `validate-branch-name.sh` and `validate-pr-create.sh`'s format checks. Breaking change, deserves its own ticket and explicit scope approval.
+- **`commit_types` project-config override** for `validate-commit-format.sh`. Not needed for MVP, nice-to-have.
+
+## Artifacts
+
+- Ticket: [me2resh/apexstack#13](https://github.com/me2resh/apexstack/issues/13)
+- Hooks added (in this PR): `require-agdr-for-arch-changes.sh`, `require-design-review-for-ui.sh`, `block-merge-on-red-ci.sh`, `validate-commit-format.sh`
+- Companion PRs merged earlier in the same session: `646302e` (explicit merge approval, #11), `d0a2128` (ticket vocabulary + verify-issue-exists, #14)
+- Hooks README section documenting the four new hooks (this PR)


### PR DESCRIPTION
## Summary

Closes four unenforced MUST rules from the apexstack rule files. Ships them as hooks with narrow default path lists and project-config overrides. Design decisions captured in the first AgDR committed to apexstack (`docs/agdr/AgDR-0001-rule-mechanization-hooks.md`).

This is the rule-mechanization-audit ticket [#13](https://github.com/me2resh/apexstack/issues/13) — the last of the "prose rules we discovered in the first session" series. Companion work shipped earlier today: [#11](https://github.com/me2resh/apexstack/issues/11) (explicit merge approval, commit `646302e`) and [#14](https://github.com/me2resh/apexstack/issues/14) (ticket vocabulary, commit `d0a2128`).

## The four new hooks

### 1. `require-agdr-for-arch-changes.sh` — PreToolUse on commit

When the staged diff touches architecture files (`infrastructure/`, `*.tf`, `Dockerfile*`, `docker-compose*.yml`, `.github/workflows/`), requires an AgDR reference in the commit message (`AgDR-NNNN` or `docs/agdr/AgDR-`) **or** a new AgDR file staged alongside (`docs/agdr/AgDR-NNNN-*.md`). Blocks the commit otherwise.

**Closes the prose-only claim** in `.claude/rules/agdr-decisions.md § Enforcement` item 4 ("Pre-commit hook warns if architecture files changed without an AgDR reference") — that hook was promised in the prose but never existed until this PR.

Default path list is **deliberately narrow** to avoid false positives. Dependency manifests (`package.json`, `go.mod`, etc.) and API schemas are NOT in the default list — see AgDR-0001 § "Threshold decisions" for rationale. Customize via `.architecture_paths` in `.claude/project-config.json`.

### 2. `require-design-review-for-ui.sh` — PreToolUse on the merge step

When the PR's diff touches UI files, requires a design-approval marker at `.claude/session/reviews/<pr>-design.approved` (matching HEAD SHA, like the existing Rex/CEO markers). Non-UI PRs bypass silently.

Default UI paths: `.tsx`, `.jsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`, `design-tokens*`.

**Critical regex detail** (caught in smoke testing): the patterns are `\.tsx$` and `\.jsx$`, NOT `\.tsx?$` / `\.jsx?$`. The original draft used the `?` form, which also matches plain `.ts` and `.js` — those are server-side TypeScript/JavaScript much more often than UI, and catching them would false-positive every backend PR. Fixed before commit, noted in the README and in AgDR-0001.

**Closes the prose-only gate** in `.claude/rules/pr-quality.md § "Design Review (UI Changes)"` and `workflows/code-review.md`.

### 3. `block-merge-on-red-ci.sh` — PreToolUse on the merge step

Runs a CI-status check against the target PR and blocks the merge if any check is failing, cancelled, timed out, pending, or in-progress. The "no checks reported" case (legitimate for repos without CI, common for early apexstack forks) is allowed with a NOTE to stderr.

**Closes the prose-only rule** in `.claude/rules/pr-quality.md § "No Red CI Before Merge"` — "Never merge with red CI, even if the failure is pre-existing or unrelated."

### 4. `validate-commit-format.sh` — PreToolUse on commit

Validates the commit subject against `^(feat|fix|refactor|test|docs|chore|style|perf|build|ci|revert)(\(scope\))?: .+`. Accepts both `type: subject` and `type(scope): subject` forms. Multi-line `-m` HEREDOC messages handled via the `COMMAND_FLAT` pattern from `verify-commit-refs.sh`.

Type list is **identical to the PR-title type list** in `git-conventions.md` (plus `revert`, which PR titles allow via the existing regex). Keeping these aligned prevents the "commit passes validation but PR title using the same type fails" asymmetry.

**Closes the prose-only rule** in `.claude/rules/git-conventions.md § "Commit Message Format"`.

## New file: AgDR-0001

`docs/agdr/AgDR-0001-rule-mechanization-hooks.md` is the first AgDR committed to the apexstack repo. It records:

- **Options considered** — broad defaults (rejected, false-positive spam), narrow defaults + config overrides (chosen), one-PR-per-hook (rejected, cross-PR coupling)
- **The decision** — Option B with explicit reasoning
- **Rules that deliberately stay advisory** — `>80% coverage`, `no bare any`, `one ticket at a time`, role trigger patterns, `/decide` trigger patterns — each with a "why not mechanized" note
- **Threshold decisions** — exact architecture path list, UI path list, commit type list, CI state handling semantics
- **Consequences + follow-up tickets** — the full audit table (`docs/rule-audit.md`), the `validate-branch-name.sh`/`validate-pr-create.sh` warning→blocker upgrade, and the `commit_types` project-config override are all captured as deferred.

AgDR-0001 sets the pattern for all future AgDRs in apexstack (follows the template in `templates/agdr.md`).

## Changes to existing files

- **`.claude/settings.json`** — four new hook registrations. Ordering is deliberate: cheap local checks (commit format, AgDR arch check) run before expensive network calls (pr-checks lookup in block-merge-on-red-ci).
- **`.claude/hooks/README.md`** — new section "The Rule-Mechanization Hooks (GH-13)" with four hook subsections (behavior, defaults, customization, what rule each enforces). Notes the settings-ordering rationale. Pre-existing-hooks table updated to call out that `validate-branch-name.sh` and `validate-pr-create.sh`'s format checks remain warning-only and are deferred to a follow-up ticket.

## Smoke tests (all passing post-fix)

```
=== 1: settings.json jq parse ===                                        valid

=== 2: validate-commit-format.sh ===
  - valid "feat: add thing" subject                                      exit=0
  - valid "feat(auth): add thing" scoped subject                         exit=0
  - INVALID "added thing" (no type prefix)                               exit=2 (block message)
  - multi-line HEREDOC with valid subject                                exit=0

=== 3: require-agdr-for-arch-changes.sh ===
  - no staged files                                                      exit=0 (allow silently)
  - non-arch file staged (notes.md)                                      exit=0 (allow silently)
  - Dockerfile staged, no AgDR ref                                       exit=2 (block with message)
  - Dockerfile staged, "per AgDR-0042" in commit message                 exit=0 (allow)

=== 4: block-merge-on-red-ci.sh ===
  - "no checks reported" case after bug fix                              exit=0 (allow with NOTE)
  - all green CI                                                         exit=0

=== 5: require-design-review-for-ui.sh ===
  - regex unit: .tsx matches                                             pass
  - regex unit: .ts does NOT match (original was \.tsx?$, fixed to \.tsx$) pass
  - regex unit: .js does NOT match (same fix)                            pass
  - full hook exec: PR with no UI changes                                exit=0 (allow silently)
```

Two bugs were found and fixed mid-smoke-test and are documented above:

1. `block-merge-on-red-ci.sh` — my original logic assumed the pr-checks command returns exit 8 for the no-CI case, but it actually returns non-zero with "no checks reported" text. Fixed to pattern-match the text.
2. `require-design-review-for-ui.sh` — original regex `\.tsx?$` matched plain `.ts` files (the `?` makes the `x` optional). Fixed to `\.tsx$` (exact). Prevents backend TypeScript PRs from hitting the design-review gate.

## Dogfooding

All four new pre-commit hooks fired on this PR's own commit and allowed it cleanly:

- `check-secrets.sh` — no secrets ✓
- `verify-commit-refs.sh` — `Closes #13` verified against apexstack, #13 exists ✓
- `validate-commit-format.sh` — `feat(#13): rule-audit hooks — ...` matches the type regex ✓
- `require-agdr-for-arch-changes.sh` — no architecture files in the diff (`.claude/settings.json`, `.claude/hooks/*.sh`, `docs/agdr/*.md` are not in the arch list), so no AgDR required on the commit itself. Interesting note: the PR *adds* AgDR-0001, but the hook doesn't require the AgDR to reference itself — that would be a loop.

The merge-gate hooks (3 and 4) will be tested at merge time: the hook will see no UI files in the diff (no `.tsx`/`.css` etc.) and allow the design gate, and the pr-checks lookup will report "no checks reported" and allow the CI gate with a NOTE.

## Deferred to follow-up tickets

Explicit non-goals for this PR, each of which should become its own ticket:

1. **`docs/rule-audit.md`** — the full audit table listing every MUST across all rule files with its mechanization status (mechanized / advisory / deferred). This PR keeps AgDR-0001 (the design-decision artifact) but defers the full enumeration. Small follow-up, pure docs.
2. **Warning → blocker upgrade** for `validate-branch-name.sh` and `validate-pr-create.sh`'s format checks. **Breaking change** — deserves its own ticket with explicit scope approval. Users currently trained on warnings will see new hard blocks.
3. **`commit_types` project-config override** for `validate-commit-format.sh`. Nice-to-have if a project wants a stricter or looser type list. Not MVP.
4. **`/approve-design <pr>` skill** (analogous to `/approve-merge`) for writing the design-review marker. The current hook requires a manual `touch` / `echo > file`. A skill would be cleaner.

## Glossary

| Term | Definition |
|------|------------|
| AgDR | Agent Decision Record — a structured markdown file at `docs/agdr/AgDR-NNNN-{slug}.md` that records a technical decision's context, options, chosen option, and consequences. Template at `templates/agdr.md`. |
| Architecture files | Files that require an AgDR when changed. Default list: `infrastructure/`, `*.tf`, `Dockerfile*`, `docker-compose*.yml`, `.github/workflows/`. Customizable per project via `.architecture_paths` in `project-config.json`. |
| UI files | Files that require a design review when changed in a PR. Default list: `.tsx`, `.jsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`, `design-tokens*`. **NOT** plain `.ts` or `.js`. |
| Design marker | `.claude/session/reviews/<pr>-design.approved` — written by the design reviewer (manually for now, `/approve-design` skill deferred). Gates the pre-merge moment for UI PRs. |
| Red CI | Any CI check in state FAILURE, CANCELLED, TIMED_OUT, PENDING, IN_PROGRESS, or QUEUED. The no-red-CI rule says merges wait until all checks are green. |
| No-checks-reported | Legitimate state for repos without CI configured. The pr-checks lookup returns text "no checks reported on the 'X' branch". The hook allows this with a NOTE rather than blocking — apexstack forks without CI shouldn't be blocked by a rule that assumes CI exists. |
| COMMAND_FLAT pattern | The `echo "$COMMAND" \| tr '\n' ' '` trick from `verify-commit-refs.sh` (GH-14 multi-line fix) that handles HEREDOC `-m` messages. All three new commit-time hooks in this PR inherit the same pattern. |

## Test plan

- [ ] Pull branch, run each smoke test above
- [ ] Read `docs/agdr/AgDR-0001-rule-mechanization-hooks.md` — does the options/decision/consequences match the template and accurately describe the tradeoffs?
- [ ] Confirm `.tsx$` regex doesn't match plain `.ts` files (catches the original draft bug)
- [ ] Confirm `block-merge-on-red-ci.sh` handles "no checks reported" as allow-with-NOTE
- [ ] Confirm all four new hooks are registered in `.claude/settings.json` in the correct matcher block
- [ ] Code Reviewer (Rex) review
- [ ] **Explicit per-PR CEO approval for this PR** (per the rule merged in #11)

## Links

- Closes #13
- AgDR: `docs/agdr/AgDR-0001-rule-mechanization-hooks.md`
- Sibling completed earlier this session: #11 (commit `646302e`), #14 (commit `d0a2128`)
- Still open: #15 (`.claude/` duplication cleanup)
- Follow-up tickets to open: full audit doc, warning→blocker upgrade, `/approve-design` skill, `commit_types` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)
