### PR TITLE
docs(#143): document split-portfolio mode + add /setup privacy gate

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -41,6 +41,48 @@ GitHub Issues for tracking, 1-week sprints."
 
 **Do NOT ask sequential questions.** The whole point of this skill is to collapse the discovery into one natural-language exchange. The user describes their world; you parse it.
 
+### Step 2a: Privacy gate — ask if any projects are private
+
+Before parsing the description into config, ask one privacy question — this determines whether the adopter needs single-fork or split-portfolio mode (see `docs/multi-project.md`):
+
+```
+Quick one before I propose your config: are any of the projects you'll
+manage on this fork private (i.e. not visible to the public)?
+
+Why I'm asking: GitHub Free disallows changing a fork's visibility, so
+the standard fork-and-commit setup will silently publish your private
+project names on a public GitHub repo. If any project is private, I'll
+walk you through the split-portfolio mode (a separate private repo for
+the registry, public fork stays slim).
+
+[y / n / "I'm on GitHub Pro/Team/Enterprise" — last option supports
+private forks of public repos and avoids the issue.]
+```
+
+Branch on the answer:
+
+- **n** (all projects public) → continue with **single-fork mode** (default; the rest of this skill applies as-is).
+- **paid plan** (Pro / Team / Enterprise) → continue with **single-fork mode**, but mention that the registry will be on the (private-fork-eligible) fork and is fine.
+- **y** (any private projects on GitHub Free) → switch to **split-portfolio mode** (Step 2b below).
+
+Detection of an existing setup: if `git remote get-url origin` resolves to a fork that contains a symlinked `apexyard.projects.yaml` (i.e. `test -L apexyard.projects.yaml`), the adopter is already in split-portfolio mode — skip Step 2b and proceed normally with the registry behind the symlink.
+
+### Step 2b: Walk through split-portfolio mode (only if Step 2a triggered)
+
+The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — public framework + private portfolio". This skill should walk through it interactively rather than dumping the doc:
+
+1. **Confirm the layout**: "Two repos in your account: `your-org/apexyard` (public, this fork) + `your-org/<private-name>` (new private repo for the portfolio). Both clones sit side-by-side on disk. OK?"
+2. **Pick the private repo name**: default suggestion `your-org/ops`. Operator confirms or overrides.
+3. **Create the private repo**: `gh repo create your-org/<name> --private --description "..."`. Confirm before running.
+4. **Clone the private repo as a sibling**: `cd .. && gh repo clone your-org/<name> portfolio`.
+5. **Initialise the portfolio**: `apexyard.projects.yaml` + empty `projects/` dir + initial commit + push. Same content as the doc's step 5.
+6. **Gitignore + symlink in the fork**: append `.gitignore` lines for `apexyard.projects.yaml` + `projects`, untrack any tracked `projects/README.md` from the upstream framework, create symlinks pointing at `../portfolio/apexyard.projects.yaml` and `../portfolio/projects`. Stage `.gitignore` for commit; the symlinks themselves are gitignored.
+7. **Verify**: `test -L apexyard.projects.yaml && test -L projects` → both should report symlinks. Confirm to the operator.
+
+Then proceed to Step 3 with the user's earlier description, configuring `onboarding.yaml` as normal. The rest of the skill is unchanged — the only difference between modes is where the registry physically lives.
+
+**Do NOT auto-migrate** an adopter who's already in single-fork mode with private project names already pushed. Direct them to the migration guide in `docs/multi-project.md` § "Migrating from single-fork to split-portfolio" — that flow involves a force-push history rewrite, redacting GitHub Issue / PR bodies, and a backup-branch dance, and is destructive enough to warrant a deliberate, eyes-open run rather than a `/setup` side-effect.
+
 ### Step 3: Parse and map to defaults
 
 From the user's description, extract:

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -6,9 +6,26 @@ ApexYard governs a **portfolio of repos as one organisation**. You fork apexyard
 
 ---
 
-## TL;DR
+## Two setup modes — pick the one that matches your privacy needs
 
-| | ApexYard |
+ApexYard ships two supported patterns. **Read this section before you fork** — picking the wrong one and pushing private project names to a public fork is hard to recover from cleanly (the GitHub PR / Issue edit history survives a force-push).
+
+| | Single-fork mode (default) | Split-portfolio mode |
+| --- | --- | --- |
+| **Repos** | One: your fork of `me2resh/apexyard` | Two: public fork **+** a separate private repo for the portfolio |
+| **Where the registry lives** | `apexyard.projects.yaml` in the fork | `apexyard.projects.yaml` in the private repo, symlinked into the fork |
+| **Where `projects/<name>/` lives** | Inside the fork | Inside the private repo, symlinked into the fork |
+| **Public exposure** | Every registered project name + handover finding is on a public GitHub repo | Public fork holds only framework files; private repo holds your portfolio data |
+| **Daily workflow** | Same | Same — skills resolve through the symlinks transparently |
+| **Pick this if…** | All your projects are already public, OR you're on GitHub Pro / Team / Enterprise (which support private forks of public repos) | You're on GitHub Free with any project you don't want named publicly |
+
+**The trip-wire**: GitHub Free disallows changing a fork's visibility — you cannot make a fork of a public repo private after the fact. Combined with the framework's default of committing the registry to the fork, free-tier adopters with any private project silently publish their portfolio names the moment they push. The split-portfolio mode below is the supported way around this.
+
+---
+
+## TL;DR — single-fork mode (default)
+
+| | ApexYard (single-fork) |
 | --- | --- |
 | **What you install** | A fork of `me2resh/apexyard`, cloned locally. No `.apexyard/` symlinks, no nested installs. |
 | **What governs the portfolio** | `apexyard.projects.yaml` at the root of your fork |
@@ -16,7 +33,9 @@ ApexYard governs a **portfolio of repos as one organisation**. You fork apexyard
 | **Where live working copies live** | `workspace/<name>/` inside your fork, gitignored |
 | **Where the registry, roadmap, ideas, updates live** | All inside your fork, alongside the apexyard primitives |
 | **How upgrades flow** | `git pull upstream main` from `me2resh/apexyard` |
-| **Best for** | CTOs, engineering leads, Chief-of-Staff roles managing 2+ repos (or 1 repo with intent to grow) |
+| **Best for** | CTOs, engineering leads, Chief-of-Staff roles managing 2+ repos (or 1 repo with intent to grow) — **all projects public, OR you have GitHub Pro / Team / Enterprise** |
+
+If you need privacy, jump to the [split-portfolio setup](#split-portfolio-mode--public-framework--private-portfolio) further down.
 
 ---
 
@@ -131,6 +150,154 @@ You should see one row per registered project. Then:
 ```
 
 Each aggregates across every registered project. You're live.
+
+---
+
+## Split-portfolio mode — public framework + private portfolio
+
+Use this mode if you're on GitHub Free with any project you don't want named publicly. The fork stays public + upstream-aligned; a separate private repo holds the registry + per-project docs.
+
+### Layout
+
+```
+~/ops/
+├── apexyard/         ← public fork of me2resh/apexyard (framework code + tooling)
+└── portfolio/        ← private repo (registry + per-project docs — never goes public)
+```
+
+Both repos live in your account; on disk they sit side-by-side. Inside the apexyard fork, `apexyard.projects.yaml` and `projects/` are symlinks into the portfolio repo (and gitignored from the fork itself), so all the existing skills work without modification.
+
+### Setup — 7 steps, ~6 minutes
+
+#### 1. Fork apexyard on GitHub
+
+Same as single-fork mode. Visit [`github.com/me2resh/apexyard`](https://github.com/me2resh/apexyard) → click **Fork**. Lands in your account as `your-org/apexyard` (public). Keep the name as `apexyard`.
+
+#### 2. Create an empty private repo for your portfolio
+
+```bash
+gh repo create your-org/ops --private \
+  --description "ApexYard private portfolio: registry + per-project handover docs"
+```
+
+`your-org/ops` is the conventional name; pick whatever you like. The framework doesn't care about the name — only the local path.
+
+#### 3. Clone both side-by-side
+
+```bash
+mkdir ~/ops && cd ~/ops
+gh repo clone your-org/apexyard
+gh repo clone your-org/ops portfolio
+```
+
+Resulting layout:
+
+```
+~/ops/
+├── apexyard/         ← public fork
+└── portfolio/        ← private (currently empty)
+```
+
+#### 4. Add `upstream` for future updates
+
+```bash
+cd ~/ops/apexyard
+git remote add upstream https://github.com/me2resh/apexyard.git
+```
+
+#### 5. Initialise the private portfolio
+
+```bash
+cd ~/ops/portfolio
+
+cat > apexyard.projects.yaml <<EOF
+version: 1
+projects: []
+defaults:
+  status: active
+  ticket_prefix: GH
+EOF
+
+mkdir projects
+
+git add apexyard.projects.yaml projects
+git commit -m "chore: initialise private portfolio"
+git push
+```
+
+#### 6. Gitignore the portfolio paths in the fork + symlink
+
+```bash
+cd ~/ops/apexyard
+
+# Tell the fork to ignore the registry + projects/ — they live in the portfolio.
+cat >> .gitignore <<'EOF'
+
+# Portfolio data lives in a separate private repo (split-portfolio mode).
+# See docs/multi-project.md.
+apexyard.projects.yaml
+projects
+EOF
+
+# If projects/README.md is currently tracked from the upstream framework,
+# untrack it so the symlink can take its place:
+git rm -r --cached projects 2>/dev/null || true
+
+# Symlink the registry and projects/ into the portfolio repo:
+ln -s ../portfolio/apexyard.projects.yaml apexyard.projects.yaml
+ln -s ../portfolio/projects projects
+
+git add .gitignore
+git commit -m "chore: configure split-portfolio mode (registry + projects/ in private sibling repo)"
+git push
+```
+
+#### 7. Verify
+
+From the fork dir:
+
+```bash
+cd ~/ops/apexyard
+/projects   # should resolve through the symlink and report 0 entries (or whatever's in your portfolio)
+```
+
+Adopt your first project with `/handover` — it writes to `../portfolio/projects/<name>/` and appends to `../portfolio/apexyard.projects.yaml`, both committed only to the private portfolio repo. The public fork stays slim.
+
+### Daily workflow under split mode
+
+```bash
+cd ~/ops/apexyard      # framework changes go here, push to public fork
+cd ~/ops/portfolio     # registry + project docs changes go here, push to private repo
+```
+
+Most ApexYard skills (`/projects`, `/inbox`, `/status`, `/tasks`, `/stakeholder-update`, `/handover`) work from the apexyard dir — they resolve paths through the symlinks. Skills that touch framework files only (`/update`, `/release`) operate on the apexyard dir alone.
+
+### Upstream sync under split mode
+
+`/update` works the same. The upstream framework occasionally ships changes to `projects/README.md` (the framework's per-project docs convention). After the symlink, your fork's `projects/README.md` is replaced by the portfolio's own README. If a future upstream sync wants to update `projects/README.md`, you'll see a conflict; resolve by either accepting the upstream version (re-tracks the file, replacing the symlink behaviour for that one path) or keeping your symlink. Most upstream releases don't touch this file.
+
+### What this mode trades off
+
+- **Two repos to maintain** instead of one. Both live in the same GitHub account; trivial overhead.
+- **Two clones on each machine.** Cross-machine setup is `gh repo clone your-org/apexyard && gh repo clone your-org/ops portfolio` instead of one clone.
+- **No automatic GitHub-UI fork-of-the-portfolio.** The portfolio repo is independent. Backups happen via your normal git push to your private GitHub repo.
+- **One conflict path on `/update`** (the `projects/README.md` case above). Resolved manually if it ever fires.
+
+In exchange, **zero of your private project names ever land on a public GitHub repo**, ever.
+
+### Migrating from single-fork to split-portfolio
+
+If you've already started in single-fork mode and pushed private project names to your public fork, the recovery flow is:
+
+1. Push the current public fork's main to a backup branch (`backup-pre-rewrite`) for safety.
+2. Reset main to the commit before the bulk-handover (or use `git filter-repo` for older history) to remove the registry + `projects/` from public main.
+3. Force-push main.
+4. Create the private portfolio repo and push the extracted registry + `projects/` content into it.
+5. Symlink + gitignore as in step 6 above.
+6. **Redact any GitHub Issue or Pull Request bodies** that named the projects — `gh issue edit <n> --body-file ...` and `gh pr edit <n> --body-file ...`. The original text survives in the timeline API but is hidden from casual viewers + search engines.
+7. Delete the backup branch after a soak window.
+
+A `/split-portfolio` migration helper to automate this flow is tracked at [me2resh/apexyard#143](https://github.com/me2resh/apexyard/issues/143). Until that ships, the steps above are manual.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the **silent privacy bug** for adopters on GitHub Free with any private project. Today's `docs/multi-project.md` instructs them to fork apexyard and commit `apexyard.projects.yaml` + `projects/<name>/` to that fork — but a fork of a public repo cannot be made private on GitHub Free, so private project names land on a public GitHub repo the moment they push.

This PR is the **docs + setup-question minimum-viable starter**:

- Documents the two supported modes (`single-fork` default; `split-portfolio` for adopters with privacy needs)
- Adds an upfront privacy gate to `/setup` that branches on the adopter's plan + project mix
- Walks through the split-portfolio setup step-by-step

The framework code refactor (`portfolio:` config block in `onboarding.yaml` + audit of every skill that hardcodes the registry path) is **out of scope** for this PR — tracked separately on #143. Until that lands, the split-portfolio mode works via manual symlinks (`ln -s ../portfolio/apexyard.projects.yaml ...`) which are documented here.

Targets `dev` per the apexyard release-cut model.

## What changes

`docs/multi-project.md` (+170 lines, -3):

- New **"Two setup modes — pick the one that matches your privacy needs"** section before TL;DR, with a side-by-side comparison table and the explicit trip-wire callout
- TL;DR retitled `TL;DR — single-fork mode (default)` with a one-line pointer down
- New **"Split-portfolio mode — public framework + private portfolio"** section with:
  - Layout diagram (`~/ops/apexyard/` + `~/ops/portfolio/`)
  - 7-step copy-pasteable setup walkthrough
  - Daily workflow + upstream-sync notes
  - Trade-offs (two repos, two clones per machine, one upstream-sync conflict path)
  - Migration recovery flow for adopters already in single-fork mode with private names pushed

`.claude/skills/setup/SKILL.md` (+42 lines):

- **Step 2a — privacy gate**: asks once whether any projects are private + branches on the answer (all-public → single-fork; paid plan → single-fork; private + GitHub Free → split mode)
- **Step 2b — split-portfolio walk-through**: interactive private-repo create + sibling clone + gitignore + symlink. Auto-detected if already in split mode (`test -L apexyard.projects.yaml`).
- Explicit **do-NOT-auto-migrate** rule for adopters already with private names committed — the recovery flow is destructive and warrants a deliberate run.

## Why "docs + question" is enough for now

The split-portfolio mode is **fully functional today** with the two manual steps the docs describe (`ln -s ...` + `.gitignore`). Every existing skill resolves through the symlinks transparently — no skill change is required for the pattern to work.

Reference implementation: `atlas-apex/apexyard` (public fork, slim) + `atlas-apex/ops` (private portfolio) — set up by the adopter who hit the trip-wire on 2026-05-02. Daily workflow has been working through symlinks for one full session without issue.

## Testing

1. **Markdownlint** — `markdownlint-cli2 docs/multi-project.md .claude/skills/setup/SKILL.md` (CI runs it).
2. **Lychee link-check** — internal anchor `#split-portfolio-mode--public-framework--private-portfolio` resolves; external links (`github.com/me2resh/apexyard`) are not new.
3. **Manual setup walkthrough** — follow the new 7-step split-portfolio section from a fresh fork and verify `/projects` resolves through the symlink at the end. (Verified by the reference adopter; capture as a test in a follow-up if useful.)
4. **Backward compatibility** — single-fork mode (the default) is **unchanged**. Existing adopters who don't touch `/setup` again or follow the new section continue working exactly as before.

## Out of scope (tracked on #143)

- `portfolio:` config block in `onboarding.yaml` schema with `registry`, `projects_dir`, `ideas_backlog` fields
- Skill audit + refactor — every skill that reads the registry currently hardcodes the path. Migrating to honour the config block is mechanical (~10 skills) but warrants its own PR for clean review
- `/split-portfolio` migration helper skill — automates the recovery flow for existing single-fork adopters who hit the trip-wire (force-push history rewrite + redact issue/PR bodies + create private repo + symlink)
- `/setup --reset` or similar to opt-out of the privacy gate when re-running on a configured fork

## Refs

- Closes none — this is the docs-and-setup-question subset of #143
- Refs #143

## Glossary

| Term | Definition |
|------|------------|
| **Single-fork mode** | Today's setup: registry + per-project docs live inside the fork itself. Works fine for all-public portfolios or paid GitHub plans (Pro / Team / Enterprise) that support private forks of public repos. |
| **Split-portfolio mode** | New supported pattern documented in this PR: public fork holds framework files, separate private repo holds the portfolio (registry + per-project docs). Two repos, both in the adopter's account, side-by-side on disk. |
| **Trip-wire** | The silent privacy bug GitHub Free adopters hit with single-fork mode + any private project: GitHub disallows `git fetch`-ing a public fork into a private one, and there's no way to make a fork private after the fact, so the registry's private project names end up published on a public GitHub repo. |
| **Privacy gate (Step 2a)** | New `/setup` question that branches the configuration flow on whether any of the adopter's projects are private + which GitHub plan they're on. Single message, three answers, prevents the trip-wire by default. |
| **Symlink-based portability** | The split-portfolio mode works with the current framework (no skill changes needed) because `apexyard.projects.yaml` and `projects/` are symlinks pointing at the private portfolio repo. Skills resolve through the symlinks transparently. The `portfolio:` config block (#143 follow-up) replaces this with a first-class config option. |
| **Recovery flow** | Documented manual steps for adopters who already hit the trip-wire — force-push history rewrite to remove the registry from public main, redact GitHub Issue / PR bodies, push a backup branch first, then migrate to split mode. The flow has one irreducible caveat: GitHub Issue / PR edit history survives force-pushes (timeline API), so redaction is partial. |
