### PR TITLE
feat(#130): /validate-idea skill — lightweight 5-question pre-spec gate

### DIFF
--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -461,12 +461,26 @@ Skipping the auto-append. If you want to add it later, copy this into apexyard.p
     roles: {derived list}
 ```
 
-### 8. Return a summary
+### 8. Offer validation (conditional, default-no)
+
+If the project looks **dormant** by the heuristic — last commit > 90 days ago AND zero open PRs AND no recent issue activity (rough thresholds, the skill can probe `gh repo view` + `gh pr list` + `gh issue list` to compute) — ask:
+
+```
+This project looks dormant — run /validate-idea {name} to confirm it's
+still worth investing in? y/n (default n)
+```
+
+If the user accepts, hand off to `/validate-idea {name}` (which reads the just-written `handover-assessment.md` as starting context and writes its output to `projects/{name}/validation/handover-validation.md`).
+
+If the project is healthy (recent commits, active PRs/issues), skip the prompt entirely. Don't ask "should I validate?" on every handover — only when the dormancy signal warrants it.
+
+### 9. Return a summary
 
 ```
 Handover assessment written: projects/{name}/handover-assessment.md
 Architecture stub:           projects/{name}/architecture/container.md ({written | preserved | skipped})
 Registry updated:            apexyard.projects.yaml ({added | skipped})
+Validation:                  {"completed — verdict <GREEN|YELLOW|RED>" | "skipped" | "not offered (project is active)"}
 
 Tech stack: {one-liner}
 Build: {ok / failed}

--- a/.claude/skills/idea/SKILL.md
+++ b/.claude/skills/idea/SKILL.md
@@ -174,6 +174,16 @@ The guiding principle: **the backlog entry is the primary artefact; the tracking
 
 If the issue is created successfully, append the issue URL to the backlog row's Description column as `(GH#NN)`.
 
+### 7. Offer validation (optional, default-no)
+
+After the GitHub Issue step (whether the user accepted or skipped it), ask:
+
+```
+Validate now? Run /validate-idea IDEA-NNN — y/n (default n)
+```
+
+Default-no respects the lightweight-capture intent of `/idea`. Most users batch-validate later. If the user accepts, hand off to `/validate-idea IDEA-NNN`; if they skip, proceed to step 8.
+
 ## Output
 
 ```
@@ -181,6 +191,7 @@ Captured: IDEA-NNN — {title}
 Backlog: {file path}
 Status: NEW
 Tracking issue: {url or "skipped"}
+Validation: {"completed — verdict <GREEN|YELLOW|RED>" | "skipped (run /validate-idea IDEA-NNN later)"}
 
 Next: triage with the team, then `/write-spec` if it survives.
 ```

--- a/.claude/skills/validate-idea/SKILL.md
+++ b/.claude/skills/validate-idea/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: validate-idea
+description: Lightweight 5-question idea validation. Sits between `/idea` and `/write-spec` as a 10-minute gate that catches "this isn't worth speccing" without heavyweight strategy ceremony. Invokable standalone or as an offered follow-up inside `/idea` and `/handover`.
+argument-hint: "<IDEA-NNN | project-name | free-form description>"
+allowed-tools: Bash, Read, Write
+---
+
+# /validate-idea — Pre-spec validation gate
+
+A 10-minute, 5-question check before committing the time of `/write-spec`. Most ideas should die before the PRD round; this skill makes that decision explicit. Invokable standalone, and offered as an optional follow-up step inside `/idea` (after capture) and `/handover` (when the project looks dormant).
+
+**What this is not.** Not Wardley mapping. Not event storming. Not business-model canvas. No scoring rubric. Five plain questions, one per turn, then a verdict.
+
+## Activated role
+
+When `/validate-idea` runs, activate the **[Product Manager](../../../roles/product/product-manager.md)** role for the validation read-out, with optional handoff to **[Head of Product](../../../roles/product/head-of-product.md)** if the verdict is `green` and a roadmap-impact call is needed. The role's "is this worth doing?" lens is exactly the right perspective.
+
+See `.claude/rules/role-triggers.md` for the activation protocol.
+
+## Usage
+
+```
+/validate-idea IDEA-042              # validate a backlog entry by ID
+/validate-idea curios-dog            # validate a registered project (handover follow-up)
+/validate-idea AI-powered linter     # free-form description (no IDEA-NNN yet)
+```
+
+## Process
+
+### 1. Resolve the input
+
+- **`IDEA-NNN` form** — read `projects/ideas-backlog.md`; pull the row's title + one-line description as starting context. Output path: `projects/<project>/validation/<IDEA-NNN>-validation.md` (or `projects/_inbox/validation/<IDEA-NNN>-validation.md` if the IDEA hasn't been assigned to a project yet).
+- **Project-name form** — read `apexyard.projects.yaml`; pull the project's README + handover-assessment if available, as starting context. Output path: `projects/<project>/validation/handover-validation.md`.
+- **Free-form description** — slugify the title; output path: `projects/_inbox/validation/<slug>.md`.
+
+If the input is ambiguous or absent, ask:
+
+```
+What are you validating? An IDEA-NNN, a project name, or a free-form pitch?
+```
+
+### 2. Show the starting context
+
+Print whatever you pulled from step 1 (3-5 lines max), so the user can read what the skill *thinks* the idea is before answering questions. If the user disagrees, they can correct in their first answer.
+
+### 3. Ask the five questions — ONE AT A TIME
+
+Never batch. Wait for the answer before asking the next.
+
+#### Q1 — Target user
+
+```
+Who specifically is this for? Be concrete — a role, a context, a moment of need.
+"Everyone" is a red flag; "freelance designers who manage three or more
+client invoices a month" is the right level.
+```
+
+If the answer is "everyone" / "anyone" / vague: probe once with `Pick the narrowest plausible group — even if you'll expand later. Who would benefit MOST from this in the first 30 days?`
+
+#### Q2 — Current alternative
+
+```
+What do they do today instead?
+```
+
+Possible answers: a competitor product (specific name), a manual workaround (e.g. "a spreadsheet"), or "nothing — it's just an unmet need." If "nothing", probe: `If there's no alternative, the gap is either real-but-low-priority or fictional. Which? What evidence?`
+
+#### Q3 — Smallest version that proves the value
+
+```
+What's the smallest thing you could build that would prove this is valuable?
+1-2 days of work, max. Not "the MVP" — the SMALLEST testable slice.
+```
+
+If the answer is large (≥ 1 week of work): probe `Cut it in half. What's the half that, if it works, tells you the rest is worth building?`
+
+#### Q4 — Kill criteria
+
+```
+What would prove this is wrong? What would you observe — concretely —
+that would tell you to park this?
+```
+
+This question is the one most ideas can't answer cleanly. Inability to articulate kill criteria is itself signal — note it in the output.
+
+#### Q5 — Build, buy, or rent
+
+```
+Is this:
+  - BUILD (genuinely differentiating — your moat is the implementation)
+  - BUY / OSS (commodity — someone has already shipped this; just adopt)
+  - RENT (utility — pay a SaaS, don't build infrastructure for it)
+```
+
+If the answer is "build" but Q2's alternative is a working competitor product, probe: `If <competitor> already does this, what's your specific angle they don't have? If "I'd do it better" — that's not a moat; surface a real differentiator or move to BUY.`
+
+### 4. Synthesise the verdict
+
+Read all five answers together. Score in the **PM's** head (no rubric — this is a judgement call):
+
+- **GREEN** — Q1 is concrete, Q2 has a clear alternative being beaten, Q3 fits in 1-2 days, Q4 is articulable, Q5 is BUILD with a real differentiator. Proceed to `/write-spec`.
+- **YELLOW** — One or two answers are weak; the idea has a kernel but needs reshaping. Park for revision; revisit in a week with sharper answers.
+- **RED** — Two or more answers are weak, OR Q5 is "build" with no differentiation, OR Q4 has no kill criteria. Park as `WONTDO`.
+
+The verdict is a one-line statement at the bottom of the output, in bold, with a one-sentence reason.
+
+### 5. Write the validation document
+
+Output template (~50 lines):
+
+```markdown
+# {Title} — Validation
+
+**Date**: YYYY-MM-DD
+**Source**: {IDEA-NNN | project name | free-form}
+**Verdict**: **{GREEN | YELLOW | RED}** — {one-sentence reason}
+
+## Starting context
+
+{3-5 lines from step 2}
+
+## Q1. Target user
+
+{user's answer + any probe response}
+
+## Q2. Current alternative
+
+{user's answer}
+
+## Q3. Smallest version
+
+{user's answer}
+
+## Q4. Kill criteria
+
+{user's answer; note explicitly if it was hard to articulate}
+
+## Q5. Build / buy / rent
+
+{user's answer + any probe}
+
+## Read-out
+
+{2-4 sentences synthesising the answers — what stood out, what's strong,
+what's weak}
+
+## Next step
+
+{ONE of:
+  - GREEN → "Proceed to `/write-spec {title}`."
+  - YELLOW → "Park for {N} days. Revisit when {sharpening criterion} is in place."
+  - RED → "Archive. Updating `projects/ideas-backlog.md` row to status WONTDO."
+}
+```
+
+### 6. Side effects on the verdict
+
+- **GREEN** — leave the IDEA-NNN backlog row at `NEW` (or whatever it was). The skill does NOT advance status; that's `/write-spec`'s job.
+- **YELLOW** — leave the row unchanged; add a comment in the validation doc noting the revisit date.
+- **RED** — if input was an IDEA-NNN, update the row in `projects/ideas-backlog.md`: change `Status` from current to `WONTDO`. Append a one-line reason to the row's notes.
+
+### 7. Confirm
+
+```
+Validation written: projects/<...>/validation/<...>-validation.md
+Verdict: {GREEN | YELLOW | RED}
+{Side effect, if any: "ideas-backlog.md updated to WONTDO." | nothing}
+```
+
+## Rules
+
+1. **One question at a time.** Never batch. The whole point is making the user *think* between answers.
+2. **No scoring rubric.** Verdict is a PM judgement call, not a numeric average.
+3. **Probes are at most one per question.** If the user's answer is still weak after one probe, capture it as-is and let it surface in the verdict.
+4. **No competitive research.** The skill doesn't crawl the web for alternatives — Q2's "what do they do today?" is the user's own observation.
+5. **Output is one page.** Synthesis section ≤ 4 sentences. Read-out should fit on one screen.
+6. **`RED` updates the backlog automatically** — `WONTDO` is a recoverable state (the row stays); no destruction.
+7. **`GREEN` does NOT auto-trigger `/write-spec`.** The user makes that call. Decoupling validation from spec-authoring keeps each step's intent explicit.
+
+## Integration with sibling skills
+
+### `/idea`
+
+After the IDEA-NNN is captured (and the optional GitHub Issue is offered), `/idea` adds a third optional step:
+
+```
+Validate now? Run /validate-idea {IDEA-NNN} — y/n (default n)
+```
+
+Default-no respects `/idea`'s lightweight-capture intent. Most users batch-validate later.
+
+### `/handover`
+
+At the end of the integration-plan emit, IF the project is dormant by the heuristic (last commit > 90 days ago AND zero open PRs AND no recent issue activity), `/handover` adds:
+
+```
+This project looks dormant — run /validate-idea {project-name} to confirm
+it's still worth investing in? y/n (default n)
+```
+
+Healthy active projects don't see the prompt. Dormant ones do.
+
+## Anti-pattern
+
+```
+User: /validate-idea AI-powered grocery picker
+Agent: [batches all 5 questions in one message]
+       1. Who is this for?
+       2. What's the alternative?
+       3. Smallest version?
+       4. Kill criteria?
+       5. Build, buy, or rent?
+```
+
+Wrong. Batching defeats the validation purpose — the user gives surface-level answers without thinking. Ask one, wait, then the next.
+
+## Related
+
+- `/idea` — captures the idea pre-validation
+- `/write-spec` — authors the PRD post-validation (only on GREEN)
+- `/decide` — captures the technical decision once the spec is in flight
+- The Mom Test (Rob Fitzpatrick) — companion reading; covers Q1 and Q2 in much more depth for live customer interviews

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Hooks | `.claude/hooks/` | 18 shell scripts that mechanically enforce SDLC rules — ticket-first, migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner |
 | Rules | `.claude/rules/` | 9 modular rule files (AgDR triggers, code standards, git conventions, parallel work, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer, Security Reviewer, Dependency Auditor, PR Manager, Ticket Manager) |
