### PR TITLE
feat(#58): /update skill for syncing ops fork with upstream

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -85,12 +85,15 @@ BEHIND=$(git rev-list --count main..upstream/main)
 Then report. Examples:
 
 **Up-to-date:**
+
 ```
 Fork is up to date with upstream/main. Nothing to sync.
 ```
+
 Exit 0.
 
 **Behind only:**
+
 ```
 Fork is 12 commits behind upstream/main.
 
@@ -104,6 +107,7 @@ Proceed with merge? [y/N]
 ```
 
 **Ahead and behind (typical fork):**
+
 ```
 Fork has 5 local commits not in upstream, and is 12 commits behind.
 
@@ -152,11 +156,13 @@ git checkout -b "$BRANCH"
 ### 6. Do the sync
 
 **Merge path:**
+
 ```bash
 git merge upstream/main --no-edit
 ```
 
 **Rebase path:**
+
 ```bash
 git rebase upstream/main
 ```
@@ -186,6 +192,7 @@ For each conflict file, get the user's choice. Default to (3) since auto-resolut
 After each file: `git add <file>` to mark resolved.
 
 When all conflicts are resolved:
+
 ```bash
 # merge path
 git commit --no-edit
@@ -195,6 +202,7 @@ git rebase --continue
 ```
 
 If at any point the user wants to bail:
+
 ```bash
 git merge --abort    # or: git rebase --abort
 git checkout main
@@ -282,6 +290,7 @@ Forks typically have genuine customisation commits (`onboarding.yaml`, `apexstac
 ### Why the skill does not run Rex or `/approve-merge`
 
 Two reasons:
+
 1. The skill's job ends at "sync branch ready to push." Running Rex would couple two unrelated concerns (upstream sync + code review).
 2. Rex + CEO approval is meant to be a discrete, per-PR moment. The skill could call them, but doing so automatically blurs the boundary the approval markers are designed to preserve. User runs Rex + `/approve-merge` themselves on the PR the skill prepared.
 

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: update
+description: Sync the ApexStack fork (ops repo) with upstream me2resh/apexstack. Fetches upstream, previews pending commits, merges (or rebases) on a sync branch, handles conflicts, and leaves a branch ready to push as a PR. Use when the SessionStart drift banner says the fork is behind, or periodically as fork maintenance.
+argument-hint: "[--dry-run] [--rebase]"
+allowed-tools: Bash, Read, Write, Edit
+---
+
+# /update — Sync ApexStack Fork from Upstream
+
+Single-command replacement for the manual "fetch → branch → merge → push → PR" dance that fork maintainers do to pull upstream apexstack changes into their ops fork.
+
+## Usage
+
+```
+/update              # merge-based sync (default, safer)
+/update --rebase     # rebase local customisations on top of upstream
+/update --dry-run    # preview only, don't touch anything
+```
+
+## Output
+
+On success: one sync branch ready to push (e.g. `chore/#N-sync-upstream-apexstack`), with an auto-generated PR body listing the commits pulled in, plus the exact next commands to run.
+
+On conflict: paused at the conflict point with per-file options (keep mine / accept upstream / open editor).
+
+On up-to-date: one line, no state change.
+
+## When NOT to use
+
+- The clone has no `upstream` remote. The skill prints the exact `git remote add upstream …` command and exits.
+- The working tree is dirty (uncommitted changes or unstaged files). The skill refuses — stash or commit first.
+- The current branch is not the default (`main` / `master`). The skill refuses — `git checkout main` first.
+- You want to sync a specific feature branch from upstream. Out of scope — this skill is for default-branch fork sync only.
+
+## Process
+
+### 1. Pre-flight
+
+Run these checks in order. On first failure, stop and explain.
+
+```bash
+# 1a. upstream remote exists
+git remote | grep -qx upstream || {
+  ORIGIN=$(git remote get-url origin)
+  echo "No 'upstream' remote configured."
+  echo "Add it with:"
+  echo "  git remote add upstream https://github.com/me2resh/apexstack.git"
+  echo "Then re-run /update."
+  exit 1
+}
+
+# 1b. working tree is clean
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Working tree is dirty. Commit or stash first, then re-run /update."
+  exit 1
+fi
+
+# 1c. on default branch
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|origin/||')
+DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then
+  echo "Not on default branch ($DEFAULT_BRANCH). Currently on: $CURRENT_BRANCH"
+  echo "Run: git checkout $DEFAULT_BRANCH"
+  exit 1
+fi
+```
+
+### 2. Fetch both remotes
+
+```bash
+git fetch upstream --quiet
+git fetch origin --quiet
+```
+
+Network failure: print a warning and exit. Don't try to "work from cache" — users should know they're seeing stale state.
+
+### 3. Preview
+
+```bash
+AHEAD=$(git rev-list --count upstream/main..main)
+BEHIND=$(git rev-list --count main..upstream/main)
+```
+
+Then report. Examples:
+
+**Up-to-date:**
+```
+Fork is up to date with upstream/main. Nothing to sync.
+```
+Exit 0.
+
+**Behind only:**
+```
+Fork is 12 commits behind upstream/main.
+
+Upstream commits to pull in:
+  c8c93bb fix: merge-gate hooks read PR HEAD via gh pr view (#57)
+  1299b59 fix(#47): catch gh api .../merge bypass (#54)
+  5f067b5 fix: reject closed issue refs (#53)
+  ... (9 more)
+
+Proceed with merge? [y/N]
+```
+
+**Ahead and behind (typical fork):**
+```
+Fork has 5 local commits not in upstream, and is 12 commits behind.
+
+Local commits (will be preserved on top of the merge):
+  f46d4e7 Merge pull request #2 from …/chore/#40-configure-ops-repo
+  840bb2d fix: auto-fix markdown lint in handover assessments
+  (… 3 more …)
+
+Upstream commits to pull in:
+  c8c93bb fix: merge-gate hooks read PR HEAD via gh pr view (#57)
+  (… 11 more …)
+
+Proceed with merge? [y/N]
+```
+
+Cap each list at 20 entries with an `(N more)` marker.
+
+If `--dry-run` is set, show the preview and exit without touching anything else.
+
+### 4. Ask merge vs rebase (unless `--rebase` was passed)
+
+If not already specified by flag:
+
+```
+Sync strategy:
+  (1) merge   — creates a merge commit. Local history is preserved as-is. Safer for shared branches. DEFAULT.
+  (2) rebase  — replays local commits on top of upstream. Cleaner linear history but rewrites local SHAs.
+
+Choose [1]:
+```
+
+Default is merge. Record the choice.
+
+### 5. Create a sync branch
+
+Rationale for diverging from the `#58` AC wording ("leaves updated local main"): apexstack's own `block-main-push.sh` hook blocks direct pushes to `main` and also blocks commits made while on `main`. A merge with conflicts requires a `git commit` to finalise, which would be blocked. A sync branch sidesteps both issues and is the same shape the project uses for all other changes.
+
+```bash
+# Find or create a tracking issue. If a recent "sync" issue is open, reuse its number.
+# Otherwise prompt the user to create one (or offer to create it via `gh issue create`).
+
+BRANCH="chore/#${TICKET}-sync-upstream-apexstack"
+git checkout -b "$BRANCH"
+```
+
+### 6. Do the sync
+
+**Merge path:**
+```bash
+git merge upstream/main --no-edit
+```
+
+**Rebase path:**
+```bash
+git rebase upstream/main
+```
+
+Capture stdout/stderr for the conflict-detection step.
+
+### 7. Handle conflicts (if any)
+
+If merge/rebase reports conflicts, show the user one file at a time:
+
+```
+CONFLICT in .claude/rules/pr-workflow.md
+
+Upstream changed:  adds "### Both merge shapes are gated (#47)" section
+Local changed:     inserted custom header paragraph at the top
+
+Options:
+  (1) Keep mine        — git checkout --ours .claude/rules/pr-workflow.md
+  (2) Accept upstream  — git checkout --theirs .claude/rules/pr-workflow.md
+  (3) Open in editor   — pause skill, wait for user to resolve, then resume
+
+Choose [3]:
+```
+
+For each conflict file, get the user's choice. Default to (3) since auto-resolution on a governance framework is risky.
+
+After each file: `git add <file>` to mark resolved.
+
+When all conflicts are resolved:
+```bash
+# merge path
+git commit --no-edit
+
+# rebase path
+git rebase --continue
+```
+
+If at any point the user wants to bail:
+```bash
+git merge --abort    # or: git rebase --abort
+git checkout main
+git branch -D "$BRANCH"
+```
+
+### 8. Final state + next steps
+
+On clean completion, print:
+
+```
+Synced to upstream/main @ <SHA> on branch <BRANCH>.
+
+  Commits merged:     <N>
+  Files changed:      <F>
+  Conflicts resolved: <C>
+
+Next steps (the skill does NOT push — per #58 AC):
+
+  1. Review the merge:
+       git log -n 5 --oneline
+
+  2. Push and open the PR:
+       git push -u origin <BRANCH>
+       gh pr create --title 'chore(#<TICKET>): sync ops fork with upstream apexstack' \\
+         --body "$(cat <<'BODY'
+## Summary
+
+Sync with upstream me2resh/apexstack — N commits.
+
+## Commits pulled in
+
+<auto-generated list>
+
+## Testing
+
+- Merged cleanly (or: conflicts resolved, listed below)
+- Local main untouched until this PR merges to origin
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| ops fork | User's fork of me2resh/apexstack used as Chief-of-Staff ops repo |
+| upstream sync | Routine maintenance pull of new framework commits from me2resh/apexstack into the fork |
+
+Closes #<TICKET>
+BODY
+)"
+
+  3. After the PR merges, fast-forward local main:
+       git checkout main && git pull --ff-only
+
+Skill done. No remote state changed.
+```
+
+### 9. Edge cases
+
+| Situation | Handling |
+|-----------|----------|
+| No `upstream` remote | Print `git remote add` command and exit |
+| Dirty working tree | Refuse, tell user to stash/commit |
+| On non-default branch | Refuse, tell user to checkout main |
+| Already up-to-date | One-line report, exit 0 |
+| Network failure on fetch | Warn, exit 1 — don't proceed on stale refs |
+| User chose rebase but has 50+ local commits | Warn about rewriting many SHAs, re-confirm |
+| Merge conflict the user aborts | Restore original branch state, delete sync branch, exit 1 |
+| Tracking issue for the sync doesn't exist | Offer to create one via `gh issue create`, get number, continue |
+
+## Design notes
+
+### Why a sync branch instead of merging directly into main
+
+The `#58` AC says "leaves updated local main for the user to push themselves." Two hooks in this repo make literal adherence impossible:
+
+- `block-main-push.sh` blocks `git push <remote> main` (direct push to main is forbidden)
+- `block-main-push.sh` also blocks `git commit` while on main — so a merge with conflicts (which requires a commit to finalise) cannot be completed on main
+
+Creating a sync branch is the same shape the project uses for every other change. It also gives the user a concrete thing to `git push -u`, a PR to open, and a merge to review — matching the Rex + CEO approval flow already in place. The trade-off is one extra indirection step vs. matching the rest of the workflow. The latter wins.
+
+### Why merge is the default, not rebase
+
+Forks typically have genuine customisation commits (`onboarding.yaml`, `apexstack.projects.yaml`, `projects/<name>/` additions). Rebasing rewrites those SHAs, which is fine for a solo user but surprising in a team setting. Merge preserves history. Users who prefer a linear log can pass `--rebase`.
+
+### Why the skill does not run Rex or `/approve-merge`
+
+Two reasons:
+1. The skill's job ends at "sync branch ready to push." Running Rex would couple two unrelated concerns (upstream sync + code review).
+2. Rex + CEO approval is meant to be a discrete, per-PR moment. The skill could call them, but doing so automatically blurs the boundary the approval markers are designed to preserve. User runs Rex + `/approve-merge` themselves on the PR the skill prepared.
+
+### Dry-run semantics
+
+`--dry-run` simulates step 3 (preview) only. It does NOT simulate the merge itself — running `git merge --no-commit --no-ff` as a dry-run leaves the working tree in a staged state that's easy to accidentally commit. If the preview says N commits to pull in, the user should run `/update` for real to see the merge.
+
+## Related
+
+- `docs/multi-project.md` § "Upgrades — pulling from upstream" — the manual flow this skill automates.
+- `.claude/rules/pr-workflow.md` — the PR workflow the sync branch will follow.
+- `.claude/hooks/block-main-push.sh` — the hook that motivates the sync-branch approach.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,10 +169,10 @@ ApexStack ships with a `.claude/` directory containing the Claude Code primitive
 | Hooks | `.claude/hooks/` | 15 shell scripts that mechanically enforce SDLC rules — ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning |
 | Rules | `.claude/rules/` | 9 modular rule files (AgDR triggers, code standards, git conventions, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer, Security Reviewer, Dependency Auditor, PR Manager, Ticket Manager) |
-| Skills | `.claude/skills/` | 27 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 31 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (30)
+### Available skills (31)
 
 | Skill | Purpose |
 |-------|---------|
@@ -199,6 +199,7 @@ ApexStack ships with a `.claude/` directory containing the Claude Code primitive
 | `/task` | Create a structured technical task ticket (driver + scope + ACs) |
 | `/idea` | Capture a new product idea to the backlog |
 | `/handover` | Onboard an external repo into ApexStack management (includes per-project discovery) |
+| `/update` | Sync the ops fork with upstream me2resh/apexstack — preview, merge-or-rebase, leaves a sync branch ready to push |
 | `/projects` | List all managed projects from the registry with status |
 | `/inbox` | Items needing your attention — PRs, issues, comments, blockers |
 | `/status` | Current snapshot — git, CI, in-progress work |

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -225,7 +225,17 @@ A typical morning as a CTO / Chief of Staff using apexstack:
 
 ## Upgrades — pulling from upstream
 
-Every few weeks, pull the latest apexstack improvements into your fork:
+Every few weeks, pull the latest apexstack improvements into your fork. The easy path is the `/update` skill:
+
+```
+/update              # preview + merge-based sync on a sync branch (default)
+/update --rebase     # rebase-based sync (cleaner linear history)
+/update --dry-run    # preview only, no state change
+```
+
+`/update` does the work of the manual flow below: fetches `upstream`, previews the commit delta, creates a sync branch (because `block-main-push.sh` forbids direct pushes to `main`), merges or rebases, walks through any conflicts with per-file options, and leaves the branch ready to push as a PR. See `.claude/skills/update/SKILL.md` for the full process.
+
+If you prefer the raw commands:
 
 ```bash
 cd ~/apexstack
@@ -236,12 +246,14 @@ git fetch upstream
 # See what's new
 git log --oneline HEAD..upstream/main
 
-# Merge them in
+# On a sync branch (direct-push-to-main is blocked by block-main-push.sh)
+git checkout -b chore/sync-upstream
 git merge upstream/main
 
 # Resolve any conflicts (usually in files you haven't customised — role files, workflow files, CLAUDE.md imports)
-# Commit the merge
-git push origin main
+# Then push and open a PR
+git push -u origin chore/sync-upstream
+gh pr create --title "chore: sync ops fork with upstream apexstack"
 ```
 
 Files you're most likely to customise:


### PR DESCRIPTION
## Summary

New `/update` skill automates the fork-sync flow. Single skill invocation takes an ops-fork user from "behind upstream" to "sync branch ready to push as PR" — replacing the manual `git fetch` → branch → merge → push → PR dance.

- `.claude/skills/update/SKILL.md` — full process: pre-flight, preview, merge-or-rebase, conflict walker, next-steps printout
- CLAUDE.md updated (27→31 skills; new `/update` row)
- docs/multi-project.md "Upgrades" section now points at `/update` first, with the raw-command flow below it corrected to use a sync branch

Ships PRD-0002 change #1 (fork-distribution PRD opened in ops fork earlier today).

## Divergence from the AC

AC #8 says "leaves updated local main for the user to push themselves." Two hooks in this repo make literal adherence impossible:

- `block-main-push.sh` blocks `git push <remote> main`
- `block-main-push.sh` also blocks `git commit` while on main — so a merge with conflicts cannot be completed on main

The skill instead leaves a sync branch ready to push. Same shape as every other change in this project. Documented in the skill's "Design notes" section. Open to changing this if the maintainer prefers the literal AC path.

## Testing

- Pre-flight logic smoke-tested against each failure mode (dirty tree, non-default branch, missing upstream remote)
- Preview output matches git rev-list --count and git log --oneline — verified against the upstream/main → ops/main delta synced earlier today (10 commits, matches the flow that produced me2resh/ops#4)
- --dry-run path exits after preview without mutation
- Conflict-walker options trace to actual git commands (--ours / --theirs / editor pause + git add)
- No unit tests — the skill is process documentation for Claude, not executable code

## Glossary

| Term | Definition |
|------|------------|
| ops fork | User's fork of me2resh/apexstack used as their Chief-of-Staff ops repo |
| upstream sync | Routine maintenance pull of new framework commits from me2resh/apexstack into the fork |
| sync branch | Short-lived branch (chore/#N-sync-upstream-apexstack) that holds the merge from upstream until the PR is merged |
| drift banner | Planned SessionStart hook (separate PR) that shows "N commits behind upstream — run /update" when the fork lags |

## Related

- Closes #58
- PRD-0002 in the ops fork (docs/prds/PRD-0002-fork-distribution-model.md) — this is change #1 of four
- Follow-up: SessionStart drift banner (change #2) will ship as a separate PR