### PR TITLE
chore(#110): block-private-refs-in-public-repos.sh hook

### DIFF
--- a/.claude/hooks/block-private-refs-in-public-repos.sh
+++ b/.claude/hooks/block-private-refs-in-public-repos.sh
@@ -1,0 +1,386 @@
+#!/bin/bash
+# Blocks issue/PR/comment creation on a public framework repo when the title
+# or body references any registered private project from the fork's
+# apexyard.projects.yaml.
+#
+# The leak vector: an agent diagnoses a framework bug while working inside a
+# private project, then files the upstream ticket with "discovered during
+# <private-project> rebuild". Once filed, the project's name is indexed
+# forever on a public issue tracker.
+#
+# Fires on PreToolUse Bash for the five gh shapes that write to a remote
+# tracker:
+#   - gh issue create --repo <repo>
+#   - gh pr create --repo <repo>
+#   - gh issue comment <n> --repo <repo>
+#   - gh pr comment <n> --repo <repo>
+#   - gh api repos/<owner>/<repo>/{issues,pulls}[...]
+#
+# Behaviour:
+#   - Target repo not public-class → exit 0 silently.
+#   - apexyard.projects.yaml missing → exit 0 silently (no scrub list).
+#   - Body empty (no title + no body + no body-file) → exit 0 silently.
+#   - Skip marker `<!-- private-refs: allow -->` in body → exit 0 with a
+#     single-line warning to stderr.
+#   - Match against any registered project `name`, `repo`, `workspace`, or
+#     an `<owner>/<repo>#<N>` reference to a registered repo → exit 2 with a
+#     message naming each leaked token and suggesting abstract replacements.
+#
+# Configuration (future): a `.claude/project-config.json` may override
+# `leak_protection.public_framework_repos` and `leak_protection.skip_marker`.
+# For now the defaults are inlined below.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Match the five covered gh shapes. If the command is anything else,
+#    silently exit 0.
+# ---------------------------------------------------------------------------
+
+IS_GH_SUBCMD=0      # gh issue create | gh pr create | gh issue comment | gh pr comment
+IS_GH_API=0         # gh api .../issues | .../pulls
+
+if echo "$COMMAND" | grep -qE '\bgh\s+issue\s+create\b'; then IS_GH_SUBCMD=1; fi
+if echo "$COMMAND" | grep -qE '\bgh\s+pr\s+create\b'; then IS_GH_SUBCMD=1; fi
+if echo "$COMMAND" | grep -qE '\bgh\s+issue\s+comment\b'; then IS_GH_SUBCMD=1; fi
+if echo "$COMMAND" | grep -qE '\bgh\s+pr\s+comment\b'; then IS_GH_SUBCMD=1; fi
+if echo "$COMMAND" | grep -qE '\bgh\s+api\b.*\b(issues|pulls)\b'; then IS_GH_API=1; fi
+
+if [ "$IS_GH_SUBCMD" -eq 0 ] && [ "$IS_GH_API" -eq 0 ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Resolve the target repo.
+#    - From `--repo owner/name` for the subcommand shape.
+#    - From the URL path for the api shape: `gh api repos/<owner>/<repo>/...`.
+# ---------------------------------------------------------------------------
+
+TARGET_REPO=""
+
+# --repo flag, supports quoted or unquoted value.
+TARGET_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+["'"'"']?([^[:space:]"'"'"']+)["'"'"']?.*/\1/p' | head -1)
+
+if [ -z "$TARGET_REPO" ] && [ "$IS_GH_API" -eq 1 ]; then
+  # Accept both `repos/owner/repo/...` and `/repos/owner/repo/...`.
+  TARGET_REPO=$(echo "$COMMAND" | grep -oE '/?repos/[^/[:space:]]+/[^/[:space:]]+' | head -1 | sed -E 's|^/?repos/||')
+fi
+
+if [ -z "$TARGET_REPO" ]; then
+  # No target repo resolvable — the hook has nothing to evaluate. Default
+  # gh behaviour (current-dir repo) is safe to ignore here: the hook is a
+  # backstop against cross-repo leaks, not a universal scrubber.
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Determine whether the target is public / framework-class.
+#    Sources (in order):
+#      1. `.claude/project-config.*.json` → `leak_protection.public_framework_repos[]`
+#         (read via the shared config lib landed in apexyard#109)
+#      2. Shipped default: `me2resh/apexyard`
+#      3. Auto-detected: whatever the fork's `upstream` remote resolves to
+#         (unless `leak_protection.auto_detect_upstream` is set to `false`).
+# ---------------------------------------------------------------------------
+
+# Load the shared config reader if available. The hook still works without
+# it — falls through to the shipped defaults.
+REPO_ROOT_FOR_CONFIG=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$REPO_ROOT_FOR_CONFIG" ] && [ -f "$REPO_ROOT_FOR_CONFIG/.claude/hooks/_lib-read-config.sh" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$REPO_ROOT_FOR_CONFIG/.claude/hooks/_lib-read-config.sh"
+  CONFIG_REPOS=$(config_get '.leak_protection.public_framework_repos[]' 2>/dev/null | tr '\n' ' ')
+  AUTO_DETECT_UPSTREAM=$(config_get_or '.leak_protection.auto_detect_upstream' 'true')
+fi
+
+PUBLIC_REPOS="${CONFIG_REPOS:-me2resh/apexyard}"
+
+if [ "${AUTO_DETECT_UPSTREAM:-true}" != "false" ]; then
+  UPSTREAM_URL=$(git remote get-url upstream 2>/dev/null)
+  if [ -n "$UPSTREAM_URL" ]; then
+    # Parse github.com/<owner>/<repo>(.git)? from either SSH or HTTPS form.
+    UPSTREAM_SLUG=$(echo "$UPSTREAM_URL" | sed -nE 's|.*github\.com[:/]([^/]+/[^/]+)(\.git)?$|\1|p' | sed -E 's/\.git$//')
+    if [ -n "$UPSTREAM_SLUG" ]; then
+      PUBLIC_REPOS="$PUBLIC_REPOS $UPSTREAM_SLUG"
+    fi
+  fi
+fi
+
+IS_PUBLIC_TARGET=0
+for r in $PUBLIC_REPOS; do
+  if [ "$TARGET_REPO" = "$r" ]; then
+    IS_PUBLIC_TARGET=1
+    break
+  fi
+done
+
+if [ "$IS_PUBLIC_TARGET" -eq 0 ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Locate apexyard.projects.yaml (walk up from CWD to find the fork root).
+# ---------------------------------------------------------------------------
+
+REGISTRY=""
+r="$PWD"
+while [ -n "$r" ] && [ "$r" != "/" ]; do
+  if [ -f "$r/apexyard.projects.yaml" ]; then
+    REGISTRY="$r/apexyard.projects.yaml"
+    break
+  fi
+  r=$(dirname "$r")
+done
+
+if [ -z "$REGISTRY" ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Extract the title + body text that will land on the public tracker.
+#    Supports --title, --body, --body-file, -F, -b, -t, and `gh api`-style
+#    `-F body=@file` / `-f body=...`.
+# ---------------------------------------------------------------------------
+
+extract_flag_value() {
+  # $1 = python-flag regex (e.g. --title | -t). Matches:
+  #   --title "value with spaces"
+  #   --title 'value'
+  #   --title value
+  local flag_re="$1"
+  local cmd="$2"
+  local v
+  v=$(echo "$cmd" | sed -nE "s/.*(${flag_re})[[:space:]]+\"([^\"]*)\".*/\2/p" | head -1)
+  if [ -n "$v" ]; then echo "$v"; return; fi
+  v=$(echo "$cmd" | sed -nE "s/.*(${flag_re})[[:space:]]+'([^']*)'.*/\2/p" | head -1)
+  if [ -n "$v" ]; then echo "$v"; return; fi
+  v=$(echo "$cmd" | sed -nE "s/.*(${flag_re})[[:space:]]+([^[:space:]]+).*/\2/p" | head -1)
+  echo "$v"
+}
+
+TITLE=$(extract_flag_value '--title|-t' "$COMMAND")
+BODY=$(extract_flag_value '--body|-b' "$COMMAND")
+
+# --body-file <path> / -F <path> (only when -F's value is NOT a key=val pair,
+# because `gh api -F body=@file` uses the same flag letter).
+BODY_FILE=$(extract_flag_value '--body-file' "$COMMAND")
+if [ -z "$BODY_FILE" ]; then
+  # gh pr create / gh issue create: -F <path>
+  F_VAL=$(echo "$COMMAND" | sed -nE "s/.*(^|[[:space:]])-F[[:space:]]+\"([^\"]*)\".*/\2/p" | head -1)
+  if [ -z "$F_VAL" ]; then
+    F_VAL=$(echo "$COMMAND" | sed -nE "s/.*(^|[[:space:]])-F[[:space:]]+'([^']*)'.*/\2/p" | head -1)
+  fi
+  if [ -z "$F_VAL" ]; then
+    F_VAL=$(echo "$COMMAND" | sed -nE "s/.*(^|[[:space:]])-F[[:space:]]+([^[:space:]]+).*/\2/p" | head -1)
+  fi
+  # Only treat as a body-file path if it does NOT look like key=value.
+  if [ -n "$F_VAL" ] && ! echo "$F_VAL" | grep -q '='; then
+    BODY_FILE="$F_VAL"
+  fi
+fi
+
+BODY_FILE_CONTENT=""
+if [ -n "$BODY_FILE" ] && [ -f "$BODY_FILE" ]; then
+  BODY_FILE_CONTENT=$(cat "$BODY_FILE" 2>/dev/null)
+fi
+
+# `gh api` body field: -F body=@file or -f body='text' or -F body='text'.
+API_BODY=""
+if [ "$IS_GH_API" -eq 1 ]; then
+  # Handle -F body=@<path> (file ref) and -f/-F body=<literal>.
+  API_BODY_PATH=$(echo "$COMMAND" | sed -nE "s/.*-F[[:space:]]+body=@([^[:space:]\"']+).*/\1/p" | head -1)
+  if [ -n "$API_BODY_PATH" ] && [ -f "$API_BODY_PATH" ]; then
+    API_BODY=$(cat "$API_BODY_PATH" 2>/dev/null)
+  else
+    # Literal body=... — may be quoted. Strip surrounding quotes.
+    API_BODY=$(echo "$COMMAND" | sed -nE "s/.*-[fF][[:space:]]+body=\"([^\"]*)\".*/\1/p" | head -1)
+    if [ -z "$API_BODY" ]; then
+      API_BODY=$(echo "$COMMAND" | sed -nE "s/.*-[fF][[:space:]]+body='([^']*)'.*/\1/p" | head -1)
+    fi
+    if [ -z "$API_BODY" ]; then
+      API_BODY=$(echo "$COMMAND" | sed -nE "s/.*-[fF][[:space:]]+body=([^[:space:]]+).*/\1/p" | head -1)
+    fi
+  fi
+
+  # Also pick up a `title` field on api-shape issue creation.
+  if [ -z "$TITLE" ]; then
+    API_TITLE=$(echo "$COMMAND" | sed -nE "s/.*-[fF][[:space:]]+title=\"([^\"]*)\".*/\1/p" | head -1)
+    if [ -z "$API_TITLE" ]; then
+      API_TITLE=$(echo "$COMMAND" | sed -nE "s/.*-[fF][[:space:]]+title='([^']*)'.*/\1/p" | head -1)
+    fi
+    if [ -z "$API_TITLE" ]; then
+      API_TITLE=$(echo "$COMMAND" | sed -nE "s/.*-[fF][[:space:]]+title=([^[:space:]]+).*/\1/p" | head -1)
+    fi
+    TITLE="$API_TITLE"
+  fi
+fi
+
+# Concatenate all candidate text. A newline between each part keeps
+# line-anchored regexes honest.
+HAYSTACK=$(printf '%s\n%s\n%s\n%s\n' "$TITLE" "$BODY" "$BODY_FILE_CONTENT" "$API_BODY")
+
+# Short-circuit on truly empty input (no title + no body + no files). This is
+# deliberate: `gh issue comment <n>` with no -b / -F triggers gh's editor and
+# the hook has nothing to scan.
+if [ -z "$(echo "$HAYSTACK" | tr -d '[:space:]')" ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Skip marker — lets a deliberate reference through (rare).
+# ---------------------------------------------------------------------------
+
+SKIP_MARKER=$(config_get_or '.leak_protection.skip_marker' '<!-- private-refs: allow -->' 2>/dev/null)
+# Fallback if the config lib didn't source successfully (e.g. on a bare
+# checkout predating apexyard#109).
+SKIP_MARKER="${SKIP_MARKER:-<!-- private-refs: allow -->}"
+if echo "$HAYSTACK" | grep -qF -- "$SKIP_MARKER"; then
+  echo "WARN: private-refs: allow marker present — leak-protection hook bypassed for this ${TARGET_REPO} call. See .claude/rules/leak-protection.md." >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Extract the scrub list from apexyard.projects.yaml — per-project
+#    `name`, `repo`, and `workspace`. awk fallback mirrors the one used
+#    by /start-ticket (see .claude/skills/start-ticket/SKILL.md) — we do
+#    not depend on yq because many forks won't have it installed.
+# ---------------------------------------------------------------------------
+
+NAMES=""
+REPOS=""
+WORKSPACES=""
+
+# awk parser: walk each `- name:` block and pull out `name`, `repo`,
+# `workspace`. Strips surrounding quotes. Assumes `- name:` is the first
+# key in each project entry (same assumption as /start-ticket).
+PARSED=$(awk '
+  function unquote(s) { gsub(/^["\x27]|["\x27]$/, "", s); return s }
+  /^[[:space:]]*- name:/       { print "NAME=" unquote($3) }
+  /^[[:space:]]*repo:/         { print "REPO=" unquote($2) }
+  /^[[:space:]]*workspace:/    { print "WORKSPACE=" unquote($2) }
+' "$REGISTRY")
+
+while IFS= read -r line; do
+  case "$line" in
+    NAME=*)
+      v=${line#NAME=}
+      [ -n "$v" ] && NAMES="$NAMES $v"
+      ;;
+    REPO=*)
+      v=${line#REPO=}
+      [ -n "$v" ] && REPOS="$REPOS $v"
+      ;;
+    WORKSPACE=*)
+      v=${line#WORKSPACE=}
+      [ -n "$v" ] && WORKSPACES="$WORKSPACES $v"
+      ;;
+  esac
+done <<EOF
+$PARSED
+EOF
+
+# ---------------------------------------------------------------------------
+# 8. Build the match list.
+#
+#   - `name` → whole-word match (grep -wE). Skip the target's own name, and
+#     skip names that collide with the target repo's own name, so mentioning
+#     "apexyard" in an apexyard upstream ticket is fine. Also skip the name
+#     whose `repo:` matches $TARGET_REPO (belt-and-braces).
+#   - `repo` slug → exact match, with optional `#<N>` suffix.
+#   - `workspace` path → whole-word match.
+# ---------------------------------------------------------------------------
+
+# Derive the target's bare repo name for exemption (e.g. "apexyard" from
+# "me2resh/apexyard").
+TARGET_NAME=$(echo "$TARGET_REPO" | awk -F/ '{print $NF}')
+
+LEAKS=""
+
+# Reusable matcher: given a pattern regex, if it fires against HAYSTACK,
+# append the token to LEAKS with a labelled prefix.
+record_if_match() {
+  local label="$1"
+  local token="$2"
+  local regex="$3"
+  if echo "$HAYSTACK" | grep -qE "$regex"; then
+    LEAKS="$LEAKS
+  - ${label}: ${token}"
+  fi
+}
+
+for n in $NAMES; do
+  # Exempt the target repo's own name.
+  if [ "$n" = "$TARGET_NAME" ]; then continue; fi
+  # Whole-word, case-insensitive. Escape regex-special chars in $n.
+  esc=$(printf '%s' "$n" | sed -E 's/[][\\/.^$*+?(){}|]/\\&/g')
+  if echo "$HAYSTACK" | grep -qiwE "$esc"; then
+    LEAKS="$LEAKS
+  - project name: $n"
+  fi
+done
+
+for rp in $REPOS; do
+  if [ "$rp" = "$TARGET_REPO" ]; then continue; fi
+  esc=$(printf '%s' "$rp" | sed -E 's/[][\\/.^$*+?(){}|]/\\&/g')
+  # Either bare slug (with word-ish boundary) or slug#<N>.
+  if echo "$HAYSTACK" | grep -qiE "(^|[^A-Za-z0-9_/-])${esc}(#[0-9]+)?([^A-Za-z0-9_/-]|$)"; then
+    LEAKS="$LEAKS
+  - project repo: $rp"
+  fi
+done
+
+for ws in $WORKSPACES; do
+  esc=$(printf '%s' "$ws" | sed -E 's/[][\\/.^$*+?(){}|]/\\&/g')
+  # Workspace-path boundaries: path-chars `/` and `-` ARE allowed *after* the
+  # match (e.g. `workspace/ws-marlow/app.ts` is a real reference — the
+  # trailing `/` marks a sub-path, not a suffix extension of the token). The
+  # leading boundary rejects alphanumeric/underscore/- to avoid matching
+  # inside another token like `myworkspace/ws-marlow`.
+  if echo "$HAYSTACK" | grep -qE "(^|[^A-Za-z0-9_-])${esc}([^A-Za-z0-9_-]|$)"; then
+    LEAKS="$LEAKS
+  - workspace path: $ws"
+  fi
+done
+
+if [ -z "$LEAKS" ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 9. Block with a message that names each leaked token and suggests abstract
+#    replacement phrasing.
+# ---------------------------------------------------------------------------
+
+cat >&2 <<MSG
+BLOCKED: private project reference detected in ${TARGET_REPO} (public framework repo).
+
+Leaked tokens (from your fork's apexyard.projects.yaml):${LEAKS}
+
+Why this is blocked:
+  Public-framework issues are indexed and searchable forever. Referencing
+  a registered private project by name, repo slug, or workspace path
+  publishes that project's existence on a public tracker — usually not
+  what you want.
+
+Rewrite with abstract phrasing. Examples:
+  "discovered during <private-project> rebuild"
+    → "discovered during a managed-project rebuild"
+  "same as <owner/repo>#42"
+    → "same as a registered project's migration ticket"
+  "in workspace/<private-project>/"
+    → "in one of the registered project workspaces"
+
+Escape hatch (rare — only when an upstream ticket legitimately needs to
+reference a registered project by name):
+  Add this HTML comment anywhere in the body:
+    ${SKIP_MARKER}
+
+See .claude/rules/leak-protection.md for the full rationale.
+MSG
+
+exit 2

--- a/.claude/hooks/tests/test_block_private_refs.sh
+++ b/.claude/hooks/tests/test_block_private_refs.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Test fixtures for block-private-refs-in-public-repos.sh.
+#
+# Each test case builds a JSON tool_input payload and pipes it to the hook,
+# then asserts on exit code and (optionally) stderr substring.
+#
+# No framework — just bash + grep + exit codes, so this runs anywhere the
+# other hooks run. To execute:
+#
+#   ./.claude/hooks/tests/test_block_private_refs.sh
+#
+# Exit 0 = all pass, exit 1 = at least one failure.
+
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+HOOK="$REPO_ROOT/.claude/hooks/block-private-refs-in-public-repos.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Set up an isolated fake fork with a minimal registry. Running tests from
+# inside the real ops fork would be fine (the real registry is available)
+# but the tests are clearer with a controlled registry.
+# ---------------------------------------------------------------------------
+
+TMPDIR=$(mktemp -d -t block-private-refs.XXXXXX)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/fork"
+cat > "$TMPDIR/fork/onboarding.yaml" <<'YAML'
+company: test
+YAML
+cat > "$TMPDIR/fork/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: curios-dog
+    repo: me2resh/curios-dog
+    workspace: workspace/curios-dog
+    status: active
+  - name: sharppick
+    repo: me2resh/SharpPick
+    workspace: workspace/sharppick
+    status: active
+  - name: marlow-core
+    repo: acme-private/marlow-svc
+    workspace: workspace/ws-marlow
+    status: active
+YAML
+
+# A directory to cd into so the hook walks up to find the registry.
+mkdir -p "$TMPDIR/fork/subdir"
+
+# Build a JSON tool_input payload. Uses jq to escape the command cleanly.
+make_payload() {
+  local cmd="$1"
+  jq -n --arg c "$cmd" '{tool_input: {command: $c}}'
+}
+
+# Run the hook with a payload and capture exit + stderr.
+# $1 = test name, $2 = expected exit code, $3 = stderr substring (optional),
+# $4 = bash command string (tool_input.command).
+run_case() {
+  local name="$1"
+  local expected_exit="$2"
+  local expected_stderr_substr="$3"
+  local cmd="$4"
+
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  # Run from the fork subdir so the registry-walk finds the fixture.
+  ( cd "$TMPDIR/fork/subdir" && echo "$(make_payload "$cmd")" | "$HOOK" ) 2> "$stderr_file"
+  local actual_exit=$?
+  local stderr_content
+  stderr_content=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+
+  local ok=1
+  if [ "$actual_exit" != "$expected_exit" ]; then
+    ok=0
+  fi
+  if [ -n "$expected_stderr_substr" ]; then
+    if ! echo "$stderr_content" | grep -qF -- "$expected_stderr_substr"; then
+      ok=0
+    fi
+  fi
+
+  if [ "$ok" = 1 ]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name"
+    echo "   expected exit=$expected_exit, got $actual_exit"
+    if [ -n "$expected_stderr_substr" ]; then
+      echo "   expected stderr to contain: $expected_stderr_substr"
+    fi
+    echo "   stderr was:"
+    echo "$stderr_content" | sed 's/^/     /'
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+# 1. Name leak — body mentions a registered project name, target is public.
+run_case "name leak on gh issue create to me2resh/apexyard" \
+  2 "project name: curios-dog" \
+  "gh issue create --repo me2resh/apexyard --title 'bug in rebuild' --body 'discovered during curios-dog rebuild'"
+
+# 2. Repo-slug leak — body contains `owner/repo#N`.
+run_case "repo-slug leak with ticket ref" \
+  2 "project repo: me2resh/curios-dog" \
+  "gh pr create --repo me2resh/apexyard --title 'fix: patch' --body 'same as me2resh/curios-dog#42'"
+
+# 3. Bare repo-slug leak without #N.
+run_case "bare repo-slug leak" \
+  2 "project repo: me2resh/SharpPick" \
+  "gh issue comment 5 --repo me2resh/apexyard --body 'reproduces in me2resh/SharpPick too'"
+
+# 4. Skip marker — body has the allow comment, hook exits 0 with a warning.
+run_case "skip marker bypasses leak check" \
+  0 "private-refs: allow marker present" \
+  "gh issue create --repo me2resh/apexyard --title 'legit cross-ref' --body 'refs curios-dog intentionally <!-- private-refs: allow -->'"
+
+# 5. Missing registry — registry file not present, hook is a no-op.
+mv "$TMPDIR/fork/apexyard.projects.yaml" "$TMPDIR/fork/apexyard.projects.yaml.bak"
+run_case "missing registry → no-op" \
+  0 "" \
+  "gh issue create --repo me2resh/apexyard --title 'x' --body 'mentions curios-dog'"
+mv "$TMPDIR/fork/apexyard.projects.yaml.bak" "$TMPDIR/fork/apexyard.projects.yaml"
+
+# 6. Non-public target — same body but a private repo target; hook ignores.
+run_case "non-public target → no-op" \
+  0 "" \
+  "gh issue create --repo me2resh/curios-dog --title 'x' --body 'mentions curios-dog freely'"
+
+# 7. Empty body — nothing to scan, hook is a no-op.
+run_case "empty body → no-op" \
+  0 "" \
+  "gh pr comment 12 --repo me2resh/apexyard"
+
+# 8. Workspace-path leak — uses a project whose workspace path does NOT
+#    also contain the project name, so the workspace match fires alone.
+run_case "workspace path leak" \
+  2 "workspace path: workspace/ws-marlow" \
+  "gh pr create --repo me2resh/apexyard --title 'fix: path' --body 'seen in workspace/ws-marlow/app.ts'"
+
+# 9. Non-gh command — hook does not fire.
+run_case "non-gh command → no-op" \
+  0 "" \
+  "echo curios-dog"
+
+# 10. gh api issues shape — mirrors gh issue create via REST.
+run_case "gh api issues leak" \
+  2 "project name: curios-dog" \
+  "gh api repos/me2resh/apexyard/issues -f title=bug -f body='discovered during curios-dog rebuild'"
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+
+echo
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -60,5 +60,13 @@
       "chore",
       "revert"
     ]
+  },
+
+  "leak_protection": {
+    "public_framework_repos": [
+      "me2resh/apexyard"
+    ],
+    "auto_detect_upstream": true,
+    "skip_marker": "<!-- private-refs: allow -->"
   }
 }

--- a/.claude/rules/leak-protection.md
+++ b/.claude/rules/leak-protection.md
@@ -1,0 +1,78 @@
+# Leak Protection — Private Registry Refs on Public Repos
+
+Private project identifiers (names, repo slugs, workspace paths) belong in your fork. They do **not** belong on public framework issue trackers. This rule exists because the leak vector is mechanical: an agent diagnoses a framework bug while working inside a private project, then files the upstream ticket with a helpful *"discovered during `<private-project>` rebuild"* reference. Once filed, that private project name is indexed on a public tracker forever, searchable by anyone.
+
+## The rule
+
+**When writing to a public framework repo (issue / PR / comment), never reference a registered private project by `name`, `repo` slug, workspace path, or `<owner>/<repo>#<N>` ticket notation.**
+
+*Public framework repo* = any repo in the hook's public-class list. Default list:
+
+- `me2resh/apexyard` (the canonical upstream)
+- Whatever `git remote get-url upstream` resolves to in the current fork
+- Future: overridable via `.claude/project-config.json` → `leak_protection.public_framework_repos`
+
+*Registered project* = any entry in your fork's `apexyard.projects.yaml`. The registry is — by convention — the fork owner's private portfolio.
+
+## What gets scrubbed
+
+- `.projects[].name` — whole-word match, case-insensitive. Skipped when the name is the target repo's own name (mentioning "apexyard" in an apexyard upstream ticket is fine).
+- `.projects[].repo` — exact `owner/repo` match, optionally followed by `#<N>` to catch ticket references. Skipped when equal to the target repo.
+- `.projects[].workspace` — whole-word match on the workspace path.
+
+## What does NOT get scrubbed
+
+- The fork owner's git identity (name / email) — that's signed on every commit anyway.
+- Generic class descriptions: *"a registered project"*, *"one of the managed project workspaces"*, *"during bulk ticket filing"*. This is the recommended rewrite shape.
+- Timeline phrases (*"on 2026-04-24"*, *"during the Q2 cleanup"*) — dates and sprint labels don't carry attribution.
+
+## Escape hatch — skip marker
+
+When an upstream ticket legitimately needs to reference a registered project by name — the rare case where the framework has to name a managed-project's tracker, for example an AgDR about a specific migration handled in a managed project — add this HTML comment to the body:
+
+```html
+<!-- private-refs: allow -->
+```
+
+The hook then exits 0 and prints a one-line warning to stderr. The marker is deliberately visible in the rendered issue so a reader can see "this reference was kept on purpose, not missed".
+
+## When the hook fires
+
+Wired to `PreToolUse` on `Bash` for five command shapes:
+
+| Shape | Example |
+|-------|---------|
+| `gh issue create --repo` | `gh issue create --repo me2resh/apexyard --title "..." --body "..."` |
+| `gh pr create --repo` | `gh pr create --repo me2resh/apexyard --title "..." --body "..."` |
+| `gh issue comment --repo` | `gh issue comment 42 --repo me2resh/apexyard --body "..."` |
+| `gh pr comment --repo` | `gh pr comment 42 --repo me2resh/apexyard --body "..."` |
+| `gh api .../issues\|/pulls` | `gh api repos/me2resh/apexyard/issues -f title=... -f body=...` |
+
+The hook silently exits 0 in three no-op cases:
+
+1. **Target not public-class** — the command points at a private registered repo (your own project); the concern doesn't apply inside your own org.
+2. **`apexyard.projects.yaml` missing** — no registry = no scrub list. The hook has nothing to enforce.
+3. **Empty title + empty body + no body-file** — `gh ... comment <n>` without a `-b` / `-F` opens the editor; the hook has nothing to scan.
+
+## False-positive handling
+
+If a project's `name` collides with a generic word (a project literally named `auth`, or `core`), the hook will block any upstream ticket that uses that word. Mitigations:
+
+1. **Don't register a private project under a generic one-word name.** `curios-dog` is fine; `auth` is not. This is a good principle independent of leak protection — it also stops `/projects` and `/tasks` from colliding.
+2. **Use the skip marker** when you've confirmed the match is incidental. The warning that accompanies the bypass is visible and auditable.
+3. **Omit the `name` field temporarily** — the hook reads only registered fields, so redacting one project's name in the registry removes it from the scrub list. Least-preferred option; you lose discovery in `/projects` for that project.
+
+## Relationship to other hooks
+
+The leak-protection hook is a **sibling to `check-secrets.sh`** — both scan outgoing content for identifiers that should never leave the local environment. The difference is scope:
+
+| Hook | Protects | When |
+|------|----------|------|
+| `check-secrets.sh` | API keys, passwords, tokens | `git commit` time (staged diff) |
+| `block-private-refs-in-public-repos.sh` | Project names, repo slugs, workspace paths | `gh` tracker-write time (title + body) |
+
+Both are backstops against routine-but-damaging leaks. Self-discipline is the primary defence; the hook catches the cases where the agent had the private information right in front of it while writing the upstream content and didn't actively suppress it.
+
+## Rationale for mechanical enforcement
+
+Self-discipline doesn't prevent this class of leak. The private project's name is *right there* in the working context while the agent is writing the upstream ticket — not referencing it takes active suppression. Mechanical enforcement is the right shape, same pattern as `check-secrets.sh` and the commit-format hooks.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -79,8 +79,33 @@
           },
           {
             "type": "command",
+            "if": "Bash(gh issue create *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+          },
+          {
+            "type": "command",
             "if": "Bash(gh pr create *)",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-pr-create.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh pr create *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh issue comment *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh pr comment *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh api *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },
           {
             "type": "command",

--- a/docs/rule-audit.md
+++ b/docs/rule-audit.md
@@ -142,17 +142,23 @@ Columns:
 | New session without `.claude/session/onboarded` → run `/onboard` | — | `onboarding-check.sh` (SessionStart) | yes | mechanized |
 | `.claude/` duplication between ops-repo and apexyard upstream | — | — | deferred | [#15][15] |
 
+### 10. Leak protection — private refs on public repos
+
+| rule | source | enforced by | mechanizable? | proposed hook / reason advisory |
+|------|--------|-------------|---------------|---------------------------------|
+| Never reference a registered private project (name / repo slug / workspace path / `owner/repo#N`) in issues, PRs, or comments written to a public framework repo | `.claude/rules/leak-protection.md § The rule` | `block-private-refs-in-public-repos.sh` | yes | mechanized ([#110][110]); covers `gh issue create`, `gh pr create`, `gh issue comment`, `gh pr comment`, and `gh api .../issues\|/pulls`; skip marker `<!-- private-refs: allow -->` bypasses with a visible warning |
+
 ---
 
 ## Summary
 
 | bucket | count |
 |--------|-------|
-| mechanized (`yes` — hook / agent enforces it fully) | 26 |
+| mechanized (`yes` — hook / agent enforces it fully) | 27 |
 | partially mechanized (`partial` — hook + prose combination) | 6 |
 | advisory (`no` — stays prose by design) | 36 |
 | deferred to a follow-up ticket (`deferred`) | 5 |
-| **total rows** | **73** |
+| **total rows** | **74** |
 | deferred tickets referenced | 6 ([#15][15], [#20][20], [#21][21], [#22][22], [#23][23], [#25][25]) |
 
 The count of deferred *rows* (5) and deferred *tickets* (6) differ because [#15][15] is a meta-chore (resolve `.claude/` duplication between ops-repo and apexyard upstream) that gets one row in the onboarding section, while the commit-related tickets [#20][20] and [#22][22] share a row via `validate-branch-name.sh` + `validate-pr-create.sh`.
@@ -181,3 +187,4 @@ The spread confirms what AgDR-0001 set out to make true: the **high-blast-radius
 [22]: https://github.com/me2resh/apexyard/issues/22
 [23]: https://github.com/me2resh/apexyard/issues/23
 [25]: https://github.com/me2resh/apexyard/issues/25
+[110]: https://github.com/me2resh/apexyard/issues/110


### PR DESCRIPTION
## Summary

Adds a new PreToolUse hook `block-private-refs-in-public-repos.sh` that scrubs registered private-project identifiers from content destined for public framework repos (`me2resh/apexyard` + whatever the fork's `upstream` remote resolves to + any extras configured under `.leak_protection.public_framework_repos`).

Catches a common leak vector: an author diagnoses a framework bug while working in a private project, then files the upstream ticket or comment with a helpful "discovered during `<private-project>` rebase" reference. Once filed, the private project's name is permanently on a public issue tracker and searchable. This hook is the mechanical backstop for the discipline in the new `.claude/rules/leak-protection.md` rule.

- New hook: `.claude/hooks/block-private-refs-in-public-repos.sh` (~230 LOC)
- New rule doc: `.claude/rules/leak-protection.md`
- Config integration: reads `.leak_protection.public_framework_repos`, `.leak_protection.auto_detect_upstream`, `.leak_protection.skip_marker` via the shared config lib introduced in #109
- Defaults: extended `.claude/project-config.defaults.json` with a `leak_protection` subtree
- Wired into `.claude/settings.json` — five PreToolUse matchers for `gh issue create`, `gh pr create`, `gh issue comment`, `gh pr comment`, `gh api`
- Audit entry: new section 10 in `docs/rule-audit.md`, mechanized count bumped
- 10 test cases in `.claude/hooks/tests/test_block_private_refs.sh`

## How it works

1. On every matched `gh` invocation, parse `--repo` (or the `repos/owner/name/...` path on `gh api`). If the target isn't public-class (not in the configured list + upstream), silent no-op.
2. Locate `apexyard.projects.yaml` by walking up from CWD; extract each project's `name`, `repo`, and `workspace` fields. If the registry is missing, silent no-op — treated as "not an apexyard fork."
3. Self-exempt the target's own slug and bare name: mentioning `apexyard` on an apexyard upstream ticket doesn't fire.
4. Scan the title + body (from `--title`, `--body`, `--body-file`, `-F <path>`, and `gh api`-style `-F body=@file` / `-f body=...`) for whole-word matches against the extracted tokens, plus `owner/repo#N` patterns.
5. Skip marker `<!-- private-refs: allow -->` in the body bypasses with a visible warning.
6. On match: exit 2 naming each leaked token and suggesting abstract replacement phrasing.

## Testing

Ran the committed test fixture — 10 cases, all pass:

```
$ bash .claude/hooks/tests/test_block_private_refs.sh
PASS: name leak on gh issue create to me2resh/apexyard
PASS: repo-slug leak with ticket ref
PASS: bare repo-slug leak
PASS: skip marker bypasses leak check
PASS: missing registry → no-op
PASS: non-public target → no-op
PASS: empty body → no-op
PASS: workspace path leak
PASS: non-gh command → no-op
PASS: gh api issues leak
Passed: 10  Failed: 0
```

Also smoke-tested the config integration after swapping the agent's inlined defaults for shared-lib reads:

- Zero config present → hook falls back to shipped defaults (same behaviour as before)
- Config with custom `public_framework_repos` → hook honours the override
- Config with `auto_detect_upstream: false` → `upstream` remote ignored
- Tests still green end-to-end

## Scope — what this does NOT do

- No CI workflow changes.
- Does not touch the registry or any skill.
- Does not alter commit-message or PR-title validation paths (handled in `validate-commit-format.sh` / `validate-pr-create.sh`).
- Does not parse the rare `--input -` / stdin-driven `gh api` shape (noted in the hook's own header comment as an accepted gap).

## Follow-ups

- Short-name / generic-word collisions (a project literally named `auth` or `core`) could produce false positives. Mitigation is documented in the rule file; can harden with a project-config-level denylist of "skip these names" if pain emerges.
- The `.claude/hooks/tests/` convention was introduced by this hook. If future hook tests accumulate, consider a tiny runner pattern doc.

## Glossary

| Term | Definition |
|------|------------|
| Public framework repo | A repo whose issues and PRs are publicly visible and indexed — `me2resh/apexyard` by default, plus each fork's configured list + upstream auto-detect. |
| Registered private project | Any entry in the fork's `apexyard.projects.yaml`. The hook treats these as "do not mention upstream." |
| Skip marker | Literal `<!-- private-refs: allow -->` in the body that lets one invocation through with a visible warning. |
| Self-exemption | The hook does NOT scrub references to the target repo itself — a ticket on the apexyard upstream can legitimately say "apexyard" without firing. |

Closes #110