### PR TITLE
fix(#42): CI — markdown lint auto-fix and lycheeignore for private repos

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -41,6 +41,7 @@ Invoked when a PR is ready for review.
 ## Review Checklist
 
 ### 1. Architecture & Design
+
 - [ ] Domain layer has no external dependencies
 - [ ] Application layer doesn't import infrastructure
 - [ ] Proper separation of commands vs queries
@@ -48,6 +49,7 @@ Invoked when a PR is ready for review.
 - [ ] Domain events for side effects
 
 ### 2. Code Quality
+
 - [ ] Type-safety enforced (strict mode where applicable)
 - [ ] No unjustified `any` types
 - [ ] Proper error handling (no swallowed errors)
@@ -55,12 +57,14 @@ Invoked when a PR is ready for review.
 - [ ] Clear naming conventions followed
 
 ### 3. Testing
+
 - [ ] Unit tests for domain logic
 - [ ] Integration tests for use cases
 - [ ] Tests test behavior, not implementation
 - [ ] Edge cases covered
 
 ### 4. Security
+
 - [ ] No secrets in code
 - [ ] Input validation present
 - [ ] No SQL/NoSQL injection vectors
@@ -68,12 +72,14 @@ Invoked when a PR is ready for review.
 - [ ] Proper authentication / authorisation checks
 
 ### 5. Performance
+
 - [ ] No N+1 query patterns
 - [ ] Appropriate indexing considered
 - [ ] No blocking operations in hot paths
 - [ ] Reasonable payload sizes
 
 ### 6. PR Description Quality
+
 - [ ] Has a clear summary of changes
 - [ ] Links the ticket
 - [ ] **Has a Glossary section** with explanations of:

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -39,24 +39,28 @@ Invoked when a PR needs security review, especially for:
 ## Security Review Checklist
 
 ### 1. Secrets and Credentials
+
 - [ ] No hardcoded secrets, API keys, or passwords
 - [ ] No credentials in configuration files
 - [ ] Environment variables used for sensitive data
 - [ ] No secrets in logs or error messages
 
 ### 2. Injection Prevention
+
 - [ ] No SQL/NoSQL injection vectors (parameterised queries used)
 - [ ] No command injection (user input not passed to a shell)
 - [ ] No LDAP injection
 - [ ] No template injection
 
 ### 3. Cross-Site Scripting (XSS)
+
 - [ ] User input is sanitised before rendering
 - [ ] No unsafe `dangerouslySetInnerHTML` without sanitisation
 - [ ] No `eval()` or `new Function()` with user input
 - [ ] Content Security Policy headers considered
 
 ### 4. Authentication and Authorisation
+
 - [ ] Proper authentication checks on protected routes
 - [ ] Authorisation verified before data access
 - [ ] Session management is secure
@@ -64,12 +68,14 @@ Invoked when a PR needs security review, especially for:
 - [ ] No privilege escalation vectors
 
 ### 5. Data Protection
+
 - [ ] Sensitive data encrypted at rest and in transit
 - [ ] PII handled according to policy
 - [ ] No sensitive data in URLs or query strings
 - [ ] Proper data validation and sanitisation
 
 ### 6. API Security
+
 - [ ] Rate limiting considered
 - [ ] Input validation on all endpoints
 - [ ] Proper error handling (no stack traces exposed)

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -82,6 +82,7 @@ These two hooks are the mechanical backstop for the rule in `.claude/rules/ticke
 **What it does:** after the existing title-format / glossary / branch-ID checks, extracts the issue number from the PR title (e.g. `14` from `feat(#14): …`) and runs `gh issue view <N> --repo <tracker>` to verify it exists. Blocks PR creation with a clear message if the issue is missing.
 
 **Tracker repo resolution:**
+
 1. First tries `.tracker_repo` in `.claude/project-config.json` if present
 2. Falls back to parsing the `origin` remote (`owner/repo` from SSH or HTTPS URL)
 
@@ -212,12 +213,14 @@ With that config, `wip: scratch work` is accepted and `refactor: cleanup` is rej
 The new hooks are registered in `.claude/settings.json` alongside the existing ones on the same `Bash(git commit *)` / `Bash(gh pr merge *)` matchers. The Claude Code harness runs all matching hooks sequentially, and **any exit-2 blocks the tool call**. Order of registration within a matcher block is execution order. Current order (GH-13 additions shown in **bold**):
 
 **On `git commit`:**
+
 1. `check-secrets.sh`
 2. `verify-commit-refs.sh`
 3. **`validate-commit-format.sh`**
 4. **`require-agdr-for-arch-changes.sh`**
 
 **On `gh pr merge`:**
+
 1. `block-unreviewed-merge.sh` (Rex + CEO markers)
 2. **`require-design-review-for-ui.sh`**
 3. **`block-merge-on-red-ci.sh`**

--- a/.claude/skills/analytics-audit/SKILL.md
+++ b/.claude/skills/analytics-audit/SKILL.md
@@ -15,6 +15,7 @@ Deep-dive analytics analysis. Checks that tracking is configured, events follow 
 ### Step 1: SDK detection
 
 Grep for analytics SDK initialization:
+
 - Google Analytics / GA4: `gtag`, `G-`, `UA-`, `analytics.js`, `@google-analytics`
 - Mixpanel: `mixpanel.init`, `@mixpanel`
 - Amplitude: `amplitude.init`, `@amplitude`
@@ -26,6 +27,7 @@ Grep for analytics SDK initialization:
 ### Step 2: Event inventory
 
 Find all tracking calls in the codebase and list them:
+
 - Event name
 - Where it fires (file + component/handler)
 - Properties sent with the event

--- a/.claude/skills/approve-design/SKILL.md
+++ b/.claude/skills/approve-design/SKILL.md
@@ -36,6 +36,7 @@ The valid invocation triggers look like this:
 ### 1. Parse the PR number
 
 Extract from `$ARGUMENTS`. If no argument is given, try to infer from:
+
 - The current branch's open PR via `gh pr view --json number --jq '.number'`
 - The user's most recent message, if it named a PR explicitly
 
@@ -138,6 +139,7 @@ Two distinct moments. One is mockup approval (design phase). The other is implem
 Both skills follow the same pattern: verify PR state → verify Rex marker → write marker at repo root → confirm → stop. Both refuse to write on a stale Rex base. Both are invalidated by new commits. Neither runs `gh pr merge`.
 
 The merge flow for a UI PR requires **three** markers before the merge-gate hooks allow through:
+
 1. `<pr>-rex.approved` — from the code-reviewer agent
 2. `<pr>-design.approved` — from this skill
 3. `<pr>-ceo.approved` — from `/approve-merge`

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -33,6 +33,7 @@ The valid invocation triggers look like this:
 ### 1. Parse the PR number
 
 Extract from `$ARGUMENTS`. If no argument is given, try to infer from:
+
 - The current branch's open PR via `gh pr view --json number --jq '.number'`
 - The user's most recent message, if it named a PR explicitly
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -40,27 +40,32 @@ See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the ful
 ## Review Checklist
 
 ### Architecture
+
 - Domain layer has no external dependencies
 - Application layer doesn't import infrastructure
 - Proper separation of commands vs queries
 
 ### Code Quality
+
 - Type-safety enforced
 - No unjustified `any` types
 - Proper error handling
 - Clear naming conventions
 
 ### Testing
+
 - Unit tests for domain logic
 - Tests test behavior, not implementation
 - Edge cases covered
 
 ### Security
+
 - No secrets in code
 - Input validation present
 - No injection vulnerabilities
 
 ### PR Description
+
 - Links to the ticket
 - **Has a Glossary section** (REQUIRED — request changes if missing)
 - AgDR links if decisions were made

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -235,7 +235,9 @@ Also derived from the risks found. Tailor to the specific repo — don't emit ge
 - [ ] Run `/audit-deps {name}` monthly for the next 3 months
 
 ## Open Questions
+
 - {anything you couldn't determine from a static read}
+
 ```
 
 ### 6. Append to the portfolio registry
@@ -243,8 +245,10 @@ Also derived from the risks found. Tailor to the specific repo — don't emit ge
 **Don't just print the snippet** — offer to append it automatically:
 
 ```
+
 Ready to add {name} to apexstack.projects.yaml? (y/n)
 > y
+
 ```
 
 If yes:

--- a/.claude/skills/launch-check/SKILL.md
+++ b/.claude/skills/launch-check/SKILL.md
@@ -74,6 +74,7 @@ Warnings (non-blocking, address before next launch):
 ### 1. Security
 
 **What to check:**
+
 - Run `npm audit` / `pip audit` / equivalent for dependency vulnerabilities
 - Grep for hardcoded secrets, API keys, tokens (same patterns as `check-secrets.sh` but against the full codebase, not just staged files)
 - Check auth flow: is there authentication? Is it using a reputable provider (Cognito, Auth0, Firebase Auth)? Are tokens stored securely (httpOnly cookies, not localStorage)?
@@ -87,6 +88,7 @@ Warnings (non-blocking, address before next launch):
 ### 2. Accessibility
 
 **What to check:**
+
 - Grep for `<img` tags without `alt` attributes
 - Check for semantic HTML: `<main>`, `<nav>`, `<header>`, `<footer>`, heading hierarchy (h1 → h2 → h3)
 - Check for `aria-label` on interactive elements without visible text
@@ -101,6 +103,7 @@ Warnings (non-blocking, address before next launch):
 ### 3. Compliance
 
 **What to check:**
+
 - Cookie consent: grep for cookie-consent libraries (cookieconsent, react-cookie-consent, etc.) or a consent banner component
 - Privacy policy: check for a `/privacy` route or `privacy-policy` page
 - Terms of service: check for a `/terms` route
@@ -114,6 +117,7 @@ Warnings (non-blocking, address before next launch):
 ### 4. Analytics
 
 **What to check:**
+
 - Grep for analytics SDK initialization (Google Analytics/GA4, Mixpanel, Amplitude, PostHog, Plausible)
 - Check for event tracking calls (gtag, track, capture, etc.)
 - Check for a config file or environment variable pointing to an analytics dashboard
@@ -126,6 +130,7 @@ Warnings (non-blocking, address before next launch):
 ### 5. SEO
 
 **What to check:**
+
 - Check for `<title>` and `<meta name="description">` on key pages
 - Check for `<meta property="og:title">`, `og:description`, `og:image` (Open Graph)
 - Check for `sitemap.xml` at the expected location
@@ -140,6 +145,7 @@ Warnings (non-blocking, address before next launch):
 ### 6. Performance
 
 **What to check:**
+
 - If there's a build output: check bundle size (look for `dist/`, `build/`, `.next/`)
 - Check for image optimization: are images served as WebP/AVIF? Are there large unoptimized images (> 500KB)?
 - Check for lazy loading on below-the-fold images (`loading="lazy"`)
@@ -153,6 +159,7 @@ Warnings (non-blocking, address before next launch):
 ### 7. Monitoring
 
 **What to check:**
+
 - Grep for error tracking SDK (Sentry, Datadog, Bugsnag, LogRocket)
 - Check for a health check endpoint (`/health`, `/healthz`, `/api/health`)
 - Check for alerting configuration (PagerDuty, OpsGenie, CloudWatch Alarms, or alerting rules in code)
@@ -166,6 +173,7 @@ Warnings (non-blocking, address before next launch):
 ### 8. Documentation
 
 **What to check:**
+
 - README.md exists and is not the default template
 - README has: project description, setup instructions, how to run locally, how to deploy
 - API documentation: if there's an API, is it documented? (OpenAPI spec, Swagger, or doc comments)
@@ -186,6 +194,7 @@ If invoked with an argument, use that path. Otherwise, use the current working d
 ### Step 2: Quick scan
 
 Read the project's structure to determine what checks apply:
+
 - Is it a web app? (has `index.html`, React/Vue/Svelte/Next.js markers) → all 8 dimensions
 - Is it an API only? (has routes/endpoints but no frontend) → skip accessibility, SEO, performance (auto-PASS)
 - Is it a CLI/library? → skip accessibility, compliance, analytics, SEO, performance (auto-PASS on those)
@@ -194,6 +203,7 @@ Read the project's structure to determine what checks apply:
 ### Step 3: Run each applicable dimension
 
 Go through each dimension in order. For each:
+
 1. Run the checks listed above (grep, file existence, SDK detection)
 2. Classify as PASS / WARN / FAIL based on the criteria
 3. Write a one-line finding for the table

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -71,6 +71,7 @@ The default milestones are **Now / Next / Later / Done** (Now-Next-Later format)
 1. Read the roadmap file
 2. Render each non-empty milestone as a table
 3. Print a footer summary:
+
    ```
    12 items · 5 in Now · 4 in Next · 3 in Later · 8 Done
    ```

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -42,31 +42,37 @@ Invoke for PRs that touch:
 ## Security Checklist
 
 ### Secrets & Credentials
+
 - No hardcoded secrets, API keys, or passwords
 - Environment variables for sensitive data
 - No secrets in logs or error messages
 
 ### Injection Prevention
+
 - Parameterised queries (no SQL injection)
 - No command injection
 - No template injection
 
 ### XSS Prevention
+
 - User input sanitised before rendering
 - No unsafe `dangerouslySetInnerHTML`
 - No `eval()` with user input
 
 ### Authentication & Authorisation
+
 - Auth checks on protected routes
 - Authorisation verified before data access
 - Secure session management
 
 ### Data Protection
+
 - Sensitive data encrypted
 - No PII in URLs or query strings
 - Proper validation and sanitisation
 
 ### API Security
+
 - Rate limiting considered
 - Input validation on endpoints
 - No stack traces exposed

--- a/.claude/skills/seo-audit/SKILL.md
+++ b/.claude/skills/seo-audit/SKILL.md
@@ -15,6 +15,7 @@ Deep-dive SEO audit against Google's best practices. Checks on-page SEO, technic
 ### Step 1: On-page SEO
 
 Check each key page (index, about, pricing, blog, product pages) for:
+
 - `<title>` tag (exists, unique per page, 50-60 chars)
 - `<meta name="description">` (exists, unique, 150-160 chars)
 - `<h1>` tag (exactly one per page, contains target keyword)

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -59,6 +59,7 @@ From the user's description, extract:
 | `team` | Team size / roles mentioned | Minimal default (1 tech lead) |
 
 Also infer non-obvious settings:
+
 - If they mention "SAM" → `tech_stack.iac: "AWS SAM"` and add `sam validate --lint` to implied checks
 - If they mention "Terraform" → `tech_stack.iac: "Terraform"` and add `terraform validate`
 - If they mention "no frontend" or don't mention a framework → `workflows.require_design_review: false` (no UI = no design gate)

--- a/.claude/skills/start-ticket/SKILL.md
+++ b/.claude/skills/start-ticket/SKILL.md
@@ -17,6 +17,7 @@ This is the mechanical enforcement of the Pre-Build Gate in `.claude/rules/workf
 ### 1. Parse Arguments
 
 Expected forms:
+
 - `42` — plain number, resolves against the current repo. Read `git remote get-url origin` and extract `<owner>/<repo>`. If there's no origin, stop and ask for a fully-qualified reference.
 - `me2resh/flat-mate#128` — fully-qualified reference.
 - `apexstack#42` — owner defaults to the current org (parsed from the origin URL).

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -59,6 +59,7 @@ For each PR, show:
 ```
 
 CI status maps:
+
 - All checks `SUCCESS` → `✅ CI green`
 - Any `FAILURE` → `❌ CI failed`
 - Any `PENDING` → `🟡 CI pending`

--- a/.claude/skills/threat-model/SKILL.md
+++ b/.claude/skills/threat-model/SKILL.md
@@ -26,6 +26,7 @@ Deep-dive security analysis using the STRIDE framework. Produces a prioritized t
 ### Step 1: Map the attack surface
 
 Read the codebase and identify:
+
 - **Entry points**: API routes, form handlers, WebSocket endpoints, file upload handlers
 - **Data stores**: databases, caches, file systems, environment variables
 - **External integrations**: third-party APIs, payment processors, email services, auth providers
@@ -67,6 +68,7 @@ Recommended priority:
 ### Step 4: Check common OWASP patterns
 
 After the STRIDE sweep, explicitly check for:
+
 - SQL/NoSQL injection (parameterized queries? ORM used consistently?)
 - XSS (dangerouslySetInnerHTML, v-html, template literals in HTML?)
 - Insecure deserialization (JSON.parse on untrusted input without validation?)

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,5 @@
+# Portfolio repo links — these repos may be private. Lychee runs
+# unauthenticated so private repos always 404.
+https://github.com/me2resh/apexstack.*
+https://github.com/me2resh/curios-dog.*
+https://github.com/me2resh/SharpPick.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ ApexStack's SDLC rules are no longer advisory prose — they're mechanically enf
 ### CI dogfooding
 
 ApexStack now runs its own CI:
+
 - `pr-title-check.yml` — enforces ticket ID in PR titles
 - `markdown-lint.yml` — lints all markdown files
 - `shellcheck.yml` — static analysis on all hook scripts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Full setup guide: @docs/multi-project.md
 ## ROLES
 
 Role definitions live in `roles/`. Each role defines:
+
 - Identity and responsibilities
 - What the role CAN and CANNOT do
 - Interfaces with other roles (who they work with)
@@ -48,6 +49,7 @@ Roles activate **on specific conditions**. The full trigger table lives in `@.cl
 - **Prompted activation** — the user can explicitly activate any role: *"act as the QA Engineer for ticket #42"*, *"put on your Tech Lead hat"*, etc.
 
 When a role activates:
+
 1. Read the file at `roles/{department}/{role}.md`
 2. Adopt the role's identity, responsibilities, CAN / CANNOT boundaries
 3. Follow the handoff rules in the role file — who you receive from, who you deliver to
@@ -102,6 +104,7 @@ Work on ONE ticket at a time. Complete fully before starting next. Each PR = one
 Full process: @workflows/code-review.md
 
 Every PR must include:
+
 - Clear description of what changed and why
 - Link to the ticket/issue
 - Testing instructions

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Full setup guide with directory layout, daily workflow, and FAQ: [`docs/multi-pr
 ApexStack includes 19 software development roles across 5 departments:
 
 ### Engineering (7 roles)
+
 - **Head of Engineering** -- Technical strategy, architecture standards, quality
 - **Tech Lead** -- Feature design, code review, team coordination
 - **Backend Engineer** -- Domain logic, APIs, infrastructure
@@ -160,21 +161,25 @@ ApexStack includes 19 software development roles across 5 departments:
 - **Site Reliability Engineer** -- Monitoring, incidents, SLOs
 
 ### Product (3 roles)
+
 - **Head of Product** -- Roadmap, prioritization, feasibility
 - **Product Manager** -- PRDs, user stories, acceptance criteria
 - **Product Analyst** -- Market research, metrics, competitive analysis
 
 ### Design (3 roles)
+
 - **Head of Design** -- Design system, UX principles, visual standards
 - **UI Designer** -- Visual design tokens, component specifications
 - **UX Designer** -- User flows, information architecture, usability
 
 ### Security (3 roles)
+
 - **Head of Security** -- Security strategy, threat modeling, compliance
 - **Security Auditor** -- Static analysis, vulnerability detection, OWASP
 - **Penetration Tester** -- Active testing, exploit discovery, API security
 
 ### Data (3 roles)
+
 - **Head of Data** -- Analytics strategy, data governance, reporting
 - **Data Analyst** -- SQL, dashboards, A/B testing, metrics
 - **Data Engineer** -- ETL pipelines, data modeling, data quality
@@ -192,6 +197,7 @@ Each phase has entry criteria, activities, exit criteria, and quality gates.
 ### Code Review Process
 
 Structured review with:
+
 - Author responsibilities and PR description format
 - Reviewer checklist (architecture, security, testing, performance)
 - Feedback severity levels (blocking, suggestion, question)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -203,6 +203,7 @@ Check that the role file exists in the expected path under `roles/`.
 ### Workflows feel too heavy for my team
 
 Customize! Edit `onboarding.yaml` to disable stages:
+
 ```yaml
 workflows:
   require_prd: false

--- a/golden-paths/pipelines/README.md
+++ b/golden-paths/pipelines/README.md
@@ -48,13 +48,16 @@ cp ~/apexstack/golden-paths/pipelines/ci.yml .github/workflows/
 **Purpose**: Governance — enforce ticket tracking.
 
 **Checks performed**:
+
 - Validates that the PR title contains a ticket ID
 - Pattern: `[A-Z]{2,5}-\d+` (project tracker) or `#\d+` (GitHub Issues)
 
 **Fail conditions**:
+
 - No ticket ID found in PR title
 
 **Valid title formats**:
+
 - `feat(ABC-123): add new feature`
 - `fix(#58): correct encryption claim`
 - `ABC-123: Add new feature`
@@ -66,6 +69,7 @@ cp ~/apexstack/golden-paths/pipelines/ci.yml .github/workflows/
 **Agent**: Shield (Security Scanner)
 
 **Checks performed**:
+
 - Semgrep SAST (OWASP Top 10, security-audit rules)
 - npm audit (vulnerability scanning)
 - TruffleHog (secrets detection)
@@ -73,10 +77,12 @@ cp ~/apexstack/golden-paths/pipelines/ci.yml .github/workflows/
 - ESLint security plugin
 
 **Fail conditions**:
+
 - Critical or high severity vulnerabilities
 - Exposed secrets detected
 
 **Required secrets**:
+
 - `SEMGREP_APP_TOKEN` (optional, for Semgrep Cloud)
 
 ---
@@ -86,15 +92,18 @@ cp ~/apexstack/golden-paths/pipelines/ci.yml .github/workflows/
 **Agent**: Guardian (Dependency Auditor)
 
 **Checks performed**:
+
 - npm audit (vulnerabilities by severity)
 - npm outdated (major / minor / patch versions behind)
 - license-checker (GPL, LGPL, unknown licenses)
 
 **Automated actions**:
+
 - Creates a GitHub issue for critical / high vulnerabilities
 - Weekly scheduled audit (Monday 9 AM UTC)
 
 **Fail conditions**:
+
 - Critical vulnerabilities found
 
 ---
@@ -104,6 +113,7 @@ cp ~/apexstack/golden-paths/pipelines/ci.yml .github/workflows/
 **Agent**: Rex (Code Reviewer)
 
 **Checks performed**:
+
 - TypeScript type checking (`npm run typecheck`)
 - ESLint (`npm run lint`)
 - Prettier formatting
@@ -111,6 +121,7 @@ cp ~/apexstack/golden-paths/pipelines/ci.yml .github/workflows/
 - Build verification
 
 **Fail conditions**:
+
 - TypeScript errors
 - ESLint errors (warnings allowed)
 - Test failures
@@ -125,10 +136,12 @@ cp ~/apexstack/golden-paths/pipelines/ci.yml .github/workflows/
 **Purpose**: prevent merging code that was pushed *after* Rex's last review.
 
 **Checks performed**:
+
 - Verifies that Rex has reviewed the latest commit on the PR
 - Compares commit SHAs from Rex's review against the current HEAD
 
 **Fail conditions**:
+
 - No Rex review found
 - Rex's last review SHA does not match the current HEAD
 
@@ -139,6 +152,7 @@ cp ~/apexstack/golden-paths/pipelines/ci.yml .github/workflows/
 **Pipeline**: SEO Check (no agent — pure CI workflow)
 
 **Checks performed**:
+
 - H1 title presence and uniqueness
 - Meta description in frontmatter
 - Content length (1000+ words recommended)

--- a/roles/data/data-analyst.md
+++ b/roles/data/data-analyst.md
@@ -102,6 +102,7 @@ You are a Data Analyst. You turn data into insights, answer business questions w
 ## Documentation Standards
 
 Every analysis should have:
+
 1. Clear question being answered
 2. Data sources used
 3. Methodology

--- a/roles/data/head-of-data.md
+++ b/roles/data/head-of-data.md
@@ -58,15 +58,18 @@ You are the Head of Data. You lead analytics strategy, data infrastructure, and 
 ## Reporting Cadence
 
 ### Weekly
+
 - Key metrics dashboard review
 - Anomaly detection report
 
 ### Monthly
+
 - Department KPI reports
 - Cohort analysis
 - Funnel performance
 
 ### Quarterly
+
 - Business review deck
 - Data quality audit
 - Infrastructure review

--- a/roles/design/head-of-design.md
+++ b/roles/design/head-of-design.md
@@ -60,6 +60,7 @@ When reviewing UI implementations:
 5. **Assess visual consistency**
 
 **Feedback format**:
+
 - Be specific (not "looks off" but "increase padding to 16px")
 - Reference design system tokens
 - Prioritize (must-fix vs nice-to-have)

--- a/roles/engineering/backend-engineer.md
+++ b/roles/engineering/backend-engineer.md
@@ -63,23 +63,27 @@ You are a Backend Engineer. You implement domain logic, APIs, and infrastructure
 Before creating a PR:
 
 **Code Quality**:
+
 - [ ] Follows clean architecture principles
 - [ ] Dependencies point inward
 - [ ] No business logic in infrastructure layer
 - [ ] Proper error handling with domain errors
 
 **Testing**:
+
 - [ ] Unit tests for domain logic
 - [ ] Integration tests for use cases
 - [ ] Tests cover edge cases
 - [ ] Tests are readable and maintainable
 
 **Documentation**:
+
 - [ ] API documented (OpenAPI or inline)
 - [ ] Complex logic has explanatory comments
 - [ ] README updated if needed
 
 **Security**:
+
 - [ ] Input validation at boundaries
 - [ ] No sensitive data logged
 - [ ] Auth/authz checked

--- a/roles/engineering/frontend-engineer.md
+++ b/roles/engineering/frontend-engineer.md
@@ -64,12 +64,14 @@ You are a Frontend Engineer. You build user interfaces following the design syst
 Before creating a PR:
 
 **Design System**:
+
 - [ ] Uses design tokens (no hardcoded values)
 - [ ] Uses standard components
 - [ ] Follows documented patterns
 - [ ] Consistent with rest of app
 
 **Accessibility**:
+
 - [ ] Keyboard navigation works
 - [ ] Focus states visible
 - [ ] ARIA labels where needed
@@ -77,17 +79,20 @@ Before creating a PR:
 - [ ] Screen reader tested
 
 **Performance**:
+
 - [ ] No unnecessary re-renders
 - [ ] Images optimized
 - [ ] Lazy loading where appropriate
 - [ ] Bundle size checked
 
 **Testing**:
+
 - [ ] Component tests written
 - [ ] Integration tests for flows
 - [ ] Accessibility tests pass
 
 **Responsiveness**:
+
 - [ ] Mobile viewport works
 - [ ] Tablet viewport works
 - [ ] Desktop viewport works

--- a/roles/engineering/head-of-engineering.md
+++ b/roles/engineering/head-of-engineering.md
@@ -69,6 +69,7 @@ When making technical decisions:
 ## Architecture Review Triggers
 
 Review required for:
+
 - New service or bounded context
 - New technology introduction
 - Major data model changes
@@ -78,6 +79,7 @@ Review required for:
 ## Quality Gates
 
 Before shipping, ensure:
+
 - [ ] Architecture review passed (if required)
 - [ ] Code review approved
 - [ ] Tests pass (>80% coverage)

--- a/roles/engineering/platform-engineer.md
+++ b/roles/engineering/platform-engineer.md
@@ -92,6 +92,7 @@ You are a Platform Engineer. You build and maintain the infrastructure, CI/CD pi
 ## Cost Optimization
 
 **Strategies**:
+
 - Right-size compute resources
 - Use auto-scaling for variable traffic
 - Implement caching to reduce origin calls
@@ -99,6 +100,7 @@ You are a Platform Engineer. You build and maintain the infrastructure, CI/CD pi
 - Monitor and alert on cost anomalies
 
 **Monitoring**:
+
 - Budget alerts at 50%, 75%, 90%
 - Weekly cost review
 - Per-service cost attribution

--- a/roles/engineering/qa-engineer.md
+++ b/roles/engineering/qa-engineer.md
@@ -150,6 +150,7 @@ What actually happens.
 ## Quality Gates
 
 Before release:
+
 - [ ] All acceptance criteria verified
 - [ ] Unit test coverage > 80%
 - [ ] Integration tests pass

--- a/roles/engineering/tech-lead.md
+++ b/roles/engineering/tech-lead.md
@@ -104,6 +104,7 @@ Decisions still needed.
 ## Code Review Standards
 
 **Must check**:
+
 - [ ] Follows architecture principles
 - [ ] Uses standard stack correctly
 - [ ] Follows coding conventions
@@ -113,6 +114,7 @@ Decisions still needed.
 - [ ] Performance is acceptable
 
 **Feedback style**:
+
 - Be specific and constructive
 - Explain *why*, not just *what*
 - Distinguish blocking vs suggestions

--- a/roles/security/head-of-security.md
+++ b/roles/security/head-of-security.md
@@ -90,6 +90,7 @@ You are the Head of Security. You protect the company's assets, data, and reputa
 ## Security Standards
 
 Enforce:
+
 - OWASP Top 10 prevention
 - Secure coding practices
 - Encryption at rest and in transit

--- a/roles/security/penetration-tester.md
+++ b/roles/security/penetration-tester.md
@@ -16,6 +16,7 @@ You are a Penetration Tester who thinks like an attacker. Your job is to find ex
 ## Testing Methodology
 
 ### Phase 1: Reconnaissance
+
 1. Map all endpoints (API docs, sitemap)
 2. Identify technologies in use
 3. Find hidden paths
@@ -23,6 +24,7 @@ You are a Penetration Tester who thinks like an attacker. Your job is to find ex
 5. Identify third-party integrations
 
 ### Phase 2: Vulnerability Discovery
+
 1. Run automated scanners
 2. Manual testing of auth flows
 3. Test each input point
@@ -30,12 +32,14 @@ You are a Penetration Tester who thinks like an attacker. Your job is to find ex
 5. Test rate limiting
 
 ### Phase 3: Exploitation
+
 1. Attempt to exploit findings
 2. Document proof of concept
 3. Assess real-world impact
 4. Chain vulnerabilities if possible
 
 ### Phase 4: Reporting
+
 1. Document all findings with evidence
 2. Provide clear reproduction steps
 3. Recommend specific fixes
@@ -44,6 +48,7 @@ You are a Penetration Tester who thinks like an attacker. Your job is to find ex
 ## Web Application Testing
 
 ### Authentication Testing
+
 - Test for default credentials
 - Test password policy enforcement
 - Test account lockout mechanism
@@ -52,6 +57,7 @@ You are a Penetration Tester who thinks like an attacker. Your job is to find ex
 - Test MFA bypass
 
 ### Authorization Testing
+
 - Test horizontal privilege escalation (access other users' data)
 - Test vertical privilege escalation (access admin functions)
 - Test IDOR (Insecure Direct Object References)
@@ -59,6 +65,7 @@ You are a Penetration Tester who thinks like an attacker. Your job is to find ex
 - Test API authorization
 
 ### Input Validation Testing
+
 - Test for XSS (reflected, stored, DOM-based)
 - Test for SQL/NoSQL injection
 - Test for command injection
@@ -68,6 +75,7 @@ You are a Penetration Tester who thinks like an attacker. Your job is to find ex
 ## API Security Testing
 
 **REST API Checklist**:
+
 - [ ] Authentication required for sensitive endpoints
 - [ ] Rate limiting implemented
 - [ ] Input validation on all parameters

--- a/roles/security/security-auditor.md
+++ b/roles/security/security-auditor.md
@@ -34,6 +34,7 @@ You are a Security Auditor specializing in code analysis and vulnerability detec
 ## Code Review Security Checklist
 
 For every PR:
+
 - [ ] No hardcoded secrets/credentials
 - [ ] Input validation on all user data
 - [ ] Output encoding to prevent XSS

--- a/templates/adr.md
+++ b/templates/adr.md
@@ -16,25 +16,30 @@
 ## Consequences
 
 ### Positive
+
 - [Benefit 1]
 - [Benefit 2]
 
 ### Negative
+
 - [Drawback 1]
 - [Drawback 2]
 
 ### Neutral
+
 - [Side effect 1]
 
 ## Alternatives Considered
 
 ### Option 1: [Name]
+
 **Description**: [What this option involves]
 **Pros**: [Benefits]
 **Cons**: [Drawbacks]
 **Why rejected**: [Reason]
 
 ### Option 2: [Name]
+
 **Description**: [What this option involves]
 **Pros**: [Benefits]
 **Cons**: [Drawbacks]

--- a/templates/agdr.md
+++ b/templates/agdr.md
@@ -13,20 +13,25 @@ status: {executed | rolled-back | superseded by AgDR-NNNN}
 > In the context of {context}, facing {concern}, I decided {decision} to achieve {goal}, accepting {tradeoff}.
 
 ## Context
+
 {Decision-relevant context only -- what influenced this choice}
 
 ## Options Considered
+
 | Option | Pros | Cons |
 |--------|------|------|
 | {option 1} | {pros} | {cons} |
 | {option 2} | {pros} | {cons} |
 
 ## Decision
+
 Chosen: **{option}**, because {justification}.
 
 ## Consequences
+
 - {consequence 1}
 - {consequence 2}
 
 ## Artifacts
+
 - {commit/PR/deployment links}

--- a/templates/prd.md
+++ b/templates/prd.md
@@ -10,17 +10,21 @@
 ## Overview
 
 ### Problem Statement
+
 [What problem are we solving? Why does it matter?]
 
 ### Target User
+
 **Primary**: [User type and description]
 **Secondary**: [User type and description] (if applicable)
 
 ### Goals
+
 1. [Goal 1 -- measurable]
 2. [Goal 2 -- measurable]
 
 ### Non-Goals (Out of Scope)
+
 - [What we are explicitly NOT doing]
 - [Feature/scope we're deferring]
 
@@ -36,9 +40,11 @@
 ## User Stories
 
 ### US-1: [Title]
+>
 > As a [user type], I want to [action], so that [benefit].
 
 **Acceptance Criteria**:
+
 - [ ] [Criterion 1]
 - [ ] [Criterion 2]
 - [ ] [Criterion 3]
@@ -46,9 +52,11 @@
 ---
 
 ### US-2: [Title]
+>
 > As a [user type], I want to [action], so that [benefit].
 
 **Acceptance Criteria**:
+
 - [ ] [Criterion 1]
 - [ ] [Criterion 2]
 
@@ -104,6 +112,7 @@
 ```
 
 ### Wireframes / Mockups
+
 [Attach images or link to design files]
 
 ---
@@ -117,6 +126,7 @@
 | [Dependency 1] | Internal/External | Ready/Blocked | [Team] |
 
 ### Technical Constraints
+
 - [Constraint 1]
 - [Constraint 2]
 
@@ -125,6 +135,7 @@
 ## Launch Plan
 
 ### Rollout Strategy
+
 - [ ] All users at once
 - [ ] Phased rollout
 - [ ] Beta program first

--- a/templates/technical-design.md
+++ b/templates/technical-design.md
@@ -10,13 +10,16 @@
 ## Overview
 
 ### Summary
+
 [1-2 sentences: What are we building and why?]
 
 ### Goals
+
 - [Goal 1]
 - [Goal 2]
 
 ### Non-Goals
+
 - [What we're explicitly not doing]
 
 ---
@@ -79,6 +82,7 @@
 **POST /api/resource**
 
 Request:
+
 ```json
 {
   "field1": "value",
@@ -87,6 +91,7 @@ Request:
 ```
 
 Response:
+
 ```json
 {
   "id": "resource_123",

--- a/workflows/code-review.md
+++ b/workflows/code-review.md
@@ -47,6 +47,7 @@ Fixes #[ticket-id]
 ```
 
 **Why a Glossary?** Every PR is a learning opportunity. Explaining concepts helps:
+
 - Junior devs learn from senior work
 - Seniors articulate their thinking
 - Future readers understand decisions
@@ -75,6 +76,7 @@ Fixes #[ticket-id]
 ### Giving Feedback
 
 **Be constructive**:
+
 ```
 BAD:  "This is wrong"
 GOOD: "This might throw a null error if user is undefined.
@@ -82,6 +84,7 @@ GOOD: "This might throw a null error if user is undefined.
 ```
 
 **Be specific**:
+
 ```
 BAD:  "Improve this function"
 GOOD: "This function has multiple responsibilities. Consider extracting
@@ -89,6 +92,7 @@ GOOD: "This function has multiple responsibilities. Consider extracting
 ```
 
 **Distinguish severity**:
+
 ```
 BLOCKING:  "This exposes user passwords in logs. Must fix."
 SUGGESTION: "NIT: Could rename this to `calculateTotal` for clarity"
@@ -108,12 +112,14 @@ QUESTION:   "Why did you choose Map over Object here?"
 ## Review Checklist
 
 ### Architecture
+
 - [ ] Follows architecture principles
 - [ ] Dependencies point inward (clean architecture)
 - [ ] Domain logic in domain layer
 - [ ] No business logic in infrastructure
 
 ### Code Quality
+
 - [ ] Follows naming conventions
 - [ ] Functions are small and focused
 - [ ] No code duplication
@@ -121,6 +127,7 @@ QUESTION:   "Why did you choose Map over Object here?"
 - [ ] Comments explain why, not what
 
 ### Security
+
 - [ ] Input validated at boundaries
 - [ ] No injection vulnerabilities
 - [ ] No XSS vulnerabilities
@@ -128,12 +135,14 @@ QUESTION:   "Why did you choose Map over Object here?"
 - [ ] Auth/authz checked
 
 ### Testing
+
 - [ ] Unit tests for domain logic
 - [ ] Integration tests for use cases
 - [ ] Edge cases covered
 - [ ] Tests are readable
 
 ### Performance
+
 - [ ] No N+1 queries
 - [ ] No unnecessary database calls
 - [ ] Async operations where appropriate
@@ -175,6 +184,7 @@ QUESTION:   "Why did you choose Map over Object here?"
 ## Metrics
 
 Track these to improve:
+
 - PR size (aim for < 400 lines)
 - Review time (aim for < 24h)
 - Review cycles (aim for < 3)

--- a/workflows/deployment.md
+++ b/workflows/deployment.md
@@ -62,25 +62,30 @@ Verify and monitor
 ## CI/CD Pipeline Stages
 
 ### 1. Build
+
 - Install dependencies
 - Compile/transpile code
 - Lint check
 
 ### 2. Test
+
 - Unit tests
 - Integration tests
 - Coverage report (must be >80%)
 
 ### 3. Security
+
 - Dependency audit
 - Static analysis scan
 
 ### 4. Deploy to Staging
+
 - Apply infrastructure changes
 - Deploy application
 - Run E2E tests
 
 ### 5. Deploy to Production (Manual Gate)
+
 - Apply infrastructure changes
 - Deploy application
 - Run smoke tests
@@ -186,12 +191,14 @@ Before promoting to production:
 ## Monitoring Post-Deploy
 
 ### First 30 Minutes
+
 - Watch error rates
 - Check response times
 - Verify key user flows
 - Monitor resource utilization
 
 ### First 24 Hours
+
 - Compare metrics to pre-deploy baseline
 - Check for gradual degradation
 - Review user feedback channels

--- a/workflows/sdlc.md
+++ b/workflows/sdlc.md
@@ -19,6 +19,7 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 > Read the Tech Lead role file and adopt it before starting this phase. See [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md) for the full activation protocol.
 
 ### Entry Criteria
+
 - Approved PRD from Product
 - Design review complete (if UI involved)
 - Priority assigned
@@ -33,6 +34,7 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 | Sprint planning | Tech Lead | Tasks assigned |
 
 ### Exit Criteria
+
 - Requirements understood
 - Estimate provided to Product
 - Tickets created and prioritized
@@ -45,6 +47,7 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 > **Primary role**: [Tech Lead](../roles/engineering/tech-lead.md) · **Escalation**: [Head of Engineering](../roles/engineering/head-of-engineering.md) (architecture review) · **Supporting**: [UX Designer](../roles/design/ux-designer.md), [UI Designer](../roles/design/ui-designer.md) (if UI involved)
 
 ### Entry Criteria
+
 - Feature in sprint
 - Requirements clear
 
@@ -58,11 +61,13 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 | Identify risks | Tech Lead | Risk register |
 
 ### Exit Criteria
+
 - Technical design approved
 - Tasks created and assigned
 - Risks documented
 
 ### When Architecture Review Required
+
 - New service or bounded context
 - New external integration
 - New technology
@@ -78,6 +83,7 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 > The engineer implementing the task activates the matching role. Cross-stack tickets may chain Backend → Frontend (or vice-versa) via an explicit handoff.
 
 ### Entry Criteria
+
 - Technical design approved
 - Tasks assigned
 - Environment ready
@@ -134,6 +140,7 @@ RIGHT:
 ```
 
 ### Exit Criteria
+
 - Code complete
 - Tests written and passing
 - PR created
@@ -147,6 +154,7 @@ RIGHT:
 > Rex reviews every commit automatically. Human reviewers (Tech Lead, Security Auditor, UI Designer) activate on the triggers above. All reviews must match the commit SHA being merged.
 
 ### Entry Criteria
+
 - PR submitted
 - CI checks passing
 - Self-review done
@@ -161,6 +169,7 @@ RIGHT:
 | Approve PR | Reviewer | Merge ready |
 
 ### Review Checklist
+
 - [ ] Follows architecture principles
 - [ ] Follows coding conventions
 - [ ] Tests adequate and passing
@@ -169,6 +178,7 @@ RIGHT:
 - [ ] Documentation updated
 
 ### Exit Criteria
+
 - Code review approved
 - Design review passed (if applicable)
 - All CI checks green
@@ -182,6 +192,7 @@ RIGHT:
 > This is the **mandatory gate** — merged code is never Done until the QA Engineer has verified every acceptance criterion. Auto-closing via `Closes #XX` is intentionally overridden with `Refs #XX` + the `qa` label when QA verification is required.
 
 ### Entry Criteria
+
 - PR approved and merged
 - Feature deployed to staging (or runnable locally)
 
@@ -206,6 +217,7 @@ In Progress --> In Review --> QA --> Done
 | Sign-off | QA Engineer | Approval to close |
 
 ### If QA Finds Issues
+
 1. QA creates bug ticket linked to original
 2. Original ticket stays in QA state
 3. Engineer fixes bug in new PR
@@ -219,11 +231,13 @@ In Progress --> In Review --> QA --> Done
 > **Primary role**: [Platform Engineer](../roles/engineering/platform-engineer.md) · **Support**: [SRE](../roles/engineering/sre.md) (runbook + rollback plan) · **Trigger**: QA sign-off complete, staging validated
 
 ### Entry Criteria
+
 - Tests passed
 - QA sign-off
 - Security review (if required)
 
 ### Deployment Checklist
+
 - [ ] Staging tested
 - [ ] Feature flags configured (if applicable)
 - [ ] Rollback plan ready
@@ -231,6 +245,7 @@ In Progress --> In Review --> QA --> Done
 - [ ] Team aware
 
 ### Exit Criteria
+
 - Successfully deployed to production
 - Smoke tests passing
 - No errors in monitoring
@@ -242,9 +257,11 @@ In Progress --> In Review --> QA --> Done
 > **Primary role**: [SRE](../roles/engineering/sre.md) · **Escalation**: [Head of Engineering](../roles/engineering/head-of-engineering.md) on sustained incident · **Trigger**: deployment to production, first 24-48h watch window
 
 ### Entry Criteria
+
 - Deployed to production
 
 ### Post-Launch
+
 - Monitor for 24-48 hours
 - Gradual rollout if feature-flagged
 - Collect metrics for success criteria


### PR DESCRIPTION
## Summary
- Run `markdownlint-cli2 --fix` across all .md files — fixes MD022/MD032 blank-line violations in 40 files
- Add `.lycheeignore` to exclude private portfolio repo links from unauthenticated link checks

## Test plan
- [ ] Markdown Lint CI check passes
- [ ] Link Check CI check passes (transient network errors excluded)

## Glossary
| Term | Definition |
|------|------------|
| MD022 | markdownlint rule requiring blank lines around headings |
| MD032 | markdownlint rule requiring blank lines around lists |
| .lycheeignore | File listing URL patterns the lychee link checker should skip |

Generated with [Claude Code](https://claude.com/claude-code)