### PR TITLE
chore(#92): site polish - AgDR, banner a11y, CSP, canonical redirect

### DIFF
--- a/docs/agdr/AgDR-0004-analytics-and-consent.md
+++ b/docs/agdr/AgDR-0004-analytics-and-consent.md
@@ -1,0 +1,72 @@
+---
+id: AgDR-0004
+timestamp: 2026-04-19T08:30:00Z
+agent: atlas
+model: claude-opus-4-7
+trigger: retrospective
+status: executed
+ticket: me2resh/apexyard#92
+---
+
+# Google Analytics + self-rolled consent banner for the landing page
+
+> In the context of needing traffic measurement on the ApexYard landing page now that it publishes at `yard.apexscript.com`, facing the choice between Google Analytics with a self-rolled consent banner, Google Analytics with a third-party CMP, a privacy-first analytics service (Plausible / Umami), or no analytics at all, I decided to ship **GA4 with Consent Mode v2 and a minimal self-rolled accept/decline banner**, accepting that the banner doesn't offer per-category granularity and that we'll owe a proper CMP the moment the site's analytics needs grow past "count visits".
+
+## Context
+
+The ApexYard landing page is a single static HTML file published to `yard.apexscript.com` via Netlify. The CEO wanted a quick way to see how much traffic the site gets — nothing sophisticated, just "is this actually getting viewed". The repo is open-source, experimental, and not monetised; there is no marketing team, no growth funnel, no retargeting.
+
+The site is served to visitors in the EU and UK, which means GDPR and ePrivacy apply. Analytics cookies / local storage / identifiers require explicit consent BEFORE they are set. Any analytics choice has to account for this.
+
+Two constraints shaped the decision:
+
+1. **The CEO already provided the GA4 tag** (`G-G3EMR3CB02`) — there was an explicit preference for Google Analytics, not an open "which tool" question.
+2. **The decision was made inline during PR #91** and shipped without an AgDR — this record is a retrospective backfill. Rex's post-review flagged the missing AgDR as a non-blocking suggestion, logged as part of #92.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **GA4 + self-rolled banner (chosen)** | Minimal code (~35 lines CSS, ~20 lines JS); matches the site's brutalist monochrome aesthetic; Consent Mode v2 means gtag loads but sends nothing until explicit grant; IP anonymization on; `ay-consent` key in localStorage persists choice. | No per-category controls (only a single analytics_storage toggle); no Do-Not-Track integration; no preference-centre UI; the banner JS and markup are maintenance surface we own. |
+| **GA4 + third-party CMP** (Cookiebot, OneTrust, Osano, Iubenda, etc.) | Legal-grade compliance; per-category granularity; audit logs; cookie auto-scan; preference centre out of the box. | Adds a vendor dependency, per-month cost (free tiers usually cap at 50k pageviews and feel spammy); extra script weight on a ~100KB static page; visually inconsistent with the brutalist design without heavy theming; overkill for "count visits on an OSS landing page". |
+| **Plausible / Umami / Fathom** (cookieless analytics) | No banner required at all (no cookies, no personal identifiers); lighter script; privacy-first narrative fits an OSS tool. | CEO's existing asset was a GA4 tag, not a Plausible account; self-hosting Umami means running a DB we don't have; Plausible SaaS is ~$9/mo (small but real); GA4's deeper ecosystem (Search Console link, BigQuery export) is unused today but available if needs grow. |
+| **No analytics** | Zero compliance surface. Simplest possible answer. | CEO explicitly asked for traffic measurement. |
+
+## Decision
+
+Chosen: **GA4 with Consent Mode v2 + self-rolled banner**, because the site's current analytics need is genuinely "count visits, nothing else", the CEO has a GA tag already, and a third-party CMP would be heavier than the analytics it gates. Consent Mode v2 specifically (rather than the older "don't load gtag until consent" pattern) because it keeps the code in one place — gtag always loads with `default: denied`, and the banner only flips a single `consent: update` call.
+
+Key configuration choices:
+
+- Default state for all four Consent Mode v2 categories (`ad_storage`, `ad_user_data`, `ad_personalization`, `analytics_storage`) = `denied`. Only `analytics_storage` is ever requested via `update`.
+- `anonymize_ip: true` on `gtag('config', ...)`.
+- Choice persisted in `localStorage['ay-consent']` as `granted` or `denied`; banner auto-hides on subsequent visits until cleared.
+- Banner uses `role="dialog"` + `aria-label` — **flagged for correction in #92** as `role="region"` is the better a11y fit for a non-modal banner (planned, separate commit on the same branch).
+
+## Consequences
+
+Positive:
+
+- Traffic is now measurable in GA4, gated by consent, starting the day DNS flips to `yard.apexscript.com`.
+- No recurring vendor cost, no extra script dependency, ~55 lines of code total.
+- The "we practise what we preach" posture — the landing page for an SDLC framework respects GDPR out of the box.
+
+Negative (accepted):
+
+- If analytics needs grow (marketing attribution, A/B testing, conversion funnels), the self-rolled banner is not sufficient. A proper CMP becomes the right answer and a migration is ours to run.
+- Per-category preferences are not offered — users choose analytics-on or analytics-off, with no "essential cookies only + no analytics" middle ground (which happens to match reality for this site since there are no other cookies, but is not explicit).
+- The banner is maintenance surface. A future dependency upgrade or CSS refactor could break it silently if we don't have a smoke test.
+
+Trigger-points for revisiting this decision:
+
+- The landing page starts selling anything (move to a full CMP).
+- We add a second analytics pixel (Segment, Hotjar, etc.) — a CMP becomes cheaper than self-rolling per-category toggles.
+- GA4 is retired or its licence changes — migrate to a cookieless alternative in one shot rather than chaining providers.
+- UK / EU enforcement tightens meaningfully on self-rolled banners.
+
+## Artifacts
+
+- Shipped in PR #91 (merge commit `6cbc95b`)
+- Banner markup + JS: `site/index.html` (bottom of body + style block)
+- gtag snippet with Consent Mode v2 defaults: `site/index.html` (head)
+- Follow-up corrections tracked in #92: `role="region"`, Escape-key dismissal, CSP header, canonical redirect

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 # Publish directory is set in the Netlify UI (site/).
-# This file only contributes security headers so they live in source.
+# This file contributes security headers + the canonical-domain redirect.
 
 [[headers]]
   for = "/*"
@@ -8,3 +8,19 @@
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "interest-cohort=()"
+    # CSP: 'unsafe-inline' is required for script-src and style-src because
+    # the page ships a single-file landing with inline <style>, inline
+    # gtag boilerplate, and inline animation JS. googletagmanager.com is
+    # allowed for the gtag.js loader; google-analytics.com + analytics.google.com
+    # cover GA4 /g/collect hits. data: images for the 1px tracking pixel.
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self'"
+
+# Canonicalize the .netlify.app hostname to the production subdomain.
+# Dormant until DNS flips yard.apexscript.com onto this Netlify site;
+# after that, visits to apexyard.netlify.app get 301'd so search
+# engines consolidate SEO signals on the custom domain.
+[[redirects]]
+  from = "https://apexyard.netlify.app/*"
+  to = "https://yard.apexscript.com/:splat"
+  status = 301
+  force = true

--- a/site/index.html
+++ b/site/index.html
@@ -1944,7 +1944,7 @@ confirm it skips the missing column before merge."</span></pre>
      Hidden if a prior choice is stored. On Accept, updates gtag
      Consent Mode to grant analytics_storage.
      ============================================================ -->
-<div id="consent" class="consent" role="dialog" aria-label="Cookie consent" hidden>
+<div id="consent" class="consent" role="region" aria-label="Cookie consent" hidden>
   <div class="consent__inner">
     <p class="consent__msg">
       This site uses Google Analytics to count visits. No ads, no cross-site tracking.
@@ -1966,15 +1966,26 @@ confirm it skips the missing column before merge."</span></pre>
   if (stored !== 'granted' && stored !== 'denied') {
     el.hidden = false;
   }
-  el.addEventListener('click', function (e) {
-    var btn = e.target.closest('[data-consent]');
-    if (!btn) return;
-    var choice = btn.getAttribute('data-consent');
+  function record(choice) {
+    if (el.hidden) return;
     try { localStorage.setItem(KEY, choice); } catch (e) {}
     if (choice === 'granted' && typeof gtag === 'function') {
       gtag('consent', 'update', { 'analytics_storage': 'granted' });
     }
     el.hidden = true;
+  }
+  el.addEventListener('click', function (e) {
+    var btn = e.target.closest('[data-consent]');
+    if (!btn) return;
+    record(btn.getAttribute('data-consent'));
+  });
+  // Escape dismisses the banner as "denied" - keyboard users without
+  // a mouse shouldn't be stuck with a fixed-bottom banner they can't
+  // dismiss. "Denied" is the non-consenting default per Consent Mode v2.
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !el.hidden) {
+      record('denied');
+    }
   });
 })();
 </script>