-| Skills | `.claude/skills/` | 34 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 35 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
 ### Available skills (34)
@@ -203,6 +203,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | `/security-review` | Invoke the Security Reviewer agent (Shield) on a PR |
 | `/audit-deps` | Audit dependencies for vulnerabilities, outdated packages, licences |
 | `/write-spec` | Generate a PRD or feature spec from a problem statement |
+| `/validate-idea` | Lightweight 5-question pre-spec gate (target user, alternative, smallest version, kill criteria, build/buy/rent). Invokable standalone or as an offered follow-up inside `/idea` and `/handover`. |
 | `/feature` | Create a structured feature request ticket (user story + ACs) |
 | `/bug` | Create a structured bug report (Given/When/Then + repro + severity) |
 | `/task` | Create a structured technical task ticket (driver + scope + ACs) |
@@ -255,7 +256,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Hooks | `.claude/hooks/` |
 | Rules (modular) | `.claude/rules/` |
 | Agents | `.claude/agents/` |
-| Skills (34 slash commands) | `.claude/skills/` |
+| Skills (35 slash commands) | `.claude/skills/` |
 | Hook wiring | `.claude/settings.json` |
 | **Per-project docs** | `projects/<name>/` |
 | **Live working copies** (gitignored) | `workspace/<name>/` |


