### PR TITLE
ci(#2): dogfood apexstack CI with pr-title, markdown, shell, link checks

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,48 @@
+# Link Check — dogfood apexstack itself
+#
+# Uses lychee to find broken links in site/index.html and all *.md files.
+# Private / loopback addresses are allowed because some docs reference
+# localhost examples.
+
+name: Link Check
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "site/**"
+      - ".github/workflows/link-check.yml"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - "site/**"
+      - ".github/workflows/link-check.yml"
+  schedule:
+    # Weekly catch for link rot on upstream docs
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  lychee:
+    name: lychee
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --include-fragments
+            --exclude-loopback
+            --exclude-private
+            --accept 200,204,206,301,302,429
+            'site/index.html'
+            '**/*.md'
+          fail: true

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,40 @@
+# Markdown Lint — dogfood apexstack itself
+#
+# Catches broken markdown and inconsistent headings across the repo.
+# Uses a relaxed ruleset via .markdownlint.json at the repo root — we care
+# about real problems (bad links, malformed tables, duplicate headings) and
+# not cosmetic nits (line length, trailing spaces, emphasis style).
+
+name: Markdown Lint
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - ".markdownlint.json"
+      - ".github/workflows/markdown-lint.yml"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - ".markdownlint.json"
+      - ".github/workflows/markdown-lint.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    name: markdownlint-cli2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          globs: |
+            **/*.md
+            #node_modules
+            #.git

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,124 @@
+# PR Title Check — Ticket Enforcement
+# Copy this to .github/workflows/pr-title-check.yml in your project.
+#
+# Purpose: ensure all PRs have a ticket ID in the title.
+# Default: GitHub Issues (#58). Also supports any uppercase tracker prefix
+# (e.g. ABC-123, PROJ-456) for teams using Linear, Jira, or similar.
+
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-title:
+    name: Verify Ticket ID
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR title for ticket ID
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+
+            // Pattern matches:
+            //   Project tracker: ABC-123, ENG-456, PROJ-789 (2-10 char uppercase prefix + dash + digits)
+            //   GitHub Issues:   #58, #123
+            //
+            // Note: pattern intentionally aligned with the local hooks
+            // (.claude/hooks/validate-branch-name.sh and validate-pr-create.sh)
+            // so anything that passes the hooks also passes this CI check.
+            const trackerPattern = /[A-Z]{2,10}-\d+/;
+            const githubPattern = /#\d+/;
+
+            const trackerMatch = title.match(trackerPattern);
+            const githubMatch = title.match(githubPattern);
+
+            if (!trackerMatch && !githubMatch) {
+              core.setFailed(
+                `❌ PR title must include a ticket ID\n\n` +
+                `Current title: "${title}"\n\n` +
+                `Valid formats:\n` +
+                `  Tracker: ABC-123, ENG-456\n` +
+                `  GitHub:  #58\n\n` +
+                `Example: "feat(ABC-123): description" or "feat(#58): description"`
+              );
+              return;
+            }
+
+            const ticketId = trackerMatch ? trackerMatch[0] : githubMatch[0];
+            console.log(`✅ Found ticket ID: ${ticketId}`);
+            core.setOutput('ticket_id', ticketId);
+
+      - name: Add ticket label
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ticketId = '${{ steps.check.outputs.ticket_id }}';
+
+            if (ticketId) {
+              const isGithubIssue = ticketId.startsWith('#');
+              const label = isGithubIssue ? 'github-issue' : 'tracked';
+
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  labels: [label, 'has-ticket']
+                });
+              } catch (e) {
+                // Labels might not exist — that's OK
+                console.log('Could not add labels:', e.message);
+              }
+            }
+
+      - name: Post comment on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+
+            const body = `## ❌ Missing Ticket ID
+
+            Your PR title must include a ticket ID (project tracker or GitHub Issue).
+
+            **Current title**: \`${title}\`
+
+            ### Valid formats
+            - \`feat(ABC-123): add new feature\` (project tracker)
+            - \`fix(#58): correct encryption claim\` (GitHub Issue)
+            - \`ABC-123: Add new feature\`
+
+            ### Why we require tickets
+            - Every change must be tracked
+            - Enables traceability and audit
+            - Links code to business requirements
+            - No exceptions — even for "small" changes`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Missing Ticket ID')
+            );
+
+            if (!botComment) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,38 @@
+# ShellCheck — dogfood apexstack itself
+#
+# Runs shellcheck against the hook scripts under .claude/hooks/ to catch
+# portability bugs, quoting mistakes, and common shell pitfalls. The hook
+# scripts are the mechanical enforcement layer for the apexstack workflow,
+# so any bug there weakens the whole stack.
+
+name: ShellCheck
+
+on:
+  pull_request:
+    paths:
+      - ".claude/hooks/**"
+      - ".github/workflows/shellcheck.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".claude/hooks/**"
+      - ".github/workflows/shellcheck.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: shellcheck .claude/hooks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: "./.claude/hooks"
+          severity: warning
+          ignore_paths: >-
+            .claude/hooks/README.md

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false,
+  "MD024": { "siblings_only": true },
+  "MD026": false,
+  "MD036": false,
+  "MD040": false,
+  "MD046": false,
+  "MD009": false,
+  "MD012": false,
+  "MD029": false,
+  "MD034": false
+}


### PR DESCRIPTION
## Summary

ApexStack now dogfoods its own CI. Four GitHub Actions workflows added so that PRs to the framework repo itself get the same quality gates it ships to adopters via `golden-paths/pipelines/`.

Refs #2

## What changed

| File | Purpose |
|------|---------|
| `.github/workflows/pr-title-check.yml` | Enforces ticket ID in PR titles using the git-conventions regex. Copied verbatim from `golden-paths/pipelines/pr-title-check.yml`. |
| `.github/workflows/markdown-lint.yml` | Runs `markdownlint-cli2` on `**/*.md`. Catches broken markdown and inconsistent headings. |
| `.github/workflows/shellcheck.yml` | Runs `shellcheck` on `.claude/hooks/*.sh`. Catches portability bugs in hook scripts. |
| `.github/workflows/link-check.yml` | Runs `lychee` on `site/index.html` and `**/*.md`. Includes weekly cron for link-rot detection. |
| `.markdownlint.json` | Relaxed ruleset (disables MD013/MD033/MD041 etc.) because existing docs use bare URLs, mixed code-fence styles, and long lines. |

## Deviations from the ticket

- **Optional `html-validate.yml` skipped** — `site/index.html` is ~2000 lines of hand-written marketing HTML with hero animations and custom attributes. html-validate would need non-trivial config and likely false-positive heavily. Not worth the noise.
- **Weekly cron added to `link-check.yml`** — catches upstream link rot between PRs at zero extra config cost.
- **Relaxed markdownlint config** — strict mode would flag hundreds of pre-existing style issues in the docs and drown the signal. The config disables line-length (MD013), inline-HTML (MD033), first-line-heading (MD041), and several other cosmetic rules. Real problems (broken links, malformed tables, unclosed fences) are still caught.

## How it was tested

- All 4 YAML files validated with `YAML.load_file` (Ruby) — valid syntax
- `.markdownlint.json` validated with `python3 json` — valid JSON
- First real CI run will happen on this PR itself

## Glossary

| Term | Definition |
|------|------------|
| Dogfooding | Using your own product. ApexStack ships CI pipelines for adopters but didn't run them on its own repo until now. |
| markdownlint-cli2 | CLI tool for linting Markdown files. Configured via `.markdownlint.json`. |
| ShellCheck | Static analysis tool for shell scripts. Catches portability bugs, quoting issues, and common errors. |
| Lychee | Fast link checker. Used here to validate URLs in Markdown files and the landing page HTML. |
| Golden paths | Reusable CI pipeline templates at `golden-paths/pipelines/` that adopters copy into their own repos. |

## Test plan

- [ ] Confirm all 4 workflows run on this PR (they should trigger on `pull_request`)
- [ ] Confirm `.markdownlint.json` config doesn't produce false-positive noise
- [ ] Confirm ShellCheck passes on all hooks in `.claude/hooks/`
- [ ] Confirm link-check doesn't flag valid internal anchors
- [ ] Code Reviewer (Rex) review
- [ ] Explicit per-PR CEO approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)
