### PR TITLE
docs(#98): correct CLAUDE.md hook/skill/rule counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,8 +169,8 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 
 | Layer | Path | Purpose |
 |-------|------|---------|
-| Hooks | `.claude/hooks/` | 17 shell scripts that mechanically enforce SDLC rules — ticket-first, migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner |
-| Rules | `.claude/rules/` | 9 modular rule files (AgDR triggers, code standards, git conventions, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
+| Hooks | `.claude/hooks/` | 18 shell scripts that mechanically enforce SDLC rules — ticket-first, migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner |
+| Rules | `.claude/rules/` | 8 modular rule files (AgDR triggers, code standards, git conventions, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer, Security Reviewer, Dependency Auditor, PR Manager, Ticket Manager) |
 | Skills | `.claude/skills/` | 33 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
@@ -246,7 +246,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Hooks | `.claude/hooks/` |
 | Rules (modular) | `.claude/rules/` |
 | Agents | `.claude/agents/` |
-| Skills (13 slash commands) | `.claude/skills/` |
+| Skills (33 slash commands) | `.claude/skills/` |
 | Hook wiring | `.claude/settings.json` |
 | **Per-project docs** | `projects/<name>/` |
 | **Live working copies** (gitignored) | `workspace/<name>/` |


### PR DESCRIPTION
## Summary

Three single-token corrections in `CLAUDE.md` to match the current state:

| Line | Before | After |
|------|--------|-------|
| 172 | 17 shell scripts | **18** |
| 173 | 9 modular rule files | **8** |
| 249 | Skills (13 slash commands) | **33** |

README.md was already fixed in #89. This closes the analogous drift in CLAUDE.md before the launch post ships with a direct link to the repo.

## Testing

1. `ls .claude/hooks/*.sh | grep -v _lib | wc -l` → 18 ✓
2. `ls .claude/rules/*.md | wc -l` → 8 ✓
3. `ls -d .claude/skills/*/ | wc -l` → 33 ✓
4. No other text in CLAUDE.md changed (verify via `git diff main...HEAD`)

Closes #98

---

## Glossary

| Term | Definition |
|------|------------|
| Hook file count | The number of distinct enforcement scripts wired to Claude Code's `PreToolUse` / `PostToolUse` / `SessionStart` events. Library files (`_lib-*.sh`) are sourced by hooks but aren't hooks themselves and shouldn't be counted. |
| Rule file count | The number of modular rule files in `.claude/rules/` that are imported via `@.claude/rules/*.md` from `CLAUDE.md`. Each rule file captures one cohesive topic (git conventions, PR workflow, etc.). |
| Skill count | The number of slash commands in `.claude/skills/`, each a directory containing a `SKILL.md` spec. |
| Drift | A count or claim in a doc that no longer matches the code. Rex caught this during PR #97 review; README was already corrected in #89, CLAUDE.md was the remaining location. |

