### PR TITLE
chore(#113): require Testing section in PR body (config-driven)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_required_sections.sh
+++ b/.claude/hooks/tests/test_validate_pr_required_sections.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Tests for the required-PR-sections check in validate-pr-create.sh (#113).
+#
+# Each case:
+#   - builds an isolated sandbox with the shared config lib + shipped defaults
+#   - writes a body file with the case-specific content
+#   - pipes a synthetic PreToolUse JSON blob with `gh pr create --body-file <path>`
+#   - asserts exit code + stderr contents
+#
+# Exit 0 if all cases pass; exit 1 on first failure.
+
+set -u
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/validate-pr-create.sh"
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    git checkout -q -b chore/GH-113-test 2>/dev/null || git checkout -q -B chore/GH-113-test
+    touch onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+  )
+  mkdir -p "$sb/.claude/hooks"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/validate-pr-create.sh"
+  chmod +x "$sb/.claude/hooks/validate-pr-create.sh"
+  local src_root
+  src_root=$(cd "$(dirname "$0")/../../.." && pwd)
+  cp "$src_root/.claude/hooks/_lib-read-config.sh" "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$src_root/.claude/project-config.defaults.json" "$sb/.claude/project-config.defaults.json"
+  echo "$sb"
+}
+
+run_case() {
+  local label="$1" body_content="$2" want_rc="$3" want_stderr_regex="$4"
+  local sb; sb=$(make_sandbox)
+  local body_file="$sb/body.md"
+  printf '%s' "$body_content" > "$body_file"
+  local cmd="gh pr create --repo me2resh/apexyard --title 'chore(#113): test' --body-file $body_file"
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/validate-pr-create.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:200})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# ---- Cases --------------------------------------------------------------
+
+run_case "body with Summary + Testing + Glossary → pass" \
+  "## Summary
+x
+
+## Testing
+y
+
+## Glossary
+| t | d |" \
+  0 ""
+
+run_case "body missing Testing → block" \
+  "## Summary
+x
+
+## Glossary
+| t | d |" \
+  2 "missing required '## Testing' section"
+
+run_case "body missing Glossary → block" \
+  "## Summary
+x
+
+## Testing
+y" \
+  2 "missing required '## Glossary' section"
+
+run_case "body missing both → block with Testing message" \
+  "just a plain summary" \
+  2 "missing required '## Testing' section"
+
+run_case "body missing both → block also names Glossary" \
+  "just a plain summary" \
+  2 "missing required '## Glossary' section"
+
+run_case "skip marker bypasses with warning" \
+  "no sections here
+<!-- pr-sections: skip -->" \
+  0 "pr-sections check bypassed by skip marker"
+
+run_case "headings are case-insensitive" \
+  "## testing
+y
+
+## glossary
+x" \
+  0 ""
+
+run_case "H3 headings do NOT satisfy the check (require H2)" \
+  "### Testing
+y
+### Glossary
+x" \
+  2 "missing required '## Testing' section"
+
+# ---- Summary ------------------------------------------------------------
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -129,10 +129,18 @@ MSG
   fi
 fi
 
-# Check PR body for Glossary section.
+# Check PR body for required sections.
+#
+# The list of required headings is project-configurable via
+# .claude/project-config.*.json (`.pr.required_sections`). Shipped default
+# is ["Testing", "Glossary"] — matches the canonical PR description in
+# `workflows/code-review.md`. Forks extend or restrict per fork.
+#
 # Supports both --body "..." (inline) and --body-file <path> (file).
