### PR TITLE
chore(#115): warn-stale-review-markers.sh PostToolUse hook

### DIFF
--- a/.claude/hooks/tests/test_warn_stale_review_markers.sh
+++ b/.claude/hooks/tests/test_warn_stale_review_markers.sh
@@ -1,0 +1,324 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/warn-stale-review-markers.sh
+#
+# Each case:
+#   - sets up an isolated sandbox repo under $TMPDIR
+#   - stages marker files (or not) under .claude/session/reviews/
+#   - stubs `gh` on PATH to return deterministic values
+#   - pipes a synthetic PostToolUse JSON blob into the hook
+#   - asserts the hook's stderr / exit code / marker-file state
+#
+# Exit 0 means all cases passed. Exit 1 on first failure with a clear message.
+
+set -u
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/warn-stale-review-markers.sh"
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# Build a fresh sandbox for each case: a tiny git repo with an onboarding.yaml
+# (so the settings.json resolver would find it), the hook copied in, and a
+# PATH-shim dir where we drop a fake `gh` script per-case.
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    touch onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+  )
+  mkdir -p "$sb/.claude/hooks" "$sb/.claude/session/reviews" "$sb/bin"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/warn-stale-review-markers.sh"
+  chmod +x "$sb/.claude/hooks/warn-stale-review-markers.sh"
+  # The hook sources the shared config reader landed in apexyard#109. The
+  # sandbox therefore needs both the reader and the shipped defaults so
+  # config lookups resolve the same way they do in a real fork.
+  local src_root
+  src_root=$(cd "$(dirname "$0")/../../.." && pwd)
+  if [ -f "$src_root/.claude/hooks/_lib-read-config.sh" ]; then
+    cp "$src_root/.claude/hooks/_lib-read-config.sh" "$sb/.claude/hooks/_lib-read-config.sh"
+  fi
+  if [ -f "$src_root/.claude/project-config.defaults.json" ]; then
+    cp "$src_root/.claude/project-config.defaults.json" "$sb/.claude/project-config.defaults.json"
+  fi
+  echo "$sb"
+}
+
+# Write a gh stub. Arguments: sandbox dir, behaviour keyword.
+#   no-pr        → all `gh pr view` calls exit 1 (no PR for branch)
+#   pr:<n>:<sha> → `gh pr view --json number` returns <n>;
+#                  `gh pr view <n> --json headRefOid` returns <sha>
+#   offline      → every gh call exits 1 with network error
+write_gh_stub() {
+  local sb="$1"
+  local mode="$2"
+  cat > "$sb/bin/gh" <<'STUB_HEAD'
+#!/bin/bash
+# Test stub for gh — behaviour controlled by $GH_STUB_MODE.
+args="$*"
+STUB_HEAD
+  cat >> "$sb/bin/gh" <<STUB_BODY
+mode="$mode"
+STUB_BODY
+  cat >> "$sb/bin/gh" <<'STUB_TAIL'
+case "$mode" in
+  no-pr)
+    # Simulates the "no PR for current branch" path.
+    exit 1
+    ;;
+  offline)
+    echo "error connecting to api.github.com" >&2
+    exit 1
+    ;;
+  pr:*)
+    # pr:<num>:<sha>
+    num="${mode#pr:}"
+    num="${num%%:*}"
+    sha="${mode##*:}"
+    # Route by args.
+    if [[ "$args" == *"--json number"* && "$args" != *"headRefOid"* ]]; then
+      echo "$num"
+      exit 0
+    fi
+    if [[ "$args" == *"headRefOid"* ]]; then
+      echo "$sha"
+      exit 0
+    fi
+    # Fallback: pretend success but empty.
+    exit 0
+    ;;
+esac
+exit 1
+STUB_TAIL
+  chmod +x "$sb/bin/gh"
+}
+
+# Run the hook inside a sandbox with a given stdin JSON and assert conditions.
+# Args: sandbox, json, expected_stderr_grep (empty for "must be silent"),
+#       expected_exit (always 0 per spec).
+run_hook() {
+  local sb="$1"
+  local json="$2"
+  local expect_grep="$3"
+  local case_name="$4"
+
+  local stderr_file
+  stderr_file=$(mktemp)
+  (
+    cd "$sb" || exit 1
+    # PATH must be exported so the piped hook subshell sees the stub.
+    # A var-prefix on `printf` alone scopes only to printf.
+    export PATH="$sb/bin:$PATH"
+    printf '%s' "$json" \
+      | "$sb/.claude/hooks/warn-stale-review-markers.sh" 2>"$stderr_file"
+  )
+  local rc=$?
+
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$case_name]: hook exited $rc (expected 0)" >&2
+    sed 's/^/    stderr: /' "$stderr_file" >&2
+    rm -f "$stderr_file"
+    FAIL=$((FAIL+1))
+    FAILED_CASES="$FAILED_CASES $case_name"
+    return 1
+  fi
+
+  if [ -z "$expect_grep" ]; then
+    # Silent expected — but tolerate the "falling back to local HEAD" WARN
+    # line because that's emitted by design when gh is unavailable.
+    local noise
+    noise=$(grep -v 'falling back to local HEAD' "$stderr_file" | tr -d '[:space:]')
+    if [ -n "$noise" ]; then
+      echo "FAIL [$case_name]: expected silent, got:" >&2
+      sed 's/^/    stderr: /' "$stderr_file" >&2
+      rm -f "$stderr_file"
+      FAIL=$((FAIL+1))
+      FAILED_CASES="$FAILED_CASES $case_name"
+      return 1
+    fi
+  else
+    if ! grep -qE "$expect_grep" "$stderr_file"; then
+      echo "FAIL [$case_name]: stderr did not match /$expect_grep/" >&2
+      sed 's/^/    stderr: /' "$stderr_file" >&2
+      rm -f "$stderr_file"
+      FAIL=$((FAIL+1))
+      FAILED_CASES="$FAILED_CASES $case_name"
+      return 1
+    fi
+  fi
+
+  rm -f "$stderr_file"
+  PASS=$((PASS+1))
+  echo "PASS [$case_name]"
+  return 0
+}
+
+push_json_success() {
+  # Simulates a successful `git push` tool_response.
+  printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git push -u origin HEAD"},"tool_response":{"stdout":"","stderr":"To https://github.com/acme/repo.git\\n   abc1234..def5678  feature -> feature"}}'
+}
+
+push_json_failure() {
+  # Simulates a failed `git push` — "rejected" marker in stderr.
+  printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git push origin HEAD"},"tool_response":{"stdout":"","stderr":"To https://github.com/acme/repo.git\\n ! [rejected] feature -> feature (non-fast-forward)\\nerror: failed to push some refs"}}'
+}
+
+# -------------------- CASE 1: no PR --------------------
+case1() {
+  local sb
+  sb=$(make_sandbox)
+  write_gh_stub "$sb" "no-pr"
+  run_hook "$sb" "$(push_json_success)" "" "no-pr-silent"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 2: no markers --------------------
+case2() {
+  local sb
+  sb=$(make_sandbox)
+  write_gh_stub "$sb" "pr:42:$(printf 'a%.0s' {1..40})"
+  # No markers written. Should be silent.
+  run_hook "$sb" "$(push_json_success)" "" "no-markers-silent"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 3: fresh markers --------------------
+case3() {
+  local sb
+  sb=$(make_sandbox)
+  local sha
+  sha=$(printf 'b%.0s' {1..40})
+  write_gh_stub "$sb" "pr:42:$sha"
+  # Markers record the current PR HEAD — not stale.
+  echo "$sha" > "$sb/.claude/session/reviews/42-rex.approved"
+  echo "$sha" > "$sb/.claude/session/reviews/42-ceo.approved"
+  run_hook "$sb" "$(push_json_success)" "" "fresh-markers-silent"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 4: stale rex marker --------------------
+case4() {
+  local sb
+  sb=$(make_sandbox)
+  local new_sha old_sha
+  new_sha=$(printf 'c%.0s' {1..40})
+  old_sha=$(printf 'd%.0s' {1..40})
+  write_gh_stub "$sb" "pr:42:$new_sha"
+  echo "$old_sha" > "$sb/.claude/session/reviews/42-rex.approved"
+  run_hook "$sb" "$(push_json_success)" \
+    "Stale review marker: 42-rex\.approved.*was ddddddd.*now ccccccc" \
+    "stale-rex-warn"
+  # Marker file should still exist (warn mode, not delete).
+  if [ ! -f "$sb/.claude/session/reviews/42-rex.approved" ]; then
+    echo "FAIL [stale-rex-warn]: marker was deleted in warn mode" >&2
+    FAIL=$((FAIL+1))
+    PASS=$((PASS-1))
+  fi
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 5: stale ceo marker --------------------
+case5() {
+  local sb
+  sb=$(make_sandbox)
+  local new_sha old_sha
+  new_sha=$(printf 'e%.0s' {1..40})
+  old_sha=$(printf 'f%.0s' {1..40})
+  write_gh_stub "$sb" "pr:42:$new_sha"
+  echo "$old_sha" > "$sb/.claude/session/reviews/42-ceo.approved"
+  run_hook "$sb" "$(push_json_success)" \
+    "Stale review marker: 42-ceo\.approved" \
+    "stale-ceo-warn"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 6: stale design marker --------------------
+case6() {
+  local sb
+  sb=$(make_sandbox)
+  local new_sha old_sha
+  new_sha=$(printf '1%.0s' {1..40})
+  old_sha=$(printf '2%.0s' {1..40})
+  write_gh_stub "$sb" "pr:42:$new_sha"
+  echo "$old_sha" > "$sb/.claude/session/reviews/42-design.approved"
+  run_hook "$sb" "$(push_json_success)" \
+    "Stale review marker: 42-design\.approved" \
+    "stale-design-warn"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 7: delete mode --------------------
+case7() {
+  local sb
+  sb=$(make_sandbox)
+  local new_sha old_sha
+  new_sha=$(printf '3%.0s' {1..40})
+  old_sha=$(printf '4%.0s' {1..40})
+  write_gh_stub "$sb" "pr:42:$new_sha"
+  echo "$old_sha" > "$sb/.claude/session/reviews/42-rex.approved"
+  # Opt in to delete mode.
+  cat > "$sb/.claude/project-config.json" <<EOF
+{"review_markers": {"on_stale": "delete"}}
+EOF
+  run_hook "$sb" "$(push_json_success)" \
+    "Stale review marker deleted: 42-rex\.approved" \
+    "stale-rex-delete"
+  if [ -f "$sb/.claude/session/reviews/42-rex.approved" ]; then
+    echo "FAIL [stale-rex-delete]: marker was NOT deleted in delete mode" >&2
+    FAIL=$((FAIL+1))
+    PASS=$((PASS-1))
+  fi
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 8: push failure --------------------
+case8() {
+  local sb
+  sb=$(make_sandbox)
+  local new_sha old_sha
+  new_sha=$(printf '5%.0s' {1..40})
+  old_sha=$(printf '6%.0s' {1..40})
+  write_gh_stub "$sb" "pr:42:$new_sha"
+  # Stale marker present — but push failed, so the hook should stay silent
+  # (the remote didn't move, so prior markers are still valid against the
+  # remote's actual HEAD).
+  echo "$old_sha" > "$sb/.claude/session/reviews/42-rex.approved"
+  run_hook "$sb" "$(push_json_failure)" "" "push-failed-silent"
+  # Marker must NOT have been deleted.
+  if [ ! -f "$sb/.claude/session/reviews/42-rex.approved" ]; then
+    echo "FAIL [push-failed-silent]: marker was touched on failed push" >&2
+    FAIL=$((FAIL+1))
+    PASS=$((PASS-1))
+  fi
+  rm -rf "$sb"
+}
+
+# Run all cases.
+case1
+case2
+case3
+case4
+case5
+case6
+case7
+case8
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/warn-stale-review-markers.sh
+++ b/.claude/hooks/warn-stale-review-markers.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# PostToolUse hook on `git push`: surfaces invalidated review markers at
+# push-time instead of waiting until merge-time.
+#
+# THE GAP THIS CLOSES
+# -------------------
+# Review markers at .claude/session/reviews/<pr>-{rex,ceo,design}.approved are
+# bound to a specific commit SHA (see block-unreviewed-merge.sh). When the
+# author pushes new commits to an already-approved PR, those markers go
+# stale — their recorded SHA no longer matches the PR's new HEAD.
+#
+# The merge-gate hooks eventually catch this, but only at `gh pr merge` time,
+# which can be hours or days after the push. The gap creates user-visible
+# confusion ("Rex already approved — why is the merge blocked?") and a
+# false-start at merge time.
+#
+# This hook fires immediately after a successful `git push` and prints one
+# warning line per stale marker so the author knows to re-invoke the
+# reviewer before they try to merge.
+#
+# CONSTRAINTS
+# -----------
+# - PostToolUse hook — CANNOT block the push (the push has already happened).
+# - Silent when there's no PR for the branch (early push before `gh pr create`).
+# - Silent when `gh` is offline / unauthenticated (can't resolve the PR HEAD).
+# - Silent when the push failed (nothing changed, markers can't have gone stale
+#   from this push). We detect failure heuristically via the tool_response and
+#   defensively by comparing against the PR's real HEAD on GitHub — which is
+#   the same source-of-truth the merge-gate hooks use post-#55.
+# - Never exits non-zero. PostToolUse exit 2 would surface as a nudge to Claude,
+#   which is inappropriate here: the rule this hook enforces (re-invoke Rex
+#   after new commits) is already enforced mechanically by block-unreviewed-
+#   merge.sh. This hook is purely informational.
+#
+# MODES
+# -----
+# Config at .claude/project-config.json → review_markers.on_stale:
+#   - "warn"   (default): print a warning per stale marker, leave files in place
+#   - "delete":          rm the marker file and print a deletion notice
+#
+# TODO(apexyard#109): switch to the shared project-config reader once it lands.
+# For now we inline the default and read from config only if the file exists.
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ "$TOOL_NAME" != "Bash" ] || [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Only fire on git push
+if ! echo "$COMMAND" | grep -qE '\bgit\s+push\b'; then
+  exit 0
+fi
+
+# -------- Detect push failure heuristically --------
+# git push prints progress to stderr; success output typically includes lines
+# like "To <remote>" and "<old>..<new>  branch -> branch" (or "[new branch]"
+# for the first push). Failure markers are "error:", "fatal:", "rejected",
+# "failed to push".
+#
+# Triple fallback on the stderr path (newer harness → older), same pattern as
+# auto-code-review.sh for stdout.
+PUSH_STDERR=$(echo "$INPUT" | jq -r '.tool_response.stderr // .tool_response.error // empty' 2>/dev/null)
+PUSH_STDOUT=$(echo "$INPUT" | jq -r '.tool_response.stdout // .tool_response.output // .tool_response // empty' 2>/dev/null)
+PUSH_COMBINED="${PUSH_STDOUT}${PUSH_STDERR}"
+
+if [ -n "$PUSH_COMBINED" ] && echo "$PUSH_COMBINED" | grep -qEi '\b(rejected|failed to push|^fatal:|^error:)\b'; then
+  # Push failed — the remote HEAD hasn't moved from this push, so any marker
+  # that was fresh before is still fresh. Nothing to warn about.
+  exit 0
+fi
+
+# -------- Resolve repo root + session/reviews dir --------
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+REVIEWS_DIR="${REPO_ROOT}/.claude/session/reviews"
+if [ ! -d "$REVIEWS_DIR" ]; then
+  # No reviews ever recorded — nothing can be stale.
+  exit 0
+fi
+
+# -------- Resolve the PR number for the current branch --------
+# `gh pr view` with no args looks up the PR for the checked-out branch.
+# If no PR exists (early push before `gh pr create`), gh exits non-zero and
+# we exit silently — this is the expected path for most first pushes.
+PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null)
+if [ -z "$PR_NUMBER" ]; then
+  exit 0
+fi
+
+# -------- Resolve the PR's HEAD SHA --------
+# Prefer `gh pr view --json headRefOid` (same source-of-truth as the merge
+# gates, post-#47/#55). Fall back to local HEAD with a visible warning if
+# gh fails (offline / rate-limited / auth expired) — matches the fallback
+# behaviour in block-unreviewed-merge.sh.
+PR_HEAD=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid' 2>/dev/null)
+if [ -z "$PR_HEAD" ]; then
+  echo "WARN: warn-stale-review-markers.sh could not resolve PR #${PR_NUMBER} HEAD via gh — falling back to local HEAD." >&2
+  PR_HEAD=$(git rev-parse HEAD 2>/dev/null)
+fi
+if [ -z "$PR_HEAD" ]; then
+  # Neither gh nor git could give us a HEAD — exit silently rather than spam.
+  exit 0
+fi
+
+# -------- Load on_stale mode from project-config (via shared lib) --------
+# The shared reader (apexyard#109) merges the shipped defaults with any
+# per-fork override. Falls back to inline default if the lib is unavailable
+# (bare checkout predating #109).
+ON_STALE="warn"
+if [ -f "$REPO_ROOT/.claude/hooks/_lib-read-config.sh" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$REPO_ROOT/.claude/hooks/_lib-read-config.sh"
+  CFG=$(config_get_or '.review_markers.on_stale' 'warn' 2>/dev/null)
+  if [ "$CFG" = "delete" ] || [ "$CFG" = "warn" ]; then
+    ON_STALE="$CFG"
+  fi
+fi
+
+# -------- Scan the marker files for staleness --------
+# Use a for-loop with a nullglob-equivalent pattern check to handle the
+# no-match case cleanly (literal glob vs empty list).
+shopt -s nullglob 2>/dev/null
+for MARKER in "$REVIEWS_DIR"/"$PR_NUMBER"-*.approved; do
+  [ -f "$MARKER" ] || continue
+
+  MARKER_SHA=$(tr -d '[:space:]' < "$MARKER")
+  if [ -z "$MARKER_SHA" ]; then
+    # Malformed marker (empty file) — treat as stale so it gets surfaced,
+    # since the merge gate will reject it anyway.
+    MARKER_SHA="(empty)"
+  fi
+
+  if [ "$MARKER_SHA" = "$PR_HEAD" ]; then
+    # Fresh — no output.
+    continue
+  fi
+
+  MARKER_NAME=$(basename "$MARKER")
+  OLD_SHORT="${MARKER_SHA:0:7}"
+  NEW_SHORT="${PR_HEAD:0:7}"
+
+  if [ "$ON_STALE" = "delete" ]; then
+    rm -f "$MARKER"
+    echo "⚠ Stale review marker deleted: ${MARKER_NAME} (reviewer must re-approve)" >&2
+  else
+    echo "⚠ Stale review marker: ${MARKER_NAME} (was ${OLD_SHORT}, now ${NEW_SHORT}) — re-invoke the reviewer." >&2
+  fi
+done
+
+exit 0

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -68,5 +68,9 @@
     ],
     "auto_detect_upstream": true,
     "skip_marker": "<!-- private-refs: allow -->"
+  },
+
+  "review_markers": {
+    "on_stale": "warn"
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -148,6 +148,11 @@
             "type": "command",
             "if": "Bash(gh pr create *)",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/auto-code-review.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(git push *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/warn-stale-review-markers.sh\"'"
           }
         ]
       }

--- a/docs/rule-audit.md
+++ b/docs/rule-audit.md
@@ -65,6 +65,7 @@ Columns:
 | Plan-level "go" / "ship it" does NOT authorize a merge | `.claude/rules/pr-workflow.md § Plan-level "go" is NOT merge approval` | `block-unreviewed-merge.sh` (CEO marker must be written via `/approve-merge`) | yes | mechanized via the marker-writing convention |
 | After `gh pr create` → invoke Code Reviewer | `.claude/rules/pr-workflow.md § After gh pr create` | `auto-code-review.sh` (PostToolUse reminder) | yes | mechanized as reminder-style nudge |
 | After pushing new commits to an open PR → re-invoke Code Reviewer | `.claude/rules/pr-workflow.md § After Pushing Commits` | `block-unreviewed-merge.sh` (SHA mismatch check) | yes | mechanized |
+| Surface invalidated review markers at push-time, not merge-time | `.claude/rules/pr-workflow.md § After Pushing Commits` | `warn-stale-review-markers.sh` (PostToolUse on `git push`) | yes | mechanized (warning-only; `review_markers.on_stale: delete` opts into auto-delete) |
 | Commit SHA matches Rex + CEO approvals at merge time | `.claude/rules/pr-quality.md § Commit SHA Verification` | `block-unreviewed-merge.sh` | yes | mechanized |
 | PR description MUST contain a Glossary section | `.claude/rules/pr-quality.md § Glossary`, `workflows/code-review.md § PR Description Format` | `validate-pr-create.sh` (warning) + `code-reviewer` agent (blocker) | yes | mechanized (warning + agent) |
 | Design review required when PR touches UI | `.claude/rules/pr-quality.md § Design Review`, `workflows/code-review.md` | `require-design-review-for-ui.sh` | yes | mechanized (AgDR-0001) |


### PR DESCRIPTION
## Summary

Adds a new PostToolUse hook `warn-stale-review-markers.sh` that fires after `git push` and surfaces review markers invalidated by new commits — immediately, instead of at `gh pr merge` time.

The gap it closes: when an author pushes new commits to a PR that already has Rex / CEO / design approvals on record, those markers are now stale (their recorded SHA ≠ PR HEAD). The merge gate catches this, but only at merge attempt — which can be hours or days after the push. Result: confusing "why is my merge blocked, Rex already approved?" moments. This hook makes the invalidation visible the moment it happens.

- New hook: `.claude/hooks/warn-stale-review-markers.sh` (~135 LOC, PostToolUse, non-blocking)
- Tests: `.claude/hooks/tests/test_warn_stale_review_markers.sh` — 8 cases, all pass
- Config integration: reads `.review_markers.on_stale` (`warn` default, `delete` opt-in) via the shared config lib landed in #109
- Defaults: extended `.claude/project-config.defaults.json` with a `review_markers` subtree
- Wired into `.claude/settings.json` — PostToolUse matcher on `Bash` commands matching `git push`
- Audit entry: new row in Section 3 of `docs/rule-audit.md`

## How it works

1. Fires after a successful `git push`. Non-blocking by design — PostToolUse exit 2 would push noise into the conversation; this hook is purely informational.
2. Resolves the PR number for the current branch via `gh pr view --json number`. Silent exit 0 if no PR.
3. Resolves the PR HEAD via `gh pr view --json headRefOid` — same source of truth the merge-gate hooks use post-#47 / #55. Falls back to local HEAD with a visible warning if `gh` is offline.
4. Scans `$(git rev-parse --show-toplevel)/.claude/session/reviews/<pr>-*.approved` for files whose recorded SHA doesn't match HEAD.
5. **warn mode** (default): prints one stderr line per stale marker, naming the file and the old/new SHAs, suggesting re-invocation.
6. **delete mode** (opt-in via `review_markers.on_stale: "delete"`): removes stale markers so the merge gate's "marker missing" message is crisper than "marker stale".
7. Silent on push failure (detected via stderr patterns from the `git push` output and the natural property that a failed push means the remote HEAD didn't advance — markers stay fresh).

## Testing

Ran the committed test fixture — 8 cases, all pass:

```
$ bash .claude/hooks/tests/test_warn_stale_review_markers.sh
PASS [no-pr-silent]
PASS [no-markers-silent]
PASS [fresh-markers-silent]
PASS [stale-rex-warn]
PASS [stale-ceo-warn]
PASS [stale-design-warn]
PASS [stale-rex-delete]
PASS [push-failed-silent]
PASS: 8   FAIL: 0
```

Small tangential fix in the test fixture: the sandbox setup now copies the shared config reader (`_lib-read-config.sh`) and the shipped defaults (`project-config.defaults.json`) into the isolated repo, so the sandboxed hook resolves config the same way it would in a real fork. Previously the sandbox didn't include the shared lib, and the `delete-mode` test would silently fall back to `warn` because `config_get_or` returned the default. Not a production issue (real forks always have both files after #109), but a correctness improvement to the test harness.

## Scope — what this does NOT do

- Does not block the push. This hook is advisory.
- Does not change the merge-gate hook (`block-unreviewed-merge.sh`) — that still catches stale markers at merge time as a final backstop.
- Does not touch `/approve-merge`, `/approve-design`, or the Rex agent.
- `--no-verify` pushes bypass this hook (same as any PostToolUse). Acceptable — bypass discipline is covered by the existing rule ("never skip hooks").

## Glossary

| Term | Definition |
|------|------------|
| Review marker | A file under `.claude/session/reviews/<pr>-<reviewer>.approved` containing the 40-char SHA of the approved commit. Written by Rex / `/approve-merge` / `/approve-design`. |
| Stale marker | A marker whose SHA no longer matches the PR's HEAD — typically because new commits were pushed after approval. |
| PostToolUse | A Claude Code hook that runs AFTER a tool call succeeds. Cannot block; used for warnings, cleanup, and auditing. |
| `warn` / `delete` | The two modes this hook supports. Default `warn` prints a stderr line per stale marker; opt-in `delete` removes the marker so the merge gate reports "missing" rather than "stale". |

Closes #115