### PR TITLE
chore(#20): upgrade validate-branch-name + validate-pr-create from warning to blocker

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -232,7 +232,7 @@ These were already in place before the enforcement layer and remain unchanged (e
 | `validate-branch-name.sh` | PreToolUse / Bash | **Warns** on non-conforming branch names before push (warning-only; warning→blocker upgrade deferred to a follow-up ticket — breaking change) |
 | `check-secrets.sh` | PreToolUse / Bash | Scans commits for hardcoded secrets |
 | `pre-push-gate.sh` | PreToolUse / Bash | Reminds to run lint / typecheck / test / build |
-| `validate-pr-create.sh` | PreToolUse / Bash | **Warns** on title format / glossary / branch ID. **Blocks** when the title's issue number doesn't exist in the tracker (extended in GH-14). Warning→blocker upgrade for the format checks deferred. |
+| `validate-pr-create.sh` | PreToolUse / Bash | **Blocks** on title format / glossary / branch ID (upgraded from warning in GH-20). Also **blocks** when the title's issue number doesn't exist in the tracker (extended in GH-14). |
 
 ## Session State Directory
 

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -30,9 +30,10 @@ fi
 # Note: this pattern is intentionally aligned with the pr-title-check.yml
 # CI workflow regex so anything that passes this hook also passes CI.
 if ! echo "$CURRENT_BRANCH" | grep -qE '^(feature|fix|refactor|chore|docs|test|spike|ci|build|perf)/([A-Z]{2,10}-[0-9]+|GH-[0-9]+|#[0-9]+)-'; then
-  echo "WARNING: Branch '$CURRENT_BRANCH' doesn't follow naming convention: {type}/{TICKET-ID}-{description}" >&2
+  echo "BLOCKED: Branch '$CURRENT_BRANCH' doesn't follow naming convention: {type}/{TICKET-ID}-{description}" >&2
   echo "Examples: feature/ABC-123-add-auth, fix/GH-45-login-bug, docs/ENG-99-update-readme" >&2
-  # Warning only — does not block
+  echo "Rename with: git branch -m \"\$(git branch --show-current)\" \"feature/GH-XX-description\"" >&2
+  exit 2
 fi
 
 exit 0

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -97,9 +97,12 @@ if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "main" ] && [ "$CURRENT_BR
 fi
 
 if [ -n "$ERRORS" ]; then
-  echo "PR VALIDATION WARNINGS:" >&2
+  echo "PR VALIDATION BLOCKED:" >&2
   printf "$ERRORS" >&2
-  # Warning only, not blocking — PR creation has valid edge cases
+  echo "" >&2
+  echo "Fix the issues above before creating the PR." >&2
+  echo "See .claude/rules/git-conventions.md and .claude/rules/pr-quality.md." >&2
+  exit 2
 fi
 
 exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Work on ONE ticket at a time. Complete fully before starting next. Each PR = one
 
 ### Quality Rules
 
+- **Branch names and PR titles are enforced, not warned** -- as of 2026-04-12 (#20), `validate-branch-name.sh` and `validate-pr-create.sh` block (exit 2) instead of warn on malformed branch names, PR titles, missing glossary, and missing branch ticket IDs. Fix the format — see @.claude/rules/git-conventions.md
 - **No direct pushes to main** -- every change through a PR
 - **Tests required** -- >80% coverage for domain logic
 - **Lint, typecheck, test, build** must pass before pushing

--- a/docs/agdr/AgDR-0002-warning-to-blocker-upgrade.md
+++ b/docs/agdr/AgDR-0002-warning-to-blocker-upgrade.md
@@ -1,0 +1,47 @@
+---
+id: AgDR-0002
+timestamp: 2026-04-12T06:00:00Z
+agent: atlas
+model: claude-opus-4-6
+trigger: user-prompt
+status: executed
+ticket: me2resh/apexstack#20
+---
+
+# Warning-to-blocker upgrade for branch-name and PR-title validation
+
+> In the context of the rule-mechanization audit (#13) which found that warnings are "prose in disguise", facing the question of whether to upgrade `validate-branch-name.sh` and `validate-pr-create.sh` from warning (exit 0) to blocker (exit 2), I decided to upgrade both to blockers to close the enforcement gap, accepting that this is a behavior-visible breaking change for existing users.
+
+## Context
+
+The first real test run of ApexStack (2026-04-11) exposed that agents drop rules under pressure. The subsequent audit identified that two pre-existing hooks — `validate-branch-name.sh` and `validate-pr-create.sh` — only warned on rule violations via stderr output but always exited 0, allowing the operation to proceed. This makes them functionally equivalent to prose advice: the harness runs them, but their warnings can be silently ignored.
+
+AgDR-0001 explicitly listed the warning-to-blocker upgrade as a deferred follow-up, noting it was a "breaking change" that deserved its own ticket.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A — Upgrade both to blockers** | Closes the enforcement gap completely. Branch names and PR titles either conform or the operation is rejected. Matches the "if it's a MUST, it's a hook" principle from the audit. | Breaking change — users who got used to pushing with non-conforming names will now be blocked. May surprise contributors on first push after upgrade. |
+| **B — Keep as warnings** | No breaking change. Familiar behavior. Users who push non-conforming branches can still do so and fix later. | Defeats the purpose of the rule-mechanization audit. Warnings were ignored in the test run — that's the incident that started this entire session. |
+| **C — Configurable severity** | Add a `hook_severity` field to `project-config.json` that lets forks choose warning vs blocker per hook. | Over-engineering for a binary choice. Adds complexity to every hook. The "make everything configurable" instinct here is premature abstraction. |
+
+## Decision
+
+**Chosen: Option A — upgrade both to blockers.**
+
+The entire session exists because prose rules and warning-only hooks were ignored under pressure. Keeping them as warnings is inconsistent with the design philosophy established in AgDR-0001 ("if a rule is important, put it in a hook; if it's a preference, put it in a rule file; if it's context, put it in CLAUDE.md"). Branch naming and PR title format are MUST rules in `git-conventions.md` — they belong in a hook that blocks, not one that warns.
+
+The breaking-change concern is real but manageable: a one-paragraph migration note in CLAUDE.md flags the change, and the block messages include actionable fix instructions (rename command for branches, format examples for PR titles).
+
+## Consequences
+
+- Push with non-conforming branch name now fails (exit 2) with a rename suggestion
+- PR creation with malformed title, missing glossary, or missing branch ticket ID now fails (exit 2) with format guidance
+- Migration note added to CLAUDE.md Quality Rules section
+- hooks/README.md updated to replace "Warns" with "Blocks" for both hooks
+
+## Artifacts
+
+- Ticket: [me2resh/apexstack#20](https://github.com/me2resh/apexstack/issues/20)
+- Parent decision: AgDR-0001 (rule-mechanization hooks)


### PR DESCRIPTION
## Summary

Upgrades `validate-branch-name.sh` and `validate-pr-create.sh` from warning (exit 0) to blocker (exit 2) when validation fails. Breaking change — users who got used to pushing with non-conforming branch names or creating PRs with malformed titles will now be blocked.

This is the final step in the rule-mechanization audit: the warnings were "prose in disguise" — the harness ran them but their output was silently ignorable. The first real test run of ApexStack confirmed this: warnings were dropped under pressure.

Closes #20

## Changes

- **`validate-branch-name.sh`** — non-conforming branch names rejected at push time with a rename suggestion (exit 2 instead of exit 0). Allowlist for main/master/develop unchanged.
- **`validate-pr-create.sh`** — malformed PR titles, missing glossary sections, and missing branch ticket IDs rejected at PR creation time (exit 2 instead of exit 0). The issue-existence check from #14 was already a blocker and is unchanged.
- **`CLAUDE.md`** — migration note in Quality Rules: "Branch names and PR titles are enforced, not warned — as of 2026-04-12."
- **`.claude/hooks/README.md`** — Pre-existing Hooks table updated from "Warns" to "Blocks" for both hooks.
- **`docs/agdr/AgDR-0002-warning-to-blocker-upgrade.md`** — decision record comparing 3 options (upgrade both, keep warnings, configurable severity), chosen: upgrade both.

## Smoke tests

- validate-branch-name.sh: allows conforming current branch (exit 0)
- validate-pr-create.sh: **blocks** malformed title (exit 2)
- validate-pr-create.sh: allows valid title + glossary (exit 0)

## Glossary

| Term | Definition |
|------|------------|
| Warning-only hook | A hook that prints to stderr but exits 0, allowing the operation to proceed. Functionally equivalent to prose advice — the harness runs it but the output is ignorable. |
| Blocker hook | A hook that exits 2, cancelling the tool call. The operation cannot proceed until the issue is fixed. |
| AgDR-0002 | The decision record for this upgrade. Compares upgrade / keep-warnings / configurable-severity options. |

## Test plan

- [ ] Confirm non-conforming branch name is rejected at push time
- [ ] Confirm malformed PR title is rejected at PR creation time
- [ ] Confirm valid formats still pass (no false positives)
- [ ] Confirm issue-existence check from #14 is not regressed
- [ ] Rex review
- [ ] Explicit per-PR CEO approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)
