### PR TITLE
feat(#102): tag-based upstream drift detection (v1.1.0)

### DIFF
--- a/.claude/hooks/check-upstream-drift.sh
+++ b/.claude/hooks/check-upstream-drift.sh
@@ -63,8 +63,9 @@ fi
 if [ "$SHOULD_FETCH" = "1" ]; then
   # Quiet fetch with a short timeout. On failure (no network, no auth), exit
   # silently — we don't want a startup banner yelling about offline state.
-  # `--tags` pulls tag refs too, which is what enables tag-based drift.
-  if ! timeout 5 git fetch upstream --tags --quiet 2>/dev/null; then
+  # `--tags --prune-tags` pulls tag refs and removes local copies of any tag
+  # upstream has retracted (rare, but keeps the local tag view honest).
+  if ! timeout 5 git fetch upstream --tags --prune-tags --quiet 2>/dev/null; then
     exit 0
   fi
   mkdir -p "$CACHE_DIR"
@@ -85,17 +86,36 @@ UPSTREAM_TAG=$(git tag --list --sort=-v:refname --merged "upstream/${DEFAULT_BRA
 LOCAL_TAG=$(git tag --list --sort=-v:refname --merged "${DEFAULT_BRANCH}" 2>/dev/null | head -n 1)
 
 if [ -n "$UPSTREAM_TAG" ]; then
-  # Upstream has at least one tag. This is the steady-state case.
-  if [ "$UPSTREAM_TAG" != "$LOCAL_TAG" ]; then
-    # Different tag — and since we sort descending by semver, upstream is
-    # ahead by definition. Name the release in the banner.
+  # Upstream has at least one tag. Steady-state path.
+
+  if [ -z "$LOCAL_TAG" ]; then
+    # Fork has never merged any tag yet. First release sync is due.
+    cat <<MSG
+ApexYard: ${UPSTREAM_TAG} available. Run /update to sync.
+MSG
+    exit 0
+  fi
+
+  if [ "$UPSTREAM_TAG" = "$LOCAL_TAG" ]; then
+    # Same release. Silent even if upstream/main has unreleased commits.
+    exit 0
+  fi
+
+  # Both tags exist and differ. Decide which is newer by semver. Naive `!=`
+  # would fire when a fork owner tagged their own main past upstream (e.g.
+  # a private v2.0.0-acme on the fork while upstream is still v1.1.0), which
+  # would nag them about an older upstream release they don't want.
+  # `sort -V` does a version-aware sort; the last line is the newer tag.
+  NEWER=$(printf '%s\n%s\n' "$UPSTREAM_TAG" "$LOCAL_TAG" | sort -V | tail -n 1)
+
+  if [ "$NEWER" = "$UPSTREAM_TAG" ]; then
+    # Upstream is strictly newer. Nag.
     cat <<MSG
 ApexYard: ${UPSTREAM_TAG} available. Run /update to sync.
 MSG
   fi
-  # Same tag (or local is the tag) → silent, even if upstream/main has
-  # commits beyond the tag. Those are unreleased chore work and we do NOT
-  # nag about them.
+  # Local is strictly newer (fork has its own tag ahead of upstream's
+  # latest release). Silent — not our business.
   exit 0
 fi
 

--- a/.claude/hooks/check-upstream-drift.sh
+++ b/.claude/hooks/check-upstream-drift.sh
@@ -1,15 +1,26 @@
 #!/bin/bash
-# SessionStart hook: shows a one-line banner when the fork is behind upstream
-# me2resh/apexyard, so the user knows to run /update.
+# SessionStart hook: shows a one-line banner when a new tagged release
+# exists on upstream me2resh/apexyard that the fork doesn't yet have.
+#
+# Tag-based drift (new in v1.1.0): small main commits (README typos, CI
+# tweaks, docs-only PRs) do NOT fire the banner. Only a new upstream tag
+# does. This keeps the signal actionable and avoids training fork owners
+# to tune out the banner over time.
+#
+# Fallback: if upstream has NEVER been tagged (brand-new project, pre-
+# release), or the fork has never merged any upstream tag, fall back to
+# commit-count drift so newly-forked users still get useful guidance.
 #
 # Silent exit paths (no output, no error):
 #   - Not a git repo
 #   - No `upstream` remote configured (this is the upstream repo itself,
 #     or the fork hasn't set up `upstream` yet — /setup reminds them)
 #   - Fetch fails (offline, git hosting down, permission)
-#   - Fork is up-to-date
+#   - Fork is up-to-date on the latest upstream tag
+#   - No upstream tags AND no commit drift
 #
-# Banner emits only when the fork is genuinely behind upstream/<default-branch>.
+# Banner emits only when there's something actionable: a new upstream tag
+# the fork hasn't merged, OR (in fallback mode) commits behind main.
 #
 # Fetch caching: the hook hits the network at most once per 10 minutes per
 # clone. A tight-loop of sessions (IDE restarts, `claude --resume`) doesn't
@@ -52,15 +63,48 @@ fi
 if [ "$SHOULD_FETCH" = "1" ]; then
   # Quiet fetch with a short timeout. On failure (no network, no auth), exit
   # silently — we don't want a startup banner yelling about offline state.
-  if ! timeout 5 git fetch upstream --quiet 2>/dev/null; then
+  # `--tags` pulls tag refs too, which is what enables tag-based drift.
+  if ! timeout 5 git fetch upstream --tags --quiet 2>/dev/null; then
     exit 0
   fi
   mkdir -p "$CACHE_DIR"
   echo "$NOW" > "$CACHE_FILE"
 fi
 
-# Count commits in upstream/<default-branch> not present in the local
-# default-branch tip. rev-list is local after fetch, no network.
+# ---------------------------------------------------------------------------
+# Tag-based drift (primary signal)
+# ---------------------------------------------------------------------------
+# Latest upstream tag reachable from upstream's default branch, sorted by
+# semver descending. We use --merged upstream/<branch> so a tag on a release
+# branch we haven't fetched doesn't count.
+UPSTREAM_TAG=$(git tag --list --sort=-v:refname --merged "upstream/${DEFAULT_BRANCH}" 2>/dev/null | head -n 1)
+
+# Latest tag the fork has actually merged into its default branch. If the
+# fork is up to date on v1.0.0 and upstream is now on v1.1.0, LOCAL_TAG is
+# v1.0.0 and UPSTREAM_TAG is v1.1.0.
+LOCAL_TAG=$(git tag --list --sort=-v:refname --merged "${DEFAULT_BRANCH}" 2>/dev/null | head -n 1)
+
+if [ -n "$UPSTREAM_TAG" ]; then
+  # Upstream has at least one tag. This is the steady-state case.
+  if [ "$UPSTREAM_TAG" != "$LOCAL_TAG" ]; then
+    # Different tag — and since we sort descending by semver, upstream is
+    # ahead by definition. Name the release in the banner.
+    cat <<MSG
+ApexYard: ${UPSTREAM_TAG} available. Run /update to sync.
+MSG
+  fi
+  # Same tag (or local is the tag) → silent, even if upstream/main has
+  # commits beyond the tag. Those are unreleased chore work and we do NOT
+  # nag about them.
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Fallback: no upstream tags at all.
+# ---------------------------------------------------------------------------
+# Honour the old commit-count behaviour so a freshly-forked project without
+# any tag history still gets a useful banner. Once upstream cuts its first
+# tag, subsequent sessions flow through the tag-based path above.
 BEHIND=$(git rev-list --count "${DEFAULT_BRANCH}..upstream/${DEFAULT_BRANCH}" 2>/dev/null)
 
 if [ -z "$BEHIND" ] || [ "$BEHIND" = "0" ]; then
@@ -74,7 +118,7 @@ else
 fi
 
 cat <<MSG
-ApexYard: ${BEHIND} ${SUFFIX} behind upstream/${DEFAULT_BRANCH}. Run /update to sync.
+ApexYard: ${BEHIND} ${SUFFIX} behind upstream/${DEFAULT_BRANCH} (no tags yet). Run /update to sync.
 MSG
 
 exit 0

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -77,14 +77,20 @@ Network failure: print a warning and exit. Don't try to "work from cache" — us
 
 ### 3. Preview
 
+Two signals matter here: a new upstream **tag** (the actionable one, meaning a real release is available), and upstream **main commits** since the fork's last sync (informational — may just be a docs typo).
+
 ```bash
 AHEAD=$(git rev-list --count upstream/main..main)
 BEHIND=$(git rev-list --count main..upstream/main)
+
+# Tag-based signal — same comparison the SessionStart drift banner uses.
+UPSTREAM_TAG=$(git tag --list --sort=-v:refname --merged upstream/main | head -n 1)
+LOCAL_TAG=$(git tag --list --sort=-v:refname --merged main | head -n 1)
 ```
 
 Then report. Examples:
 
-**Up-to-date:**
+**Up-to-date (no tag drift, no commit drift):**
 
 ```
 Fork is up to date with upstream/main. Nothing to sync.
@@ -92,10 +98,21 @@ Fork is up to date with upstream/main. Nothing to sync.
 
 Exit 0.
 
-**Behind only:**
+**No release drift, but main has moved (common, NOT actionable):**
 
 ```
-Fork is 12 commits behind upstream/main.
+Fork is on upstream's latest release (v1.1.0) but upstream/main has 3 unreleased commits.
+These are typically docs tweaks, CI fixes, or work-in-progress.
+
+Sync anyway? [y/N]
+```
+
+Default answer is "no" — small main commits aren't worth syncing. Surface this without nagging; the user can still choose to pull in bleeding-edge.
+
+**Behind only — new release available (actionable, default):**
+
+```
+New release available: v1.1.0 (you are on v1.0.0, 12 commits behind upstream/main).
 
 Upstream commits to pull in:
   c8c93bb fix: merge-gate hooks read PR HEAD via gh pr view (#57)
@@ -103,8 +120,10 @@ Upstream commits to pull in:
   5f067b5 fix: reject closed issue refs (#53)
   ... (9 more)
 
-Proceed with merge? [y/N]
+Proceed with merge? [Y/n]
 ```
+
+Default answer is "yes" in this mode — there's a real release the user asked about by running `/update`.
 
 **Ahead and behind (typical fork):**
 

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -127,6 +127,11 @@ Default answer is "yes" in this mode — there's a real release the user asked a
 
 **Ahead and behind (typical fork):**
 
+The prompt's default answer branches on whether a new release is available:
+
+- If `UPSTREAM_TAG` is strictly newer than `LOCAL_TAG` → default `[Y/n]` (there's a real release to pull in).
+- If they're equal (no new release, just main drift) → default `[y/N]` (likely noise).
+
 ```
 Fork has 5 local commits not in upstream, and is 12 commits behind.
 
@@ -139,7 +144,9 @@ Upstream commits to pull in:
   c8c93bb fix: merge-gate hooks read PR HEAD via gh pr view (#57)
   (… 11 more …)
 
-Proceed with merge? [y/N]
+New release available: v1.1.0 (you are on v1.0.0).
+
+Proceed with merge? [Y/n]
 ```
 
 Cap each list at 20 entries with an `(N more)` marker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to ApexYard are documented here.
 
+## [1.1.0] — 2026-04-19
+
+### Tag-based upstream drift detection
+
+The SessionStart drift banner and the `/update` skill now treat a **new upstream release (tag)** as the actionable signal, not every single commit on `upstream/main`. Small upstream work (README typos, CI tweaks, docs-only PRs) stops nagging every downstream fork.
+
+### Why
+
+Each commit to `me2resh/apexyard:main` used to trigger every fork's banner with "N commits behind upstream/main. Run /update". For a framework repo with many forks, that's noise — it trains people to tune out the banner and miss real releases. The fix: make the banner fire only when there's a new tag.
+
+### What changed
+
+- **`check-upstream-drift.sh`** — now compares the latest upstream tag (sorted by semver, `--merged upstream/main`) against the fork's latest merged tag. If they differ, the banner names the release: `ApexYard: v1.1.0 available. Run /update to sync.` Same tag → silent, even if `upstream/main` has unreleased commits.
+- **`/update` skill** — preview now distinguishes "new release available" (default **yes** to sync) from "unreleased main commits, no tag drift" (default **no** — typically docs/CI noise the user can ignore).
+- **Fallback** — if upstream has never been tagged (brand-new project, pre-release), the hook falls back to the previous commit-count behaviour so early-stage forks still get useful signal.
+
+### Migration notes
+
+- **No config to change.** Tag-based is the new default; no opt-in or opt-out flag to set.
+- **First session on v1.1.0** — the banner will name the first upstream tag higher than your fork's last merged tag.
+- **Forks with never-merged-a-tag history** — fall through to the commit-count fallback on the first run, then the tag-based path after they sync once.
+
 ## [1.0.0] — 2026-04-18
 
 ### Rebrand: ApexStack is now ApexYard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Each commit to `me2resh/apexyard:main` used to trigger every fork's banner with 
 - **No config to change.** Tag-based is the new default; no opt-in or opt-out flag to set.
 - **First session on v1.1.0** — the banner will name the first upstream tag higher than your fork's last merged tag.
 - **Forks with never-merged-a-tag history** — fall through to the commit-count fallback on the first run, then the tag-based path after they sync once.
+- **Cache interaction**: existing installs may have a `.claude/session/last-upstream-fetch` file from pre-1.1.0. That cache still applies — so the first v1.1.0 session may wait up to 10 minutes before the new `--tags` fetch runs. Force an immediate re-check with `rm .claude/session/last-upstream-fetch`.
 
 ## [1.0.0] — 2026-04-18
 

--- a/docs/agdr/AgDR-0005-tag-based-upstream-drift.md
+++ b/docs/agdr/AgDR-0005-tag-based-upstream-drift.md
@@ -1,0 +1,78 @@
+---
+id: AgDR-0005
+timestamp: 2026-04-19T18:30:00Z
+agent: atlas
+model: claude-opus-4-7
+trigger: user-prompt
+status: executed
+ticket: me2resh/apexyard#102
+---
+
+# Tag-based upstream drift detection (shift from per-commit)
+
+> In the context of the SessionStart drift banner nagging every forked ops repo on every upstream main commit, facing the choice between keeping commit-based drift, switching to tag-based drift with a fallback, or adding a config flag with both modes selectable per fork, I decided to **switch the default to tag-based drift with a commit-count fallback** (no config flag), accepting that a fork owner who wants bleeding-edge tracking has to ignore the silent banner and run `/update` on their own cadence.
+
+## Context
+
+The upstream drift banner runs on every Claude Code session start. Its job is to tell a fork owner when the upstream apexyard has moved and they should run `/update`. Until v1.1.0 the signal was `git rev-list --count main..upstream/main` — any commit on upstream main that the fork hasn't absorbed. This worked correctly but produced way too much noise for a framework repo with many forks:
+
+- A README typo fix on upstream main fires the banner on every fork.
+- A CI tweak fires the banner on every fork.
+- A docs-only PR fires the banner on every fork.
+- Anything on upstream main that isn't a release fires the banner on every fork.
+
+The failure mode is not wrong output — the banner accurately reports drift. The failure mode is that fork owners *learn to ignore the banner* because most of the time it's shouting about something they genuinely don't need to sync. By the time a real release (`v1.1.0`, `v2.0.0`) ships, the banner has no attention left.
+
+For a framework we expect to have hundreds of downstream forks, getting this right once means every fork owner going forward gets a quiet, actionable banner. Getting it wrong means training every adopter to tune us out.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **(A) Keep commit-based drift** | No code change. Fires even on "important" untagged commits. | Noisy. Trains fork owners to ignore the banner. Scales poorly with upstream activity. |
+| **(B) Tag-based drift with commit-count fallback** *(chosen)* | Actionable signal (fires only on new releases). Quiet for chore commits. Brand-new projects with no tag history still get a useful signal via fallback. Zero config. | Relies on upstream tagging discipline. If upstream pushes a critical fix to main and forgets to tag, downstream forks don't see a banner until the next tag. |
+| **(C) Config flag (`upstream_sync_mode: tag | main`)** | Satisfies both audiences — conservative (tag) and bleeding-edge (main). | Doubled surface area. More to document, test, and maintain. Most fork owners won't ever change the default, so the flag is dead weight for the majority. Slippery slope toward more flags. |
+
+### Decision dimensions weighted
+
+| Dimension | Weight | (A) Commit | (B) Tag + fallback | (C) Config flag |
+|-----------|--------|------------|--------------------|-----------------|
+| **Signal-to-noise in steady state** | Critical | ❌ | ✅ | ✅ (if set right) |
+| **Zero-config for fork owner** | High | ✅ | ✅ | ❌ |
+| **Works for pre-release projects** | High | ✅ | ✅ (via fallback) | ✅ |
+| **Fork owner can still run `/update` ad-hoc** | High | ✅ | ✅ | ✅ |
+| **Code surface + maintenance cost** | Medium | ✅ (none) | ~ (small) | ❌ (significant) |
+| **Catches critical un-tagged hotfix** | Low | ✅ | ❌ | ✅ (if set to main) |
+
+Options (B) and (C) both dominate (A) on the critical dimension. The choice between B and C turns on whether the config-flag's extra complexity is worth preserving the "catch un-tagged hotfix" case. Judgement call: it isn't. Upstream should **tag hotfixes** — that's what tagging discipline is for. If upstream forgets to tag a critical fix, that's a process failure we should solve at the upstream end, not paper over with a user-facing flag.
+
+## Decision
+
+Chosen: **(B) Tag-based drift with commit-count fallback, no config flag**, because (a) it eliminates the noise problem for steady-state releases without adding config surface, (b) the fallback path handles the "no tags yet" edge case cleanly, and (c) any future need for a bleeding-edge mode can be added later as a pure additive change — we're not locked in.
+
+Implementation specifics in PR #103:
+
+- Hook compares latest upstream tag against the fork's latest merged tag. Fires only when upstream is strictly newer (semver-sorted via `sort -V`). Silent on equal-tag, silent when fork is ahead of upstream tags (e.g. private fork-specific tags).
+- `/update` skill distinguishes "new release available" (actionable — defaults to sync) from "unreleased main commits, no new release" (informational — defaults to skip).
+- Fallback triggers only when `git tag --merged upstream/main` returns nothing.
+
+## Consequences
+
+Positive:
+
+- Every fork owner going forward sees an actionable banner only when a real release ships. No training-to-ignore.
+- The "on v1.0.0 but upstream has 3 docs commits" scenario — which fires the banner every session under commit-based — is now silent.
+- One place to bump the signal: `git tag vX.Y.Z` on upstream is both the public release and the downstream nudge. Aligned.
+
+Negative / accepted:
+
+- **Upstream must tag every meaningful change.** A critical hotfix pushed without a tag won't nag downstream. This is accepted because the alternative (firing on every commit) scales worse in aggregate. Upstream process: every merge that users should pull in should land as part of a tagged release.
+- **Fork owners who legitimately want bleeding-edge tracking** have to manually run `/update` or watch GitHub releases. For the current user base (ops repos that want stability), this is the right default. If a meaningful cohort wants bleeding-edge, adding the flag later is backward-compatible (default stays `tag`).
+- **First session after v1.1.0 ships** will fire the banner on every existing fork naming v1.1.0. That's the intended behaviour — it's the first legitimate release-drift signal under the new regime.
+
+## Artifacts
+
+- PR: https://github.com/me2resh/apexyard/pull/103
+- Hook: `.claude/hooks/check-upstream-drift.sh`
+- Skill: `.claude/skills/update/SKILL.md` § Preview
+- CHANGELOG: `[1.1.0] — 2026-04-19 — Tag-based upstream drift detection`

--- a/docs/agdr/AgDR-0005-tag-based-upstream-drift.md
+++ b/docs/agdr/AgDR-0005-tag-based-upstream-drift.md
@@ -31,7 +31,7 @@ For a framework we expect to have hundreds of downstream forks, getting this rig
 |--------|------|------|
 | **(A) Keep commit-based drift** | No code change. Fires even on "important" untagged commits. | Noisy. Trains fork owners to ignore the banner. Scales poorly with upstream activity. |
 | **(B) Tag-based drift with commit-count fallback** *(chosen)* | Actionable signal (fires only on new releases). Quiet for chore commits. Brand-new projects with no tag history still get a useful signal via fallback. Zero config. | Relies on upstream tagging discipline. If upstream pushes a critical fix to main and forgets to tag, downstream forks don't see a banner until the next tag. |
-| **(C) Config flag (`upstream_sync_mode: tag | main`)** | Satisfies both audiences — conservative (tag) and bleeding-edge (main). | Doubled surface area. More to document, test, and maintain. Most fork owners won't ever change the default, so the flag is dead weight for the majority. Slippery slope toward more flags. |
+| **(C) Config flag (`upstream_sync_mode: tag \| main`)** | Satisfies both audiences — conservative (tag) and bleeding-edge (main). | Doubled surface area. More to document, test, and maintain. Most fork owners won't ever change the default, so the flag is dead weight for the majority. Slippery slope toward more flags. |
 
 ### Decision dimensions weighted
 

--- a/site/index.html
+++ b/site/index.html
@@ -1303,7 +1303,7 @@ footer.foot {
         <span class="titlebar__dot"></span>
         <span class="titlebar__dot is-warn"></span>
       </span>
-      <span class="titlebar__path">~/<b>apexyard</b> <span class="dim">- main · v1.0</span></span>
+      <span class="titlebar__path">~/<b>apexyard</b> <span class="dim">- main · v1.1</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
       <a href="#quickstart">quickstart</a>
@@ -1323,14 +1323,14 @@ footer.foot {
   <div class="hero__inner">
 
     <div class="hero__eyebrow rise rise-1">
-      <span class="pill">apexyard v1.0</span>
+      <span class="pill">apexyard v1.1</span>
       <span>open source · MIT · for founders forging multiple products</span>
     </div>
 
     <h1 class="hero__title rise rise-2">apexyard</h1>
 
     <p class="hero__version rise rise-2" style="margin:-0.5em 0 0.5em;font-size:14px;opacity:0.7;letter-spacing:0.05em;">
-      <a href="https://github.com/me2resh/apexyard/releases/tag/v1.0.0" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v1.0.0</a>
+      <a href="https://github.com/me2resh/apexyard/releases/tag/v1.1.0" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v1.1.0</a>
       &nbsp;·&nbsp;
       <a href="https://github.com/me2resh/apexyard/blob/main/CHANGELOG.md" style="color:inherit;text-decoration:underline;text-underline-offset:3px;" target="_blank" rel="noopener">changelog</a>
     </p>


### PR DESCRIPTION
## Summary

Stops `check-upstream-drift.sh` from nagging every fork on every upstream commit. New behaviour: only a **new upstream tag** fires the SessionStart banner. Small commits (README typos, CI tweaks, docs-only PRs) are silent.

### Why

For a framework repo with many forks, every push to upstream main fired "N commits behind, run /update" on every fork's session start. After enough noise, fork owners tune it out and miss real releases. Tag-based drift makes the signal rare and actionable — "v1.1.0 available" actually means something.

### What changed

- **`.claude/hooks/check-upstream-drift.sh`** — primary path compares latest upstream tag (`git tag --sort=-v:refname --merged upstream/main | head -1`) against the fork's latest merged tag. Different → banner names the release. Same tag → silent, even if upstream/main has unreleased commits.
- **Fallback** — if upstream has **never** been tagged, keeps the old commit-count behaviour. Fresh OSS projects adopting the stack pre-release still get useful signal.
- **`.claude/skills/update/SKILL.md` § Preview** — distinguishes "new release available" (defaults sync-prompt to **yes**) from "unreleased main commits, no tag drift" (defaults to **no** — typically noise).
- **`CHANGELOG.md`** — new `[1.1.0]` entry.

No config flag added — keeping the interface simple. If a specific user wants bleeding-edge-on-every-commit behaviour later, we can add `upstream_sync_mode: main` to the registry in a follow-up.

## Testing

1. `bash -n .claude/hooks/check-upstream-drift.sh` passes (static syntax check).
2. On a fork that's already on `v1.0.0`: run `.claude/hooks/check-upstream-drift.sh` — no output (same tag upstream + local).
3. Push an untagged commit to upstream main, re-run the hook on the fork — still no output (this is the behaviour the whole PR is about).
4. Tag `v1.1.0` on upstream, re-run the hook → expect `ApexYard: v1.1.0 available. Run /update to sync.`
5. On a hypothetical brand-new repo with no tags in upstream history, push a commit, run the hook → fallback path emits `ApexYard: 1 commit behind upstream/main (no tags yet). Run /update to sync.`
6. `prefers-reduced-motion` / user-facing visual behaviour: unchanged (backend hook only).

After merge, I'll cut `v1.1.0` on apexyard — which is the first live test of the new banner on every existing fork (going from v1.0.0 → v1.1.0).

Closes #102

---

## Glossary

| Term | Definition |
|------|------------|
| Drift detection | The class of upstream-awareness checks that tell a fork owner when the upstream they forked from has moved. Used here to nudge the user to run `/update`. |
| Tag-based drift | Signal derived from comparing the latest upstream tag against the fork's latest merged tag. Silent between tags; fires on each new release. |
| Commit-based drift | The previous signal: `git rev-list --count main..upstream/main`. Fires on every unreleased commit — noisy for active repos. |
| Merged tag | A tag whose underlying commit is reachable from a given branch. `git tag --merged main` returns only the tags the branch has actually absorbed, which is the relevant set when asking "has this fork seen this release?". |
| Fallback path | The branch of the hook that runs when upstream has never been tagged. Preserves the old commit-count behaviour so early-stage OSS projects still have working drift detection before their first release. |

