### PR TITLE
fix(#106): CHANGELOG fallback in drift hook for squash-merged forks

### DIFF
--- a/.claude/hooks/check-upstream-drift.sh
+++ b/.claude/hooks/check-upstream-drift.sh
@@ -73,6 +73,37 @@ if [ "$SHOULD_FETCH" = "1" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Helper: does the fork's CHANGELOG.md mention the given upstream version?
+#
+# Squash-merge breaks the `--merged main` tag-reachability check because a
+# squash collapses upstream commits into a synthetic commit with no ancestor
+# link to the upstream tag's target SHA. The CHANGELOG content survives the
+# squash, so a `## [X.Y.Z]` heading on the fork's default branch is a
+# reliable secondary signal that the release was absorbed.
+#
+# Format expected (matches apexyard's CHANGELOG.md from v1.1.0 onward):
+#   ## [1.1.0] — 2026-04-19
+# Tag input is `v1.1.0` — we strip the leading `v` before matching.
+#
+# Tolerant of: missing CHANGELOG.md (returns 1 — proceed with banner),
+# different prefix conventions on the heading line, version-only matches
+# with surrounding `[`/`]` brackets.
+#
+# See AgDR-0008 + apexyard#106.
+changelog_has_version() {
+  local tag="$1"
+  local version="${tag#v}"
+  # `git show <branch>:CHANGELOG.md` fetches the file at the branch tip
+  # without affecting the working tree. Falls back silently if the file
+  # doesn't exist on that branch.
+  if git show "${DEFAULT_BRANCH}:CHANGELOG.md" 2>/dev/null \
+       | grep -qE "^##[[:space:]]+\[${version}\]"; then
+    return 0
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
 # Tag-based drift (primary signal)
 # ---------------------------------------------------------------------------
 # Latest upstream tag reachable from upstream's default branch, sorted by
@@ -89,7 +120,13 @@ if [ -n "$UPSTREAM_TAG" ]; then
   # Upstream has at least one tag. Steady-state path.
 
   if [ -z "$LOCAL_TAG" ]; then
-    # Fork has never merged any tag yet. First release sync is due.
+    # Fork has never merged any tag (tag-reachable). Fall back to the
+    # CHANGELOG check — squash-merged sync PRs leave no reachable tag but
+    # do absorb the release-notes content.
+    if changelog_has_version "$UPSTREAM_TAG"; then
+      exit 0
+    fi
+    # Genuinely behind. First release sync is due.
     cat <<MSG
 ApexYard: ${UPSTREAM_TAG} available. Run /update to sync.
 MSG
@@ -109,7 +146,13 @@ MSG
   NEWER=$(printf '%s\n%s\n' "$UPSTREAM_TAG" "$LOCAL_TAG" | sort -V | tail -n 1)
 
   if [ "$NEWER" = "$UPSTREAM_TAG" ]; then
-    # Upstream is strictly newer. Nag.
+    # Upstream looks strictly newer by tag. Before nagging, check the
+    # CHANGELOG fallback — the fork might have squash-merged the release
+    # without inheriting the tag SHA reachability.
+    if changelog_has_version "$UPSTREAM_TAG"; then
+      exit 0
+    fi
+    # Genuinely behind.
     cat <<MSG
 ApexYard: ${UPSTREAM_TAG} available. Run /update to sync.
 MSG

--- a/.claude/hooks/tests/test_check_upstream_drift.sh
+++ b/.claude/hooks/tests/test_check_upstream_drift.sh
@@ -83,7 +83,7 @@ case_squash_caught_up() {
   local up; up=$(make_upstream)
   local fk; fk=$(make_fork "$up")
   (
-    cd "$fk"
+    cd "$fk" || exit 1
     git checkout -q main
     git reset --hard HEAD~3 2>/dev/null
     git merge --squash upstream/main >/dev/null 2>&1
@@ -98,7 +98,7 @@ case_merge_commit_caught_up() {
   local up; up=$(make_upstream)
   local fk; fk=$(make_fork "$up")
   (
-    cd "$fk"
+    cd "$fk" || exit 1
     git checkout -q main
     git reset --hard HEAD~3 2>/dev/null
     git merge --no-edit upstream/main >/dev/null 2>&1
@@ -112,7 +112,7 @@ case_genuinely_behind() {
   local up; up=$(make_upstream)
   local fk; fk=$(make_fork "$up")
   (
-    cd "$fk"
+    cd "$fk" || exit 1
     git checkout -q main
     git reset --hard v1.0.0 2>/dev/null
   )
@@ -125,7 +125,7 @@ case_fork_ahead() {
   local up; up=$(make_upstream)
   local fk; fk=$(make_fork "$up")
   (
-    cd "$fk"
+    cd "$fk" || exit 1
     git checkout -q main
     # Fork merges v1.1.0 cleanly first
     git reset --hard HEAD~3 2>/dev/null
@@ -145,7 +145,7 @@ case_squash_no_changelog() {
   local up; up=$(make_upstream)
   local fk; fk=$(make_fork "$up")
   (
-    cd "$fk"
+    cd "$fk" || exit 1
     git checkout -q main
     git reset --hard HEAD~3 2>/dev/null
     # Squash-merge but immediately blow away CHANGELOG.md (simulate a fork that

--- a/.claude/hooks/tests/test_check_upstream_drift.sh
+++ b/.claude/hooks/tests/test_check_upstream_drift.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/check-upstream-drift.sh — focused on the
+# CHANGELOG-fallback path added by apexyard#106 (AgDR-0008).
+#
+# Each case:
+#   - builds a tiny upstream + fork pair under $TMPDIR
+#   - simulates a specific merge mode (squash-merge / merge-commit / no-sync)
+#   - runs the hook from the fork's directory
+#   - asserts banner output / silence
+
+set -u
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/check-upstream-drift.sh"
+PASS=0
+FAIL=0
+FAILED=""
+
+# Build an upstream with a v1.0.0 release and a v1.1.0 release; both have
+# CHANGELOG entries. Returns the upstream repo path.
+make_upstream() {
+  local up
+  up=$(mktemp -d)
+  (
+    cd "$up" || exit 1
+    git init -q -b main
+    git config user.email t@t && git config user.name t
+    echo "init" > a.txt && git add a.txt && git commit -q -m "init"
+    echo "v1.0.0" > a.txt && git commit -q -am "release v1.0.0"
+    printf '# Changelog\n\n## [1.0.0]\nfirst release\n' > CHANGELOG.md
+    git add CHANGELOG.md && git commit -q -m "v1.0.0 changelog"
+    git tag v1.0.0
+    echo "v1.1.0 work" >> a.txt && git commit -q -am "v1.1.0 work"
+    printf '# Changelog\n\n## [1.1.0] — 2026-04-19\nnew release\n\n## [1.0.0]\nfirst release\n' > CHANGELOG.md
+    git add CHANGELOG.md && git commit -q -m "v1.1.0 changelog"
+    git tag v1.1.0
+  )
+  echo "$up"
+}
+
+# Clone upstream as a fork, copy the hook in, configure the upstream remote.
+make_fork() {
+  local up="$1"
+  local fk
+  fk=$(mktemp -d)/fork
+  git clone -q --no-tags "$up" "$fk"
+  (
+    cd "$fk" || exit 1
+    git config user.email t@t && git config user.name t
+    git remote add upstream "$up"
+    git fetch upstream --tags --quiet
+    mkdir -p .claude/hooks .claude/session
+    cp "$HOOK_SRC" .claude/hooks/check-upstream-drift.sh
+    chmod +x .claude/hooks/check-upstream-drift.sh
+  )
+  echo "$fk"
+}
+
+run_hook_from() {
+  local fk="$1"
+  ( cd "$fk" || exit 1; bash .claude/hooks/check-upstream-drift.sh 2>&1 )
+}
+
+assert() {
+  local label="$1" expected_pattern="$2" output="$3"
+  if [ -z "$expected_pattern" ]; then
+    if [ -z "$output" ]; then
+      echo "PASS [$label] — silent"
+      PASS=$((PASS+1)); return
+    fi
+    echo "FAIL [$label] — expected silent, got: $output" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "; return
+  fi
+  if echo "$output" | grep -qE "$expected_pattern"; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1)); return
+  fi
+  echo "FAIL [$label] — expected /$expected_pattern/, got: $output" >&2
+  FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+}
+
+# CASE 1: squash-merge fork at v1.1.0 (the bug scenario from #106)
+case_squash_caught_up() {
+  local up; up=$(make_upstream)
+  local fk; fk=$(make_fork "$up")
+  (
+    cd "$fk"
+    git checkout -q main
+    git reset --hard HEAD~3 2>/dev/null
+    git merge --squash upstream/main >/dev/null 2>&1
+    git commit -q -m "chore: squash sync of v1.1.0"
+  )
+  assert "squash-merge fork caught up to v1.1.0 → silent (FIXED by #106)" "" "$(run_hook_from "$fk")"
+  rm -rf "$up" "$(dirname "$fk")"
+}
+
+# CASE 2: merge-commit fork at v1.1.0 (existing path — must not regress)
+case_merge_commit_caught_up() {
+  local up; up=$(make_upstream)
+  local fk; fk=$(make_fork "$up")
+  (
+    cd "$fk"
+    git checkout -q main
+    git reset --hard HEAD~3 2>/dev/null
+    git merge --no-edit upstream/main >/dev/null 2>&1
+  )
+  assert "merge-commit fork caught up to v1.1.0 → silent" "" "$(run_hook_from "$fk")"
+  rm -rf "$up" "$(dirname "$fk")"
+}
+
+# CASE 3: fork genuinely behind (no v1.1.0 in CHANGELOG) — banner must fire
+case_genuinely_behind() {
+  local up; up=$(make_upstream)
+  local fk; fk=$(make_fork "$up")
+  (
+    cd "$fk"
+    git checkout -q main
+    git reset --hard v1.0.0 2>/dev/null
+  )
+  assert "fork stopped at v1.0.0 → banner fires" "v1.1.0 available" "$(run_hook_from "$fk")"
+  rm -rf "$up" "$(dirname "$fk")"
+}
+
+# CASE 4: fork has its own newer tag than upstream — silent (not our business)
+case_fork_ahead() {
+  local up; up=$(make_upstream)
+  local fk; fk=$(make_fork "$up")
+  (
+    cd "$fk"
+    git checkout -q main
+    # Fork merges v1.1.0 cleanly first
+    git reset --hard HEAD~3 2>/dev/null
+    git merge --no-edit upstream/main >/dev/null 2>&1
+    # Then tags its own v2.0.0-acme
+    git tag v2.0.0-acme
+  )
+  assert "fork has its own newer tag → silent" "" "$(run_hook_from "$fk")"
+  rm -rf "$up" "$(dirname "$fk")"
+}
+
+# CASE 5: squash-merge with NO CHANGELOG entry on fork main (e.g. fork forked
+# pre-CHANGELOG, then squash-merged a release without absorbing the file).
+# Banner SHOULD fire — fallback fails open, primary tag check fails, so we
+# correctly nag.
+case_squash_no_changelog() {
+  local up; up=$(make_upstream)
+  local fk; fk=$(make_fork "$up")
+  (
+    cd "$fk"
+    git checkout -q main
+    git reset --hard HEAD~3 2>/dev/null
+    # Squash-merge but immediately blow away CHANGELOG.md (simulate a fork that
+    # doesn't keep the file). The release content is "absorbed" only via the
+    # source code, not the changelog.
+    git merge --squash upstream/main >/dev/null 2>&1
+    rm -f CHANGELOG.md && git add -A && git commit -q -m "chore: squash sync, no CHANGELOG"
+  )
+  assert "squash-merge but no CHANGELOG on fork → banner fires (no false silence)" "v1.1.0 available" "$(run_hook_from "$fk")"
+  rm -rf "$up" "$(dirname "$fk")"
+}
+
+case_squash_caught_up
+case_merge_commit_caught_up
+case_genuinely_behind
+case_fork_ahead
+case_squash_no_changelog
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED" >&2
+  exit 1
+fi
+exit 0

--- a/docs/agdr/AgDR-0008-changelog-fallback-for-squash-merged-forks.md
+++ b/docs/agdr/AgDR-0008-changelog-fallback-for-squash-merged-forks.md
@@ -1,0 +1,61 @@
+---
+id: AgDR-0008
+timestamp: 2026-04-25T05:00:00Z
+agent: claude
+model: claude-opus-4-7
+trigger: user-prompt
+status: executed
+---
+
+# CHANGELOG-fallback in check-upstream-drift.sh for squash-merged sync PRs
+
+> In the context of fork maintainers using GitHub's default squash-merge for `/update` sync PRs, facing the problem that the v1.1.0 tag-reachability check (`git tag --merged main`) returns nothing because squash collapses the upstream-tag commit into a synthetic SHA, I decided to add a CHANGELOG-content fallback (`grep ^## \[X.Y.Z\] CHANGELOG.md`) that fires when the tag check fails, to achieve correct silence on caught-up squash-merged forks without breaking the existing merge-commit / rebase paths, accepting that the fallback depends on apexyard maintaining its CHANGELOG with a stable heading format.
+
+## Context
+
+- Tag-based drift detection landed in v1.1.0 (AgDR-0005). It uses `git tag --list --merged "${DEFAULT_BRANCH}"` to ask "has the fork's main absorbed this tag?". The proxy: tag SHA is reachable from the fork's main → tag is "merged" → silent banner.
+- Squash-merge breaks this proxy. `git merge --squash` (the default for many GitHub repos via the "Squash and merge" button) collapses N upstream commits into one synthetic squash commit. The squash commit has no ancestor link to the upstream tag's target SHA. The tag stays unreachable from the fork's main → the hook says "vX.Y.Z available" forever, even though the fork is caught up content-wise.
+- Discovered on `me2resh/ops#10` (2026-04-23), the first real-world use of the v1.1.0 `/update` skill: ops fork merged via GitHub's default squash-merge, banner kept firing. Filed as `me2resh/apexyard#106`.
+- Squash-merge is GitHub's default on many repos. A drift hook that only works for non-default merge modes is a footgun.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Fork-tag convention** — after sync PR, manually tag fork main with upstream version | Trivial hook change, zero new deps | Manual step; easy to forget; same failure mode if forgotten |
+| **B. CHANGELOG-only check** — replace tag-reachability with CHANGELOG grep | Single source of truth | Loses the working merge-commit/rebase paths' clarity; pure CHANGELOG grep is brittle to format changes |
+| **C. Hybrid (tag primary + CHANGELOG fallback) — CHOSEN** | Preserves working paths intact; adds recovery path for squash-merge; no manual step; backward compat | CHANGELOG format dependency; if someone customises CHANGELOG headings, fallback breaks |
+| **D. Last-sync state file** — `/update` writes upstream SHA to a committed file at sync time | Most accurate; works for any merge mode | New file convention; requires the file to be committed (not gitignored); migration cost |
+
+## Decision
+
+Chosen: **Option C — Hybrid**. The tag-reachability primary keeps the v1.1.0 fast-path intact for forks that don't squash-merge (small content overhead, exactly the same behaviour). The CHANGELOG fallback fires only when the primary fails and saves the squash-merge case from the misfire. The CHANGELOG format dependency is acceptable because:
+
+1. apexyard owns the CHANGELOG; the format is stable (one team's discretion to evolve, with backward-compat heading patterns).
+2. The grep is intentionally tolerant — `^##\s+\[VERSION\]` matches heading variations, and the leading-`v` stripping handles the tag-vs-heading-prefix difference.
+3. The fallback is best-effort silence, not a hard claim. If a fork radically customises CHANGELOG and the fallback misses, the user sees an incorrect banner; running `/update` again proves there's no actual delta and the noise is one banner per session — annoying but not blocking.
+
+Option D was rejected for this round because it requires a new file convention (committed, not gitignored) and a migration story for existing forks. If C's CHANGELOG format dependency turns out to bite, revisit D as a follow-up.
+
+## Consequences
+
+**Kept:**
+- Tag-reachability primary check — unchanged. Forks using merge-commit or rebase workflows see exactly the same behaviour.
+- The `/update` skill — no skill change required. Existing flow works; the hook just tolerates squash-merge afterwards.
+- Tag-based drift's "actionable signal" promise — small upstream commits still don't fire.
+
+**Added:**
+- `changelog_has_version()` helper in the hook. Tolerant grep against `${DEFAULT_BRANCH}:CHANGELOG.md`.
+- Fallback fires in two paths: (1) `LOCAL_TAG` empty (first sync, squash-merged); (2) `UPSTREAM_TAG > LOCAL_TAG` by semver (intermediate sync, squash-merged).
+
+**Non-consequences (explicitly):**
+- No CHANGELOG schema enforcement. The hook is tolerant; the maintainer's discretion governs format.
+- No new committed state file. The fallback uses an existing artefact (`CHANGELOG.md`) that maintainers already keep current via `/release`.
+- No retroactive fix for forks already showing the misfire — they'll go silent the next time their fork's CHANGELOG has the upstream version's heading.
+
+## Artifacts
+
+- Implementing ticket: `me2resh/apexyard#106`
+- Hook diff: `.claude/hooks/check-upstream-drift.sh` (added `changelog_has_version` helper + two fallback gates)
+- Reference for CHANGELOG format: `CHANGELOG.md` on `me2resh/apexyard` `main` (v1.1.0 onward)
+- Prior decision this extends: AgDR-0005 (tag-based drift)

--- a/docs/agdr/AgDR-0008-changelog-fallback-for-squash-merged-forks.md
+++ b/docs/agdr/AgDR-0008-changelog-fallback-for-squash-merged-forks.md
@@ -21,7 +21,7 @@ status: executed
 ## Options Considered
 
 | Option | Pros | Cons |
-|--------|------|------|
+| -------- | ------ | ------ |
 | **A. Fork-tag convention** — after sync PR, manually tag fork main with upstream version | Trivial hook change, zero new deps | Manual step; easy to forget; same failure mode if forgotten |
 | **B. CHANGELOG-only check** — replace tag-reachability with CHANGELOG grep | Single source of truth | Loses the working merge-commit/rebase paths' clarity; pure CHANGELOG grep is brittle to format changes |
 | **C. Hybrid (tag primary + CHANGELOG fallback) — CHOSEN** | Preserves working paths intact; adds recovery path for squash-merge; no manual step; backward compat | CHANGELOG format dependency; if someone customises CHANGELOG headings, fallback breaks |
@@ -40,15 +40,18 @@ Option D was rejected for this round because it requires a new file convention (
 ## Consequences
 
 **Kept:**
+
 - Tag-reachability primary check — unchanged. Forks using merge-commit or rebase workflows see exactly the same behaviour.
 - The `/update` skill — no skill change required. Existing flow works; the hook just tolerates squash-merge afterwards.
 - Tag-based drift's "actionable signal" promise — small upstream commits still don't fire.
 
 **Added:**
+
 - `changelog_has_version()` helper in the hook. Tolerant grep against `${DEFAULT_BRANCH}:CHANGELOG.md`.
 - Fallback fires in two paths: (1) `LOCAL_TAG` empty (first sync, squash-merged); (2) `UPSTREAM_TAG > LOCAL_TAG` by semver (intermediate sync, squash-merged).
 
 **Non-consequences (explicitly):**
+
 - No CHANGELOG schema enforcement. The hook is tolerant; the maintainer's discretion governs format.
 - No new committed state file. The fallback uses an existing artefact (`CHANGELOG.md`) that maintainers already keep current via `/release`.
 - No retroactive fix for forks already showing the misfire — they'll go silent the next time their fork's CHANGELOG has the upstream version's heading.


### PR DESCRIPTION
## Summary

Fixes the bug from #106: the v1.1.0 tag-based drift hook keeps firing on forks that sync via GitHub's default squash-merge. The squash collapses the upstream-tag commit into a synthetic SHA, the tag becomes unreachable from the fork's main, and `git tag --merged main` returns empty — so the hook says "vX.Y.Z available" forever.

Adds a **CHANGELOG-content fallback** that fires only when the primary tag-reachability check fails. If the fork's main has a `## [X.Y.Z]` heading matching the upstream tag's version, the release is treated as absorbed and the banner stays silent.

- `changelog_has_version()` helper does a tolerant grep against `${DEFAULT_BRANCH}:CHANGELOG.md`. Strips leading `v` from the tag for the heading match.
- Two fallback gates: (1) `LOCAL_TAG` empty (first sync, squash-merged); (2) `UPSTREAM_TAG` strictly newer than `LOCAL_TAG` (intermediate sync, squash-merged).
- Merge-commit and rebase paths unchanged — the primary tag check still works for them, the fallback only kicks in on its failure.
- Records the strategy update in `docs/agdr/AgDR-0008-changelog-fallback-for-squash-merged-forks.md` (extends AgDR-0005's original tag-based-drift design).

## Why this approach

The ticket listed four options:

- **(A) Manual fork-tag convention** — relies on humans/skill to remember; same failure mode if forgotten
- **(B) Pure CHANGELOG check** — discards the working tag-reachability fast path
- **(C) Hybrid (chosen)** — preserves working merge-commit/rebase paths; adds recovery for squash-merge
- **(D) New committed state file** — most accurate but new file convention + migration cost

(C) is in-place: zero changes to the `/update` skill, zero new files outside the AgDR, zero migration story for existing forks. The CHANGELOG format dependency is acceptable because apexyard owns the CHANGELOG and the format is stable from v1.1.0 onward. AgDR-0008 documents the option table.

## Testing

5 cases in `.claude/hooks/tests/test_check_upstream_drift.sh`. Each builds a tiny upstream + fork pair under `$TMPDIR`, simulates a specific merge mode, runs the hook, asserts banner / silence:

```
$ bash .claude/hooks/tests/test_check_upstream_drift.sh
PASS [squash-merge fork caught up to v1.1.0 → silent (FIXED by #106)]
PASS [merge-commit fork caught up to v1.1.0 → silent]
PASS [fork stopped at v1.0.0 → banner fires]
PASS [fork has its own newer tag → silent]
PASS [squash-merge but no CHANGELOG on fork → banner fires (no false silence)]
PASS: 5   FAIL: 0
```

The fifth case is the critical "fail-open" check — a fork that squash-merges but doesn't keep CHANGELOG.md should NOT be silenced incorrectly. Regression-protected.

## Acceptance criteria (from #106)

- [x] After a squash-merged sync PR lands on a fork, the SessionStart banner goes silent
- [x] Fix doesn't regress merge-commit / rebase workflows (covered by case 2)
- [x] CHANGELOG + docs updated — AgDR-0008 added; CHANGELOG.md update lands with the v1.2.0 release entry
- [x] Regression test / verification recipe — `tests/test_check_upstream_drift.sh`

## Scope — what this does NOT do

- Does not modify the `/update` skill. Existing flow works as-is.
- Does not introduce a new committed state file (Option D — deferred; revisit if the CHANGELOG-format dependency turns out to bite).
- Does not retroactively fix forks already showing the misfire — they go silent the next time their fork's CHANGELOG has the upstream version's heading (typically: the next session after they manually drop a `## [X.Y.Z]` line into their fork's CHANGELOG, or after the next `/update` sync).

## Glossary

| Term | Definition |
|------|------------|
| Squash-merge | GitHub's default "Squash and merge" mode — collapses N commits in a PR into one synthetic commit on the target branch. Severs ancestor reachability to the source commits. |
| Tag reachability | `git tag --merged BRANCH` — does the tag's target SHA appear in BRANCH's ancestry? Reliable for merge-commit / rebase, not for squash-merge. |
| CHANGELOG fallback | Content-based "did we absorb this release" check via `^##\s+\[X.Y.Z\]` heading grep. Tolerant secondary signal. |
| Fail-open | If the fallback can't confirm absorption, fire the banner — don't silence on missing evidence. (Case 5 covers this.) |

Closes #106