### PR TITLE
feat(#49): structured ticket templates — /feature, /bug, /task

### DIFF
--- a/.claude/hooks/suggest-ticket-template.sh
+++ b/.claude/hooks/suggest-ticket-template.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# PreToolUse hook on `gh issue create`: reminds the user to use /feature, /bug,
+# or /task instead of freeform gh issue create. These skills ensure every ticket
+# has the right structure (user story, bug scenario, or driver + ACs).
+#
+# This is advisory, not blocking — exit 0 always. The reminder prints to stderr
+# so Claude sees it and can suggest the skill to the user.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Only trigger on gh issue create (not gh issue view, gh issue list, etc.)
+if ! echo "$COMMAND" | grep -qE '\bgh\s+issue\s+create\b'; then
+  exit 0
+fi
+
+cat >&2 <<MSG
+NOTE: ApexStack has structured ticket templates. Consider using:
+
+  /feature  — for user-facing features (includes user story + ACs)
+  /bug      — for bug reports (includes Given/When/Then + repro steps)
+  /task     — for tech debt, refactoring, CI, or non-user-facing work
+
+These ensure every ticket has the right structure and labels.
+If this is a quick operational issue (closing, commenting, labeling),
+proceed with gh issue create as-is.
+MSG
+
+# Advisory only — don't block
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -66,6 +66,11 @@
           },
           {
             "type": "command",
+            "if": "Bash(gh issue create *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/suggest-ticket-template.sh\"'"
+          },
+          {
+            "type": "command",
             "if": "Bash(gh pr create *)",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-pr-create.sh\"'"
           },