### PR DESCRIPTION
## Summary

Follow-up to PR #91 addressing all five of Rex's non-blocking suggestions as one batch since they're all small and land on the same surface.

1. **AgDR-0004 backfill** for the GA + self-rolled-banner choice (was flagged as missing during #91 review). Captures the four options considered, the decision, and the trigger-points that should prompt revisiting (adding a second pixel, monetisation, GA4 retirement, UK/EU enforcement tightening).
2. **Banner `role=\"dialog\"` → `role=\"region\"`** — the banner is non-modal so `role=\"dialog\"` was misleading assistive tech.
3. **Escape-key dismissal** records `ay-consent=denied` and hides the banner, so pure-keyboard users aren't stuck with it. Small refactor extracted a shared `record(choice)` helper.
4. **CSP header** in `netlify.toml` — explicit allow-list for `googletagmanager.com`, `google-analytics.com`, `analytics.google.com`, `fonts.googleapis.com`, `fonts.gstatic.com`, plus `'unsafe-inline'` on script-src/style-src because the single-file landing has inline styles and inline gtag/animation/banner JS. Includes defensive `frame-ancestors`, `base-uri`, `form-action` = `'self'`.
5. **Netlify 301 redirect** from `https://apexyard.netlify.app/*` → `https://yard.apexscript.com/:splat`. Dormant until DNS flips; once the custom domain is live, visits to the `.netlify.app` host canonicalize so search engines consolidate SEO signals.

## Testing

1. **Banner a11y**: open the deploy preview, Tab to the banner, press Escape — banner hides, DevTools → Application → Local Storage shows `ay-consent=denied`. Reload — banner stays hidden.
2. **CSP**: open the deploy preview with DevTools → Console. No CSP violations expected. After accepting the banner, network tab should show a successful request to `www.google-analytics.com/g/collect?...`. If either is broken, the CSP is too tight — loosen before merge.
3. **Canonical redirect**: tested after DNS flips. Once `yard.apexscript.com` resolves, `curl -sI https://apexyard.netlify.app/` should return `HTTP/2 301` + `location: https://yard.apexscript.com/`.
4. **AgDR**: no runtime effect — docs only.

Closes #92

---

## Glossary

| Term | Definition |
|------|------------|
| AgDR | Agent Decision Record — ApexYard's project-scoped equivalent of an ADR. One per significant technical decision; captures options considered, the choice, and consequences. Lives at `docs/agdr/AgDR-NNNN-slug.md`. |
| `role=\"region\"` | ARIA landmark role for a "significant section with a label". Correct for a non-modal labelled banner. Distinct from `role=\"dialog\"`, which tells assistive tech to expect modal semantics (focus trap, page blocked). |
| Content-Security-Policy (CSP) | HTTP response header that tells the browser which origins are allowed for each resource type (scripts, styles, fonts, images, XHR destinations, etc.). Violations are console-logged and the offending resource is blocked. |
| `'unsafe-inline'` | CSP token allowing inline `<script>`/`<style>` + inline event handlers. Required here because the single-file landing has inline everything; the alternative is moving all styles/scripts to external files or using nonces, which is heavier than the single-page format warrants. |
| `[[redirects]]` | Netlify `netlify.toml` array-of-tables for URL redirects. Each entry has `from` / `to` / `status` / optional `force`. `force = true` means redirect even if the file exists at the `from` path. |
| Canonical host | The "intended" hostname for a page when it's reachable via multiple URLs (`.netlify.app` preview vs production custom domain). A 301 to the canonical URL consolidates SEO signals and matches `<link rel=\"canonical\">`. |