### PR TITLE
fix(#47): catch gh api .../merge bypass in merge-gate hooks

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -225,6 +225,8 @@ The new hooks are registered in `.claude/settings.json` alongside the existing o
 2. **`require-design-review-for-ui.sh`**
 3. **`block-merge-on-red-ci.sh`**
 
+All three merge-gate hooks are **also** registered on `Bash(gh api *)` so the REST-API merge shape (`gh api repos/<owner>/<repo>/pulls/<N>/merge -X PUT`) can't silently bypass them. The merge-shape detection and PR-number extraction live in the shared sourced helper `_lib-extract-pr.sh` — any future change to PR-number parsing should be made there, not in the individual hooks. Context: [#47](https://github.com/me2resh/apexstack/issues/47).
+
 The ordering is deliberate: cheap local checks first, expensive remote checks (`gh pr checks`) last, so that a merge already blocked by Rex/CEO/design markers doesn't pay the network cost.
 
 ## Pre-existing Hooks

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Shared PR-number extraction for the three merge-gate hooks:
+#   - block-unreviewed-merge.sh
+#   - require-design-review-for-ui.sh
+#   - block-merge-on-red-ci.sh
+#
+# Not a hook itself (prefixed with `_lib-` so it's never wired as one). Sourced
+# by the hooks above via `. "$(dirname "$0")/_lib-extract-pr.sh"`.
+#
+# WHY THIS EXISTS
+# ---------------
+# The merge gates originally only matched `gh pr merge <N>`. Incident (#47):
+# merges via `gh api repos/<owner>/<repo>/pulls/<N>/merge -X PUT` silently
+# bypassed all three gates because neither the matcher nor the PR-number
+# extraction knew about the API shape. This helper gives every gate a single,
+# tested way to recognise both shapes:
+#
+#   1. `gh pr merge 42 --squash`                                  → PR is 42
+#   2. `gh api repos/owner/repo/pulls/42/merge -X PUT`            → PR is 42
+#
+# Any tool that edits one of the three merge hooks MUST keep calling this
+# helper, not re-implement the parsing inline. That's the whole point.
+#
+# USAGE
+# -----
+#   . "$(dirname "$0")/_lib-extract-pr.sh"
+#   if ! is_merge_command "$COMMAND"; then exit 0; fi
+#   PR_NUMBER=$(extract_pr_number "$COMMAND")
+
+# Returns 0 if $1 looks like a merge command this gate should fire on.
+# Matches EITHER:
+#   - `gh pr merge ...`
+#   - `gh api ... repos/<owner>/<repo>/pulls/<N>/merge ...`
+is_merge_command() {
+  local cmd="$1"
+  if echo "$cmd" | grep -qE '\bgh\s+pr\s+merge\b'; then
+    return 0
+  fi
+  # `gh api` with a `/pulls/<N>/merge` path anywhere in the command. The path
+  # may be quoted, slash-separated, and may include query params.
+  if echo "$cmd" | grep -qE '\bgh\s+api\b.*repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge\b'; then
+    return 0
+  fi
+  return 1
+}
+
+# Echoes the PR number extracted from the command, or empty if none found.
+# Tries (in order):
+#   1. `gh api .../pulls/<N>/merge` URL path
+#   2. `gh pr merge <N>` first numeric arg
+#   3. falls back to `gh pr view --json number` (current branch's PR)
+extract_pr_number() {
+  local cmd="$1"
+  local pr=""
+
+  # 1. gh api path extraction — greps the /pulls/<N>/merge segment directly.
+  pr=$(echo "$cmd" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | grep -oE '/pulls/[0-9]+/' | grep -oE '[0-9]+' | head -1)
+
+  # 2. gh pr merge positional arg — first bare number after `gh pr merge`,
+  #    ignoring anything on the right side of a pipe / && / ; to avoid picking
+  #    up a number from a follow-up command.
+  if [ -z "$pr" ]; then
+    pr=$(echo "$cmd" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*' | grep -oE '[0-9]+' | head -1)
+  fi
+
+  # 3. Last resort: ask gh which PR the current branch points at.
+  if [ -z "$pr" ]; then
+    pr=$(gh pr view --json number --jq '.number' 2>/dev/null)
+  fi
+
+  echo "$pr"
+}

--- a/.claude/hooks/block-merge-on-red-ci.sh
+++ b/.claude/hooks/block-merge-on-red-ci.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-# PreToolUse hook on `gh pr merge`: blocks the merge if any required CI
-# check is failing, pending, or cancelled.
+# PreToolUse hook on `gh pr merge` AND `gh api .../pulls/<N>/merge`: blocks the
+# merge if any required CI check is failing, pending, or cancelled.
+#
+# Both merge shapes are covered — see _lib-extract-pr.sh for the parser and
+# #47 for why the API-shape bypass was a gap worth closing.
 #
 # Enforces .claude/rules/pr-quality.md § "No Red CI Before Merge" —
 # "Never merge with red CI - even if the failure is pre-existing or
@@ -31,22 +34,27 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+merge\b'; then
+# Shared merge-shape detector + PR-number parser (see _lib-extract-pr.sh).
+# Handles `gh pr merge <N>` and `gh api repos/<owner>/<repo>/pulls/<N>/merge`.
+. "$(dirname "$0")/_lib-extract-pr.sh"
+
+if ! is_merge_command "$COMMAND"; then
   exit 0
 fi
 
-# Parse --repo from the command for cross-repo merge operations
+# Parse --repo (for `gh pr merge --repo owner/repo`). Fallback: recover from
+# the `gh api .../pulls/<N>/merge` URL path so `gh pr checks` below is still
+# scoped correctly.
 CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+if [ -z "$CMD_REPO" ]; then
+  CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
+fi
 REPO_FLAG=""
 if [ -n "$CMD_REPO" ]; then
   REPO_FLAG="--repo $CMD_REPO"
 fi
 
-# Extract PR number (same approach as the other merge-gate hooks)
-PR_NUMBER=$(echo "$COMMAND" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*' | grep -oE '[0-9]+' | head -1)
-if [ -z "$PR_NUMBER" ]; then
-  PR_NUMBER=$(gh pr view $REPO_FLAG --json number --jq '.number' 2>/dev/null)
-fi
+PR_NUMBER=$(extract_pr_number "$COMMAND")
 
 if [ -z "$PR_NUMBER" ]; then
   # Another hook will handle "no PR number" — skip

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-# PreToolUse hook on `gh pr merge`: blocks merging a PR that does not have
-# BOTH required approval markers in place.
+# PreToolUse hook on `gh pr merge` AND `gh api .../pulls/<N>/merge`: blocks
+# merging a PR that does not have BOTH required approval markers in place.
+#
+# Both merge shapes are covered — see _lib-extract-pr.sh for the parser and
+# #47 for why the API-shape bypass was a gap worth closing.
 #
 # Enforces workflow-gates rule #5 ("2 reviews — agent + human, CI green,
 # commit SHA matches review") at the merge boundary, mechanically. Two
@@ -35,24 +38,29 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-# Only check on gh pr merge
-if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+merge\b'; then
+# Shared merge-shape detector + PR-number parser (see _lib-extract-pr.sh).
+# Handles `gh pr merge <N>` and `gh api repos/<owner>/<repo>/pulls/<N>/merge`.
+. "$(dirname "$0")/_lib-extract-pr.sh"
+
+if ! is_merge_command "$COMMAND"; then
   exit 0
 fi
 
-# Parse --repo from the command for cross-repo merge operations
+# Parse --repo (for `gh pr merge --repo owner/repo`). The API-shape encodes
+# the repo in its URL path so we don't need the flag there — downstream
+# `gh pr view` / `gh pr checks` calls still benefit when the flag was passed.
 CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+# If the command uses the API shape, recover owner/repo from the URL path
+# so other gh calls below can still be scoped correctly.
+if [ -z "$CMD_REPO" ]; then
+  CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
+fi
 REPO_FLAG=""
 if [ -n "$CMD_REPO" ]; then
   REPO_FLAG="--repo $CMD_REPO"
 fi
 
-# Extract PR number: either from the command args or from the current branch's PR.
-# Handles both `gh pr merge 42` and flag-first forms like `gh pr merge --auto 42`.
-PR_NUMBER=$(echo "$COMMAND" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*' | grep -oE '[0-9]+' | head -1)
-if [ -z "$PR_NUMBER" ]; then
-  PR_NUMBER=$(gh pr view $REPO_FLAG --json number --jq '.number' 2>/dev/null)
-fi
+PR_NUMBER=$(extract_pr_number "$COMMAND")
 
 if [ -z "$PR_NUMBER" ]; then
   echo "BLOCKED: Could not determine PR number for merge. Run from a PR branch or pass an explicit PR number." >&2

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -55,10 +55,6 @@ CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1
 if [ -z "$CMD_REPO" ]; then
   CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
 fi
-REPO_FLAG=""
-if [ -n "$CMD_REPO" ]; then
-  REPO_FLAG="--repo $CMD_REPO"
-fi
 
 PR_NUMBER=$(extract_pr_number "$COMMAND")
 

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
-# PreToolUse hook on `gh pr merge`: when the PR's diff touches UI files,
-# require a design approval marker at .claude/session/reviews/<pr>-design.approved
-# (with a matching HEAD SHA) before letting the merge through.
+# PreToolUse hook on `gh pr merge` AND `gh api .../pulls/<N>/merge`: when the
+# PR's diff touches UI files, require a design approval marker at
+# .claude/session/reviews/<pr>-design.approved (with a matching HEAD SHA) before
+# letting the merge through.
+#
+# Both merge shapes are covered — see _lib-extract-pr.sh for the parser and
+# #47 for why the API-shape bypass was a gap worth closing.
 #
 # Enforces .claude/rules/pr-quality.md § "Design Review" and
 # workflows/code-review.md § "UI Designer (conditional)" — which were
@@ -32,22 +36,27 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+merge\b'; then
+# Shared merge-shape detector + PR-number parser (see _lib-extract-pr.sh).
+# Handles `gh pr merge <N>` and `gh api repos/<owner>/<repo>/pulls/<N>/merge`.
+. "$(dirname "$0")/_lib-extract-pr.sh"
+
+if ! is_merge_command "$COMMAND"; then
   exit 0
 fi
 
-# Parse --repo from the command for cross-repo merge operations
+# Parse --repo (for `gh pr merge --repo owner/repo`). Fallback: recover from
+# the `gh api .../pulls/<N>/merge` URL path so downstream `gh pr diff` calls
+# still know which repo to talk to.
 CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+if [ -z "$CMD_REPO" ]; then
+  CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
+fi
 REPO_FLAG=""
 if [ -n "$CMD_REPO" ]; then
   REPO_FLAG="--repo $CMD_REPO"
 fi
 
-# Extract PR number (same approach as block-unreviewed-merge.sh)
-PR_NUMBER=$(echo "$COMMAND" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*' | grep -oE '[0-9]+' | head -1)
-if [ -z "$PR_NUMBER" ]; then
-  PR_NUMBER=$(gh pr view $REPO_FLAG --json number --jq '.number' 2>/dev/null)
-fi
+PR_NUMBER=$(extract_pr_number "$COMMAND")
 
 if [ -z "$PR_NUMBER" ]; then
   # Let block-unreviewed-merge.sh handle the "no PR number" error — we skip

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -91,7 +91,7 @@ This also applies to other destructive / externally-visible / hard-to-reverse ac
 
 ### Mechanical enforcement
 
-The `block-unreviewed-merge.sh` hook enforces this rule at the shell level. It requires **two** approval markers in `.claude/session/reviews/` before letting any `gh pr merge` command through:
+The `block-unreviewed-merge.sh` hook enforces this rule at the shell level. It requires **two** approval markers in `.claude/session/reviews/` before letting any merge command through:
 
 | Marker | Written by | Semantics |
 |--------|------------|-----------|
@@ -101,6 +101,19 @@ The `block-unreviewed-merge.sh` hook enforces this rule at the shell level. It r
 Both markers must contain the current HEAD SHA, and both SHAs must match the live HEAD. New commits after approval invalidate both — you must re-review and re-approve.
 
 Claude can technically `rm` or `touch` these files by hand. Doing so is a visible, auditable, grep-able rule violation — and the whole point of recording the rule mechanically is so that the failure mode is "Claude ignored a hook" (visible) instead of "Claude inferred approval from something vague" (invisible).
+
+### Both merge shapes are gated (#47)
+
+All three merge-gate hooks (`block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, `require-design-review-for-ui.sh`) fire on **both** the `gh` subcommand shape and the raw REST-API shape:
+
+| Shape | Example |
+|-------|---------|
+| `gh pr merge` | `gh pr merge 123 --squash` |
+| `gh api .../pulls/<N>/merge` | `gh api repos/owner/repo/pulls/123/merge -X PUT` |
+
+Historically only the first shape was matched. In April 2026 (incident: `me2resh/curios-dog#190` was merged via `gh api` while CI was still running), the second shape was discovered as a silent bypass and closed in [#47](https://github.com/me2resh/apexstack/issues/47). Both the matcher entries in `.claude/settings.json` and the PR-number extraction in each hook (`.claude/hooks/_lib-extract-pr.sh`) now recognise both shapes. Invoking either triggers the gate — there is no supported merge path that skips the two-reviews rule.
+
+Using `gh api .../merge` as a workaround for other issues (e.g. cross-repo resolution, hook flakiness) is itself a rule violation on par with forging an approval marker. If a gate is mis-firing, fix the gate.
 
 ## After Pushing Commits to an Open PR
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -81,12 +81,27 @@
           },
           {
             "type": "command",
+            "if": "Bash(gh api *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-unreviewed-merge.sh\"'"
+          },
+          {
+            "type": "command",
             "if": "Bash(gh pr merge *)",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
           },
           {
             "type": "command",
+            "if": "Bash(gh api *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
+          },
+          {
+            "type": "command",
             "if": "Bash(gh pr merge *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh api *)",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
           }
         ]


### PR DESCRIPTION
## Summary

Closes the silent merge-gate bypass surfaced in [#47](https://github.com/me2resh/apexstack/issues/47). The three merge-gate hooks were only wired on `Bash(gh pr merge *)`, so merges performed via the raw REST-API shape `gh api repos/<owner>/<repo>/pulls/<N>/merge -X PUT` skipped all three gates. Incident: `me2resh/curios-dog#190` was merged via `gh api` while CI was still running.

- **Shared helper** — `.claude/hooks/_lib-extract-pr.sh` exposes `is_merge_command` + `extract_pr_number`, recognising both `gh pr merge <N>` and `gh api .../pulls/<N>/merge`. Sourced by all three merge-gate hooks so the parser lives in exactly one place.
- **Hooks refactored** — `block-unreviewed-merge.sh`, `require-design-review-for-ui.sh`, and `block-merge-on-red-ci.sh` now call the helper instead of inline-grepping. Each also recovers `owner/repo` from the `gh api` URL path when `--repo` is absent, so downstream `gh pr view` / `gh pr diff` / `gh pr checks` remain scoped correctly.
- **Settings wiring** — `.claude/settings.json` gets sibling `Bash(gh api *)` matcher entries for each of the three hooks. Option A (sibling entries), because the `if` field is a glob pattern, not a regex, so alternation isn't supported. The hooks themselves filter non-merge `gh api` calls via `is_merge_command`, which specifically looks for `/pulls/<N>/merge` in the URL path — any other `gh api` call exits 0 silently.
- **Docs** — `.claude/rules/pr-workflow.md § "Both merge shapes are gated (#47)"` states the rule explicitly and calls out that using `gh api .../merge` to route around a gate is itself a rule violation on par with forging an approval marker. `.claude/hooks/README.md` notes the dual registration.

## Test plan

- [x] `bash .claude/hooks/block-unreviewed-merge.sh` stdin = classic shape → BLOCKED, PR=99999
- [x] `bash .claude/hooks/block-unreviewed-merge.sh` stdin = API shape → BLOCKED, PR=99999
- [x] `bash .claude/hooks/block-merge-on-red-ci.sh` stdin = API shape → fires `gh pr checks` against the correct repo
- [x] `bash .claude/hooks/require-design-review-for-ui.sh` stdin = API shape → extracts PR, proceeds through diff check
- [x] Non-merge `gh pr view 123` passes through silently (exit 0)
- [x] Non-merge `gh api repos/foo/bar/issues/42` passes through silently (helper `is_merge_command` requires `/pulls/<N>/merge`)
- [x] JSON still valid after settings.json edit (`jq . .claude/settings.json`)
- [ ] End-to-end verification that a real `gh api` merge attempt is blocked in a live Claude Code session (requires a PR to merge against — ideally this PR itself, after approval)

## Glossary

| Term | Definition |
|------|------------|
| Merge-gate hook | A PreToolUse hook that runs before a merge command and exits 2 to block the merge when preconditions aren't met (Rex approval, CEO approval, green CI, design review for UI). |
| `gh pr merge` shape | The high-level `gh` subcommand form of merging a PR, e.g. `gh pr merge 123 --squash`. What Claude is supposed to use. |
| `gh api` shape | The raw REST-API form, e.g. `gh api repos/owner/repo/pulls/123/merge -X PUT`. Equivalent effect, different matcher — which is exactly what let it bypass the gates. |
| Matcher (`if` field) | The glob pattern in `.claude/settings.json` that decides whether a hook fires on a given tool call. Globs don't support alternation, so two shapes need two matcher entries. |
| Option A vs Option B | A — sibling matcher entries per hook (chosen, because globs only). B — one catch-all regex matcher (rejected, unsupported). |
| `_lib-` prefix | Convention for a sourced helper script in `.claude/hooks/` that is NOT a hook itself. The harness ignores it; other hook scripts `source` it. |
| Silent bypass | A merge that appears to succeed and produces no hook output because no matcher pattern matched the command. The worst kind of failure — there's no audit trail. |

Ticket: https://github.com/me2resh/apexstack/issues/47