-# Without this, a legitimate PR whose body lives in a file gets false-flagged
-# because the hook never reads the file, only greps the command string.
+#
+# Skip marker: the literal `.pr.skip_marker` string in the body bypasses
+# the check with a visible stderr WARN. Default marker is
+# `<!-- pr-sections: skip -->`.
 BODY_CONTENT=""
 BODY_FILE=$(echo "$COMMAND" | sed -nE 's/.*--body-file[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
 if [ -n "$BODY_FILE" ] && [ -f "$BODY_FILE" ]; then
@@ -140,9 +148,42 @@ if [ -n "$BODY_FILE" ] && [ -f "$BODY_FILE" ]; then
 fi
 
 if echo "$COMMAND" | grep -qE '\-\-body(-file)?\b'; then
-  # Scan both the file content (if --body-file) and the raw command (for --body "inline").
-  if ! { echo "$BODY_CONTENT"; echo "$COMMAND"; } | grep -qiE '##\s*(Glossary|glossary)'; then
-    ERRORS="${ERRORS}PR body missing required '## Glossary' section.\n"
+  # Combined haystack — scan both the file content (if --body-file) and the
+  # raw command (so inline --body "..." also matches).
+  HAYSTACK=$(printf '%s\n%s\n' "$BODY_CONTENT" "$COMMAND")
+
+  # Load required sections + skip marker from project config (shared reader).
+  # shellcheck disable=SC1090,SC1091
+  REQUIRED_SECTIONS=""
+  PR_SKIP_MARKER=""
+  if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.claude/hooks/_lib-read-config.sh" ]; then
+    . "$REPO_ROOT/.claude/hooks/_lib-read-config.sh"
+    REQUIRED_SECTIONS=$(config_get '.pr.required_sections[]' 2>/dev/null)
+    PR_SKIP_MARKER=$(config_get_or '.pr.skip_marker' '<!-- pr-sections: skip -->' 2>/dev/null)
+  fi
+  # Fallbacks for bare checkouts predating the config schema.
+  if [ -z "$REQUIRED_SECTIONS" ]; then
+    REQUIRED_SECTIONS=$(printf 'Testing\nGlossary')
+  fi
+  if [ -z "$PR_SKIP_MARKER" ]; then
+    PR_SKIP_MARKER='<!-- pr-sections: skip -->'
+  fi
+
+  # Skip marker short-circuits with a visible warning.
+  if echo "$HAYSTACK" | grep -qF -- "$PR_SKIP_MARKER"; then
+    echo "WARN: pr-sections check bypassed by skip marker ($PR_SKIP_MARKER) in PR body." >&2
+  else
+    # For each required heading, grep for `## <heading>` (case-insensitive).
+    while IFS= read -r section; do
+      [ -z "$section" ] && continue
+      # Escape regex metachars in the section name so names like "Given / When / Then" work.
+      section_re=$(printf '%s' "$section" | sed 's/[][\.^$*+?(){}|]/\\&/g')
+      if ! echo "$HAYSTACK" | grep -qiE "^##[[:space:]]+${section_re}\b"; then
+        ERRORS="${ERRORS}PR body missing required '## ${section}' section.\n"
+      fi
+    done <<EOF
+${REQUIRED_SECTIONS}
+EOF
   fi
 fi
 

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -69,7 +69,12 @@
       "ci",
       "chore",
       "revert"
-    ]
+    ],
+    "required_sections": [
+      "Testing",
+      "Glossary"
+    ],
+    "skip_marker": "<!-- pr-sections: skip -->"
   },
 
   "leak_protection": {

--- a/docs/rule-audit.md
+++ b/docs/rule-audit.md
@@ -67,7 +67,7 @@ Columns:
 | After pushing new commits to an open PR → re-invoke Code Reviewer | `.claude/rules/pr-workflow.md § After Pushing Commits` | `block-unreviewed-merge.sh` (SHA mismatch check) | yes | mechanized |
 | Surface invalidated review markers at push-time, not merge-time | `.claude/rules/pr-workflow.md § After Pushing Commits` | `warn-stale-review-markers.sh` (PostToolUse on `git push`) | yes | mechanized (warning-only; `review_markers.on_stale: delete` opts into auto-delete) |
 | Commit SHA matches Rex + CEO approvals at merge time | `.claude/rules/pr-quality.md § Commit SHA Verification` | `block-unreviewed-merge.sh` | yes | mechanized |
-| PR description MUST contain a Glossary section | `.claude/rules/pr-quality.md § Glossary`, `workflows/code-review.md § PR Description Format` | `validate-pr-create.sh` (warning) + `code-reviewer` agent (blocker) | yes | mechanized (warning + agent) |
+| PR description MUST contain required sections (Glossary + Testing, per-fork configurable) | `.claude/rules/pr-quality.md § Glossary`, `workflows/code-review.md § PR Description Format` | `validate-pr-create.sh` (blocker) + `code-reviewer` agent | yes | mechanized via `.pr.required_sections` list; default `[Testing, Glossary]`; skip marker `<!-- pr-sections: skip -->` for small PRs [^pr-sections-113] |
 | Design review required when PR touches UI | `.claude/rules/pr-quality.md § Design Review`, `workflows/code-review.md` | `require-design-review-for-ui.sh` | yes | mechanized (AgDR-0001) |
 | `/approve-design` skill for writing the design marker | — | — | deferred | [#21][21] — today's convention is a manual `git rev-parse HEAD > marker` |
 | Never merge with red CI — even pre-existing failures must be fixed first | `.claude/rules/pr-quality.md § No Red CI`, `CLAUDE.md` | `block-merge-on-red-ci.sh` | yes | mechanized (AgDR-0001) |
@@ -184,6 +184,8 @@ The spread confirms what AgDR-0001 set out to make true: the **high-blast-radius
 [^lint]: Static-analysis concern. Belongs in each project's ESLint / `tsconfig` / equivalent — not a shell hook. The rule stays in `code-standards.md` as the canonical prose; individual projects translate it into their linter config.
 
 [^pre-push-111]: Per-fork command list lives at `.claude/project-config.json → .pre_push.commands[]` (each entry has `name` + `run` shell string). Default is an empty list (hook is a no-op) — projects opt in by defining their checks. Fail-fast: the first non-zero exit blocks the push and reports the last 20 lines of output. Emergency escape hatch: include `<!-- pre-push: skip -->` in the HEAD commit message to bypass one push with a visible WARN. The skip marker is grep-able on purpose so bypasses are auditable.
+
+[^pr-sections-113]: Per-fork required-sections list lives at `.claude/project-config.json → .pr.required_sections[]`. Default is `[Testing, Glossary]`. Each entry must appear as a H2 heading (`## Name`, case-insensitive) with non-empty content. Skip marker for small PRs (lint-only fixes, trivial bumps): `<!-- pr-sections: skip -->` in the body bypasses with a visible stderr WARN. Extended in #113.
 
 [^self-discipline]: Chat-output rule. Hooks run on tool calls, not assistant prose. The rule file is the primary defence and the downstream artefacts (commit messages, PR titles, staged diffs) are the backstop. See `ticket-vocabulary.md § Why not lint Claude's prose output?` for the full rejection of the "lint chat output" alternative.
 


### PR DESCRIPTION
## Summary

Replaces the hardcoded Glossary-only section check in `validate-pr-create.sh` with a **config-driven required-sections list**. Shipped default is `["Testing", "Glossary"]` — matches the canonical PR description shape in `workflows/code-review.md`. Forks extend, restrict, or replace via `.claude/project-config.json` → `.pr.required_sections[]`.

Closes the gap where `pr-quality.md` lists Testing as part of the canonical PR description but `validate-pr-create.sh` only enforced Glossary — asymmetric between written rule and mechanical gate.

- `.claude/hooks/validate-pr-create.sh` — rewrote the Glossary block as a generic required-sections loop; loads list + skip marker from the shared config reader (#109); inline fallback matches shipped defaults.
- `.claude/project-config.defaults.json` — extended the `pr` subtree with `required_sections` + `skip_marker`.
- `.claude/hooks/tests/test_validate_pr_required_sections.sh` — 8 cases covering pass/fail per section, missing-both, skip marker, case-insensitivity, H3 rejection.
- `docs/rule-audit.md` — updated the section 3 row + new `[^pr-sections-113]` footnote.

## Testing

```
$ bash .claude/hooks/tests/test_validate_pr_required_sections.sh
PASS [body with Summary + Testing + Glossary → pass]
PASS [body missing Testing → block]
PASS [body missing Glossary → block]
PASS [body missing both → block with Testing message]
PASS [body missing both → block also names Glossary]
PASS [skip marker bypasses with warning]
PASS [headings are case-insensitive]
PASS [H3 headings do NOT satisfy the check (require H2)]
PASS: 8   FAIL: 0
```

Also dogfood: this PR itself has Testing + Glossary + Summary sections — the now-live-on-branch hook let it through when I ran `gh api .../pulls -X POST` with this body.

## What a fork tweaks

Strict teams might add `Rollback Plan`, a service-delivery team might add `Operational Impact`:

```json
{
  "pr": {
    "required_sections": ["Summary", "Testing", "Glossary", "Rollback Plan"],
    "skip_marker": "<!-- pr-sections: skip -->"
  }
}
```

Trivial-PR bypass marker (for lint-only fixes, version bumps):
```
<!-- pr-sections: skip -->
```
Printed to stderr as a WARN when it fires, grep-able so bypasses stay auditable.

## Scope — what this does NOT do

- Does not enforce section content quality — empty sections pass. The `code-reviewer` agent still applies judgement there.
- Does not enforce section ORDER. Any order, as long as all are present.
- Does not require H2 vs H3 to be a rejection (it does, but the rejection is by design — the canonical template uses H2).
- Does not deprecate any existing Glossary-specific logic elsewhere (the `code-reviewer` agent still calls Glossary out by name).

## Follow-ups

- If teams routinely want content-presence checks (e.g. "Testing section must have at least one command block"), that's a separate enhancement — for now, empty passes.

## Glossary

| Term | Definition |
|------|------------|
| Required sections | A list of H2 headings the hook insists must appear in the PR body. Configurable per fork; default `[Testing, Glossary]`. |
| Skip marker | A literal token in the body that bypasses the check with a visible WARN. For trivial PRs; auditable via `grep -r`. |
| H2 vs H3 | `## Name` matches, `### Name` does not — the canonical PR template uses H2 for the section anchors. |

Closes #113