### PR TITLE
feat(#50): Mermaid C4 architecture diagrams — L1 + L2 templates + dogfood

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,8 @@ Template: @templates/agdr.md
 | Technical Design | Planning implementation | `templates/technical-design.md` |
 | ADR | Recording architecture decisions | `templates/adr.md` |
 | AgDR | Recording AI agent decisions | `templates/agdr.md` |
+| C4 Context (L1) | System + external actors (one per project) | `templates/architecture/c4-context.md` |
+| C4 Container (L2) | Deployable units inside the system | `templates/architecture/c4-container.md` |
 
 ---
 

--- a/docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md
+++ b/docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md
@@ -1,0 +1,86 @@
+---
+id: AgDR-0003
+timestamp: 2026-04-17T09:20:00Z
+agent: atlas
+model: claude-opus-4-7
+trigger: user-prompt
+status: executed
+ticket: me2resh/apexstack#50
+---
+
+# Mermaid C4 as the diagramming format for ApexStack-managed projects
+
+> In the context of adding architecture-diagram support to ApexStack per #50, facing the choice between Mermaid C4, Structurizr DSL, PlantUML C4, and D2, I decided to ship **Mermaid C4 only** for v1 (L1 context + L2 container templates), accepting that L3+ precision and "proper" Structurizr-style modelling are deferred until a real project actually needs them.
+
+## Context
+
+Per issue #50, ApexStack-managed projects should include architecture diagrams in their documentation, with the C4 model (Context, Container, Component, Code) as the target. The CEO prefers C4 and is open to the choice of tool.
+
+The v1 target is L1 (system + external actors) and L2 (containers: frontend, backend, database, CDN) — enough to communicate "how this project fits together" to a new engineer or external reader. L3 (component-level) and L4 (code-level) are explicitly out of scope for this AgDR — the issue itself flags them as rare / auto-generated.
+
+Two audiences matter:
+
+1. **Framework users** (fork-based distribution) — they read diagrams on GitHub or in their IDE. They have `gh`, `git`, and a shell. They may not have Java, Docker, or a Go toolchain.
+2. **New engineers joining a managed project** — they open `docs/architecture/` in their browser (via GitHub) or an editor with a Markdown preview. They expect diagrams to render without setup.
+
+## Options Considered
+
+| Tool | Format | Rendering | Pros | Cons |
+|------|--------|-----------|------|------|
+| **Mermaid C4** | Markdown-embedded ```mermaid C4Context/C4Container blocks``` | Native on GitHub; native in VS Code preview; native in most Markdown viewers | Zero install. Every GitHub user sees it inline. Renders in the repo's file view. Single-source (Markdown is the whole artifact). | C4 support in Mermaid is "beta" — fewer features than Structurizr. No automatic L1→L2→L3 zoom. Less precise about technology-vs-container distinction. |
+| **Structurizr DSL** | Custom text DSL (`.dsl` file) | Structurizr Lite (Docker) or CLI; output is SVG/PNG/PlantUML | Purpose-built for C4. Single model, auto-renders all zoom levels. Industry-standard for C4. | Requires Docker or a Java CLI to render. GitHub doesn't render `.dsl` files inline — users see raw DSL. Two-source problem: DSL + rendered PNG committed together, or you lose the "view on GitHub" experience. |
+| **PlantUML C4** | Text DSL (`.puml`) with C4 library includes | PlantUML jar or server; output is SVG/PNG | Mature C4 library. Widely used in enterprise. | Java dependency. Same two-source problem as Structurizr. GitHub renders PlantUML in README previews only via a third-party service (unreliable). |
+| **D2** | Text DSL (`.d2`) | `d2` CLI (Go binary) | Modern aesthetics. No Java. Fast. | Not C4-native — general-purpose diagramming. Would need a C4-shaped convention on top, maintained by us. GitHub doesn't render `.d2` natively either. |
+
+### Decision dimensions weighted
+
+| Dimension | Weight | Mermaid | Structurizr | PlantUML | D2 |
+|-----------|--------|---------|-------------|----------|-----|
+| **GitHub inline render** (most users will open the repo and read the diagram there) | Critical | ✅ | ❌ | ~ (flaky) | ❌ |
+| **Zero external dependency** (no Java, no Docker, no Go) | High | ✅ | ❌ | ❌ | ❌ |
+| **C4 fidelity** (do L1/L2 diagrams look like proper C4?) | Medium | ~ | ✅ | ✅ | ~ |
+| **Supports L3+ when we need it** | Low (deferred per #50) | ~ | ✅ | ✅ | ~ |
+| **Single-source (no "DSL + rendered PNG" two-commit dance)** | High | ✅ | ❌ | ❌ | ❌ |
+
+Mermaid wins on three of the four critical/high dimensions. Loses on C4 fidelity (fine for L1/L2, mediocre for L3+ — but L3+ is out of scope).
+
+## Decision
+
+Chosen: **Mermaid C4 for L1 + L2, in Markdown files committed alongside the rest of the docs**.
+
+Concretely:
+
+- Templates at `templates/architecture/c4-context.md` (L1) and `templates/architecture/c4-container.md` (L2) — both Markdown with a Mermaid C4 block inside.
+- Rendered-in-place: users view diagrams by opening the `.md` file on GitHub; no separate PNG commit, no render step.
+- Directory convention: framework-level diagrams in `docs/architecture/`, per-managed-project apexstack docs in `projects/<name>/architecture/`, project-internal code-level diagrams in that project's own `docs/architecture/` (follows the split already documented in `docs/multi-project.md`).
+
+## Consequences
+
+### Immediate (shipped with this AgDR)
+
+- Two templates in `templates/architecture/` that any project / `/handover` output can copy and fill in.
+- ApexStack dogfoods: `docs/architecture/apexstack-context.md` (L1) and `docs/architecture/apexstack-container.md` (L2) show the framework's own C4 diagrams. Meta, but demonstrates the convention.
+- `docs/multi-project.md` updated with a "Architecture diagrams" subsection pointing at the convention.
+
+### Deferred (follow-up issues filed with this PR)
+
+- `/handover` skill emits a stub L2 container diagram from the assessment — useful but non-trivial change to the skill; bundled separately.
+- Structurizr DSL as an escape hatch for projects that hit Mermaid's C4 ceiling (L3 component diagrams, precise "technology" metadata, auto-zoom). Add when a project asks.
+- L3 component and L4 code templates — most projects won't need these; add when one does.
+
+### Costs if we're wrong
+
+Low. If a project later needs L3 precision, Structurizr can be added without deprecating Mermaid — they coexist happily (Mermaid for L1/L2 overview, Structurizr for deep L3 workspace). The templates are simple Markdown; deleting them is one commit. No lock-in.
+
+### Costs if we're right but wait
+
+Higher. Without diagrams, new engineers onboard more slowly on each managed project. Handover docs feel incomplete. The gap grows as the portfolio grows. Shipping Mermaid now is low-risk and makes the ApexStack-managed-project experience noticeably better.
+
+## Artifacts
+
+- Templates: `templates/architecture/c4-context.md`, `templates/architecture/c4-container.md`
+- Dogfood examples: `docs/architecture/apexstack-context.md`, `docs/architecture/apexstack-container.md`
+- Documentation: `docs/multi-project.md` § "Architecture diagrams"
+- Follow-up issues (filed with the PR): `/handover` auto-generation, Structurizr DSL support, L3+ templates
+- Ticket: [#50](https://github.com/me2resh/apexstack/issues/50)
+- PR: (filled at merge time)

--- a/docs/architecture/apexstack-container.md
+++ b/docs/architecture/apexstack-container.md
@@ -73,6 +73,7 @@ The diagram captures which "container" does what *when interpreted by the right 
 ## Maintenance
 
 Updates when:
+
 - A new top-level directory is added or removed (e.g. if `.claude/skills/` were renamed)
 - A new "container" type joins the architecture (e.g. a `templates/` folder were promoted to first-class)
 - The Claude Code integration model changes (new event type, new agent shape)

--- a/docs/architecture/apexstack-container.md
+++ b/docs/architecture/apexstack-container.md
@@ -1,0 +1,80 @@
+# Container Diagram — ApexStack
+
+> **C4 Level 2** — the functional subsystems inside the ApexStack fork. Non-traditional: ApexStack has no runtime of its own. Each "container" is a folder-scoped set of files interpreted by an external system (Claude Code CLI, the user, or GitHub's rendering).
+
+## Diagram
+
+```mermaid
+C4Container
+    title Container Diagram for ApexStack
+
+    Person(ops, "CEO / CoS / Tech Lead")
+    System_Ext(claude, "Claude Code CLI")
+    System_Ext(github, "GitHub")
+
+    System_Boundary(apex, "ApexStack (ops fork)") {
+        Container(claudemd, "CLAUDE.md", "Markdown", "Entry point. Claude Code reads this first. Imports rules and role-triggers.")
+        Container(rules, ".claude/rules/", "Markdown", "Modular rule files — git conventions, ticket vocabulary, PR workflow, AgDR, PR quality, role triggers, workflow gates, code standards.")
+        Container(hooks, ".claude/hooks/", "Shell scripts", "Mechanical enforcement — merge gates, ticket-first, secrets check, commit format, drift banner. Runs on PreToolUse / PostToolUse / SessionStart events.")
+        Container(skills, ".claude/skills/", "Markdown SKILL.md files", "Slash commands — /setup, /handover, /update, /status, /inbox, /approve-merge, /approve-design, /decide, /code-review, etc. (31 skills)")
+        Container(agents, ".claude/agents/", "Markdown agent defs", "Sub-agent definitions — code-reviewer (Rex), security-reviewer (Shield), dependency-auditor, pr-manager, ticket-manager.")
+        Container(roles, "roles/", "Markdown role files", "19 role definitions across engineering / product / design / security / data. Activated by role-triggers.md matcher rules.")
+        Container(workflows, "workflows/", "Markdown process docs", "SDLC, code review, deployment — the prose contract for how work moves.")
+        Container(registry, "apexstack.projects.yaml", "YAML", "Portfolio registry. Lists every managed project. Skills iterate this to aggregate across projects.")
+        Container(onboarding, "onboarding.yaml", "YAML", "Per-fork configuration — company, team, tech stack, quality bar.")
+        Container(projectdocs, "projects/", "Per-project Markdown", "ApexStack docs about each managed project — handover assessments, per-project roadmaps, stakeholder updates.")
+        Container(goldens, "golden-paths/", "YAML + Markdown", "Reusable GitHub Actions workflow templates — CI, security, dependency audit, PR title check, review check.")
+    }
+
+    Rel(ops, claudemd, "Reads / edits", "via Claude Code or editor")
+    Rel(claude, claudemd, "Loads on session start")
+    Rel(claudemd, rules, "Imports via @.claude/rules/*.md")
+    Rel(claude, hooks, "Executes on tool events", "bash")
+    Rel(claude, skills, "Invokes on /slash-command", "Skill tool")
+    Rel(claude, agents, "Spawns sub-agents", "Agent tool")
+    Rel(hooks, github, "Calls gh CLI", "gh pr / gh issue")
+    Rel(skills, github, "Calls gh CLI", "gh pr / gh issue / gh api")
+    Rel(skills, registry, "Reads for portfolio iteration")
+    Rel(skills, projectdocs, "Reads / writes per-project docs")
+    Rel(hooks, onboarding, "SessionStart config check")
+    Rel(workflows, roles, "References role files at phase boundaries")
+```
+
+## How to read this
+
+ApexStack is unusual in C4 terms: there is **no running process that IS ApexStack**. Every "container" above is a folder of files. The "runtime" is either:
+
+- **Claude Code CLI** — reads `CLAUDE.md`, executes hooks, invokes skills, spawns sub-agents
+- **The user** — reads role files, workflow docs, and the portfolio registry manually
+- **GitHub** — renders Markdown in the repo view, enforces branch protection, runs CI on `golden-paths/` pipelines copied into project repos
+
+The diagram captures which "container" does what *when interpreted by the right runtime*. It's a useful zoom level even though it diverges from the typical "containers are deployable units" framing of L2.
+
+## Key relationships
+
+- **CLAUDE.md → rules** is the single most important arrow. Every rule file is imported via `@.claude/rules/*.md` from `CLAUDE.md`, and Claude Code applies them. Without that import chain, rules are orphaned prose.
+- **hooks → github** — hooks call `gh` directly (e.g. `block-merge-on-red-ci.sh` runs `gh pr checks`). This is how ApexStack's mechanical enforcement reaches the remote tracker state.
+- **skills → github** — skills are the user-facing portfolio-aware commands. Most call `gh` at some point; some also read the registry to iterate.
+- **skills → registry / projectdocs** — the portfolio-level read/write flow. `/inbox` / `/status` / `/projects` / `/stakeholder-update` all live here.
+
+## What this diagram does NOT show
+
+- Specific hook-to-rule mapping (which hook enforces which rule) — see `docs/rule-audit.md` for that.
+- The full list of 31 skills — see CLAUDE.md § "Available skills".
+- The full list of 19 roles — see `.claude/rules/role-triggers.md`.
+- The user's local `workspace/<name>/` clones of managed projects — they're gitignored and sit outside the ApexStack boundary (they belong to the managed project, not to ApexStack).
+
+## Related diagrams
+
+- L1 system context: [`apexstack-context.md`](./apexstack-context.md)
+- SDLC sequence (how a feature flows phase by phase): `workflows/sdlc.md`
+- Rule audit (every MUST → hook / advisory / deferred): `docs/rule-audit.md`
+
+## Maintenance
+
+Updates when:
+- A new top-level directory is added or removed (e.g. if `.claude/skills/` were renamed)
+- A new "container" type joins the architecture (e.g. a `templates/` folder were promoted to first-class)
+- The Claude Code integration model changes (new event type, new agent shape)
+
+Skill-count / hook-count / role-count drift goes in the relevant summary docs (CLAUDE.md, hooks/README.md), not here. This diagram stays at the "shape of the fork" level.

--- a/docs/architecture/apexstack-context.md
+++ b/docs/architecture/apexstack-context.md
@@ -1,0 +1,56 @@
+# System Context — ApexStack
+
+> **C4 Level 1** — how ApexStack fits into the day of a CEO / Chief-of-Staff / Tech Lead managing a portfolio of projects.
+
+## Diagram
+
+```mermaid
+C4Context
+    title System Context for ApexStack
+
+    Person(ops, "CEO / Chief of Staff / Tech Lead", "Solo operator running a portfolio of projects. The 'user' of ApexStack.")
+    Person(contributor, "Contributor", "Framework author pushing upstream changes. Usually the same human as the ops role, but a distinct hat.")
+
+    System(apex, "ApexStack (fork)", "Governance, workflow, and SDLC primitives for a managed project portfolio. Lives as a GitHub fork in the user's org; clone is the ops repo.")
+
+    System_Ext(claude, "Claude Code CLI", "The execution environment. Reads CLAUDE.md, runs hooks, invokes skills, spawns sub-agents. Without Claude Code, ApexStack is just markdown.")
+    System_Ext(github, "GitHub", "Hosts the ops fork, hosts every managed project, hosts all issue trackers. Merge gates, CI, PR reviews all live here.")
+    System_Ext(projects, "Managed Projects", "The N repos under the ops repo's registry. Each has its own GitHub repo, its own issues, its own CI. ApexStack governs them; it does not host them.")
+    System_Ext(upstream, "me2resh/apexstack (upstream)", "The canonical ApexStack framework. The ops fork pulls from here periodically via /update.")
+
+    Rel(ops, apex, "Uses daily", "gh + Claude Code")
+    Rel(ops, claude, "Invokes", "terminal")
+    Rel(claude, apex, "Reads CLAUDE.md, runs hooks, invokes skills")
+    Rel(apex, github, "Reads issues, opens PRs, posts reviews, merges", "gh CLI")
+    Rel(apex, projects, "Governs via the registry (apexstack.projects.yaml)")
+    Rel(contributor, upstream, "Contributes back to", "PRs")
+    Rel(apex, upstream, "Syncs from periodically", "/update skill")
+```
+
+## How to read this
+
+- **The user is the ops role.** Whoever runs Claude Code in the ops fork. In a solo setup that's one person wearing many hats; in a team setup it's a small group.
+- **ApexStack itself is a collection of docs, hooks, skills, and registries** — it doesn't "run" anywhere standalone. It's interpreted by Claude Code. Everything ApexStack enforces, it enforces through Claude Code hooks or through human-read rules in CLAUDE.md.
+- **GitHub is the source of truth** for tracker state, PR state, merge state. ApexStack never holds state that should live in GitHub — the approval markers in `.claude/session/reviews/` are session-local and gitignored.
+- **Managed projects are first-class external systems.** ApexStack does not ingest their code; it points at them via the registry. Their own git history, CI, and issues stay in their own repos.
+
+## Why these relationships matter
+
+- `ops → apex` **via Claude Code** — the user never edits ApexStack files through some proprietary UI; they use the CLI, which means shell tooling, git, and gh remain the authoritative interface.
+- `apex → github` — the single integration point. No Jira, no Linear, no Notion. If you want ApexStack to feel different, the work lives in adding GitHub integrations, not in replacing GitHub.
+- `apex → upstream` **via /update** — the fork-sync path. Without `/update`, forks silently drift (PRD-0002 problem #1). The SessionStart drift banner ensures the user knows when to invoke it.
+
+## What this diagram does NOT show
+
+- Internal structure of ApexStack (hooks, skills, agents, rules, workflows) — that's the L2 container diagram in `apexstack-container.md`.
+- Deployment topology — ApexStack doesn't "deploy." It lives in the user's local clone and on GitHub.
+- The flow of a specific feature from idea to production — that's the SDLC, documented in `workflows/sdlc.md` as a sequence, not a context diagram.
+
+## Maintenance
+
+Should change only when a major new external dependency enters or leaves. Candidates:
+- If ApexStack ever gains a first-class Linear / Jira integration → add those as external systems
+- If the managed-project model is replaced or extended (unlikely) → re-draw the boundary
+- If upstream naming / sync model changes — edit accordingly
+
+Target: no more than one or two updates per year.

--- a/docs/architecture/apexstack-context.md
+++ b/docs/architecture/apexstack-context.md
@@ -49,6 +49,7 @@ C4Context
 ## Maintenance
 
 Should change only when a major new external dependency enters or leaves. Candidates:
+
 - If ApexStack ever gains a first-class Linear / Jira integration → add those as external systems
 - If the managed-project model is replaced or extended (unlikely) → re-draw the boundary
 - If upstream naming / sync model changes — edit accordingly

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -210,6 +210,29 @@ Skills that aren't portfolio-aware (`/decide`, `/write-spec`, `/code-review`, `/
 
 ---
 
+## Architecture diagrams
+
+Every managed project should have at least a **C4 Level 1 (System Context)** diagram, and ideally a **Level 2 (Container)** one. Diagrams are written as Mermaid inside Markdown files — GitHub renders them inline, zero build step.
+
+Templates:
+
+- `templates/architecture/c4-context.md` — L1, system + external actors
+- `templates/architecture/c4-container.md` — L2, deployable units inside the system boundary
+
+Where to put the diagrams (same split as every other kind of doc — "would this follow the code if the project spun out?"):
+
+| Scope | Location |
+|-------|----------|
+| Framework-wide (ApexStack itself) | `docs/architecture/` in the ops fork |
+| ApexStack's view of a managed project | `projects/<name>/architecture/` in the ops fork |
+| Internal to a project's own repo | `docs/architecture/` in that project's repo (via `workspace/<name>/docs/architecture/`) |
+
+ApexStack dogfoods its own convention — see `docs/architecture/apexstack-context.md` and `apexstack-container.md` for a worked example.
+
+Decision rationale (tool choice — Mermaid C4 over Structurizr DSL / PlantUML / D2): [`docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md`](agdr/AgDR-0003-mermaid-c4-for-diagrams.md).
+
+---
+
 ## Daily workflow
 
 A typical morning as a CTO / Chief of Staff using apexstack:

--- a/templates/architecture/c4-container.md
+++ b/templates/architecture/c4-container.md
@@ -68,6 +68,6 @@ Expect to update this every few releases of significant architectural work. If i
 
 ## References
 
-- [C4 Model — Level 2](https://c4model.com/#ContainerDiagram)
+- [C4 Model — Level 2](https://c4model.com/diagrams/container)
 - [Mermaid C4 syntax](https://mermaid.js.org/syntax/c4.html)
 - ApexStack's own L2 for reference: `docs/architecture/apexstack-container.md`

--- a/templates/architecture/c4-container.md
+++ b/templates/architecture/c4-container.md
@@ -1,0 +1,73 @@
+# Container Diagram — {Project Name}
+
+> **C4 Level 2** — the system broken down into deployable/runnable containers. Audience: the dev team. One diagram per managed project; usually zoomed in from the L1 context diagram.
+
+## Diagram
+
+```mermaid
+C4Container
+    title Container Diagram for {Project Name}
+
+    Person(user, "User", "The primary human actor")
+
+    System_Boundary(boundary, "{Project Name}") {
+        Container(web, "Web App", "Next.js / React", "Renders the UI, handles session state")
+        Container(api, "API", "Node / Express (or your stack)", "Business logic, auth, orchestration")
+        Container(worker, "Background Worker", "Node / BullMQ (or your stack)", "Async jobs — email, webhooks, ETL. Remove if synchronous-only.")
+        ContainerDb(db, "Primary Database", "PostgreSQL", "Relational data")
+        ContainerDb(cache, "Cache", "Redis", "Session + hot lookups. Remove if not used.")
+    }
+
+    System_Ext(auth, "Auth Provider", "e.g. Auth0")
+    System_Ext(email, "Email Provider", "e.g. Postmark")
+
+    Rel(user, web, "Uses", "HTTPS")
+    Rel(web, api, "Calls", "HTTPS / JSON")
+    Rel(api, db, "Reads / writes", "SQL")
+    Rel(api, cache, "Reads / writes", "TCP")
+    Rel(api, worker, "Enqueues jobs", "Redis / queue")
+    Rel(worker, email, "Sends email", "API")
+    Rel(api, auth, "Validates tokens", "OIDC")
+```
+
+## How to use this template
+
+1. Copy this file to `docs/architecture/container.md` (inside a project repo) or `projects/{name}/architecture/container.md` (in the ApexStack portfolio docs).
+2. Replace `{Project Name}` and every placeholder inside the `C4Container` block with your real containers.
+3. A "container" in C4 terms is a **deployable / runnable unit**: a web app, a mobile app, an API, a database, a queue, a worker. It is NOT a Docker container (confusing but standard). Use the tech label to name the runtime (`Next.js`, `PostgreSQL`, `Redis`, etc.).
+4. Keep it to **5–9 containers max**. More than that and you're probably drawing L3 detail inside an L2.
+5. Commit. Renders on GitHub.
+
+## What goes in L2 (container)
+
+- Every deployable unit: web apps, mobile apps, APIs, workers, databases, caches, queues.
+- People only on the boundary — show how they enter the system, not how they thread through every internal container.
+- External systems from L1 that the containers actually talk to (keep the boundary; remove external systems nothing internal calls).
+- Arrows with **direction** and a **short label** describing the interaction (`Calls` with `HTTPS / JSON`, `Enqueues jobs` with `Redis`). The protocol matters — it's half the point of L2.
+
+## What does NOT go in L2
+
+- Classes, functions, modules inside a container — that's L3.
+- External systems from L1 if no internal container talks to them — drop them; they clutter the picture.
+- Deployment topology (regions, AZs, load balancers) — separate diagram if needed.
+- Every single side service (logging, metrics, tracing) — include only if they shape the architecture. Usually a "observability goes to DataDog" note in the accompanying prose is enough.
+
+## Relation to the L1 context diagram
+
+The L2 container diagram is the L1 system "zoomed in" — you should be able to collapse every container back into the single `System(main, ...)` box from the L1 diagram and the external relationships should still match. If they don't, one of the two diagrams is wrong.
+
+## Maintenance
+
+More volatile than L1. Changes when:
+
+- A new container is added (new worker, new mobile app, new cache layer)
+- A container is split or merged
+- The communication pattern changes (e.g. API direct-reads-DB → API goes through a read replica)
+
+Expect to update this every few releases of significant architectural work. If it's changing every sprint, your architecture is churning faster than it should be.
+
+## References
+
+- [C4 Model — Level 2](https://c4model.com/#ContainerDiagram)
+- [Mermaid C4 syntax](https://mermaid.js.org/syntax/c4.html)
+- ApexStack's own L2 for reference: `docs/architecture/apexstack-container.md`

--- a/templates/architecture/c4-context.md
+++ b/templates/architecture/c4-context.md
@@ -51,6 +51,6 @@ The L1 diagram should change maybe once or twice a year — only when the system
 
 ## References
 
-- [C4 Model — Level 1](https://c4model.com/#SystemContextDiagram)
+- [C4 Model — Level 1](https://c4model.com/diagrams/system-context)
 - [Mermaid C4 syntax](https://mermaid.js.org/syntax/c4.html)
 - ApexStack's own L1 for reference: `docs/architecture/apexstack-context.md`

--- a/templates/architecture/c4-context.md
+++ b/templates/architecture/c4-context.md
@@ -1,0 +1,56 @@
+# System Context — {Project Name}
+
+> **C4 Level 1** — the system and everyone/everything it talks to. Audience: everyone. One diagram per managed project.
+
+## Diagram
+
+```mermaid
+C4Context
+    title System Context for {Project Name}
+
+    Person(user, "User", "The primary human actor — describe who this is")
+    Person(admin, "Admin", "A privileged user — remove if you don't have one")
+
+    System(main, "{Project Name}", "One-sentence description of what the system does")
+
+    System_Ext(auth, "Auth Provider", "e.g. Auth0, Clerk, Supabase Auth")
+    System_Ext(payments, "Payment Processor", "e.g. Stripe, Paddle — remove if N/A")
+    System_Ext(email, "Email Provider", "e.g. Postmark, SES — remove if N/A")
+
+    Rel(user, main, "Uses", "HTTPS")
+    Rel(admin, main, "Administers", "HTTPS")
+    Rel(main, auth, "Authenticates via", "OAuth / OIDC")
+    Rel(main, payments, "Charges / webhooks", "HTTPS + webhook")
+    Rel(main, email, "Sends transactional email", "SMTP / API")
+```
+
+## How to use this template
+
+1. Copy this file to `docs/architecture/context.md` (for code-level diagrams inside a repo) or `projects/{name}/architecture/context.md` (for portfolio-level ApexStack docs).
+2. Replace every `{Project Name}` and every placeholder in the `C4Context` block with your real system.
+3. Remove external systems you don't use, add the ones you do.
+4. Keep the diagram **one screen tall on GitHub**. If it doesn't fit, you're probably trying to show L2 detail in an L1 diagram — create the container diagram instead (see `c4-container.md`).
+5. Commit. GitHub renders the diagram inline in the file view — no build step.
+
+## What goes in L1 (context)
+
+- The system (one box, your name on it)
+- **People** who use the system (users, admins, operators)
+- **External systems** the system depends on (auth, payments, email, third-party APIs, cloud services — at the level of "we talk to Stripe", not "the `stripe-node` client in the backend calls `stripe.charges.create`")
+- Arrows showing the direction and gist of interaction
+
+## What does NOT go in L1
+
+- Internal containers (frontend / backend / database) — that's L2. If you find yourself drawing them here, you're conflating levels.
+- Deployment topology (regions, load balancers, CDNs) — that's a separate concern. C4 doesn't cover it; use a deployment diagram elsewhere if you need one.
+- Code-level details (classes, functions, database schema) — L3 or L4 if you ever need them.
+
+## Maintenance
+
+The L1 diagram should change maybe once or twice a year — only when the system's external relationships change (new integration, removed dependency, new class of users). If you find yourself updating it every sprint, you're probably putting L2 details in it.
+
+## References
+
+- [C4 Model — Level 1](https://c4model.com/#SystemContextDiagram)
+- [Mermaid C4 syntax](https://mermaid.js.org/syntax/c4.html)
+- ApexStack's own L1 for reference: `docs/architecture/apexstack-context.md`


### PR DESCRIPTION
## Summary

Ships v1 of architecture-diagram support per issue #50. Mermaid C4 only — GitHub renders it inline, no Java/Docker/Go install required. L3+ precision and Structurizr DSL deferred to dedicated follow-ups (#67, #68) that land only when a project actually needs them.

## What changed

- **`docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md`** — decision record. Options matrix, weighted dimensions (GitHub-inline render + zero dep + single-source all favour Mermaid), consequences, deferred follow-ups.
- **`templates/architecture/c4-context.md`** — L1 template with a filled-in Mermaid `C4Context` block and inline guidance on what goes/doesn't go in L1.
- **`templates/architecture/c4-container.md`** — L2 template with a Mermaid `C4Container` block and L1↔L2 consistency guidance.
- **`docs/architecture/apexstack-context.md`** — dogfood L1 for ApexStack itself (ops role, framework fork, Claude Code + GitHub + managed projects + upstream).
- **`docs/architecture/apexstack-container.md`** — dogfood L2. Documents the non-traditional interpretation of "container" for ApexStack (folder-scoped file sets interpreted by Claude Code / the user / GitHub) and explains why.
- **`docs/multi-project.md`** — new "Architecture diagrams" subsection with the directory split (framework-wide / per-project-apexstack-docs / per-project-repo).
- **`CLAUDE.md`** — templates table gains two rows.

## Testing

Doc + template-only change. No executable code; no unit tests.

Manual verification:
- Both dogfood diagrams render on the GitHub branch preview (verify before merge — GitHub renders Mermaid in the file view)
- Templates parse as valid Mermaid (copy-paste into Mermaid Live Editor, diagram renders)
- AgDR links in docs/multi-project.md and CLAUDE.md resolve

## Follow-up tickets filed with this PR

- **#67** — `/handover` skill auto-generates a stub L2 container diagram from repo signals (`package.json`, `Dockerfile`, `docker-compose.yml`, etc.). Meaningful skill change — bundled separately.
- **#68** — Structurizr DSL as escape hatch for L3+ precision. Explicit "NOT NOW" — open only when a project hits Mermaid's C4 ceiling.

## Glossary

| Term | Definition |
|------|------------|
| C4 model | A 4-level architecture-diagram convention (Context / Container / Component / Code) from Simon Brown. Level = zoom dimension, not quality tier. |
| L1 context | The system as a single box + every person and external system it touches |
| L2 container | The system broken down into deployable / runnable units (web app, API, DB, worker) |
| Mermaid C4 | GitHub-native Markdown-embedded C4 diagramming dialect. Renders inline in file previews. Beta support in Mermaid, sufficient for L1/L2 |
| AgDR | Agent Decision Record — lightweight `docs/agdr/AgDR-NNNN-slug.md` file capturing why a technical decision was made (options, tradeoffs, consequences) |
| dogfood | A vendor using their own product in production. Here: ApexStack documents its own architecture using the diagram convention it ships. |

## Related

- Closes #50
- Deferred follow-ups: #67, #68
- Decision rationale: `docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md`