### PR TITLE
feat(#59): ticket-first gate for database migrations + /migration skill + migration AgDR template

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -28,11 +28,27 @@ These four hooks make the SDLC mechanical instead of advisory. Each enforces a r
 
 **Event:** `PreToolUse` on `Edit | Write | MultiEdit`.
 
-**What it does:** blocks edits to any code path unless `.claude/session/current-ticket` exists. Exempts `.claude/`, `docs/`, `projects/*/docs/`, and any `*.md` file so framework / doc / meta work is still fluid.
+**What it does:** blocks edits to any code path unless a session marker exists. Resolution is two-tier (#41): per-project marker at `<ops_root>/.claude/session/tickets/<project>` when `FILE_PATH` is under `<ops_root>/workspace/<project>/`, otherwise falls back to `<ops_root>/.claude/session/current-ticket`. Exempts `.claude/`, `docs/`, `projects/*/docs/`, and any `*.md` file so framework / doc / meta work is still fluid.
 
 **Enforces:** the Pre-Build Gate in `.claude/rules/workflow-gates.md` — "do not start coding until the ticket exists, has acceptance criteria, and is broken into tasks."
 
-**Unblock:** run `/start-ticket <issue>`. The skill verifies the issue via `gh issue view` and writes the marker.
+**Unblock:** run `/start-ticket <issue>`. The skill verifies the issue via `gh issue view`, resolves the project from the ticket's tracker repo via the portfolio registry, and writes either the per-project or fallback marker.
+
+### 1a. Migration ticket-first — `require-migration-ticket.sh`
+
+**Event:** `PreToolUse` on `Edit | Write | MultiEdit`. Runs **before** `require-active-ticket.sh` so migration-specific messages surface first.
+
+**What it does:** if `FILE_PATH` matches a migration-path pattern (`migrate-*.{ts,js,py,sql}`, `**/migrations/**`, `prisma/schema.prisma` + `prisma/migrations/**`, `src/migrations/*.{ts,js}` for TypeORM, `alembic/versions/*.py`, `db/migrate/*.rb`), verifies three gates:
+
+1. Active ticket marker exists (same resolution as hook #1)
+2. The referenced tracker issue is OPEN and carries the `migration` label (default; overridable per project via `.claude/project-config.json` → `migration_label`)
+3. The issue body references a migration AgDR at `docs/agdr/AgDR-\d+-.*migration.*\.md`
+
+If any gate fails, blocks with a message pointing at the `/migration` skill. If `FILE_PATH` doesn't match a migration pattern, exits silently (hook #1 handles the normal ticket check).
+
+**Enforces:** gate 3a in `.claude/rules/workflow-gates.md` — "any edit to migration paths requires a labelled migration ticket + linked AgDR".
+
+**Unblock:** run `/migration` to create a labelled ticket + migration AgDR in one flow, then `/start-ticket` the new ticket.
 
 ### 2. Auto code review — `auto-code-review.sh`
 

--- a/.claude/hooks/require-migration-ticket.sh
+++ b/.claude/hooks/require-migration-ticket.sh
@@ -47,9 +47,11 @@ fi
 # These never need a migration ticket regardless of path, so short-circuit
 # before doing any network calls.
 case "$FILE_PATH" in
-  */.claude/*|*/.claude|*/docs/*|*/docs|*/projects/*/docs/*) exit 0 ;;
+  */.claude/*|*/.claude|*/docs/*|*/docs) exit 0 ;;
   *.md|*.example) exit 0 ;;
 esac
+# Note: `*/projects/*/docs/*` is subsumed by `*/docs/*` above (shell case `*`
+# crosses `/`), so no separate arm is needed.
 
 # --------- Discover ops root ---------
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -89,6 +91,9 @@ is_migration_path() {
   if [ -n "$CUSTOM_PATHS" ]; then
     while IFS= read -r pat; do
       [ -z "$pat" ] && continue
+      # SC2254: unquoted expansion is intentional — the project-configured
+      # pattern should be interpreted as a glob, not compared literally.
+      # shellcheck disable=SC2254
       case "$path" in
         $pat) return 0 ;;
       esac
@@ -98,10 +103,12 @@ is_migration_path() {
     return 1
   fi
 
-  # Default patterns
+  # Default patterns.
+  # Note: shell case `*` crosses `/`, so `*/migrations/*.sql` already covers
+  # nested paths like `*/migrations/<sub>/file.sql` — no separate arm needed.
   case "$path" in
-    # SQL migrations in any `migrations/` directory
-    */migrations/*.sql|*/migrations/*/*.sql) return 0 ;;
+    # SQL migrations anywhere under a `migrations/` directory
+    */migrations/*.sql) return 0 ;;
     # `migrate-*.ts` / `.js` / `.py` / `.sql` anywhere
     */migrate-*.ts|*/migrate-*.js|*/migrate-*.py|*/migrate-*.sql) return 0 ;;
     # Prisma

--- a/.claude/hooks/require-migration-ticket.sh
+++ b/.claude/hooks/require-migration-ticket.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+# PreToolUse hook on Write/Edit/MultiEdit: when the target path looks like a
+# database migration file, enforce the migration-ticket-first rule.
+#
+# Enforces `.claude/rules/workflow-gates.md` gate 4a (migration) —
+# "any edit to migration paths requires a labelled migration ticket +
+# linked migration AgDR". Backs up the `/migration` skill: skill creates
+# the ticket + AgDR; this hook refuses to let writes happen without them.
+#
+# Three gates in order:
+#
+#   G1. Active ticket marker exists (same resolution as
+#       require-active-ticket.sh — per-project first, then fallback).
+#   G2. The referenced tracker issue is OPEN and carries the migration
+#       label (default "migration", overridable per project).
+#   G3. The issue body references an AgDR at
+#       `docs/agdr/AgDR-\d+-.*migration.*\.md`.
+#
+# If any gate fails, block with a message pointing at `/migration`.
+#
+# Pass-through (exit 0) paths:
+#   - FILE_PATH doesn't match any migration-path pattern
+#   - FILE_PATH is under .claude/, docs/, projects/*/docs/, any *.md
+#     (meta / docs edits don't need a migration ticket even on paths
+#     that look migration-ish)
+#   - Any *.example file (migration templates in golden-paths/ etc.)
+#
+# Path patterns are overridable per project via
+# `.claude/project-config.json`:
+#
+#   {
+#     "migration_paths": ["src/db/**", "db/migrations/**"],
+#     "migration_label": "database"
+#   }
+#
+# The config is read from `<ops_root>/.claude/project-config.json` if
+# present, otherwise defaults below apply.
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# --------- Exempt meta / docs / example files ---------
+# These never need a migration ticket regardless of path, so short-circuit
+# before doing any network calls.
+case "$FILE_PATH" in
+  */.claude/*|*/.claude|*/docs/*|*/docs|*/projects/*/docs/*) exit 0 ;;
+  *.md|*.example) exit 0 ;;
+esac
+
+# --------- Discover ops root ---------
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+OPS_ROOT=""
+if [ -n "$REPO_ROOT" ]; then
+  r="$REPO_ROOT"
+  while [ -n "$r" ] && [ "$r" != "/" ]; do
+    if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexstack.projects.yaml" ]; then
+      OPS_ROOT="$r"
+      break
+    fi
+    r=$(dirname "$r")
+  done
+fi
+MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
+MARKER_HOME="${MARKER_HOME:-.}"
+
+# --------- Load project-config overrides ---------
+MIGRATION_LABEL="migration"
+CUSTOM_PATHS=""
+PCONFIG="$MARKER_HOME/.claude/project-config.json"
+if [ -f "$PCONFIG" ] && command -v jq >/dev/null 2>&1; then
+  label=$(jq -r '.migration_label // empty' "$PCONFIG" 2>/dev/null)
+  [ -n "$label" ] && MIGRATION_LABEL="$label"
+  CUSTOM_PATHS=$(jq -r '.migration_paths // [] | join("\n")' "$PCONFIG" 2>/dev/null)
+fi
+
+# --------- Does this path look like a migration? ---------
+#
+# Defaults cover the common tool / convention set. Patterns use shell
+# glob semantics (`*` crosses `/` inside case). Add to this list sparingly
+# — false positives on non-migration files block productive edits.
+is_migration_path() {
+  local path="$1"
+
+  # Project-configured patterns take precedence if any
+  if [ -n "$CUSTOM_PATHS" ]; then
+    while IFS= read -r pat; do
+      [ -z "$pat" ] && continue
+      case "$path" in
+        $pat) return 0 ;;
+      esac
+    done <<< "$CUSTOM_PATHS"
+    # When custom patterns are set, don't fall through to defaults —
+    # projects that override are saying "only these paths"
+    return 1
+  fi
+
+  # Default patterns
+  case "$path" in
+    # SQL migrations in any `migrations/` directory
+    */migrations/*.sql|*/migrations/*/*.sql) return 0 ;;
+    # `migrate-*.ts` / `.js` / `.py` / `.sql` anywhere
+    */migrate-*.ts|*/migrate-*.js|*/migrate-*.py|*/migrate-*.sql) return 0 ;;
+    # Prisma
+    */prisma/schema.prisma|*/prisma/migrations/*) return 0 ;;
+    # TypeORM (typical convention)
+    */src/migrations/*.ts|*/src/migrations/*.js) return 0 ;;
+    # Alembic
+    */alembic/versions/*.py) return 0 ;;
+    # Rails / ActiveRecord
+    */db/migrate/*.rb) return 0 ;;
+    # Generic — any file immediately under a `migrations/` directory, any extension
+    */migrations/*) return 0 ;;
+  esac
+  return 1
+}
+
+if ! is_migration_path "$FILE_PATH"; then
+  # Not a migration file — other hooks handle the standard ticket check.
+  exit 0
+fi
+
+# --------- Gate 1: active ticket marker ---------
+# Reuse the #41 resolution: per-project marker if FILE_PATH is under
+# ops_root/workspace/<project>/, otherwise the ops-level fallback.
+PROJECT=""
+if [ -n "$OPS_ROOT" ]; then
+  case "$FILE_PATH" in
+    "$OPS_ROOT"/workspace/*)
+      tail="${FILE_PATH#$OPS_ROOT/workspace/}"
+      PROJECT="${tail%%/*}"
+      ;;
+  esac
+fi
+
+MARKER=""
+if [ -n "$PROJECT" ] && [ -f "$MARKER_HOME/.claude/session/tickets/$PROJECT" ]; then
+  MARKER="$MARKER_HOME/.claude/session/tickets/$PROJECT"
+elif [ -f "$MARKER_HOME/.claude/session/current-ticket" ]; then
+  MARKER="$MARKER_HOME/.claude/session/current-ticket"
+fi
+
+if [ -z "$MARKER" ]; then
+  cat >&2 <<MSG
+BLOCKED: No active ticket set — and this file looks like a database migration.
+
+Migrations need a dedicated labelled ticket + AgDR, not just any ticket.
+Run /migration to create both in one guided flow:
+
+  /migration${PROJECT:+ $PROJECT}
+
+Then /start-ticket <owner/repo>#<number> to activate the new ticket for
+this session, and retry the edit.
+
+Path matched migration pattern: $FILE_PATH
+MSG
+  exit 2
+fi
+
+# --------- Parse marker for repo + issue number ---------
+TICKET_REPO=$(grep -E '^repo=' "$MARKER" | head -1 | cut -d= -f2-)
+TICKET_NUM=$(grep -E '^number=' "$MARKER" | head -1 | cut -d= -f2-)
+
+if [ -z "$TICKET_REPO" ] || [ -z "$TICKET_NUM" ]; then
+  cat >&2 <<MSG
+BLOCKED: Active ticket marker at $MARKER is missing \`repo=\` or
+\`number=\` — can't verify migration discipline without those fields.
+
+Re-run /start-ticket to rewrite the marker cleanly, or /migration to
+create a fresh migration ticket.
+MSG
+  exit 2
+fi
+
+# --------- Gate 2: issue is open + has migration label ---------
+ISSUE_JSON=$(gh issue view "$TICKET_NUM" --repo "$TICKET_REPO" --json state,labels,body 2>/dev/null)
+if [ -z "$ISSUE_JSON" ]; then
+  cat >&2 <<MSG
+BLOCKED: Could not fetch ${TICKET_REPO}#${TICKET_NUM} from GitHub.
+Network / auth problem? Or the issue doesn't exist?
+
+Migration files can't be edited without a verifiable migration ticket.
+Check your gh auth status, or run /migration to create a new ticket.
+MSG
+  exit 2
+fi
+
+STATE=$(echo "$ISSUE_JSON" | jq -r .state)
+HAS_LABEL=$(echo "$ISSUE_JSON" | jq -r --arg L "$MIGRATION_LABEL" '.labels | map(.name) | index($L) != null')
+BODY=$(echo "$ISSUE_JSON" | jq -r .body)
+
+if [ "$STATE" != "OPEN" ]; then
+  cat >&2 <<MSG
+BLOCKED: Active ticket ${TICKET_REPO}#${TICKET_NUM} is $STATE, not OPEN.
+Migration files require an OPEN labelled ticket. Run /migration to create
+a fresh one, or /start-ticket on a different OPEN migration ticket.
+MSG
+  exit 2
+fi
+
+if [ "$HAS_LABEL" != "true" ]; then
+  cat >&2 <<MSG
+BLOCKED: Active ticket ${TICKET_REPO}#${TICKET_NUM} does not have the
+\`$MIGRATION_LABEL\` label.
+
+Migrations need a dedicated labelled ticket — the label is the signal
+that a reviewer should scrutinise rollback plan, downtime, and
+cross-service impact before approval.
+
+Two options:
+  1. Add the label to the existing ticket if it genuinely is a migration:
+       gh issue edit $TICKET_NUM --repo $TICKET_REPO --add-label "$MIGRATION_LABEL"
+     Then edit the body to include the migration-shape fields and link an
+     AgDR (see /migration output for the body template).
+  2. Create a fresh migration ticket + AgDR:
+       /migration${PROJECT:+ $PROJECT}
+     Then /start-ticket the new ticket and retry.
+MSG
+  exit 2
+fi
+
+# --------- Gate 3: body references a migration AgDR ---------
+if ! echo "$BODY" | grep -qE 'docs/agdr/AgDR-[0-9]+-[^[:space:]]*migration[^[:space:]]*\.md'; then
+  cat >&2 <<MSG
+BLOCKED: Active ticket ${TICKET_REPO}#${TICKET_NUM} has the
+\`$MIGRATION_LABEL\` label but its body does not reference a migration
+AgDR matching \`docs/agdr/AgDR-\\d+-.*migration.*\\.md\`.
+
+A migration-class change needs a paired Agent Decision Record capturing
+rollback plan, downtime, cross-service consumers, and observability.
+
+Create one with /migration, or if the AgDR already exists, edit the
+ticket body to include a reference to it:
+
+  gh issue edit $TICKET_NUM --repo $TICKET_REPO --body-file <path>
+
+The regex the hook checks is permissive — any occurrence of the AgDR
+relative path in the body satisfies gate 3.
+MSG
+  exit 2
+fi
+
+# All gates passed — allow the edit.
+exit 0

--- a/.claude/rules/workflow-gates.md
+++ b/.claude/rules/workflow-gates.md
@@ -5,6 +5,7 @@
 | 1 | PRD → Tech Design | PRD approved, parent epic exists |
 | 2 | Tech Design → Build | Design approved, story tickets exist, **AgDR for key decisions** |
 | 3 | Starting code | Ticket exists, branch created, design review if UI work |
+| 3a | Starting a **migration** edit | Active ticket has the `migration` label **and** its body references a migration AgDR at `docs/agdr/AgDR-\d+-.*migration.*\.md`. Enforced by `require-migration-ticket.sh`. Use `/migration` to produce both artefacts in one flow. |
 | 4 | Creating PR | Tests pass, checks pass, **> 80% coverage**, **AgDR linked if decisions made** |
 | 5 | Merging PR | 2 reviews (agent + human), CI green, **commit SHA matches review** |
 | 6 | Ticket → Done | QA verified, signed off |
@@ -34,6 +35,26 @@ Do not start coding until **all** of these exist in your ticket tracker:
 - Each story has acceptance criteria
 - Technical tasks broken down
 - Tickets moved to "Todo" or "In Progress"
+
+## Migration Gate (3a) — dedicated ticket + AgDR
+
+Any edit to a file that matches the migration-path patterns (configurable via `.claude/project-config.json` → `migration_paths`) requires:
+
+1. An OPEN tracker issue with the `migration` label (default, overridable via `migration_label`)
+2. The issue body contains a reference to a migration AgDR at `docs/agdr/AgDR-\d+-.*migration.*\.md`
+
+Default migration paths:
+
+- `**/migrate-*.{ts,js,py,sql}` — one-off migration scripts
+- `**/migrations/**` — any file under a migrations/ directory
+- `prisma/schema.prisma`, `prisma/migrations/**` — Prisma
+- `src/migrations/*.{ts,js}` — TypeORM
+- `alembic/versions/*.py` — Alembic
+- `db/migrate/*.rb` — Rails
+
+**Enforcement**: `require-migration-ticket.sh` fires on PreToolUse for Edit / Write / MultiEdit. Runs BEFORE `require-active-ticket.sh` in the hook chain — if the path isn't a migration path, it's a no-op and the normal active-ticket check applies.
+
+**How to satisfy**: run `/migration` — it asks for migration type, affected tables, rollback plan, downtime estimate, cross-service consumers, data volume, testing plan, and observability, then creates the labelled issue AND writes the AgDR in one flow.
 
 ## QA State is Mandatory
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-migration-ticket.sh\"'"
+          },
+          {
+            "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
           }
         ]

--- a/.claude/skills/migration/SKILL.md
+++ b/.claude/skills/migration/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: migration
+description: Create a structured database-migration ticket and its matching migration AgDR in one guided flow. Use BEFORE touching any migration files (migrate-*.ts, migrations/*, Prisma / TypeORM / Alembic dirs, infrastructure DB resources) — the require-migration-ticket.sh hook blocks edits to those paths until both artefacts exist.
+argument-hint: "[<project>]"
+allowed-tools: Bash, Read, Write
+---
+
+# /migration — Create a Migration Ticket + AgDR
+
+Migrations are high-blast-radius: data loss, downtime, lock contention, cross-service coordination. ApexStack treats them as a distinct class of change from code — a migration PR needs:
+
+1. A tracker issue with the `migration` label (plus priority) that captures the plan.
+2. A migration AgDR at `docs/agdr/AgDR-NNNN-migration-<slug>.md` that captures the options considered, rollback plan, downtime estimate, cross-service consumers, data volume, testing plan, and observability.
+
+`require-migration-ticket.sh` (the matching PreToolUse hook) refuses to let you write to migration paths without both artefacts in place. This skill produces both in one pass.
+
+## Usage
+
+```
+/migration                 # prompts for everything, creates ticket + AgDR in the current project
+/migration curios-dog      # explicitly target a registered project
+```
+
+## When to invoke
+
+- Before writing a new SQL migration file
+- Before adding/modifying a DynamoDB table in `backend/template.yaml`
+- Before adding/modifying an `aws_rds_*` / `aws_dynamodb_table` resource in Terraform
+- Before editing a Prisma schema in a way that will produce a migration
+- Before editing TypeORM / Alembic migration directories
+- Generally: BEFORE the first `Write` on anything the migration-gate hook blocks
+
+## Process
+
+### 1. Resolve the target project
+
+If the user passed `<project>`, use that. Otherwise:
+
+- If cwd is under `<ops_root>/workspace/<project>/`, infer project from the path
+- Otherwise ask explicitly: "Which project is this migration for?"
+
+Look up the project in `apexstack.projects.yaml` to get `repo` (the tracker) and `workspace` (for computing the AgDR path).
+
+If the project isn't registered, stop — file one via `/handover` first, or pass the ticket as a plain ops-level change.
+
+### 2. Gather the migration facts (conversational)
+
+Ask each of the following. Each answer feeds both the issue body and the AgDR — the skill writes them into both so the user never retypes.
+
+1. **One-line summary** — goes in the ticket title: `[Migration] <type>: <summary>`
+2. **Migration type** — `schema | data | sql | orm` (pick one; if it straddles, use the most invasive)
+3. **Affected tables / entities** — comma-separated list. Required non-empty.
+4. **Rollback plan** — free text, required non-empty. Ask "if this goes wrong in prod at 3am, what exactly does the rollback runbook look like?" Capture the actual steps, not a promise to figure it out later.
+5. **Rollback tested against** — `staging | copy of prod | unit fixture | not tested`. If "not tested", flag it in the AgDR and tell the user this is a blocker for prod apply (not for creating the ticket).
+6. **Estimated downtime** — `none | seconds | minutes | hours`. Plus reasoning: "why this much / this little?"
+7. **Cross-service consumers** — list every service that reads or writes the affected tables. If genuinely none, say so (makes review easier).
+8. **Deploy-order constraint** — if any service must deploy before or after this migration, record it.
+9. **Data volume** — rough row/item count. If unknown, note that and add "size check" to the testing plan.
+10. **Testing plan** — dev smoke command, staging verify steps, canary / phased rollout if applicable.
+11. **Observability** — metrics/logs that will confirm success during and after. If the project already has dashboards, link them.
+12. **Priority** — `P0 | P1 | P2 | P3`. Default `P1` for migrations (blast radius).
+
+Re-prompt if rollback plan is empty, affected tables is empty, or priority is missing — these are the three fields with no safe default.
+
+### 3. Preview
+
+Before creating anything, echo back a structured preview so the user can correct mistakes:
+
+```
+Ticket:
+  Tracker:      <owner/repo>
+  Title:        [Migration] <type>: <summary>
+  Labels:       migration, <priority>
+  Body:         (formatted — see below)
+
+AgDR:
+  Path:         docs/agdr/AgDR-NNNN-migration-<slug>.md
+  Next number:  NNNN = max(existing AgDR ids in that dir) + 1
+```
+
+Ask "Create ticket + AgDR? [y/N]". Only proceed on explicit `y`.
+
+### 4. Create the AgDR first (local write, reversible)
+
+Copy `templates/agdr-migration.md` to the resolved path, filling in:
+
+- Frontmatter (`id`, `timestamp`, `agent`, `model`, `trigger: user-prompt`, `status: draft`, `ticket` — left as `TBD` until step 5 creates the issue and we know the number)
+- The title, one-sentence summary, and every Section (Context, Options, Decision, Rollback Plan, Cross-Service Consumers, Testing Plan, Observability, Consequences) with the user's answers
+
+AgDRs are written in the RIGHT repo:
+
+| Where the migration runs | AgDR path |
+|--------------------------|-----------|
+| Inside a managed project's own code repo | `workspace/<project>/docs/agdr/AgDR-NNNN-migration-<slug>.md` |
+| Against the apexstack framework itself (rare — only for framework-level data/config migrations) | `docs/agdr/AgDR-NNNN-migration-<slug>.md` in the ops fork |
+
+For the `NNNN` id: scan the target `docs/agdr/` directory for existing `AgDR-\d+-.*\.md` files, take the max id, increment. Zero-pad to 4 digits.
+
+### 5. Create the GitHub issue
+
+Title: `[Migration] <type>: <summary>`
+
+Labels: `migration` (or whatever the project configures as its migration label — check `.claude/project-config.json` key `migration_label`, default `migration`), plus the priority label (`P0` / `P1` / `P2` / `P3`).
+
+Body (CommonMark, must include a ref to the AgDR so `require-migration-ticket.sh` can verify it):
+
+```markdown
+## Migration
+
+**Type**: <type>
+**Affected tables/entities**: <list>
+**Estimated downtime**: <level> — <reasoning>
+**Data volume**: <count or "unknown">
+**Priority**: <priority>
+
+## Rollback Plan
+
+<rollback plan verbatim>
+
+**Tested against**: <staging | copy of prod | unit fixture | not tested>
+
+## Cross-Service Consumers
+
+<list or "none">
+
+**Deploy-order constraint**: <constraint or "none">
+
+## Testing Plan
+
+- Dev smoke: <command>
+- Staging verify: <steps>
+- Canary / phased rollout: <plan or "n/a">
+
+## Observability
+
+<what to watch during + after>
+
+## Agent Decision Record
+
+Migration AgDR: `<relative-path-to-AgDR>`
+
+---
+
+Created by `/migration`. Do not edit the labels off this issue — the
+migration-gate hook (`require-migration-ticket.sh`) verifies the
+`migration` label is present before allowing edits to migration files.
+```
+
+Create via:
+
+```bash
+gh issue create \
+  --repo "<owner/repo>" \
+  --title "[Migration] <type>: <summary>" \
+  --label "migration" \
+  --label "<priority>" \
+  --body "$BODY"
+```
+
+Capture the returned URL and issue number.
+
+### 6. Back-fill the AgDR with the issue reference
+
+Open the AgDR written in step 4 and update:
+
+- Frontmatter `ticket: <owner/repo>#<number>`
+- The Artifacts section: add the ticket URL
+
+This lets a future reader land on the AgDR and find the ticket, and land on the ticket and find the AgDR.
+
+### 7. Return a summary
+
+Single-line output:
+
+```
+Migration ticket: <ticket-url>
+Migration AgDR:   <relative-path-to-AgDR>
+Next step:        run /start-ticket <owner/repo>#<number>, then begin editing the migration files
+```
+
+**Do NOT automatically run `/start-ticket`** — the user may have other context to set first, and the explicit handoff makes the workflow legible. The migration gate will block edits until the marker points at this ticket.
+
+## Rules
+
+1. **Never ship without a rollback plan**. If the user cannot articulate rollback steps, the migration isn't ready — the skill refuses to create the ticket until they type something in that field.
+2. **Never auto-assign priority**. Migrations span from "trivial schema rename" (P3) to "primary-key column type change on a 100M-row table at peak traffic" (P0). Ask.
+3. **Never skip the AgDR**. Even small migrations get one. If it feels like overkill for a 3-line change, the AgDR entries will be short — that's fine. The value is in the forcing function of thinking through rollback + observability, not in the document length.
+4. **Never create the AgDR under `.claude/` or `docs/` unless the migration IS against apexstack itself**. For managed projects, the AgDR lives inside that project's repo (`workspace/<project>/docs/agdr/`), not in the ops fork.
+5. **Write AgDR first, ticket second, back-fill third** — the AgDR is a local file, reversible with `rm`. The ticket is remote state. If anything errors after the ticket is created, the user has a ghost ticket to clean up; minimise that exposure.
+6. **Tell the user the next step is `/start-ticket`** — the migration-gate hook checks the active ticket has the `migration` label, so they need to declare it before touching migration files.
+
+## Relation to the migration gate
+
+| Hook | `require-migration-ticket.sh` (fires PreToolUse on Write/Edit to migration paths) |
+|------|------------------------------------------------------------------------------------|
+| Gate 1 | Active ticket exists (same as require-active-ticket.sh) |
+| Gate 2 | The active ticket on GitHub has the `migration` label |
+| Gate 3 | The active ticket's body references an AgDR at `docs/agdr/AgDR-\d+-.*migration.*\.md` |
+| Fail message | Points at this skill with the exact invocation to run |
+
+The skill and the gate are two halves of the same mechanism: gate detects the situation and blocks, skill builds the artefacts needed to unblock.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ Template: @templates/agdr.md
 | Technical Design | Planning implementation | `templates/technical-design.md` |
 | ADR | Recording architecture decisions | `templates/adr.md` |
 | AgDR | Recording AI agent decisions | `templates/agdr.md` |
+| Migration AgDR | Recording migration decisions (rollback, downtime, consumers, observability) | `templates/agdr-migration.md` |
 | C4 Context (L1) | System + external actors (one per project) | `templates/architecture/c4-context.md` |
 | C4 Container (L2) | Deployable units inside the system | `templates/architecture/c4-container.md` |
 
@@ -168,13 +169,13 @@ ApexStack ships with a `.claude/` directory containing the Claude Code primitive
 
 | Layer | Path | Purpose |
 |-------|------|---------|
-| Hooks | `.claude/hooks/` | 16 shell scripts that mechanically enforce SDLC rules — ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner |
+| Hooks | `.claude/hooks/` | 17 shell scripts that mechanically enforce SDLC rules — ticket-first, migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner |
 | Rules | `.claude/rules/` | 9 modular rule files (AgDR triggers, code standards, git conventions, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer, Security Reviewer, Dependency Auditor, PR Manager, Ticket Manager) |
-| Skills | `.claude/skills/` | 31 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 32 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (31)
+### Available skills (32)
 
 | Skill | Purpose |
 |-------|---------|
@@ -199,6 +200,7 @@ ApexStack ships with a `.claude/` directory containing the Claude Code primitive
 | `/feature` | Create a structured feature request ticket (user story + ACs) |
 | `/bug` | Create a structured bug report (Given/When/Then + repro + severity) |
 | `/task` | Create a structured technical task ticket (driver + scope + ACs) |
+| `/migration` | Create a labelled migration ticket + migration AgDR in one guided flow (required by the migration gate) |
 | `/idea` | Capture a new product idea to the backlog |
 | `/handover` | Onboard an external repo into ApexStack management (includes per-project discovery) |
 | `/update` | Sync the ops fork with upstream me2resh/apexstack — preview, merge-or-rebase, leaves a sync branch ready to push |

--- a/templates/agdr-migration.md
+++ b/templates/agdr-migration.md
@@ -1,0 +1,73 @@
+# {Short Title}
+
+> In the context of {context}, facing {concern}, I decided to execute {migration type} affecting {tables/entities} to achieve {goal}, accepting {tradeoff}.
+
+**Migration type**: schema | data | sql | orm
+**Affected tables / entities**: {comma-separated}
+**Estimated downtime**: none | seconds | minutes | hours — {reasoning}
+**Data volume**: {rough row/item count, or "unknown"}
+**Target environment(s)**: staging → prod | prod-only | dev-only
+
+## Context
+
+{Why this migration is needed. What changed about the requirements, data model, or external constraints that prompted it. Non-obvious context only — don't re-derive what's already in the ticket.}
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| {option 1} | {pros} | {cons} |
+| {option 2} | {pros} | {cons} |
+
+## Decision
+
+Chosen: **{option}**, because {justification}.
+
+## Rollback Plan
+
+**Explicit rollback steps** — write these out concretely, in order. A migration without a tested rollback is not ready for production.
+
+1. {step one — e.g. "Run `DROP TABLE foo_new` to reverse the split"}
+2. {step two}
+3. {step three}
+
+**Rollback tested against**: {staging | copy of prod | unit fixture | not tested — must fix before shipping}
+**Rollback window**: {how long after apply is rollback safe? e.g. "24h — after that, new-shape writes accumulate and the reverse mapping loses fidelity"}
+
+## Cross-Service Consumers
+
+Every service that reads or writes the affected tables/entities must be coordinated. List them explicitly.
+
+- {service A} — {how it accesses this data, deploy order constraint}
+- {service B} — {…}
+- **none** — {if truly none, say so; this makes review easier}
+
+Deploy-order constraint (if any):
+- {e.g. "backend must deploy before the ETL job picks up the new column"}
+
+## Testing Plan
+
+- **Dev smoke**: {local command / test case that exercises the migration path}
+- **Staging verify**: {steps + expected state change + query to confirm}
+- **Canary / phased rollout**: {if applicable — which slice first, what threshold to proceed}
+
+## Observability
+
+What metrics / logs will confirm the migration succeeded and did not degrade the service?
+
+- **During apply**: {query latency, lock contention, error-rate deltas}
+- **Post-apply**: {business metric that should be unchanged, new metric that should now exist}
+- **Alerts armed**: {specific thresholds on specific dashboards — "p99 answers query > 500ms for 5m"}
+
+## Consequences
+
+- {consequence 1 — e.g. new shape enables feature X}
+- {consequence 2 — e.g. removes option to do Y without another migration}
+- {consequence 3 — e.g. increases cold-start DB size by Z GB}
+
+## Artifacts
+
+- Ticket: {#N in tracker repo}
+- Commits / PRs: {filled in as the migration ships}
+- Staging-run log: {link to CI job or manual run output}
+- Post-apply dashboard snapshot: {link once done}

--- a/templates/agdr-migration.md
+++ b/templates/agdr-migration.md
@@ -43,6 +43,7 @@ Every service that reads or writes the affected tables/entities must be coordina
 - **none** — {if truly none, say so; this makes review easier}
 
 Deploy-order constraint (if any):
+
 - {e.g. "backend must deploy before the ETL job picks up the new column"}
 
 ## Testing Plan

--- a/workflows/sdlc.md
+++ b/workflows/sdlc.md
@@ -145,6 +145,37 @@ RIGHT:
 - Tests written and passing
 - PR created
 
+### Sub-Workflow: Database Migrations
+
+> **Primary role**: [Data Engineer](../roles/data/data-engineer.md) / [Backend Engineer](../roles/engineering/backend-engineer.md) · **Supporting**: [Tech Lead](../roles/engineering/tech-lead.md) (approve blast-radius), [SRE](../roles/engineering/sre.md) (rollback + observability) · **Gate hook**: `require-migration-ticket.sh` · **Skill**: `/migration`
+
+Database migrations (schema / data / SQL / ORM-generated) are a distinct class of Build-phase work. High blast radius — data loss, downtime, lock contention, cross-service coordination — so they get a dedicated ticket + AgDR pair, and edits to migration files are gated until both exist.
+
+Flow:
+
+```
+/migration  →  creates labelled ticket + migration AgDR
+   │
+   └─► /start-ticket <new-ticket>  → activates the migration ticket for this session
+          │
+          └─► Edit migration files  → require-migration-ticket.sh verifies:
+                                        - active ticket has `migration` label
+                                        - ticket body references the AgDR
+                                        - issue is OPEN
+                 │
+                 └─► Dev smoke     (local command / test case)
+                         │
+                         └─► Staging verify  (apply + assert + rollback-tested)
+                                 │
+                                 └─► Prod apply  (rollback runbook ready, dashboards armed)
+                                         │
+                                         └─► QA / Monitor phases (per the main SDLC)
+```
+
+Rollback readiness is checked at the migration-ticket-creation stage, not at PR review — the AgDR forces the author to articulate rollback steps + a tested-against environment before the feature work begins. A migration that only articulates rollback post-hoc during PR review is already too late.
+
+See `.claude/rules/workflow-gates.md` § "Migration Gate (3a)" for the mechanical check, and `.claude/skills/migration/SKILL.md` for the skill's process.
+
 ---
 
 ## Phase 4: Code Review


### PR DESCRIPTION
## Summary

Ships Phase 1 of the migration-gate feature: a new hook that refuses edits to migration files without a labelled migration ticket + linked AgDR, plus the `/migration` skill that produces both artefacts in one guided flow, plus the migration AgDR template.

Three layers:

1. **Hook** (`.claude/hooks/require-migration-ticket.sh`) — PreToolUse on Edit/Write/MultiEdit. On migration-path match, runs three gates: active ticket marker exists, referenced issue is OPEN with `migration` label, issue body references a migration AgDR. Runs **before** `require-active-ticket.sh` so migration-specific messages surface first.

2. **Skill** (`.claude/skills/migration/SKILL.md`) — asks for type / affected tables / rollback plan / downtime / consumers / volume / testing / observability. Writes the AgDR first (reversible local write), then creates the labelled GitHub issue, then back-fills the AgDR with the ticket URL. Tells the user to run `/start-ticket` as the next step — doesn't do it automatically so the handoff stays explicit.

3. **Template** (`templates/agdr-migration.md`) — extends the base AgDR shape with migration-specific sections: explicit Rollback Plan (not buried under Consequences), Cross-Service Consumers, Testing Plan, Observability, plus frontmatter fields for migration type / affected tables / downtime / data volume / target environments.

## Default migration paths (overridable per project via `.claude/project-config.json` → `migration_paths`)

- `**/migrate-*.{ts,js,py,sql}` — one-off migration scripts
- `**/migrations/**` — any file under a migrations/ directory
- `prisma/schema.prisma`, `prisma/migrations/**` — Prisma
- `src/migrations/*.{ts,js}` — TypeORM convention
- `alembic/versions/*.py` — Alembic
- `db/migrate/*.rb` — Rails
- `*.sql` under any `migrations/` subtree

Exempt regardless of pattern: `.claude/`, `docs/`, `projects/*/docs/`, any `*.md`, any `*.example`.

## Docs wiring

- `.claude/rules/workflow-gates.md`: new gate row 3a + dedicated "Migration Gate" section
- `.claude/hooks/README.md`: new section 1a
- `CLAUDE.md`: hook count 16→17, skill count 31→32, template + skill table rows
- `workflows/sdlc.md`: new "Sub-Workflow: Database Migrations" block after Phase 3 showing `/migration` → `/start-ticket` → edit → dev smoke → staging → prod → monitor

## Testing

11 path-matching smoke cases against an isolated `/tmp` mock ops root — all pass:

```
PASS  non-migration *.ts → pass-through
PASS  *.md → pass-through
PASS  .claude/ → pass-through
PASS  *.example → pass-through
PASS  migrate-*.ts, no marker → BLOCK
PASS  migrations/NNN.sql, no marker → BLOCK
PASS  prisma/schema.prisma, no marker → BLOCK
PASS  src/migrations/*.ts, no marker → BLOCK
PASS  alembic/versions/*.py, no marker → BLOCK
PASS  db/migrate/*.rb, no marker → BLOCK
PASS  any file under migrations/, no marker → BLOCK
```

Gates 2 (label check) and 3 (AgDR body ref) require live `gh` calls — verified in real-usage flow: `/migration` → create ticket + AgDR → `/start-ticket` → retry the migration-file edit → hook allows.

## Deferred — issue's Phase 2

`sam validate` / `terraform plan` introspection to auto-detect `AWS::DynamoDB::Table` / `aws_rds_cluster` / `aws_dynamodb_table` additions-or-modifications. Complex, and 80% of the value comes from the path-pattern heuristic + per-project `migration_paths` overrides.

## Glossary

| Term | Definition |
|------|------------|
| migration gate | The three-check PreToolUse hook that refuses migration-file edits without a labelled ticket + AgDR |
| migration path | A file path matching one of the default patterns (or a project-configured pattern) that identifies a database-migration file |
| migration AgDR | An Agent Decision Record that captures rollback plan, downtime, cross-service consumers, testing plan, and observability for a migration — lives at `docs/agdr/AgDR-NNNN-migration-<slug>.md` in the project's repo |
| rollback runbook | The explicit step-by-step sequence to reverse a migration, written at AgDR time (not post-hoc during review) |

## Related

- Closes #59
- Depends on #41 (per-project ticket markers) — the migration hook reuses that resolution
- Complements existing `require-active-ticket.sh` (runs after migration hook; handles non-migration ticket-first enforcement)