### PR TITLE
feat(#94): add creator attribution + update footer socials

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -257,8 +257,25 @@ a:hover { color: var(--accent); }
   color: var(--ink);
   max-width: 60ch;
   line-height: 1.25;
-  margin-bottom: 1rem;
+  margin-bottom: 0.4rem;
   letter-spacing: -0.015em;
+}
+
+.hero__builtby {
+  font-size: 12px;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 1.25rem;
+}
+.hero__builtby a {
+  color: var(--ink-soft);
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 1px;
+}
+.hero__builtby a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 
 .hero__sub {
@@ -1119,7 +1136,15 @@ footer.foot {
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
-.foot__inner a:hover { color: var(--accent); }
+.foot__inner a {
+  color: var(--ink-soft);
+  border-bottom: 1px solid var(--rule-faint);
+  padding-bottom: 1px;
+}
+.foot__inner a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
 
 /* ============================================================
    page-load reveal - staggered, restrained
@@ -1283,6 +1308,10 @@ footer.foot {
 
     <p class="hero__tagline rise rise-3">
       Where projects get forged.
+    </p>
+
+    <p class="hero__builtby rise rise-3">
+      Built by <a href="https://me2resh.com" target="_blank" rel="noopener">me2resh</a>
     </p>
 
     <p class="hero__sub rise rise-3">
@@ -1655,10 +1684,14 @@ confirm it skips the missing column before merge."</span></pre>
 <!-- ============================================================
      FOOTER
      ============================================================ -->
-<footer class="foot">
+<footer class="foot" role="contentinfo">
   <div class="foot__inner">
-    <span>apexyard v1.0 · MIT · plain markdown · zero dependencies</span>
-    <span><a href="https://github.com/me2resh/apexyard">github</a> · <a href="https://github.com/me2resh/apexyard/issues">issues</a> · <a href="https://github.com/me2resh/apexyard/pulls">prs</a></span>
+    <span>Built by <a href="https://me2resh.com" target="_blank" rel="noopener">me2resh</a> · MIT · plain markdown · zero dependencies</span>
+    <span>
+      <a href="https://github.com/me2resh" target="_blank" rel="noopener">github</a> ·
+      <a href="https://twitter.com/me2resh" target="_blank" rel="noopener">twitter</a> ·
+      <a href="https://me2resh.com" target="_blank" rel="noopener">blog</a>
+    </span>
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary

Gives apexyard a human face:

1. **Hero attribution line** directly under the tagline — small uppercase monospace "Built by [me2resh](https://me2resh.com)". Subtle but visible at first glance, with the subdued underline style that signals "this is clickable" without competing with the hero CTA.
2. **Footer refresh** — left span swaps the generic brand line for "Built by me2resh · MIT · plain markdown · zero dependencies". Right span adds `twitter` + `blog` to the existing `github` link (drops the `issues` + `prs` links that are already in the "final" CTA block just above).

Tagline bottom margin tightened (`1rem → 0.4rem`) so the attribution sits visually glued to the tagline rather than floating as a separate paragraph.

## Testing

1. Load the deploy preview. Hero shows: `Where projects get forged.` → `BUILT BY ME2RESH` in small monospace caps with an underline on "me2resh". Hover turns it red (`--accent`).
2. Scroll to bottom. Footer reads: `Built by me2resh · MIT · plain markdown · zero dependencies` on the left; `github · twitter · blog` on the right. All four links open in a new tab.
3. DevTools → Console: no CSP violations (these are navigation targets, not resource fetches).
4. Mobile (320px): hero attribution wraps cleanly; footer stacks onto two rows without overlap.
5. Dark mode (macOS Appearance: Dark): both attribution and footer remain readable.

Closes #94

---

## Glossary

| Term | Definition |
|------|------------|
| Hero attribution | A short "Built by [creator]" line placed inside the hero region — positioned where first-time visitors look, unlike a footer-only attribution which few readers reach. |
| `role="contentinfo"` | ARIA landmark role for a page's footer. Signals to assistive tech that this region contains information about the parent document (copyright, author, related links) rather than primary content. |
| `target="_blank" rel="noopener"` | Pairing that opens a link in a new tab while severing the `window.opener` reference, preventing the new tab's page from manipulating the opener's `window.location`. Standard hygiene for any outbound link. |
| Navigation target vs resource fetch | CSP's `connect-src` / `script-src` / etc. govern resource fetches (XHR, script loads, stylesheet loads). Plain `<a href>` navigation that leaves the page is outside CSP's remit — no policy update needed when adding outbound links. |
| Tagline vs sub | Two distinct hero paragraphs: the tagline is the 3-word brand promise; the sub is a multi-sentence elaboration. The attribution line sits between them now. |