### PR TITLE
chore(#116): adopt release-cut branch model (dev/main + tags) — framework only

### DIFF
--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
-# Blocks direct pushes and commits to main/master branch.
+# Blocks direct pushes and commits to long-lived integration branches.
 # All changes must go through pull requests.
+#
+# Protected branches (default): main / master / dev / develop.
+# `dev` was added in apexyard#116 (release-cut model — see AgDR-0007). Forks
+# that legitimately use `dev` as a daily-work trunk under their own
+# convention can override the protected list via
+# `.claude/project-config.json` → `.git.protected_branches[]`.
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -9,17 +15,30 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-# Block: git push origin main, git push origin master
-if echo "$COMMAND" | grep -qE '\bgit\s+push\s+\S+\s+(main|master)(\s|$)'; then
-  echo "BLOCKED: Cannot push directly to main/master. All changes must go through a PR." >&2
+# Resolve protected-branch list from project config (shared reader, #109).
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+PROTECTED=""
+if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.claude/hooks/_lib-read-config.sh" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$REPO_ROOT/.claude/hooks/_lib-read-config.sh"
+  PROTECTED=$(config_get '.git.protected_branches[]' 2>/dev/null | paste -sd'|' -)
+fi
+if [ -z "$PROTECTED" ]; then
+  PROTECTED="main|master|dev|develop"
+fi
+
+# Block: git push <remote> <protected>
+if echo "$COMMAND" | grep -qE "\bgit\s+push\s+\S+\s+(${PROTECTED})(\s|$)"; then
+  echo "BLOCKED: Cannot push directly to a protected branch. All changes must go through a PR." >&2
+  echo "Protected branches: ${PROTECTED//|/, }" >&2
   exit 2
 fi
 
-# Block: git commit on main/master branch
+# Block: git commit on a protected branch
 if echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
   CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
-  if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
-    echo "BLOCKED: Cannot commit directly on $CURRENT_BRANCH. Create a feature branch first." >&2
+  if [ -n "$CURRENT_BRANCH" ] && echo "$CURRENT_BRANCH" | grep -qE "^(${PROTECTED})$"; then
+    echo "BLOCKED: Cannot commit directly on protected branch '$CURRENT_BRANCH'. Create a feature branch first." >&2
     exit 2
   fi
 fi

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -89,6 +89,15 @@
     "on_stale": "warn"
   },
 
