### PR TITLE
feat(#45): hooks resolve ops root from any workspace directory

### DIFF
--- a/.claude/hooks/block-merge-on-red-ci.sh
+++ b/.claude/hooks/block-merge-on-red-ci.sh
@@ -35,10 +35,17 @@ if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+merge\b'; then
   exit 0
 fi
 
+# Parse --repo from the command for cross-repo merge operations
+CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+REPO_FLAG=""
+if [ -n "$CMD_REPO" ]; then
+  REPO_FLAG="--repo $CMD_REPO"
+fi
+
 # Extract PR number (same approach as the other merge-gate hooks)
 PR_NUMBER=$(echo "$COMMAND" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*' | grep -oE '[0-9]+' | head -1)
 if [ -z "$PR_NUMBER" ]; then
-  PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null)
+  PR_NUMBER=$(gh pr view $REPO_FLAG --json number --jq '.number' 2>/dev/null)
 fi
 
 if [ -z "$PR_NUMBER" ]; then
@@ -49,7 +56,7 @@ fi
 # Query checks. gh pr checks returns text output; we check both the exit code
 # and a "no checks reported" substring — the latter is how gh reports the
 # genuinely-unchecked case regardless of exit code version.
-CHECKS_OUTPUT=$(gh pr checks "$PR_NUMBER" 2>&1)
+CHECKS_OUTPUT=$(gh pr checks "$PR_NUMBER" $REPO_FLAG 2>&1)
 CHECKS_RC=$?
 
 # "no checks reported on the 'X' branch" — legitimate no-CI state. Allow.

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -40,11 +40,18 @@ if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+merge\b'; then
   exit 0
 fi
 
+# Parse --repo from the command for cross-repo merge operations
+CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+REPO_FLAG=""
+if [ -n "$CMD_REPO" ]; then
+  REPO_FLAG="--repo $CMD_REPO"
+fi
+
 # Extract PR number: either from the command args or from the current branch's PR.
 # Handles both `gh pr merge 42` and flag-first forms like `gh pr merge --auto 42`.
 PR_NUMBER=$(echo "$COMMAND" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*' | grep -oE '[0-9]+' | head -1)
 if [ -z "$PR_NUMBER" ]; then
-  PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null)
+  PR_NUMBER=$(gh pr view $REPO_FLAG --json number --jq '.number' 2>/dev/null)
 fi
 
 if [ -z "$PR_NUMBER" ]; then

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -36,10 +36,17 @@ if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+merge\b'; then
   exit 0
 fi
 
+# Parse --repo from the command for cross-repo merge operations
+CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+REPO_FLAG=""
+if [ -n "$CMD_REPO" ]; then
+  REPO_FLAG="--repo $CMD_REPO"
+fi
+
 # Extract PR number (same approach as block-unreviewed-merge.sh)
 PR_NUMBER=$(echo "$COMMAND" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*' | grep -oE '[0-9]+' | head -1)
 if [ -z "$PR_NUMBER" ]; then
-  PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null)
+  PR_NUMBER=$(gh pr view $REPO_FLAG --json number --jq '.number' 2>/dev/null)
 fi
 
 if [ -z "$PR_NUMBER" ]; then
@@ -71,7 +78,7 @@ if [ -n "$REPO_ROOT" ] && [ -f "${REPO_ROOT}/.claude/project-config.json" ]; the
 fi
 
 # Get the PR's changed files
-CHANGED=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null)
+CHANGED=$(gh pr diff "$PR_NUMBER" $REPO_FLAG --name-only 2>/dev/null)
 if [ -z "$CHANGED" ]; then
   # Couldn't determine files — skip rather than false-positive
   exit 0

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -16,6 +16,9 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
+# Parse --repo from the gh command for cross-repo PR creation
+CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+
 # Only check on gh pr create
 if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+create\b'; then
   exit 0
@@ -50,10 +53,12 @@ if [ -n "$TICKET_REF" ]; then
   # Extract digits from the ref (works for both #N and PREFIX-N)
   TICKET_NUM=$(echo "$TICKET_REF" | grep -oE '[0-9]+$')
 
