### PR TITLE
feat(#32): /setup first-run bootstrap + deprecate /onboard + update CLAUDE.md

### DIFF
--- a/.claude/hooks/onboarding-check.sh
+++ b/.claude/hooks/onboarding-check.sh
@@ -1,46 +1,39 @@
 #!/bin/bash
-# SessionStart hook: checks whether this repo has been onboarded to ApexStack.
-# If not, injects a visible reminder so Claude prompts the user to run /onboard
-# before doing any work.
+# SessionStart hook: checks whether this ApexStack fork has been configured.
 #
-# "Onboarded" means .claude/session/onboarded exists. The /onboard skill creates
-# it after asking the discovery questions (project identity, tracker repo,
-# required CI checks, reviewers, UI/backend, deploy targets, sensitive topics).
+# Detection: reads onboarding.yaml and checks if company.name is still the
+# placeholder value "Your Company Name". If so, the fork hasn't been set up
+# yet and the user should run /setup.
 #
-# Same principle as the role-triggers rule: don't start work until you know
-# who, what, why, and under which constraints.
+# Why onboarding.yaml and not a session marker: onboarding.yaml is COMMITTED,
+# so the setup state persists across clones and team members. A fresh clone
+# of a configured fork already has real values — no per-machine marker needed.
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-MARKER="${REPO_ROOT:-.}/.claude/session/onboarded"
+CONFIG="${REPO_ROOT:-.}/onboarding.yaml"
 
-if [ -f "$MARKER" ]; then
+# No onboarding.yaml at all — not an apexstack fork, skip silently
+if [ ! -f "$CONFIG" ]; then
   exit 0
 fi
 
-cat <<MSG
-APEXSTACK ONBOARDING NOT RUN
+# Check if the placeholder is still present
+if grep -q '"Your Company Name"' "$CONFIG" 2>/dev/null; then
+  cat <<MSG
+APEXSTACK SETUP NOT RUN
 
-This repository has no onboarding marker at:
-  ${MARKER}
+This fork hasn't been configured yet. onboarding.yaml still has
+placeholder values ("Your Company Name").
 
-ApexStack needs a short discovery pass before the first session so hooks,
-reviewers, and gates know:
+Run /setup to configure your fork in ~2 minutes:
 
-  - What project this is and where its code + tickets live
-  - Which CI checks must run before push (lint, typecheck, test, build,
-    framework-specific validators like \`sam validate --lint\` or \`terraform validate\`)
-  - Who the reviewers are (Rex + human approver — Tech Lead, CEO, owner)
-  - Whether this repo has UI work (design-review gate)
-  - Deploy targets (staging, prod, where URLs live, auto-on-merge or manual)
-  - Sensitive topics (anything that must never land in git or public issues)
+  1. Describe your company and tech stack (one question)
+  2. Review the proposed defaults
+  3. Accept or customize
 
-Before starting any work in this repo, ask the user to run:
-
-  /onboard
-
-The skill will ask the questions and write both the marker above and
-.claude/project-config.json. If the user wants to skip onboarding for a quick
-one-off, they can:
-  touch ${MARKER}
+The config is committed to onboarding.yaml so it persists across
+clones and team members — you only need to do this once per fork.
 MSG
+fi
+
 exit 0

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -1,125 +1,29 @@
 ---
 name: onboard
-description: First-run discovery pass for a new ApexStack repo. Asks the questions a Chief-of-Staff / engineering lead would ask on day one — project identity, tracker repo, required CI checks, reviewers, UI/backend, deploy targets, sensitive topics — and writes the onboarding marker plus a machine-readable project-config.json so other hooks and skills stop assuming defaults.
+description: "DEPRECATED — use /setup for framework configuration, /handover for adding a project to the portfolio. This skill redirects to the correct flow."
 disable-model-invocation: false
 argument-hint: ""
-effort: medium
+effort: low
 ---
 
-# /onboard - ApexStack Discovery Pass
+# /onboard — DEPRECATED
 
-Same principle as `.claude/rules/role-triggers.md`: do not start work until you know who, what, why, and under which constraints. Run this skill the **first time** you open a new repo under the ApexStack harness. It's idempotent — running it again updates the config.
+This skill has been split into two purpose-specific flows:
 
-## When This Runs
+| What you want to do | Run instead |
+|---------------------|-------------|
+| **Configure the ApexStack fork** (first-run setup, company info, tech stack defaults) | `/setup` |
+| **Add a project to the portfolio** (onboard an external repo, per-project discovery) | `/handover <repo>` |
 
-The `onboarding-check.sh` SessionStart hook flags missing onboarding at the top of every session. Invoke `/onboard` as the first action in a new repo, or any time the answers materially change (e.g., a new CI check was added, a reviewer rotated, deploy target moved).
+## Why the split
 
-## Process
+`/onboard` mixed two concerns: framework-level bootstrap (writing `onboarding.yaml`) and per-project discovery (writing `project-config.json`). These happen at different times, write to different files, and have different triggers:
 
-Ask the questions **one at a time**, not all at once. Wait for each answer before moving on. If the answer is obvious from the repo (e.g., project name = directory name, code repo = `git remote get-url origin`), **propose the default and ask for confirmation** rather than making the user type it.
+- `/setup` runs **once per fork** and writes `onboarding.yaml` (committed, framework-wide).
+- `/handover` runs **once per project** and writes `project-config.json` (per-project, in the workspace).
 
-### Q1: Project Identity
+The per-project discovery questions (tracker repo, CI checks, architecture paths, UI paths, commit types) are now part of `/handover`'s assessment flow — they're asked when a project enters the portfolio, not as a standalone ceremony.
 
-```
-What is this project and what does it do? (one sentence)
-```
+## If you got here from the SessionStart hook
 
-Then: `What GitHub repo holds its code?` — default to the current `git remote get-url origin` when available.
-
-### Q2: Ticket Tracker
-
-```
-Where do tickets for this project live? (owner/repo for GitHub Issues)
-```
-
-Default to the code repo unless the user says otherwise. Exceptions (e.g., framework repos whose tickets live in a separate ops repo) must be stated explicitly.
-
-### Q3: Required CI Checks
-
-```
-What must pass locally before `git push`? List commands, grouped by sub-project if this is a monorepo.
-```
-
-Typical answers (adapt to stack):
-
-- TypeScript / Node: `npm run lint && npm run typecheck && npm run test && npm run build`
-- AWS SAM backend: add `sam validate --lint`
-- Terraform: `terraform fmt -check && terraform validate`
-- Swift / SPM: `swift build && swift test`
-- Python: `ruff check && mypy && pytest`
-
-Capture per sub-project if monorepo; the `pre-push-gate.sh` hook will later reference these.
-
-**Optional follow-up:** if the project uses non-standard commit types (e.g. `wip`, `security`, `deps`), ask whether to set `.commit_types` in `project-config.json` to override the default 11-type list. Most projects don't need this — only ask if the CI checks or team conventions differ from the standard `feat|fix|refactor|test|docs|chore|style|perf|build|ci|revert` list.
-
-### Q4: Reviewers
-
-```
-Who reviews PRs for this repo?
-```
-
-Default: **Rex (code-reviewer agent) + one human approver** (Tech Lead / Project owner / CEO, depending on the team). Note any extras — `Shield` (security-reviewer) for auth/crypto code, domain expert for specialised areas, UI Designer for UI-heavy PRs.
-
-### Q5: UI Work
-
-```
-Does this repo ship user-facing UI?
-```
-
-If yes: any PR touching `.tsx|.jsx|.vue|.svelte|.css|.scss` should go through the `/frontend-design` skill before implementation, and merge requires a design review per `workflows/code-review.md`.
-
-### Q6: Deploy Targets
-
-```
-What environments does this repo deploy to and where are the URLs?
-```
-
-Capture staging + prod URLs, any env-var names for secrets (never the values), and whether deploys are automatic (on merge) or manual.
-
-### Q7: Sensitive Topics
-
-```
-Is there any info that must NEVER be committed or put in GitHub Issues?
-```
-
-Common: cloud account IDs, DB connection strings, pool / tenant IDs, internal dashboard URLs, customer names. Record these as "memory-only" topics — they go into the user's auto-memory, never into git.
-
-## Write the Config
-
-Create `.claude/project-config.json` (overwrite if exists):
-
-```json
-{
-  "project": "<name>",
-  "description": "<one-sentence>",
-  "code_repo": "<owner/repo>",
-  "tracker_repo": "<owner/repo>",
-  "required_checks": {
-    "<sub-project>": ["<command>", "..."]
-  },
-  "reviewers": ["rex", "<human-approver>"],
-  "has_ui": true,
-  "deploy": {
-    "staging": "<url>",
-    "prod": "<url>",
-    "mode": "auto-on-merge | manual"
-  },
-  "sensitive_topics": ["..."],
-  "onboarded_at": "<ISO-8601>",
-  "onboarded_by": "<agent-or-user>"
-}
-```
-
-Then: `touch .claude/session/onboarded` so the SessionStart hook stops flagging.
-
-## Confirm to the User
-
-Print a short summary of what was captured and where it's stored. Offer to save any sensitive-topic answers into the memory system (never into git, never into the project-config).
-
-## Rules
-
-1. **One question at a time** — avoid a wall of questions.
-2. **Propose defaults** — read the repo to guess, then ask the user to confirm / override.
-3. **Never commit the config automatically** — `.claude/project-config.json` is gitignored by default so sensitive deploy URLs and topic lists do not leak.
-4. **Sensitive data → memory, never git** — cloud account IDs, secrets, and credentials belong in the user's auto-memory system, never in the config or issues.
-5. **Re-run anytime** — the skill is idempotent. CI commands change, people rotate, deploys move; re-run and let it overwrite.
+The `onboarding-check.sh` hook now checks `onboarding.yaml` for placeholder values, not a session marker. Run `/setup` to configure your fork.

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: setup
+description: First-run framework bootstrap for a new ApexStack fork. Three exchanges — "describe your stack", "here are the defaults", "accept or customize?" — and the fork is configured. Run once after forking; re-run anytime to update.
+disable-model-invocation: false
+argument-hint: "[--reset]"
+effort: medium
+---
+
+# /setup — ApexStack First-Run Bootstrap
+
+Configures `onboarding.yaml` for a new ApexStack fork in three exchanges instead of eight sequential questions. The "describe, propose, confirm" pattern gets most users from fork to working in under 2 minutes.
+
+## When this runs
+
+The `onboarding-check.sh` SessionStart hook detects that `onboarding.yaml` still has placeholder values (e.g. `company.name: "Your Company Name"`) and prompts the user to run `/setup`. After `/setup` fills in real values and commits, the hook goes silent forever — even on fresh clones, because `onboarding.yaml` is committed.
+
+Re-running `/setup` on an already-configured fork shows the current config and asks what to update. Use `--reset` to clear everything and start from scratch.
+
+## Process
+
+### Step 1: Check current state
+
+Read `onboarding.yaml`. Two modes:
+
+- **First run** (placeholder values detected): proceed to Step 2.
+- **Already configured** (real values): show a summary of the current config and ask "What would you like to update?" — then jump to the specific section. Don't re-ask everything.
+- **`--reset` flag**: clear `onboarding.yaml` back to the template defaults (copy from the upstream example or regenerate) and proceed as first run.
+
+Detection: `grep -q '"Your Company Name"' onboarding.yaml` — if found, it's still a template.
+
+### Step 2: One question — describe your world
+
+Ask a single open-ended question:
+
+```
+Tell me about your company and tech stack in a few sentences.
+For example: "We're a 3-person startup building a property management
+SaaS. TypeScript + React frontend, AWS SAM backend with DynamoDB.
+GitHub Issues for tracking, 1-week sprints."
+```
+
+**Do NOT ask sequential questions.** The whole point of this skill is to collapse the discovery into one natural-language exchange. The user describes their world; you parse it.
+
+### Step 3: Parse and map to defaults
+
+From the user's description, extract:
+
+| Field | Parse from | Default if not mentioned |
+|-------|-----------|------------------------|
+| `company.name` | Company name in the description | Ask explicitly — this one's required |
+| `company.mission` | What they're building | `""` (leave blank, user fills later) |
+| `tech_stack.language` | "TypeScript", "Python", "Go", etc. | `"TypeScript"` |
+| `tech_stack.framework` | "React", "Vue", "Svelte", etc. | `""` (no frontend) |
+| `tech_stack.backend` | "Express", "FastAPI", "SAM", etc. | Inferred from language |
+| `tech_stack.database` | "PostgreSQL", "DynamoDB", "MongoDB", etc. | `""` |
+| `tech_stack.hosting` | "AWS", "GCP", "Azure", "Vercel", etc. | `"AWS"` |
+| `project_management.tool` | "GitHub Issues", "Linear", "Jira" | `"GitHub Issues"` |
+| `quality.required_checks` | Inferred from stack | `[lint, typecheck, test, build]` |
+| `team` | Team size / roles mentioned | Minimal default (1 tech lead) |
+
+Also infer non-obvious settings:
+- If they mention "SAM" → `tech_stack.iac: "AWS SAM"` and add `sam validate --lint` to implied checks
+- If they mention "Terraform" → `tech_stack.iac: "Terraform"` and add `terraform validate`
+- If they mention "no frontend" or don't mention a framework → `workflows.require_design_review: false` (no UI = no design gate)
+- If they mention "solo" or "1 person" → simplify team to just them, `required_reviews: 0`
+
+### Step 4: Present the proposed config
+
+Show a clean summary (NOT raw YAML — a formatted table or bulleted list):
+
+```
+Based on your description, here's how I'd configure your fork:
+
+Company: ApexScript
+Stack: TypeScript + React (frontend), AWS SAM + DynamoDB (backend)
+Hosting: AWS
+CI checks: npm run lint, npm run typecheck, npm run test, npm run build, sam validate --lint
+Tracker: GitHub Issues, 1-week sprints
+Reviewers: Rex (code-reviewer agent) + you
+Quality: 80% coverage target, thorough review style
+Team: 1 tech lead (you)
+
+Design review gate: ON (React = UI work)
+AgDR gate: ON (default architecture paths)
+Commit types: framework defaults (feat, fix, refactor, test, docs, chore, style, perf, build, ci, revert)
+
+Use these defaults, or customize?
+```
+
+### Step 5: Confirm or customize
+
+- **"yes" / "looks good" / "use defaults"** → proceed to Step 6.
+- **"customize X"** → ask about the specific field, update, re-show the summary with the change highlighted, re-confirm.
+- **"no, actually we use Y"** → re-parse, re-propose.
+
+Don't loop more than twice. If the user keeps correcting, switch to "tell me exactly what to change" direct-edit mode.
+
+### Step 6: Write onboarding.yaml
+
+Read the current `onboarding.yaml` template, replace placeholder values with the confirmed config, and write back. Preserve the file's structure and comments — the comments are documentation for future readers.
+
+**Important:** use `Edit` tool to modify in-place, not `Write` to overwrite — this preserves comments and structure that the user didn't touch.
+
+After writing:
+
+```bash
+git add onboarding.yaml
+```
+
+Stage but do NOT commit — let the user review the diff and commit when ready. Tell them:
+
+```
+onboarding.yaml updated and staged. Review with `git diff --cached` and
+commit when you're happy: git commit -m "chore: configure apexstack for <company>"
+```
+
+### Step 7: Optionally seed the project registry
+
+If the user mentioned a specific project in their description, offer to add it:
+
+```
+You mentioned a property management SaaS. Want me to register it as
+your first managed project in apexstack.projects.yaml?
+I'll need: repo name (owner/repo) and a short project name.
+```
+
+If yes → append to `apexstack.projects.yaml`, stage alongside `onboarding.yaml`.
+If no → skip. They can add projects later with `/handover`.
+
+## Rules
+
+1. **One question to start.** Do not ask about company, then stack, then team, then tools separately. One open-ended prompt, one natural-language response, one proposed config.
+2. **Propose, don't interrogate.** Show the full config with sensible defaults and let the user correct. Most fields have obvious defaults from the description.
+3. **Stage, don't commit.** The user should see the diff before it's committed. `/setup` stages; the user commits.
+4. **Preserve structure.** `onboarding.yaml` has comments that explain each section. Don't blow them away — edit in place.
+5. **Idempotent.** Running `/setup` again shows current config and asks what to update. Running with `--reset` clears and re-asks.
+6. **No project-config.json.** `/setup` configures the FRAMEWORK (onboarding.yaml). Per-project config is handled by `/handover` and `/idea` when projects enter the portfolio.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,23 +163,27 @@ ApexStack ships with a `.claude/` directory containing the Claude Code primitive
 
 | Layer | Path | Purpose |
 |-------|------|---------|
-| Hooks | `.claude/hooks/` | Shell scripts that block / warn on risky operations (`git add -A`, push to main, hardcoded secrets, branch / PR-title format) |
-| Rules | `.claude/rules/` | Modular rule files imported into your project's `CLAUDE.md` (AgDR triggers, code standards, git conventions, PR quality, workflow gates) |
+| Hooks | `.claude/hooks/` | 14 shell scripts that mechanically enforce SDLC rules — ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning |
+| Rules | `.claude/rules/` | 9 modular rule files (AgDR triggers, code standards, git conventions, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer, Security Reviewer, Dependency Auditor, PR Manager, Ticket Manager) |
-| Skills | `.claude/skills/` | 13 slash commands — see the full list below |
-| Settings | `.claude/settings.json` | Wires the hooks to `PreToolUse` events |
+| Skills | `.claude/skills/` | 17 slash commands — see the full list below |
+| Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (13)
+### Available skills (17)
 
 | Skill | Purpose |
 |-------|---------|
+| `/setup` | **First-run bootstrap** — describe your stack, accept defaults, configure `onboarding.yaml` in 3 exchanges |
+| `/start-ticket` | Declare an active ticket for this session (required before code edits) |
+| `/approve-merge` | Record per-PR CEO approval for a specific merge (required by merge gate) |
+| `/approve-design` | Record per-PR design-review approval for UI PRs (required by design gate) |
 | `/decide` | Make a technical decision and create an Agent Decision Record (AgDR) |
 | `/code-review` | Invoke the Code Reviewer agent (Rex) on a PR |
 | `/security-review` | Invoke the Security Reviewer agent (Shield) on a PR |
 | `/audit-deps` | Audit dependencies for vulnerabilities, outdated packages, licences |
 | `/write-spec` | Generate a PRD or feature spec from a problem statement |
 | `/idea` | Capture a new product idea to the backlog |
-| `/handover` | Onboard an external repo into ApexStack management |
+| `/handover` | Onboard an external repo into ApexStack management (includes per-project discovery) |
 | `/projects` | List all managed projects from the registry with status |
 | `/inbox` | Items needing your attention — PRs, issues, comments, blockers |
 | `/status` | Current snapshot — git, CI, in-progress work |


### PR DESCRIPTION
## Summary

New \`/setup\` skill for first-run bootstrap — "describe your stack, accept defaults, done in 3 exchanges." Replaces the 7-question sequential \`/onboard\` flow. \`onboarding-check.sh\` now checks \`onboarding.yaml\` (committed) instead of a gitignored session marker.

Closes #32

## Design

| Skill | Scope | Writes to | When |
|-------|-------|-----------|------|
| \`/setup\` (new) | Framework-level | \`onboarding.yaml\` | Once per fork |
| \`/handover\` (existing) | Project-level | \`project-config.json\` | Once per managed project |
| \`/onboard\` (deprecated) | — | Redirect only | — |

## Changes

- **New \`.claude/skills/setup/SKILL.md\`** — "describe, propose, confirm" UX. Parses natural-language stack description, maps to \`onboarding.yaml\` fields, proposes complete config, one yes/no confirm. Stages but doesn't commit. Idempotent + \`--reset\` support.
- **\`.claude/hooks/onboarding-check.sh\`** — now checks \`onboarding.yaml\` for placeholder "Your Company Name" instead of the \`.claude/session/onboarded\` marker. Config file IS the flag — committed, persists across clones, no hidden state.
- **\`.claude/skills/onboard/SKILL.md\`** — replaced with a redirect page pointing at \`/setup\` and \`/handover\`.
- **\`CLAUDE.md\`** — skills table updated: 13 → 17 skills, hooks description updated (14 hooks, 3 event types), rules count updated (9 files).

## Glossary

| Term | Definition |
|------|------------|
| /setup | First-run bootstrap skill. Configures \`onboarding.yaml\` for a new ApexStack fork in 3 exchanges. |
| Placeholder detection | The SessionStart hook greps \`onboarding.yaml\` for "Your Company Name". If found → prompt /setup. If real value → silent. |
| Describe-propose-confirm | The UX pattern: one open-ended question → one proposed config → one yes/no. Replaces sequential interrogation. |

## Test plan

- [ ] Fresh fork with template \`onboarding.yaml\` → SessionStart hook prompts \`/setup\`
- [ ] After \`/setup\` fills in real values → hook goes silent
- [ ] Running \`/onboard\` shows the deprecation redirect
- [ ] CLAUDE.md skills table counts match reality (17 skills, 14 hooks)
- [ ] Rex review
- [ ] Explicit per-PR CEO approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)