### PR TITLE
feat(#22): commit_types project-config override for validate-commit-format

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -200,6 +200,14 @@ Accepts `type: subject` and `type(scope): subject`. Rejects subjects without a v
 
 **Why this list of types:** identical to the PR-title type list in `git-conventions.md`, plus `revert` which PR titles allow. Keeping the commit-type list aligned with the PR-title list prevents "commit passes but PR title using the same type fails" asymmetry.
 
+**Customize:** set `.commit_types` in `.claude/project-config.json` to a JSON array of strings. When set, ONLY those types are accepted — the default list is **not** merged; the override replaces it entirely. This lets teams with strict conventions whitelist exactly the types they use:
+
+```json
+{ "commit_types": ["wip", "feat", "fix"] }
+```
+
+With that config, `wip: scratch work` is accepted and `refactor: cleanup` is rejected. Remove the field or the file to restore the default 11-type list.
+
 **Interactive commits (no `-m` / `-F`)** are skipped — accepted gap, matches sibling hooks' policy.
 
 **Enforces:** `.claude/rules/git-conventions.md § "Commit Message Format"` — was prose-only.

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -61,13 +61,24 @@ fi
 #   type: subject         (no scope)
 #   type(scope): subject  (with scope — superset)
 #
-# Types per .claude/rules/git-conventions.md:
-#   feat, fix, refactor, test, docs, chore, style, perf
+# Default types per .claude/rules/git-conventions.md:
+#   feat, fix, refactor, test, docs, chore, style, perf, build, ci, revert
 #
-# ApexStack also accepts (build, ci, revert) since those types appear in the
-# PR-title regex in git-conventions.md — staying consistent prevents commit
-# messages from being valid in PR titles but not commits.
-TYPE_REGEX='^(feat|fix|refactor|test|docs|chore|style|perf|build|ci|revert)(\([^)]+\))?:[[:space:]]+.+'
+# Projects can override the type list via .claude/project-config.json:
+#   { "commit_types": ["wip", "feat", "fix"] }
+# When set, ONLY those types are accepted. The default list is NOT merged —
+# the override replaces it entirely. This lets teams with strict conventions
+# whitelist exactly the types they use.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+DEFAULT_TYPES="feat|fix|refactor|test|docs|chore|style|perf|build|ci|revert"
+TYPES="$DEFAULT_TYPES"
+if [ -n "$REPO_ROOT" ] && [ -f "${REPO_ROOT}/.claude/project-config.json" ]; then
+  CUSTOM=$(jq -r '.commit_types // [] | join("|")' "${REPO_ROOT}/.claude/project-config.json" 2>/dev/null)
+  if [ -n "$CUSTOM" ] && [ "$CUSTOM" != "null" ] && [ "$CUSTOM" != "" ]; then
+    TYPES="$CUSTOM"
+  fi
+fi
+TYPE_REGEX="^(${TYPES})(\([^)]+\))?:[[:space:]]+.+"
 
 if ! echo "$SUBJECT" | grep -qE "$TYPE_REGEX"; then
   cat >&2 <<MSG_END

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -50,6 +50,8 @@ Typical answers (adapt to stack):
 
 Capture per sub-project if monorepo; the `pre-push-gate.sh` hook will later reference these.
 
+**Optional follow-up:** if the project uses non-standard commit types (e.g. `wip`, `security`, `deps`), ask whether to set `.commit_types` in `project-config.json` to override the default 11-type list. Most projects don't need this — only ask if the CI checks or team conventions differ from the standard `feat|fix|refactor|test|docs|chore|style|perf|build|ci|revert` list.
+
 ### Q4: Reviewers
 
 ```


### PR DESCRIPTION
## Summary

`validate-commit-format.sh` now reads a `commit_types` field from `.claude/project-config.json` before falling back to the hardcoded default list. When set, ONLY those types are accepted — the override replaces the defaults entirely, giving teams full control over their commit vocabulary without touching framework code.

Closes #22

## Example

```json
{ "commit_types": ["wip", "feat", "fix"] }
```

With this config:
- `wip: scratch work` is **accepted** (in the custom list)
- `refactor: cleanup` is **rejected** (not in the custom list — `refactor` is only in the defaults)

Remove the field or the file to restore the default 11-type list.

## Changes

- **`.claude/hooks/validate-commit-format.sh`** — reads `.commit_types` from project-config via `jq`, joins with `|`, uses as the regex type group. Falls back to default `feat|fix|refactor|test|docs|chore|style|perf|build|ci|revert` when no override is present.
- **`.claude/hooks/README.md`** — documents the override in the commit-format hook section with an example.
- **`.claude/skills/onboard/SKILL.md`** — adds an optional follow-up note in Q3 (Required CI Checks) about `commit_types` for teams with non-standard conventions.

## Smoke tests (all 4 pass)

```
=== 1: default list — "feat: ok" → allow ===           exit=0
=== 2: default list — "wip: scratch" → block ===       exit=2
=== 3: custom list — "wip: scratch" → allow ===        exit=0
=== 3: custom list — "refactor: cleanup" → block ===   exit=2
=== 4: config removed — "refactor: cleanup" → allow === exit=0
```

## Glossary

| Term | Definition |
|------|------------|
| commit_types | A JSON array of strings in `.claude/project-config.json` that overrides the default commit-type list for `validate-commit-format.sh`. Replaces (does not merge with) the defaults. |
| project-config.json | Per-project configuration file at `.claude/project-config.json`. Gitignored. Written by `/onboard`. Also used by `validate-pr-create.sh` (tracker_repo), `require-agdr-for-arch-changes.sh` (architecture_paths), and `require-design-review-for-ui.sh` (ui_paths). |

## Test plan

- [ ] Set `commit_types` in a test project-config, confirm custom types accepted and non-listed types rejected
- [ ] Remove the config, confirm defaults restored
- [ ] Confirm the override replaces (not merges with) the defaults
- [ ] Rex review
- [ ] Explicit per-PR CEO approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)