### PR TITLE
chore(#107): validate-issue-structure.sh PreToolUse hook

### DIFF
--- a/.claude/hooks/tests/test_validate_issue_structure.sh
+++ b/.claude/hooks/tests/test_validate_issue_structure.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+# Test fixtures for validate-issue-structure.sh.
+#
+# Each case builds a JSON tool_input payload, pipes it to the hook, then
+# asserts on exit code and (optionally) a stderr substring. Same shape as
+# test_block_private_refs.sh — bash + jq + grep, no framework.
+#
+# Run:
+#   ./.claude/hooks/tests/test_validate_issue_structure.sh
+#
+# Exit 0 = all pass, exit 1 = at least one failure.
+
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+HOOK="$REPO_ROOT/.claude/hooks/validate-issue-structure.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+# An isolated fake fork with defaults copied in so the hook's config reader
+# walks up to THIS root, not the real repo's. Running against the real repo
+# would also work (the real defaults match), but a fixture keeps the test
+# self-contained and immune to upstream changes.
+TMPDIR=$(mktemp -d -t validate-issue-structure.XXXXXX)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/fork/.claude/hooks" "$TMPDIR/fork/subdir"
+cat > "$TMPDIR/fork/onboarding.yaml" <<'YAML'
+company: test
+YAML
+# Seed the fake fork with git metadata so `git rev-parse --show-toplevel`
+# resolves to the fixture, not the real repo.
+( cd "$TMPDIR/fork" && git init -q && git config user.email t@t && git config user.name t && git add -f onboarding.yaml && git commit -q -m init ) >/dev/null 2>&1
+
+# Copy the real defaults + lib so the hook reads real schema.
+cp "$REPO_ROOT/.claude/project-config.defaults.json" "$TMPDIR/fork/.claude/project-config.defaults.json"
+cp "$REPO_ROOT/.claude/hooks/_lib-read-config.sh" "$TMPDIR/fork/.claude/hooks/_lib-read-config.sh"
+
+# Build a JSON tool_input payload.
+make_payload() {
+  local cmd="$1"
+  jq -n --arg c "$cmd" '{tool_input: {command: $c}}'
+}
+
+# $1 = test name, $2 = expected exit code, $3 = stderr substring ('' to skip),
+# $4 = bash command string.
+run_case() {
+  local name="$1"
+  local expected_exit="$2"
+  local expected_stderr_substr="$3"
+  local cmd="$4"
+
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  ( cd "$TMPDIR/fork/subdir" && echo "$(make_payload "$cmd")" | "$HOOK" ) 2> "$stderr_file"
+  local actual_exit=$?
+  local stderr_content
+  stderr_content=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+
+  local ok=1
+  if [ "$actual_exit" != "$expected_exit" ]; then
+    ok=0
+  fi
+  if [ -n "$expected_stderr_substr" ]; then
+    if ! echo "$stderr_content" | grep -qF -- "$expected_stderr_substr"; then
+      ok=0
+    fi
+  fi
+
+  if [ "$ok" = 1 ]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name"
+    echo "   expected exit=$expected_exit, got $actual_exit"
+    if [ -n "$expected_stderr_substr" ]; then
+      echo "   expected stderr to contain: $expected_stderr_substr"
+    fi
+    echo "   stderr was:"
+    echo "$stderr_content" | sed 's/^/     /'
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+# --- Feature: pass path ----------------------------------------------------
+FEATURE_OK_BODY='## User Story
+As a user I want to log in so that I can access my account.
+
+## Acceptance Criteria
+- [ ] login form present
+- [ ] error on bad creds'
+
+run_case "Feature with User Story + Acceptance Criteria → pass" \
+  0 "" \
+  "gh issue create --title '[Feature] add login' --body \"$FEATURE_OK_BODY\""
+
+# --- Feature: fail path — missing Acceptance Criteria ----------------------
+FEATURE_BAD_BODY='## User Story
+As a user I want login.'
+
+run_case "Feature missing Acceptance Criteria → block" \
+  2 "missing section: ## Acceptance Criteria" \
+  "gh issue create --title '[Feature] add login' --body \"$FEATURE_BAD_BODY\""
+
+# --- Chore: pass path ------------------------------------------------------
+CHORE_OK_BODY='## Driver
+Replace hardcoded config with project-config.
+
+## Scope
+- update hook
+- update defaults
+
+## Acceptance Criteria
+- [ ] hook reads config'
+
+run_case "Chore with all three sections → pass" \
+  0 "" \
+  "gh issue create --title '[Chore] config-driven hook' --body \"$CHORE_OK_BODY\""
+
+# --- Chore: fail path — missing Scope --------------------------------------
+CHORE_BAD_BODY='## Driver
+Just the driver.
+
+## Acceptance Criteria
+- [ ] done'
+
+run_case "Chore missing Scope → block" \
+  2 "missing section: ## Scope" \
+  "gh issue create --title '[Chore] refactor X' --body \"$CHORE_BAD_BODY\""
+
+# --- Bug: pass path (canonical Given / When / Then heading) ----------------
+BUG_OK_BODY='## Given / When / Then
+Given a logged-in user
+When they click logout
+Then the session ends
+
+## Repro
+1. login
+2. click logout
+3. session cookie still present'
+
+run_case "Bug with Given / When / Then + Repro → pass" \
+  0 "" \
+  "gh issue create --title '[Bug] logout not clearing session' --body \"$BUG_OK_BODY\""
+
+# --- Bug: heading variant — no spaces around slashes -----------------------
+BUG_OK_COMPACT='## Given/When/Then
+Given X
+When Y
+Then Z
+
+## Repro
+1. do X'
+
+run_case "Bug with Given/When/Then compact heading → pass" \
+  0 "" \
+  "gh issue create --title '[Bug] compact heading' --body \"$BUG_OK_COMPACT\""
+
+# --- Bug: fail path — missing Repro ----------------------------------------
+BUG_BAD_BODY='## Given / When / Then
+Given X, When Y, Then Z.'
+
+run_case "Bug missing Repro → block" \
+  2 "missing section: ## Repro" \
+  "gh issue create --title '[Bug] oops' --body \"$BUG_BAD_BODY\""
+
+# --- Empty section check ---------------------------------------------------
+EMPTY_SECTION_BODY='## User Story
+
+## Acceptance Criteria
+- [ ] something'
+
+run_case "Feature with empty User Story section → block" \
+  2 "empty section: ## User Story" \
+  "gh issue create --title '[Feature] empty header' --body \"$EMPTY_SECTION_BODY\""
+
+# --- Skip marker bypasses every check --------------------------------------
+SKIP_BODY='free-form epic body, no required sections.
+<!-- validate-issue-structure: skip -->'
+
+run_case "skip marker bypasses validation" \
+  0 "validate-issue-structure bypassed" \
+  "gh issue create --title '[Feature] epic meta-thread' --body \"$SKIP_BODY\""
+
+# --- Unknown prefix --------------------------------------------------------
+run_case "unknown title prefix → block" \
+  2 "unrecognised prefix" \
+  "gh issue create --title '[Spike] explore X' --body 'whatever'"
+
+# --- No bracketed prefix → silent pass (not every issue uses [Foo]) --------
+run_case "title without bracketed prefix → pass" \
+  0 "" \
+  "gh issue create --title 'just a note' --body 'some content'"
+
+# --- Non-gh command → silent pass ------------------------------------------
+run_case "non gh-issue-create command → no-op" \
+  0 "" \
+  "echo hello"
+
+# --- No body (gh opens editor) → silent pass -------------------------------
+run_case "gh issue create with no body → no-op" \
+  0 "" \
+  "gh issue create --title '[Feature] interactive'"
+
+# --- Docs prefix -----------------------------------------------------------
+DOCS_OK='## Driver
+The docs are stale.
+
+## Acceptance Criteria
+- [ ] update README'
+
+run_case "Docs with Driver + Acceptance Criteria → pass" \
+  0 "" \
+  "gh issue create --title '[Docs] refresh README' --body \"$DOCS_OK\""
+
+# --- body-file path support ------------------------------------------------
+BODY_FILE_PATH="$TMPDIR/body.md"
+cat > "$BODY_FILE_PATH" <<'EOF'
+## User Story
+As a user I want Y.
+
+## Acceptance Criteria
+- [ ] X
+EOF
+
+run_case "--body-file path with valid Feature body → pass" \
+  0 "" \
+  "gh issue create --title '[Feature] X' --body-file $BODY_FILE_PATH"
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+
+echo
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/validate-issue-structure.sh
+++ b/.claude/hooks/validate-issue-structure.sh
@@ -1,0 +1,341 @@
+#!/bin/bash
+# Validates `gh issue create` body shape per title prefix.
+#
+# Fires on PreToolUse Bash(gh issue create …). Enforces the team's ticket
+# schema (required sections per bracketed prefix) as a mechanical backstop
+# for the /feature, /task, /bug skills: agents that bypass the interactive
+# skills and file raw `gh issue create` calls with bespoke body shapes get
+# blocked here with a message that names the missing sections and points
+# at the matching skill.
+#
+# Schema source:
+#   .claude/project-config.defaults.json → .ticket.required_sections (map)
+#   .claude/project-config.json          → user overrides (shallow-merged)
+# Read via the shared _lib-read-config.sh landed in apexyard#109. If the
+# lib is missing (very bare checkout), the hook falls back to inlined
+# defaults that match the shipped schema.
+#
+# Behaviour:
+#   - Non-`gh issue create` command          → exit 0 silently.
+#   - No body (interactive issue editor)     → exit 0 silently.
+#   - Skip marker in body                    → exit 0, WARN on stderr.
+#   - Prefix not in prefix_whitelist         → exit 2, name accepted prefixes.
+#   - Prefix has no schema entry             → exit 0 silently (nothing to check).
+#   - Required section missing (or empty)    → exit 2 with per-section messages.
+#   - Config lib + defaults both absent      → exit 0 silently (no-op).
+#
+# Section matching:
+#   - Case-insensitive.
+#   - Whitespace-tolerant: `## User Story`, `##  User  Story`, `##User Story`.
+#   - Slash variants are canonicalised: a section named "Given / When / Then"
+#     matches headings like `## Given/When/Then`, `## Given / When / Then`,
+#     `## given when then`. Slashes and the spaces around them are optional.
+#   - Content check: the heading must be followed by at least one non-empty,
+#     non-heading line before the next `##` heading.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Only fire on `gh issue create`. Any other invocation is a silent no-op.
+if ! echo "$COMMAND" | grep -qE '\bgh\s+issue\s+create\b'; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Arg extraction — lifted from block-private-refs-in-public-repos.sh so that
+# quoting / spacing variants are handled consistently across the gh hooks.
+# ---------------------------------------------------------------------------
+
+extract_flag_value() {
+  # $1 = python-flag regex (e.g. --title|-t). Matches (possibly multi-line):
+  #   --title "value"
+  #   --title 'value'
+  #   --title value
+  #
+  # Agents commonly pass `--body "…literal newlines…"`, so the extractor
+  # must handle multi-line values. Portable awk doesn't have a reliable way
+  # to consume stdin as a single record (`RS="\0"` triggers paragraph mode
+  # on BSD awk), so we build up one big string line-by-line in awk and run
+  # match() against it in END.
+  local flag_re="$1"
+  local cmd="$2"
+  printf '%s' "$cmd" | awk -v FLAG_RE="$flag_re" -v SQ="'" '
+    { buf = (NR == 1 ? $0 : buf "\n" $0) }
+    END {
+      s = buf
+      # Try double-quoted value first.
+      re = "(" FLAG_RE ")[[:space:]]+\"([^\"]*)\""
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^(" FLAG_RE ")[[:space:]]+\"", "", chunk)
+        sub("\"$", "", chunk)
+        print chunk
+        exit
+      }
+      re = "(" FLAG_RE ")[[:space:]]+" SQ "([^" SQ "]*)" SQ
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^(" FLAG_RE ")[[:space:]]+" SQ, "", chunk)
+        sub(SQ "$", "", chunk)
+        print chunk
+        exit
+      }
+      re = "(" FLAG_RE ")[[:space:]]+[^[:space:]]+"
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^(" FLAG_RE ")[[:space:]]+", "", chunk)
+        print chunk
+        exit
+      }
+    }
+  '
+}
+
+TITLE=$(extract_flag_value '--title|-t' "$COMMAND")
+BODY=$(extract_flag_value '--body|-b' "$COMMAND")
+
+# --body-file <path> / -F <path> (only when -F's value is NOT a key=val pair,
+# because some gh shapes reuse -F for field values).
+BODY_FILE=$(extract_flag_value '--body-file' "$COMMAND")
+if [ -z "$BODY_FILE" ]; then
+  F_VAL=$(echo "$COMMAND" | sed -nE "s/.*(^|[[:space:]])-F[[:space:]]+\"([^\"]*)\".*/\2/p" | head -1)
+  if [ -z "$F_VAL" ]; then
+    F_VAL=$(echo "$COMMAND" | sed -nE "s/.*(^|[[:space:]])-F[[:space:]]+'([^']*)'.*/\2/p" | head -1)
+  fi
+  if [ -z "$F_VAL" ]; then
+    F_VAL=$(echo "$COMMAND" | sed -nE "s/.*(^|[[:space:]])-F[[:space:]]+([^[:space:]]+).*/\2/p" | head -1)
+  fi
+  if [ -n "$F_VAL" ] && ! echo "$F_VAL" | grep -q '='; then
+    BODY_FILE="$F_VAL"
+  fi
+fi
+
+BODY_FILE_CONTENT=""
+if [ -n "$BODY_FILE" ] && [ -f "$BODY_FILE" ]; then
+  BODY_FILE_CONTENT=$(cat "$BODY_FILE" 2>/dev/null)
+fi
+
+# Full body text to inspect — inline --body and/or file contents.
+FULL_BODY=$(printf '%s\n%s\n' "$BODY" "$BODY_FILE_CONTENT")
+
+# Strip the leading / trailing blank line the printf inevitably adds, so
+# "empty body" detection is accurate.
+BODY_STRIPPED=$(echo "$FULL_BODY" | tr -d '[:space:]')
+
+if [ -z "$BODY_STRIPPED" ]; then
+  # No body — `gh issue create` opens the editor. Nothing to validate.
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Config: load prefix_whitelist, required_sections, skip_marker.
+# ---------------------------------------------------------------------------
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+PREFIX_WHITELIST=""
+SKIP_MARKER=""
+HAVE_CONFIG_LIB=0
+
+if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.claude/hooks/_lib-read-config.sh" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$REPO_ROOT/.claude/hooks/_lib-read-config.sh"
+  HAVE_CONFIG_LIB=1
+  PREFIX_WHITELIST=$(config_get '.ticket.prefix_whitelist[]' 2>/dev/null | tr '\n' ' ')
+  SKIP_MARKER=$(config_get_or '.ticket.skip_marker' '<!-- validate-issue-structure: skip -->' 2>/dev/null)
+fi
+
+# Inline defaults for bare checkouts predating apexyard#109. Mirror the
+# shipped .claude/project-config.defaults.json so behaviour is identical.
+if [ -z "$PREFIX_WHITELIST" ]; then
+  PREFIX_WHITELIST="Feature Bug Chore Refactor Testing CI Docs"
+fi
+SKIP_MARKER="${SKIP_MARKER:-<!-- validate-issue-structure: skip -->}"
+
+# ---------------------------------------------------------------------------
+# Skip marker — visible bypass, logs to stderr.
+# ---------------------------------------------------------------------------
+
+if echo "$FULL_BODY" | grep -qF -- "$SKIP_MARKER"; then
+  echo "WARN: $SKIP_MARKER present — validate-issue-structure bypassed." >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Extract title prefix: `[Feature]`, `[Bug]`, etc. Leading whitespace allowed.
+# Case-insensitive whitelist check.
+# ---------------------------------------------------------------------------
+
+if [ -z "$TITLE" ]; then
+  # Title not resolvable — likely an unusual invocation shape; hook cannot
+  # meaningfully validate body against prefix. Fall through to prefix-less
+  # handling (no-op).
+  exit 0
+fi
+
+PREFIX=$(echo "$TITLE" | sed -nE 's/^[[:space:]]*\[([A-Za-z]+)\].*/\1/p' | head -1)
+
+if [ -z "$PREFIX" ]; then
+  # No bracketed prefix — nothing to key the schema on. Let it through; the
+  # hook only enforces shape when a prefix is declared.
+  exit 0
+fi
+
+# Case-insensitive whitelist match. Capture the canonical-cased name from
+# the whitelist so downstream lookups hit the JSON key exactly.
+PREFIX_LC=$(echo "$PREFIX" | tr '[:upper:]' '[:lower:]')
+CANONICAL_PREFIX=""
+for p in $PREFIX_WHITELIST; do
+  p_lc=$(echo "$p" | tr '[:upper:]' '[:lower:]')
+  if [ "$p_lc" = "$PREFIX_LC" ]; then
+    CANONICAL_PREFIX="$p"
+    break
+  fi
+done
+
+if [ -z "$CANONICAL_PREFIX" ]; then
+  # Prefix not on the whitelist.
+  ACCEPTED=$(echo "$PREFIX_WHITELIST" | sed -E 's/[[:space:]]+/, /g; s/, $//')
+  cat >&2 <<MSG
+BLOCKED: issue title '[${PREFIX}]' uses an unrecognised prefix.
+
+Accepted prefixes (from .claude/project-config.*.json → .ticket.prefix_whitelist):
+  ${ACCEPTED}
+
+Either fix the bracketed prefix in the title, or extend prefix_whitelist in
+.claude/project-config.json if this team actually uses a new category.
+
+See docs/project-config.md for the config schema.
+MSG
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Required sections for this prefix. If the schema has no entry, silent pass.
+# ---------------------------------------------------------------------------
+
+REQUIRED_SECTIONS=""
+if [ "$HAVE_CONFIG_LIB" = "1" ]; then
+  # Read the array for this prefix. jq handles missing keys by emitting null,
+  # which config_get swallows to an empty string.
+  REQUIRED_SECTIONS=$(config_get ".ticket.required_sections[\"${CANONICAL_PREFIX}\"][]? // empty" 2>/dev/null)
+fi
+
+# Inline fallback matching the shipped defaults, keyed by canonical prefix.
+if [ -z "$REQUIRED_SECTIONS" ] && [ "$HAVE_CONFIG_LIB" = "0" ]; then
+  case "$CANONICAL_PREFIX" in
+    Feature) REQUIRED_SECTIONS=$(printf 'User Story\nAcceptance Criteria\n') ;;
+    Chore)   REQUIRED_SECTIONS=$(printf 'Driver\nScope\nAcceptance Criteria\n') ;;
+    Bug)     REQUIRED_SECTIONS=$(printf 'Given / When / Then\nRepro\n') ;;
+    Docs)    REQUIRED_SECTIONS=$(printf 'Driver\nAcceptance Criteria\n') ;;
+    *)       REQUIRED_SECTIONS="" ;;
+  esac
+fi
+
+if [ -z "$REQUIRED_SECTIONS" ]; then
+  # No schema for this prefix — hook has nothing to enforce, silent pass.
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Section presence + content checks.
+#
+# For each required section:
+#   1. Build a whitespace-tolerant, slash-tolerant regex for the heading.
+#   2. Find the line of the first match.
+#   3. Scan forward until the next `##` heading or EOF. If no non-heading,
+#      non-whitespace line appears in that range, the section is empty.
+# ---------------------------------------------------------------------------
+
+# Skill suggestion per prefix. Chore / Refactor / Testing / CI / Docs all
+# use /task; Feature uses /feature; Bug uses /bug.
+case "$CANONICAL_PREFIX" in
+  Feature)                              SUGGESTED_SKILL="/feature" ;;
+  Bug)                                  SUGGESTED_SKILL="/bug" ;;
+  Chore|Refactor|Testing|CI|Docs)       SUGGESTED_SKILL="/task" ;;
+  *)                                    SUGGESTED_SKILL="" ;;
+esac
+
+# Build a regex that matches a heading case-insensitively, with flexible
+# whitespace around slashes. Called per-section.
+heading_regex() {
+  local section="$1"
+  # Escape regex-special characters except '/', which we'll soften.
+  local esc
+  esc=$(printf '%s' "$section" | sed -E 's/[][\\.^$*+?(){}|]/\\&/g')
+  # Collapse whitespace to a single space, then replace spaces with a
+  # regex fragment that matches any whitespace (including zero around a
+  # slash separator).
+  esc=$(echo "$esc" | tr -s ' ')
+  # Convert ` / ` (with surrounding spaces) to `[[:space:]]*/[[:space:]]*`,
+  # then remaining single spaces to `[[:space:]]+`. Order matters.
+  esc=$(echo "$esc" | sed -E 's# +/ +#[[:space:]]*/[[:space:]]*#g')
+  esc=$(echo "$esc" | sed -E 's# +#[[:space:]]+#g')
+  # Also accept bare `/` without surrounding spaces (already handled when
+  # the input had spaces; no change needed for bare).
+  echo "^[[:space:]]*##[[:space:]]*${esc}[[:space:]]*\$"
+}
+
+ERRORS=""
+
+# Iterate required sections line-by-line. REQUIRED_SECTIONS is newline-separated.
+while IFS= read -r section; do
+  [ -z "$section" ] && continue
+
+  regex=$(heading_regex "$section")
+
+  # Find the line number of the first matching heading (case-insensitive).
+  line_no=$(echo "$FULL_BODY" | grep -n -iE "$regex" | head -1 | cut -d: -f1)
+
+  if [ -z "$line_no" ]; then
+    ERRORS="${ERRORS}  - missing section: ## ${section}
+"
+    continue
+  fi
+
+  # Slice from line_no+1 to the next `## ` heading (or EOF). awk is clearer
+  # than sed for this range.
+  content=$(echo "$FULL_BODY" | awk -v start="$line_no" '
+    NR <= start { next }
+    /^[[:space:]]*##[[:space:]]/ { exit }
+    { print }
+  ')
+
+  # Non-empty = at least one line with a non-whitespace, non-heading char.
+  stripped=$(echo "$content" | sed -E '/^[[:space:]]*$/d; /^[[:space:]]*##[[:space:]]/d' | tr -d '[:space:]')
+  if [ -z "$stripped" ]; then
+    ERRORS="${ERRORS}  - empty section: ## ${section} (heading present, no content)
+"
+  fi
+done <<EOF
+$REQUIRED_SECTIONS
+EOF
+
+if [ -z "$ERRORS" ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Block with a message naming missing / empty sections and the right skill.
+# ---------------------------------------------------------------------------
+
+cat >&2 <<MSG
+BLOCKED: issue body for '[${CANONICAL_PREFIX}]' does not match the required schema.
+
+Problems:
+${ERRORS}
+Fix the body and retry, or use the matching interactive skill${SUGGESTED_SKILL:+ (${SUGGESTED_SKILL})}.
+The skill produces a body that satisfies this check by construction.
+
+Escape hatch (rare — legitimate off-template tickets like epics or meta-threads):
+  Add this marker anywhere in the body:
+    ${SKIP_MARKER}
+
+Schema source: .claude/project-config.*.json → .ticket.required_sections.
+See docs/project-config.md for the full config reference.
+MSG
+
+exit 2

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -12,7 +12,17 @@
       "CI",
       "Docs"
     ],
-    "label_priority_scheme": "P0,P1,P2,P3"
+    "label_priority_scheme": "P0,P1,P2,P3",
+    "required_sections": {
+      "Feature": ["User Story", "Acceptance Criteria"],
+      "Chore": ["Driver", "Scope", "Acceptance Criteria"],
+      "Refactor": ["Driver", "Scope", "Acceptance Criteria"],
+      "Testing": ["Driver", "Scope", "Acceptance Criteria"],
+      "CI": ["Driver", "Scope", "Acceptance Criteria"],
+      "Docs": ["Driver", "Acceptance Criteria"],
+      "Bug": ["Given / When / Then", "Repro"]
+    },
+    "skip_marker": "<!-- validate-issue-structure: skip -->"
   },
 
   "branch": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -80,6 +80,11 @@
           {
             "type": "command",
             "if": "Bash(gh issue create *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-issue-structure.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh issue create *)",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },
           {

--- a/docs/rule-audit.md
+++ b/docs/rule-audit.md
@@ -149,17 +149,23 @@ Columns:
 |------|--------|-------------|---------------|---------------------------------|
 | Never reference a registered private project (name / repo slug / workspace path / `owner/repo#N`) in issues, PRs, or comments written to a public framework repo | `.claude/rules/leak-protection.md § The rule` | `block-private-refs-in-public-repos.sh` | yes | mechanized ([#110][110]); covers `gh issue create`, `gh pr create`, `gh issue comment`, `gh pr comment`, and `gh api .../issues\|/pulls`; skip marker `<!-- private-refs: allow -->` bypasses with a visible warning |
 
+### 11. Ticket body shape
+
+| rule | source | enforced by | mechanizable? | proposed hook / reason advisory |
+|------|--------|-------------|---------------|---------------------------------|
+| Issue body must match the schema for its bracketed title prefix (`[Feature]` → `## User Story` + `## Acceptance Criteria`; `[Chore]` / `[Refactor]` / `[Testing]` / `[CI]` → `## Driver` + `## Scope` + `## Acceptance Criteria`; `[Docs]` → `## Driver` + `## Acceptance Criteria`; `[Bug]` → `## Given / When / Then` + `## Repro`) | `.claude/skills/{feature,task,bug}/SKILL.md` templates | `validate-issue-structure.sh` | yes | mechanized ([#107][107]); reads schema from `.claude/project-config.*.json` → `.ticket.required_sections`; skip marker `<!-- validate-issue-structure: skip -->` bypasses with a visible warning |
+
 ---
 
 ## Summary
 
 | bucket | count |
 |--------|-------|
-| mechanized (`yes` — hook / agent enforces it fully) | 27 |
+| mechanized (`yes` — hook / agent enforces it fully) | 28 |
 | partially mechanized (`partial` — hook + prose combination) | 6 |
 | advisory (`no` — stays prose by design) | 36 |
 | deferred to a follow-up ticket (`deferred`) | 5 |
-| **total rows** | **74** |
+| **total rows** | **75** |
 | deferred tickets referenced | 6 ([#15][15], [#20][20], [#21][21], [#22][22], [#23][23], [#25][25]) |
 
 The count of deferred *rows* (5) and deferred *tickets* (6) differ because [#15][15] is a meta-chore (resolve `.claude/` duplication between ops-repo and apexyard upstream) that gets one row in the onboarding section, while the commit-related tickets [#20][20] and [#22][22] share a row via `validate-branch-name.sh` + `validate-pr-create.sh`.
@@ -188,4 +194,5 @@ The spread confirms what AgDR-0001 set out to make true: the **high-blast-radius
 [22]: https://github.com/me2resh/apexyard/issues/22
 [23]: https://github.com/me2resh/apexyard/issues/23
 [25]: https://github.com/me2resh/apexyard/issues/25
+[107]: https://github.com/me2resh/apexyard/issues/107
 [110]: https://github.com/me2resh/apexyard/issues/110


### PR DESCRIPTION
## Summary

Adds a new PreToolUse hook `validate-issue-structure.sh` that fires on `gh issue create` and enforces a body-shape schema per bracketed title prefix. Closes the gap where agents bypass the interactive `/feature` / `/task` / `/bug` skills and file raw `gh issue create` with bespoke body shapes.

The rule was already in `.claude/rules/ticket-vocabulary.md` and the individual skill docs, but until now it was self-discipline. This hook is the mechanical backstop: if the body doesn't have the required sections for its prefix, the issue-creation call exits 2 with a message naming the missing sections and pointing at the right skill.

- New hook: `.claude/hooks/validate-issue-structure.sh` (~340 LOC)
- Config integration: reads `.ticket.required_sections` + `.ticket.skip_marker` via the shared reader from #109. Extended `.claude/project-config.defaults.json` with the mapping (Feature → [User Story, Acceptance Criteria]; Chore/Refactor/Testing/CI → [Driver, Scope, Acceptance Criteria]; Docs → [Driver, Acceptance Criteria]; Bug → [Given / When / Then, Repro]).
- Wired into `.claude/settings.json` — PreToolUse matcher on `Bash(gh issue create *)`.
- New section 11 in `docs/rule-audit.md` for the rule; mechanized count bumped.
- 15 test cases covering every prefix's pass + fail + the empty-section path + the skip marker.

## How it works

1. Matches `gh issue create` only. Silent pass on everything else.
2. Parses `--title` and `--body` / `--body-file` / `-F <path>` (lifted the arg-extractor style from `block-private-refs-in-public-repos.sh`, with awk-based multi-line body handling so bodies with `\n` survive intact — `sed` is line-oriented and would have truncated).
3. Extracts the bracketed prefix (`[Feature]`, `[Chore]`, etc.), lowercases for the whitelist match, preserves canonical case for the required-sections lookup. Blocks if the prefix isn't whitelisted.
4. For each required section, greps for `## <name>` (case-insensitive, with tolerance for `## Given/When/Then` vs `## Given / When / Then` vs `## given/when/then`).
5. Empty-content check: after each heading, awk from the heading line to the next `##` (or EOF) and strip whitespace — an empty range fails.
6. Skip marker: `<!-- validate-issue-structure: skip -->` in the body bypasses with a visible stderr WARN. For epics, meta-threads, parking-lot issues that don't fit the schema.
7. Silent pass conditions: no body (interactive `gh issue create`), prefix not in the schema, config completely absent.

## Testing

```
$ bash .claude/hooks/tests/test_validate_issue_structure.sh
PASS: Feature with User Story + Acceptance Criteria → pass
PASS: Feature missing Acceptance Criteria → block
PASS: Chore with all three sections → pass
PASS: Chore missing Scope → block
PASS: Bug with Given / When / Then + Repro → pass
PASS: Bug with Given/When/Then compact heading → pass
PASS: Bug missing Repro → block
PASS: Feature with empty User Story section → block
PASS: skip marker bypasses validation
PASS: unknown title prefix → block
PASS: title without bracketed prefix → pass
PASS: non gh-issue-create command → no-op
PASS: gh issue create with no body → no-op
PASS: Docs with Driver + Acceptance Criteria → pass
PASS: --body-file path with valid Feature body → pass
Passed: 15  Failed: 0
```

Rebased cleanly onto the current `dev` HEAD after #111 landed — auto-merge of `.claude/project-config.defaults.json` (nested `ticket` subtree gained `required_sections` + `skip_marker`) and `docs/rule-audit.md` (new row at section 11). Both resolved without conflict.

## Scope — what this does NOT do

- Does not touch the `/feature` / `/task` / `/bug` skill files — they already reference config in their Rules sections (landed in #109).
- Does not change `validate-pr-create.sh` — that's separate (#113 / #114).
- `--body-file -` (stdin) shape is a known gap — the hook silently skips rather than trying to read stdin, same pattern as sibling hooks. Low frequency, noted in the header comment.

## Follow-ups

- If short or generic prefixes emerge (`[Infra]`, `[Scaffold]`, `[Design]`, `[Security]`) — teams extend by adding to `.ticket.prefix_whitelist` + `.ticket.required_sections` in their per-fork `project-config.json`. No framework edits required per apexyard#109's config-driven design.

## Glossary

| Term | Definition |
|------|------------|
| Required section | A Markdown heading (`## Name`) that must appear in the body with non-empty content. |
| Prefix whitelist | The set of bracketed title prefixes the hook recognises. Extended per-fork via `.ticket.prefix_whitelist`. |
| Empty-section check | After finding a heading, scan forward to the next `##` — if there's no non-whitespace content, the section is flagged as empty. |
| Skip marker | `<!-- validate-issue-structure: skip -->` — bypasses validation for one invocation with a visible WARN. |

Closes #107