### PR TITLE
chore(#75): release v0.3.0 — multi-project + C4 + migrations + site refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to ApexStack are documented here.
 
+## [0.3.0] — 2026-04-18
+
+### Multi-project comes alive
+
+v0.2 made forking apexstack the supported install path. v0.3 makes the **multi-project workflow** that fork enables actually work end-to-end: per-project context for the hooks, an upstream-drift signal at session start, and a one-command sync skill so keeping the fork current isn't archaeology.
+
+- **Per-project active-ticket markers** (#41) — `require-active-ticket.sh` now resolves the active ticket per-project (one marker per `workspace/<name>/`), so working in two project clones in the same session no longer cross-contaminates ticket state.
+- **`/update` skill** (#58) — sync the ops fork with `me2resh/apexstack` from one prompt: previews the commit delta, creates a sync branch (because direct push to main is blocked), merges or rebases, walks per-file conflicts, and leaves the branch ready to push as a PR.
+- **SessionStart drift banner** (#63) — `check-upstream-drift.sh` runs at session start (cached to once per 10 minutes), prints a one-line banner when your fork is behind. Silent if up-to-date, silent on network failure, silent when no `upstream` remote is configured.
+
+### Architecture diagrams as a first-class artefact
+
+- **Mermaid C4 templates** (#50) — Level 1 (System Context) and Level 2 (Container) templates at `templates/architecture/`. ApexStack itself dogfoods the convention at `docs/architecture/apexstack-context.md` and `apexstack-container.md`.
+- **`/handover` generates a stub C4 L2 container diagram** (#67) — onboarding an external repo now seeds a starter Mermaid diagram alongside the assessment, so new projects don't begin with an empty `docs/architecture/`.
+- AgDR-0003 captures the choice of Mermaid C4 over Structurizr DSL / PlantUML / D2 — GitHub renders Mermaid inline, zero build step, no proprietary tooling.
+
+### Database migrations get their own gate
+
+Migrations are high-blast-radius work that sit awkwardly inside the standard build flow: rollback plans, downtime windows, lock contention, and cross-service consumers are easier to spec **before** the SQL is written than during PR review.
+
+- **`require-migration-ticket.sh` hook** (#59) — fires on `Edit` / `Write` / `MultiEdit` against migration paths (`**/migrate-*.{ts,js,py,sql}`, `**/migrations/**`, `prisma/schema.prisma`, etc.). Verifies the active ticket has the `migration` label and references a migration AgDR. Project-config-overridable.
+- **`/migration` skill** — guided flow that asks for migration type, affected tables, rollback plan, downtime estimate, cross-service consumers, data volume, testing plan, and observability — then creates the labelled ticket AND writes the AgDR in one step.
+- **`templates/agdr-migration.md`** — migration-specific AgDR template that prompts for the rollback steps, the tested-against environment, and the consumers that need a pre-deploy heads-up.
+- **Workflow gate 3a** added to `.claude/rules/workflow-gates.md`.
+
+### Site refresh
+
+- **Whole-framework positioning** (#73) — `site/index.html` retired the v0.1-era "rules + hooks" framing and now leads with the multi-project / portfolio model, the SDLC walkthrough, and the role-activated workflow as the headline.
+
+### Hook robustness
+
+- **`gh api .../merge` bypass closed** (#47) — all three merge-gate hooks now match both `gh pr merge` and the raw REST shape `gh api repos/.../pulls/N/merge`. Discovered after `me2resh/curios-dog#190` was merged via `gh api` while CI was still running. The shared PR-number extractor at `.claude/hooks/_lib-extract-pr.sh` recognises both forms.
+- **Absolute-path exemptions in `require-active-ticket.sh`** (#56) — `/docs/`, `/projects/<name>/docs/`, and `*.md` paths are now exempt regardless of whether they're passed as relative or absolute. Closes a class of false-positive blocks when an editor passed absolute paths.
+- **Rex marker format enforcement** (#62 → fix #66) — the code-reviewer agent definition now requires markers to be a bare 40-character SHA + newline. Earlier informal formats (`PR: 61\nSHA: ...`) silently broke the merge gate.
+- **Merge gates resolve PR HEAD via `gh pr view`** — earlier hooks compared marker SHAs against `git rev-parse HEAD` (the local working tree), which forced a `gh pr checkout` dance before every merge. The hooks now resolve the PR's real HEAD on GitHub and fall back to local HEAD only with a visible warning when the gh call fails.
+- **Reject closed-issue refs in PR + commit hooks** — `validate-pr-create.sh` and `verify-commit-refs.sh` now reject titles / commit messages referencing closed issues, not just non-existent ones.
+- **Hooks resolve ops root from any workspace directory** — every hook now walks up from `$PWD` looking for `onboarding.yaml`, so they fire correctly when invoked from `workspace/<name>/` (the most common case in multi-project work).
+
+### New skills
+
+- `/migration` — guided migration ticket + AgDR creation (see migrations section above).
+- `/update` — fork sync (see multi-project section above).
+- `/feature`, `/bug`, `/task` — structured ticket templates with user-story / Given-When-Then / driver-scope-ACs scaffolds.
+
+### Stats
+
+- **17 commits** on `main` since v0.2.0 (9 features, 8 fixes), all PR-merged.
+- **17 hooks** wired in `.claude/settings.json` (up from 15 in v0.2).
+- **32 skills** available as slash commands (up from 27 in v0.2).
+- **9 modular rule files** in `.claude/rules/` (unchanged).
+
+### Upgrade notes
+
+- `apexstack.projects.yaml` is unchanged from v0.2 — your registry continues to work.
+- The new migration gate (`require-migration-ticket.sh`) is a no-op for projects that don't touch migration paths. If you have non-default migration locations, override `migration_paths` in `.claude/project-config.json`.
+- The new `check-upstream-drift.sh` runs on every session start. It will be silent unless your fork is behind upstream — no action needed unless you see the banner. To skip the upstream check entirely, remove the SessionStart entry from `.claude/settings.json`.
+
+---
+
 ## [0.2.0] — 2026-04-12
 
 ### Mechanical enforcement layer

--- a/site/index.html
+++ b/site/index.html
@@ -1097,7 +1097,7 @@ footer.foot {
         <span class="titlebar__dot"></span>
         <span class="titlebar__dot is-warn"></span>
       </span>
-      <span class="titlebar__path">~/<b>apexstack</b> <span class="dim">— main · v0.1</span></span>
+      <span class="titlebar__path">~/<b>apexstack</b> <span class="dim">— main · v0.3</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
       <a href="#layers">layers</a>
@@ -1118,14 +1118,14 @@ footer.foot {
   <div class="hero__inner">
 
     <div class="hero__eyebrow rise rise-1">
-      <span class="pill">apexstack v0.1</span>
+      <span class="pill">apexstack v0.3</span>
       <span>open source · MIT · for founders forging multiple products</span>
     </div>
 
     <h1 class="hero__title rise rise-2">apexstack</h1>
 
     <p class="hero__version rise rise-2" style="margin:-0.5em 0 0.5em;font-size:14px;opacity:0.7;letter-spacing:0.05em;">
-      <a href="https://github.com/me2resh/apexstack/releases/tag/v0.2.0" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v0.2.0</a>
+      <a href="https://github.com/me2resh/apexstack/releases/tag/v0.3.0" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v0.3.0</a>
       &nbsp;·&nbsp;
       <a href="https://github.com/me2resh/apexstack/blob/main/CHANGELOG.md" style="color:inherit;text-decoration:underline;text-underline-offset:3px;" target="_blank" rel="noopener">changelog</a>
     </p>
@@ -1599,7 +1599,7 @@ cd apexstack</pre>
      ============================================================ -->
 <footer class="foot">
   <div class="foot__inner">
-    <span>apexstack v0.1 · MIT · plain markdown · zero dependencies</span>
+    <span>apexstack v0.3 · MIT · plain markdown · zero dependencies</span>
     <span><a href="https://github.com/me2resh/apexstack">github</a> · <a href="https://github.com/me2resh/apexstack/issues">issues</a> · <a href="https://github.com/me2resh/apexstack/pulls">prs</a></span>
   </div>
 </footer>


### PR DESCRIPTION
## Summary

Cuts the v0.3.0 changelog and updates `site/index.html` version refs (which were stale at v0.1 in three places). 17 commits since v0.2.0 — 9 features, 8 fixes, all PR-merged.

### Themes captured in CHANGELOG.md

- **Multi-project comes alive** — per-project active-ticket markers (#41), `/update` skill (#58), SessionStart drift banner (#63).
- **C4 architecture diagrams** — Mermaid L1+L2 templates (#50), `/handover` seeds a stub L2 (#67).
- **Migration gate** — `require-migration-ticket.sh` (#59), `/migration` skill, `agdr-migration` template, workflow gate 3a.
- **Site refresh** — whole-framework positioning (#73).
- **Hook robustness** — `gh api .../merge` bypass closed (#47), absolute-path exemptions (#56), Rex marker format enforcement (#62/#66), gh-pr-view fallback for HEAD resolution.

### Plan after merge

1. Tag v0.3.0 on the merge commit
2. Push the tag
3. Create the GitHub release with the changelog body

## Testing

1. CHANGELOG renders cleanly on GitHub
2. `grep -nE "v0\.[0-9]" site/index.html` returns four lines, all v0.3 / v0.3.0
3. CI green

Closes #75

---

## Glossary

| Term | Definition |
|------|------------|
| Semver minor bump | v0.x.0 → v0.(x+1).0 — adds backward-compatible features. Justified here because 9 features landed since v0.2.0 |
| Drift banner | One-line SessionStart message showing how many commits behind upstream the fork is |
| C4 model | Context / Container / Component / Code — Simon Brown's hierarchical architecture-diagram framework |
| Migration gate | The PreToolUse hook + active-ticket check that blocks edits to schema-migration files until a labelled ticket + AgDR exist |