### PR TITLE
fix(#52): reject closed issue refs in PR and commit hooks

### DIFF
--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -68,7 +68,10 @@ if [ -n "$TICKET_REF" ]; then
   fi
 
   if [ -n "$TICKET_NUM" ] && [ -n "$TRACKER_REPO" ]; then
-    if ! gh issue view "$TICKET_NUM" --repo "$TRACKER_REPO" --json state >/dev/null 2>&1; then
+    # Fetch both number and state in one call so we can distinguish
+    # "does not exist" from "exists but CLOSED". Both are blocking.
+    ISSUE_JSON=$(gh issue view "$TICKET_NUM" --repo "$TRACKER_REPO" --json number,state 2>/dev/null)
+    if [ -z "$ISSUE_JSON" ]; then
       cat >&2 <<MSG
 BLOCKED: PR title references ${TICKET_REF} but issue #${TICKET_NUM} does not
 exist in ${TRACKER_REPO}.
@@ -81,6 +84,31 @@ If you intended to create the PR for a real ticket, verify the number.
 If you were about to file work that has no ticket yet, create one first:
   gh issue create --repo ${TRACKER_REPO} --title "..."
 and use the returned number in your PR title.
+MSG
+      exit 2
+    fi
+
+    ISSUE_STATE=$(echo "$ISSUE_JSON" | jq -r '.state // empty' 2>/dev/null)
+    if [ "$ISSUE_STATE" = "CLOSED" ]; then
+      cat >&2 <<MSG
+BLOCKED: PR title references ${TICKET_REF} but issue #${TICKET_NUM} in
+${TRACKER_REPO} is CLOSED.
+
+Every PR needs its own OPEN ticket. Referencing a closed issue means the PR
+has no live acceptance criteria, no QA handoff, and no tracker row to move
+through the SDLC states — the ticket is already Done.
+
+Common causes:
+  - The work is a follow-up to the closed issue → create a NEW ticket that
+    describes the follow-up, link back to the closed one in the body, and
+    use the new number in the PR title.
+  - The closed issue was auto-closed by a prior PR that didn't fully finish
+    the work → re-open it (gh issue reopen ${TICKET_NUM} --repo ${TRACKER_REPO})
+    or create a new ticket for the remaining work.
+  - The number is a typo → fix the PR title.
+
+See .claude/rules/ticket-vocabulary.md and the "every PR needs its own open
+ticket" feedback in memory.
 MSG
       exit 2
     fi

--- a/.claude/hooks/verify-commit-refs.sh
+++ b/.claude/hooks/verify-commit-refs.sh
@@ -99,12 +99,25 @@ if [ -z "$TRACKER_REPO" ]; then
   exit 0
 fi
 
-# Verify each referenced issue exists
+# Verify each referenced issue exists. Fabricated #N (issue not found) is
+# BLOCKING — that's the failure mode the ticket-vocabulary rule targets.
+# References to CLOSED issues are WARNED (not blocked) because a commit may
+# legitimately reference the closed issue it just finished (e.g. a revert or
+# a follow-up clarification commit after the closing PR already shipped).
+# The PR-level hook (validate-pr-create.sh) is the right place to enforce
+# "every PR needs its own OPEN ticket".
 MISSING=""
+CLOSED=""
 for REF in $REFS; do
   NUM=$(echo "$REF" | tr -d '#')
-  if ! gh issue view "$NUM" --repo "$TRACKER_REPO" --json state >/dev/null 2>&1; then
+  ISSUE_JSON=$(gh issue view "$NUM" --repo "$TRACKER_REPO" --json number,state 2>/dev/null)
+  if [ -z "$ISSUE_JSON" ]; then
     MISSING="${MISSING}${REF} "
+    continue
+  fi
+  ISSUE_STATE=$(echo "$ISSUE_JSON" | jq -r '.state // empty' 2>/dev/null)
+  if [ "$ISSUE_STATE" = "CLOSED" ]; then
+    CLOSED="${CLOSED}${REF} "
   fi
 done
 
@@ -126,6 +139,17 @@ If the reference is truly informational (cross-repo link that can't be verified
 with \`gh issue view\`), write it as a plain URL instead of #N notation.
 MSG
   exit 2
+fi
+
+if [ -n "$CLOSED" ]; then
+  cat >&2 <<MSG
+WARN: Commit message references CLOSED issue(s) in ${TRACKER_REPO}:
+  ${CLOSED}
+This commit is allowed through — a commit may legitimately reference the
+issue it just closed. But at PR-create time the stricter rule applies: every
+PR needs its own OPEN ticket. If this commit will end up in a PR that points
+at the closed issue as its primary ticket, create a new open ticket first.
+MSG
 fi
 
 exit 0


### PR DESCRIPTION
## Summary

- `validate-pr-create.sh`: in addition to rejecting PRs that reference a non-existent issue, now also reject PRs that reference a **closed** issue. Every PR needs its own OPEN ticket.
- `verify-commit-refs.sh`: same fetch on the commit-level hook, but CLOSED is **warn** (stderr, exit 0), not block. A commit may legitimately reference the issue it just closed (reverts, follow-ups); the PR-level check is the right place to enforce the "open ticket" rule.

## Why

PR `me2resh/curios-dog#218` was created with title `fix(#210): ...` but `#210` was already closed. The old hook passed because `gh issue view #210` still resolves successfully for closed issues — it just didn't check state. The CEO caught it by eye, but the hook is supposed to be the backstop for exactly this failure mode, so it's closing an observability gap in the governance layer.

Full incident + reproduction context lives on the upstream issue:
<https://github.com/me2resh/apexstack/issues/52>

## Changes

**`.claude/hooks/validate-pr-create.sh`** — one call becomes one call that captures both number and state:

```diff
-if ! gh issue view "$TICKET_NUM" --repo "$TRACKER_REPO" --json state >/dev/null 2>&1; then
+ISSUE_JSON=$(gh issue view "$TICKET_NUM" --repo "$TRACKER_REPO" --json number,state 2>/dev/null)
+if [ -z "$ISSUE_JSON" ]; then
   # ... existing "does not exist" block
 fi
+ISSUE_STATE=$(echo "$ISSUE_JSON" | jq -r '.state // empty')
+if [ "$ISSUE_STATE" = "CLOSED" ]; then
+  # new "issue is closed" block with the three-cause explanation
+fi
```

The new block message lists the three common root causes (follow-up, premature auto-close, typo) and tells the author what to do — create a new open ticket, reopen, or fix the number.

**`.claude/hooks/verify-commit-refs.sh`** — tracks missing and closed separately. Missing still blocks, closed warns:

```diff
-if ! gh issue view "$NUM" --repo "$TRACKER_REPO" --json state >/dev/null 2>&1; then
-  MISSING="${MISSING}${REF} "
+ISSUE_JSON=$(gh issue view "$NUM" --repo "$TRACKER_REPO" --json number,state 2>/dev/null)
+if [ -z "$ISSUE_JSON" ]; then
+  MISSING="${MISSING}${REF} "
+  continue
 fi
+ISSUE_STATE=$(echo "$ISSUE_JSON" | jq -r '.state // empty')
+if [ "$ISSUE_STATE" = "CLOSED" ]; then
+  CLOSED="${CLOSED}${REF} "
+fi
```

## Testing

Self-tested on the ops fork:

- ✅ Committing with a fake `#99999` → blocks (existing behavior preserved)
- ✅ Committing with a closed real issue → warns on stderr, commit proceeds
- ✅ Creating a PR whose title references a closed issue → blocks
- ✅ Creating a PR whose title references an open issue → passes
- ✅ `bash -n` syntax check passes on both scripts

Note on testing: the commit message of this very PR could not use `Closes #52` because the commit-level hook (on this ops-repo fork) detects `me2resh/ops` as the tracker via `git remote get-url origin`, but issue `#52` lives on `me2resh/apexstack` (upstream). The hook treats that as "issue does not exist in tracker" and blocks. Workaround here: cite the upstream issue by URL in the commit body. A follow-up ticket is worth filing on upstream to let contributors from forks reference upstream issues via full URL syntax — but that's out of scope for this fix.

---

## Glossary

| Term | Definition |
|------|------------|
| **Tracker repo** | The GitHub repo that hosts the project's issues. For apexstack (and each managed project in the ApexStack portfolio) this is the project's own repo. Hooks infer it from `.claude/project-config.json` or from `git remote get-url origin`. |
| **Cross-fork PR** | This PR's source branch lives on `me2resh/ops` (a fork of apexstack), but the PR targets `me2resh/apexstack:main`. Standard OSS contribution pattern. |
| **`--json number,state`** | Fetching both fields in one `gh issue view` call so the hook can distinguish "does not exist" (empty response) from "exists but CLOSED" (non-empty, state=CLOSED). Cheaper than two separate HTTP calls. |
| **Backstop hook** | A hook that validates work at the moment it becomes a durable artifact (PR title, commit message), as opposed to catching the root cause in prose. The primary fix for "referenced closed issue" is self-discipline — this hook is the backstop when discipline fails. |
| **`Closes #N` / `Refs #N` / `Fixes #N` / `Resolves #N`** | GitHub-recognized issue linking keywords in commit messages. GitHub auto-closes the referenced issue on merge for `Closes`/`Fixes`/`Resolves`. |
| **WARN vs BLOCK** | In ApexStack's hook convention, `exit 2` blocks the tool use (commit refused); anything written to stderr with `exit 0` is a warning that the user sees but the action proceeds. Chosen per-hook based on how often a false positive would be disruptive. |
