### PR TITLE
chore(#84): add `cd apexyard` to quickstart step 02

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1344,7 +1344,8 @@ git remote add upstream \
       <div class="step__num">02 - claude, /setup</div>
       <h3 class="step__title">Open Claude Code and run <code>/setup</code></h3>
       <p class="step__desc">Everything loads automatically from <code>CLAUDE.md</code>. On first run, a session-start hook checks upstream drift. Then run <code>/setup</code> once - three exchanges to configure company, team, and tech stack.</p>
-      <pre class="step__code">claude
+      <pre class="step__code">cd apexyard
+claude
 <span class="acc">/setup</span>
 <span class="cm"># three questions → onboarding.yaml is configured</span></pre>
     </article>


### PR DESCRIPTION
## Summary

One-line content fix in `site/index.html`. Step 02 in the quickstart ("claude, /setup") now starts with `cd apexyard` so the reader knows explicitly which directory to run `claude` from, rather than implicitly relying on having stayed in the directory created by step 01.

## Diff

Step 02 code block — was:

```
claude
/setup
# three questions → onboarding.yaml is configured
```

Now:

```
cd apexyard
claude
/setup
# three questions → onboarding.yaml is configured
```

## Testing

1. Open `site/index.html` — quickstart step 02 shows the new first line.
2. Lychee + markdownlint CI pass.

Closes #84

---

## Glossary

| Term | Definition |
|------|------------|
| Self-contained step | A code block that a reader can run in isolation without assumptions about state left by a previous step |