### PR TITLE
feat(#23): support Conventional Commits breaking-change marker

### DIFF
--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -58,8 +58,10 @@ if [ -z "$SUBJECT" ]; then
 fi
 
 # Validate:
-#   type: subject         (no scope)
-#   type(scope): subject  (with scope — superset)
+#   type: subject              (no scope)
+#   type(scope): subject       (with scope)
+#   type!: subject             (breaking change, Conventional Commits 1.0)
+#   type(scope)!: subject      (breaking change with scope)
 #
 # Default types per .claude/rules/git-conventions.md:
 #   feat, fix, refactor, test, docs, chore, style, perf, build, ci, revert
@@ -78,7 +80,7 @@ if [ -n "$REPO_ROOT" ] && [ -f "${REPO_ROOT}/.claude/project-config.json" ]; the
     TYPES="$CUSTOM"
   fi
 fi
-TYPE_REGEX="^(${TYPES})(\([^)]+\))?:[[:space:]]+.+"
+TYPE_REGEX="^(${TYPES})(\([^)]+\))?!?:[[:space:]]+.+"
 
 if ! echo "$SUBJECT" | grep -qE "$TYPE_REGEX"; then
   cat >&2 <<MSG_END
@@ -90,6 +92,8 @@ Subject was:
 Expected format (from .claude/rules/git-conventions.md):
   type: subject
   type(scope): subject
+  type!: subject             (breaking change)
+  type(scope)!: subject      (breaking change with scope)
 
 Where type is one of:
   feat, fix, refactor, test, docs, chore, style, perf, build, ci, revert
@@ -97,6 +101,8 @@ Where type is one of:
 Examples:
   feat: add user avatar upload
   fix(auth): handle expired refresh tokens
+  feat!: remove deprecated v1 endpoints
+  feat(api)!: change response format to JSON:API
   refactor: split order service into read/write sides
   docs(#42): update deployment runbook
 

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -30,12 +30,13 @@ if [ -z "$TITLE" ]; then
 fi
 
 # Validate PR title format if we can extract it
-# Accepts: type(<UPPERCASE-PREFIX 2-10 chars>-<digits>): … or type(#<digits>): …
+# Accepts: type(<TICKET>): … or type(<TICKET>)!: … (breaking change)
+# The !? makes the breaking-change marker optional per Conventional Commits 1.0.
 # Note: this pattern is intentionally aligned with the pr-title-check.yml
 # CI workflow regex so anything that passes this hook also passes CI.
 TICKET_REF=""
 if [ -n "$TITLE" ]; then
-  if ! echo "$TITLE" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\(([A-Z]{2,10}-[0-9]+|#[0-9]+)\):'; then
+  if ! echo "$TITLE" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\(([A-Z]{2,10}-[0-9]+|#[0-9]+)\)!?:'; then
     ERRORS="${ERRORS}PR title '$TITLE' doesn't match format: type(TICKET-ID): description\n"
   else
     # Extract the ticket reference so we can verify it exists

--- a/.claude/rules/git-conventions.md
+++ b/.claude/rules/git-conventions.md
@@ -16,17 +16,20 @@ The `TICKET-ID` should reference an issue in the project's own GitHub repo. Defa
 
 ## PR Title Format
 
-Must match: `type(TICKET): description`
+Must match: `type(TICKET): description` or `type(TICKET)!: description` (breaking change)
 
-Regex: `^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\(([A-Z]+-[0-9]+|#[0-9]+)\):`
+Regex: `^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\(([A-Z]+-[0-9]+|#[0-9]+)\)!?:`
 
 - One ticket ID per PR title — multi-ticket titles like `fix(ABC-1,2,3):` are rejected
 - GitHub Issues use `#XX` format: `fix(#58): description`
+- Breaking changes use `!` before the colon: `feat(#58)!: remove deprecated v1 endpoints`
 
 ## Commit Message Format
 
 ```
 type: subject
+type!: subject (breaking change)
+type(scope)!: subject (breaking change with scope)
 
 - Detailed change 1
 - Detailed change 2


### PR DESCRIPTION
## Summary

Both \`validate-commit-format.sh\` and \`validate-pr-create.sh\` now accept the \`!\` breaking-change marker per Conventional Commits 1.0. Minimal change — \`!?\` (optional) before the colon in both hooks' type regex. Also updates \`.claude/rules/git-conventions.md\` to document the marker with examples.

Closes #23

## Examples now accepted

\`\`\`
feat!: remove deprecated v1 endpoints
feat(api)!: change response format to JSON:API
feat(#42)!: breaking PR title with ticket ref
\`\`\`

All non-breaking forms (\`feat:\`, \`feat(scope):\`, \`feat(#42):\`) continue to work unchanged.

## Smoke tests (all 6 pass)

- \`feat!: breaking\` → exit=0
- \`feat(api)!: breaking with scope\` → exit=0
- \`feat: regular (no !)\` → exit=0
- \`"broke stuff" (invalid)\` → exit=2
- \`feat(#23)!: breaking PR title\` → exit=0
- \`feat(#23): regular PR title\` → exit=0

## Glossary

| Term | Definition |
|------|------------|
| Breaking-change marker | The \`!\` character placed before the colon in a Conventional Commits subject (\`feat!: ...\`). Signals a breaking change. Optional — its absence doesn't mean the change isn't breaking. |
| Conventional Commits 1.0 | Industry-standard commit message specification. ApexStack now supports its full type + scope + breaking marker syntax. |

## Test plan

- [ ] Confirm \`feat!:\` and \`feat(scope)!:\` accepted by commit-format hook
- [ ] Confirm \`feat(#N)!:\` accepted by PR-title hook
- [ ] Confirm non-breaking forms still pass (no regression)
- [ ] Confirm invalid subjects still blocked
- [ ] Rex review
- [ ] Explicit per-PR CEO approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)