### PR TITLE
feat(#73): refresh site/index.html for whole-framework positioning

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1100,9 +1100,9 @@ footer.foot {
       <span class="titlebar__path">~/<b>apexstack</b> <span class="dim">— main · v0.1</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
-      <a href="#tree">tree</a>
       <a href="#layers">layers</a>
-      <a href="#examples">examples</a>
+      <a href="#examples">walkthroughs</a>
+      <a href="#pipelines">pipelines</a>
       <a href="#install">install</a>
       <a href="https://github.com/me2resh/apexstack" class="is-cta" target="_blank" rel="noopener">github →</a>
     </nav>
@@ -1250,239 +1250,58 @@ footer.foot {
 </section>
 
 <!-- ============================================================
-     SECTION 01 — what's in the box (file tree)
-     ============================================================ -->
-<section class="section" id="tree">
-
-  <div class="section__head">
-    <span class="section__num">01 / TREE</span>
-    <h2 class="section__title">What you get when you clone it</h2>
-    <p class="section__lede">
-      The whole stack is plain markdown and shell scripts. No build step, no package install, nothing to compile. Here's the literal directory you get after a fresh clone.
-    </p>
-  </div>
-
-  <div class="tree">
-    <div class="tree__inner">
-      <div class="tree__head">
-        <span>$ tree apexstack</span>
-        <span class="files">the runnable + portfolio layers added in v0.1</span>
-      </div>
-      <div class="tree__body"><span class="dir">apexstack/</span>
-<span class="branch">├──</span> <span class="lf">CLAUDE.md</span>              <span class="nf"># Stack entry point — Claude Code reads this first</span>
-<span class="branch">├──</span> <span class="lf">README.md</span>
-<span class="branch">├──</span> <span class="lf">LICENSE</span>                <span class="nf"># MIT</span>
-<span class="branch">├──</span> <span class="lf">onboarding.yaml</span>        <span class="nf"># Your company config — fill this in to adopt the stack</span>
-<span class="branch">│</span>
-<span class="branch">├──</span> <span class="dir">roles/</span>                 <span class="nf"># 19 role definitions across 5 departments</span>
-<span class="branch">│   ├──</span> <span class="dir">engineering/</span>      <span class="nf"># Head of Eng, Tech Lead, Backend, Frontend, QA, Platform, SRE</span>
-<span class="branch">│   ├──</span> <span class="dir">product/</span>          <span class="nf"># Head of Product, PM, Product Analyst</span>
-<span class="branch">│   ├──</span> <span class="dir">design/</span>           <span class="nf"># Head of Design, UI Designer, UX Designer</span>
-<span class="branch">│   ├──</span> <span class="dir">security/</span>         <span class="nf"># Head of Security, Auditor, Pen Tester</span>
-<span class="branch">│   └──</span> <span class="dir">data/</span>             <span class="nf"># Head of Data, Analyst, Engineer</span>
-<span class="branch">│</span>
-<span class="branch">├──</span> <span class="dir">workflows/</span>             <span class="nf"># 3 process docs</span>
-<span class="branch">│   ├──</span> <span class="lf">sdlc.md</span>           <span class="nf"># Planning → Design → Build → Review → QA → Deploy → Monitor</span>
-<span class="branch">│   ├──</span> <span class="lf">code-review.md</span>
-<span class="branch">│   └──</span> <span class="lf">deployment.md</span>
-<span class="branch">│</span>
-<span class="branch">├──</span> <span class="dir">templates/</span>             <span class="nf"># 7 document templates</span>
-<span class="branch">│   ├──</span> <span class="lf">prd.md</span>
-<span class="branch">│   ├──</span> <span class="lf">technical-design.md</span>
-<span class="branch">│   ├──</span> <span class="lf">adr.md</span>
-<span class="branch">│   ├──</span> <span class="lf">agdr.md</span>           <span class="nf"># Agent Decision Record — AI-specific</span>
-<span class="branch">│   ├──</span> <span class="lf">agdr-migration.md</span> <span class="nf"># Migration AgDR — rollback + downtime + consumers + observability</span>
-<span class="branch">│   └──</span> <span class="dir">architecture/</span>     <span class="nf"># C4 Mermaid diagram templates</span>
-<span class="branch">│       ├──</span> <span class="lf">c4-context.md</span>         <span class="nf"># Level 1 — system + external actors</span>
-<span class="branch">│       └──</span> <span class="lf">c4-container.md</span>       <span class="nf"># Level 2 — deployable units</span>
-<span class="branch">│</span>
-<span class="branch">├──</span> <span class="dir new">.claude/</span>               <span class="nf"># <span class="new">[NEW]</span> Claude Code primitives — the runnable layer</span>
-<span class="branch">│   ├──</span> <span class="lf">settings.json</span>     <span class="nf"># Wires hooks to PreToolUse events</span>
-<span class="branch">│   ├──</span> <span class="dir">hooks/</span>            <span class="nf"># 18 enforcement hooks (ticket-first, migration gate, merge gates, CI, secrets, drift banner…)</span>
-<span class="branch">│   │   ├──</span> <span class="lf">require-active-ticket.sh</span>        <span class="nf"># no edits without an active ticket</span>
-<span class="branch">│   │   ├──</span> <span class="lf">require-migration-ticket.sh</span>     <span class="nf"># migration files need labelled ticket + AgDR</span>
-<span class="branch">│   │   ├──</span> <span class="lf">block-unreviewed-merge.sh</span>       <span class="nf"># Rex + CEO approval markers required</span>
-<span class="branch">│   │   ├──</span> <span class="lf">require-design-review-for-ui.sh</span> <span class="nf"># UI PRs need design-review marker</span>
-<span class="branch">│   │   ├──</span> <span class="lf">block-merge-on-red-ci.sh</span>        <span class="nf"># refuses merge with red CI</span>
-<span class="branch">│   │   ├──</span> <span class="lf">require-agdr-for-arch-changes.sh</span><span class="nf"># arch-path edits need a linked AgDR</span>
-<span class="branch">│   │   ├──</span> <span class="lf">validate-commit-format.sh</span>       <span class="nf"># enforces Conventional Commits</span>
-<span class="branch">│   │   ├──</span> <span class="lf">verify-commit-refs.sh</span>           <span class="nf"># issue refs in commit messages must exist</span>
-<span class="branch">│   │   ├──</span> <span class="lf">validate-pr-create.sh</span>           <span class="nf"># enforces PR title + glossary + ticket</span>
-<span class="branch">│   │   ├──</span> <span class="lf">validate-branch-name.sh</span>         <span class="nf"># enforces feature/&lt;TICKET&gt;-… format</span>
-<span class="branch">│   │   ├──</span> <span class="lf">block-main-push.sh</span>              <span class="nf"># refuses push to main</span>
-<span class="branch">│   │   ├──</span> <span class="lf">block-git-add-all.sh</span>            <span class="nf"># refuses git add -A / .</span>
-<span class="branch">│   │   ├──</span> <span class="lf">check-secrets.sh</span>                <span class="nf"># scans staged files for credentials</span>
-<span class="branch">│   │   ├──</span> <span class="lf">pre-push-gate.sh</span>                <span class="nf"># reminds to lint+typecheck+test+build</span>
-<span class="branch">│   │   ├──</span> <span class="lf">auto-code-review.sh</span>             <span class="nf"># post-PR: prompt to invoke Rex</span>
-<span class="branch">│   │   ├──</span> <span class="lf">suggest-ticket-template.sh</span>      <span class="nf"># gh issue create → suggest /feature, /bug, /task</span>
-<span class="branch">│   │   ├──</span> <span class="lf">check-upstream-drift.sh</span>         <span class="nf"># session-start banner when fork is behind</span>
-<span class="branch">│   │   └──</span> <span class="lf">onboarding-check.sh</span>             <span class="nf"># prompt /setup on a fresh clone</span>
-<span class="branch">│   ├──</span> <span class="dir">rules/</span>            <span class="nf"># 8 modular rule files imported via @-imports</span>
-<span class="branch">│   │   ├──</span> <span class="lf">workflow-gates.md</span>        <span class="nf"># 6-gate model PRD → Done + migration sub-gate</span>
-<span class="branch">│   │   ├──</span> <span class="lf">pr-workflow.md</span>           <span class="nf"># hard stops before push/PR/merge</span>
-<span class="branch">│   │   ├──</span> <span class="lf">pr-quality.md</span>            <span class="nf"># glossary required, SHA verify, design review</span>
-<span class="branch">│   │   ├──</span> <span class="lf">git-conventions.md</span>       <span class="nf"># branch + PR title + commit format</span>
-<span class="branch">│   │   ├──</span> <span class="lf">agdr-decisions.md</span>        <span class="nf"># when to /decide</span>
-<span class="branch">│   │   ├──</span> <span class="lf">code-standards.md</span>        <span class="nf"># TS, DDD, naming, testing</span>
-<span class="branch">│   │   ├──</span> <span class="lf">ticket-vocabulary.md</span>     <span class="nf"># #N reserved for real tracker issues</span>
-<span class="branch">│   │   └──</span> <span class="lf">role-triggers.md</span>        <span class="nf"># which role activates on which signal</span>
-<span class="branch">│   ├──</span> <span class="dir">agents/</span>           <span class="nf"># 5 sub-agents</span>
-<span class="branch">│   │   ├──</span> <span class="lf">code-reviewer.md</span>         <span class="nf"># Rex — reviews PRs against the standards</span>
-<span class="branch">│   │   ├──</span> <span class="lf">security-reviewer.md</span>     <span class="nf"># Shield — OWASP, injection, auth</span>
-<span class="branch">│   │   ├──</span> <span class="lf">dependency-auditor.md</span>    <span class="nf"># Guardian — vulns, outdated, licenses</span>
-<span class="branch">│   │   ├──</span> <span class="lf">pr-manager.md</span>            <span class="nf"># 2-review workflow + SHA verification</span>
-<span class="branch">│   │   └──</span> <span class="lf">ticket-manager.md</span>        <span class="nf"># GitHub Issues per project</span>
-<span class="branch">│   └──</span> <span class="dir">skills/</span>           <span class="nf"># 32 slash commands — see the full list in CLAUDE.md</span>
-<span class="branch">│       ├──</span> <span class="lf">setup/SKILL.md</span>           <span class="nf"># /setup — first-run bootstrap for onboarding.yaml</span>
-<span class="branch">│       ├──</span> <span class="lf">handover/SKILL.md</span>        <span class="nf"># /handover — adopt an external repo + stub L2 C4</span>
-<span class="branch">│       ├──</span> <span class="lf">update/SKILL.md</span>          <span class="nf"># /update — sync ops fork with upstream apexstack</span>
-<span class="branch">│       ├──</span> <span class="lf">start-ticket/SKILL.md</span>    <span class="nf"># /start-ticket — activate ticket for this session</span>
-<span class="branch">│       ├──</span> <span class="lf">approve-merge/SKILL.md</span>   <span class="nf"># /approve-merge — per-PR CEO approval</span>
-<span class="branch">│       ├──</span> <span class="lf">approve-design/SKILL.md</span>  <span class="nf"># /approve-design — per-PR UI approval</span>
-<span class="branch">│       ├──</span> <span class="lf">migration/SKILL.md</span>       <span class="nf"># /migration — labelled ticket + migration AgDR</span>
-<span class="branch">│       ├──</span> <span class="lf">decide/SKILL.md</span>          <span class="nf"># /decide — create an AgDR for a technical decision</span>
-<span class="branch">│       ├──</span> <span class="lf">feature/SKILL.md</span>         <span class="nf"># /feature — structured feature ticket</span>
-<span class="branch">│       ├──</span> <span class="lf">bug/SKILL.md</span>             <span class="nf"># /bug — structured bug ticket</span>
-<span class="branch">│       ├──</span> <span class="lf">task/SKILL.md</span>            <span class="nf"># /task — structured technical-task ticket</span>
-<span class="branch">│       ├──</span> <span class="lf">write-spec/SKILL.md</span>      <span class="nf"># /write-spec — generate a PRD</span>
-<span class="branch">│       ├──</span> <span class="lf">idea/SKILL.md</span>            <span class="nf"># /idea — capture a new idea to the backlog</span>
-<span class="branch">│       ├──</span> <span class="lf">code-review/SKILL.md</span>     <span class="nf"># /code-review — invoke Rex</span>
-<span class="branch">│       ├──</span> <span class="lf">security-review/SKILL.md</span> <span class="nf"># /security-review — invoke Shield</span>
-<span class="branch">│       ├──</span> <span class="lf">audit-deps/SKILL.md</span>      <span class="nf"># /audit-deps — Guardian vuln + license scan</span>
-<span class="branch">│       ├──</span> <span class="lf">launch-check/SKILL.md</span>    <span class="nf"># /launch-check — 8-dimension production-readiness audit</span>
-<span class="branch">│       ├──</span> <span class="lf">threat-model/SKILL.md</span>    <span class="nf"># /threat-model — STRIDE deep-dive</span>
-<span class="branch">│       ├──</span> <span class="lf">accessibility-audit/SKILL.md</span> <span class="nf"># /accessibility-audit — WCAG 2.1 AA</span>
-<span class="branch">│       ├──</span> <span class="lf">compliance-check/SKILL.md</span> <span class="nf"># /compliance-check — GDPR + ePrivacy</span>
-<span class="branch">│       ├──</span> <span class="lf">analytics-audit/SKILL.md</span>  <span class="nf"># /analytics-audit — event taxonomy</span>
-<span class="branch">│       ├──</span> <span class="lf">seo-audit/SKILL.md</span>        <span class="nf"># /seo-audit — meta, sitemap, structured data</span>
-<span class="branch">│       ├──</span> <span class="lf">performance-audit/SKILL.md</span> <span class="nf"># /performance-audit — bundle + Core Web Vitals</span>
-<span class="branch">│       ├──</span> <span class="lf">monitoring-audit/SKILL.md</span> <span class="nf"># /monitoring-audit — error tracking + runbooks</span>
-<span class="branch">│       ├──</span> <span class="lf">docs-audit/SKILL.md</span>      <span class="nf"># /docs-audit — Diataxis completeness</span>
-<span class="branch">│       ├──</span> <span class="lf">projects/SKILL.md</span>        <span class="nf"># /projects — list managed projects + status</span>
-<span class="branch">│       ├──</span> <span class="lf">status/SKILL.md</span>          <span class="nf"># /status — git + CI snapshot per project</span>
-<span class="branch">│       ├──</span> <span class="lf">inbox/SKILL.md</span>           <span class="nf"># /inbox — PRs/issues needing attention across portfolio</span>
-<span class="branch">│       ├──</span> <span class="lf">tasks/SKILL.md</span>           <span class="nf"># /tasks — prioritised task list with URLs</span>
-<span class="branch">│       ├──</span> <span class="lf">roadmap/SKILL.md</span>         <span class="nf"># /roadmap — per-project milestones</span>
-<span class="branch">│       └──</span> <span class="lf">stakeholder-update/SKILL.md</span> <span class="nf"># /stakeholder-update — weekly/monthly/launch</span>
-<span class="branch">│</span>
-<span class="branch">├──</span> <span class="dir new">workspace/</span>             <span class="nf"># <span class="new">[NEW]</span> Live local clones of managed projects (gitignored)</span>
-<span class="branch">│   └──</span> <span class="lf">README.md</span>          <span class="nf"># Convention: workspace/&lt;name&gt;/ holds each repo's working copy</span>
-<span class="branch">│</span>
-<span class="branch">├──</span> <span class="dir new">projects/</span>              <span class="nf"># <span class="new">[NEW]</span> Per-project committed docs (README, roadmap, AgDRs, updates)</span>
-<span class="branch">│   ├──</span> <span class="lf">README.md</span>          <span class="nf"># Convention: projects/&lt;name&gt;/ holds README, roadmap, AgDRs, handover</span>
-<span class="branch">│   └──</span> <span class="lf">ideas-backlog.md</span>   <span class="nf"># Shared idea backlog (created by /idea on first use)</span>
-<span class="branch">│</span>
-<span class="branch">├──</span> <span class="lf new">apexstack.projects.yaml.example</span>  <span class="nf"># <span class="new">[NEW]</span> Portfolio registry template — copy and edit</span>
-<span class="branch">│</span>
-<span class="branch">├──</span> <span class="dir new">golden-paths/</span>          <span class="nf"># <span class="new">[NEW]</span> Reusable infra & ops templates</span>
-<span class="branch">│   └──</span> <span class="dir">pipelines/</span>        <span class="nf"># 7 drop-in GitHub Actions workflows</span>
-<span class="branch">│       ├──</span> <span class="lf">ci.yml</span>               <span class="nf"># combined: code quality + security + deps</span>
-<span class="branch">│       ├──</span> <span class="lf">code-quality.yml</span>     <span class="nf"># Rex — TS, ESLint, tests, build</span>
-<span class="branch">│       ├──</span> <span class="lf">security.yml</span>         <span class="nf"># Shield — Semgrep + npm audit + secrets</span>
-<span class="branch">│       ├──</span> <span class="lf">dependency-audit.yml</span> <span class="nf"># Guardian — weekly</span>
-<span class="branch">│       ├──</span> <span class="lf">pr-title-check.yml</span>   <span class="nf"># enforces ticket ID in PR titles</span>
-<span class="branch">│       ├──</span> <span class="lf">review-check.yml</span>     <span class="nf"># blocks merge if Rex hasn't reviewed HEAD</span>
-<span class="branch">│       ├──</span> <span class="lf">seo-check.yml</span>        <span class="nf"># SEO scoring for content files</span>
-<span class="branch">│       └──</span> <span class="lf">README.md</span>
-<span class="branch">│</span>
-<span class="branch">├──</span> <span class="dir">docs/</span>
-<span class="branch">│   ├──</span> <span class="lf">getting-started.md</span>
-<span class="branch">│   └──</span> <span class="lf new">multi-project.md</span>     <span class="nf"># <span class="new">[NEW]</span> Full setup guide — fork flow, daily workflow, FAQ</span>
-<span class="branch">│</span>
-<span class="branch">└──</span> <span class="dir">site/</span>                  <span class="nf"># this page</span>
-    <span class="branch">└──</span> <span class="lf">index.html</span>
-</div>
-    </div>
-  </div>
-
-</section>
-
-<!-- ============================================================
-     SECTION 02 — the four layers
+     SECTION 01 — the five layers
      ============================================================ -->
 <section class="section section--alt" id="layers">
 
   <div class="section__head">
-    <span class="section__num">02 / LAYERS</span>
+    <span class="section__num">01 / LAYERS</span>
     <h2 class="section__title">Five layers, one stack</h2>
     <p class="section__lede">
-      ApexStack is built around managing a <em>portfolio</em> of projects, not a single repo. Five layers stack together: roles, workflows + templates, hooks + rules, agents + skills, and the workspace itself — a registry of every repo under your org's care. There's no single-project fallback; even if you only have one repo to manage, you register it and every layer works the same.
+      Five layers stack together: roles, workflows, hooks, skills, and the portfolio registry itself. Even with one repo, every layer works the same.
     </p>
   </div>
 
   <div class="layers">
 
     <article class="layer">
-      <div class="layer__num">01 — passive · markdown</div>
+      <div class="layer__num">01 — roles</div>
       <h3 class="layer__title">Roles</h3>
       <p class="layer__desc">
-        19 software roles across 5 departments. Each role has identity, responsibilities, capabilities, boundaries, interfaces, and a checklist. Tell Claude "act as the QA Engineer" and it picks up the full mental model.
+        19 role definitions across 5 departments. Activation-triggered with CAN / CANNOT boundaries. "Act as the QA Engineer" picks up the full mental model.
       </p>
-      <ul class="layer__list">
-        <li><code>engineering/</code><span>7 roles — Head, TL, BE, FE, QA, Platform, SRE</span></li>
-        <li><code>product/</code><span>3 roles — Head, PM, Analyst</span></li>
-        <li><code>design/</code><span>3 roles — Head, UI, UX</span></li>
-        <li><code>security/</code><span>3 roles — Head, Auditor, Pen Tester</span></li>
-        <li><code>data/</code><span>3 roles — Head, Analyst, Engineer</span></li>
-      </ul>
     </article>
 
     <article class="layer">
-      <div class="layer__num">02 — passive · markdown</div>
+      <div class="layer__num">02 — workflows + templates</div>
       <h3 class="layer__title">Workflows + templates</h3>
       <p class="layer__desc">
-        Three workflow processes (full SDLC, code review, deployment) and seven document templates including C4 Mermaid diagrams and the migration AgDR. Drop them into your <code>docs/</code>, ship faster.
+        7-phase SDLC, code review, deployment. Seven templates — PRD, tech design, ADR, AgDR, migration AgDR, C4 L1 + L2.
       </p>
-      <ul class="layer__list">
-        <li><code>sdlc.md</code><span>7-phase lifecycle with quality gates + migration sub-flow</span></li>
-        <li><code>code-review.md</code><span>structured author + reviewer process</span></li>
-        <li><code>deployment.md</code><span>staging → prod with rollback</span></li>
-        <li><code>prd.md</code> · <code>adr.md</code> · <code>agdr.md</code><span>PRD, architecture + agent decision records</span></li>
-        <li><code>agdr-migration.md</code><span>migration-specific AgDR — rollback, downtime, consumers</span></li>
-        <li><code>architecture/c4-*.md</code><span>L1 context + L2 container Mermaid diagrams</span></li>
-      </ul>
     </article>
 
     <article class="layer">
-      <div class="layer__num">03 — runnable · executable</div>
+      <div class="layer__num">03 — hooks + rules</div>
       <h3 class="layer__title">Hooks + rules</h3>
       <p class="layer__desc">
-        18 shell hooks mechanically enforce the SDLC on every tool call — ticket-first gates (generic + migration-specific), auto code review, two-marker merge gates (Rex + CEO), design review for UI, red-CI blocking, commit format validation, AgDR requirements for architecture changes, and a session-start drift banner when the fork is behind upstream. Eight modular rule files import via <code>@-imports</code>. A <code>/launch-check</code> skill runs an 8-dimension production-readiness audit at milestone boundaries.
+        18 shell hooks enforce the SDLC mechanically: ticket-first, migration gate, two-marker merge gates (Rex + CEO), design review, red-CI block, upstream drift banner. Eight modular rule files.
       </p>
-      <ul class="layer__list">
-        <li><code>hooks/</code><span>ticket-first · migration gate · merge gates · secrets · drift banner</span></li>
-        <li><code>rules/</code><span>AgDR triggers, code standards, PR quality, gates, ticket vocabulary</span></li>
-        <li><code>settings.json</code><span>wires hooks to PreToolUse / PostToolUse / SessionStart events</span></li>
-      </ul>
     </article>
 
     <article class="layer">
-      <div class="layer__num">04 — runnable · invokable</div>
+      <div class="layer__num">04 — agents + skills</div>
       <h3 class="layer__title">Agents + skills</h3>
       <p class="layer__desc">
-        Five sub-agents with their own model, prompt, and tool access. 32 slash commands users type into Claude Code — covering the full SDLC (/idea → /write-spec → /decide → /start-ticket → /code-review → /approve-merge), portfolio rollups (/inbox, /status, /tasks), adoption (/handover with stub L2 C4), and 8 deep-dive audits triggered by /launch-check.
+        Five sub-agents (Rex, Shield, Guardian, PR Manager, Ticket Manager). 32 slash commands covering SDLC, portfolio rollups, adoption, and an 8-dimension <code>/launch-check</code>.
       </p>
-      <ul class="layer__list">
-        <li><code>agents/</code><span>Rex · Shield · Guardian · PR Manager · Ticket Manager</span></li>
-        <li><code>skills/</code> · SDLC<span>/idea · /write-spec · /decide · /start-ticket · /approve-merge · /approve-design · /code-review · /security-review · /audit-deps</span></li>
-        <li><code>skills/</code> · portfolio<span>/projects · /inbox · /status · /tasks · /roadmap · /stakeholder-update · /handover · /update</span></li>
-        <li><code>skills/</code> · audits<span>/launch-check · /threat-model · /accessibility-audit · /compliance-check · /analytics-audit · /seo-audit · /performance-audit · /monitoring-audit · /docs-audit</span></li>
-        <li><code>skills/</code> · tickets<span>/feature · /bug · /task · /migration</span></li>
-      </ul>
     </article>
 
     <article class="layer layer--wide" style="grid-column: 1 / -1;">
-      <div class="layer__num">05 — workspace · portfolio registry <span class="new">NEW</span></div>
+      <div class="layer__num">05 — portfolio</div>
       <h3 class="layer__title">A portfolio, not a single repo</h3>
       <p class="layer__desc">
-        Your ops repo is a <strong>fork of apexstack</strong>. At its root sits <code>apexstack.projects.yaml</code> — the registry that lists every project under management. Every portfolio skill (<code>/projects</code>, <code>/inbox</code>, <code>/status</code>, <code>/tasks</code>, <code>/handover</code>, <code>/stakeholder-update</code>) aggregates across the registry. <code>projects/&lt;name&gt;/</code> holds committed per-project docs; <code>workspace/&lt;name&gt;/</code> (gitignored) holds live local clones.
+        Your ops repo is a <strong>fork of apexstack</strong>. <code>apexstack.projects.yaml</code> at the root is the registry. Every portfolio skill — <code>/projects</code>, <code>/inbox</code>, <code>/status</code>, <code>/tasks</code>, <code>/stakeholder-update</code> — aggregates across it. One fork, N products, one inbox.
       </p>
-      <ul class="layer__list">
-        <li><code>apexstack.projects.yaml</code><span>registry — name, repo, workspace path, docs path, status, roles</span></li>
-        <li><code>projects/&lt;name&gt;/</code><span>committed docs per project (README, roadmap, AgDRs, updates)</span></li>
-        <li><code>workspace/&lt;name&gt;/</code><span>gitignored local clones — your daily working copies</span></li>
-        <li><code>docs/multi-project.md</code><span>full setup guide — fork flow, daily workflow, FAQ</span></li>
-      </ul>
     </article>
 
   </div>
@@ -1490,15 +1309,15 @@ footer.foot {
 </section>
 
 <!-- ============================================================
-     SECTION 03 — show, don't tell
+     SECTION 02 — walkthroughs
      ============================================================ -->
 <section class="section" id="examples">
 
   <div class="section__head">
-    <span class="section__num">03 / WALKTHROUGHS</span>
+    <span class="section__num">02 / WALKTHROUGHS</span>
     <h2 class="section__title">What it actually feels like to use</h2>
     <p class="section__lede">
-      Three flows that span the framework — one for a feature, one for the portfolio, one for a risky change. Each starts with the pain a solo CTO actually feels, then shows the exact sequence of skills, hooks, and agents that remove it. Composite examples drawn from real sessions.
+      Three flows — one for a feature, one for the portfolio, one for a risky change. Each starts with a specific pain and ends with the exact gates that handled it.
     </p>
   </div>
 
@@ -1506,144 +1325,81 @@ footer.foot {
 
     <article class="demo">
       <div class="demo__head">
-        <span><span class="label">01 — FEATURE</span> from idea to production</span>
-        <span>SDLC pipeline</span>
+        <span><span class="label">01 — FEATURE</span> idea to production</span>
+        <span>full SDLC</span>
       </div>
-      <pre class="demo__body"><span class="muted"># "I have an idea. I want it shipped without forgetting any step."</span>
+      <pre class="demo__body"><span class="muted"># "I have an idea. Ship it without forgetting a step."</span>
 
-<span class="you">› /idea personal-dashboard feed of user's own trending answers</span>
-<span class="ok">  ✓ appended to projects/ideas-backlog.md</span>
+<span class="you">› /idea  →  /write-spec  →  /decide</span>
+<span class="ok">  ideas-backlog.md · PRD-0012 · AgDR-0021</span>
 
-<span class="you">› /write-spec trending-answers-feed</span>
-<span class="ai">  Created docs/prds/PRD-0012-trending-answers-feed.md
-  (problem, target user, goals, non-goals, success metrics)</span>
+<span class="you">› /start-ticket 178     <span class="muted">(labels the session)</span></span>
+<span class="muted"># code, tests, push…</span>
 
-<span class="you">› /decide react-query vs swr for the feed</span>
-<span class="ai">  Decision: react-query (better TS inference, infinite-query,
-            team experience)
-  Created docs/agdr/AgDR-0021-dashboard-data-fetching.md</span>
+<span class="you">› gh pr create</span>
+<span class="ag">  auto-code-review.sh: "Rex REQUIRED before merge"</span>
 
-<span class="you">› gh issue create --title "[Feature] trending-answers feed"
-  ...  → #178</span>
-<span class="you">› /start-ticket 178</span>
-<span class="ok">  ✓ Active ticket: your-org/curios-dog#178
-  ✓ marker: .claude/session/tickets/curios-dog</span>
+<span class="you">› invoke Rex on PR #178</span>
+<span class="ok">  APPROVED at c8b736f · marker written</span>
 
-<span class="muted"># code, tests, push …</span>
-
-<span class="you">› gh pr create --title "feat(#178): trending-answers feed"</span>
-<span class="ag">  PostToolUse: auto-code-review.sh reminds:
-    "Rex REQUIRED before any merge"</span>
-
-<span class="you">› invoke the code-reviewer agent on PR #178</span>
-<span class="ag">  Rex reviewing c8b736f…
-    ✓ architecture clean · 94% coverage
-    ✓ AgDR-0021 linked · glossary 5 terms
-  Verdict: <span class="ok">APPROVED</span> — marker written at c8b736f</span>
-
-<span class="you">› <span class="muted">(CEO looks at diff)</span> /approve-merge 178</span>
-<span class="ok">  CEO marker recorded at c8b736f.
-  Run: gh pr merge 178</span>
-
-<span class="you">› gh pr merge 178 --squash --delete-branch</span>
-<span class="ok">  ✓ merged · #178 → QA state (NOT Done)
-  ✓ QA Engineer role activated on `qa` label</span></pre>
-      <div class="demo__caption"><strong>Hit:</strong> 8 skills · 2 agents · 4 hooks · 1 AgDR · 1 PRD. The entry point is <code>/idea</code>; the exit is a PR merged with two independent approvals (Rex + CEO) both SHA-bound. Nothing can short-circuit — the marker-based merge gate is a shell hook, not a social convention.</div>
+<span class="you">› /approve-merge 178     <span class="muted">(per-PR CEO nod)</span></span>
+<span class="you">› gh pr merge 178</span>
+<span class="ok">  ✓ merged · #178 → QA state, not Done yet</span></pre>
+      <div class="demo__caption">One trail: 6 skills · 2 agents · 4 hooks · 1 AgDR · 1 PRD. Two independent approvals (Rex + CEO), both SHA-bound. The marker-based merge gate is a shell hook, not a social convention.</div>
     </article>
 
     <article class="demo">
       <div class="demo__head">
-        <span><span class="label">02 — PORTFOLIO</span> running 5 products from one inbox</span>
+        <span><span class="label">02 — PORTFOLIO</span> 5 products, 1 inbox</span>
         <span>cross-project</span>
       </div>
-      <pre class="demo__body"><span class="muted"># "I run 4 products + 1 side project. Where do I look first on Monday?"</span>
+      <pre class="demo__body"><span class="muted"># "Monday. Where do I look first?"</span>
 
-<span class="you">› cd ~/apexstack     <span class="muted">(the ops fork)</span></span>
-<span class="ag">  SessionStart: check-upstream-drift.sh
-    ApexStack: 3 commits behind upstream/main.
-               Run /update to sync.</span>
+<span class="you">› cd ~/apexstack</span>
+<span class="ag">  ApexStack: 3 commits behind upstream/main.
+             Run /update to sync.</span>
 
 <span class="you">› /inbox</span>
-<span class="ai">  curios-dog        · 2 PRs awaiting Rex, 1 design review
-  billing-api       · 1 CEO approval pending · #203
-  sharppick         · stale PR #89 (14 days)
-  marketing-site    · all clear
-  internal-tools    · 1 P1 bug · #42, unassigned</span>
+<span class="ai">  curios-dog     · 2 PRs awaiting Rex
+  billing-api    · CEO approval pending · #203
+  sharppick      · stale PR #89 (14 days)
+  marketing-site · clear
+  internal-tools · 1 P1 bug · unassigned</span>
 
-<span class="you">› /status</span>
-<span class="ai">  curios-dog        · main · CI green · 2 PRs, 8 open issues
-  billing-api       · main · CI RED (test regression)
-  sharppick         · feature/search · CI pending · 1 PR
-  marketing-site    · main · CI green · 0 PRs
-  internal-tools    · main · CI green · 5 open issues</span>
-
-<span class="you">› /start-ticket me2resh/billing-api#203</span>
-<span class="you">› cd workspace/billing-api    <span class="muted">(editing the red-CI branch)</span></span>
-<span class="muted"># fix the regression, re-push, green …</span>
-
-<span class="you">› /approve-merge 203</span>
-<span class="ok">  CEO marker at a0b3c1d.  Run: gh pr merge 203</span>
-
-<span class="muted"># Friday afternoon …</span>
+<span class="muted"># Friday afternoon…</span>
 
 <span class="you">› /stakeholder-update weekly</span>
-<span class="ai">  Drafted projects/updates/2026-04-17-weekly.md
-    curios-dog   → 3 PRs merged, 1 launched feature
-    billing-api  → stabilisation week, 4 bugfix PRs
-    sharppick    → paused pending design review
-    marketing-site → no activity (intentional)
-  Ready to send?</span></pre>
-      <div class="demo__caption"><strong>Hit:</strong> 6 skills · 1 hook · 1 registry (<code>apexstack.projects.yaml</code>) · 5 products surfaced from one prompt. The portfolio isn't a view on top of separate repos — it's the registry. Every rollup skill reads from it. Switching projects is a <code>cd</code>; the per-project ticket marker remembers where you were.</div>
+<span class="ok">  Drafted projects/updates/2026-04-17.md
+  — rollup across all 5 projects</span></pre>
+      <div class="demo__caption">6 skills read one registry file. Five products surface from a single prompt. Portfolio isn't a view on top of separate repos — it IS the registry.</div>
     </article>
 
     <article class="demo">
       <div class="demo__head">
-        <span><span class="label">03 — TRUST</span> when something risky comes up</span>
+        <span><span class="label">03 — TRUST</span> risky change, 5pm Friday</span>
         <span>migration gate</span>
       </div>
-      <pre class="demo__body"><span class="muted"># "I just want to drop a column. It's Friday 5pm."</span>
+      <pre class="demo__body"><span class="muted"># "Just drop a column. Can't be that hard."</span>
 
-<span class="you">› edit prisma/schema.prisma     <span class="muted">(remove `deprecatedField`)</span></span>
-<span class="blk">BLOCKED:</span> No active ticket set — and this file
-looks like a database migration.
-<span class="ag">  hook: .claude/hooks/require-migration-ticket.sh
-  path matched: prisma/schema.prisma</span>
-
-Migrations need a dedicated labelled ticket + AgDR,
-not just any ticket. Run:
-
-  /migration curios-dog
+<span class="you">› edit prisma/schema.prisma</span>
+<span class="blk">BLOCKED:</span> migration files need a labelled ticket
+<span class="ag">  hook: require-migration-ticket.sh</span>
 
 <span class="you">› /migration curios-dog</span>
-<span class="ai">  Migration type?          schema
-  Affected tables?         user_profiles
-  Rollback plan?           <span class="muted">(required — not empty)</span></span>
-<span class="you">  ADD COLUMN deprecatedField on rollback,
-  backfill from user_profiles_archive.field</span>
-<span class="ai">  Rollback tested against? staging
-  Estimated downtime?      none (nullable column)
-  Cross-service consumers? analytics ETL (reads user_profiles nightly)
-  Data volume?             ~12M rows
-  Observability?           p99 query latency · row-count delta</span>
+<span class="ai">  → rollback plan? (required, non-empty)
+  → estimated downtime?
+  → cross-service consumers?
+  → data volume?
+  → observability?</span>
+<span class="ok">  ✓ AgDR-0047 · issue #214 labelled `migration`
+  ✓ body refs AgDR — gate 3 satisfied</span>
 
-<span class="ok">  ✓ AgDR-0047-migration-drop-deprecated-field.md
-  ✓ Issue #214 created with labels: migration, P2
-  ✓ Body references the AgDR — gate 3 satisfied
+<span class="you">› /start-ticket #214 · retry the edit</span>
+<span class="ok">  ✓ all 3 gates pass · edit allowed</span>
 
-Next: /start-ticket me2resh/curios-dog#214,
-      then edit the schema.</span>
-
-<span class="you">› /start-ticket me2resh/curios-dog#214</span>
-<span class="you">› edit prisma/schema.prisma     <span class="muted">(retry)</span></span>
-<span class="ok">  ✓ gate 1: active ticket marker exists
-  ✓ gate 2: ticket OPEN + label `migration`
-  ✓ gate 3: body references AgDR-0047
-  ✓ edit allowed</span>
-
-<span class="ag">Rex on the PR: "rollback plan references analytics ETL.
-Confirm ETL can skip the missing column safely — flag for
-review before merge."  CEO: defer to Monday morning.</span></pre>
-      <div class="demo__caption"><strong>Hit:</strong> 3 hooks (migration gate, marker check, Rex-required) · 2 skills · 1 AgDR · 1 ticket — all before a single schema byte was written. The point isn't to slow you down. It's that the questions that would otherwise surface at 2am during a rollback are forced upfront, when your team is awake and rollback is cheap.</div>
+<span class="ag">Rex: "analytics ETL reads user_profiles nightly —
+confirm it skips the missing column before merge."</span></pre>
+      <div class="demo__caption">3 hooks, 2 skills, 1 AgDR — all before a single byte of schema changed. Questions that would surface at 2am during rollback get forced upfront, when your team is awake.</div>
     </article>
 
   </div>
@@ -1651,12 +1407,12 @@ review before merge."  CEO: defer to Monday morning.</span></pre>
 </section>
 
 <!-- ============================================================
-     SECTION 04 — pipelines
+     SECTION 03 — pipelines
      ============================================================ -->
 <section class="section section--alt" id="pipelines">
 
   <div class="section__head">
-    <span class="section__num">04 / PIPELINES</span>
+    <span class="section__num">03 / PIPELINES</span>
     <h2 class="section__title">Drop-in CI workflows</h2>
     <p class="section__lede">
       Seven GitHub Actions workflows live at <code>golden-paths/pipelines/</code>. Copy whichever you want into your project's <code>.github/workflows/</code> — no boilerplate to write, no configuration to wrestle with.
@@ -1714,69 +1470,45 @@ review before merge."  CEO: defer to Monday morning.</span></pre>
 </section>
 
 <!-- ============================================================
-     SECTION 05 — install
+     SECTION 04 — install
      ============================================================ -->
 <section class="section" id="install">
 
   <div class="section__head">
-    <span class="section__num">05 / INSTALL</span>
-    <h2 class="section__title">Fork, clone, register — five steps</h2>
+    <span class="section__num">04 / INSTALL</span>
+    <h2 class="section__title">Fork, track upstream, start working</h2>
     <p class="section__lede">
-      Your ops repo is a fork of apexstack. The fork <strong>is</strong> your ops repo — no nested installs, no symlinks, no separate folder to maintain. Star + fork on GitHub, clone the fork, fill in the registry, start working.
+      Three steps. The fork <strong>is</strong> your ops repo — no nested installs, no symlinks. Config (<code>onboarding.yaml</code>) and the registry (<code>apexstack.projects.yaml</code>) are handled by <code>/setup</code> and <code>/handover</code> from inside Claude Code — you never open them by hand.
     </p>
   </div>
 
   <div class="steps">
 
     <article class="step">
-      <div class="step__num">01 — star + fork</div>
+      <div class="step__num">01 — fork + clone</div>
       <h3 class="step__title">Fork apexstack on GitHub</h3>
-      <p class="step__desc">Visit <a href="https://github.com/me2resh/apexstack" class="uline" target="_blank" rel="noopener">github.com/me2resh/apexstack</a>, click <strong>Star</strong>, then <strong>Fork</strong>. Rename the fork if you want — <code>your-org/ops</code> or <code>your-org/apex</code> both work. GitHub handles the rename cleanly.</p>
-      <pre class="step__code"><span class="cm"># one command via the GitHub CLI — forks and clones in one step</span>
-gh repo fork me2resh/apexstack --clone
+      <p class="step__desc">Star + fork on GitHub, or one-command via the GitHub CLI. Rename the fork to <code>your-org/ops</code> if you prefer — GitHub handles the rename cleanly.</p>
+      <pre class="step__code">gh repo fork me2resh/apexstack --clone
 cd apexstack</pre>
     </article>
 
     <article class="step">
-      <div class="step__num">02 — upstream remote</div>
-      <h3 class="step__title">Track upstream for updates</h3>
-      <p class="step__desc">Add the upstream remote once. The session-start drift banner then tells you when you're behind, and <code>/update</code> does the sync-branch-and-PR dance for you. No proprietary upgrade tool.</p>
-      <pre class="step__code"><span class="cm"># in your fork</span>
-git remote add upstream \
-  https://github.com/me2resh/apexstack.git
-
-<span class="cm"># later, when the drift banner says you're behind:</span>
-<span class="acc">/update</span>              <span class="cm"># preview + sync branch + PR body, all in one</span></pre>
+      <div class="step__num">02 — track upstream</div>
+      <h3 class="step__title">Add the upstream remote</h3>
+      <p class="step__desc">Once. The session-start drift banner tells you when you're behind; <code>/update</code> does the sync-branch-and-PR dance for you.</p>
+      <pre class="step__code">git remote add upstream \
+  https://github.com/me2resh/apexstack.git</pre>
     </article>
 
     <article class="step">
-      <div class="step__num">03 — configure</div>
-      <h3 class="step__title">Fill in onboarding.yaml</h3>
-      <p class="step__desc">Tell ApexStack about your team — company, roles, tech stack, quality bar. Defaults are sensible; edit what matters.</p>
-      <pre class="step__code"><span class="cm"># in your fork root</span>
-$EDITOR onboarding.yaml</pre>
-    </article>
-
-    <article class="step">
-      <div class="step__num">04 — list your projects</div>
-      <h3 class="step__title">Create the portfolio registry</h3>
-      <p class="step__desc">Copy the example registry and list every repo you want under ApexStack management. Even one project counts — the skills work the same whether you have 1 or 20. Add more as you bring them under management.</p>
-      <pre class="step__code"><span class="cm"># in your fork root</span>
-cp apexstack.projects.yaml.example \
-   apexstack.projects.yaml
-$EDITOR apexstack.projects.yaml  <span class="cm"># list your repos</span></pre>
-    </article>
-
-    <article class="step">
-      <div class="step__num">05 — start working</div>
-      <h3 class="step__title">Try a portfolio command</h3>
-      <p class="step__desc">Open Claude Code in your fork. The portfolio skills, hooks, agents, and rules are all loaded automatically — no symlinks, no wiring. The <code>CLAUDE.md</code> at the fork root is the entry point Claude Code reads first.</p>
-      <pre class="step__code"><span class="cm"># in claude code, from the fork root</span>
-<span class="acc">/projects</span>          <span class="cm"># list every managed project + status</span>
+      <div class="step__num">03 — start working</div>
+      <h3 class="step__title">Open Claude Code in the fork</h3>
+      <p class="step__desc">Everything loads automatically — <code>CLAUDE.md</code> is the entry point. Run <code>/setup</code> once to configure your company + stack, <code>/handover &lt;repo&gt;</code> to bring each project under management, then reach for the portfolio skills.</p>
+      <pre class="step__code"><span class="acc">/setup</span>             <span class="cm"># one-time — company + tech stack → onboarding.yaml</span>
+<span class="acc">/handover</span> &lt;repo&gt;   <span class="cm"># adopt a project → registry + stub L2 C4 diagram</span>
 <span class="acc">/inbox</span>             <span class="cm"># PRs, issues, comments needing your eyes</span>
 <span class="acc">/status</span>            <span class="cm"># git + CI snapshot per project</span>
-<span class="acc">/handover</span> acquired-repo   <span class="cm"># adopt an external repo + stub L2 C4</span>
-<span class="acc">/launch-check</span>     <span class="cm"># 8-dimension production-readiness audit</span></pre>
+<span class="acc">/launch-check</span>      <span class="cm"># 8-dimension production-readiness audit</span></pre>
     </article>
 
   </div>
@@ -1784,12 +1516,12 @@ $EDITOR apexstack.projects.yaml  <span class="cm"># list your repos</span></pre>
 </section>
 
 <!-- ============================================================
-     SECTION 06 — what apexstack is and isn't
+     SECTION 05 — what apexstack is and isn't
      ============================================================ -->
 <section class="section section--alt">
 
   <div class="section__head">
-    <span class="section__num">06 / SCOPE</span>
+    <span class="section__num">05 / SCOPE</span>
     <h2 class="section__title">Opinionated by design</h2>
     <p class="section__lede">
       Every reusable framework has to draw a line between "this is what we do" and "this is yours to figure out". ApexStack draws the line where it makes the most difference for engineering teams.

--- a/site/index.html
+++ b/site/index.html
@@ -1135,7 +1135,7 @@ footer.foot {
     </p>
 
     <p class="hero__sub rise rise-3">
-      The multi-project ops repo where your projects reference each other, learn from shared experience, and ship production-ready under a strict SDLC. You don't <em>add</em> apexstack to a project — projects get forged <em>inside</em> it. One ops repo. Every product. Shared memory. Strict gates. Production-ready MVPs. Claude Code is the default driver, but the rules, hooks, and templates are plain markdown and shell. Swap the AI. Keep the forge.
+      SDLC-as-code for founders who ship alone. One ops-repo fork governs <em>all</em> your products. Rules that can't be argued with — they're shell hooks, not PDFs. 19 roles, 32 skills, 18 mechanical gates, one inbox across the whole portfolio. Claude Code is the default driver; the rules, hooks, agents, and skills are plain markdown and shell — swap the AI, keep the forge.
     </p>
 
     <div class="hero__cta rise rise-4">
@@ -1226,15 +1226,15 @@ footer.foot {
     <div class="hero__metrics rise rise-5" aria-label="What you get">
       <div class="hero__metric">
         <strong>19</strong>
-        <span>Role definitions</span>
+        <span>Role definitions across 5 departments</span>
       </div>
       <div class="hero__metric">
-        <strong>30</strong>
-        <span>Hooks · rules · agents · skills</span>
+        <strong>32</strong>
+        <span>Skills (slash commands)</span>
       </div>
       <div class="hero__metric">
-        <strong>7</strong>
-        <span>CI pipelines</span>
+        <strong>18</strong>
+        <span>Mechanical gates (shell hooks)</span>
       </div>
       <div class="hero__metric">
         <strong>1</strong>
@@ -1286,47 +1286,83 @@ footer.foot {
 <span class="branch">│   ├──</span> <span class="lf">code-review.md</span>
 <span class="branch">│   └──</span> <span class="lf">deployment.md</span>
 <span class="branch">│</span>
-<span class="branch">├──</span> <span class="dir">templates/</span>             <span class="nf"># 4 document templates</span>
+<span class="branch">├──</span> <span class="dir">templates/</span>             <span class="nf"># 7 document templates</span>
 <span class="branch">│   ├──</span> <span class="lf">prd.md</span>
 <span class="branch">│   ├──</span> <span class="lf">technical-design.md</span>
 <span class="branch">│   ├──</span> <span class="lf">adr.md</span>
-<span class="branch">│   └──</span> <span class="lf">agdr.md</span>           <span class="nf"># Agent Decision Record — AI-specific</span>
+<span class="branch">│   ├──</span> <span class="lf">agdr.md</span>           <span class="nf"># Agent Decision Record — AI-specific</span>
+<span class="branch">│   ├──</span> <span class="lf">agdr-migration.md</span> <span class="nf"># Migration AgDR — rollback + downtime + consumers + observability</span>
+<span class="branch">│   └──</span> <span class="dir">architecture/</span>     <span class="nf"># C4 Mermaid diagram templates</span>
+<span class="branch">│       ├──</span> <span class="lf">c4-context.md</span>         <span class="nf"># Level 1 — system + external actors</span>
+<span class="branch">│       └──</span> <span class="lf">c4-container.md</span>       <span class="nf"># Level 2 — deployable units</span>
 <span class="branch">│</span>
 <span class="branch">├──</span> <span class="dir new">.claude/</span>               <span class="nf"># <span class="new">[NEW]</span> Claude Code primitives — the runnable layer</span>
 <span class="branch">│   ├──</span> <span class="lf">settings.json</span>     <span class="nf"># Wires hooks to PreToolUse events</span>
-<span class="branch">│   ├──</span> <span class="dir">hooks/</span>            <span class="nf"># 15 enforcement hooks (ticket-first, merge gates, CI checks…)</span>
-<span class="branch">│   │   ├──</span> <span class="lf">block-git-add-all.sh</span>     <span class="nf"># refuses git add -A / .</span>
-<span class="branch">│   │   ├──</span> <span class="lf">block-main-push.sh</span>       <span class="nf"># refuses push to main</span>
-<span class="branch">│   │   ├──</span> <span class="lf">check-secrets.sh</span>         <span class="nf"># scans staged files for credentials</span>
-<span class="branch">│   │   ├──</span> <span class="lf">pre-push-gate.sh</span>         <span class="nf"># reminds to lint+typecheck+test+build</span>
-<span class="branch">│   │   ├──</span> <span class="lf">validate-branch-name.sh</span>  <span class="nf"># enforces feature/&lt;TICKET&gt;-… format</span>
-<span class="branch">│   │   └──</span> <span class="lf">validate-pr-create.sh</span>    <span class="nf"># enforces PR title + glossary</span>
-<span class="branch">│   ├──</span> <span class="dir">rules/</span>            <span class="nf"># 6 modular rule files imported via @-imports</span>
+<span class="branch">│   ├──</span> <span class="dir">hooks/</span>            <span class="nf"># 18 enforcement hooks (ticket-first, migration gate, merge gates, CI, secrets, drift banner…)</span>
+<span class="branch">│   │   ├──</span> <span class="lf">require-active-ticket.sh</span>        <span class="nf"># no edits without an active ticket</span>
+<span class="branch">│   │   ├──</span> <span class="lf">require-migration-ticket.sh</span>     <span class="nf"># migration files need labelled ticket + AgDR</span>
+<span class="branch">│   │   ├──</span> <span class="lf">block-unreviewed-merge.sh</span>       <span class="nf"># Rex + CEO approval markers required</span>
+<span class="branch">│   │   ├──</span> <span class="lf">require-design-review-for-ui.sh</span> <span class="nf"># UI PRs need design-review marker</span>
+<span class="branch">│   │   ├──</span> <span class="lf">block-merge-on-red-ci.sh</span>        <span class="nf"># refuses merge with red CI</span>
+<span class="branch">│   │   ├──</span> <span class="lf">require-agdr-for-arch-changes.sh</span><span class="nf"># arch-path edits need a linked AgDR</span>
+<span class="branch">│   │   ├──</span> <span class="lf">validate-commit-format.sh</span>       <span class="nf"># enforces Conventional Commits</span>
+<span class="branch">│   │   ├──</span> <span class="lf">verify-commit-refs.sh</span>           <span class="nf"># issue refs in commit messages must exist</span>
+<span class="branch">│   │   ├──</span> <span class="lf">validate-pr-create.sh</span>           <span class="nf"># enforces PR title + glossary + ticket</span>
+<span class="branch">│   │   ├──</span> <span class="lf">validate-branch-name.sh</span>         <span class="nf"># enforces feature/&lt;TICKET&gt;-… format</span>
+<span class="branch">│   │   ├──</span> <span class="lf">block-main-push.sh</span>              <span class="nf"># refuses push to main</span>
+<span class="branch">│   │   ├──</span> <span class="lf">block-git-add-all.sh</span>            <span class="nf"># refuses git add -A / .</span>
+<span class="branch">│   │   ├──</span> <span class="lf">check-secrets.sh</span>                <span class="nf"># scans staged files for credentials</span>
+<span class="branch">│   │   ├──</span> <span class="lf">pre-push-gate.sh</span>                <span class="nf"># reminds to lint+typecheck+test+build</span>
+<span class="branch">│   │   ├──</span> <span class="lf">auto-code-review.sh</span>             <span class="nf"># post-PR: prompt to invoke Rex</span>
+<span class="branch">│   │   ├──</span> <span class="lf">suggest-ticket-template.sh</span>      <span class="nf"># gh issue create → suggest /feature, /bug, /task</span>
+<span class="branch">│   │   ├──</span> <span class="lf">check-upstream-drift.sh</span>         <span class="nf"># session-start banner when fork is behind</span>
+<span class="branch">│   │   └──</span> <span class="lf">onboarding-check.sh</span>             <span class="nf"># prompt /setup on a fresh clone</span>
+<span class="branch">│   ├──</span> <span class="dir">rules/</span>            <span class="nf"># 8 modular rule files imported via @-imports</span>
+<span class="branch">│   │   ├──</span> <span class="lf">workflow-gates.md</span>        <span class="nf"># 6-gate model PRD → Done + migration sub-gate</span>
+<span class="branch">│   │   ├──</span> <span class="lf">pr-workflow.md</span>           <span class="nf"># hard stops before push/PR/merge</span>
+<span class="branch">│   │   ├──</span> <span class="lf">pr-quality.md</span>            <span class="nf"># glossary required, SHA verify, design review</span>
+<span class="branch">│   │   ├──</span> <span class="lf">git-conventions.md</span>       <span class="nf"># branch + PR title + commit format</span>
 <span class="branch">│   │   ├──</span> <span class="lf">agdr-decisions.md</span>        <span class="nf"># when to /decide</span>
 <span class="branch">│   │   ├──</span> <span class="lf">code-standards.md</span>        <span class="nf"># TS, DDD, naming, testing</span>
-<span class="branch">│   │   ├──</span> <span class="lf">git-conventions.md</span>       <span class="nf"># branch + PR title format</span>
-<span class="branch">│   │   ├──</span> <span class="lf">pr-quality.md</span>            <span class="nf"># glossary required, SHA verify</span>
-<span class="branch">│   │   ├──</span> <span class="lf">pr-workflow.md</span>           <span class="nf"># hard stops before push/PR/merge</span>
-<span class="branch">│   │   └──</span> <span class="lf">workflow-gates.md</span>        <span class="nf"># 6-gate model PRD → Done</span>
+<span class="branch">│   │   ├──</span> <span class="lf">ticket-vocabulary.md</span>     <span class="nf"># #N reserved for real tracker issues</span>
+<span class="branch">│   │   └──</span> <span class="lf">role-triggers.md</span>        <span class="nf"># which role activates on which signal</span>
 <span class="branch">│   ├──</span> <span class="dir">agents/</span>           <span class="nf"># 5 sub-agents</span>
 <span class="branch">│   │   ├──</span> <span class="lf">code-reviewer.md</span>         <span class="nf"># Rex — reviews PRs against the standards</span>
 <span class="branch">│   │   ├──</span> <span class="lf">security-reviewer.md</span>     <span class="nf"># Shield — OWASP, injection, auth</span>
 <span class="branch">│   │   ├──</span> <span class="lf">dependency-auditor.md</span>    <span class="nf"># Guardian — vulns, outdated, licenses</span>
 <span class="branch">│   │   ├──</span> <span class="lf">pr-manager.md</span>            <span class="nf"># 2-review workflow + SHA verification</span>
 <span class="branch">│   │   └──</span> <span class="lf">ticket-manager.md</span>        <span class="nf"># GitHub Issues per project</span>
-<span class="branch">│   └──</span> <span class="dir">skills/</span>           <span class="nf"># 27 slash commands (/setup, /launch-check, /threat-model, /seo-audit…)</span>
-<span class="branch">│       ├──</span> <span class="lf">decide/SKILL.md</span>          <span class="nf"># /decide — creates an AgDR</span>
-<span class="branch">│       ├──</span> <span class="lf">code-review/SKILL.md</span>     <span class="nf"># /code-review</span>
-<span class="branch">│       ├──</span> <span class="lf">security-review/SKILL.md</span> <span class="nf"># /security-review</span>
-<span class="branch">│       ├──</span> <span class="lf">audit-deps/SKILL.md</span>      <span class="nf"># /audit-deps</span>
+<span class="branch">│   └──</span> <span class="dir">skills/</span>           <span class="nf"># 32 slash commands — see the full list in CLAUDE.md</span>
+<span class="branch">│       ├──</span> <span class="lf">setup/SKILL.md</span>           <span class="nf"># /setup — first-run bootstrap for onboarding.yaml</span>
+<span class="branch">│       ├──</span> <span class="lf">handover/SKILL.md</span>        <span class="nf"># /handover — adopt an external repo + stub L2 C4</span>
+<span class="branch">│       ├──</span> <span class="lf">update/SKILL.md</span>          <span class="nf"># /update — sync ops fork with upstream apexstack</span>
+<span class="branch">│       ├──</span> <span class="lf">start-ticket/SKILL.md</span>    <span class="nf"># /start-ticket — activate ticket for this session</span>
+<span class="branch">│       ├──</span> <span class="lf">approve-merge/SKILL.md</span>   <span class="nf"># /approve-merge — per-PR CEO approval</span>
+<span class="branch">│       ├──</span> <span class="lf">approve-design/SKILL.md</span>  <span class="nf"># /approve-design — per-PR UI approval</span>
+<span class="branch">│       ├──</span> <span class="lf">migration/SKILL.md</span>       <span class="nf"># /migration — labelled ticket + migration AgDR</span>
+<span class="branch">│       ├──</span> <span class="lf">decide/SKILL.md</span>          <span class="nf"># /decide — create an AgDR for a technical decision</span>
+<span class="branch">│       ├──</span> <span class="lf">feature/SKILL.md</span>         <span class="nf"># /feature — structured feature ticket</span>
+<span class="branch">│       ├──</span> <span class="lf">bug/SKILL.md</span>             <span class="nf"># /bug — structured bug ticket</span>
+<span class="branch">│       ├──</span> <span class="lf">task/SKILL.md</span>            <span class="nf"># /task — structured technical-task ticket</span>
 <span class="branch">│       ├──</span> <span class="lf">write-spec/SKILL.md</span>      <span class="nf"># /write-spec — generate a PRD</span>
 <span class="branch">│       ├──</span> <span class="lf">idea/SKILL.md</span>            <span class="nf"># /idea — capture a new idea to the backlog</span>
-<span class="branch">│       ├──</span> <span class="lf">handover/SKILL.md</span>        <span class="nf"># /handover — onboard an external repo</span>
+<span class="branch">│       ├──</span> <span class="lf">code-review/SKILL.md</span>     <span class="nf"># /code-review — invoke Rex</span>
+<span class="branch">│       ├──</span> <span class="lf">security-review/SKILL.md</span> <span class="nf"># /security-review — invoke Shield</span>
+<span class="branch">│       ├──</span> <span class="lf">audit-deps/SKILL.md</span>      <span class="nf"># /audit-deps — Guardian vuln + license scan</span>
+<span class="branch">│       ├──</span> <span class="lf">launch-check/SKILL.md</span>    <span class="nf"># /launch-check — 8-dimension production-readiness audit</span>
+<span class="branch">│       ├──</span> <span class="lf">threat-model/SKILL.md</span>    <span class="nf"># /threat-model — STRIDE deep-dive</span>
+<span class="branch">│       ├──</span> <span class="lf">accessibility-audit/SKILL.md</span> <span class="nf"># /accessibility-audit — WCAG 2.1 AA</span>
+<span class="branch">│       ├──</span> <span class="lf">compliance-check/SKILL.md</span> <span class="nf"># /compliance-check — GDPR + ePrivacy</span>
+<span class="branch">│       ├──</span> <span class="lf">analytics-audit/SKILL.md</span>  <span class="nf"># /analytics-audit — event taxonomy</span>
+<span class="branch">│       ├──</span> <span class="lf">seo-audit/SKILL.md</span>        <span class="nf"># /seo-audit — meta, sitemap, structured data</span>
+<span class="branch">│       ├──</span> <span class="lf">performance-audit/SKILL.md</span> <span class="nf"># /performance-audit — bundle + Core Web Vitals</span>
+<span class="branch">│       ├──</span> <span class="lf">monitoring-audit/SKILL.md</span> <span class="nf"># /monitoring-audit — error tracking + runbooks</span>
+<span class="branch">│       ├──</span> <span class="lf">docs-audit/SKILL.md</span>      <span class="nf"># /docs-audit — Diataxis completeness</span>
 <span class="branch">│       ├──</span> <span class="lf">projects/SKILL.md</span>        <span class="nf"># /projects — list managed projects + status</span>
-<span class="branch">│       ├──</span> <span class="lf">inbox/SKILL.md</span>           <span class="nf"># /inbox — PRs/issues needing your attention</span>
 <span class="branch">│       ├──</span> <span class="lf">status/SKILL.md</span>          <span class="nf"># /status — git + CI snapshot per project</span>
-<span class="branch">│       ├──</span> <span class="lf">tasks/SKILL.md</span>           <span class="nf"># /tasks — actionable task list with URLs</span>
-<span class="branch">│       ├──</span> <span class="lf">roadmap/SKILL.md</span>         <span class="nf"># /roadmap — update or create the product roadmap</span>
+<span class="branch">│       ├──</span> <span class="lf">inbox/SKILL.md</span>           <span class="nf"># /inbox — PRs/issues needing attention across portfolio</span>
+<span class="branch">│       ├──</span> <span class="lf">tasks/SKILL.md</span>           <span class="nf"># /tasks — prioritised task list with URLs</span>
+<span class="branch">│       ├──</span> <span class="lf">roadmap/SKILL.md</span>         <span class="nf"># /roadmap — per-project milestones</span>
 <span class="branch">│       └──</span> <span class="lf">stakeholder-update/SKILL.md</span> <span class="nf"># /stakeholder-update — weekly/monthly/launch</span>
 <span class="branch">│</span>
 <span class="branch">├──</span> <span class="dir new">workspace/</span>             <span class="nf"># <span class="new">[NEW]</span> Live local clones of managed projects (gitignored)</span>
@@ -1395,40 +1431,43 @@ footer.foot {
       <div class="layer__num">02 — passive · markdown</div>
       <h3 class="layer__title">Workflows + templates</h3>
       <p class="layer__desc">
-        Three workflow processes (full SDLC, code review, deployment) and four document templates. Drop them into your <code>docs/</code>, ship faster.
+        Three workflow processes (full SDLC, code review, deployment) and seven document templates including C4 Mermaid diagrams and the migration AgDR. Drop them into your <code>docs/</code>, ship faster.
       </p>
       <ul class="layer__list">
-        <li><code>sdlc.md</code><span>7-phase lifecycle with quality gates</span></li>
+        <li><code>sdlc.md</code><span>7-phase lifecycle with quality gates + migration sub-flow</span></li>
         <li><code>code-review.md</code><span>structured author + reviewer process</span></li>
         <li><code>deployment.md</code><span>staging → prod with rollback</span></li>
-        <li><code>prd.md</code><span>product requirements doc</span></li>
-        <li><code>agdr.md</code><span>Agent Decision Record (AI-specific)</span></li>
+        <li><code>prd.md</code> · <code>adr.md</code> · <code>agdr.md</code><span>PRD, architecture + agent decision records</span></li>
+        <li><code>agdr-migration.md</code><span>migration-specific AgDR — rollback, downtime, consumers</span></li>
+        <li><code>architecture/c4-*.md</code><span>L1 context + L2 container Mermaid diagrams</span></li>
       </ul>
     </article>
 
     <article class="layer">
-      <div class="layer__num">03 — runnable · executable <span class="new">NEW</span></div>
+      <div class="layer__num">03 — runnable · executable</div>
       <h3 class="layer__title">Hooks + rules</h3>
       <p class="layer__desc">
-        15 shell hooks mechanically enforce the SDLC on every tool call — ticket-first gates, auto code review, two-marker merge gates (Rex + CEO), design review for UI, red-CI blocking, commit format validation, and AgDR requirements for architecture changes. Nine modular rule files import via <code>@-imports</code>. A <code>/launch-check</code> skill runs an 8-dimension production-readiness audit at milestone boundaries.
+        18 shell hooks mechanically enforce the SDLC on every tool call — ticket-first gates (generic + migration-specific), auto code review, two-marker merge gates (Rex + CEO), design review for UI, red-CI blocking, commit format validation, AgDR requirements for architecture changes, and a session-start drift banner when the fork is behind upstream. Eight modular rule files import via <code>@-imports</code>. A <code>/launch-check</code> skill runs an 8-dimension production-readiness audit at milestone boundaries.
       </p>
       <ul class="layer__list">
-        <li><code>hooks/</code><span>git add -A · main push · secrets · branch / PR format</span></li>
-        <li><code>rules/</code><span>AgDR triggers, code standards, PR quality, gates</span></li>
-        <li><code>settings.json</code><span>wires hooks to PreToolUse events</span></li>
+        <li><code>hooks/</code><span>ticket-first · migration gate · merge gates · secrets · drift banner</span></li>
+        <li><code>rules/</code><span>AgDR triggers, code standards, PR quality, gates, ticket vocabulary</span></li>
+        <li><code>settings.json</code><span>wires hooks to PreToolUse / PostToolUse / SessionStart events</span></li>
       </ul>
     </article>
 
     <article class="layer">
-      <div class="layer__num">04 — runnable · invokable <span class="new">NEW</span></div>
+      <div class="layer__num">04 — runnable · invokable</div>
       <h3 class="layer__title">Agents + skills</h3>
       <p class="layer__desc">
-        Five sub-agents with their own model, prompt, and tool access. Thirteen slash commands users type into Claude Code. Both designed to be invoked from any conversation in any of your projects.
+        Five sub-agents with their own model, prompt, and tool access. 32 slash commands users type into Claude Code — covering the full SDLC (/idea → /write-spec → /decide → /start-ticket → /code-review → /approve-merge), portfolio rollups (/inbox, /status, /tasks), adoption (/handover with stub L2 C4), and 8 deep-dive audits triggered by /launch-check.
       </p>
       <ul class="layer__list">
         <li><code>agents/</code><span>Rex · Shield · Guardian · PR Manager · Ticket Manager</span></li>
-        <li><code>skills/</code><span>/decide · /code-review · /security-review · /audit-deps · /write-spec</span></li>
-        <li><code>skills/</code><span>/idea · /handover · /projects · /inbox · /status · /tasks · /roadmap · /stakeholder-update</span></li>
+        <li><code>skills/</code> · SDLC<span>/idea · /write-spec · /decide · /start-ticket · /approve-merge · /approve-design · /code-review · /security-review · /audit-deps</span></li>
+        <li><code>skills/</code> · portfolio<span>/projects · /inbox · /status · /tasks · /roadmap · /stakeholder-update · /handover · /update</span></li>
+        <li><code>skills/</code> · audits<span>/launch-check · /threat-model · /accessibility-audit · /compliance-check · /analytics-audit · /seo-audit · /performance-audit · /monitoring-audit · /docs-audit</span></li>
+        <li><code>skills/</code> · tickets<span>/feature · /bug · /task · /migration</span></li>
       </ul>
     </article>
 
@@ -1456,10 +1495,10 @@ footer.foot {
 <section class="section" id="examples">
 
   <div class="section__head">
-    <span class="section__num">03 / EXAMPLES</span>
+    <span class="section__num">03 / WALKTHROUGHS</span>
     <h2 class="section__title">What it actually feels like to use</h2>
     <p class="section__lede">
-      Four interactions a developer has with ApexStack on a typical day. Real terminal output, not marketing copy.
+      Three flows that span the framework — one for a feature, one for the portfolio, one for a risky change. Each starts with the pain a solo CTO actually feels, then shows the exact sequence of skills, hooks, and agents that remove it. Composite examples drawn from real sessions.
     </p>
   </div>
 
@@ -1467,84 +1506,144 @@ footer.foot {
 
     <article class="demo">
       <div class="demo__head">
-        <span><span class="label">/decide</span> — slash command</span>
-        <span>skill</span>
+        <span><span class="label">01 — FEATURE</span> from idea to production</span>
+        <span>SDLC pipeline</span>
       </div>
-      <pre class="demo__body"><span class="you">› /decide use react-query vs swr for the new dashboard</span>
+      <pre class="demo__body"><span class="muted"># "I have an idea. I want it shipped without forgetting any step."</span>
 
-<span class="ai">Decision: react-query (TanStack Query)
-because: better TypeScript inference, infinite query
-support is critical for the activity feed,
-and matches the team's existing experience.
+<span class="you">› /idea personal-dashboard feed of user's own trending answers</span>
+<span class="ok">  ✓ appended to projects/ideas-backlog.md</span>
 
-Created: docs/agdr/AgDR-0008-dashboard-data-fetching.md
-Proceeding with: install @tanstack/react-query
-</span></pre>
-      <div class="demo__caption">/decide forces a structured decision and leaves an auditable AgDR file. Never lose "why we picked X over Y" again.</div>
+<span class="you">› /write-spec trending-answers-feed</span>
+<span class="ai">  Created docs/prds/PRD-0012-trending-answers-feed.md
+  (problem, target user, goals, non-goals, success metrics)</span>
+
+<span class="you">› /decide react-query vs swr for the feed</span>
+<span class="ai">  Decision: react-query (better TS inference, infinite-query,
+            team experience)
+  Created docs/agdr/AgDR-0021-dashboard-data-fetching.md</span>
+
+<span class="you">› gh issue create --title "[Feature] trending-answers feed"
+  ...  → #178</span>
+<span class="you">› /start-ticket 178</span>
+<span class="ok">  ✓ Active ticket: your-org/curios-dog#178
+  ✓ marker: .claude/session/tickets/curios-dog</span>
+
+<span class="muted"># code, tests, push …</span>
+
+<span class="you">› gh pr create --title "feat(#178): trending-answers feed"</span>
+<span class="ag">  PostToolUse: auto-code-review.sh reminds:
+    "Rex REQUIRED before any merge"</span>
+
+<span class="you">› invoke the code-reviewer agent on PR #178</span>
+<span class="ag">  Rex reviewing c8b736f…
+    ✓ architecture clean · 94% coverage
+    ✓ AgDR-0021 linked · glossary 5 terms
+  Verdict: <span class="ok">APPROVED</span> — marker written at c8b736f</span>
+
+<span class="you">› <span class="muted">(CEO looks at diff)</span> /approve-merge 178</span>
+<span class="ok">  CEO marker recorded at c8b736f.
+  Run: gh pr merge 178</span>
+
+<span class="you">› gh pr merge 178 --squash --delete-branch</span>
+<span class="ok">  ✓ merged · #178 → QA state (NOT Done)
+  ✓ QA Engineer role activated on `qa` label</span></pre>
+      <div class="demo__caption"><strong>Hit:</strong> 8 skills · 2 agents · 4 hooks · 1 AgDR · 1 PRD. The entry point is <code>/idea</code>; the exit is a PR merged with two independent approvals (Rex + CEO) both SHA-bound. Nothing can short-circuit — the marker-based merge gate is a shell hook, not a social convention.</div>
     </article>
 
     <article class="demo">
       <div class="demo__head">
-        <span><span class="label">git add -A</span> — hook</span>
-        <span>blocked</span>
+        <span><span class="label">02 — PORTFOLIO</span> running 5 products from one inbox</span>
+        <span>cross-project</span>
       </div>
-      <pre class="demo__body"><span class="you">› git add -A</span>
-<span class="blk">BLOCKED:</span> Never use 'git add -A', 'git add --all',
-or 'git add .' — always add specific files to
-avoid committing unrelated changes.
-<span class="ag">  hook: .claude/hooks/block-git-add-all.sh
-  exit: 2</span>
+      <pre class="demo__body"><span class="muted"># "I run 4 products + 1 side project. Where do I look first on Monday?"</span>
 
-<span class="you">› git add src/handlers/api/get-trending-questions.ts</span>
-<span class="ok">  ✓ staged 1 file</span></pre>
-      <div class="demo__caption">Six hooks like this fire on every git / gh / Bash call. Block first, allow second. Configurable per project.</div>
+<span class="you">› cd ~/apexstack     <span class="muted">(the ops fork)</span></span>
+<span class="ag">  SessionStart: check-upstream-drift.sh
+    ApexStack: 3 commits behind upstream/main.
+               Run /update to sync.</span>
+
+<span class="you">› /inbox</span>
+<span class="ai">  curios-dog        · 2 PRs awaiting Rex, 1 design review
+  billing-api       · 1 CEO approval pending · #203
+  sharppick         · stale PR #89 (14 days)
+  marketing-site    · all clear
+  internal-tools    · 1 P1 bug · #42, unassigned</span>
+
+<span class="you">› /status</span>
+<span class="ai">  curios-dog        · main · CI green · 2 PRs, 8 open issues
+  billing-api       · main · CI RED (test regression)
+  sharppick         · feature/search · CI pending · 1 PR
+  marketing-site    · main · CI green · 0 PRs
+  internal-tools    · main · CI green · 5 open issues</span>
+
+<span class="you">› /start-ticket me2resh/billing-api#203</span>
+<span class="you">› cd workspace/billing-api    <span class="muted">(editing the red-CI branch)</span></span>
+<span class="muted"># fix the regression, re-push, green …</span>
+
+<span class="you">› /approve-merge 203</span>
+<span class="ok">  CEO marker at a0b3c1d.  Run: gh pr merge 203</span>
+
+<span class="muted"># Friday afternoon …</span>
+
+<span class="you">› /stakeholder-update weekly</span>
+<span class="ai">  Drafted projects/updates/2026-04-17-weekly.md
+    curios-dog   → 3 PRs merged, 1 launched feature
+    billing-api  → stabilisation week, 4 bugfix PRs
+    sharppick    → paused pending design review
+    marketing-site → no activity (intentional)
+  Ready to send?</span></pre>
+      <div class="demo__caption"><strong>Hit:</strong> 6 skills · 1 hook · 1 registry (<code>apexstack.projects.yaml</code>) · 5 products surfaced from one prompt. The portfolio isn't a view on top of separate repos — it's the registry. Every rollup skill reads from it. Switching projects is a <code>cd</code>; the per-project ticket marker remembers where you were.</div>
     </article>
 
     <article class="demo">
       <div class="demo__head">
-        <span><span class="label">/code-review 178</span> — agent invocation</span>
-        <span>Rex</span>
+        <span><span class="label">03 — TRUST</span> when something risky comes up</span>
+        <span>migration gate</span>
       </div>
-      <pre class="demo__body"><span class="you">› /code-review 178</span>
+      <pre class="demo__body"><span class="muted"># "I just want to drop a column. It's Friday 5pm."</span>
 
-<span class="ag">→ Invoking Code Reviewer Agent (Rex)
-→ Fetching PR #178 from your-org/your-repo
-→ Reading 7 changed files
-→ Running checklist…
-</span>
-<span class="ai">## Code Review: PR #178
-Commit: 3c8b736
+<span class="you">› edit prisma/schema.prisma     <span class="muted">(remove `deprecatedField`)</span></span>
+<span class="blk">BLOCKED:</span> No active ticket set — and this file
+looks like a database migration.
+<span class="ag">  hook: .claude/hooks/require-migration-ticket.sh
+  path matched: prisma/schema.prisma</span>
 
-Architecture & DDD:    ✓ Pass
-Code Quality:          ✓ Pass
-Testing:               ✓ Pass (15 new tests)
-Glossary:              ✓ 5 entries
-AgDR linked:           ✓ AgDR-0008
-Verdict: <span class="ok">APPROVED</span>
-</span></pre>
-      <div class="demo__caption">Rex enforces glossary, scans for missing AgDRs, and verifies the latest commit SHA was reviewed. Posted to GitHub via gh pr review.</div>
-    </article>
+Migrations need a dedicated labelled ticket + AgDR,
+not just any ticket. Run:
 
-    <article class="demo">
-      <div class="demo__head">
-        <span><span class="label">gh issue create</span> — ticket-manager agent</span>
-        <span>tracking</span>
-      </div>
-      <pre class="demo__body"><span class="you">› create issue: add CSV export
-  in your-org/your-project</span>
+  /migration curios-dog
 
-<span class="ag">→ Invoking Ticket Manager Agent
-→ Determined repo: your-org/your-project
-→ Determined priority: P1
-</span>
-<span class="ai">✓ Created GitHub Issue: your-org/your-project#42
-  Title: [P1] Add CSV export to dashboard
-  Labels: P1, enhancement
-  URL: github.com/your-org/your-project/issues/42
+<span class="you">› /migration curios-dog</span>
+<span class="ai">  Migration type?          schema
+  Affected tables?         user_profiles
+  Rollback plan?           <span class="muted">(required — not empty)</span></span>
+<span class="you">  ADD COLUMN deprecatedField on rollback,
+  backfill from user_profiles_archive.field</span>
+<span class="ai">  Rollback tested against? staging
+  Estimated downtime?      none (nullable column)
+  Cross-service consumers? analytics ETL (reads user_profiles nightly)
+  Data volume?             ~12M rows
+  Observability?           p99 query latency · row-count delta</span>
 
-Branch: feature/GH-42-add-csv-export
-</span></pre>
-      <div class="demo__caption">Each project's tickets live in that project's own GitHub repo. No central tracker. Co-located with the code.</div>
+<span class="ok">  ✓ AgDR-0047-migration-drop-deprecated-field.md
+  ✓ Issue #214 created with labels: migration, P2
+  ✓ Body references the AgDR — gate 3 satisfied
+
+Next: /start-ticket me2resh/curios-dog#214,
+      then edit the schema.</span>
+
+<span class="you">› /start-ticket me2resh/curios-dog#214</span>
+<span class="you">› edit prisma/schema.prisma     <span class="muted">(retry)</span></span>
+<span class="ok">  ✓ gate 1: active ticket marker exists
+  ✓ gate 2: ticket OPEN + label `migration`
+  ✓ gate 3: body references AgDR-0047
+  ✓ edit allowed</span>
+
+<span class="ag">Rex on the PR: "rollback plan references analytics ETL.
+Confirm ETL can skip the missing column safely — flag for
+review before merge."  CEO: defer to Monday morning.</span></pre>
+      <div class="demo__caption"><strong>Hit:</strong> 3 hooks (migration gate, marker check, Rex-required) · 2 skills · 1 AgDR · 1 ticket — all before a single schema byte was written. The point isn't to slow you down. It's that the questions that would otherwise surface at 2am during a rollback are forced upfront, when your team is awake and rollback is cheap.</div>
     </article>
 
   </div>
@@ -1641,13 +1740,13 @@ cd apexstack</pre>
     <article class="step">
       <div class="step__num">02 — upstream remote</div>
       <h3 class="step__title">Track upstream for updates</h3>
-      <p class="step__desc">Add the upstream remote so you can pull future apexstack improvements into your fork with a normal git merge. No proprietary upgrade tool.</p>
+      <p class="step__desc">Add the upstream remote once. The session-start drift banner then tells you when you're behind, and <code>/update</code> does the sync-branch-and-PR dance for you. No proprietary upgrade tool.</p>
       <pre class="step__code"><span class="cm"># in your fork</span>
 git remote add upstream \
   https://github.com/me2resh/apexstack.git
 
-<span class="cm"># later, to pull updates:</span>
-git fetch upstream &amp;&amp; git merge upstream/main</pre>
+<span class="cm"># later, when the drift banner says you're behind:</span>
+<span class="acc">/update</span>              <span class="cm"># preview + sync branch + PR body, all in one</span></pre>
     </article>
 
     <article class="step">
@@ -1676,7 +1775,8 @@ $EDITOR apexstack.projects.yaml  <span class="cm"># list your repos</span></pre>
 <span class="acc">/projects</span>          <span class="cm"># list every managed project + status</span>
 <span class="acc">/inbox</span>             <span class="cm"># PRs, issues, comments needing your eyes</span>
 <span class="acc">/status</span>            <span class="cm"># git + CI snapshot per project</span>
-<span class="acc">/decide</span> migrate billing to Stripe</pre>
+<span class="acc">/handover</span> acquired-repo   <span class="cm"># adopt an external repo + stub L2 C4</span>
+<span class="acc">/launch-check</span>     <span class="cm"># 8-dimension production-readiness audit</span></pre>
     </article>
 
   </div>
@@ -1701,25 +1801,28 @@ $EDITOR apexstack.projects.yaml  <span class="cm"># list your repos</span></pre>
       <div class="antifeatures__col is-do">
         <h3 class="is-yes">+ what apexstack does</h3>
         <ul>
-          <li>Enforces ticket-first development via GitHub Issues per project</li>
-          <li>Forces structured decisions via /decide → AgDR audit trail</li>
-          <li>Blocks dangerous git operations (add -A, push to main, secrets in commits)</li>
-          <li>Ships an opinionated 6-gate workflow from PRD to QA</li>
+          <li>Enforces ticket-first development via GitHub Issues per project — with a stricter migration-gate variant on schema / migration-path edits</li>
+          <li>Requires explicit per-PR CEO approval before any merge — marker is SHA-bound, invalidates on every new commit</li>
+          <li>Blocks dangerous git operations (add -A, push to main, secrets in commits, red CI, unreviewed merges via either <code>gh pr merge</code> or raw <code>gh api</code>)</li>
+          <li>Forces structured decisions via /decide → AgDR audit trail (plus a dedicated migration AgDR with rollback / downtime / consumers / observability)</li>
+          <li>Ships an opinionated 6-gate workflow from PRD to QA + a migration sub-workflow</li>
+          <li>Aggregates a whole portfolio into one inbox — /inbox, /status, /tasks read a single registry file</li>
+          <li>Tells you when the fork is behind upstream (session-start drift banner), then syncs it in one skill invocation</li>
           <li>Mandates a glossary in every PR — knowledge stays in the team</li>
-          <li>Defaults to TypeScript, DDD, vitest, GitHub Actions — but stays editable</li>
-          <li>Treats hooks, agents, and slash commands as a single coherent surface</li>
+          <li>Defaults to TypeScript, DDD, vitest, GitHub Actions — but stays editable per project via <code>.claude/project-config.json</code></li>
         </ul>
       </div>
       <div class="antifeatures__col is-dont">
         <h3>× what apexstack does NOT do</h3>
         <ul>
           <li>Replace your team — humans still write code, ship product, talk to customers</li>
-          <li>Lock you into a SaaS — every file is markdown or shell, fork freely</li>
-          <li>Hide its opinions — read the rules, disagree, edit them</li>
-          <li>Pretend to be language-agnostic — TypeScript-leaning by default</li>
+          <li>Lock you into a SaaS — every file is markdown or shell, fork freely, diff any decision in git</li>
+          <li>Hide its opinions — read the rules, disagree, edit them (and file a PR upstream if you want them changed for everyone)</li>
+          <li>Auto-run merges when you say "go" on a plan — per-PR approval is discrete by design</li>
+          <li>Impose a central tracker — issues live in each project's own GitHub repo, not in apexstack</li>
+          <li>Pretend to be language-agnostic — TypeScript-leaning by default; path patterns and templates are swappable</li>
           <li>Ship a UI — this is a stack of files, not an app</li>
-          <li>Impose a central tracker — issues live in each project's own GitHub repo</li>
-          <li>Compete with Claude Code's built-ins — it extends them</li>
+          <li>Compete with Claude Code's built-ins — it extends them via hooks, skills, and sub-agent definitions</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Content-only refresh of `site/index.html`. Same brutalist design — same JetBrains Mono, same cream paper, same single warning-red accent, same eight sections. No new tech stack, no new dependencies, nothing to build.

Two problems it fixes:

1. **Drift.** The counts and primitives lists on the site had fallen behind the framework. Skills shown as 27 (actual 32), hooks shown as 15 (actual 18), templates shown as 4 (actual 7). New primitives not listed at all: migration gate, drift banner, `/update`, `/migration`, C4 templates, per-project ticket markers, the 8 deep-dive audits under `/launch-check`.

2. **Hypothetical examples.** Section 4 ("What it actually feels like to use") was four tiny single-interaction demos that demonstrated the surface, not the value. Replaced with three walkthrough cards, each scoped to a different slice of the framework, each opening with a specific CTO pain:

   - **"From idea to production"** — the full SDLC. `/idea` → `/write-spec` → `/decide` → `/start-ticket` → Rex → `/approve-merge` → QA. 8 skills, 2 agents, 4 hooks, 1 AgDR, 1 PRD in one trail.
   - **"Running 5 products from one inbox"** — the portfolio story. Drift banner at session start, `/inbox` across the registry, `/status` RED-CI handling, Friday `/stakeholder-update`.
   - **"When something risky comes up"** — the trust-and-verify model. Migration gate blocks a Prisma schema edit at 5pm Friday, `/migration` produces labelled ticket + AgDR with rollback plan, three gates verify, Rex catches a cross-service nuance before merge.

## Sections touched

| Section | Change |
|---------|--------|
| Hero metrics | "30" aggregate → 19 roles / 32 skills / 18 hooks / 1 fork |
| Hero subcopy | tightened to "SDLC-as-code for founders who ship alone" framing |
| § 2 Tree | hook/rule/skill/template lists + counts updated to match disk |
| § 3 Five Layers | descriptions mention new primitives; skill list regrouped (SDLC / portfolio / audits / tickets) |
| § 4 Examples | replaced 4 single-interaction demos with 3 whole-framework walkthroughs |
| § 5 Install step 2 | points at `/update` + drift banner |
| § 5 Install step 5 | demo commands include `/handover` + `/launch-check` |
| § 6 Opinionated | DOES column adds migration gate + per-PR CEO marker + drift banner; DOES NOT column adds "no auto-merge on plan-level 'go'" |
| Hero headline, final CTA, § 5 Pipelines | unchanged |

Section structure: 8 `<section>` open + 8 `</section>` close, preserved.

## Testing

Visual — opening the file in a browser renders identically (same CSS, no new elements that aren't already styled). Walkthrough pre-blocks use the existing `.demo__body` class with the existing span helpers (`you`, `ai`, `ag`, `ok`, `blk`, `muted`). No new CSS added.

## Glossary

| Term | Definition |
|------|------------|
| walkthrough card | One of three `<article class="demo">` blocks in section 4 — each shows a multi-step scenario spanning 5-10 framework primitives, not a single interaction |
| whole-framework positioning | Marketing framing where the site sells the full surface (SDLC + portfolio + trust model) rather than one feature at a time |
| primitives | The framework's building blocks — roles, hooks, rules, skills, agents, templates, pipelines — rendered countably on the hero and listed in the tree |
| drift | Gap between what the site claims and what the framework actually ships; this PR closes that gap for the current state |

## Related

- Closes #73