### PR TITLE
chore(#86): reframe final CTA copy from delete-to-exit to fork-to-own

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1537,7 +1537,7 @@ confirm it skips the missing column before merge."</span></pre>
     <div>
       <h2>Fork it, clone it,<br>run <span class="acc">claude</span>.</h2>
       <p>
-        MIT. Plain markdown and shell. Delete the directory and you're back where you started.
+        MIT. Plain markdown and shell. Fork freely, edit any rule, hook, or skill to match your team.
       </p>
     </div>
     <div class="final__actions">


### PR DESCRIPTION
## Summary

One-line content fix in `site/index.html` final CTA.

**Was:** *\"MIT. Plain markdown and shell. Delete the directory and you're back where you started.\"*

**Now:** *\"MIT. Plain markdown and shell. Fork freely, edit any rule, hook, or skill to match your team.\"*

Same MIT / markdown / shell credibility, reframed around ownership rather than leaveability. A landing-page final CTA shouldn't offer an exit ramp.

Closes #86

---

## Glossary

| Term | Definition |
|------|------------|
| Exit ramp copy | Call-to-action phrasing that invites the visitor to walk away rather than engage further |