### PR TITLE
feat(#63): SessionStart drift banner — show when fork is behind upstream

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -71,6 +71,22 @@ For adversarial trust, rely on remote branch-protection rules (GitHub required r
 
 **What it does:** on every new session, if `.claude/session/onboarded` is missing, injects a reminder telling Claude to run `/onboard` with the user before doing work. The `/onboard` skill asks the day-one discovery questions (project identity, tracker, required checks, reviewers, UI, deploy targets, sensitive topics) and writes the marker plus `.claude/project-config.json`.
 
+### 4a. Upstream drift — `check-upstream-drift.sh`
+
+**Event:** `SessionStart`.
+
+**What it does:** if the repo has an `upstream` remote, runs `git fetch upstream --quiet` (cached to once per 10 minutes via `.claude/session/last-upstream-fetch`) and prints a one-line banner when the local default branch is behind `upstream/<default-branch>`:
+
+```
+ApexStack: 12 commits behind upstream/main. Run /update to sync.
+```
+
+Silent if: no `upstream` remote (upstream repo itself, or fork that hasn't configured it), fetch fails (offline / hosting down), or up-to-date.
+
+**Runtime:** < 200ms on cache hit, 1-3s on cache miss (depends on fetch latency). `timeout 5 git fetch` caps the worst case.
+
+**Companion skill:** `/update` performs the actual sync.
+
 ## The Ticket-Vocabulary Backstops
 
 These two hooks are the mechanical backstop for the rule in `.claude/rules/ticket-vocabulary.md` — "`Ticket`, `#N`, and dependency notation refer ONLY to real GitHub issues". The rule itself is self-discipline; these hooks catch the downstream symptom (a fabricated `#N` that slipped into a durable artifact).

--- a/.claude/hooks/check-upstream-drift.sh
+++ b/.claude/hooks/check-upstream-drift.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# SessionStart hook: shows a one-line banner when the fork is behind upstream
+# me2resh/apexstack, so the user knows to run /update.
+#
+# Silent exit paths (no output, no error):
+#   - Not a git repo
+#   - No `upstream` remote configured (this is the upstream repo itself,
+#     or the fork hasn't set up `upstream` yet — /setup reminds them)
+#   - Fetch fails (offline, git hosting down, permission)
+#   - Fork is up-to-date
+#
+# Banner emits only when the fork is genuinely behind upstream/<default-branch>.
+#
+# Fetch caching: the hook hits the network at most once per 10 minutes per
+# clone. A tight-loop of sessions (IDE restarts, `claude --resume`) doesn't
+# hammer origin. Cache lives at .claude/session/last-upstream-fetch — session
+# state, already gitignored.
+#
+# Runtime: < 200ms on cache hit, 1-3s on cache miss (depends on fetch latency).
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+cd "$REPO_ROOT" || exit 0
+
+# Bail if no upstream remote — either this IS the upstream repo, or the fork
+# owner hasn't run `git remote add upstream …` yet. Either case: silent.
+if ! git remote | grep -qx upstream; then
+  exit 0
+fi
+
+# Default branch (usually `main`, sometimes `master`). Resolve from origin's HEAD.
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's|origin/||')
+DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+
+# Fetch cache: skip the network call if we fetched within the last 10 minutes.
+CACHE_DIR="${REPO_ROOT}/.claude/session"
+CACHE_FILE="${CACHE_DIR}/last-upstream-fetch"
+TTL_SECONDS=600
+NOW=$(date +%s)
+
+SHOULD_FETCH=1
+if [ -f "$CACHE_FILE" ]; then
+  LAST=$(cat "$CACHE_FILE" 2>/dev/null)
+  if [ -n "$LAST" ] && [ "$((NOW - LAST))" -lt "$TTL_SECONDS" ]; then
+    SHOULD_FETCH=0
+  fi
+fi
+
+if [ "$SHOULD_FETCH" = "1" ]; then
+  # Quiet fetch with a short timeout. On failure (no network, no auth), exit
+  # silently — we don't want a startup banner yelling about offline state.
+  if ! timeout 5 git fetch upstream --quiet 2>/dev/null; then
+    exit 0
+  fi
+  mkdir -p "$CACHE_DIR"
+  echo "$NOW" > "$CACHE_FILE"
+fi
+
+# Count commits in upstream/<default-branch> not present in the local
+# default-branch tip. rev-list is local after fetch, no network.
+BEHIND=$(git rev-list --count "${DEFAULT_BRANCH}..upstream/${DEFAULT_BRANCH}" 2>/dev/null)
+
+if [ -z "$BEHIND" ] || [ "$BEHIND" = "0" ]; then
+  exit 0
+fi
+
+if [ "$BEHIND" = "1" ]; then
+  SUFFIX="commit"
+else
+  SUFFIX="commits"
+fi
+
+cat <<MSG
+ApexStack: ${BEHIND} ${SUFFIX} behind upstream/${DEFAULT_BRANCH}. Run /update to sync.
+MSG
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/onboarding-check.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-upstream-drift.sh\"'"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ ApexStack ships with a `.claude/` directory containing the Claude Code primitive
 
 | Layer | Path | Purpose |
 |-------|------|---------|
-| Hooks | `.claude/hooks/` | 15 shell scripts that mechanically enforce SDLC rules — ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning |
+| Hooks | `.claude/hooks/` | 16 shell scripts that mechanically enforce SDLC rules — ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner |
 | Rules | `.claude/rules/` | 9 modular rule files (AgDR triggers, code standards, git conventions, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer, Security Reviewer, Dependency Auditor, PR Manager, Ticket Manager) |
 | Skills | `.claude/skills/` | 31 slash commands — see the full list below |

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -225,6 +225,18 @@ A typical morning as a CTO / Chief of Staff using apexstack:
 
 ## Upgrades — pulling from upstream
 
+### How you know it's time
+
+On every Claude Code session start, the `check-upstream-drift.sh` hook runs `git fetch upstream` (cached to once per 10 minutes) and prints a one-line banner if your fork is behind:
+
+```
+ApexStack: 12 commits behind upstream/main. Run /update to sync.
+```
+
+Silent if up-to-date, silent on network failure, silent if no `upstream` remote is configured. No extra startup cost when there's nothing to say.
+
+### Syncing
+
 Every few weeks, pull the latest apexstack improvements into your fork. The easy path is the `/update` skill:
 
 ```


### PR DESCRIPTION
## Summary

SessionStart hook that prints a one-line banner when the fork is behind upstream `me2resh/apexstack`. Silent on network failure, silent if no `upstream` remote, silent when up-to-date. Runs once per 10 minutes via a session cache.

Ships PRD-0002 change #2. Compounds with #58 (`/update`): banner tells you **when** to sync, skill **does** the sync.

## What changed

- `.claude/hooks/check-upstream-drift.sh` — new hook (2.5 KB). Handles remote detection, fetch caching, default-branch resolution (main/master), and singular/plural output.
- `.claude/settings.json` — wires the hook into SessionStart alongside `onboarding-check.sh`.
- `CLAUDE.md` — hook count 15 → 16, brief reference.
- `docs/multi-project.md` — new "How you know it's time" subsection in the Upgrades section.
- `.claude/hooks/README.md` — hook documented as section 4a.

## Testing

Verified end-to-end:

- Runs in the upstream apexstack repo (no `upstream` remote) → exits silent, no output
- Runs in the ops fork at `~/apexstack` (has upstream, 1 commit behind after #58 merged) → prints:
  ```
  ApexStack: 1 commit behind upstream/main. Run /update to sync.
  ```
- Second run in same directory within 10 min → no re-fetch (cache hit), still prints correct count
- Cache file at `.claude/session/last-upstream-fetch` is a single timestamp, gitignored

## Glossary

| Term | Definition |
|------|------------|
| upstream drift | Ops fork lagging behind `me2resh/apexstack` in commits. Problem #1 in PRD-0002. |
| fetch cache | `.claude/session/last-upstream-fetch` holds a Unix timestamp so the hook skips the network call if run within the last 10 minutes. Session state, gitignored. |
| SessionStart | Claude Code hook event that fires on every new session start. Used for setup reminders and status banners. |
| default branch | The repo's conventional integration branch, resolved from `refs/remotes/origin/HEAD`. Usually `main`, sometimes `master`. |

## Related

- Closes #63
- Compounds with #58 (`/update` skill) which landed in #61
- PRD-0002 (fork distribution model) — change #2 of 4
- Follow-up: PRD-0002 changes #3 (`local/` overlay + hook kill-switch) and #5 (CHANGELOG + tagged releases) remain