### PR TITLE
chore(#80): site refresh — practical usage replaces marketing prose

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1198,7 +1198,7 @@ footer.foot {
     <div class="hero__cta rise rise-4">
       <a href="https://github.com/me2resh/apexstack" class="cta cta--primary" target="_blank" rel="noopener">★ Star &nbsp;·&nbsp; ⑂ Fork on GitHub</a>
       <span class="cta__sep" aria-hidden="true">·</span>
-      <a href="#quickstart" class="cta cta--ghost">or see the 4-step quickstart ↓</a>
+      <a href="#quickstart" class="cta cta--ghost">or see the 3-step quickstart ↓</a>
     </div>
 
     <div class="shell-demo shell-demo--tall rise rise-4" id="shell-lifecycle" aria-label="Demo of a full ticket lifecycle in apexstack, from inbox pickup to QA sign-off">
@@ -1321,41 +1321,35 @@ footer.foot {
 
   <div class="section__head">
     <span class="section__num">01 / QUICKSTART</span>
-    <h2 class="section__title">Get started in four steps</h2>
+    <h2 class="section__title">Get started in three steps</h2>
     <p class="section__lede">
-      From invite to first command. Works the same whether you were added to someone's org or are starting your own fork.
+      From fork to first command. Everything is public; no invite needed.
     </p>
   </div>
 
   <div class="steps">
 
     <article class="step">
-      <div class="step__num">01 - invite (or fork yourself)</div>
-      <h3 class="step__title">Get access</h3>
-      <p class="step__desc">Either someone in an apexstack-managed org invites you as a collaborator, or you fork upstream. Same result either way - you land with a repo that already has apexstack's <code>.claude/</code>, <code>CLAUDE.md</code>, and <code>apexstack.projects.yaml</code> inside.</p>
-    </article>
-
-    <article class="step">
-      <div class="step__num">02 - star, fork, clone</div>
+      <div class="step__num">01 - star, fork, clone</div>
       <h3 class="step__title">Pull it to your machine</h3>
-      <p class="step__desc">One command via the GitHub CLI. Rename to <code>your-org/ops</code> if you prefer - GitHub handles the rename cleanly.</p>
+      <p class="step__desc">One command via the GitHub CLI. Rename to <code>your-org/ops</code> if you prefer - GitHub handles the rename cleanly. Adding <code>upstream</code> lets you sync later via <code>/update</code>.</p>
       <pre class="step__code">gh repo fork me2resh/apexstack --clone
 cd apexstack
 git remote add upstream \
   https://github.com/me2resh/apexstack.git</pre>
     </article>
 
-    <article class="step step--wide" style="grid-column: 1 / -1;">
-      <div class="step__num">03 - claude, /setup</div>
+    <article class="step">
+      <div class="step__num">02 - claude, /setup</div>
       <h3 class="step__title">Open Claude Code and run <code>/setup</code></h3>
-      <p class="step__desc">Everything loads automatically from <code>CLAUDE.md</code>. On first run, a session-start hook checks upstream drift. Then run <code>/setup</code> once - it walks you through company, team, and tech stack in three exchanges and writes <code>onboarding.yaml</code>.</p>
+      <p class="step__desc">Everything loads automatically from <code>CLAUDE.md</code>. On first run, a session-start hook checks upstream drift. Then run <code>/setup</code> once - three exchanges to configure company, team, and tech stack.</p>
       <pre class="step__code">claude
 <span class="acc">/setup</span>
 <span class="cm"># three questions → onboarding.yaml is configured</span></pre>
     </article>
 
     <article class="step step--wide" style="grid-column: 1 / -1;">
-      <div class="step__num">04 - bring a project in, or capture an idea</div>
+      <div class="step__num">03 - bring a project in, or capture an idea</div>
       <h3 class="step__title">Adopt, or originate</h3>
       <p class="step__desc">Two entry points depending on what you walked in with. <code>/handover</code> takes an existing repo and generates an assessment + C4 L2 stub + registry entry. <code>/idea</code> captures a new product concept to the shared backlog so it doesn't evaporate.</p>
       <pre class="step__code"><span class="acc">/handover</span> &lt;repo-url&gt;   <span class="cm"># existing project → assessment + registry + architecture stub</span>

--- a/site/index.html
+++ b/site/index.html
@@ -264,7 +264,6 @@ a:hover { color: var(--accent); }
   padding: 1rem 1.25rem;
   margin-bottom: 1rem;
   font-size: 14px;
-  max-width: 720px;
 }
 .install__prompt { color: var(--accent); font-weight: 700; user-select: none; }
 .install__cmd {
@@ -274,6 +273,10 @@ a:hover { color: var(--accent); }
   scrollbar-width: none;
 }
 .install__cmd::-webkit-scrollbar { display: none; }
+@media (max-width: 520px) {
+  .install { font-size: 12px; padding: 0.85rem 1rem; gap: 0.5rem; }
+  .install__cmd { white-space: normal; overflow-x: visible; word-break: break-all; }
+}
 .install__copy {
   background: transparent;
   border: 1px solid var(--rule-faint);
@@ -762,6 +765,7 @@ a:hover { color: var(--accent); }
   display: flex;
   flex-direction: column;
 }
+.demo--wide { grid-column: 1 / -1; }
 .demo__head {
   display: flex;
   align-items: center;
@@ -1279,13 +1283,13 @@ git remote add upstream \
   https://github.com/me2resh/apexstack.git</pre>
     </article>
 
-    <article class="step">
-      <div class="step__num">03 — claude, hi</div>
-      <h3 class="step__title">Open Claude Code and say hi</h3>
-      <p class="step__desc">Everything loads automatically from <code>CLAUDE.md</code>. On first run, a session-start hook checks upstream drift and asks you to run <code>/setup</code> once to fill in <code>onboarding.yaml</code> — company, team, stack.</p>
+    <article class="step step--wide" style="grid-column: 1 / -1;">
+      <div class="step__num">03 — claude, /setup</div>
+      <h3 class="step__title">Open Claude Code and run <code>/setup</code></h3>
+      <p class="step__desc">Everything loads automatically from <code>CLAUDE.md</code>. On first run, a session-start hook checks upstream drift. Then run <code>/setup</code> once — it walks you through company, team, and tech stack in three exchanges and writes <code>onboarding.yaml</code>.</p>
       <pre class="step__code">claude
-<span class="acc">hi</span>
-<span class="cm"># first-time: /setup runs through company + stack config</span></pre>
+<span class="acc">/setup</span>
+<span class="cm"># three questions → onboarding.yaml is configured</span></pre>
     </article>
 
     <article class="step step--wide" style="grid-column: 1 / -1;">
@@ -1366,7 +1370,7 @@ git remote add upstream \
       <div class="demo__caption">6 skills read one registry file. Five products surface from a single prompt. Portfolio isn't a view on top of separate repos — it IS the registry.</div>
     </article>
 
-    <article class="demo">
+    <article class="demo demo--wide">
       <div class="demo__head">
         <span><span class="label">03 — TRUST</span> risky change, 5pm Friday</span>
         <span>migration gate</span>
@@ -1446,19 +1450,14 @@ confirm it skips the missing column before merge."</span></pre>
       </p>
     </article>
 
-    <article class="layer">
-      <div class="layer__num">CI · 7 golden-path workflows</div>
-      <h3 class="layer__title">Drop-in GitHub Actions</h3>
-      <p class="layer__desc">
-        At <code>golden-paths/pipelines/</code>: <code>ci.yml</code> (combined), <code>code-quality.yml</code>, <code>security.yml</code> (Semgrep + npm audit + TruffleHog), <code>dependency-audit.yml</code> (weekly), <code>pr-title-check.yml</code>, <code>review-check.yml</code> (blocks merge until Rex has reviewed HEAD), <code>seo-check.yml</code>. Copy what you need into each project's <code>.github/workflows/</code>.
-      </p>
-    </article>
-
     <article class="layer layer--wide" style="grid-column: 1 / -1;">
-      <div class="layer__num">portfolio · one fork, N products</div>
-      <h3 class="layer__title">One inbox across everything</h3>
+      <div class="layer__num">portfolio + CI · one fork, N products</div>
+      <h3 class="layer__title">One inbox across everything, ready-made pipelines to drop in</h3>
       <p class="layer__desc">
-        <code>apexstack.projects.yaml</code> at your fork root lists every repo you manage. Skills like <code>/inbox</code>, <code>/status</code>, <code>/tasks</code>, <code>/stakeholder-update</code> aggregate across it. Add a project with <code>/handover</code>; sync with upstream via <code>/update</code>.
+        <code>apexstack.projects.yaml</code> at your fork root lists every repo you manage. Skills like <code>/inbox</code>, <code>/status</code>, <code>/tasks</code>, <code>/stakeholder-update</code> aggregate across it — one prompt, every project. Add a project with <code>/handover</code>; sync with upstream via <code>/update</code>.
+      </p>
+      <p class="layer__desc" style="margin-top:0.75rem;">
+        On the CI side: <code>golden-paths/pipelines/</code> ships 7 reusable GitHub Actions workflows — <code>ci.yml</code> (combined), <code>code-quality.yml</code>, <code>security.yml</code> (Semgrep + npm audit + TruffleHog), <code>dependency-audit.yml</code> (weekly), <code>pr-title-check.yml</code>, <code>review-check.yml</code> (blocks merge until Rex has reviewed HEAD), <code>seo-check.yml</code>. Copy what you need into each project's <code>.github/workflows/</code>.
       </p>
     </article>
 
@@ -1476,6 +1475,9 @@ confirm it skips the missing column before merge."</span></pre>
       <p>
         MIT. Plain markdown and shell. Delete the directory and you're back where you started.
       </p>
+      <p style="margin-top:0.75rem;opacity:0.75;">
+        Want apexstack set up for your team — custom roles, company-specific rules, onboarded repos, the works? <a href="https://me2resh.com/about" class="uline" target="_blank" rel="noopener">Get in touch about professional setup</a>.
+      </p>
     </div>
     <div class="final__actions">
       <a href="https://github.com/me2resh/apexstack" class="final__btn" target="_blank" rel="noopener">
@@ -1485,6 +1487,10 @@ confirm it skips the missing column before merge."</span></pre>
       <a href="#quickstart" class="final__btn">
         <span>back to quickstart</span>
         <span class="arrow">↑</span>
+      </a>
+      <a href="https://me2resh.com/about" class="final__btn" target="_blank" rel="noopener">
+        <span>professional setup</span>
+        <span class="arrow">→</span>
       </a>
       <a href="https://github.com/me2resh/apexstack/issues" class="final__btn" target="_blank" rel="noopener">
         <span>open an issue</span>

--- a/site/index.html
+++ b/site/index.html
@@ -1193,7 +1193,7 @@ footer.foot {
     </p>
 
     <p class="hero__sub rise rise-3">
-      SDLC-as-code for founders who ship alone. One ops-repo fork governs <em>all</em> your products. Rules that can't be argued with - they're shell hooks, not PDFs. 19 roles, 32 skills, 18 mechanical gates, one inbox across the whole portfolio. Claude Code is the default driver; the rules, hooks, agents, and skills are plain markdown and shell - swap the AI, keep the forge.
+      SDLC-as-code for founders who ship alone, or companies standing up AI-enabled squads. One ops-repo fork governs <em>all</em> your products. Rules that can't be argued with - they're shell hooks, not PDFs. 19 roles, 33 skills, 18 mechanical gates, one inbox across the whole portfolio. Claude Code is the default driver; the rules, hooks, agents, and skills are plain markdown and shell - swap the AI, keep the forge.
     </p>
 
     <div class="hero__cta rise rise-4">
@@ -1549,7 +1549,7 @@ confirm it skips the missing column before merge."</span></pre>
         <span class="arrow">↑</span>
       </a>
       <a href="https://github.com/me2resh/apexstack/issues" class="final__btn" target="_blank" rel="noopener">
-        <span>open an issue</span>
+        <span>report an issue</span>
         <span class="arrow">→</span>
       </a>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -3,15 +3,15 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>ApexStack — where projects get forged</title>
-<meta name="description" content="ApexStack is a multi-project ops repo where your projects reference each other, learn from shared experience, and ship production-ready under a strict SDLC. Built for founders running 2–5 products at once. Open source. Claude Code native, but plain markdown underneath.">
+<title>ApexStack - where projects get forged</title>
+<meta name="description" content="ApexStack is a multi-project ops repo where your projects reference each other, learn from shared experience, and ship production-ready under a strict SDLC. Built for founders running 2-5 products at once. Open source. Claude Code native, but plain markdown underneath.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet">
 
 <style>
 /* ============================================================
-   ApexStack — terminal-native brutalism
+   ApexStack - terminal-native brutalism
    One typeface (JetBrains Mono), warm cream paper, single
    warning-red accent. No gradients. No shadows. Sharp corners.
    The page is one big README rendered with care.
@@ -29,7 +29,7 @@
   --ink-faint: #877E70;
   --ink-ghost: #B6AD9B;
 
-  /* the single accent — used like a stamp, never as a fill */
+  /* the single accent - used like a stamp, never as a fill */
   --accent:      #C8321A;
   --accent-soft: #E07050;
 
@@ -90,7 +90,7 @@ a:hover { color: var(--accent); }
 :focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
 
 /* ============================================================
-   utility — the box-drawing primitive
+   utility - the box-drawing primitive
    ============================================================ */
 
 .dash { color: var(--ink-faint); user-select: none; }
@@ -109,7 +109,7 @@ a:hover { color: var(--accent); }
 }
 
 /* ============================================================
-   site header — sticky terminal title bar
+   site header - sticky terminal title bar
    ============================================================ */
 
 .titlebar {
@@ -183,7 +183,7 @@ a:hover { color: var(--accent); }
 }
 
 /* ============================================================
-   hero — full-bleed ascii poster
+   hero - full-bleed ascii poster
    ============================================================ */
 
 .hero {
@@ -253,7 +253,19 @@ a:hover { color: var(--accent); }
   margin-bottom: 2.5rem;
 }
 
-/* the install command — the most important element on the page */
+/* the install row - the most important element on the page. holds the
+   `gh repo fork` command + a professional-setup CTA side by side so the
+   page reads "here's how to self-serve / or pay us to do it for you" */
+.install-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  max-width: 780px;   /* matches .shell-demo max-width so they align */
+}
+@media (max-width: 720px) {
+  .install-row { grid-template-columns: 1fr; }
+}
 .install {
   display: grid;
   grid-template-columns: auto 1fr auto;
@@ -262,9 +274,29 @@ a:hover { color: var(--accent); }
   background: var(--paper-2);
   border: 1px solid var(--rule);
   padding: 1rem 1.25rem;
-  margin-bottom: 1rem;
   font-size: 14px;
+  min-width: 0;
 }
+.install__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  padding: 1rem 1.25rem;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.install__cta:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.install__cta__arrow { transition: transform 0.15s ease; }
+.install__cta:hover .install__cta__arrow { transform: translateX(2px); }
 .install__prompt { color: var(--accent); font-weight: 700; user-select: none; }
 .install__cmd {
   color: var(--ink);
@@ -350,7 +382,7 @@ a:hover { color: var(--accent); }
 }
 
 /* ============================================================
-   shell demo — animated /idea walkthrough in the hero
+   shell demo - animated /idea walkthrough in the hero
    ============================================================ */
 
 .shell-demo {
@@ -448,7 +480,7 @@ a:hover { color: var(--accent); }
   color: var(--ink-faint);
 }
 
-/* tall variant for the full-lifecycle demo — fixed 10-line viewport that
+/* tall variant for the full-lifecycle demo - fixed 10-line viewport that
    scrolls like a real terminal as new lines stream in. Old lines push up
    and out of view. Users with JS disabled can still scroll manually. */
 .shell-demo--tall .shell-demo__body {
@@ -457,7 +489,7 @@ a:hover { color: var(--accent); }
   font-size: 12px;
   line-height: 1.55;
   overflow-y: auto;
-  scroll-behavior: auto;        /* instant snap — matches terminal feel */
+  scroll-behavior: auto;        /* instant snap - matches terminal feel */
   scrollbar-width: none;        /* Firefox */
 }
 .shell-demo--tall .shell-demo__body::-webkit-scrollbar {
@@ -486,7 +518,7 @@ a:hover { color: var(--accent); }
   }
 }
 
-/* proven-stacks tagline — small caption below the hero metrics */
+/* proven-stacks tagline - small caption below the hero metrics */
 .hero__proof {
   margin-top: 1.25rem;
   font-size: 12px;
@@ -537,7 +569,7 @@ a:hover { color: var(--accent); }
 }
 
 /* ============================================================
-   ascii section — boxed
+   ascii section - boxed
    ============================================================ */
 
 .section {
@@ -584,7 +616,7 @@ a:hover { color: var(--accent); }
 }
 
 /* ============================================================
-   file tree — ASCII rendered, monospace, semantic
+   file tree - ASCII rendered, monospace, semantic
    ============================================================ */
 
 .tree {
@@ -635,7 +667,7 @@ a:hover { color: var(--accent); }
 }
 
 /* ============================================================
-   layers — 4 cards in a 2x2 with sharp borders
+   layers - 4 cards in a 2x2 with sharp borders
    ============================================================ */
 
 .layers {
@@ -710,7 +742,7 @@ a:hover { color: var(--accent); }
   font-weight: 600;
 }
 
-/* wide variant — 2-column internal layout so the card fills the grid row
+/* wide variant - 2-column internal layout so the card fills the grid row
    it spans (used for layer 05 since it's the only full-width card) */
 .layer--wide {
   display: grid;
@@ -745,7 +777,7 @@ a:hover { color: var(--accent); }
 }
 
 /* ============================================================
-   show, don't tell — example demos
+   show, don't tell - example demos
    ============================================================ */
 
 .demos {
@@ -766,6 +798,28 @@ a:hover { color: var(--accent); }
   flex-direction: column;
 }
 .demo--wide { grid-column: 1 / -1; }
+
+/* split layer: two sub-sections inside one full-width card,
+   separated by a vertical rule. used for portfolio + CI combined row. */
+.layer--split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  padding: 0;
+}
+.layer--split > .layer__half {
+  padding: 2rem 1.75rem;
+}
+.layer--split > .layer__half:first-child {
+  border-right: 1px solid var(--rule-faint);
+}
+@media (max-width: 720px) {
+  .layer--split { grid-template-columns: 1fr; }
+  .layer--split > .layer__half:first-child {
+    border-right: none;
+    border-bottom: 1px solid var(--rule-faint);
+  }
+}
 .demo__head {
   display: flex;
   align-items: center;
@@ -848,7 +902,7 @@ a:hover { color: var(--accent); }
 }
 
 /* ============================================================
-   install steps — actual numbered steps with code
+   install steps - actual numbered steps with code
    ============================================================ */
 
 .steps {
@@ -900,7 +954,7 @@ a:hover { color: var(--accent); }
 .step__code .cm { color: var(--ink-faint); font-style: italic; }
 
 /* ============================================================
-   anti-features — what apexstack is NOT
+   anti-features - what apexstack is NOT
    ============================================================ */
 
 .antifeatures {
@@ -1049,7 +1103,7 @@ footer.foot {
 .foot__inner a:hover { color: var(--accent); }
 
 /* ============================================================
-   page-load reveal — staggered, restrained
+   page-load reveal - staggered, restrained
    ============================================================ */
 
 @keyframes rise {
@@ -1091,7 +1145,7 @@ footer.foot {
 <a href="#main" class="skip">Skip to content</a>
 
 <!-- ============================================================
-     TITLE BAR — sticky
+     TITLE BAR - sticky
      ============================================================ -->
 <header class="titlebar">
   <div class="titlebar__inner">
@@ -1101,7 +1155,7 @@ footer.foot {
         <span class="titlebar__dot"></span>
         <span class="titlebar__dot is-warn"></span>
       </span>
-      <span class="titlebar__path">~/<b>apexstack</b> <span class="dim">— main · v0.3</span></span>
+      <span class="titlebar__path">~/<b>apexstack</b> <span class="dim">- main · v0.3</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
       <a href="#quickstart">quickstart</a>
@@ -1138,7 +1192,7 @@ footer.foot {
     </p>
 
     <p class="hero__sub rise rise-3">
-      SDLC-as-code for founders who ship alone. One ops-repo fork governs <em>all</em> your products. Rules that can't be argued with — they're shell hooks, not PDFs. 19 roles, 32 skills, 18 mechanical gates, one inbox across the whole portfolio. Claude Code is the default driver; the rules, hooks, agents, and skills are plain markdown and shell — swap the AI, keep the forge.
+      SDLC-as-code for founders who ship alone. One ops-repo fork governs <em>all</em> your products. Rules that can't be argued with - they're shell hooks, not PDFs. 19 roles, 32 skills, 18 mechanical gates, one inbox across the whole portfolio. Claude Code is the default driver; the rules, hooks, agents, and skills are plain markdown and shell - swap the AI, keep the forge.
     </p>
 
     <div class="hero__cta rise rise-4">
@@ -1154,7 +1208,7 @@ footer.foot {
           <span class="shell-demo__dot"></span>
           <span class="shell-demo__dot is-warn"></span>
         </span>
-        <span class="shell-demo__title">claude code — apexstack — one ticket, start to finish</span>
+        <span class="shell-demo__title">claude code - apexstack - one ticket, start to finish</span>
         <button type="button" class="shell-demo__replay" id="shell-lifecycle-replay" aria-label="Replay the lifecycle demo">replay ↻</button>
       </div>
       <div class="shell-demo__body" id="shell-lifecycle-body">
@@ -1193,7 +1247,7 @@ footer.foot {
         <div class="line muted">&nbsp;&nbsp;Tests&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;· 94% coverage</div>
         <div class="line muted">&nbsp;&nbsp;AgDR&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;· AgDR-0014 linked</div>
         <div class="line muted">&nbsp;&nbsp;Glossary&nbsp;&nbsp;&nbsp;&nbsp;· 5 terms</div>
-        <div class="line ok">&nbsp;&nbsp;Verdict&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;· APPROVE — deferring to CEO</div>
+        <div class="line ok">&nbsp;&nbsp;Verdict&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;· APPROVE - deferring to CEO</div>
         <div class="line">&nbsp;</div>
         <div class="line sys">Waiting for CEO 👍</div>
         <div class="line">&nbsp;</div>
@@ -1216,14 +1270,22 @@ footer.foot {
       </div>
     </div>
 
-    <div class="install rise rise-4" id="install-block">
-      <span class="install__prompt">$</span>
-      <code class="install__cmd" id="install-cmd">gh repo fork me2resh/apexstack --clone</code>
-      <button type="button" class="install__copy" id="install-copy" aria-label="Copy install command">copy</button>
+    <div class="install-row rise rise-4">
+      <div class="install" id="install-block">
+        <span class="install__prompt">$</span>
+        <code class="install__cmd" id="install-cmd">gh repo fork me2resh/apexstack --clone</code>
+        <button type="button" class="install__copy" id="install-copy" aria-label="Copy install command">copy</button>
+      </div>
+      <a href="#" class="install__cta" id="pro-setup-cta"
+         data-u="hello+apexstack" data-d="me2resh.com"
+         aria-label="Contact for professional setup">
+        <span class="install__cta__label">professional setup</span>
+        <span class="install__cta__arrow">→</span>
+      </a>
     </div>
 
     <p class="install__caveat rise rise-4">
-      One command forks apexstack into your org and clones the fork locally. The fork <strong>is</strong> your ops repo — no nested installs, no symlinks. Full walkthrough in the <a href="#quickstart" class="uline">quickstart</a> below. Rename the fork to <code>your-org/ops</code> if you prefer — GitHub handles the rename cleanly.
+      One command forks apexstack into your org and clones the fork locally. The fork <strong>is</strong> your ops repo - no nested installs, no symlinks. Full walkthrough in the <a href="#quickstart" class="uline">quickstart</a> below. Rename the fork to <code>your-org/ops</code> if you prefer - GitHub handles the rename cleanly.
     </p>
 
     <div class="hero__metrics rise rise-5" aria-label="What you get">
@@ -1253,7 +1315,7 @@ footer.foot {
 </section>
 
 <!-- ============================================================
-     SECTION 01 — quickstart
+     SECTION 01 - quickstart
      ============================================================ -->
 <section class="section section--alt" id="quickstart">
 
@@ -1268,15 +1330,15 @@ footer.foot {
   <div class="steps">
 
     <article class="step">
-      <div class="step__num">01 — invite (or fork yourself)</div>
+      <div class="step__num">01 - invite (or fork yourself)</div>
       <h3 class="step__title">Get access</h3>
-      <p class="step__desc">Either someone in an apexstack-managed org invites you as a collaborator, or you fork upstream. Same result either way — you land with a repo that already has apexstack's <code>.claude/</code>, <code>CLAUDE.md</code>, and <code>apexstack.projects.yaml</code> inside.</p>
+      <p class="step__desc">Either someone in an apexstack-managed org invites you as a collaborator, or you fork upstream. Same result either way - you land with a repo that already has apexstack's <code>.claude/</code>, <code>CLAUDE.md</code>, and <code>apexstack.projects.yaml</code> inside.</p>
     </article>
 
     <article class="step">
-      <div class="step__num">02 — star, fork, clone</div>
+      <div class="step__num">02 - star, fork, clone</div>
       <h3 class="step__title">Pull it to your machine</h3>
-      <p class="step__desc">One command via the GitHub CLI. Rename to <code>your-org/ops</code> if you prefer — GitHub handles the rename cleanly.</p>
+      <p class="step__desc">One command via the GitHub CLI. Rename to <code>your-org/ops</code> if you prefer - GitHub handles the rename cleanly.</p>
       <pre class="step__code">gh repo fork me2resh/apexstack --clone
 cd apexstack
 git remote add upstream \
@@ -1284,16 +1346,16 @@ git remote add upstream \
     </article>
 
     <article class="step step--wide" style="grid-column: 1 / -1;">
-      <div class="step__num">03 — claude, /setup</div>
+      <div class="step__num">03 - claude, /setup</div>
       <h3 class="step__title">Open Claude Code and run <code>/setup</code></h3>
-      <p class="step__desc">Everything loads automatically from <code>CLAUDE.md</code>. On first run, a session-start hook checks upstream drift. Then run <code>/setup</code> once — it walks you through company, team, and tech stack in three exchanges and writes <code>onboarding.yaml</code>.</p>
+      <p class="step__desc">Everything loads automatically from <code>CLAUDE.md</code>. On first run, a session-start hook checks upstream drift. Then run <code>/setup</code> once - it walks you through company, team, and tech stack in three exchanges and writes <code>onboarding.yaml</code>.</p>
       <pre class="step__code">claude
 <span class="acc">/setup</span>
 <span class="cm"># three questions → onboarding.yaml is configured</span></pre>
     </article>
 
     <article class="step step--wide" style="grid-column: 1 / -1;">
-      <div class="step__num">04 — bring a project in, or capture an idea</div>
+      <div class="step__num">04 - bring a project in, or capture an idea</div>
       <h3 class="step__title">Adopt, or originate</h3>
       <p class="step__desc">Two entry points depending on what you walked in with. <code>/handover</code> takes an existing repo and generates an assessment + C4 L2 stub + registry entry. <code>/idea</code> captures a new product concept to the shared backlog so it doesn't evaporate.</p>
       <pre class="step__code"><span class="acc">/handover</span> &lt;repo-url&gt;   <span class="cm"># existing project → assessment + registry + architecture stub</span>
@@ -1305,7 +1367,7 @@ git remote add upstream \
 </section>
 
 <!-- ============================================================
-     SECTION 02 — walkthroughs
+     SECTION 02 - walkthroughs
      ============================================================ -->
 <section class="section" id="examples">
 
@@ -1313,7 +1375,7 @@ git remote add upstream \
     <span class="section__num">02 / WALKTHROUGHS</span>
     <h2 class="section__title">What it actually feels like to use</h2>
     <p class="section__lede">
-      Three flows — one for a feature, one for the portfolio, one for a risky change. Each starts with a specific pain and ends with the exact gates that handled it.
+      Three flows - one for a feature, one for the portfolio, one for a risky change. Each starts with a specific pain and ends with the exact gates that handled it.
     </p>
   </div>
 
@@ -1321,7 +1383,7 @@ git remote add upstream \
 
     <article class="demo">
       <div class="demo__head">
-        <span><span class="label">01 — FEATURE</span> idea to production</span>
+        <span><span class="label">01 - FEATURE</span> idea to production</span>
         <span>full SDLC</span>
       </div>
       <pre class="demo__body"><span class="muted"># "I have an idea. Ship it without forgetting a step."</span>
@@ -1346,7 +1408,7 @@ git remote add upstream \
 
     <article class="demo">
       <div class="demo__head">
-        <span><span class="label">02 — PORTFOLIO</span> 5 products, 1 inbox</span>
+        <span><span class="label">02 - PORTFOLIO</span> 5 products, 1 inbox</span>
         <span>cross-project</span>
       </div>
       <pre class="demo__body"><span class="muted"># "Monday. Where do I look first?"</span>
@@ -1366,13 +1428,13 @@ git remote add upstream \
 
 <span class="you">› /stakeholder-update weekly</span>
 <span class="ok">  Drafted projects/updates/2026-04-17.md
-  — rollup across all 5 projects</span></pre>
-      <div class="demo__caption">6 skills read one registry file. Five products surface from a single prompt. Portfolio isn't a view on top of separate repos — it IS the registry.</div>
+  - rollup across all 5 projects</span></pre>
+      <div class="demo__caption">6 skills read one registry file. Five products surface from a single prompt. Portfolio isn't a view on top of separate repos - it IS the registry.</div>
     </article>
 
     <article class="demo demo--wide">
       <div class="demo__head">
-        <span><span class="label">03 — TRUST</span> risky change, 5pm Friday</span>
+        <span><span class="label">03 - TRUST</span> risky change, 5pm Friday</span>
         <span>migration gate</span>
       </div>
       <pre class="demo__body"><span class="muted"># "Just drop a column. Can't be that hard."</span>
@@ -1388,14 +1450,14 @@ git remote add upstream \
   → data volume?
   → observability?</span>
 <span class="ok">  ✓ AgDR-0047 · issue #214 labelled `migration`
-  ✓ body refs AgDR — gate 3 satisfied</span>
+  ✓ body refs AgDR - gate 3 satisfied</span>
 
 <span class="you">› /start-ticket #214 · retry the edit</span>
 <span class="ok">  ✓ all 3 gates pass · edit allowed</span>
 
-<span class="ag">Rex: "analytics ETL reads user_profiles nightly —
+<span class="ag">Rex: "analytics ETL reads user_profiles nightly -
 confirm it skips the missing column before merge."</span></pre>
-      <div class="demo__caption">3 hooks, 2 skills, 1 AgDR — all before a single byte of schema changed. Questions that would surface at 2am during rollback get forced upfront, when your team is awake.</div>
+      <div class="demo__caption">3 hooks, 2 skills, 1 AgDR - all before a single byte of schema changed. Questions that would surface at 2am during rollback get forced upfront, when your team is awake.</div>
     </article>
 
   </div>
@@ -1404,7 +1466,7 @@ confirm it skips the missing column before merge."</span></pre>
 
 
 <!-- ============================================================
-     SECTION 04 — what's in the box
+     SECTION 04 - what's in the box
      ============================================================ -->
 <section class="section" id="in-the-box">
 
@@ -1422,7 +1484,7 @@ confirm it skips the missing column before merge."</span></pre>
       <div class="layer__num">roles · 19</div>
       <h3 class="layer__title">Activate by trigger</h3>
       <p class="layer__desc">
-        PR touches auth → Security Auditor activates. Ticket hits QA → QA Engineer. Migration edit → Data Engineer + migration AgDR. Each role has CAN / CANNOT lists — it won't step outside its lane.
+        PR touches auth → Security Auditor activates. Ticket hits QA → QA Engineer. Migration edit → Data Engineer + migration AgDR. Each role has CAN / CANNOT lists - it won't step outside its lane.
       </p>
     </article>
 
@@ -1450,15 +1512,21 @@ confirm it skips the missing column before merge."</span></pre>
       </p>
     </article>
 
-    <article class="layer layer--wide" style="grid-column: 1 / -1;">
-      <div class="layer__num">portfolio + CI · one fork, N products</div>
-      <h3 class="layer__title">One inbox across everything, ready-made pipelines to drop in</h3>
-      <p class="layer__desc">
-        <code>apexstack.projects.yaml</code> at your fork root lists every repo you manage. Skills like <code>/inbox</code>, <code>/status</code>, <code>/tasks</code>, <code>/stakeholder-update</code> aggregate across it — one prompt, every project. Add a project with <code>/handover</code>; sync with upstream via <code>/update</code>.
-      </p>
-      <p class="layer__desc" style="margin-top:0.75rem;">
-        On the CI side: <code>golden-paths/pipelines/</code> ships 7 reusable GitHub Actions workflows — <code>ci.yml</code> (combined), <code>code-quality.yml</code>, <code>security.yml</code> (Semgrep + npm audit + TruffleHog), <code>dependency-audit.yml</code> (weekly), <code>pr-title-check.yml</code>, <code>review-check.yml</code> (blocks merge until Rex has reviewed HEAD), <code>seo-check.yml</code>. Copy what you need into each project's <code>.github/workflows/</code>.
-      </p>
+    <article class="layer layer--wide layer--split" style="grid-column: 1 / -1;">
+      <div class="layer__half">
+        <div class="layer__num">portfolio &middot; one fork, N products</div>
+        <h3 class="layer__title">One inbox across everything</h3>
+        <p class="layer__desc">
+          <code>apexstack.projects.yaml</code> at your fork root lists every repo you manage. Skills like <code>/inbox</code>, <code>/status</code>, <code>/tasks</code>, <code>/stakeholder-update</code> aggregate across it. One prompt, every project. Add a project with <code>/handover</code>; sync with upstream via <code>/update</code>.
+        </p>
+      </div>
+      <div class="layer__half">
+        <div class="layer__num">CI &middot; 7 golden-path workflows</div>
+        <h3 class="layer__title">Drop-in GitHub Actions</h3>
+        <p class="layer__desc">
+          At <code>golden-paths/pipelines/</code>: <code>ci.yml</code>, <code>code-quality.yml</code>, <code>security.yml</code>, <code>dependency-audit.yml</code>, <code>pr-title-check.yml</code>, <code>review-check.yml</code>, <code>seo-check.yml</code>. Copy what you need into each project's <code>.github/workflows/</code>.
+        </p>
+      </div>
     </article>
 
   </div>
@@ -1475,9 +1543,6 @@ confirm it skips the missing column before merge."</span></pre>
       <p>
         MIT. Plain markdown and shell. Delete the directory and you're back where you started.
       </p>
-      <p style="margin-top:0.75rem;opacity:0.75;">
-        Want apexstack set up for your team — custom roles, company-specific rules, onboarded repos, the works? <a href="https://me2resh.com/about" class="uline" target="_blank" rel="noopener">Get in touch about professional setup</a>.
-      </p>
     </div>
     <div class="final__actions">
       <a href="https://github.com/me2resh/apexstack" class="final__btn" target="_blank" rel="noopener">
@@ -1487,10 +1552,6 @@ confirm it skips the missing column before merge."</span></pre>
       <a href="#quickstart" class="final__btn">
         <span>back to quickstart</span>
         <span class="arrow">↑</span>
-      </a>
-      <a href="https://me2resh.com/about" class="final__btn" target="_blank" rel="noopener">
-        <span>professional setup</span>
-        <span class="arrow">→</span>
       </a>
       <a href="https://github.com/me2resh/apexstack/issues" class="final__btn" target="_blank" rel="noopener">
         <span>open an issue</span>
@@ -1549,11 +1610,36 @@ confirm it skips the missing column before merge."</span></pre>
   }
 })();
 
+// ---- professional-setup CTA: non-scrapable email assembly ----
+// The mailto: address is never present in the page source. Data attributes
+// hold the user + domain parts separately, and we only assemble and set
+// the href on the first user hover / focus / touch. Basic crawlers that
+// read HTML will find neither an @ sign nor the composed address.
+(function () {
+  var a = document.getElementById('pro-setup-cta');
+  if (!a) return;
+  var assembled = false;
+  function assemble() {
+    if (assembled) return;
+    var u = a.getAttribute('data-u') || '';
+    var d = a.getAttribute('data-d') || '';
+    if (!u || !d) return;
+    a.setAttribute('href', 'mail' + 'to:' + u + '\u0040' + d + '?subject=' + encodeURIComponent('ApexStack - professional setup enquiry'));
+    assembled = true;
+  }
+  ['mouseenter', 'focus', 'touchstart'].forEach(function (ev) {
+    a.addEventListener(ev, assemble, { once: false, passive: true });
+  });
+  // Safety net: if someone clicks before any of the above fire (keyboard
+  // activation on some browsers), assemble first and let the click proceed.
+  a.addEventListener('click', assemble);
+})();
+
 // ---- full lifecycle shell animation (hero) ----
-// The demo lives in the hero so it's visible on load — IntersectionObserver
+// The demo lives in the hero so it's visible on load - IntersectionObserver
 // still used so the play trigger stays consistent, and the hasPlayed gate
 // ensures it only auto-plays once. Falls back to delayed auto-play if IO is
-// missing. Respects prefers-reduced-motion — static content stays, no
+// missing. Respects prefers-reduced-motion - static content stays, no
 // animation. The small 17rem shell-demo--tall viewport scrolls to the
 // bottom on each new line so old lines push up and out, like a terminal.
 (function () {
@@ -1569,7 +1655,7 @@ confirm it skips the missing column before merge."</span></pre>
   // Script: [type, text, delayAfterMs, typeSpeedMs (0 = instant)]
   // Types: sys (narrated agent action / header), you (human input, typed),
   //        ok (success line), muted (dim detail), blank (empty spacer).
-  // Autonomous by default — the ONLY human touchpoints are the two `you`
+  // Autonomous by default - the ONLY human touchpoints are the two `you`
   // responses (plan approval + push approval) and the CEO 👍 wait/marker.
   var script = [
     ['sys',   'Inbox:',                                                                    200, 0],
@@ -1607,7 +1693,7 @@ confirm it skips the missing column before merge."</span></pre>
     ['muted', '  Tests        · 94% coverage',                                             250, 0],
     ['muted', '  AgDR         · AgDR-0014 linked',                                         250, 0],
     ['muted', '  Glossary     · 5 terms',                                                  300, 0],
-    ['ok',    '  Verdict      · APPROVE — deferring to CEO',                               800, 0],
+    ['ok',    '  Verdict      · APPROVE - deferring to CEO',                               800, 0],
     ['blank', '',                                                                          200, 0],
     ['sys',   'Waiting for CEO 👍',                                                       1500, 0],
     ['blank', '',                                                                          200, 0],
@@ -1690,7 +1776,7 @@ confirm it skips the missing column before merge."</span></pre>
       }
 
       if (type === 'you') {
-        // The ONLY type with a prompt — human input marker
+        // The ONLY type with a prompt - human input marker
         var prompt = document.createElement('span');
         prompt.className = 'prompt';
         prompt.textContent = '> ';
@@ -1703,7 +1789,7 @@ confirm it skips the missing column before merge."</span></pre>
           timeouts.push(setTimeout(next, delayAfter));
         });
       } else {
-        // sys / ok / muted / (any other) — autonomous agent output,
+        // sys / ok / muted / (any other) - autonomous agent output,
         // rendered as plain text with the type class driving colour
         line.textContent = text;
         scrollToBottom();
@@ -1723,7 +1809,7 @@ confirm it skips the missing column before merge."</span></pre>
     });
   }
 
-  // Intersection observer — auto-play ONCE when the demo scrolls into view
+  // Intersection observer - auto-play ONCE when the demo scrolls into view
   if ('IntersectionObserver' in window) {
     var io = new IntersectionObserver(function (entries) {
       entries.forEach(function (entry) {

--- a/site/index.html
+++ b/site/index.html
@@ -689,7 +689,8 @@ a:hover { color: var(--accent); }
   position: relative;
 }
 .layer:nth-child(2n) { border-right: none; }
-.layer:nth-last-child(-n+2) { border-bottom: none; }
+.layer:last-child { border-bottom: none; }
+.layer:last-child.layer--wide { border-right: none; }
 @media (max-width: 720px) {
   .layer { border-right: none; }
   .layer:not(:last-child) { border-bottom: 1px solid var(--rule-faint); }
@@ -1618,7 +1619,27 @@ confirm it skips the missing column before merge."</span></pre>
     var u = a.getAttribute('data-u') || '';
     var d = a.getAttribute('data-d') || '';
     if (!u || !d) return;
-    a.setAttribute('href', 'mail' + 'to:' + u + '\u0040' + d + '?subject=' + encodeURIComponent('ApexStack - professional setup enquiry'));
+    var subject = 'ApexStack - professional setup enquiry';
+    var body = [
+      'Hi Ahmed,',
+      '',
+      "I'd like to set up apexstack for my team. A few quick details so you can scope the work:",
+      '',
+      '- Company / org:',
+      '- Team size:',
+      '- Stack (languages / frameworks):',
+      '- Number of repos to bring under management:',
+      "- What you're trying to solve (engineering consistency, portfolio visibility, onboarding speed, something else):",
+      '- Timeline / urgency:',
+      '',
+      'Thanks,',
+      ''
+    ].join('\n');
+    a.setAttribute('href',
+      'mail' + 'to:' + u + '\u0040' + d +
+      '?subject=' + encodeURIComponent(subject) +
+      '&body=' + encodeURIComponent(body)
+    );
     assembled = true;
   }
   ['mouseenter', 'focus', 'touchstart'].forEach(function (ev) {

--- a/site/index.html
+++ b/site/index.html
@@ -1100,10 +1100,9 @@ footer.foot {
       <span class="titlebar__path">~/<b>apexstack</b> <span class="dim">— main · v0.3</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
-      <a href="#layers">layers</a>
+      <a href="#quickstart">quickstart</a>
       <a href="#examples">walkthroughs</a>
-      <a href="#pipelines">pipelines</a>
-      <a href="#install">install</a>
+      <a href="#in-the-box">what's in the box</a>
       <a href="https://github.com/me2resh/apexstack" class="is-cta" target="_blank" rel="noopener">github →</a>
     </nav>
   </div>
@@ -1141,7 +1140,7 @@ footer.foot {
     <div class="hero__cta rise rise-4">
       <a href="https://github.com/me2resh/apexstack" class="cta cta--primary" target="_blank" rel="noopener">★ Star &nbsp;·&nbsp; ⑂ Fork on GitHub</a>
       <span class="cta__sep" aria-hidden="true">·</span>
-      <a href="#install" class="cta cta--ghost">or see the install steps ↓</a>
+      <a href="#quickstart" class="cta cta--ghost">or see the 4-step quickstart ↓</a>
     </div>
 
     <div class="shell-demo shell-demo--tall rise rise-4" id="shell-lifecycle" aria-label="Demo of a full ticket lifecycle in apexstack, from inbox pickup to QA sign-off">
@@ -1220,7 +1219,7 @@ footer.foot {
     </div>
 
     <p class="install__caveat rise rise-4">
-      One command forks apexstack into your org and clones the fork locally. The fork <strong>is</strong> your ops repo — no nested installs, no symlinks. Full walkthrough in <a href="#install" class="uline">install</a> below. No magic. No build. No SaaS. Rename the fork to <code>your-org/ops</code> if you prefer — GitHub handles the rename cleanly.
+      One command forks apexstack into your org and clones the fork locally. The fork <strong>is</strong> your ops repo — no nested installs, no symlinks. Full walkthrough in the <a href="#quickstart" class="uline">quickstart</a> below. Rename the fork to <code>your-org/ops</code> if you prefer — GitHub handles the rename cleanly.
     </p>
 
     <div class="hero__metrics rise rise-5" aria-label="What you get">
@@ -1250,58 +1249,51 @@ footer.foot {
 </section>
 
 <!-- ============================================================
-     SECTION 01 — the five layers
+     SECTION 01 — quickstart
      ============================================================ -->
-<section class="section section--alt" id="layers">
+<section class="section section--alt" id="quickstart">
 
   <div class="section__head">
-    <span class="section__num">01 / LAYERS</span>
-    <h2 class="section__title">Five layers, one stack</h2>
+    <span class="section__num">01 / QUICKSTART</span>
+    <h2 class="section__title">Get started in four steps</h2>
     <p class="section__lede">
-      Five layers stack together: roles, workflows, hooks, skills, and the portfolio registry itself. Even with one repo, every layer works the same.
+      From invite to first command. Works the same whether you were added to someone's org or are starting your own fork.
     </p>
   </div>
 
-  <div class="layers">
+  <div class="steps">
 
-    <article class="layer">
-      <div class="layer__num">01 — roles</div>
-      <h3 class="layer__title">Roles</h3>
-      <p class="layer__desc">
-        19 role definitions across 5 departments. Activation-triggered with CAN / CANNOT boundaries. "Act as the QA Engineer" picks up the full mental model.
-      </p>
+    <article class="step">
+      <div class="step__num">01 — invite (or fork yourself)</div>
+      <h3 class="step__title">Get access</h3>
+      <p class="step__desc">Either someone in an apexstack-managed org invites you as a collaborator, or you fork upstream. Same result either way — you land with a repo that already has apexstack's <code>.claude/</code>, <code>CLAUDE.md</code>, and <code>apexstack.projects.yaml</code> inside.</p>
     </article>
 
-    <article class="layer">
-      <div class="layer__num">02 — workflows + templates</div>
-      <h3 class="layer__title">Workflows + templates</h3>
-      <p class="layer__desc">
-        7-phase SDLC, code review, deployment. Seven templates — PRD, tech design, ADR, AgDR, migration AgDR, C4 L1 + L2.
-      </p>
+    <article class="step">
+      <div class="step__num">02 — star, fork, clone</div>
+      <h3 class="step__title">Pull it to your machine</h3>
+      <p class="step__desc">One command via the GitHub CLI. Rename to <code>your-org/ops</code> if you prefer — GitHub handles the rename cleanly.</p>
+      <pre class="step__code">gh repo fork me2resh/apexstack --clone
+cd apexstack
+git remote add upstream \
+  https://github.com/me2resh/apexstack.git</pre>
     </article>
 
-    <article class="layer">
-      <div class="layer__num">03 — hooks + rules</div>
-      <h3 class="layer__title">Hooks + rules</h3>
-      <p class="layer__desc">
-        18 shell hooks enforce the SDLC mechanically: ticket-first, migration gate, two-marker merge gates (Rex + CEO), design review, red-CI block, upstream drift banner. Eight modular rule files.
-      </p>
+    <article class="step">
+      <div class="step__num">03 — claude, hi</div>
+      <h3 class="step__title">Open Claude Code and say hi</h3>
+      <p class="step__desc">Everything loads automatically from <code>CLAUDE.md</code>. On first run, a session-start hook checks upstream drift and asks you to run <code>/setup</code> once to fill in <code>onboarding.yaml</code> — company, team, stack.</p>
+      <pre class="step__code">claude
+<span class="acc">hi</span>
+<span class="cm"># first-time: /setup runs through company + stack config</span></pre>
     </article>
 
-    <article class="layer">
-      <div class="layer__num">04 — agents + skills</div>
-      <h3 class="layer__title">Agents + skills</h3>
-      <p class="layer__desc">
-        Five sub-agents (Rex, Shield, Guardian, PR Manager, Ticket Manager). 32 slash commands covering SDLC, portfolio rollups, adoption, and an 8-dimension <code>/launch-check</code>.
-      </p>
-    </article>
-
-    <article class="layer layer--wide" style="grid-column: 1 / -1;">
-      <div class="layer__num">05 — portfolio</div>
-      <h3 class="layer__title">A portfolio, not a single repo</h3>
-      <p class="layer__desc">
-        Your ops repo is a <strong>fork of apexstack</strong>. <code>apexstack.projects.yaml</code> at the root is the registry. Every portfolio skill — <code>/projects</code>, <code>/inbox</code>, <code>/status</code>, <code>/tasks</code>, <code>/stakeholder-update</code> — aggregates across it. One fork, N products, one inbox.
-      </p>
+    <article class="step step--wide" style="grid-column: 1 / -1;">
+      <div class="step__num">04 — bring a project in, or capture an idea</div>
+      <h3 class="step__title">Adopt, or originate</h3>
+      <p class="step__desc">Two entry points depending on what you walked in with. <code>/handover</code> takes an existing repo and generates an assessment + C4 L2 stub + registry entry. <code>/idea</code> captures a new product concept to the shared backlog so it doesn't evaporate.</p>
+      <pre class="step__code"><span class="acc">/handover</span> &lt;repo-url&gt;   <span class="cm"># existing project → assessment + registry + architecture stub</span>
+<span class="acc">/idea</span>                  <span class="cm"># new concept → ideas-backlog.md, optional GitHub issue</span></pre>
     </article>
 
   </div>
@@ -1406,158 +1398,70 @@ confirm it skips the missing column before merge."</span></pre>
 
 </section>
 
+
 <!-- ============================================================
-     SECTION 03 — pipelines
+     SECTION 04 — what's in the box
      ============================================================ -->
-<section class="section section--alt" id="pipelines">
+<section class="section" id="in-the-box">
 
   <div class="section__head">
-    <span class="section__num">03 / PIPELINES</span>
-    <h2 class="section__title">Drop-in CI workflows</h2>
+    <span class="section__num">04 / WHAT'S IN THE BOX</span>
+    <h2 class="section__title">What you can actually do</h2>
     <p class="section__lede">
-      Seven GitHub Actions workflows live at <code>golden-paths/pipelines/</code>. Copy whichever you want into your project's <code>.github/workflows/</code> — no boilerplate to write, no configuration to wrestle with.
+      Everything below is already wired in your fork. Nothing to install, nothing to configure beyond <code>/setup</code>.
     </p>
   </div>
 
-  <div class="pipelines">
-    <div class="pipelines__inner">
+  <div class="layers">
 
-      <div class="pipeline">
-        <div class="pipeline__file">ci.yml</div>
-        <div class="pipeline__desc">Combined pipeline — code quality + security + dependencies in one file. Start here.</div>
-        <div class="pipeline__agent">Rex · Shield · Guardian</div>
-      </div>
-
-      <div class="pipeline">
-        <div class="pipeline__file">code-quality.yml</div>
-        <div class="pipeline__desc">TypeScript check, ESLint, Prettier, tests with coverage, build verification. Posts a summary comment on every PR.</div>
-        <div class="pipeline__agent">Rex</div>
-      </div>
-
-      <div class="pipeline">
-        <div class="pipeline__file">security.yml</div>
-        <div class="pipeline__desc">Semgrep SAST (OWASP Top 10), npm audit, TruffleHog secrets detection, optional CodeQL. Fails on critical or high severity.</div>
-        <div class="pipeline__agent">Shield</div>
-      </div>
-
-      <div class="pipeline">
-        <div class="pipeline__file">dependency-audit.yml</div>
-        <div class="pipeline__desc">Weekly vulnerability scan (Mondays 09:00 UTC) plus on every package.json change. Auto-creates a security issue when something critical lands.</div>
-        <div class="pipeline__agent">Guardian</div>
-      </div>
-
-      <div class="pipeline">
-        <div class="pipeline__file">pr-title-check.yml</div>
-        <div class="pipeline__desc">Enforces a ticket ID in every PR title. Default: GitHub Issues (#58). Also accepts any uppercase tracker prefix.</div>
-        <div class="pipeline__agent">governance</div>
-      </div>
-
-      <div class="pipeline">
-        <div class="pipeline__file">review-check.yml</div>
-        <div class="pipeline__desc">Blocks merge if Rex hasn't reviewed the latest commit on the PR. Compares review SHAs against HEAD.</div>
-        <div class="pipeline__agent">Rex (verification)</div>
-      </div>
-
-      <div class="pipeline">
-        <div class="pipeline__file">seo-check.yml</div>
-        <div class="pipeline__desc">SEO scoring for content files — H1, meta description, length, headings, alt text, internal links. For docs and blog sites.</div>
-        <div class="pipeline__agent">no agent</div>
-      </div>
-
-    </div>
-  </div>
-
-</section>
-
-<!-- ============================================================
-     SECTION 04 — install
-     ============================================================ -->
-<section class="section" id="install">
-
-  <div class="section__head">
-    <span class="section__num">04 / INSTALL</span>
-    <h2 class="section__title">Fork, track upstream, start working</h2>
-    <p class="section__lede">
-      Three steps. The fork <strong>is</strong> your ops repo — no nested installs, no symlinks. Config (<code>onboarding.yaml</code>) and the registry (<code>apexstack.projects.yaml</code>) are handled by <code>/setup</code> and <code>/handover</code> from inside Claude Code — you never open them by hand.
-    </p>
-  </div>
-
-  <div class="steps">
-
-    <article class="step">
-      <div class="step__num">01 — fork + clone</div>
-      <h3 class="step__title">Fork apexstack on GitHub</h3>
-      <p class="step__desc">Star + fork on GitHub, or one-command via the GitHub CLI. Rename the fork to <code>your-org/ops</code> if you prefer — GitHub handles the rename cleanly.</p>
-      <pre class="step__code">gh repo fork me2resh/apexstack --clone
-cd apexstack</pre>
+    <article class="layer">
+      <div class="layer__num">roles · 19</div>
+      <h3 class="layer__title">Activate by trigger</h3>
+      <p class="layer__desc">
+        PR touches auth → Security Auditor activates. Ticket hits QA → QA Engineer. Migration edit → Data Engineer + migration AgDR. Each role has CAN / CANNOT lists — it won't step outside its lane.
+      </p>
     </article>
 
-    <article class="step">
-      <div class="step__num">02 — track upstream</div>
-      <h3 class="step__title">Add the upstream remote</h3>
-      <p class="step__desc">Once. The session-start drift banner tells you when you're behind; <code>/update</code> does the sync-branch-and-PR dance for you.</p>
-      <pre class="step__code">git remote add upstream \
-  https://github.com/me2resh/apexstack.git</pre>
+    <article class="layer">
+      <div class="layer__num">skills · 33 slash commands</div>
+      <h3 class="layer__title">One prompt, one thing</h3>
+      <p class="layer__desc">
+        <code>/handover</code> adopts a project. <code>/idea</code> captures a concept. <code>/inbox</code>, <code>/status</code>, <code>/tasks</code> triage the portfolio. <code>/decide</code> records a technical call as an AgDR. <code>/launch-check</code> runs an 8-dimension readiness audit. <code>/c4</code> generates L1 + L2 architecture diagrams from a codebase.
+      </p>
     </article>
 
-    <article class="step">
-      <div class="step__num">03 — start working</div>
-      <h3 class="step__title">Open Claude Code in the fork</h3>
-      <p class="step__desc">Everything loads automatically — <code>CLAUDE.md</code> is the entry point. Run <code>/setup</code> once to configure your company + stack, <code>/handover &lt;repo&gt;</code> to bring each project under management, then reach for the portfolio skills.</p>
-      <pre class="step__code"><span class="acc">/setup</span>             <span class="cm"># one-time — company + tech stack → onboarding.yaml</span>
-<span class="acc">/handover</span> &lt;repo&gt;   <span class="cm"># adopt a project → registry + stub L2 C4 diagram</span>
-<span class="acc">/inbox</span>             <span class="cm"># PRs, issues, comments needing your eyes</span>
-<span class="acc">/status</span>            <span class="cm"># git + CI snapshot per project</span>
-<span class="acc">/launch-check</span>      <span class="cm"># 8-dimension production-readiness audit</span></pre>
+    <article class="layer">
+      <div class="layer__num">hooks · 18 shell scripts</div>
+      <h3 class="layer__title">Rules that fire themselves</h3>
+      <p class="layer__desc">
+        Ticket-first on every edit. Migration gate on schema paths. Two-marker merge (Rex + CEO), SHA-bound, invalidates on every commit. Red CI block. Secrets scanner. Design-review gate on UI PRs. Upstream-drift banner at session start.
+      </p>
     </article>
 
-  </div>
+    <article class="layer">
+      <div class="layer__num">agents · 5 sub-agents</div>
+      <h3 class="layer__title">Reviewers that don't rubber-stamp</h3>
+      <p class="layer__desc">
+        Rex (code review) checks architecture + tests + AgDR links + glossary. Shield (security) flags auth / crypto / secrets. Guardian (deps) scans vulnerabilities + licences. PR Manager + Ticket Manager handle the orchestration.
+      </p>
+    </article>
 
-</section>
+    <article class="layer">
+      <div class="layer__num">CI · 7 golden-path workflows</div>
+      <h3 class="layer__title">Drop-in GitHub Actions</h3>
+      <p class="layer__desc">
+        At <code>golden-paths/pipelines/</code>: <code>ci.yml</code> (combined), <code>code-quality.yml</code>, <code>security.yml</code> (Semgrep + npm audit + TruffleHog), <code>dependency-audit.yml</code> (weekly), <code>pr-title-check.yml</code>, <code>review-check.yml</code> (blocks merge until Rex has reviewed HEAD), <code>seo-check.yml</code>. Copy what you need into each project's <code>.github/workflows/</code>.
+      </p>
+    </article>
 
-<!-- ============================================================
-     SECTION 05 — what apexstack is and isn't
-     ============================================================ -->
-<section class="section section--alt">
+    <article class="layer layer--wide" style="grid-column: 1 / -1;">
+      <div class="layer__num">portfolio · one fork, N products</div>
+      <h3 class="layer__title">One inbox across everything</h3>
+      <p class="layer__desc">
+        <code>apexstack.projects.yaml</code> at your fork root lists every repo you manage. Skills like <code>/inbox</code>, <code>/status</code>, <code>/tasks</code>, <code>/stakeholder-update</code> aggregate across it. Add a project with <code>/handover</code>; sync with upstream via <code>/update</code>.
+      </p>
+    </article>
 
-  <div class="section__head">
-    <span class="section__num">05 / SCOPE</span>
-    <h2 class="section__title">Opinionated by design</h2>
-    <p class="section__lede">
-      Every reusable framework has to draw a line between "this is what we do" and "this is yours to figure out". ApexStack draws the line where it makes the most difference for engineering teams.
-    </p>
-  </div>
-
-  <div class="antifeatures">
-    <div class="antifeatures__inner">
-      <div class="antifeatures__col is-do">
-        <h3 class="is-yes">+ what apexstack does</h3>
-        <ul>
-          <li>Enforces ticket-first development via GitHub Issues per project — with a stricter migration-gate variant on schema / migration-path edits</li>
-          <li>Requires explicit per-PR CEO approval before any merge — marker is SHA-bound, invalidates on every new commit</li>
-          <li>Blocks dangerous git operations (add -A, push to main, secrets in commits, red CI, unreviewed merges via either <code>gh pr merge</code> or raw <code>gh api</code>)</li>
-          <li>Forces structured decisions via /decide → AgDR audit trail (plus a dedicated migration AgDR with rollback / downtime / consumers / observability)</li>
-          <li>Ships an opinionated 6-gate workflow from PRD to QA + a migration sub-workflow</li>
-          <li>Aggregates a whole portfolio into one inbox — /inbox, /status, /tasks read a single registry file</li>
-          <li>Tells you when the fork is behind upstream (session-start drift banner), then syncs it in one skill invocation</li>
-          <li>Mandates a glossary in every PR — knowledge stays in the team</li>
-          <li>Defaults to TypeScript, DDD, vitest, GitHub Actions — but stays editable per project via <code>.claude/project-config.json</code></li>
-        </ul>
-      </div>
-      <div class="antifeatures__col is-dont">
-        <h3>× what apexstack does NOT do</h3>
-        <ul>
-          <li>Replace your team — humans still write code, ship product, talk to customers</li>
-          <li>Lock you into a SaaS — every file is markdown or shell, fork freely, diff any decision in git</li>
-          <li>Hide its opinions — read the rules, disagree, edit them (and file a PR upstream if you want them changed for everyone)</li>
-          <li>Auto-run merges when you say "go" on a plan — per-PR approval is discrete by design</li>
-          <li>Impose a central tracker — issues live in each project's own GitHub repo, not in apexstack</li>
-          <li>Pretend to be language-agnostic — TypeScript-leaning by default; path patterns and templates are swappable</li>
-          <li>Ship a UI — this is a stack of files, not an app</li>
-          <li>Compete with Claude Code's built-ins — it extends them via hooks, skills, and sub-agent definitions</li>
-        </ul>
-      </div>
-    </div>
   </div>
 
 </section>
@@ -1568,11 +1472,9 @@ cd apexstack</pre>
 <section class="final">
   <div class="final__inner">
     <div>
-      <h2>Stop reinventing<br>the same <span class="acc">processes</span>.</h2>
+      <h2>Fork it, clone it,<br>run <span class="acc">claude</span>.</h2>
       <p>
-        ApexStack is one fork, one clone, and one config file away.
-        It's MIT licensed, plain markdown, and edits are encouraged.
-        If you change your mind, you delete the directory and you're back where you started.
+        MIT. Plain markdown and shell. Delete the directory and you're back where you started.
       </p>
     </div>
     <div class="final__actions">
@@ -1580,8 +1482,8 @@ cd apexstack</pre>
         <span>view on github</span>
         <span class="arrow">→</span>
       </a>
-      <a href="#install" class="final__btn">
-        <span>back to install</span>
+      <a href="#quickstart" class="final__btn">
+        <span>back to quickstart</span>
         <span class="arrow">↑</span>
       </a>
       <a href="https://github.com/me2resh/apexstack/issues" class="final__btn" target="_blank" rel="noopener">


### PR DESCRIPTION
## Summary

Refreshes `site/index.html` so a newcomer lands and sees **what to do**, not marketing prose about what the framework is. Mirrors the 4-step invite-to-first-command path the CEO typed out when onboarding a friend.

### Kept (sacred)

- Hero with titlebar, version pill, changelog link, release link
- The shell-demo terminal-replay at the top of the hero
- The three walkthrough demos (feature / portfolio / migration-gate) — these are the practical-usage narrative the site earns its keep on

### Replaced

| Out | In |
|---|---|
| "Five layers, one stack" — layer cards | **01 / QUICKSTART** — the four concrete steps: invite / fork+clone / `claude` + hi / `/handover` or `/idea` |
| "Fork, track upstream, start working" — old 3-step install | folded into the new quickstart |
| "Opinionated by design" — does/doesn't bullets | **04 / WHAT'S IN THE BOX** — roles · skills · hooks · agents · CI · portfolio, each with a one-line practical description |

### Dropped entirely

- "03 / PIPELINES" — 63-line section of 7 CI-workflow cards. Replaced with a single compressed row inside "What's in the box" so the info is discoverable but doesn't dominate.

### Net

- `site/index.html`: **1840 → 1742 lines** (−98 lines, -182/+84)
- CSS, JS, font stack, colour tokens, `rise` animation classes — untouched
- Titlebar nav simplified: `quickstart / walkthroughs / what's in the box`

## Testing

1. Open `site/index.html` in a browser — layout intact, terminal-replay animates as before.
2. Click every internal anchor — `#main`, `#quickstart`, `#examples`, `#in-the-box` — all resolve.
3. Hero CTA, install__caveat, final CTA all point at `#quickstart`.
4. Lychee link-check (CI) should pass — no external URLs changed.
5. Markdownlint (CI) N/A — HTML file, not markdown.

Closes #80

---

## Glossary

| Term | Definition |
|------|------------|
| Shell-demo / terminal-replay | The animated terminal-style block in the hero showing a full ticket lifecycle — designated sacred by CEO |
| Quickstart | The new 4-step onboarding flow that matches what the CEO actually types to invite a new user |
| What's in the box | The practical-inventory section listing roles, skills, hooks, agents, CI workflows, and portfolio mechanics |
| rise / rise-N | Existing animation utility classes for staggered fade-up entry — preserved verbatim |