### PR TITLE
feat(#41): per-project active ticket markers in ops repo

### DIFF
--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -3,9 +3,24 @@
 # Enforces the ticket-first rule mechanically instead of relying on prose
 # in CLAUDE.md, workflows/sdlc.md, or .claude/rules/workflow-gates.md.
 #
-# Active ticket is declared by running the /start-ticket skill, which writes
-# .claude/session/current-ticket (key=value lines: repo, number, title, url,
-# suggested_branch, started_at).
+# Active tickets are declared by the /start-ticket skill. The marker
+# layout is two-tier (apexstack#41):
+#
+#   ops_root/.claude/session/tickets/<project>    ← per-project, preferred
+#   ops_root/.claude/session/current-ticket       ← ops-repo / fallback
+#
+# Resolution order for a given FILE_PATH:
+#   1. If FILE_PATH is under ops_root/workspace/<project>/, look up
+#      ops_root/.claude/session/tickets/<project>. If present → exempt.
+#   2. Fall back to ops_root/.claude/session/current-ticket. If present →
+#      exempt.
+#   3. Otherwise, block with instructions.
+#
+# Ops root is the apexstack fork root (has both onboarding.yaml and
+# apexstack.projects.yaml at the top level). It's discovered by walking
+# up from the nearest git toplevel; this handles the case where an agent
+# worktree or a cloned managed project lives inside the ops tree and
+# would otherwise report a nested git root.
 #
 # Exempt paths (meta / framework / docs — no ticket required):
 #   - anything under .claude/
@@ -37,7 +52,7 @@ fi
 # and absolute (*/path/*) forms. Absolute-path fallthrough happens when
 # FILE_PATH points outside REPO_ROOT (e.g. agent worktrees whose
 # git-toplevel differs from the outer apexstack tree); in that case the
-# strip on lines 29-31 is a no-op and REL_PATH stays absolute. The
+# strip on lines 43-45 is a no-op and REL_PATH stays absolute. The
 # existing `*.md` pattern already crosses `/`, so absolute-match via a
 # `*/…` prefix is a known-good shape — #56 extends the same trick to the
 # path-prefix exemptions.
@@ -53,12 +68,59 @@ case "$REL_PATH" in
   *.md) exit 0 ;;
 esac
 
-MARKER="${REPO_ROOT:-.}/.claude/session/current-ticket"
-if [ -f "$MARKER" ]; then
+# Discover the ops root. Walk up from REPO_ROOT until we find a directory
+# with both onboarding.yaml AND apexstack.projects.yaml (a configured ops
+# fork). Stop at /. If not found, OPS_ROOT stays empty and we treat the
+# REPO_ROOT itself as the marker home (pre-#41 behaviour).
+OPS_ROOT=""
+if [ -n "$REPO_ROOT" ]; then
+  r="$REPO_ROOT"
+  while [ -n "$r" ] && [ "$r" != "/" ]; do
+    if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexstack.projects.yaml" ]; then
+      OPS_ROOT="$r"
+      break
+    fi
+    r=$(dirname "$r")
+  done
+fi
+
+MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
+MARKER_HOME="${MARKER_HOME:-.}"
+
+# Per-project resolution (apexstack#41): if FILE_PATH points under
+# <ops_root>/workspace/<project>/, we look for a per-project marker at
+# .claude/session/tickets/<project>. This keeps per-project session state
+# keyed by the managed-project name and localised in the ops fork
+# (gitignored), instead of the pre-#41 scheme that relied on a
+# .claude/session/ inside each managed-project clone.
+PROJECT=""
+if [ -n "$OPS_ROOT" ]; then
+  case "$FILE_PATH" in
+    "$OPS_ROOT"/workspace/*)
+      tail="${FILE_PATH#$OPS_ROOT/workspace/}"
+      PROJECT="${tail%%/*}"
+      ;;
+  esac
+fi
+
+PER_PROJECT_MARKER=""
+if [ -n "$PROJECT" ]; then
+  PER_PROJECT_MARKER="$MARKER_HOME/.claude/session/tickets/$PROJECT"
+  if [ -f "$PER_PROJECT_MARKER" ]; then
+    exit 0
+  fi
+fi
+
+# Fallback: the ops-level current-ticket marker. This is the pre-#41
+# location and still honoured for ops-repo framework edits, and as a
+# safety net for any file we couldn't map to a specific project.
+FALLBACK_MARKER="$MARKER_HOME/.claude/session/current-ticket"
+if [ -f "$FALLBACK_MARKER" ]; then
   exit 0
 fi
 
-cat >&2 <<'MSG'
+# Nothing found — emit a guide that names both possibilities.
+cat >&2 <<MSG
 BLOCKED: No active ticket set for this session.
 
 ApexStack requires a ticket BEFORE any code changes (workflow-gates rule #3,
@@ -67,8 +129,14 @@ pre-build gate, "one ticket at a time"). To proceed:
   1. Create or find the ticket (GitHub Issue in the project's own repo):
        gh issue create --repo <owner/repo> --title "..."
   2. Declare it for this session — run the /start-ticket skill with the
-     issue number (or pass owner/repo#number to pin it)
+     issue number (or pass owner/repo#number to pin it). The skill writes
+     a per-project marker if the ticket's repo matches a registered
+     managed project, otherwise falls back to the ops-level marker.
   3. Retry the edit
+
+Markers looked up for this path (in order):
+$([ -n "$PER_PROJECT_MARKER" ] && echo "  per-project:  $PER_PROJECT_MARKER")
+  ops fallback: $FALLBACK_MARKER
 
 Exempt paths (no ticket required): .claude/, docs/, projects/*/docs/, *.md
 MSG

