### PR TITLE
chore(#112): require-agdr-for-arch-pr.sh PreToolUse hook

### DIFF
--- a/.claude/hooks/require-agdr-for-arch-pr.sh
+++ b/.claude/hooks/require-agdr-for-arch-pr.sh
@@ -1,0 +1,397 @@
+#!/bin/bash
+# PreToolUse hook on `gh pr create`: when the PR's diff touches architecture
+# paths OR adds a new dependency, require the PR body to reference an AgDR
+# (matching `AgDR-\d+-[a-z0-9-]+`).
+#
+# This is the PR-time counterpart to `require-agdr-for-arch-changes.sh`
+# (commit-time). The commit-time hook catches a single architectural change
+# on its way into the repo; this hook catches the *cumulative* diff of a PR —
+# the place where reviewers need a pointer to the decision record.
+#
+# Closes the asymmetry noted in `.claude/rules/agdr-decisions.md`:
+# every other HARD STOP in the ruleset (merge approval, ticket-first,
+# migration-first) is mechanically enforced — this one was prose-only.
+#
+# Behaviour:
+#   - Matches ONLY on `gh pr create …`. Silent no-op on other commands.
+#   - Computes the diff vs the base branch (parsed from --base; falls back
+#     to `upstream/dev`, `origin/dev`, `upstream/main`, `origin/main`).
+#   - Config via .claude/project-config.defaults.json (shallow-merged with
+#     .claude/project-config.json):
+#       .agdr_trigger_paths       → list of shell globs (case-style patterns)
+#       .agdr_trigger_dep_files   → list of literal basenames (package.json, …)
+#   - Architecture change detected if ANY of:
+#       (a) a changed file matches any trigger path glob
+#       (b) a dep file was changed AND the diff shows dependency ADDITIONS
+#           (not version-only bumps — those are an /audit-deps concern).
+#   - If arch change detected AND body does NOT contain `AgDR-\d+-[a-z0-9-]+`
+#     → exit 2 with a helpful message.
+#   - Skip marker `<!-- agdr: not-applicable -->` in body → exit 0 with a
+#     visible WARN on stderr.
+#   - Empty diff or unresolvable base → silent exit 0.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Match only on `gh pr create …`.
+if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+create\b'; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Extract --title, --body, --body-file, -F <path> from the command.
+#    Same parser shape as block-private-refs-in-public-repos.sh — lifted here
+#    to avoid creating a shared extractor library solely for one new caller.
+# ---------------------------------------------------------------------------
+
+extract_flag_value() {
+  # $1 = flag regex (e.g. --title | -t). Matches:
+  #   --title "value with spaces"
+  #   --title 'value'
+  #   --title value
+  local flag_re="$1"
+  local cmd="$2"
+  local v
+  v=$(echo "$cmd" | sed -nE "s/.*(${flag_re})[[:space:]]+\"([^\"]*)\".*/\2/p" | head -1)
+  if [ -n "$v" ]; then echo "$v"; return; fi
+  v=$(echo "$cmd" | sed -nE "s/.*(${flag_re})[[:space:]]+'([^']*)'.*/\2/p" | head -1)
+  if [ -n "$v" ]; then echo "$v"; return; fi
+  v=$(echo "$cmd" | sed -nE "s/.*(${flag_re})[[:space:]]+([^[:space:]]+).*/\2/p" | head -1)
+  echo "$v"
+}
+
+TITLE=$(extract_flag_value '--title|-t' "$COMMAND")
+BODY=$(extract_flag_value '--body|-b' "$COMMAND")
+
+# --body-file <path> / -F <path> (only when -F's value is NOT a key=val pair,
+# because `gh api -F body=@file` uses the same flag letter).
+BODY_FILE=$(extract_flag_value '--body-file' "$COMMAND")
+if [ -z "$BODY_FILE" ]; then
+  F_VAL=$(echo "$COMMAND" | sed -nE "s/.*(^|[[:space:]])-F[[:space:]]+\"([^\"]*)\".*/\2/p" | head -1)
+  if [ -z "$F_VAL" ]; then
+    F_VAL=$(echo "$COMMAND" | sed -nE "s/.*(^|[[:space:]])-F[[:space:]]+'([^']*)'.*/\2/p" | head -1)
+  fi
+  if [ -z "$F_VAL" ]; then
+    F_VAL=$(echo "$COMMAND" | sed -nE "s/.*(^|[[:space:]])-F[[:space:]]+([^[:space:]]+).*/\2/p" | head -1)
+  fi
+  if [ -n "$F_VAL" ] && ! echo "$F_VAL" | grep -q '='; then
+    BODY_FILE="$F_VAL"
+  fi
+fi
+
+BODY_FILE_CONTENT=""
+if [ -n "$BODY_FILE" ] && [ -f "$BODY_FILE" ]; then
+  BODY_FILE_CONTENT=$(cat "$BODY_FILE" 2>/dev/null)
+fi
+
+# Build the body haystack. Title is included so an AgDR reference in the
+# title also satisfies the requirement (reviewers will see it either way).
+HAYSTACK=$(printf '%s\n%s\n%s\n' "$TITLE" "$BODY" "$BODY_FILE_CONTENT")
+
+# ---------------------------------------------------------------------------
+# 2. Skip marker short-circuit.
+# ---------------------------------------------------------------------------
+SKIP_MARKER='<!-- agdr: not-applicable -->'
+if echo "$HAYSTACK" | grep -qF -- "$SKIP_MARKER"; then
+  echo "WARN: agdr: not-applicable marker present — require-agdr-for-arch-pr bypassed. See .claude/rules/agdr-decisions.md." >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Resolve base branch and compute the PR diff.
+#
+#    Precedence:
+#      a. --base <branch> on the command
+#      b. first of: upstream/dev, origin/dev, upstream/main, origin/main
+#    If none resolve to a real ref, exit 0 silently — the hook has nothing to
+#    evaluate and the PR creation itself will fail more loudly than we can.
+# ---------------------------------------------------------------------------
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+BASE_ARG=$(extract_flag_value '--base|-B' "$COMMAND")
+BASE_REF=""
+
+resolve_ref() {
+  # Verify a ref exists; echo it if so, else empty.
+  local ref="$1"
+  if git rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then
+    echo "$ref"
+  fi
+}
+
+if [ -n "$BASE_ARG" ]; then
+  # Try upstream/<arg>, origin/<arg>, <arg> in that order.
+  for candidate in "upstream/$BASE_ARG" "origin/$BASE_ARG" "$BASE_ARG"; do
+    r=$(resolve_ref "$candidate")
+    if [ -n "$r" ]; then BASE_REF="$r"; break; fi
+  done
+fi
+
+if [ -z "$BASE_REF" ]; then
+  for candidate in upstream/dev origin/dev upstream/main origin/main main master; do
+    r=$(resolve_ref "$candidate")
+    if [ -n "$r" ]; then BASE_REF="$r"; break; fi
+  done
+fi
+
+if [ -z "$BASE_REF" ]; then
+  # Can't determine base — silent no-op.
+  exit 0
+fi
+
+MERGE_BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null)
+if [ -z "$MERGE_BASE" ]; then
+  exit 0
+fi
+
+CHANGED_FILES=$(git diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null)
+if [ -z "$CHANGED_FILES" ]; then
+  # No files changed — nothing to evaluate.
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Load trigger config.
+#    - `.agdr_trigger_paths[]`    → globs (shell case patterns)
+#    - `.agdr_trigger_dep_files[]` → literal basenames
+#    Both have inline fallbacks if the config lib / defaults file are missing.
+# ---------------------------------------------------------------------------
+
+TRIGGER_PATHS=""
+TRIGGER_DEP_FILES=""
+
+if [ -f "$REPO_ROOT/.claude/hooks/_lib-read-config.sh" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$REPO_ROOT/.claude/hooks/_lib-read-config.sh"
+  TRIGGER_PATHS=$(config_get '.agdr_trigger_paths[]' 2>/dev/null)
+  TRIGGER_DEP_FILES=$(config_get '.agdr_trigger_dep_files[]' 2>/dev/null)
+fi
+
+# Fallback defaults — kept in sync with .claude/project-config.defaults.json.
+if [ -z "$TRIGGER_PATHS" ]; then
+  TRIGGER_PATHS='**/domain/**
+**/infrastructure/**
+**/migrations/**
+infrastructure/**
+template.yaml
+**/*.tf
+**/*.tfvars
+.github/workflows/**'
+fi
+
+if [ -z "$TRIGGER_DEP_FILES" ]; then
+  TRIGGER_DEP_FILES='package.json
+pyproject.toml
+Cargo.toml
+go.mod
+Gemfile'
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Decide whether any changed file triggers the arch requirement.
+#
+# Path match: we translate each glob to a shell `case` pattern. `**` in
+# shell-case isn't literally supported but `*` crosses `/` in case patterns
+# (POSIX shell), so `*/domain/*` matches the intent of `**/domain/**`.
+# ---------------------------------------------------------------------------
+
+matches_glob() {
+  # $1 = path, $2 = glob (one per call). Returns 0 if match.
+  local path="$1"
+  local glob="$2"
+  # Rewrite `**` → `*` for shell case. `*/foo/**/bar` → `*/foo/*/bar`.
+  # shell case `*` already crosses `/`, so this is close enough for our
+  # trigger list (which only uses `**` at path boundaries).
+  local sg
+  sg=$(echo "$glob" | sed 's|\*\*|*|g')
+  # shellcheck disable=SC2254
+  case "$path" in
+    $sg) return 0 ;;
+  esac
+  # Also try with a leading `*/` for patterns that start at an arbitrary
+  # depth (e.g. `**/domain/**` should match `foo/domain/x.ts` as well as
+  # `domain/x.ts`). The rewrite above turned it into `*/domain/*` which
+  # needs a leading directory; patch by trying the leading-optional form.
+  case "$glob" in
+    \*\**)
+      local stripped
+      stripped=$(echo "$glob" | sed -E 's|^\*\*/||; s|\*\*|*|g')
+      # shellcheck disable=SC2254
+      case "$path" in
+        $stripped) return 0 ;;
+      esac
+      ;;
+  esac
+  return 1
+}
+
+TRIGGERED_FILES=""
+TRIGGERED_DEP_FILES=""
+
+# (a) Path-based triggers.
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  while IFS= read -r pat; do
+    [ -z "$pat" ] && continue
+    if matches_glob "$file" "$pat"; then
+      TRIGGERED_FILES="${TRIGGERED_FILES}${file}
+"
+      break
+    fi
+  done <<EOF
+$TRIGGER_PATHS
+EOF
+done <<EOF
+$CHANGED_FILES
+EOF
+
+# (b) Dep-file additions.
+#
+# For each dep-file listed in config, check whether it's in the changed set.
+# If so, decide whether the diff is "add a new dep" vs "version bump only".
+#
+# JSON dep files (only package.json today): compare the union of `.dependencies`
+# + `.devDependencies` + `.peerDependencies` + `.optionalDependencies` keys at
+# MERGE_BASE vs HEAD. Any key present at HEAD but not at MERGE_BASE is an
+# addition → fire.
+#
+# Non-JSON dep files (pyproject.toml, Cargo.toml, go.mod, Gemfile): crude
+# heuristic — count the number of ADDED lines (`^+` in unified diff) that
+# look like a dep declaration and do NOT correspond to a matching REMOVED
+# line with the same dep name. A version bump shows up as a matched +/- pair
+# on the same dep name; a new dep shows up as a `+` with no counterpart. The
+# heuristic is: `grep -E '^\+[^+]' diff | wc -l` > `grep -E '^-[^-]' diff | wc -l`.
+# Not perfect — reorderings can false-positive — but it's good enough for the
+# "did you *add* something" signal. Projects that need exact parsing can
+# install a linter and wire it into CI.
+while IFS= read -r depfile; do
+  [ -z "$depfile" ] && continue
+  # Does the diff actually touch this file (at any depth)?
+  TOUCHED=$(echo "$CHANGED_FILES" | grep -E "(^|/)$(printf '%s' "$depfile" | sed -E 's/[.[\\/^$*+?(){}|]/\\&/g')$" || true)
+  [ -z "$TOUCHED" ] && continue
+
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    case "$depfile" in
+      package.json)
+        BASE_JSON=$(git show "$MERGE_BASE:$file" 2>/dev/null)
+        HEAD_JSON=$(git show "HEAD:$file" 2>/dev/null)
+        # File may be newly added → BASE_JSON empty → any deps are additions.
+        if [ -z "$BASE_JSON" ]; then
+          if [ -n "$HEAD_JSON" ] && command -v jq >/dev/null 2>&1; then
+            HEAD_KEYS=$(echo "$HEAD_JSON" | jq -r '
+              (.dependencies // {}) + (.devDependencies // {}) +
+              (.peerDependencies // {}) + (.optionalDependencies // {})
+              | keys[]' 2>/dev/null)
+            if [ -n "$HEAD_KEYS" ]; then
+              TRIGGERED_DEP_FILES="${TRIGGERED_DEP_FILES}${file} (new file, ${HEAD_KEYS:+deps added})
+"
+            fi
+          fi
+          continue
+        fi
+        if command -v jq >/dev/null 2>&1; then
+          BASE_KEYS=$(echo "$BASE_JSON" | jq -r '
+            (.dependencies // {}) + (.devDependencies // {}) +
+            (.peerDependencies // {}) + (.optionalDependencies // {})
+            | keys[]' 2>/dev/null | sort -u)
+          HEAD_KEYS=$(echo "$HEAD_JSON" | jq -r '
+            (.dependencies // {}) + (.devDependencies // {}) +
+            (.peerDependencies // {}) + (.optionalDependencies // {})
+            | keys[]' 2>/dev/null | sort -u)
+          ADDED=$(comm -13 <(echo "$BASE_KEYS") <(echo "$HEAD_KEYS") | tr '\n' ' ')
+          ADDED=$(echo "$ADDED" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+          if [ -n "$ADDED" ]; then
+            TRIGGERED_DEP_FILES="${TRIGGERED_DEP_FILES}${file} (added: ${ADDED})
+"
+          fi
+        fi
+        ;;
+      *)
+        # Non-JSON heuristic. Pull the unified diff for this file.
+        DIFF=$(git diff "$MERGE_BASE"..HEAD -- "$file" 2>/dev/null)
+        [ -z "$DIFF" ] && continue
+        ADDED_LINES=$(echo "$DIFF" | grep -cE '^\+[^+]' || true)
+        REMOVED_LINES=$(echo "$DIFF" | grep -cE '^-[^-]' || true)
+        # If strictly more lines added than removed, treat as a probable
+        # dep addition (a version bump should be a matched +/- pair).
+        if [ "${ADDED_LINES:-0}" -gt "${REMOVED_LINES:-0}" ]; then
+          TRIGGERED_DEP_FILES="${TRIGGERED_DEP_FILES}${file} (likely dep addition; +${ADDED_LINES} / -${REMOVED_LINES})
+"
+        fi
+        ;;
+    esac
+  done <<EOF
+$TOUCHED
+EOF
+done <<EOF
+$TRIGGER_DEP_FILES
+EOF
+
+# If neither category fired, nothing to enforce.
+if [ -z "$TRIGGERED_FILES" ] && [ -z "$TRIGGERED_DEP_FILES" ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Body must contain an AgDR reference. Regex is intentionally the same
+#    shape the /decide skill generates: AgDR-<digits>-<kebab-slug>.
+# ---------------------------------------------------------------------------
+
+if echo "$HAYSTACK" | grep -qE 'AgDR-[0-9]+-[a-z0-9-]+'; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Block with a helpful message.
+# ---------------------------------------------------------------------------
+
+{
+  echo "BLOCKED: PR diff includes architecture changes but the PR body has no AgDR reference."
+  echo
+  if [ -n "$TRIGGERED_FILES" ]; then
+    echo "Triggering paths (matched agdr_trigger_paths):"
+    printf '%s' "$TRIGGERED_FILES" | sed 's/^/  - /' | grep -v '^  - $'
+  fi
+  if [ -n "$TRIGGERED_DEP_FILES" ]; then
+    echo "Triggering dep-file additions (matched agdr_trigger_dep_files):"
+    printf '%s' "$TRIGGERED_DEP_FILES" | sed 's/^/  - /' | grep -v '^  - $'
+  fi
+  cat <<'MSG'
+
+Why this is blocked:
+  .claude/rules/agdr-decisions.md calls /decide a HARD STOP before any
+  technical decision — library choice, architecture move, new dependency,
+  infra shape. Other HARD STOPs in the ruleset (merge approval, ticket-
+  first, migration-first) are mechanically enforced at PR time; this one
+  closes the gap.
+
+To unblock:
+  1. Run /decide to walk through the decision and generate an AgDR file
+     at docs/agdr/AgDR-NNNN-{slug}.md
+  2. Commit the AgDR on this branch.
+  3. Reference the AgDR in the PR body (any occurrence matching
+     `AgDR-\d+-[a-z0-9-]+` satisfies the hook).
+
+Escape hatch (rare — e.g. a refactor that moves files through a trigger
+path without a new decision, or a dep rename without a semantic change):
+  Add this HTML comment anywhere in the body:
+    <!-- agdr: not-applicable -->
+
+Trigger paths + dep files are configurable in
+.claude/project-config.json via:
+  - .agdr_trigger_paths[]     (shell globs)
+  - .agdr_trigger_dep_files[] (literal filenames)
+See .claude/project-config.defaults.json for the shipped defaults.
+MSG
+} >&2
+
+exit 2

--- a/.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
+++ b/.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# Test fixtures for require-agdr-for-arch-pr.sh.
+#
+# Each case builds a JSON tool_input payload, primes a throwaway git repo
+# with base/HEAD state, and pipes the payload to the hook. We assert on the
+# exit code and (optionally) a substring of stderr.
+#
+# To run:  ./.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
+# Exit 0 = all pass, 1 = at least one failure.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../.." && pwd)
+HOOK="$REPO_ROOT/.claude/hooks/require-agdr-for-arch-pr.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+make_payload() {
+  local cmd="$1"
+  jq -n --arg c "$cmd" '{tool_input: {command: $c}}'
+}
+
+# Create a minimal fake fork: an isolated git repo with a main branch plus a
+# feature branch carrying the changes we want to test.
+# Usage: setup_repo <base-setup-fn> <feature-setup-fn>
+#   base-setup-fn      : runs on main, commits the starting state
+#   feature-setup-fn   : runs on the feature branch, commits the PR changes
+setup_repo() {
+  local base_fn="$1"
+  local feat_fn="$2"
+  local dir
+  dir=$(mktemp -d -t agdr-pr.XXXXXX)
+  (
+    cd "$dir" || exit 1
+    git init -q -b main
+    git config user.email t@t.test
+    git config user.name test
+    # Fork marker so the hook's (future) root-walk finds a plausible ops root.
+    echo "company: test" > onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m init
+    "$base_fn"
+    git checkout -q -b feature
+    "$feat_fn"
+  )
+  echo "$dir"
+}
+
+# Run the hook from inside $1 with payload built from $2 (command string).
+# $3 = expected exit code, $4 = optional stderr substring.
+run_case() {
+  local name="$1"
+  local dir="$2"
+  local expected_exit="$3"
+  local expected_stderr_substr="$4"
+  local cmd="$5"
+
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  ( cd "$dir" && echo "$(make_payload "$cmd")" | "$HOOK" ) 2> "$stderr_file"
+  local actual_exit=$?
+  local stderr_content
+  stderr_content=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+
+  local ok=1
+  if [ "$actual_exit" != "$expected_exit" ]; then ok=0; fi
+  if [ -n "$expected_stderr_substr" ]; then
+    if ! echo "$stderr_content" | grep -qF -- "$expected_stderr_substr"; then
+      ok=0
+    fi
+  fi
+
+  if [ "$ok" = 1 ]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name"
+    echo "   expected exit=$expected_exit, got $actual_exit"
+    if [ -n "$expected_stderr_substr" ]; then
+      echo "   expected stderr to contain: $expected_stderr_substr"
+    fi
+    echo "   stderr was:"
+    echo "$stderr_content" | sed 's/^/     /'
+    FAIL=$((FAIL + 1))
+  fi
+
+  rm -rf "$dir"
+}
+
+# ---------------------------------------------------------------------------
+# Fixture setup helpers
+# ---------------------------------------------------------------------------
+
+# 1. Arch path change (domain/) on feature branch, no AgDR in body → BLOCK.
+c1_base() {
+  mkdir -p src/domain
+  echo "export const x = 1" > src/domain/widget.ts
+  git add src/domain/widget.ts
+  git commit -q -m "base: add domain"
+}
+c1_feat() {
+  echo "export const x = 2" > src/domain/widget.ts
+  git add src/domain/widget.ts
+  git commit -q -m "feat: tweak domain"
+}
+
+# 2. Same as above but PR body links an AgDR → PASS.
+#    (Reuses c1_*)
+
+# 3. Dep added to package.json (no version bump) → BLOCK.
+c3_base() {
+  cat > package.json <<'JSON'
+{
+  "name": "t",
+  "version": "0.0.1",
+  "dependencies": {
+    "lodash": "^4.0.0"
+  }
+}
+JSON
+  git add package.json
+  git commit -q -m "base: pkg"
+}
+c3_feat() {
+  cat > package.json <<'JSON'
+{
+  "name": "t",
+  "version": "0.0.1",
+  "dependencies": {
+    "lodash": "^4.0.0",
+    "zod": "^3.0.0"
+  }
+}
+JSON
+  git add package.json
+  git commit -q -m "feat: add zod"
+}
+
+# 4. Version-only bump — same keys, different version → NO FIRE → PASS.
+c4_base() {
+  cat > package.json <<'JSON'
+{
+  "name": "t",
+  "dependencies": {
+    "lodash": "^4.0.0"
+  }
+}
+JSON
+  git add package.json
+  git commit -q -m "base: pkg"
+}
+c4_feat() {
+  cat > package.json <<'JSON'
+{
+  "name": "t",
+  "dependencies": {
+    "lodash": "^4.17.0"
+  }
+}
+JSON
+  git add package.json
+  git commit -q -m "feat: bump lodash"
+}
+
+# 5. Skip marker with arch change → PASS with warning on stderr.
+#    (Reuses c1_*)
+
+# 6. Non-triggering diff — a plain README change → PASS.
+c6_base() {
+  echo "# hello" > README.md
+  git add README.md
+  git commit -q -m "base: readme"
+}
+c6_feat() {
+  echo "# hello world" > README.md
+  git add README.md
+  git commit -q -m "feat: tweak readme"
+}
+
+# ---------------------------------------------------------------------------
+# Run cases
+# ---------------------------------------------------------------------------
+
+DIR=$(setup_repo c1_base c1_feat)
+run_case "arch path changed, no AgDR → BLOCK" \
+  "$DIR" 2 "no AgDR reference" \
+  "gh pr create --base main --title 'feat(#1): tweak domain' --body 'just a change'"
+
+DIR=$(setup_repo c1_base c1_feat)
+run_case "arch path changed, AgDR referenced → PASS" \
+  "$DIR" 0 "" \
+  "gh pr create --base main --title 'feat(#1): tweak domain' --body 'See AgDR-0007-tweak-domain for rationale.'"
+
+DIR=$(setup_repo c3_base c3_feat)
+run_case "new dep added, no AgDR → BLOCK" \
+  "$DIR" 2 "Triggering dep-file additions" \
+  "gh pr create --base main --title 'feat(#2): add zod' --body 'needed it'"
+
+DIR=$(setup_repo c4_base c4_feat)
+run_case "version-only bump → PASS (no fire)" \
+  "$DIR" 0 "" \
+  "gh pr create --base main --title 'chore(#3): bump lodash' --body 'no decision here'"
+
+DIR=$(setup_repo c1_base c1_feat)
+run_case "skip marker bypasses → PASS with warning" \
+  "$DIR" 0 "agdr: not-applicable marker present" \
+  "gh pr create --base main --title 'refactor(#4): move domain' --body 'pure rename <!-- agdr: not-applicable -->'"
+
+DIR=$(setup_repo c6_base c6_feat)
+run_case "non-matching diff → PASS" \
+  "$DIR" 0 "" \
+  "gh pr create --base main --title 'docs(#5): readme' --body 'no arch change'"
+
+DIR=$(setup_repo c1_base c1_feat)
+run_case "non-gh command → no-op" \
+  "$DIR" 0 "" \
+  "git status"
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+
+echo
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -87,5 +87,24 @@
   "pre_push": {
     "commands": [],
     "_comment": "Default is empty — per-fork overrides (see docs/project-config.md) populate this with the commands the project actually runs (lint, typecheck, test, build). An empty list makes pre-push-gate.sh a no-op."
-  }
+  },
+
+  "agdr_trigger_paths": [
+    "**/domain/**",
+    "**/infrastructure/**",
+    "**/migrations/**",
+    "infrastructure/**",
+    "template.yaml",
+    "**/*.tf",
+    "**/*.tfvars",
+    ".github/workflows/**"
+  ],
+
+  "agdr_trigger_dep_files": [
+    "package.json",
+    "pyproject.toml",
+    "Cargo.toml",
+    "go.mod",
+    "Gemfile"
+  ]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -99,6 +99,11 @@
           },
           {
             "type": "command",
+            "if": "Bash(gh pr create *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-agdr-for-arch-pr.sh\"'"
+          },
+          {
+            "type": "command",
             "if": "Bash(gh issue comment *)",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },

--- a/docs/rule-audit.md
+++ b/docs/rule-audit.md
@@ -84,9 +84,10 @@ Columns:
 |------|--------|-------------|---------------|---------------------------------|
 | HARD STOP — run `/decide` before any technical decision | `.claude/rules/agdr-decisions.md § Trigger Patterns` | prose (self-discipline) | no | trigger patterns are chat-output phrases; linting assistant prose was rejected for the same reason as in `ticket-vocabulary.md` [^self-discipline] |
 | AgDR required for architecture / infra commits | `.claude/rules/agdr-decisions.md § Enforcement` | `require-agdr-for-arch-changes.sh` | yes | mechanized (AgDR-0001); narrow default path list, project-config override via `.architecture_paths` |
+| AgDR required at PR time when diff touches architecture paths OR adds a new dependency | `.claude/rules/agdr-decisions.md § Enforcement` | `require-agdr-for-arch-pr.sh` | yes | mechanized ([#112][112]); fires on `gh pr create`, config via `.agdr_trigger_paths[]` + `.agdr_trigger_dep_files[]`; skip marker `<!-- agdr: not-applicable -->` bypasses with a visible warning |
 | Extend default `architecture_paths` to cover SAM / Helm / K8s / Serverless Framework | — | — | deferred | [#25][25] — default list is deliberately narrow; follow-up broadens safely |
 | AgDRs stored at `{project}/docs/agdr/AgDR-NNNN-{slug}.md` | `.claude/rules/agdr-decisions.md § What /decide Does` | prose | no | path convention, not a gatekeeping rule |
-| Code Reviewer flags PRs with arch changes that don't link an AgDR | `.claude/rules/agdr-decisions.md § Enforcement` | `code-reviewer` agent + `require-agdr-for-arch-changes.sh` | yes | mechanized |
+| Code Reviewer flags PRs with arch changes that don't link an AgDR | `.claude/rules/agdr-decisions.md § Enforcement` | `code-reviewer` agent + `require-agdr-for-arch-changes.sh` + `require-agdr-for-arch-pr.sh` | yes | mechanized |
 
 ### 5. Ticket vocabulary
 
@@ -161,11 +162,11 @@ Columns:
 
 | bucket | count |
 |--------|-------|
-| mechanized (`yes` — hook / agent enforces it fully) | 28 |
+| mechanized (`yes` — hook / agent enforces it fully) | 29 |
 | partially mechanized (`partial` — hook + prose combination) | 6 |
 | advisory (`no` — stays prose by design) | 36 |
 | deferred to a follow-up ticket (`deferred`) | 5 |
-| **total rows** | **75** |
+| **total rows** | **76** |
 | deferred tickets referenced | 6 ([#15][15], [#20][20], [#21][21], [#22][22], [#23][23], [#25][25]) |
 
 The count of deferred *rows* (5) and deferred *tickets* (6) differ because [#15][15] is a meta-chore (resolve `.claude/` duplication between ops-repo and apexyard upstream) that gets one row in the onboarding section, while the commit-related tickets [#20][20] and [#22][22] share a row via `validate-branch-name.sh` + `validate-pr-create.sh`.
@@ -196,3 +197,4 @@ The spread confirms what AgDR-0001 set out to make true: the **high-blast-radius
 [25]: https://github.com/me2resh/apexyard/issues/25
 [107]: https://github.com/me2resh/apexyard/issues/107
 [110]: https://github.com/me2resh/apexyard/issues/110
+[112]: https://github.com/me2resh/apexyard/issues/112


### PR DESCRIPTION
## Summary

Adds a new PreToolUse hook `require-agdr-for-arch-pr.sh` that blocks `gh pr create` when the PR's diff touches architecture paths OR adds a new dependency, AND the PR body does not link an `AgDR-\d+-[a-z0-9-]+` reference.

Closes the gap where `.claude/rules/agdr-decisions.md` calls `/decide` a HARD STOP before architectural choices, but nothing mechanically enforced it at PR time. The Code Reviewer agent would flag missing AgDRs post-hoc, which is late — this hook fires *before* the PR is filed and gives the author a chance to run `/decide` first.

- New hook: `.claude/hooks/require-agdr-for-arch-pr.sh` (~280 LOC)
- Tests: `.claude/hooks/tests/test_require_agdr_for_arch_pr.sh` — 7 cases, all pass
- Config integration: reads `.agdr_trigger_paths[]` and `.agdr_trigger_dep_files[]` via the shared reader from #109
- Defaults: extended `.claude/project-config.defaults.json` with both arrays at sensible defaults (hexagonal domain/infrastructure, Terraform, migrations, CI workflows for paths; package.json, pyproject.toml, Cargo.toml, go.mod, Gemfile for deps)
- Wired into `.claude/settings.json` — PreToolUse matcher on `Bash(gh pr create *)`
- New row in `docs/rule-audit.md`, mechanized count bumped to 29

## How it works

1. Matches `gh pr create` only. Silent pass on everything else.
2. Parses `--title` / `--body` / `--body-file` / `-F <path>` (same extractor style as sibling hooks).
3. Resolves the PR base branch from `--base <arg>` with a sensible fallback chain: `upstream/dev` → `origin/dev` → `upstream/main` → `origin/main` → `main` → `master`. Stops at first resolvable.
4. Computes diff: `git diff $(git merge-base HEAD <base>)..HEAD --name-only`.
5. For each changed file, checks against `agdr_trigger_paths[]` globs (hexagonal layers, infra, migrations, CI).
6. For dep files, uses `jq` diff of `.dependencies + .devDependencies + .peerDependencies + .optionalDependencies` key sets between MERGE_BASE and HEAD to detect **additions** (not version bumps). For non-JSON dep files, uses a simpler `+` vs `-` line count heuristic (documented inline).
7. If arch change detected AND body lacks an `AgDR-\d+-` reference → exit 2 with a message naming triggering files and suggesting `/decide`.
8. Skip marker: `<!-- agdr: not-applicable -->` in body → exit 0 with visible WARN on stderr.
9. Silent pass: no matching diff, or base branch unresolvable.

## Testing

```
$ bash .claude/hooks/tests/test_require_agdr_for_arch_pr.sh
PASS: arch path changed, no AgDR → BLOCK
PASS: arch path changed, AgDR referenced → PASS
PASS: new dep added, no AgDR → BLOCK
PASS: version-only bump → PASS (no fire)
PASS: skip marker bypasses → PASS with warning
PASS: non-matching diff → PASS
PASS: non-gh command → no-op
Passed: 7  Failed: 0
```

Cherry-picked onto fresh `dev` HEAD after #107 / #111 landed. The cherry-pick had three auto-merge conflicts (`.claude/project-config.defaults.json`, `.claude/settings.json`, `docs/rule-audit.md`) — all resolved by including both sides of each conflict (the existing `ticket` subtree + the new `agdr_trigger_*` arrays; the existing 4 `gh pr create` matchers + the new one; the existing section-11 row + bumped summary counts to 29/76).

## Scope — what this does NOT do

- Does not fire on the rare `--input -` / stdin-driven `gh api` shape (accepted gap, same pattern as sibling hooks).
- The non-JSON dep-file heuristic is a rough `+`/`-` count diff — a version-only bump with multiple lockfile reformats could produce a false positive. For accurate per-ecosystem parsing (pyproject.toml, Cargo.toml semantics), each project's CI is the right layer.
- Does not retroactively check merged PRs — only new PR creations going forward.

## Follow-ups

- Adding more path globs to defaults as conventions emerge (for example, a team that uses `src/ports/` or `apps/api/` as its hexagonal boundary would extend via per-fork config — no framework edit needed per apexyard#109's design).

## Glossary

| Term | Definition |
|------|------------|
| AgDR | Agent Decision Record — a Markdown file under `docs/agdr/` recording a technical decision. `.claude/rules/agdr-decisions.md` calls `/decide` a HARD STOP before architectural choices; this hook enforces the HARD STOP at PR time. |
| Trigger path / dep file | File globs or literal dep-manifest filenames from project config; any match in the PR diff fires the requirement. |
| Dep addition (vs version bump) | A **new** key in a dependency-manifest object — not a version change on an existing one. Version bumps are a separate `/audit-deps` concern. |

Closes #112