### PR TITLE
chore(#111): upgrade pre-push-gate from advisory reminder to blocking check-runner

### DIFF
--- a/.claude/hooks/pre-push-gate.sh
+++ b/.claude/hooks/pre-push-gate.sh
@@ -1,8 +1,32 @@
 #!/bin/bash
-# Reminds the user to run CI checks locally before pushing.
-# Outputs a warning, does not block.
+# pre-push-gate.sh — blocks `git push` on red local checks.
 #
-# Customize the checklist below for your project's actual commands.
+# Upgraded from an advisory reminder (pre-#111) to a blocking check-runner:
+# reads a list of shell commands from `.claude/project-config.*.json`
+# (`.pre_push.commands`) and runs them in sequence before the push is
+# allowed through. Non-zero exit from any command blocks the push.
+#
+# This implements the HARD STOP documented in `.claude/rules/pr-workflow.md`
+# — "Never push without running CI checks locally." Previously the rule
+# was self-discipline; now it's mechanical.
+#
+# Silent pass conditions (exit 0, no output):
+#   - Not a `git push` command.
+#   - No `.claude/project-config.defaults.json` AND no `package.json` in the
+#     repo → treat as a non-runnable repo (docs-only, newly-forked, etc.).
+#   - HEAD commit subject contains the skip marker `<!-- pre-push: skip -->`
+#     → emergency escape hatch; prints a visible WARN and lets the push
+#     through. Leaves a grep-able trace so bypasses are auditable.
+#
+# Configured commands (example, from the shipped defaults):
+#   - lint:      npm run lint
+#   - typecheck: npm run typecheck
+#   - test:      npm run test
+#   - build:     npm run build
+#
+# Skip marker: include the literal string `<!-- pre-push: skip -->` in the
+# HEAD commit message (subject or body) to bypass for that one push.
+# The hook prints the bypassed command set to stderr so the skip is visible.
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -11,16 +35,107 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-# Only check on git push
 if ! echo "$COMMAND" | grep -qE '\bgit\s+push\b'; then
   exit 0
 fi
 
-echo "PRE-PUSH REMINDER: Ensure these passed locally before pushing:" >&2
-echo "  [ ] Lint                  (e.g. npm run lint)" >&2
-echo "  [ ] Type check            (e.g. npm run typecheck)" >&2
-echo "  [ ] Tests                 (e.g. npm run test)" >&2
-echo "  [ ] Build                 (e.g. npm run build)" >&2
-echo "  [ ] Framework validation  (e.g. sam validate, terraform validate)" >&2
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Skip marker — check HEAD commit message for the escape hatch.
+# ---------------------------------------------------------------------------
+
+SKIP_MARKER='<!-- pre-push: skip -->'
+HEAD_MSG=$(cd "$REPO_ROOT" && git log -1 --format='%B' 2>/dev/null)
+if echo "$HEAD_MSG" | grep -qF -- "$SKIP_MARKER"; then
+  echo "WARN: pre-push gate bypassed by skip marker in HEAD commit message." >&2
+  echo "      Skipped commands will run in CI regardless — fix broken state before merging." >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Load command list from project config via the shared reader.
+# Shipped defaults ship at .claude/project-config.defaults.json.
+# See docs/project-config.md and apexyard#109.
+# ---------------------------------------------------------------------------
+
+CMDS_JSON=""
+if [ -f "$REPO_ROOT/.claude/hooks/_lib-read-config.sh" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$REPO_ROOT/.claude/hooks/_lib-read-config.sh"
+  # Produce a JSON array of {name, run} objects.
+  CMDS_JSON=$(config_get '.pre_push.commands' 2>/dev/null)
+fi
+
+# Check that the config actually contains commands. Silent skip if not —
+# the hook is a no-op on repos that haven't configured any (docs-only
+# repos, newly forked skeletons, the apexyard framework repo itself before
+# it configures its own CI in a separate ticket).
+if [ -z "$CMDS_JSON" ] || [ "$CMDS_JSON" = "null" ] || [ "$CMDS_JSON" = "[]" ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Run each command. On first non-zero, block with a summary.
+# ---------------------------------------------------------------------------
+
+cd "$REPO_ROOT" || exit 0
+
+FAILURES=""
+NUM_CMDS=$(echo "$CMDS_JSON" | jq 'length' 2>/dev/null)
+if [ -z "$NUM_CMDS" ] || [ "$NUM_CMDS" = "null" ]; then
+  exit 0
+fi
+
+i=0
+while [ "$i" -lt "$NUM_CMDS" ]; do
+  NAME=$(echo "$CMDS_JSON" | jq -r ".[$i].name // \"step-$i\"" 2>/dev/null)
+  RUN=$(echo "$CMDS_JSON" | jq -r ".[$i].run // empty" 2>/dev/null)
+  i=$((i + 1))
+
+  if [ -z "$RUN" ]; then
+    continue
+  fi
+
+  # Run each command capturing last 20 lines for the error report.
+  TMP_LOG=$(mktemp -t pre-push-gate.XXXXXX)
+  if bash -c "$RUN" >"$TMP_LOG" 2>&1; then
+    rm -f "$TMP_LOG"
+    continue
+  fi
+
+  # Command failed — accumulate a summary. Keep the log for the final
+  # block message; clean up after we print.
+  TAIL=$(tail -20 "$TMP_LOG" 2>/dev/null)
+  rm -f "$TMP_LOG"
+
+  FAILURES="${FAILURES}${NAME}: FAILED
+  command: ${RUN}
+  last 20 lines of output:
+${TAIL}
+
+"
+  # Fail-fast: don't keep running subsequent commands once one has failed.
+  # (Parallel execution is a follow-up — ticket notes it as a P2 polish.)
+  break
+done
+
+if [ -n "$FAILURES" ]; then
+  cat >&2 <<MSG
+BLOCKED: pre-push-gate detected failing check(s). Fix before pushing.
+
+${FAILURES}
+To override for a genuine emergency (the fix will run in CI regardless):
+  git commit --amend -m "\$(git log -1 --format=%B)
+  ${SKIP_MARKER}"
+
+The skip marker is grep-able on purpose — bypasses should be rare and
+auditable. See .claude/rules/pr-workflow.md "Before git push (HARD STOP)".
+MSG
+  exit 2
+fi
 
 exit 0

--- a/.claude/hooks/tests/test_pre_push_gate.sh
+++ b/.claude/hooks/tests/test_pre_push_gate.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/pre-push-gate.sh
+#
+# Each case:
+#   - sets up an isolated sandbox repo under $TMPDIR
+#   - seeds a project-config.json with a specific `.pre_push.commands` array
+#   - pipes a synthetic PreToolUse JSON blob into the hook
+#   - asserts exit code + stderr contents
+#
+# Exit 0 if all cases pass; exit 1 on first failure with a clear message.
+
+set -u
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/pre-push-gate.sh"
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# -- sandbox builder -----------------------------------------------------
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    touch onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+  )
+  mkdir -p "$sb/.claude/hooks" "$sb/.claude/session"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/pre-push-gate.sh"
+  chmod +x "$sb/.claude/hooks/pre-push-gate.sh"
+
+  # Copy the shared reader + shipped defaults so config lookups resolve
+  # the same way they do in a real fork (same pattern as #115 test harness).
+  local src_root
+  src_root=$(cd "$(dirname "$0")/../../.." && pwd)
+  if [ -f "$src_root/.claude/hooks/_lib-read-config.sh" ]; then
+    cp "$src_root/.claude/hooks/_lib-read-config.sh" "$sb/.claude/hooks/_lib-read-config.sh"
+  fi
+  if [ -f "$src_root/.claude/project-config.defaults.json" ]; then
+    cp "$src_root/.claude/project-config.defaults.json" "$sb/.claude/project-config.defaults.json"
+  fi
+  echo "$sb"
+}
+
+push_json() {
+  cat <<EOF
+{"tool_input":{"command":"git push origin HEAD"}}
+EOF
+}
+
+run_hook() {
+  local sb="$1"
+  local stdin_payload="$2"
+  local want_rc="$3"
+  local want_stderr_regex="$4"
+  local label="$5"
+  (
+    cd "$sb" || exit 1
+    echo "$stdin_payload" | bash .claude/hooks/pre-push-gate.sh 2>/tmp/pre-push-gate-stderr.$$
+  )
+  local got_rc=$?
+  local got_stderr
+  got_stderr=$(cat /tmp/pre-push-gate-stderr.$$ 2>/dev/null)
+  rm -f /tmp/pre-push-gate-stderr.$$
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:200})" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# -------------------- CASE 1: non-git-push command --------------------
+case1() {
+  local sb; sb=$(make_sandbox)
+  echo '{"tool_input":{"command":"ls -la"}}' | (cd "$sb" && bash .claude/hooks/pre-push-gate.sh 2>/dev/null)
+  local rc=$?
+  if [ "$rc" = "0" ]; then
+    echo "PASS [non-git-push-silent]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [non-git-push-silent]: want rc=0, got $rc" >&2
+    FAIL=$((FAIL+1))
+  fi
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 2: empty commands → no-op --------------------
+case2() {
+  local sb; sb=$(make_sandbox)
+  cat > "$sb/.claude/project-config.json" <<'EOF'
+{"pre_push": {"commands": []}}
+EOF
+  run_hook "$sb" "$(push_json)" 0 "" "empty-commands-noop"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 3: passing command --------------------
+case3() {
+  local sb; sb=$(make_sandbox)
+  cat > "$sb/.claude/project-config.json" <<'EOF'
+{"pre_push": {"commands": [{"name": "echo-ok", "run": "true"}]}}
+EOF
+  run_hook "$sb" "$(push_json)" 0 "" "passing-command"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 4: failing command --------------------
+case4() {
+  local sb; sb=$(make_sandbox)
+  cat > "$sb/.claude/project-config.json" <<'EOF'
+{"pre_push": {"commands": [{"name": "deliberate-fail", "run": "echo oops; exit 1"}]}}
+EOF
+  run_hook "$sb" "$(push_json)" 2 "deliberate-fail: FAILED" "failing-command-blocks"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 5: skip marker in HEAD commit --------------------
+case5() {
+  local sb; sb=$(make_sandbox)
+  cat > "$sb/.claude/project-config.json" <<'EOF'
+{"pre_push": {"commands": [{"name": "should-skip", "run": "exit 1"}]}}
+EOF
+  # Amend the HEAD commit message to include the skip marker.
+  (cd "$sb" && git commit --amend -q -m "init
+
+<!-- pre-push: skip -->")
+  run_hook "$sb" "$(push_json)" 0 "pre-push gate bypassed by skip marker" "skip-marker-bypasses"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 6: multiple commands, first fails --------------------
+case6() {
+  local sb; sb=$(make_sandbox)
+  cat > "$sb/.claude/project-config.json" <<'EOF'
+{"pre_push": {"commands": [
+  {"name": "lint", "run": "exit 1"},
+  {"name": "test", "run": "true"}
+]}}
+EOF
+  run_hook "$sb" "$(push_json)" 2 "lint: FAILED" "fail-fast-on-first-red"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 7: no config at all → no-op --------------------
+case7() {
+  local sb; sb=$(make_sandbox)
+  # No project-config.json at all; defaults ship with empty commands.
+  run_hook "$sb" "$(push_json)" 0 "" "no-config-noop"
+  rm -rf "$sb"
+}
+
+case1; case2; case3; case4; case5; case6; case7
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -72,5 +72,10 @@
 
   "review_markers": {
     "on_stale": "warn"
+  },
+
+  "pre_push": {
+    "commands": [],
+    "_comment": "Default is empty — per-fork overrides (see docs/project-config.md) populate this with the commands the project actually runs (lint, typecheck, test, build). An empty list makes pre-push-gate.sh a no-op."
   }
 }

--- a/docs/rule-audit.md
+++ b/docs/rule-audit.md
@@ -176,8 +176,6 @@ The spread confirms what AgDR-0001 set out to make true: the **high-blast-radius
 
 [^lint]: Static-analysis concern. Belongs in each project's ESLint / `tsconfig` / equivalent — not a shell hook. The rule stays in `code-standards.md` as the canonical prose; individual projects translate it into their linter config.
 
-[^project-cmds]: Historical footnote preserved for context. Pre-#111 `pre-push-gate.sh` was an advisory reminder; #111 upgraded it to a blocking runner that reads commands from `.claude/project-config.*.json` → `.pre_push.commands`. See the `[^pre-push-111]` footnote.
-
 [^pre-push-111]: Per-fork command list lives at `.claude/project-config.json → .pre_push.commands[]` (each entry has `name` + `run` shell string). Default is an empty list (hook is a no-op) — projects opt in by defining their checks. Fail-fast: the first non-zero exit blocks the push and reports the last 20 lines of output. Emergency escape hatch: include `<!-- pre-push: skip -->` in the HEAD commit message to bypass one push with a visible WARN. The skip marker is grep-able on purpose so bypasses are auditable.
 
 [^self-discipline]: Chat-output rule. Hooks run on tool calls, not assistant prose. The rule file is the primary defence and the downstream artefacts (commit messages, PR titles, staged diffs) are the backstop. See `ticket-vocabulary.md § Why not lint Claude's prose output?` for the full rejection of the "lint chat output" alternative.

--- a/docs/rule-audit.md
+++ b/docs/rule-audit.md
@@ -48,7 +48,7 @@ Columns:
 | Gate 1 — PRD approved + parent epic exists before tech design | `.claude/rules/workflow-gates.md` | prose | no | requires product-doc review; not a shell-observable signal [^advisory] |
 | Gate 2 — design approved + story tickets exist + AgDR for key decisions before build | `.claude/rules/workflow-gates.md` | prose + `require-agdr-for-arch-changes.sh` (arch half) | partial | AgDR half mechanized on arch commits; "design approved" stays prose |
 | Gate 3 — ticket exists + branch created + design review if UI before starting code | `.claude/rules/workflow-gates.md` | `require-active-ticket.sh` (ticket half) + prose | partial | design-review gate fires at *merge* time via `require-design-review-for-ui.sh`, not at build start |
-| Gate 4 — tests pass + checks pass + >80% coverage + AgDR linked before PR | `.claude/rules/workflow-gates.md`, `.claude/rules/pr-workflow.md` | `pre-push-gate.sh` (reminder) + prose | partial | lint/typecheck/test/build reminder mechanized; >80% coverage stays advisory — per-project CI concern [^coverage] |
+| Gate 4 — tests pass + checks pass + >80% coverage + AgDR linked before PR | `.claude/rules/workflow-gates.md`, `.claude/rules/pr-workflow.md` | `pre-push-gate.sh` (blocking runner, #111) + prose | partial | lint/typecheck/test/build now executes + blocks via configured commands; >80% coverage stays advisory — per-project CI concern [^coverage] |
 | Gate 5 — two reviews + CI green + commit SHA matches review before merge | `.claude/rules/workflow-gates.md`, `.claude/rules/pr-quality.md` | `block-unreviewed-merge.sh` + `block-merge-on-red-ci.sh` | yes | mechanized (two hooks together) |
 | Gate 6 — QA verified before ticket → Done | `.claude/rules/workflow-gates.md`, `workflows/sdlc.md § Phase 5` | prose | no | QA sign-off is a human handoff; not a shell-observable signal [^advisory] |
 | One ticket at a time (one PR = one ticket) | `.claude/rules/workflow-gates.md`, `workflows/sdlc.md` | prose | no | behavioral rule; detection would need per-session PR tracking that isn't worth the complexity [^advisory] |
@@ -72,7 +72,7 @@ Columns:
 | `/approve-design` skill for writing the design marker | — | — | deferred | [#21][21] — today's convention is a manual `git rev-parse HEAD > marker` |
 | Never merge with red CI — even pre-existing failures must be fixed first | `.claude/rules/pr-quality.md § No Red CI`, `CLAUDE.md` | `block-merge-on-red-ci.sh` | yes | mechanized (AgDR-0001) |
 | No merge on pending / in-progress CI (pending is not green) | `.claude/rules/pr-quality.md § No Red CI` | `block-merge-on-red-ci.sh` | yes | mechanized |
-| Before `git push`: lint, typecheck, test, build must pass locally | `.claude/rules/pr-workflow.md § Before git push`, `CLAUDE.md § Quality Rules` | `pre-push-gate.sh` (reminder) | partial | reminder mechanized; actual pass/fail stays per-project CI [^project-cmds] |
+| Before `git push`: lint, typecheck, test, build must pass locally | `.claude/rules/pr-workflow.md § Before git push`, `CLAUDE.md § Quality Rules` | `pre-push-gate.sh` (blocking runner) | yes | per-fork commands from `.pre_push.commands` execute on each push; first red blocks with exit 2; skip marker in HEAD commit provides audited bypass [^pre-push-111] |
 | Ticket must exist before `gh pr create` | `.claude/rules/pr-workflow.md § Before gh pr create` | `validate-pr-create.sh` (branch-ID + issue-exists checks) | yes | mechanized |
 | Ticket must have acceptance criteria before `gh pr create` | `.claude/rules/pr-workflow.md § Before gh pr create` | prose | no | AC-content detection needs issue-body parsing and scoring — not a shell-hook job [^advisory] |
 | Branch name has ticket ID before `gh pr create` | `.claude/rules/pr-workflow.md § Before gh pr create` | `validate-branch-name.sh` + `validate-pr-create.sh` | yes | mechanized |
@@ -176,7 +176,9 @@ The spread confirms what AgDR-0001 set out to make true: the **high-blast-radius
 
 [^lint]: Static-analysis concern. Belongs in each project's ESLint / `tsconfig` / equivalent — not a shell hook. The rule stays in `code-standards.md` as the canonical prose; individual projects translate it into their linter config.
 
-[^project-cmds]: `pre-push-gate.sh` is a reminder that echoes the commands, not a runner. Actually executing lint / typecheck / test / build requires knowing the project's package manager and script names — left to per-project CI.
+[^project-cmds]: Historical footnote preserved for context. Pre-#111 `pre-push-gate.sh` was an advisory reminder; #111 upgraded it to a blocking runner that reads commands from `.claude/project-config.*.json` → `.pre_push.commands`. See the `[^pre-push-111]` footnote.
+
+[^pre-push-111]: Per-fork command list lives at `.claude/project-config.json → .pre_push.commands[]` (each entry has `name` + `run` shell string). Default is an empty list (hook is a no-op) — projects opt in by defining their checks. Fail-fast: the first non-zero exit blocks the push and reports the last 20 lines of output. Emergency escape hatch: include `<!-- pre-push: skip -->` in the HEAD commit message to bypass one push with a visible WARN. The skip marker is grep-able on purpose so bypasses are auditable.
 
 [^self-discipline]: Chat-output rule. Hooks run on tool calls, not assistant prose. The rule file is the primary defence and the downstream artefacts (commit messages, PR titles, staged diffs) are the backstop. See `ticket-vocabulary.md § Why not lint Claude's prose output?` for the full rejection of the "lint chat output" alternative.
 


### PR DESCRIPTION
## Summary

Upgrades `pre-push-gate.sh` from an advisory reminder (prints a checklist and exits 0) to a blocking check-runner (reads a configured list of shell commands, executes them, blocks on red with exit 2).

The rule in `.claude/rules/pr-workflow.md § Before git push (HARD STOP)` has always said *"Never push without running CI checks locally."* The old hook printed a reminder, so the mechanical enforcement didn't actually match the written rule. This PR closes that asymmetry.

- Hook now reads `.pre_push.commands` from project config (shared reader from #109) and runs each entry's `run` field in sequence.
- First non-zero exit blocks the push; the failing command name + last 20 lines of output go to stderr.
- Shipped default is an empty command list — hook stays a no-op until a fork opts in by defining its checks. (Deliberate: the framework repo itself doesn't have lint/test/build to run; each fork wires its own CI per its stack.)
- Emergency bypass: `<!-- pre-push: skip -->` in the HEAD commit message. Grep-able on purpose so bypasses are auditable.
- Fail-fast: once a command fails, subsequent commands don't run. Parallel execution is a polish-level follow-up.

Changed files:

- `.claude/hooks/pre-push-gate.sh` — rewritten
- `.claude/hooks/tests/test_pre_push_gate.sh` — new, 7 cases
- `.claude/project-config.defaults.json` — added `pre_push.commands` subtree (empty by default)
- `docs/rule-audit.md` — flipped "Before git push" rule from "partial" to "yes" + updated the footnote

## Testing

```
$ bash .claude/hooks/tests/test_pre_push_gate.sh
PASS [non-git-push-silent]
PASS [empty-commands-noop]
PASS [passing-command]
PASS [failing-command-blocks]
PASS [skip-marker-bypasses]
PASS [fail-fast-on-first-red]
PASS [no-config-noop]
PASS: 7   FAIL: 0
```

Also dogfood: this very PR was pushed through the upgraded hook. Since the framework repo has no configured `.pre_push.commands` in its defaults file, the gate exits 0 silently — proving the "empty-commands-noop" path works end-to-end against the apexyard repo itself.

## What a per-fork override looks like

Minimal example in a fork's `.claude/project-config.json`:

```json
{
  "pre_push": {
    "commands": [
      { "name": "lint",      "run": "npm run lint" },
      { "name": "typecheck", "run": "npm run typecheck" },
      { "name": "test",      "run": "npm run test" },
      { "name": "build",     "run": "npm run build" }
    ]
  }
}
```

Teams on yarn, pnpm, make, cargo, go, mix and so on all configure here — the hook doesn't care about the package manager. The command runs in a sub-shell rooted at the repo top-level.

## Scope — what this does NOT do

- No change to the shipped default command set. Adopters opt in per-fork; the framework itself stays no-op. Changing the shipped default is a separate call.
- No parallel execution. Fail-fast sequential is the v1. If fork owners report the time cost is painful, add a `parallel: true` flag in a follow-up.
- No change to `pre-push-gate.sh`'s matcher wiring in `.claude/settings.json` — same matcher, new behaviour.

## Follow-ups

- Parallel execution within a command group (lint + typecheck can usually run in parallel).
- Richer command spec (e.g. `run_if_exists: "package.json"` to skip on repos without that file).
- Deprecation warning on the legacy flat `commit_types` key in `validate-commit-format.sh` (noted in AgDR-0006 as a deferred item).

## Glossary

| Term | Definition |
|------|------------|
| Pre-push gate | The hook that fires on `Bash` commands matching `git push`. Enforces the HARD STOP rule that local checks must pass before pushing. |
| Skip marker | A literal token in the HEAD commit message that lets a single push through without running checks. Leaves a grep-able trace. |
| Fail-fast | The first non-zero command aborts the whole gate. The alternative (run all, aggregate) is a follow-up. |

Closes #111