### PR TITLE
chore(#90): publish site to yard.apexscript.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Claude Code is the default driver, but the rules, hooks, and templates are plain
 
 **Proven shipping** TypeScript + AWS Lambda backends, Next.js web apps, Chrome extensions, and native **Swift** macOS desktop apps. The stack is process and guardrails — not a language or framework lock-in.
 
-Inspired by [gstacks.org](https://gstacks.org/) — but purpose-built for software teams running more than one product at a time.
-
 ## What's Inside
 
 ```

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,5 @@
-[build]
-  # Static site - no build step. Ship what's in site/.
-  publish = "site"
+# Publish directory is set in the Netlify UI (site/).
+# This file only contributes security headers so they live in source.
 
 [[headers]]
   for = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+[build]
+  # Static site - no build step. Ship what's in site/.
+  publish = "site"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "interest-cohort=()"

--- a/site/index.html
+++ b/site/index.html
@@ -1158,7 +1158,82 @@ footer.foot {
   font-size: 12px;
 }
 .skip:focus { left: 1rem; top: 1rem; }
+
+/* ============================================================
+   cookie consent banner - minimal, non-blocking.
+   Gates Google Analytics (Consent Mode v2) for GDPR/ePrivacy.
+   ============================================================ */
+
+.consent {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--paper);
+  border-top: 1px solid var(--ink);
+  z-index: 100;
+  font-size: 12px;
+  padding: 1rem var(--gutter);
+}
+.consent[hidden] { display: none; }
+.consent__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.consent__msg {
+  flex: 1;
+  min-width: 260px;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+.consent__msg a { color: var(--accent); }
+.consent__actions { display: flex; gap: 0.5rem; }
+.consent__btn {
+  font: inherit;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.consent__btn:hover { border-color: var(--ink); }
+.consent__btn--accept {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.consent__btn--accept:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+}
 </style>
+
+<!-- Google tag (gtag.js) with Consent Mode v2 - analytics_storage defaults to denied
+     until the consent banner below records an explicit choice. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G3EMR3CB02"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    'ad_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'analytics_storage': 'denied'
+  });
+  try {
+    if (localStorage.getItem('ay-consent') === 'granted') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+  } catch (e) {}
+  gtag('js', new Date());
+  gtag('config', 'G-G3EMR3CB02', { 'anonymize_ip': true });
+</script>
 </head>
 <body>
 <a href="#main" class="skip">Skip to content</a>
@@ -1861,6 +1936,46 @@ confirm it skips the missing column before merge."</span></pre>
       if (!hasPlayed) { hasPlayed = true; play(); }
     }, 3000));
   }
+})();
+</script>
+
+<!-- ============================================================
+     COOKIE CONSENT BANNER
+     Hidden if a prior choice is stored. On Accept, updates gtag
+     Consent Mode to grant analytics_storage.
+     ============================================================ -->
+<div id="consent" class="consent" role="dialog" aria-label="Cookie consent" hidden>
+  <div class="consent__inner">
+    <p class="consent__msg">
+      This site uses Google Analytics to count visits. No ads, no cross-site tracking.
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy</a>.
+    </p>
+    <div class="consent__actions">
+      <button type="button" class="consent__btn" data-consent="denied">Decline</button>
+      <button type="button" class="consent__btn consent__btn--accept" data-consent="granted">Accept</button>
+    </div>
+  </div>
+</div>
+<script>
+(function () {
+  var KEY = 'ay-consent';
+  var el = document.getElementById('consent');
+  if (!el) return;
+  var stored = null;
+  try { stored = localStorage.getItem(KEY); } catch (e) {}
+  if (stored !== 'granted' && stored !== 'denied') {
+    el.hidden = false;
+  }
+  el.addEventListener('click', function (e) {
+    var btn = e.target.closest('[data-consent]');
+    if (!btn) return;
+    var choice = btn.getAttribute('data-consent');
+    try { localStorage.setItem(KEY, choice); } catch (e) {}
+    if (choice === 'granted' && typeof gtag === 'function') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+    el.hidden = true;
+  });
 })();
 </script>
 

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,22 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>ApexYard - where projects get forged</title>
-<meta name="description" content="ApexYard is a multi-project ops repo where your projects reference each other, learn from shared experience, and ship production-ready under a strict SDLC. Built for founders running 2-5 products at once. Open source. Claude Code native, but plain markdown underneath.">
+<meta name="description" content="SDLC-as-code for founders who ship alone, or companies standing up AI-enabled squads. One ops repo governs all your projects. 33 skills, 18 hooks, 19 roles. MIT, plain markdown and shell, Claude Code native.">
+<link rel="canonical" href="https://yard.apexscript.com/">
+
+<!-- Open Graph -->
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="ApexYard">
+<meta property="og:url" content="https://yard.apexscript.com/">
+<meta property="og:title" content="ApexYard - where projects get forged">
+<meta property="og:description" content="SDLC-as-code for founders who ship alone, or companies standing up AI-enabled squads. One ops repo governs all your projects. MIT, plain markdown and shell.">
+
+<!-- Twitter / X -->
+<meta name="twitter:card" content="summary">
+<meta name="twitter:url" content="https://yard.apexscript.com/">
+<meta name="twitter:title" content="ApexYard - where projects get forged">
+<meta name="twitter:description" content="SDLC-as-code for founders who ship alone, or companies standing up AI-enabled squads. MIT, plain markdown and shell.">
+
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet">
@@ -169,6 +184,7 @@ a:hover { color: var(--accent); }
 .titlebar__right a {
   color: var(--ink-soft);
   position: relative;
+  white-space: nowrap;
 }
 .titlebar__right a:hover { color: var(--accent); }
 .titlebar__right a.is-cta {
@@ -786,17 +802,18 @@ a:hover { color: var(--accent); }
   margin: 0 auto;
   padding: 0 var(--gutter);
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 1.5rem;
 }
 @media (max-width: 900px) {
-  .demos { grid-template-columns: 1fr; }
+  .demos { grid-template-columns: minmax(0, 1fr); }
 }
 .demo {
   background: var(--paper-2);
   border: 1px solid var(--rule);
   display: flex;
   flex-direction: column;
+  min-width: 0;
 }
 .demo--wide { grid-column: 1 / -1; }
 
@@ -911,16 +928,17 @@ a:hover { color: var(--accent); }
   margin: 0 auto;
   padding: 0 var(--gutter);
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1.5rem;
 }
 @media (max-width: 900px) {
-  .steps { grid-template-columns: 1fr; }
+  .steps { grid-template-columns: minmax(0, 1fr); }
 }
 .step {
   border: 1px solid var(--rule);
   background: var(--paper);
   padding: 1.5rem 1.5rem 1.25rem;
+  min-width: 0;
 }
 .step__num {
   font-size: 11px;


### PR DESCRIPTION
## Summary

Prep for publishing the landing page at yard.apexscript.com on Netlify:

- `netlify.toml` at repo root — `publish = "site"` + security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy).
- `site/index.html` head — canonical URL, Open Graph, Twitter card meta so link previews render.
- Google Analytics (G-G3EMR3CB02) via Consent Mode v2 — `analytics_storage` defaults to denied; a minimal fixed-bottom accept/decline banner records the visitor's choice in localStorage and calls `gtag('consent', 'update', ...)` on accept. IP anonymization on. No ad_storage / ad_user_data / ad_personalization ever requested.
- Mobile fixes — `.steps` and `.demos` grids switched from `1fr` to `minmax(0, 1fr)` and `min-width: 0` on `.step` / `.demo`, so long `<pre>` content (white-space: pre) no longer inflates grid tracks past the viewport. `white-space: nowrap` on titlebar nav links so "what's in the box" stops breaking mid-phrase.
- README — dropped a single historical reference line.

## Testing

1. Open `site/index.html` locally — banner appears on first load, hides after Accept or Decline.
2. DevTools → Application → Local Storage → confirm `ay-consent` = `granted` or `denied`.
3. DevTools → Network → before Accept, no hits to `google-analytics.com`. After Accept, `collect?...` request fires.
4. Resize to 320px width — code blocks scroll horizontally within their container instead of spilling past the viewport; titlebar nav "what's in the box" stays on one visual phrase.
5. After merge + Netlify re-deploy + CNAME flip, verify:
   - `curl -I https://yard.apexscript.com/` shows security headers
   - `<link rel="canonical">` resolves to the same URL
   - `https://metatags.io/?url=https://yard.apexscript.com/` shows OG/Twitter preview

Closes #90

---

## Glossary

| Term | Definition |
|------|------------|
| Consent Mode v2 | Google's framework for loading gtag.js but deferring actual cookie writes / hit sends until a consent signal is granted. Replaces the older "don't load gtag until consent" pattern with a finer-grained denied/granted toggle per data category. |
| `analytics_storage` | One of five Consent Mode v2 categories; controls whether gtag may set the `_ga`/`_ga_*` cookies and send page_view hits. The only category this site ever requests. |
| `minmax(0, 1fr)` | CSS Grid track sizing that overrides the default `minmax(auto, 1fr)`. Prevents a child's intrinsic min-content width (e.g. a long `<pre>` line) from inflating the track past the container. |
| `min-width: 0` | Applied to a flex/grid item to override its default `min-width: auto`, which would otherwise prevent the item from shrinking below its intrinsic content width. Required when the item contains overflowing content that should scroll or truncate. |
| Canonical URL | `<link rel="canonical">` tells search engines which URL is the definitive version of the page, consolidating SEO signals when the same content is reachable via multiple URLs (e.g. `.netlify.app` preview vs production domain). |
| Open Graph / Twitter card | Meta tag vocabularies (`og:*`, `twitter:*`) that tell social/chat apps how to render a link preview — title, description, image, URL. |