### PR TITLE
fix(#18): regex anchors for monorepo Dockerfiles + dead code cleanup

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -122,15 +122,18 @@ Four more hooks added by the rule-audit ticket ([#13](https://github.com/me2resh
 **Default architecture paths** (regex):
 
 ```
-infrastructure/           # terraform, pulumi, cdk, cfn layouts
-\.tf$ / \.tfvars$         # terraform files
-^terraform/
-^docker-compose.*\.ya?ml$ # container orchestration
-^Dockerfile               # dockerfiles
-^\.github/workflows/      # CI/CD pipeline changes
+\.tf$                         # any terraform file at any depth
+\.tfvars$                     # any terraform vars at any depth
+(^|/)docker-compose.*\.ya?ml$ # compose files at root or in monorepo subdirs
+(^|/)Dockerfile               # Dockerfiles at root or in monorepo subdirs
+^\.github/workflows/          # GitHub Actions workflow files
 ```
 
+All path patterns use the `(^|/)` anchor so they catch **monorepo layouts** (`backend/Dockerfile`, `web/docker-compose.yml`, `services/api/Dockerfile.prod`) as well as root-level files. This was refined post-#13 in #18 — the original `^Dockerfile` only caught root-level files and silently skipped monorepo Dockerfiles.
+
 **Customize:** set `.architecture_paths` in `.claude/project-config.json` to a JSON array of regex patterns. The default list is deliberately narrow — see AgDR-0001 for why dependency manifests (`package.json`, `go.mod`) and API schemas are explicitly excluded.
+
+**Not in the default list (known gap):** CDK / Pulumi / generic-IaC projects that use plain `.ts` / `.py` / `.go` files inside an `infrastructure/` directory. The original draft had a generic `(^|/)infrastructure/` pattern for this, but testing showed it false-positives on `docs/infrastructure/notes.md` and `src/types/infrastructure/foo.ts` — the word "infrastructure" is ambiguous as a directory name. Projects that want CDK-style coverage should add an explicit override like `(^|/)infrastructure/.*\.(ts|py|go)$` via `.architecture_paths`.
 
 **Enforces:** `.claude/rules/agdr-decisions.md § Enforcement` — specifically the line "Pre-commit hook warns if architecture files changed without an AgDR reference", which was prose-only until this hook shipped.
 

--- a/.claude/hooks/block-merge-on-red-ci.sh
+++ b/.claude/hooks/block-merge-on-red-ci.sh
@@ -65,10 +65,8 @@ if [ "$CHECKS_RC" = "0" ]; then
   exit 0
 fi
 
-# Red CI (exit 1) or unknown non-zero. Build a readable report.
-FAILED_COUNT=$(echo "$CHECKS_OUTPUT" | grep -c -E '^(fail|FAIL|✗|X)' 2>/dev/null || echo 0)
-PENDING_COUNT=$(echo "$CHECKS_OUTPUT" | grep -c -E '^(pending|PENDING|\*|-)' 2>/dev/null || echo 0)
-
+# Red CI (exit 1) or unknown non-zero. Emit the raw check output in the
+# error message so the user can see exactly which checks are red.
 cat >&2 <<MSG
 BLOCKED: PR #${PR_NUMBER} has red CI. Cannot merge.
 

--- a/.claude/hooks/require-agdr-for-arch-changes.sh
+++ b/.claude/hooks/require-agdr-for-arch-changes.sh
@@ -45,12 +45,30 @@ if [ -z "$STAGED" ]; then
 fi
 
 # Default architecture path patterns. Projects can override via project-config.
-ARCH_GLOBS='infrastructure/
-\.tf$
+#
+# All patterns are designed to match both root-level files AND monorepo
+# subdirectory files. Rex flagged the original anchors in the review of #13 /
+# PR #17: ^Dockerfile / ^docker-compose missed backend/Dockerfile etc., which
+# is the common layout for real monorepos.
+#
+# (^|/) = "start of string OR preceded by a slash". This matches:
+#   Dockerfile                   ← root
+#   backend/Dockerfile           ← monorepo subdir
+#   services/api/Dockerfile.prod ← nested subdir
+# but NOT:
+#   notes-about-Dockerfile.md    ← no slash or start boundary
+#
+# Why no `infrastructure/` or `terraform/` directory pattern: testing showed
+# those match `docs/infrastructure/notes.md` and `src/types/infrastructure/foo.ts`
+# as false positives (the word "infrastructure" is ambiguous as a directory
+# name — IaC vs library code). Terraform files are caught via `\.tf$` at any
+# depth, which is unambiguous. CDK / Pulumi projects that use plain .ts / .py
+# files inside an `infrastructure/` directory need to override via
+# .architecture_paths in project-config.json.
+ARCH_GLOBS='\.tf$
 \.tfvars$
-^terraform/
-^docker-compose.*\.ya?ml$
-^Dockerfile
+(^|/)docker-compose.*\.ya?ml$
+(^|/)Dockerfile
 ^\.github/workflows/'
 
 # Allow project-config to override

--- a/docs/agdr/AgDR-0001-rule-mechanization-hooks.md
+++ b/docs/agdr/AgDR-0001-rule-mechanization-hooks.md
@@ -163,3 +163,25 @@ This is the same list used in the PR-title regex in `git-conventions.md` (plus `
 - Hooks added (in this PR): `require-agdr-for-arch-changes.sh`, `require-design-review-for-ui.sh`, `block-merge-on-red-ci.sh`, `validate-commit-format.sh`
 - Companion PRs merged earlier in the same session: `646302e` (explicit merge approval, #11), `d0a2128` (ticket vocabulary + verify-issue-exists, #14)
 - Hooks README section documenting the four new hooks (this PR)
+
+## Post-ship amendments
+
+This AgDR is historical — the threshold decisions below reflect the state at the time of writing (2026-04-11, commit `772506e` on PR #17). Post-ship refinements are tracked here as a changelog so the original decision block stays intact.
+
+### 2026-04-11 — architecture path anchors refined for monorepos ([#18](https://github.com/me2resh/apexstack/issues/18) / PR to follow)
+
+Rex's review of PR #17 flagged that the original `^Dockerfile` / `^docker-compose.*` anchors silently missed monorepo layouts (`backend/Dockerfile`, `web/docker-compose.yml`). The original unanchored `infrastructure/` matched `docs/infrastructure/notes.md` as a false positive. Refined defaults:
+
+**Removed from defaults** (ambiguous directory name, false-positive-prone):
+
+- `(^|/)infrastructure/` — "infrastructure" is used for IaC in some projects and library code in others. Dropped in favor of relying on file-extension patterns. Projects that use CDK/Pulumi with plain `.ts`/`.py` files in `infrastructure/` should override via `.architecture_paths` (e.g. `(^|/)infrastructure/.*\.(ts|py|go)$`).
+- `(^|/)terraform/` — same ambiguity, and Terraform files are already caught unambiguously via `\.tf$` and `\.tfvars$` at any depth.
+
+**Anchoring updated to `(^|/)` prefix** so monorepo subdirectory paths match:
+
+- `^Dockerfile` → `(^|/)Dockerfile`
+- `^docker-compose.*\.ya?ml$` → `(^|/)docker-compose.*\.ya?ml$`
+
+**Verified with 21 path fixtures** in PR #18's smoke tests (13 should-match cases including monorepo layouts, 8 should-NOT-match cases including the previously-false-positive `docs/infrastructure/` and `docs/terraform-primer.md` paths).
+
+**Also in #18**: dead-code cleanup (`FAILED_COUNT` / `PENDING_COUNT` in `block-merge-on-red-ci.sh` lines 69–70, defined but never referenced).


### PR DESCRIPTION
## Summary

Closes three of the four nice-to-haves Rex flagged on PR #17 (the rule-mechanization audit). The fourth — Conventional Commits breaking-change marker support — is tracked separately as #23 because it needs a design decision, not just a regex fix.

Small focused PR: 4 files, 56 insertions, 15 deletions.

## Changes

### 1. `require-agdr-for-arch-changes.sh` — monorepo-safe anchoring

Rex's live testing of the original regex showed `^Dockerfile` and `^docker-compose.*` only matched root-level files. Monorepos with `backend/Dockerfile`, `web/docker-compose.yml`, `services/api/Dockerfile.prod` — the common real-world layout — silently escaped the gate. Material gap, especially for FlatMate-style monorepo forks.

**Anchor update** — all path patterns now use `(^|/)` prefix so they match both root-level AND monorepo subdirectory paths:

```
\.tf$                         # any terraform file, any depth
\.tfvars$                     # any terraform vars, any depth
(^|/)docker-compose.*\.ya?ml$ # compose files at root or in subdirs
(^|/)Dockerfile               # Dockerfiles at root or in subdirs
^\.github/workflows/          # GitHub Actions (canonical root location)
```

**Dropped patterns** (ambiguous directory names — testing showed false-positives):

- `(^|/)infrastructure/` — matches `docs/infrastructure/notes.md` and `src/types/infrastructure/foo.ts` as false positives. "Infrastructure" as a directory name is ambiguous (IaC vs library code). Dropped in favor of file-extension patterns. Terraform files are caught unambiguously via `\.tf$` at any depth.
- `(^|/)terraform/` — same ambiguity (matches `docs/terraform-primer.md`). Also redundant with `\.tf$`.

**Known gap documented:** CDK / Pulumi / generic-IaC projects that use plain `.ts` / `.py` / `.go` files inside an `infrastructure/` directory are **not** caught by the defaults. Projects that want CDK-style coverage should override via `.architecture_paths` in `project-config.json` (e.g. `(^|/)infrastructure/.*\.(ts|py|go)$`). This is explicitly called out in both the hooks README and AgDR-0001's post-ship amendment section.

### 2. `block-merge-on-red-ci.sh` — dead code removal

Deleted two lines that defined `FAILED_COUNT` / `PENDING_COUNT` but never referenced them. Rex flagged this as nice-to-have. Pure cleanup, no behavior change.

### 3. `.claude/hooks/README.md` — architecture-paths section updated

The `require-agdr-for-arch-changes.sh` section now shows the post-#18 regex list and explicitly calls out the CDK known-gap with an example override pattern.

### 4. `docs/agdr/AgDR-0001-rule-mechanization-hooks.md` — post-ship amendment

Appended a "Post-ship amendments" section at the bottom with a dated changelog entry documenting this refinement. The original decision block is **untouched** — AgDRs are historical records and shouldn't be rewritten; amendments go in an explicit changelog so future maintainers can trace the evolution.

## Smoke tests

21 path fixtures tested against the new regex list, all passing:

**13 should-match cases:**

```
  OK Dockerfile
  OK backend/Dockerfile
  OK services/api/Dockerfile.prod
  OK docker-compose.yml
  OK web/docker-compose.yml
  OK environments/staging/docker-compose.yaml
  OK infrastructure/main.tf
  OK backend/infrastructure/main.tf
  OK terraform/variables.tf
  OK modules/terraform/vpc.tf
  OK .github/workflows/ci.yml
  OK main.tf
  OK environments/prod.tfvars
```

**8 should-NOT-match cases** (including the two previously-false-positive paths):

```
  OK docs/infrastructure/notes.md     (previously FALSE POSITIVE — now correctly excluded)
  OK src/types/infrastructure/foo.ts  (previously FALSE POSITIVE — now correctly excluded)
  OK notes-about-Dockerfile.md
  OK README.md
  OK package.json
  OK src/main.ts
  OK docs/docker-compose-guide.md
  OK docs/terraform-primer.md
```

## Deferred to separate tickets

- **#19** — Full rule-audit table at `docs/rule-audit.md`
- **#20** — Warning → blocker upgrade for `validate-branch-name.sh` and `validate-pr-create.sh`
- **#21** — `/approve-design` skill (analogous to `/approve-merge`)
- **#22** — `commit_types` project-config override
- **#23** — Conventional Commits breaking-change marker (`feat!:`)

## Glossary

| Term | Definition |
|------|------------|
| Monorepo anchor | The `(^|/)` regex prefix that matches both root-level paths and subdirectory paths. Closes the monorepo blind spot from the original #13 defaults. |
| Ambiguous directory name | A directory name with legitimate meaning in both IaC and library contexts (e.g. `infrastructure/`, `terraform/`). Dropped from defaults to avoid false positives. |
| Known gap | A failure mode explicitly accepted and documented rather than fixed here. The CDK/Pulumi infrastructure-dir case is the known gap; projects override via project-config. |
| Post-ship amendment | A dated changelog entry appended to a historical AgDR to record how the decision evolved, without rewriting the original. New pattern from this PR. |

## Test plan

- [ ] Pull branch, run the 21-fixture smoke test
- [ ] Confirm `backend/Dockerfile` matches and `docs/infrastructure/notes.md` does NOT match
- [ ] Confirm `block-merge-on-red-ci.sh` still parses (`bash -n`) after dead-code delete
- [ ] Confirm AgDR-0001 post-ship amendment is at the bottom, original block untouched
- [ ] Code Reviewer (Rex) review
- [ ] **Explicit per-PR CEO approval** (per rule from #11)

## Links

- Closes #18
- Parent: #13 (closed)
- Sibling follow-ups opened alongside: #19, #20, #21, #22, #23
- Rex's review of #17 where findings originated: https://github.com/me2resh/apexstack/pull/17

🤖 Generated with [Claude Code](https://claude.com/claude-code)