### PR DESCRIPTION
## User Story

As a solo founder running ApexYard, I want a lightweight 5-question idea-validation skill I can invoke either standalone (`/validate-idea IDEA-NNN`) or as an offered follow-up step inside `/idea` and `/handover`, so that I have a 10-minute pre-spec gate that catches "this idea isn't worth a PRD" without needing event storming, Wardley mapping, or any heavyweight strategy ceremony.

## Summary

New skill at `.claude/skills/validate-idea/SKILL.md`. Five questions (target user, current alternative, smallest version, kill criteria, build/buy/rent), asked one at a time, ending in a **GREEN / YELLOW / RED** verdict. RED automatically updates the IDEA-NNN row in `projects/ideas-backlog.md` to `WONTDO`.

Two integrations:

- **`/idea`** — at the end of the capture flow (after the optional GitHub Issue offer), a third optional step: *"Validate now? Run /validate-idea IDEA-NNN — y/n (default n)"*. Default-no respects the lightweight-capture intent.
- **`/handover`** — at the end of the integration-plan emit, a conditional offer gated on a dormancy heuristic (last commit > 90 days AND zero open PRs AND no recent issue activity). Active projects don't see the prompt; dormant ones do.

## Why this and not something heavier

The user-and-I pair-debated the "should we add validation tooling?" question and rejected event storming + Wardley mapping as too heavy for the audience (solo founders). Both are 4–5-stakeholder workshops, neither fits the "single-Claude-session, 10 minutes max" shape ApexYard's other skills hold to (`/idea`, `/decide`, `/write-spec`).

