### PR TITLE
fix(#55): merge-gate hooks read PR HEAD via gh pr view, not local git HEAD

### DIFF
--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -70,3 +70,46 @@ extract_pr_number() {
 
   echo "$pr"
 }
+
+# Echoes the PR's HEAD SHA as reported by GitHub, or empty on failure.
+#
+# Why this exists (see #55): merge-gate hooks previously compared approval
+# markers against `git rev-parse HEAD` (local HEAD). But `gh pr merge <N>`
+# merges the PR's branch on GitHub's side, which is almost never equal to
+# the local HEAD (local is usually `main` or a different feature branch).
+# That meant every merge required a `gh pr checkout <N> && gh pr merge <N>`
+# dance. Tedious and error-prone.
+#
+# This helper asks GitHub directly for the PR's HEAD via `gh pr view`.
+# Works for both the `gh pr merge` and `gh api .../pulls/<N>/merge` shapes.
+#
+# Usage:
+#   PR_HEAD=$(resolve_pr_head "$PR_NUMBER" "$CMD_REPO")
+#   # Compare PR_HEAD against marker SHAs instead of git rev-parse HEAD.
+#
+# Failure modes (returns empty, caller should fall back):
+#   - Network error / rate limit / gh auth expired
+#   - PR doesn't exist (wrong number, closed, or wrong repo)
+#   - GitHub API transient failure
+#
+# On failure the caller should fall back to `git rev-parse HEAD` with a
+# visible warning — better to block a valid merge that the user can retry
+# than silently allow a merge on the wrong SHA.
+resolve_pr_head() {
+  local pr_number="$1"
+  local cmd_repo="$2"
+  local sha=""
+
+  if [ -z "$pr_number" ]; then
+    echo ""
+    return
+  fi
+
+  if [ -n "$cmd_repo" ]; then
+    sha=$(gh pr view "$pr_number" --repo "$cmd_repo" --json headRefOid --jq '.headRefOid' 2>/dev/null)
+  else
+    sha=$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid' 2>/dev/null)
+  fi
+
+  echo "$sha"
+}

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -67,7 +67,19 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 REVIEWS_DIR="${REPO_ROOT:-.}/.claude/session/reviews"
 REX_APPROVAL="${REVIEWS_DIR}/${PR_NUMBER}-rex.approved"
 CEO_APPROVAL="${REVIEWS_DIR}/${PR_NUMBER}-ceo.approved"
-CURRENT_SHA=$(git rev-parse HEAD 2>/dev/null)
+
+# Resolve the PR's real HEAD via GitHub, not local git (see #55). The local
+# HEAD is rarely the PR's HEAD — usually main or an unrelated feature
+# branch. Asking gh directly removes the need for `gh pr checkout <N>`
+# before every `gh pr merge <N>`.
+#
+# Fallback to local HEAD if the gh call fails, with a visible warning, so
+# a transient network / auth issue doesn't brick merges entirely.
+CURRENT_SHA=$(resolve_pr_head "$PR_NUMBER" "$CMD_REPO")
+if [ -z "$CURRENT_SHA" ]; then
+  echo "WARN: Could not resolve PR #${PR_NUMBER} HEAD via gh — falling back to local HEAD. If this merge fails, run 'gh pr checkout ${PR_NUMBER}' first or re-authenticate gh." >&2
+  CURRENT_SHA=$(git rev-parse HEAD 2>/dev/null)
+fi
 
 # --- Rex marker check ---
 if [ ! -f "$REX_APPROVAL" ]; then

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -146,9 +146,15 @@ MSG
   exit 2
 fi
 
-# SHA consistency check
+# SHA consistency check — resolve the PR's real HEAD via GitHub rather than
+# local HEAD (see #55). Falls back to local HEAD with a warning if the
+# gh call fails (network, auth).
 APPROVED_SHA=$(tr -d '[:space:]' < "$APPROVAL")
-CURRENT_SHA=$(git rev-parse HEAD 2>/dev/null)
+CURRENT_SHA=$(resolve_pr_head "$PR_NUMBER" "$CMD_REPO")
+if [ -z "$CURRENT_SHA" ]; then
+  echo "WARN: Could not resolve PR #${PR_NUMBER} HEAD via gh — falling back to local HEAD. If this merge fails, run 'gh pr checkout ${PR_NUMBER}' first or re-authenticate gh." >&2
+  CURRENT_SHA=$(git rev-parse HEAD 2>/dev/null)
+fi
 if [ -n "$APPROVED_SHA" ] && [ -n "$CURRENT_SHA" ] && [ "$APPROVED_SHA" != "$CURRENT_SHA" ]; then
   cat >&2 <<MSG
 BLOCKED: Design review approved commit ${APPROVED_SHA:0:7} but HEAD is now ${CURRENT_SHA:0:7}.

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -98,7 +98,9 @@ The `block-unreviewed-merge.sh` hook enforces this rule at the shell level. It r
 | `<pr>-rex.approved` | the `code-reviewer` agent after a successful review | Code reviewed, no blocking issues |
 | `<pr>-ceo.approved` | the `/approve-merge <pr>` skill, **only** on explicit user invocation | CEO has looked at this specific PR and said ship it |
 
-Both markers must contain the current HEAD SHA, and both SHAs must match the live HEAD. New commits after approval invalidate both — you must re-review and re-approve.
+Both markers must contain the current HEAD SHA, and both SHAs must match the PR's HEAD as reported by GitHub (`gh pr view <N> --json headRefOid`). New commits after approval invalidate both — you must re-review and re-approve.
+
+**Note on "HEAD":** the merge gates compare marker SHAs against the PR's real HEAD on GitHub, not the local working tree's HEAD. Earlier versions of the hooks used `git rev-parse HEAD`, which forced a `gh pr checkout <N>` dance before every `gh pr merge <N>` (local was rarely the PR branch, and any mismatch blocked the merge). After #55, the hooks resolve the PR HEAD via `gh pr view` and fall back to local HEAD with a visible warning only when the gh call fails (network / auth).
 
 Claude can technically `rm` or `touch` these files by hand. Doing so is a visible, auditable, grep-able rule violation — and the whole point of recording the rule mechanically is so that the failure mode is "Claude ignored a hook" (visible) instead of "Claude inferred approval from something vague" (invisible).
 


### PR DESCRIPTION
## Summary

Closes **apexstack#55**. Fixes the "every merge requires `gh pr checkout` first" papercut by making the two SHA-comparing merge-gate hooks read the PR's HEAD from GitHub instead of the local working tree.

## The problem

`block-unreviewed-merge.sh` and `require-design-review-for-ui.sh` both validated approval markers by comparing the marker SHA to `git rev-parse HEAD`. That's the local clone's HEAD — which is almost never the PR's branch HEAD when you run `gh pr merge <N>` from a different branch (typically `main` or an unrelated feature branch). So every merge during 2026-04-14 required:

```bash
gh pr checkout 241 && gh pr merge 241 --squash --delete-branch
```

Hit on every merge of the 6-PR train that day. Tedious, forgettable, and left stray local branches behind.

## The fix

Add a `resolve_pr_head()` helper to `_lib-extract-pr.sh` that queries GitHub directly:

```bash
resolve_pr_head() {
  local pr_number="$1"
  local cmd_repo="$2"
  if [ -n "$cmd_repo" ]; then
    gh pr view "$pr_number" --repo "$cmd_repo" --json headRefOid --jq '.headRefOid' 2>/dev/null
  else
    gh pr view "$pr_number" --json headRefOid --jq '.headRefOid' 2>/dev/null
  fi
}
```

Both affected hooks now use this instead of `git rev-parse HEAD`, with a fallback to local HEAD + a visible warning only if the gh call fails (network / auth / rate limit):

```bash
CURRENT_SHA=$(resolve_pr_head "$PR_NUMBER" "$CMD_REPO")
if [ -z "$CURRENT_SHA" ]; then
  echo "WARN: Could not resolve PR #${PR_NUMBER} HEAD via gh — falling back to local HEAD..." >&2
  CURRENT_SHA=$(git rev-parse HEAD 2>/dev/null)
fi
```

The third merge-gate hook (`block-merge-on-red-ci.sh`) doesn't need the change — it uses `gh pr checks <N>` which is PR-scoped, not SHA-compared.

## Cross-repo support (free)

`resolve_pr_head` takes `$CMD_REPO` so it works transparently for:

- `gh pr merge 42 --repo owner/repo` — repo flag parsed
- `gh api repos/owner/repo/pulls/42/merge -X PUT` — repo recovered from URL path by existing `_lib-extract-pr.sh` logic (#47)
- `gh pr merge 42` without `--repo` — defaults to the repo resolved by `gh`'s working-directory context

## Testing

Smoke-tested manually (`bash` sourcing the helper and calling with known inputs):

| Test | Input | Output |
|------|-------|--------|
| Real PR in apexstack | `resolve_pr_head 53 me2resh/apexstack` | `2960b4dc9d803d...` (the real PR #53 HEAD) |
| Empty PR number | `resolve_pr_head "" ...` | empty string |
| gh shape parser regression | `extract_pr_number "gh pr merge 123 --squash"` | `123` |
| api shape parser regression | `extract_pr_number "gh api repos/me2resh/curios-dog/pulls/456/merge -X PUT"` | `456` |
| merge-command detector regression | `is_merge_command "gh pr view 1"` | miss (correct) |

`bash -n` clean on all four touched files.

## Impact on ongoing sessions

Once this merges, existing hook users will notice:

- Merges from `main` / any branch → work without `gh pr checkout`
- On network failure, visible WARN on stderr; merge proceeds against local HEAD (may block if local is wrong — transparent error path)

No config change required. No workflow-gates rule change required.

## Why a PR, not a deeper refactor

I considered moving ALL SHA resolution into the shared helper (a `resolve_approval_context` that returns both PR HEAD and marker path). Decided against it — too much scope for a papercut fix. Future refactor if/when the merge gates diverge further.

Upstream issue: https://github.com/me2resh/apexstack/issues/55

---

## Glossary

| Term | Definition |
|------|------------|
| **Local HEAD vs PR HEAD** | `git rev-parse HEAD` returns the local clone's current commit. `gh pr view <N> --json headRefOid` returns the commit GitHub thinks is the PR branch's tip. When you run `gh pr merge` from `main`, these diverge — and the merge targets GitHub's view, not the local one. |
| **`gh pr view` for SHA resolution** | `--json headRefOid --jq .headRefOid` is the canonical way to get a PR's HEAD from GitHub without cloning, fetching, or checking out. Works for closed PRs too. |
| **Marker SHA constraint** | Approval markers (`<pr>-rex.approved`, `<pr>-ceo.approved`, `<pr>-design.approved`) each store a specific commit SHA. The merge gates refuse if the PR's current HEAD differs from the marker — that's how "new commits after approval invalidate it" is enforced. This PR doesn't change that; it just changes *which* HEAD the comparison uses. |
| **`_lib-extract-pr.sh`** | Shared bash library sourced by the three merge-gate hooks to parse PR number, repo, and (now) HEAD SHA from the raw `gh pr merge` or `gh api .../merge` command string. Not a hook itself — prefix `_lib-` prevents the hook-loader from firing it. Introduced in #47. |
| **Fallback to local HEAD** | If `gh pr view` fails (network outage, auth expired, rate limit, nonexistent PR), the hook falls back to `git rev-parse HEAD` with a visible warning. Worse case: the merge blocks because local HEAD is wrong, and the user sees WHY in stderr and can retry. Better than silently allowing merges. |