--- a/.claude/skills/bug/SKILL.md
+++ b/.claude/skills/bug/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: bug
+description: Create a structured bug report with Given/When/Then scenario, repro steps, and severity. Use when reporting a bug or unexpected behavior.
+argument-hint: "<short description of the bug>"
+allowed-tools: Bash, Read, Write
+---
+
+# /bug — Create a Bug Report Ticket
+
+Creates a structured GitHub Issue for a bug with Given/When/Then scenario, repro steps, environment, and severity. Asks guided questions, shows the formatted ticket for confirmation, then creates the issue.
+
+## Usage
+
+```
+/bug Profile picture upload fails
+/bug RTL resets on navigation
+/bug Follow button state not persisted
+```
+
+## Process
+
+### 1. Resolve the target repo
+
+Read `.claude/session/current-ticket` to determine which repo we're working in. If no active ticket, check `apexstack.projects.yaml` for managed projects. If only one project, use it. If multiple, ask:
+
+```
+Which project is this bug in?
+```
+
+If no projects are registered, ask for the repo in `owner/repo` format.
+
+### 2. Parse or ask for the title
+
+Take the title from `$ARGUMENTS`. If empty, ask:
+
+```
+What's the bug? Give me a short description.
+```
+
+### 3. Gather details (one question at a time)
+
+Ask conversationally — do NOT batch all questions. Wait for each answer before asking the next.
+
+**a) Bug Scenario**
+
+```
+Describe the bug scenario:
+- Given: what's the starting state?
+- When: what action triggers the bug?
+- Then: what happens (the broken behavior)?
+- Expected: what should happen instead?
+```
+
+If the user gives a casual description, restructure it into Given/When/Then/Expected format and confirm.
+
+**b) Repro Steps**
+
+```
+What are the exact steps to reproduce?
+```
+
+**c) Severity**
+
+```
+How severe is this?
+1. P0 — blocks a core feature, must fix immediately
+2. P1 — important, fix soon
+3. P2 — minor, fix when convenient
+```
+
+**d) Environment (optional)**
+
+```
+Any environment details? (browser, device, staging/prod, or Enter to skip)
+```
+
+**e) Investigation Notes (optional)**
+
+```
+Any initial investigation? (root cause hypothesis, relevant code paths, or Enter to skip)
+```
+
+### 4. Show the formatted ticket for confirmation
+
+Display the full ticket:
+
+```
+Here's the ticket I'll create:
+
+---
+**[{P0|P1|P2}] {title}**
+
+## Bug Scenario
+**Given** {precondition}
+**When** {action}
+**Then** {unexpected result}
+**Expected** {correct behavior}
+
+## Repro Steps
+1. {step 1}
+2. {step 2}
+3. ...
+
+## Environment
+{environment or "Not specified"}
+
+## Severity
+{P0-critical / P1-important / P2-later}
+
+## Investigation Notes
+{notes or "—"}
+---
+
+Labels: bug, {P0|P1|P2}
+Repo: {owner/repo}
+
+Create this ticket? (yes / edit / cancel)
+```
+
+### 5. Handle response
+
+- **yes** / **looks good** / **go** → create the issue
+- **edit** / **change X** → ask what to change, update, re-show
+- **cancel** / **no** → abort
+
+### 6. Create the GitHub Issue
+
+```bash
+gh issue create --repo {owner/repo} \
+  --title "[{P0|P1|P2}] {title}" \
+  --label "bug,{priority}" \
+  --body "{formatted body}"
+```
+
+### 7. Return the URL
+
+```
+Created: {owner/repo}#{number} — {title}
+{url}
+```
+
+## Rules
+
+1. **One question at a time.** Never batch questions. Wait for each answer.
+2. **Always confirm before creating.** Show the full ticket and get explicit "yes".
+3. **Given/When/Then is required.** Restructure casual descriptions into the format.
+4. **At least one repro step.** Don't create bugs without repro.
+5. **Labels auto-applied.** `bug` always, plus the severity label.
+6. **Title prefix.** Severity in brackets: `[P0]`, `[P1]`, or `[P2]`.

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: feature
+description: Create a structured feature request ticket with user story, acceptance criteria, and design notes. Use when proposing a new user-facing feature.
+argument-hint: "<short title of the feature>"
+allowed-tools: Bash, Read, Write
+---
+
+# /feature — Create a Feature Request Ticket
+
+Creates a structured GitHub Issue for a new feature with a user story, acceptance criteria, and design notes. Asks guided questions, shows the formatted ticket for confirmation, then creates the issue.
+
+## Usage
+
+```
+/feature Profile picture upload
+/feature Arabic language support
+/feature Likes on answers
+```
+
+## Process
+
+### 1. Resolve the target repo
+
+Read `.claude/session/current-ticket` to determine which repo we're working in. If no active ticket, check `apexstack.projects.yaml` for managed projects. If only one project, use it. If multiple, ask:
+
+```
+Which project is this feature for?
+```
+
+If no projects are registered, ask for the repo in `owner/repo` format.
+
+### 2. Parse or ask for the title
+
+Take the title from `$ARGUMENTS`. If empty, ask:
+
+```
+What's the feature? Give me a short title.
+```
+
+### 3. Gather details (one question at a time)
+
+Ask conversationally — do NOT batch all questions. Wait for each answer before asking the next.
+
+**a) User Story**
+
+```
+Who is this for and what do they want?
+Format: As a [persona], I want [goal] so that [benefit].
+```
+
+If the user gives a casual answer ("users should be able to upload photos"), restructure it into the user story format and confirm.
+
+**b) Acceptance Criteria**
+
+```
+What are the acceptance criteria? List the specific things that must be true when this is done.
+(You can write them as bullet points — I'll format them as checkboxes.)
+```
+
+**c) Design Notes**
+
+```
+Any design notes? (screenshots, mockups, Figma links, or "no UI changes")
+```
+
+If the user says something like "no" or "none", use "No UI changes" as the value.
+
+**d) Priority**
+
+```
+Priority?
+1. P0 — must-have for current milestone
+2. P1 — ship soon after launch
+3. P2 — future / v2+
+```
+
+**e) Out of Scope (optional)**
+
+```
+Anything explicitly out of scope? (or press Enter to skip)
+```
+
+### 4. Show the formatted ticket for confirmation
+
+Display the full ticket:
+
+```
+Here's the ticket I'll create:
+
+---
+**[Feature] {title}**
+
+## User Story
+As a {persona}, I want {goal} so that {benefit}.
+
+## Acceptance Criteria
+- [ ] {criterion 1}
+- [ ] {criterion 2}
+- [ ] ...
+
+## Design Notes
+{notes}
+
+## Out of Scope
+{out of scope or "—"}
+
+## Effort Estimate
+TBD
+---
+
+Labels: enhancement, {P0|P1|P2}
+Repo: {owner/repo}
+
+Create this ticket? (yes / edit / cancel)
+```
+
+### 5. Handle response
+
+- **yes** / **looks good** / **go** → create the issue
+- **edit** / **change X** → ask what to change, update, re-show
+- **cancel** / **no** → abort
+
+### 6. Create the GitHub Issue
+
+```bash
+gh issue create --repo {owner/repo} \
+  --title "[Feature] {title}" \
+  --label "enhancement,{priority}" \
+  --body "{formatted body}"
+```
+
+### 7. Return the URL
+
+```
+Created: {owner/repo}#{number} — {title}
+{url}
+```
+
+## Rules
+
+1. **One question at a time.** Never batch questions. Wait for each answer.
+2. **Always confirm before creating.** Show the full ticket and get explicit "yes".
+3. **User story format is required.** Restructure casual answers into As a / I want / So that.
+4. **At least one acceptance criterion.** Don't create tickets with empty ACs.
+5. **Labels auto-applied.** `enhancement` always, plus the priority label.
+6. **Title prefix.** Always `[Feature]` in the issue title.

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: task
+description: Create a structured technical task ticket with driver, scope, and acceptance criteria. Use for tech debt, infrastructure work, refactoring, or non-user-facing changes.
+argument-hint: "<short title of the task>"
+allowed-tools: Bash, Read, Write
+---
+
+# /task — Create a Technical Task Ticket
+
+Creates a structured GitHub Issue for a technical task with driver (why), scope (what), acceptance criteria, and risks. Used for tech debt, infrastructure, refactoring, dependency updates, or any non-user-facing work that doesn't fit /feature or /bug.
+
+## Usage
+
+```
+/task Set up PR-triggered CI pipeline
+/task Extract shared LikeCount component
+/task Migrate from DiceBear to local avatars
+```
+
+## Process
+
+### 1. Resolve the target repo
+
+Read `.claude/session/current-ticket` to determine which repo we're working in. If no active ticket, check `apexstack.projects.yaml` for managed projects. If only one project, use it. If multiple, ask:
+
+```
+Which project is this task for?
+```
+
+If no projects are registered, ask for the repo in `owner/repo` format.
+
+### 2. Parse or ask for the title
+
+Take the title from `$ARGUMENTS`. If empty, ask:
+
+```
+What's the task? Give me a short title.
+```
+
+### 3. Gather details (one question at a time)
+
+Ask conversationally — do NOT batch all questions. Wait for each answer before asking the next.
+
+**a) Driver**
+
+```
+Why is this work needed? (upstream ticket, tech debt rationale, Rex recommendation, dependency requirement, etc.)
+```
+
+**b) Scope**
+
+```
+What specifically needs to change? Be concrete — which files, services, or systems are affected.
+```
+
+**c) Acceptance Criteria**
+
+```
+What are the acceptance criteria? What must be true when this is done?
+```
+
+**d) Priority**
+
+```
+Priority?
+1. P0 — blocks other work
+2. P1 — important, schedule soon
+3. P2 — nice to have, do when convenient
+```
+
+**e) Risks / Dependencies (optional)**
+
+```
+Any risks or dependencies? (what could block this, what depends on it, or Enter to skip)
+```
+
+### 4. Show the formatted ticket for confirmation
+
+Display the full ticket:
+
+```
+Here's the ticket I'll create:
+
+---
+**[{Chore|Refactor|Test|CI}] {title}**
+
+## Driver
+{why this work is needed}
+
+## Scope
+{what specifically needs to change}
+
+## Acceptance Criteria
+- [ ] {criterion 1}
+- [ ] {criterion 2}
+- [ ] ...
+
+## Risks / Dependencies
+{risks or "None identified"}
+---
+
+Labels: {type}, {P0|P1|P2}
+Repo: {owner/repo}
+
+Create this ticket? (yes / edit / cancel)
+```
+
+The title prefix is derived from the content:
+- Testing work → `[Testing]`
+- CI/CD work → `[CI]`
+- Refactoring → `[Refactor]`
+- Everything else → `[Chore]`
+
+### 5. Handle response
+
+- **yes** / **looks good** / **go** → create the issue
+- **edit** / **change X** → ask what to change, update, re-show
+- **cancel** / **no** → abort
+
+### 6. Create the GitHub Issue
+
+```bash
+gh issue create --repo {owner/repo} \
+  --title "[{type}] {title}" \
+  --label "{priority}" \
+  --body "{formatted body}"
+```
+
+### 7. Return the URL
+
+```
+Created: {owner/repo}#{number} — {title}
+{url}
+```
+
+## Rules
+
+1. **One question at a time.** Never batch questions. Wait for each answer.
+2. **Always confirm before creating.** Show the full ticket and get explicit "yes".
+3. **Driver is required.** Every technical task needs a "why".
+4. **At least one acceptance criterion.** Don't create tasks with empty ACs.
+5. **Labels auto-applied.** Priority label always applied.
+6. **Title prefix.** Derived from the nature of the work: Testing, CI, Refactor, or Chore.

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -106,6 +106,7 @@ Create this ticket? (yes / edit / cancel)
 ```
 
 The title prefix is derived from the content:
+
 - Testing work → `[Testing]`
 - CI/CD work → `[CI]`
 - Refactoring → `[Refactor]`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ ApexStack ships with a `.claude/` directory containing the Claude Code primitive
 | Skills | `.claude/skills/` | 27 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (27)
+### Available skills (30)
 
 | Skill | Purpose |
 |-------|---------|
@@ -194,6 +194,9 @@ ApexStack ships with a `.claude/` directory containing the Claude Code primitive
 | `/security-review` | Invoke the Security Reviewer agent (Shield) on a PR |
 | `/audit-deps` | Audit dependencies for vulnerabilities, outdated packages, licences |
 | `/write-spec` | Generate a PRD or feature spec from a problem statement |
+| `/feature` | Create a structured feature request ticket (user story + ACs) |
+| `/bug` | Create a structured bug report (Given/When/Then + repro + severity) |
+| `/task` | Create a structured technical task ticket (driver + scope + ACs) |
 | `/idea` | Capture a new product idea to the backlog |
 | `/handover` | Onboard an external repo into ApexStack management (includes per-project discovery) |
 | `/projects` | List all managed projects from the registry with status |


### PR DESCRIPTION
## Summary
- 3 new slash commands: `/feature`, `/bug`, `/task`
- Each asks guided questions one at a time, shows formatted ticket for confirmation, then creates the GitHub issue
- `/feature`: user story + ACs + design notes + priority
- `/bug`: Given/When/Then + repro steps + severity + investigation notes
- `/task`: driver + scope + ACs + risks + priority
- Advisory `suggest-ticket-template.sh` hook on `gh issue create` reminds to use the skills
- CLAUDE.md updated: skill count 27 → 30, table updated

## Test plan
- [ ] Run `/feature test feature` → should ask guided questions, show ticket, create on confirm
- [ ] Run `/bug test bug` → same flow with Given/When/Then format
- [ ] Run `/task test task` → same flow with driver/scope
- [ ] Run `gh issue create` directly → should see advisory note suggesting the skills

Closes #49

---

## Glossary
| Term | Definition |
|------|------------|
| User story | As a [persona], I want [goal] so that [benefit] — standard format for feature requests |
| Given/When/Then | BDD-style scenario description for bug reports |
| Driver | The reason a technical task exists — upstream ticket, tech debt rationale, etc. |

Generated with [Claude Code](https://claude.com/claude-code)