+  "git": {
+    "protected_branches": [
+      "main",
+      "master",
+      "dev",
+      "develop"
+    ]
+  },
+
   "pre_push": {
     "commands": [],
     "_comment": "Default is empty — per-fork overrides (see docs/project-config.md) populate this with the commands the project actually runs (lint, typecheck, test, build). An empty list makes pre-push-gate.sh a no-op."

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: release
+description: Cut a new apexyard release — diff dev against main, pick a semver bump, generate a CHANGELOG draft from conventional commits, open the release PR, and (after merge) tag + push.
+argument-hint: "<optional explicit version, e.g. v1.2.0>"
+allowed-tools: Bash, Read, Write
+---
+
+# /release — Cut an apexyard release
+
+Standardises the `dev` → `main` release flow introduced by AgDR-0007. Reads the conventional-commit log between `main` and `dev`, proposes a semver bump, generates a CHANGELOG entry, opens the release PR, and (after the user merges) tags the resulting commit and pushes the tag.
+
+This skill is **framework-only** — it's for cutting apexyard releases, not for releasing managed projects under governance. Managed projects stay trunk-based and don't have a release-cut flow.
+
+## Usage
+
+```
+/release             # auto-detect bump from conventional commits
+/release v1.2.0      # explicit version, skip auto-detect
+/release --dry-run   # preview only, don't create the PR
+```
+
+## Process
+
+### 1. Pre-flight
+
+Verify:
+
+- Current repo IS the apexyard framework (origin or upstream is `me2resh/apexyard`). Refuse otherwise — this skill is framework-only.
+- Working tree is clean. Refuse if uncommitted changes.
+- `dev` branch exists (`git rev-parse --verify upstream/dev`). Refuse if absent — adopt the dev/main model first.
+- `dev` is ahead of `main` by ≥ 1 commit. Refuse if equal — nothing to release.
+
+### 2. Pick a version
+
+If `<version>` arg was passed, use it (must match `v\d+\.\d+\.\d+`).
+
+Otherwise auto-detect from the conventional-commit types in `git log main..upstream/dev`:
+
+| Found | Bump |
+|-------|------|
+| Any commit subject starts with `feat!:` / `feat(...)!:` / `<type>!:` (breaking marker) | **MAJOR** |
+| Any `feat:` / `feat(...):` (and no breaking) | **MINOR** |
+| Only `fix:` / `chore:` / `docs:` / `refactor:` / `test:` / `style:` / `perf:` / `build:` / `ci:` (and no `feat:` or breaking) | **PATCH** |
+
+Read the current latest tag (`git describe --tags --abbrev=0 main` or `gh api repos/me2resh/apexyard/releases/latest`) and bump accordingly. Show the user:
+
+```
+Current latest tag: vX.Y.Z
+Proposed next:      vA.B.C  (MINOR — N feat commits, M fix commits)
+Override? [Enter to accept, or type a version like v1.3.0]
+```
+
+### 3. Generate the CHANGELOG draft
+
+Run `git log <prev-tag>..upstream/dev --pretty=format:'%h %s'` and group by conventional-commit type:
+
+```markdown
+## vX.Y.Z — YYYY-MM-DD
+
+### Added (feat)
+- (#NN) <subject> — <short-sha>
+- ...
+
+### Fixed (fix)
+- (#NN) <subject> — <short-sha>
+
+### Changed (refactor / chore / docs)
+- (#NN) <subject> — <short-sha>
+
+### Breaking
+- <only if breaking-marker commits exist>
+
+### Closes
+- <enumerate every `Closes #N` from PR bodies merged to dev since last tag>
+```
+
+Show the draft and let the user edit interactively before opening the PR.
+
+### 4. Open the release PR
+
+Branch from `dev`: `release/vA.B.C`. Push to `upstream`. Open PR:
+
+- **Base**: `main`
+- **Head**: `release/vA.B.C`
+- **Title**: `release: vA.B.C`
+- **Body**: the CHANGELOG draft + an explicit "this PR will tag `vA.B.C` on `main` after merge"
+
+The PR body should aggregate every `Closes #N` from the included commits so that merging the release PR auto-closes all of them on GitHub at once.
+
+Skip-marker note: the release PR's body legitimately has many `Closes #N`. The hook from #114 (single-Closes-per-PR) will block it. Use `<!-- multi-close: approved -->` to bypass — release PRs are exactly the umbrella case the marker is designed for.
+
+### 5. Wait for review + merge
+
+The release PR runs through the normal flow:
+
+- Code Reviewer (Rex) on the PR
+- CEO `/approve-merge`
+- Merge gate green
+- Squash-merge to `main`
+
+`/release` does not auto-merge. The CEO retains the discrete moment.
+
+### 6. Tag + push (after merge)
+
+Once the release PR merges, the user invokes `/release --tag vA.B.C` (or runs the suggested commands manually):
+
+```bash
+git fetch upstream main
+git tag vA.B.C upstream/main
+git push upstream vA.B.C
+```
+
+### 7. Optional: GitHub Release
+
+If the user wants a Release entry on GitHub:
+
+```bash
+gh release create vA.B.C \
+  --repo me2resh/apexyard \
+  --title "vA.B.C" \
+  --notes-file <changelog-section>
+```
+
+The CHANGELOG section from step 3 is the body.
+
+### 8. Confirm
+
+```
+Released vA.B.C — tag pushed to upstream/main.
+N tickets auto-closed via the release PR.
+Drift banner on adopters' forks will fire on next session.
+```
+
+## Rules
+
+1. **Framework-only.** Refuse to run on a managed project. The dev/main split is apexyard-the-framework's pattern, not the portfolio's.
+2. **Pre-flight every check** in step 1 — never proceed past a dirty tree, missing dev branch, or zero-commit delta.
+3. **Always show the bump for confirmation** — auto-detection is a proposal, not a fait accompli. The CEO's eyes are the final check on semver intent.
+4. **CHANGELOG is editable** before the release PR opens. Don't auto-file what hasn't been reviewed.
+5. **Never auto-merge the release PR.** Rex + CEO approval applies as for any PR. The skill stops at "PR opened."
+6. **Never tag before merge.** Tags follow the merge commit on `main`, not the dev HEAD.
+7. **`<!-- multi-close: approved -->`** in the release PR body is required — release PRs legitimately close many tickets at once.
+
+## Related
+
+- `AgDR-0007` — the decision record this skill enacts
+- `docs/release-process.md` — the prose runbook (this skill is the automation; the doc is the manual fallback)
+- `.claude/skills/update/SKILL.md` — the inverse skill, used by adopters pulling new releases into their fork

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,12 @@ Closes #123
 
 NEVER use `git add -A` or `git add .` -- always add specific files.
 
+### Branch model — framework only
+
+The apexyard framework repo (`me2resh/apexyard`) uses a **release-cut** branch model: daily PRs merge to `dev`; `main` only receives release PRs from `dev` (tagged with semver on each merge). This is sometimes called gitflow-lite — it is **not** full git flow (no `release/*` / `hotfix/*` branches). See `docs/release-process.md` and AgDR-0007.
+
+**This is a framework-only pattern.** Managed projects under apexyard governance (entries in `apexyard.projects.yaml`) stay **trunk-based** — PRs merge to `main` directly because they have no downstream consumers. Do **NOT** cargo-cult the dev/main split into project templates, project scaffolds, or `/handover` output. The `/release` skill is the only piece that's framework-specific and refuses to run on a managed project.
+
 ---
 
 ## CLAUDE CODE INTEGRATION
@@ -172,7 +178,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Hooks | `.claude/hooks/` | 18 shell scripts that mechanically enforce SDLC rules — ticket-first, migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner |
 | Rules | `.claude/rules/` | 8 modular rule files (AgDR triggers, code standards, git conventions, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer, Security Reviewer, Dependency Auditor, PR Manager, Ticket Manager) |
-| Skills | `.claude/skills/` | 33 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 34 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
 ### Available skills (33)
@@ -205,6 +211,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | `/handover` | Onboard an external repo into ApexYard management (includes per-project discovery) |
 | `/c4` | Generate C4 L1 (System Context) + L2 (Container) Mermaid diagrams for a project by reading its codebase |
 | `/update` | Sync the ops fork with upstream me2resh/apexyard — preview, merge-or-rebase, leaves a sync branch ready to push |
+| `/release` | (Framework-only) Cut a new apexyard release — diff dev against main, pick a semver bump, generate a CHANGELOG, open the release PR, and tag after merge |
 | `/projects` | List all managed projects from the registry with status |
 | `/inbox` | Items needing your attention — PRs, issues, comments, blockers |
 | `/status` | Current snapshot — git, CI, in-progress work |
@@ -246,7 +253,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Hooks | `.claude/hooks/` |
 | Rules (modular) | `.claude/rules/` |
 | Agents | `.claude/agents/` |
-| Skills (33 slash commands) | `.claude/skills/` |
+| Skills (34 slash commands) | `.claude/skills/` |
 | Hook wiring | `.claude/settings.json` |
 | **Per-project docs** | `projects/<name>/` |
 | **Live working copies** (gitignored) | `workspace/<name>/` |

--- a/docs/agdr/AgDR-0007-release-cut-branch-model.md
+++ b/docs/agdr/AgDR-0007-release-cut-branch-model.md
@@ -26,7 +26,7 @@ status: executed
 ## Options Considered
 
 | Option | Pros | Cons |
-|--------|------|------|
+| -------- | ------ | ------ |
 | **A. Stay trunk-based (status quo)** | Zero change cost; one branch to reason about | Adopters pull WIP; no release promise; cumulative effect on downstream forks |
 | **B. Trunk + tags only (forks pin to tags)** | Minimal policy change | `/update` still pulls `main` HEAD unless rewritten to pull latest tag; adopters who don't pin still see WIP |
 | **C. Release-cut (dev + main + tags) — CHOSEN** | Clean promise: main = released; light ceremony; compatible with existing tag-based drift | Contributors retarget PRs; release cadence must be curated; slight onboarding friction |
@@ -41,11 +41,13 @@ Naming: this is **NOT** git flow. It's "release-cut" or "gitflow-lite". Be preci
 ## Consequences
 
 **Kept:**
+
 - All existing hooks (block-main-push, validate-branch-name, validate-pr-create, merge-gate hooks) — they apply to `dev` PRs as-is.
 - Tag-based drift detection — continues unchanged.
 - `/update` skill — no behavioural change; semantic upgrade (pulls release-only content).
 
 **Added:**
+
 - `dev` branch as the daily-work trunk; default branch for PRs.
 - Release-PR flow (`dev` → `main` + semver tag).
 - `/release` skill to standardise the cut (this PR).
@@ -53,9 +55,11 @@ Naming: this is **NOT** git flow. It's "release-cut" or "gitflow-lite". Be preci
 - `block-main-push.sh` extended to block direct pushes/commits to `dev` too (long-lived integration branch, all changes via PR).
 
 **Dropped:**
+
 - Rolling-HEAD semantics on `main`. Adopters can no longer casually pull unreviewed WIP.
 
 **Non-consequences (explicitly):**
+
 - Managed projects under apexyard governance do **NOT** adopt this pattern. They stay trunk-based because they have no downstream consumers (only the framework does). The `docs/multi-project.md` and CLAUDE.md explicitly call this out so the pattern doesn't cargo-cult into project templates.
 - No hotfix/support branches. If multi-version maintenance becomes a need, revisit.
 - No automatic on-merge issue closing for dev PRs (GitHub auto-close only fires on default-branch merges). Each dev-PR closes its ticket manually with a merge-trace comment; the eventual release PR's body aggregates all `Closes #N` for the batch and triggers auto-close en masse when it merges to `main`. Workflow automation for the meantime is a follow-up.

--- a/docs/agdr/AgDR-0007-release-cut-branch-model.md
+++ b/docs/agdr/AgDR-0007-release-cut-branch-model.md
@@ -1,0 +1,69 @@
+---
+id: AgDR-0007
+timestamp: 2026-04-25T03:50:00Z
+agent: claude
+model: claude-opus-4-7
+trigger: user-prompt
+status: executed
+---
+
+# Adopt release-cut branch model (dev + main + tags) for apexyard
+
+> In the context of external adopters now forking apexyard and pulling from `upstream/main`,
+> facing the problem that daily work-in-progress was polluting what downstream users see as "the framework",
+> I decided to move daily work to a `dev` branch and reserve `main` for tagged releases (dev → main merge + semver tag),
+> to achieve a predictable, adopter-safe upstream without the ceremony of full git flow,
+> accepting that contributors need to learn a slightly different target branch and that release cadence must be curated.
+
+## Context
+
+- apexyard started as a single-user framework; `main` was both the working branch and the consumed surface.
+- External adopters now fork the repo and sync via `/update` (which pulls `upstream/main`). Every commit on main reaches them immediately.
+- Drift detection is already tag-based (apexyard v1.1.0 introduced tag-aware drift). The infrastructure for release semantics exists; the policy did not.
+- The model must stay lightweight — apexyard is docs + hooks + skills, not a compiled artefact needing stabilisation windows.
+- Eight enforcement-hook PRs (#109/#110/#115/#111/#107/#112/#113/#114) merged to a *temporary* `dev` branch this cycle, awaiting v1.2.0 cut. The branch already exists; this AgDR formalises the policy that brought it into being.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Stay trunk-based (status quo)** | Zero change cost; one branch to reason about | Adopters pull WIP; no release promise; cumulative effect on downstream forks |
+| **B. Trunk + tags only (forks pin to tags)** | Minimal policy change | `/update` still pulls `main` HEAD unless rewritten to pull latest tag; adopters who don't pin still see WIP |
+| **C. Release-cut (dev + main + tags) — CHOSEN** | Clean promise: main = released; light ceremony; compatible with existing tag-based drift | Contributors retarget PRs; release cadence must be curated; slight onboarding friction |
+| **D. Full git flow (main + develop + release/* + hotfix/* + support/*)** | Handles multi-version maintenance, stabilisation windows, emergency patches | Heavy for a framework with one supported version and no compilation; most modern teams don't need it; overkill |
+
+## Decision
+
+Chosen: **Option C (release-cut)**, because it gives external adopters the release promise they need without the ceremony they don't. Full git flow's extra branch types (`release/*`, `hotfix/*`, `support/*`) solve problems apexyard doesn't have — there's no stabilisation window, no multi-version maintenance, and no compilation step that benefits from a soak period.
+
+Naming: this is **NOT** git flow. It's "release-cut" or "gitflow-lite". Be precise in docs so contributors who think git flow don't expect the full ceremony.
+
+## Consequences
+
+**Kept:**
+- All existing hooks (block-main-push, validate-branch-name, validate-pr-create, merge-gate hooks) — they apply to `dev` PRs as-is.
+- Tag-based drift detection — continues unchanged.
+- `/update` skill — no behavioural change; semantic upgrade (pulls release-only content).
+
+**Added:**
+- `dev` branch as the daily-work trunk; default branch for PRs.
+- Release-PR flow (`dev` → `main` + semver tag).
+- `/release` skill to standardise the cut (this PR).
+- Branch protection on `main` restricting merges to release-PRs only (manual GitHub setting, documented in `docs/release-process.md`).
+- `block-main-push.sh` extended to block direct pushes/commits to `dev` too (long-lived integration branch, all changes via PR).
+
+**Dropped:**
+- Rolling-HEAD semantics on `main`. Adopters can no longer casually pull unreviewed WIP.
+
+**Non-consequences (explicitly):**
+- Managed projects under apexyard governance do **NOT** adopt this pattern. They stay trunk-based because they have no downstream consumers (only the framework does). The `docs/multi-project.md` and CLAUDE.md explicitly call this out so the pattern doesn't cargo-cult into project templates.
+- No hotfix/support branches. If multi-version maintenance becomes a need, revisit.
+- No automatic on-merge issue closing for dev PRs (GitHub auto-close only fires on default-branch merges). Each dev-PR closes its ticket manually with a merge-trace comment; the eventual release PR's body aggregates all `Closes #N` for the batch and triggers auto-close en masse when it merges to `main`. Workflow automation for the meantime is a follow-up.
+
+## Artifacts
+
+- Implementing ticket: `me2resh/apexyard#116`
+- `/release` skill: `.claude/skills/release/SKILL.md`
+- Process doc: `docs/release-process.md`
+- Hook update: `.claude/hooks/block-main-push.sh` (now also blocks `dev`)
+- CLAUDE.md + `docs/multi-project.md` updated to clarify framework-only scope

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -249,6 +249,10 @@ A typical morning as a CTO / Chief of Staff using apexyard:
 
 ## Upgrades — pulling from upstream
 
+`upstream/main` is **release-only** (since v1.2.0 — see [AgDR-0007](agdr/AgDR-0007-release-cut-branch-model.md)). The framework repo cuts releases via `dev → main` PRs with semver tags; adopters pull tagged releases via `/update`. You will not see WIP commits on `upstream/main` — only the curated release stream.
+
+> **Note for fork owners:** the dev/main split applies to `me2resh/apexyard` only. Your ops fork stays trunk-based on `main` (your daily work merges directly), and so do all the projects you manage under it. Don't cargo-cult the dev/main pattern into managed projects; they have no downstream consumers and don't need it.
+
 ### How you know it's time
 
 On every Claude Code session start, the `check-upstream-drift.sh` hook runs `git fetch upstream` (cached to once per 10 minutes) and prints a one-line banner if your fork is behind:

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -9,7 +9,7 @@ ApexYard governs a **portfolio of repos as one organisation**. You fork apexyard
 ## TL;DR
 
 | | ApexYard |
-|---|---|
+| --- | --- |
 | **What you install** | A fork of `me2resh/apexyard`, cloned locally. No `.apexyard/` symlinks, no nested installs. |
 | **What governs the portfolio** | `apexyard.projects.yaml` at the root of your fork |
 | **Where per-project docs live** | `projects/<name>/` inside your fork, committed |
@@ -196,7 +196,7 @@ The test for *"where does this doc go?"* is **"would I want this to follow the c
 Every portfolio skill reads `apexyard.projects.yaml` and iterates the registry.
 
 | Skill | Behaviour |
-|-------|-----------|
+| ------- | ----------- |
 | `/projects` | Reads the registry, shows one row per project with status, branch, open PRs, open issues |
 | `/status` | Same as `/projects` but with git + CI snapshots per project, separated by headers |
 | `/inbox` | Aggregates PRs, issues, and comments needing your attention across every registered project |
@@ -223,7 +223,7 @@ Templates:
 Where to put the diagrams (same split as every other kind of doc — "would this follow the code if the project spun out?"):
 
 | Scope | Location |
-|-------|----------|
+| ------- | ---------- |
 | Framework-wide (ApexYard itself) | `docs/architecture/` in the ops fork |
 | ApexYard's view of a managed project | `projects/<name>/architecture/` in the ops fork |
 | Internal to a project's own repo | `docs/architecture/` in that project's repo (via `workspace/<name>/docs/architecture/`) |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,120 @@
+# apexyard release process
+
+apexyard uses a **release-cut** branch model (sometimes called gitflow-lite) for the framework repo. This doc is the prose runbook for cutting a release. The `/release` skill at `.claude/skills/release/SKILL.md` automates most of the steps; this doc is the manual fallback and the conceptual reference.
+
+**Important — framework only.** This release model is for `me2resh/apexyard` itself, not for managed projects under apexyard governance. Managed projects stay trunk-based (PRs merge to `main`); only the framework has dev/main + tags. See `docs/multi-project.md` for the rationale.
+
+Decision record: [`docs/agdr/AgDR-0007-release-cut-branch-model.md`](agdr/AgDR-0007-release-cut-branch-model.md).
+
+## Branch model
+
+```
+dev  ──●──●──●──●──●──●──────●──●──────●──●──────  (daily work; PRs land here)
+        \                    /          /
+         \                  /          /
+main ─────●────────────────●──────────●──────────────  (released only; tagged on each merge)
+          v1.1.0           v1.2.0    v1.2.1
+```
+
+- **`dev`** — every feature/fix/chore PR targets here. All hooks + review gates apply unchanged.
+- **`main`** — only receives merges from `dev`, via release PRs. Every merge to `main` is tagged with a semver. Direct pushes blocked by `block-main-push.sh`.
+- Releases are `dev → main` merge commits, tagged `vX.Y.Z`.
+- No `release/*` branches (no stabilisation window needed for docs+hooks).
+- No `hotfix/*` branches (no multi-version support; forks always run latest).
+
+## When to cut a release
+
+Curated cadence — release when there's a meaningful batch on `dev` that's worth surfacing to adopters. Loose guidance:
+
+- **Patch (`vX.Y.Z+1`)** — bug fixes only. Cut whenever there are ≥ 1 fix and adopters would benefit.
+- **Minor (`vX.Y+1.0`)** — new features (additive). Cut every 1–2 weeks if there's been net-new feature work.
+- **Major (`vX+1.0.0`)** — breaking changes. Coordinate with adopters first; release notes call out migrations.
+
+If `dev` is N commits ahead and nothing's broken, you're free to NOT release — adopters will stay on the previous tag and the drift banner will tell them about the new tag when it's cut.
+
+## Cutting a release — happy path
+
+Use `/release` for the full guided flow. Manual steps for reference:
+
+```bash
+# 1. Verify pre-conditions
+git fetch upstream
+git rev-parse upstream/main upstream/dev    # both should resolve
+git log upstream/main..upstream/dev --oneline | head    # should be non-empty
+
+# 2. Pick the version (e.g. v1.2.0 — minor bump because of feat: commits)
+
+# 3. Cut release branch from dev
+git checkout -b release/v1.2.0 upstream/dev
+git push upstream release/v1.2.0
+
+# 4. Open release PR
+gh api repos/me2resh/apexyard/pulls -X POST \
+  -f title="release: v1.2.0" \
+  -f body-file=/tmp/changelog-v1.2.0.md \
+  -f head="release/v1.2.0" \
+  -f base="main"
+
+# 5. Run normal review flow on the PR
+#    - Code Reviewer (Rex)
+#    - /approve-merge <pr>
+#    - gh pr merge <pr> --squash
+
+# 6. After merge: tag main + push the tag
+git fetch upstream main
+git tag v1.2.0 upstream/main
+git push upstream v1.2.0
+
+# 7. Optional: GitHub Release entry
+gh release create v1.2.0 \
+  --repo me2resh/apexyard \
+  --title "v1.2.0" \
+  --notes-file /tmp/changelog-v1.2.0.md
+```
+
+## Release PR caveats
+
+The release PR's body legitimately contains many `Closes #N` references — every ticket that landed on `dev` since the last release. The single-Closes-per-PR check from #114 will block the open. Add the skip marker to the body:
+
+```
+<!-- multi-close: approved -->
+```
+
+The marker is grep-able on purpose; release PRs are exactly the umbrella case it's designed for.
+
+## Drift banner behaviour
+
+After a release tag is pushed, every fork's `check-upstream-drift.sh` hook (tag-based since v1.1.0) prints a banner on next session:
+
+```
+ApexYard: v1.2.0 available. Run /update to sync.
+```
+
+`/update` pulls `upstream/main` into the fork's main — which now contains only the released content.
+
+## Hotfix path (not implemented; revisit if needed)
+
+apexyard does NOT have a hotfix flow today. If a critical bug ships in `vX.Y.Z` and adopters need a fix without waiting for the next normal release, the workaround:
+
+1. Cut a normal `dev → main` release with just the fix (a `vX.Y.Z+1` patch).
+2. Release within hours rather than days; cadence is the only difference.
+
+If multi-version maintenance becomes a real need (e.g. some adopters can't upgrade past `v1.x.x`), revisit AgDR-0007 with a new options table — full git flow's `hotfix/*` and `support/*` patterns become relevant.
+
+## Branch protection (manual GitHub setting)
+
+For maintainers of `me2resh/apexyard`, configure GitHub branch protection on `main`:
+
+- Require pull request before merging
+- Require approvals: 1
+- Require status checks to pass before merging (markdownlint, lychee, shellcheck, Verify Ticket ID)
+- Restrict who can push to matching branches (only repo admins, for the rare manual tag-fix case)
+
+Branch protection on `dev` matches the prior `main` setup — required reviews + required checks.
+
+## Related
+
+- `AgDR-0007` — the decision record
+- `.claude/skills/release/SKILL.md` — the automated flow
+- `.claude/skills/update/SKILL.md` — the inverse skill, for adopters pulling new releases
+- `docs/multi-project.md § "Upgrades — pulling from upstream"` — adopter side of the relationship


### PR DESCRIPTION
## Summary

Formalises the **release-cut** branch model (sometimes called gitflow-lite) that the framework repo has been operating under informally since the start of this hooks-wave. `dev` is daily-work; `main` only receives release PRs from `dev`; each release-PR merge tags a semver. Adopters' `/update` skill pulls `upstream/main`, which is now strictly release-only — no more WIP commits leaking to forks.

**Framework-only.** This pattern is for `me2resh/apexyard` itself. Managed projects under apexyard governance (entries in `apexyard.projects.yaml`) stay trunk-based — they have no downstream consumers and don't need the ceremony. Both CLAUDE.md and `docs/multi-project.md` call this out explicitly so the pattern doesn't cargo-cult into project templates.

Added:

- **AgDR-0007** — decision record with the options table (full git flow vs trunk-only vs gitflow-lite — chose gitflow-lite)
- **`/release` skill** at `.claude/skills/release/SKILL.md` — diffs dev against main, proposes a semver bump from conventional-commit types, generates a CHANGELOG draft, opens the release PR, tags + pushes after merge
- **`docs/release-process.md`** — prose runbook (the skill is the automation; the doc is the manual fallback + conceptual reference)
- **`.git.protected_branches`** in `project-config.defaults.json` (default `[main, master, dev, develop]`)

Modified:

- **`block-main-push.sh`** — extended to block direct pushes/commits to ALL protected branches, not just main/master. Reads the list from project config via the shared reader (#109). Forks that legitimately use `dev` as a working trunk under their own convention can override.
- **`CLAUDE.md`** — new "Branch model — framework only" subsection under Git Conventions. `/release` added to the skills table.
- **`docs/multi-project.md`** — note in the "Upgrades" section that `upstream/main` is release-only as of v1.2.0 + reminder that the split applies to apexyard itself, not to managed projects.

## Testing

No automated tests (the `/release` skill is a markdown spec; `block-main-push.sh` extension is verified by tracing the regex against the protected list).

Manual smoke:

```bash
# Hook respects the new protected list
echo '{"tool_input":{"command":"git push origin dev"}}' | bash .claude/hooks/block-main-push.sh
# → exit 2, "Cannot push directly to a protected branch"

# Hook still blocks main
echo '{"tool_input":{"command":"git push origin main"}}' | bash .claude/hooks/block-main-push.sh
# → exit 2

# Feature-branch push still allowed
echo '{"tool_input":{"command":"git push origin chore/GH-116-foo"}}' | bash .claude/hooks/block-main-push.sh
# → exit 0
```

The first real `/release` invocation will be the v1.2.0 cut — at that point we'll dogfood the skill end-to-end and any rough edges show up there.

## Scope — what this does NOT do

- **No automatic on-merge issue close** for dev-targeting PRs. GitHub auto-close only fires on default-branch merges. The release PR's body aggregates all `Closes #N` for the batch and triggers auto-close en masse when it merges to `main`. Manual close-with-merge-trace in the meantime (see closing pattern on #109/#110/#115/#111/#107/#112/#113/#114). A small post-merge automation could be a follow-up.
- **No `release/*` or `hotfix/*` branches.** Hotfixes are just patches cut quickly. If multi-version maintenance becomes a real need, revisit AgDR-0007.
- **No CI workflow edits** — `pull_request` triggers fire regardless of base branch, so dev-targeting PRs already get the full check matrix.

## Branch protection (manual GitHub setting)

For maintainers of `me2resh/apexyard`, configure GitHub branch protection on `main` per `docs/release-process.md § Branch protection`:

- Require pull request before merging
- Require approvals: 1
- Require all status checks to pass
- (Optional) Restrict who can push (admins only, for the rare manual tag-fix case)

This is documentation-only here — the actual GitHub setting is a one-time admin action.

## Glossary

| Term | Definition |
|------|------------|
| Release-cut model | Two-branch (dev + main) + tags. Daily work on dev, releases on main. Sometimes called "gitflow-lite". |
| Framework-only | This pattern applies to `me2resh/apexyard` itself, NOT to managed projects under governance. |
| Protected branch | A branch where direct pushes and commits are blocked by `block-main-push.sh`. Default list is configurable. |
| Release PR | A `dev → main` PR that, when merged, becomes the source for a new semver tag. Body uses the `<!-- multi-close: approved -->` skip marker because it legitimately closes many tickets. |

Closes #116