-  # Resolve tracker repo: prefer .claude/project-config.json, fall back to origin
+  # Resolve tracker repo: prefer --repo flag, then project-config.json, then origin
   REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
   TRACKER_REPO=""
-  if [ -f "${REPO_ROOT}/.claude/project-config.json" ]; then
+  if [ -n "$CMD_REPO" ]; then
+    TRACKER_REPO="$CMD_REPO"
+  elif [ -f "${REPO_ROOT}/.claude/project-config.json" ]; then
     TRACKER_REPO=$(jq -r '.tracker_repo // empty' "${REPO_ROOT}/.claude/project-config.json" 2>/dev/null)
   fi
   if [ -z "$TRACKER_REPO" ]; then

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,12 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "$schema": "https://json-schema.org/claude-code-settings.json",
   "hooks": {
     "SessionStart": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/onboarding-check.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/onboarding-check.sh\"'"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/require-active-ticket.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
           }
         ]
       },
@@ -27,62 +27,62 @@
           {
             "type": "command",
             "if": "Bash(git add *)",
-            "command": ".claude/hooks/block-git-add-all.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-git-add-all.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": ".claude/hooks/block-main-push.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-main-push.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": ".claude/hooks/validate-branch-name.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-branch-name.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": ".claude/hooks/check-secrets.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-secrets.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": ".claude/hooks/verify-commit-refs.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/verify-commit-refs.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": ".claude/hooks/validate-commit-format.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-commit-format.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": ".claude/hooks/require-agdr-for-arch-changes.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-agdr-for-arch-changes.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": ".claude/hooks/pre-push-gate.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/pre-push-gate.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr create *)",
-            "command": ".claude/hooks/validate-pr-create.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-pr-create.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr merge *)",
-            "command": ".claude/hooks/block-unreviewed-merge.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-unreviewed-merge.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr merge *)",
-            "command": ".claude/hooks/require-design-review-for-ui.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr merge *)",
-            "command": ".claude/hooks/block-merge-on-red-ci.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
           }
         ]
       }
@@ -94,7 +94,7 @@
           {
             "type": "command",
             "if": "Bash(gh pr create *)",
-            "command": ".claude/hooks/auto-code-review.sh"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/auto-code-review.sh\"'"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/claude-code-settings.json",
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary
- All 14 hook commands in settings.json now use an inline resolver that walks up from $PWD to find `onboarding.yaml` (the ops root marker), then exec the hook from the resolved absolute path
- 4 cross-repo hooks now parse `--repo` from the command and pass it to `gh` API calls
- Fixes "No such file or directory" errors when working inside `workspace/<project>/`

## Changes
| File | What changed |
|------|-------------|
| `.claude/settings.json` | All 14 `command` entries use inline ops-root resolver |
| `validate-pr-create.sh` | Parse `--repo` for cross-repo issue validation |
| `block-merge-on-red-ci.sh` | Parse `--repo`, pass to `gh pr checks/view` |
| `block-unreviewed-merge.sh` | Parse `--repo`, pass to `gh pr view` fallback |
| `require-design-review-for-ui.sh` | Parse `--repo`, pass to `gh pr view/diff` |

## Test plan
- [x] Resolver finds ops root from `workspace/curios-dog/backend/`
- [x] Resolver works from ops repo root (no regression)
- [x] Hooks block correctly when invoked via resolver (`block-main-push`, `block-git-add-all` tested)
- [ ] End-to-end: work on a ticket in a workspace project, hooks enforce SDLC

Closes #45

---

## Glossary
| Term | Definition |
|------|------------|
| Ops root | The ApexStack fork directory containing `onboarding.yaml`, `.claude/`, and `workspace/` |
| Inline resolver | A `bash -c` one-liner that walks up from $PWD looking for `onboarding.yaml` to find the ops root |
| Cross-repo hook | A hook that validates against a different repo than origin (via `--repo` flag) |

Generated with [Claude Code](https://claude.com/claude-code)