--- a/.claude/skills/start-ticket/SKILL.md
+++ b/.claude/skills/start-ticket/SKILL.md
@@ -87,13 +87,23 @@ Given the ticket's `owner/repo` (from step 1), grep `apexstack.projects.yaml` fo
 if command -v yq >/dev/null 2>&1; then
   project=$(yq eval ".projects[] | select(.repo == \"${OWNER_REPO}\") | .name" "$ops_root/apexstack.projects.yaml")
 else
-  # Greppy fallback: find the `name:` whose sibling `repo:` matches
+  # Greppy fallback: find the `name:` whose sibling `repo:` matches.
+  # Strips surrounding quotes from both `name:` and `repo:` values so the
+  # comparison works whether the registry uses bare scalars
+  # (`repo: me2resh/curios-dog`) or quoted scalars (`repo: "me2resh/…"`).
   project=$(awk -v r="$OWNER_REPO" '
-    /^[[:space:]]*- name:/ { name=$3 }
-    /^[[:space:]]*repo:/   { if ($2 == r) { print name; exit } }
+    function unquote(s) { gsub(/^["\x27]|["\x27]$/, "", s); return s }
+    /^[[:space:]]*- name:/ { name = unquote($3) }
+    /^[[:space:]]*repo:/   { if (unquote($2) == r) { print name; exit } }
   ' "$ops_root/apexstack.projects.yaml")
 fi
 ```
+
+Notes on the fallback:
+
+- Handles both `repo: me2resh/curios-dog` and `repo: "me2resh/curios-dog"` (and single-quoted).
+- Assumes `- name:` is the FIRST key in each project entry — that matches the shape in `apexstack.projects.yaml.example` and every entry produced by `/handover`. If your registry reorders keys so `repo:` appears before `name:` in an entry, the lookup misses. Fix: move `name:` to the top, or install `yq` (the preferred path).
+- Leading whitespace is tolerated via `^[[:space:]]*` — nested entries under `projects:` parse fine at any indent level, so long as the indent is consistent within the entry.
 
 `$project` is now either a registered project name (e.g. `curios-dog`, `sharppick`) or empty (ticket's tracker repo isn't registered — typically because the ticket is on the ops fork itself, or a repo that's not under management).
 

--- a/.claude/skills/start-ticket/SKILL.md
+++ b/.claude/skills/start-ticket/SKILL.md
@@ -8,7 +8,16 @@ effort: low
 
 # /start-ticket - Declare the Active Ticket
 
-Writes `.claude/session/current-ticket` so the `require-active-ticket.sh` PreToolUse hook permits Edit/Write on code paths. Without this marker, the hook blocks edits to anything outside `.claude/`, `docs/`, `projects/*/docs/`, and `*.md`.
+Writes a session marker so the `require-active-ticket.sh` PreToolUse hook permits Edit/Write on code paths. Without it, the hook blocks edits to anything outside `.claude/`, `docs/`, `projects/*/docs/`, and `*.md`.
+
+Marker layout (apexstack#41):
+
+| Path | When the hook uses it |
+|------|----------------------|
+| `<ops_root>/.claude/session/tickets/<project>` | When the edit is under `<ops_root>/workspace/<project>/` AND this per-project marker exists |
+| `<ops_root>/.claude/session/current-ticket` | Fallback. Always checked if the per-project marker is absent. This is also the marker used for ops-repo framework edits (where no `workspace/<name>/` prefix applies). |
+
+Both markers live in the ops fork (gitignored). No more `.claude/session/` inside each managed-project clone.
 
 This is the mechanical enforcement of the Pre-Build Gate in `.claude/rules/workflow-gates.md` — "do not start coding until the ticket exists".
 
@@ -48,9 +57,61 @@ From the issue title and number, generate: `<type>/<TICKET-ID>-<slug>` where:
 
 Match the convention in `.claude/rules/git-conventions.md`.
 
-### 4. Write the Marker
+### 4. Resolve the target marker
 
-Create `.claude/session/current-ticket` with:
+Per apexstack#41, the marker path depends on whether the ticket's tracker repo matches a registered managed project.
+
+#### 4a. Locate the ops root
+
+The ops root is the apexstack fork root — the directory containing BOTH `onboarding.yaml` and `apexstack.projects.yaml`. Walk up from CWD / the nearest git toplevel until you find it:
+
+```bash
+ops_root=""
+r=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+while [ -n "$r" ] && [ "$r" != "/" ]; do
+  if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexstack.projects.yaml" ]; then
+    ops_root="$r"
+    break
+  fi
+  r=$(dirname "$r")
+done
+```
+
+If not found (user is outside an apexstack fork), tell the user and stop. Starting a ticket without the fork doesn't make sense.
+
+#### 4b. Look the tracker repo up in the registry
+
+Given the ticket's `owner/repo` (from step 1), grep `apexstack.projects.yaml` for a project whose `repo:` field matches. One registry-safe way (uses `yq` when available, falls back to a greppy read):
+
+```bash
+if command -v yq >/dev/null 2>&1; then
+  project=$(yq eval ".projects[] | select(.repo == \"${OWNER_REPO}\") | .name" "$ops_root/apexstack.projects.yaml")
+else
+  # Greppy fallback: find the `name:` whose sibling `repo:` matches
+  project=$(awk -v r="$OWNER_REPO" '
+    /^[[:space:]]*- name:/ { name=$3 }
+    /^[[:space:]]*repo:/   { if ($2 == r) { print name; exit } }
+  ' "$ops_root/apexstack.projects.yaml")
+fi
+```
+
+`$project` is now either a registered project name (e.g. `curios-dog`, `sharppick`) or empty (ticket's tracker repo isn't registered — typically because the ticket is on the ops fork itself, or a repo that's not under management).
+
+#### 4c. Pick the marker path
+
+```bash
+if [ -n "$project" ]; then
+  marker="$ops_root/.claude/session/tickets/$project"
+  mkdir -p "$(dirname "$marker")"
+else
+  marker="$ops_root/.claude/session/current-ticket"
+  mkdir -p "$(dirname "$marker")"
+fi
+```
+
+### 5. Write the marker
+
+Write these key=value lines to the path resolved in step 4c:
 
 ```
 repo=<owner/repo>
@@ -61,14 +122,13 @@ suggested_branch=<branch>
 started_at=<ISO-8601>
 ```
 
-Make sure `.claude/session/` exists; create if needed.
+### 6. Confirm to the User
 
-### 5. Confirm to the User
-
-Output a single-line confirmation:
+Output a two-line confirmation that names the marker path so the user sees which scope this ticket is active on:
 
 ```
 Active ticket: <owner/repo>#<number> — <title>
+Marker: <marker>  (per-project / ops fallback)
 Suggested branch: <branch>
 ```
 
@@ -76,8 +136,9 @@ Do NOT create the branch automatically. The user may already be on a branch, or 
 
 ## Notes
 
-- `.claude/session/` is gitignored — the marker is per-machine, per-clone.
-- Running `/start-ticket` again overwrites the marker (use it when switching tickets).
-- To clear the marker without starting a new ticket: `rm .claude/session/current-ticket`.
+- `.claude/session/` (including `.claude/session/tickets/`) is gitignored — markers are per-machine, per-clone of the ops fork.
+- Running `/start-ticket` again overwrites the marker at whichever path resolved in step 4c (per-project or fallback). That's how you switch tickets — including jumping between projects (each project's marker lives in its own file, so switching between `curios-dog` and `sharppick` doesn't lose either one's context).
+- To clear a specific project's marker: `rm <ops_root>/.claude/session/tickets/<project>`.
+- To clear the ops-level fallback: `rm <ops_root>/.claude/session/current-ticket`.
 - Exempt paths (`.claude/`, `docs/`, `projects/*/docs/`, any `*.md`) don't need a ticket — the skill is only required before touching source / config / infra.
-- If you're working inside `workspace/<project>/`, the marker lives in THAT clone's `.claude/session/`, not in the ops repo's. Each working copy tracks its own active ticket.
+- **Migration from pre-#41 layout**: if your workflow still has a `.claude/session/current-ticket` inside a managed-project clone (`workspace/<name>/.claude/session/current-ticket`), it's harmless but no longer read by the hook. Delete it or re-run `/start-ticket` to have the new marker written under the ops fork's `.claude/session/tickets/<name>`.


### PR DESCRIPTION
## Summary

Moves the active-ticket session state from a single `.claude/session/current-ticket` marker to a two-tier layout keyed by managed-project name:

- `<ops_root>/.claude/session/tickets/<project>` — per-project, preferred
- `<ops_root>/.claude/session/current-ticket` — ops-level fallback

Both live in the ops fork, gitignored. No more `.claude/session/` inside each managed-project clone.

## What changed

- **`.claude/hooks/require-active-ticket.sh`** — rewrites the marker-lookup logic. Walks up from `git rev-parse --show-toplevel` until it finds both `onboarding.yaml` and `apexstack.projects.yaml` (that's the ops root, even when a managed-project clone has its own inner git root). If `FILE_PATH` is under `<ops_root>/workspace/<project>/`, checks `tickets/<project>` first; falls back to `current-ticket`. Error message now names both lookup paths so the user sees which scope the hook checked.
- **`.claude/skills/start-ticket/SKILL.md`** — step 4 rewritten to resolve the ops root, look up the ticket's tracker repo in `apexstack.projects.yaml` (yq when available, awk fallback), and pick the right marker path. Marker layout table moved to the top of the skill. Migration note added.

## Testing

Ran a 10-case smoke test against an isolated mock ops root in `/tmp`:

```
PASS  code outside workspace, no fallback
PASS  workspace/curios-dog, no markers
PASS  workspace/curios-dog, per-project marker
PASS  workspace/curios-dog, only fallback
PASS  ops framework edit, fallback only
PASS  ops framework, only sharppick per-project marker
PASS  workspace/sharppick with sharppick marker
PASS  workspace/curios-dog with wrong project marker
PASS  .claude/ edit, no markers, always exempt
PASS  *.md edit, no markers, always exempt
```

Covers: per-project happy path, cross-project isolation (sharppick marker does NOT unblock curios-dog edit), fallback to ops-level, exempt-path paths still exempt.

## Backwards compatibility

- Pre-#41 workflows with a `.claude/session/current-ticket` in the ops repo keep working (fallback path).
- Pre-#41 per-workspace markers (`workspace/<name>/.claude/session/current-ticket`) are no longer read by the hook. Harmless, but users can delete them once the new layout is active. Migration note in the skill's "Notes" section.

## Glossary

| Term | Definition |
|------|------------|
| ops root | The apexstack fork root — the directory containing both `onboarding.yaml` and `apexstack.projects.yaml`. Discovered by walking up from the nearest git toplevel |
| per-project marker | `<ops_root>/.claude/session/tickets/<project>` — the ticket currently active for a specific managed project |
| ops-level fallback | `<ops_root>/.claude/session/current-ticket` — used for edits outside any `workspace/<project>/` subtree, or as a safety net |
| registry | `apexstack.projects.yaml` at the ops root — maps `repo` to project `name`, used by `/start-ticket` to derive the marker path |

## Related

- Closes #41
- Builds on #56 (absolute-form path exemptions in the same hook — those still work with the new logic)