The lighter alternative — five plain questions with a one-page output — fits. It nudges the user to think falsifiably (Q4 — kill criteria) and surface the build-or-rent call early (Q5), without imposing a methodology.

## Testing

Skills are markdown specs — no shell test fixture. Conformance is exercised by the agent following the spec.

Smoke check on the skill structure:

```bash
# Front-matter has the standard fields
head -10 .claude/skills/validate-idea/SKILL.md

# Five questions, one per turn — verify the spec calls out "ONE AT A TIME"
grep -c "ASK ONE AT A TIME\|one at a time" .claude/skills/validate-idea/SKILL.md
# Expect: ≥ 1

# Verdict path includes side effects on RED
grep -A 1 "RED.*backlog" .claude/skills/validate-idea/SKILL.md
```

The actual dogfood will be the next idea I capture — the spec is followable as-is.

## Scope — what this does NOT do

- **No automated competitive research.** Q2 ("what do they do today?") is the user's own observation, not a skill that crawls the web.
- **No scoring rubric.** Verdict is a PM judgement call (Product Manager role activates for the read-out). Tried scoring rubrics; they're either too coarse or too detailed for one page.
- **No auto-trigger of `/write-spec` on GREEN.** The user makes that call separately. Decoupling validation from spec-authoring keeps each step's intent explicit.
- **No event storming, no Wardley mapping.** Out of scope by design — wrong methodology weight for solo founders. Captured in the skill's "Out of scope" + the issue body.

## Glossary

| Term | Definition |
|------|------------|
| Validation gate | The lightweight pre-spec check this skill performs. Sits between `/idea` capture and `/write-spec` PRD authoring. |
| Kill criteria | Concrete observable signals that would end the experiment — what data would tell you "this is wrong"? Most ideas can't articulate this clearly; that's signal. |
| Build / buy / rent | Three positions for any capability: build it (differentiating), buy/use OSS (commodity), or rent SaaS (utility). Forcing this question kills the "build everything" default. |
| Dormancy heuristic | For `/handover`'s integration: last commit > 90d AND zero open PRs AND no recent issue activity. Triggers the "validate this is worth investing in?" prompt. |

Closes #130