### PR TITLE
feat(#100): SDLC-loop manifesto callout on landing

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -618,11 +618,13 @@ a:hover { color: var(--accent); }
   position: relative;
 }
 .manifesto__text {
-  font-size: clamp(1rem, 1.6vw, 1.25rem);
+  font-size: clamp(1rem, 1.5vw, 1.2rem);
   line-height: 1.7;
   color: var(--ink);
   font-weight: 500;
-  max-width: 60ch;
+  /* No max-width cap - each clause wants to sit on one line at desktop
+     width, and wraps naturally on narrower screens. Bounded by the
+     .manifesto__inner container's max-width already. */
 }
 @media (max-width: 720px) {
   .manifesto__text { font-size: 15px; line-height: 1.65; }

--- a/site/index.html
+++ b/site/index.html
@@ -602,6 +602,33 @@ a:hover { color: var(--accent); }
 }
 
 /* ============================================================
+   manifesto - the SDLC loop, one-line callout between hero and quickstart
+   ============================================================ */
+
+.manifesto {
+  padding: clamp(2.5rem, 5vw, 4rem) 0;
+  background: var(--paper-3);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+.manifesto__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+  position: relative;
+}
+.manifesto__text {
+  font-size: clamp(1rem, 1.6vw, 1.25rem);
+  line-height: 1.7;
+  color: var(--ink);
+  font-weight: 500;
+  max-width: 60ch;
+}
+@media (max-width: 720px) {
+  .manifesto__text { font-size: 15px; line-height: 1.65; }
+}
+
+/* ============================================================
    ascii section - boxed
    ============================================================ */
 
@@ -1434,6 +1461,19 @@ footer.foot {
       Proven shipping · <span class="kw">TypeScript</span> + AWS Lambda backends · <span class="kw">Next.js</span> web apps · <span class="kw">Chrome</span> extensions · native <span class="kw">Swift</span> macOS apps
     </p>
 
+  </div>
+</section>
+
+<!-- ============================================================
+     MANIFESTO - the SDLC loop, in one line
+     ============================================================ -->
+<section class="manifesto" aria-label="What apexyard mechanically enforces">
+  <div class="manifesto__inner">
+    <p class="manifesto__text">
+      Every pull request ties to a ticket.<br>
+      Every ticket has acceptance criteria.<br>
+      Code review validates against those criteria, and QA verifies the result in a separate pass before the ticket closes.
+    </p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary

Adds a full-width brutalist manifesto callout between the hero section and the `/quickstart` section on the landing page, carrying the SDLC-loop quote verbatim:

> Every pull request ties to a ticket.
> Every ticket has acceptance criteria.
> Code review validates against those criteria, and QA verifies the result in a separate pass before the ticket closes.

Triggered by real-world tester feedback (2 weeks of usage) that this specific line is the clearest one-line articulation of what apexyard mechanically enforces, and it needs more surface area than just appearing inside a paragraph on the blog post.

## Testing

1. Open the Netlify deploy preview.
2. First-scroll view: manifesto appears after hero + install-row + shell-demo, before the "Get started in three steps" quickstart section.
3. Mobile (320px): reads clean, no horizontal overflow, three clauses wrap gracefully.
4. Dark mode (macOS): legible.
5. Screen reader: the section has `aria-label="What apexyard mechanically enforces"`.
6. Paper tones visually distinguish the manifesto from surrounding sections (`--paper-3` vs `--paper` in hero / `--paper-2` in quickstart).

Closes #100

---

## Glossary

| Term | Definition |
|------|------------|
| Manifesto callout | A visually-distinguished one-idea block used to anchor a single strong claim. Not a testimonial (no attribution), not a pull-quote (not repeating a nearby line) - it's a standalone statement of what the system does. |
| Brutalist callout | Matches the rest of the landing's design language: sharp corners, flat colour, thin ink rules for separation, JetBrains Mono type. No gradients, no shadows, no rounding. |
| `--paper` / `--paper-2` / `--paper-3` | The three cream tones in apexyard's brand palette (lightest to slightly darker). Used to tonally separate full-width sections without changing the overall aesthetic. Manifesto uses `--paper-3` so it sits between hero (`--paper`) and quickstart (`--paper-2`) with a tiny tonal lift. |
| `clamp(min, preferred, max)` | CSS function for fluid sizing. The manifesto font-size `clamp(1rem, 1.6vw, 1.25rem)` means "16px on small screens, grow with viewport up to 20px on large screens, never exceed 20px" - readable on mobile, proportional on desktop. |

