### PR TITLE
feat(#117): /fan-out skill + parallel-work rule for proactive parallel proposal

### DIFF
--- a/.claude/rules/parallel-work.md
+++ b/.claude/rules/parallel-work.md
@@ -1,0 +1,60 @@
+# Parallel Work — When to Offer Fan-Out
+
+ApexYard ships the `/fan-out` skill for spawning N parallel agents on independent tasks. The skill is the happy path; this rule is the **trigger heuristic** — it defines when an agent should *proactively offer* fan-out instead of executing work serially by default.
+
+A typical session serialises tasks that don't need to be serial — N unrelated audits, N independent tickets, research across N unrelated areas. The framework should make parallel execution the default *offer* when it's safe, not a pattern each user rediscovers.
+
+## When to OFFER parallel fan-out (proactively)
+
+Heuristic: when the user's request decomposes into ≥ 2 work items that are all of:
+
+- **File-independent** — different write targets, no shared edits
+- **Context-independent** — one task's output does not feed another's input
+- **Individually substantial** — ≥ 5 minutes of work each. Not "read 3 lines from 3 files" (overhead exceeds gain)
+
+Examples that should trigger an offer:
+
+- "Implement these 3 independent tickets" (each touches different code paths)
+- "Audit hooks, skills, and rules for X" (3 unrelated codebase areas)
+- "Add a hook for X, a skill for Y, and a rule for Z" (3 different files)
+- "Research how libraries A, B, and C handle pagination" (3 unrelated reads)
+
+## When NOT to fan out
+
+- **Shared state or files** — two tasks edit the same file → serial. Worktree merge-back conflicts cost more than the concurrency win.
+- **Sequential dependencies** — task B needs task A's output → serial.
+- **Architecture / AgDR-class decisions** — the work IS the cross-task reasoning. Splitting it loses the shared context that makes a good decision possible.
+- **Single large indivisible task** — e.g. "refactor module X from MVC to clean architecture". Splitting by file usually creates a sequential chain.
+- **Trivial work** — three two-line edits. Spawning agents adds more overhead than it saves.
+
+## How to offer
+
+Short, explicit, non-pushy. Let the user pick:
+
+```
+These N items are independent — write targets don't overlap and outputs
+don't chain. Want to fan them out via /fan-out (each on its own
+worktree), or run serial?
+```
+
+If the user says yes → invoke `/fan-out`. If serial → proceed normally.
+
+## Self-check before responding
+
+Before answering a multi-item user request, scan your planned response for:
+
+```
+[ ] ≥ 2 work items in the response?
+[ ] Are they file-independent?
+[ ] Are they context-independent?
+[ ] Are they each substantial (≥ 5 min)?
+[ ] Did I OFFER /fan-out, or default-silently to serial?
+```
+
+If all four boxes are checked and you didn't offer fan-out, you missed a parallel-work opportunity.
+
+## Backstop
+
+This rule is **primarily self-discipline**. Mechanical enforcement isn't viable — no shell hook can see "the agent didn't propose parallel" in assistant prose. Pair this rule with feedback memory: if the CEO has previously asked "why didn't you fan this out?", surface the offer more aggressively next time.
+
+The cost of offering fan-out and being told "no, just serial" is one sentence. The cost of silently serialising N independent items is N times the wall-clock latency the user notices.

--- a/.claude/skills/fan-out/SKILL.md
+++ b/.claude/skills/fan-out/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: fan-out
+description: Spawn N parallel Agent calls in a single assistant message, optionally with worktree isolation for code-writing tasks and background mode for long runs. Use when the user's request decomposes into independent work items that share no files and have no sequential dependencies.
+disable-model-invocation: false
+argument-hint: "<task1, task2, ...> | <path/to/tasks.md> | --from-tickets <ref1,ref2,...>"
+effort: medium
+---
+
+# /fan-out — Parallel Agent Fan-Out
+
+Spawns multiple specialised agents in parallel — each on its own task, optionally in its own git worktree — so independent work items progress concurrently instead of being silently serialised behind a single agent's session.
+
+This skill is the **happy path** for parallel execution. The companion rule [`.claude/rules/parallel-work.md`](../../rules/parallel-work.md) defines **when** to *offer* fan-out proactively. Read both before invoking.
+
+## When to use
+
+The trigger heuristic is in [`parallel-work.md`](../../rules/parallel-work.md). The short version: use `/fan-out` when the user's request decomposes into ≥ 2 work items that are file-independent, context-independent, and individually substantial.
+
+Do NOT use when:
+
+- Tasks share file write targets (worktree merge-back will conflict)
+- One task's output is another's input (sequential dependency)
+- The work is a single indivisible task
+- The decision itself is the work (architecture / AgDR-class) — that needs cross-task reasoning, not concurrency
+
+## Process
+
+### 1. Gather tasks
+
+Accept tasks from any of these forms:
+
+- `$ARGUMENTS` as a comma-separated list: `"audit hooks dir, audit skills dir, audit rules dir"`
+- A markdown file path: `/fan-out tasks.md` — one task per line, blank lines and `#` comments ignored
+- `--from-tickets <list>`: `/fan-out --from-tickets apexyard#109,apexyard#110,apexyard#111` — fetch each issue title + body via `gh issue view` and use them as task descriptions
+- Interactive entry — if `$ARGUMENTS` is empty, prompt: *"Paste your tasks, one per line. Blank line to finish."*
+
+Trim whitespace, drop empties. If the result is fewer than 2 tasks, stop: fan-out is overkill for one item.
+
+### 2. Per-task questions — ASK ONCE per task
+
+For each task, infer the answer from the description first, then ask only when ambiguous.
+
+**Agent type** — default `general-purpose`. Options:
+
+| Agent | Use for |
+|-------|---------|
+| `general-purpose` | Implementation, multi-step research, anything mixed |
+| `Explore` | Read-only research, codebase questions, audits |
+| `code-reviewer` | Reviewing an existing PR (read-only) |
+| `security-reviewer` | Security audit of a PR (read-only) |
+| `Plan` | Plan-mode — produces a plan, no edits |
+| Custom | Any subagent in `.claude/agents/` |
+
+If a task obviously needs editing (verbs like *implement*, *add*, *fix*, *refactor*, *migrate*, *write*), reject any read-only agent type and suggest `general-purpose`.
+
+**Isolation** — default `worktree` if any agent will write code; `shared` if all agents are read-only research. Infer from the task verb. Ask only when ambiguous.
+
+**Mode** — default `foreground` (≤ 2-minute estimated runtime); `background` if estimated > 2 minutes. Estimate from task scope (single-file edit ≈ short; cross-cutting refactor ≈ long; full audit ≈ long). Ask only when ambiguous.
+
+### 3. Active-ticket safety check
+
+For every task that involves code edits (not pure research), verify a ticket marker exists:
+
+- Per-project: `<ops_root>/.claude/session/tickets/<project>` if the task targets a managed project's `workspace/<name>/`
+- Fallback: `<ops_root>/.claude/session/current-ticket` for ops-fork edits
+
+If missing, **refuse the entire fan-out** and tell the user:
+
+```
+Cannot fan out — task "<task>" needs an active ticket. Run:
+  /start-ticket <ref>
+…then re-run /fan-out.
+```
+
+The `require-active-ticket.sh` hook would block edits anyway. Failing fast at fan-out time is kinder UX than letting 3 of 5 agents start, then 2 fail mid-run.
+
+### 4. File-collision guard
+
+Heuristically detect tasks that target the same file paths. Compare file paths mentioned in each task description (literal paths, glob patterns, or implied file scope).
+
+If two or more tasks share write targets, **refuse parallel** and recommend serial:
+
+```
+Cannot fan out — these tasks share write targets:
+  - Task 2: edits .claude/hooks/pre-push-gate.sh
+  - Task 4: edits .claude/hooks/pre-push-gate.sh
+
+Run them serially, or split task boundaries so each owns distinct files.
+```
+
+The alternative is `git` worktree merge conflicts on merge-back — recoverable but always painful.
+
+### 5. Show the plan and confirm
+
+Print a table:
+
+```
+| # | Task | Agent | Isolation | Mode |
+|---|------|-------|-----------|------|
+| 1 | …    | general-purpose | worktree | foreground |
+| 2 | …    | Explore | shared | foreground |
+…
+```
+
+Wait for the user's `yes` / `confirm` / `go` before spawning. Edits to the plan in this step are fine — re-print the table and re-ask.
+
+### 6. Spawn — ALL CALLS IN A SINGLE ASSISTANT MESSAGE
+
+This is the only step where parallelism actually happens. Emit a SINGLE assistant message containing N `Agent` tool calls (one per task). Looping `Agent` invocations across multiple messages serialises them — the second agent will not start until the first returns.
+
+```
+Spawning 4 agents in parallel…
+[Agent call 1]
+[Agent call 2]
+[Agent call 3]
+[Agent call 4]
+```
+
+Each agent's prompt must be **self-contained** — sub-agents do not inherit the parent's conversation context. Include in each prompt:
+
+- The task description verbatim
+- Any reference paths the agent needs to read
+- The expected output format (what to return to the parent)
+- Constraints inherited from the parent (e.g. "don't push", "use specific git add")
+
+For tasks with `isolation: worktree`, pass `isolation: worktree` in the Agent call. For long-running tasks with `mode: background`, pass `run_in_background: true`.
+
+### 7. Collect results
+
+Foreground tasks return inline — wait for all of them. Background tasks return asynchronously — note their IDs and tell the user how to check on them later.
+
+For each returned result, capture:
+
+- Task ID
+- Status (success / failure / partial)
+- Branch name (if worktree was used)
+- Summary of what the agent did
+- Any follow-ups the agent flagged
+
+### 8. Worktree merge-back
+
+If any agents used `worktree` isolation, list the branches they created. Then offer to sequence the merge-back:
+
+```
+Worktree branches to merge:
+  1. feature/#117-add-fan-out-skill        (agent 1)
+  2. feature/#118-add-parallel-rule        (agent 2)
+  3. fix/#120-bug-in-X                     (agent 3)
+
+Merge back in order? [y/n/select]
+```
+
+For each branch in turn:
+
+1. Switch to the branch (`git checkout`)
+2. Rebase onto the latest base if needed
+3. Optionally cherry-pick into the user's working branch
+4. **Pause on conflict** — ask the user to resolve interactively. Do not auto-resolve.
+
+Each project owns one merge-back attempt. If the user wants to skip a branch (e.g. open as its own PR instead), record that and continue.
+
+### 9. Final report
+
+```
+Fan-out complete (N tasks, M succeeded, K background still running).
+
+| # | Task | Status | Branch | Follow-ups |
+|---|------|--------|--------|------------|
+| 1 | …    | done   | …      | …          |
+…
+
+Background tasks running: <ids>. They'll surface results when done.
+```
+
+## Rules
+
+1. **All `Agent` tool calls for a single fan-out MUST be in the SAME assistant message.** Multi-message loops do not get concurrency — they serialise. This is the most important rule in this skill.
+2. **Use `isolation: worktree` whenever any agent will write code.** Required to prevent file-level races between agents sharing one working directory.
+3. **Refuse fan-out when tasks share file write targets.** Serialise instead — the merge-back conflict cost outweighs any concurrency win.
+4. **Refuse fan-out when tasks have sequential dependencies.** If task B reads task A's output, they cannot run in parallel.
+5. **Cap at 5 concurrent agents per invocation.** If the user wants more, ask them to split into batches. Beyond 5, returns diminish (review fatigue, merge-back queue) and risk grows (rate limits, context dilution).
+6. **Each agent's prompt must be self-contained** — sub-agents do not see the parent conversation. Include task description, reference paths, expected output format, and any inherited constraints inline.
+7. **Background mode only for >2-minute estimated work.** For short tasks, foreground is faster end-to-end (no async overhead).
+8. **Refuse a read-only agent type for an editing task.** `Explore`, `code-reviewer`, `security-reviewer`, and `Plan` cannot write. If the task verb says "implement" / "fix" / "add" / "refactor", suggest `general-purpose`.
+9. **Active-ticket check happens at step 3, not step 6.** Failing at plan-time is kinder than failing mid-spawn.
+10. **Pause on merge-back conflict — never auto-resolve.** The user owns the merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,12 +170,12 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Layer | Path | Purpose |
 |-------|------|---------|
 | Hooks | `.claude/hooks/` | 18 shell scripts that mechanically enforce SDLC rules — ticket-first, migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner |
-| Rules | `.claude/rules/` | 8 modular rule files (AgDR triggers, code standards, git conventions, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
+| Rules | `.claude/rules/` | 9 modular rule files (AgDR triggers, code standards, git conventions, parallel work, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer, Security Reviewer, Dependency Auditor, PR Manager, Ticket Manager) |
-| Skills | `.claude/skills/` | 33 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 34 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (33)
+### Available skills (34)
 
 | Skill | Purpose |
 |-------|---------|
@@ -211,6 +211,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | `/tasks` | Actionable task list with direct URLs, prioritised |
 | `/roadmap` | Update or create the product roadmap |
 | `/stakeholder-update` | Generate weekly / monthly / launch updates |
+| `/fan-out` | Spawn N parallel agents in one message — per-task agent type, worktree isolation, foreground/background mode (see `.claude/rules/parallel-work.md` for when to offer) |
 
 The hooks, agents, and skills are picked up automatically by Claude Code when this directory lives at the project root. The rules are imported via `@.claude/rules/*.md` from your project's `CLAUDE.md`.
 
@@ -246,7 +247,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Hooks | `.claude/hooks/` |
 | Rules (modular) | `.claude/rules/` |
 | Agents | `.claude/agents/` |
-| Skills (33 slash commands) | `.claude/skills/` |
+| Skills (34 slash commands) | `.claude/skills/` |
 | Hook wiring | `.claude/settings.json` |
 | **Per-project docs** | `projects/<name>/` |
 | **Live working copies** (gitignored) | `workspace/<name>/` |


### PR DESCRIPTION
## User Story

As an agent driving a portfolio of independent work, I want a skill that spawns N parallel `Agent` tool calls in one assistant message — so that genuinely-independent tasks run concurrently instead of serially, and I have a clear pattern to recommend whenever the user's request decomposes that way.

## Summary

Two coupled artefacts that ship together:

1. **`/fan-out` skill** at `.claude/skills/fan-out/SKILL.md` — spec for spawning N parallel `Agent` calls (single assistant message, with `isolation: worktree` for code-writers, `run_in_background: true` for long runs). Includes the active-ticket safety check, file-collision guard, plan confirmation, worktree merge-back, and 5-agent cap.
2. **`.claude/rules/parallel-work.md`** — rule doc defining WHEN an agent should *proactively offer* fan-out. The skill is the happy path; the rule is the trigger heuristic.

Together they fix the "agent silently serialises independent work" failure mode that surfaces every time we have ≥ 2 independent tickets in flight (observed eight times this hooks-wave). The rule says "offer parallel"; the skill is what they invoke when the user accepts.

CLAUDE.md updated:

- `/fan-out` added to Skills table
- "Rules" line updated to cover the new `parallel-work.md`
- Skills count bumped to 34 (will rebase to whatever the count actually is at merge time given other PRs in flight)

## Testing

Skills + rules are markdown — no shell test fixture. The dogfood for this PR is *the work that produced the previous 8 hooks*: those landed via parallel agent fan-out (with worktree isolation, sequential merge-back) under the prior session's ad-hoc pattern. This PR formalises that pattern as a reusable skill.

Verify spec quality:

```bash
# Spec must call out single-message-spawn as the most important rule
grep -A 1 "SAME assistant message" .claude/skills/fan-out/SKILL.md

# Spec must enforce isolation: worktree when agents write code
grep "isolation: worktree" .claude/skills/fan-out/SKILL.md

# Cap at 5 documented
grep "Max 5" .claude/skills/fan-out/SKILL.md
```

Real validation will be the next "≥ 2 independent tickets" moment — the skill is followable as-is; rough edges surface there.

## Scope — what this does NOT do

- No cross-agent coordination (agents talking to each other mid-run). Independent tasks only.
- No automatic resume of partial fan-outs after a session restart. First cut is one-session.
- No dynamic task generation (agent A spawns agent B). Static plan only.
- No automatic merge-conflict resolution on merge-back. Skill pauses on conflict and asks.

## Caveats from the agent that built this

- **Branch name nonconformance noted.** The agent's worktree branch was `worktree-agent-aac0660c` — not `feature/GH-117-…`. I cherry-picked the commit onto a properly-named branch (`feature/GH-117-fan-out-skill`) for this PR.
- **Skills + rules count** in CLAUDE.md may differ from upstream by the time this PR is reviewed (other PRs in flight bump the same lines). Will rebase if needed.

## Glossary

| Term | Definition |
|------|------------|
| Fan-out | Spawning N parallel agents from a single assistant message — only way to get true concurrency in Claude Code (multi-message loops are serialised). |
| Worktree isolation | `isolation: worktree` on an `Agent` call gives it its own git worktree + branch, so two agents writing code don't race on the filesystem. |
| Background mode | `run_in_background: true` lets the parent continue working while the agent runs. Required for >2-minute estimated work. |
| Offer-parallel rule | Heuristic in `.claude/rules/parallel-work.md` — proactively propose fan-out when work decomposes into ≥ 2 independent file-and-context-independent tasks. |

Closes #117