### PR TITLE
feat(#145): portfolio config + self-healing + /split-portfolio helper

### DIFF
--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# _lib-portfolio-paths.sh — resolve portfolio paths from project-config.
+#
+# Source this library from any hook or skill that reads/writes the
+# portfolio registry, per-project docs dir, or ideas backlog. Reads the
+# `portfolio` block from .claude/project-config.{defaults,}.json (via
+# _lib-read-config.sh's `config_get_or`).
+#
+# Usage:
+#   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+#   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+#   registry=$(portfolio_registry)
+#   projects_dir=$(portfolio_projects_dir)
+#   ideas_backlog=$(portfolio_ideas_backlog)
+#   portfolio_validate || echo "broken: $(portfolio_validate)"
+#
+# All resolvers output absolute paths. Relative config values resolve
+# against the ops-fork root (dir containing both onboarding.yaml and
+# apexyard.projects.yaml). Outside an apexyard fork the resolvers fall
+# back to the current git toplevel; outside any git repo they output
+# the relative literal so callers can detect the no-fork state.
+#
+# Defaults (when config is missing entirely):
+#   registry      → ./apexyard.projects.yaml
+#   projects_dir  → ./projects
+#   ideas_backlog → ./projects/ideas-backlog.md
+#
+# Caching: results cached per-process in shell vars to avoid repeat jq
+# calls. Same pattern as _CONFIG_CACHE in _lib-read-config.sh.
+
+# ------------------------------------------------------------------------------
+# Internal: resolve the ops-fork root (dir with onboarding.yaml AND
+# apexyard.projects.yaml). Walks up from the git toplevel.
+# Falls back to git toplevel if not inside an apexyard fork.
+# ------------------------------------------------------------------------------
+_PORTFOLIO_ROOT_CACHE=""
+_portfolio_root() {
+  if [ -n "$_PORTFOLIO_ROOT_CACHE" ]; then
+    echo "$_PORTFOLIO_ROOT_CACHE"
+    return 0
+  fi
+
+  local r
+  r=$(git rev-parse --show-toplevel 2>/dev/null) || r=""
+  if [ -z "$r" ]; then
+    # Outside any git repo — caller decides what to do.
+    return 0
+  fi
+
+  local cur="$r"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      _PORTFOLIO_ROOT_CACHE="$cur"
+      echo "$cur"
+      return 0
+    fi
+    cur=$(dirname "$cur")
+  done
+
+  # Not under an apexyard fork — fall back to git toplevel so callers
+  # working inside a managed-project clone (workspace/<name>/) still get
+  # a sensible-ish answer (their own clone root).
+  _PORTFOLIO_ROOT_CACHE="$r"
+  echo "$r"
+}
+
+# ------------------------------------------------------------------------------
+# Internal: resolve a possibly-relative path against the ops-fork root.
+# Outputs an absolute path. If the input is already absolute, echo as-is.
+# ------------------------------------------------------------------------------
+_portfolio_resolve() {
+  local p="$1"
+  case "$p" in
+    /*) echo "$p" ;;
+    *)
+      local root
+      root=$(_portfolio_root)
+      if [ -n "$root" ]; then
+        # Strip leading ./ for tidier output.
+        echo "$root/${p#./}"
+      else
+        # No root — return the literal so caller can detect.
+        echo "$p"
+      fi
+      ;;
+  esac
+}
+
+# ------------------------------------------------------------------------------
+# Internal: resolve one config key with a default. Source _lib-read-config.sh
+# if it isn't already loaded (idempotent — sourcing twice is fine).
+# ------------------------------------------------------------------------------
+_portfolio_get() {
+  local key="$1"
+  local fallback="$2"
+
+  if ! command -v config_get_or >/dev/null 2>&1; then
+    local root
+    root=$(_portfolio_root)
+    if [ -n "$root" ] && [ -f "$root/.claude/hooks/_lib-read-config.sh" ]; then
+      # shellcheck source=/dev/null
+      . "$root/.claude/hooks/_lib-read-config.sh"
+    fi
+  fi
+
+  if command -v config_get_or >/dev/null 2>&1; then
+    config_get_or "$key" "$fallback"
+  else
+    echo "$fallback"
+  fi
+}
+
+# ------------------------------------------------------------------------------
+# Public resolvers — each outputs an absolute path.
+# Cached per-process.
+# ------------------------------------------------------------------------------
+_PORTFOLIO_REGISTRY_CACHE=""
+portfolio_registry() {
+  if [ -n "$_PORTFOLIO_REGISTRY_CACHE" ]; then
+    echo "$_PORTFOLIO_REGISTRY_CACHE"
+    return 0
+  fi
+  local raw
+  raw=$(_portfolio_get '.portfolio.registry' './apexyard.projects.yaml')
+  _PORTFOLIO_REGISTRY_CACHE=$(_portfolio_resolve "$raw")
+  echo "$_PORTFOLIO_REGISTRY_CACHE"
+}
+
+_PORTFOLIO_PROJECTS_DIR_CACHE=""
+portfolio_projects_dir() {
+  if [ -n "$_PORTFOLIO_PROJECTS_DIR_CACHE" ]; then
+    echo "$_PORTFOLIO_PROJECTS_DIR_CACHE"
+    return 0
+  fi
+  local raw
+  raw=$(_portfolio_get '.portfolio.projects_dir' './projects')
+  _PORTFOLIO_PROJECTS_DIR_CACHE=$(_portfolio_resolve "$raw")
+  echo "$_PORTFOLIO_PROJECTS_DIR_CACHE"
+}
+
+_PORTFOLIO_IDEAS_BACKLOG_CACHE=""
+portfolio_ideas_backlog() {
+  if [ -n "$_PORTFOLIO_IDEAS_BACKLOG_CACHE" ]; then
+    echo "$_PORTFOLIO_IDEAS_BACKLOG_CACHE"
+    return 0
+  fi
+  local raw
+  raw=$(_portfolio_get '.portfolio.ideas_backlog' './projects/ideas-backlog.md')
+  _PORTFOLIO_IDEAS_BACKLOG_CACHE=$(_portfolio_resolve "$raw")
+  echo "$_PORTFOLIO_IDEAS_BACKLOG_CACHE"
+}
+
+# ------------------------------------------------------------------------------
+# Public: portfolio_validate
+#   Sanity-check that resolved paths are actually usable.
+#   On success: prints nothing, returns 0.
+#   On failure: prints "broken: <reason>" on stdout, returns 1.
+#
+#   Checks:
+#     - registry file exists and is readable
+#     - registry parses as YAML and contains a top-level `projects:` key
+#     - projects_dir exists and is a directory
+#     - ideas_backlog file exists OR its parent dir exists (creatable)
+#
+#   Cheap (~tens of ms with yq, ~1ms without) — safe to call from
+#   SessionStart hooks without measurable session-start lag.
+# ------------------------------------------------------------------------------
+portfolio_validate() {
+  local registry projects_dir ideas_backlog
+  registry=$(portfolio_registry)
+  projects_dir=$(portfolio_projects_dir)
+  ideas_backlog=$(portfolio_ideas_backlog)
+
+  if [ ! -f "$registry" ]; then
+    echo "broken: portfolio.registry resolved to $registry — file does not exist"
+    return 1
+  fi
+  if [ ! -r "$registry" ]; then
+    echo "broken: portfolio.registry at $registry is not readable"
+    return 1
+  fi
+
+  # Parse as YAML if yq is available; else minimal grep check.
+  if command -v yq >/dev/null 2>&1; then
+    if ! yq eval '.' "$registry" >/dev/null 2>&1; then
+      echo "broken: portfolio.registry at $registry does not parse as valid YAML"
+      return 1
+    fi
+    local has_projects
+    has_projects=$(yq eval 'has("projects")' "$registry" 2>/dev/null)
+    if [ "$has_projects" != "true" ]; then
+      echo "broken: portfolio.registry at $registry has no top-level 'projects:' key"
+      return 1
+    fi
+  else
+    # yq not installed — minimal sanity check; don't block on parse depth.
+    if ! grep -q '^projects:' "$registry" 2>/dev/null; then
+      echo "broken: portfolio.registry at $registry has no top-level 'projects:' key (yq not installed; only doing grep check)"
+      return 1
+    fi
+  fi
+
+  if [ ! -d "$projects_dir" ]; then
+    echo "broken: portfolio.projects_dir resolved to $projects_dir — directory does not exist"
+    return 1
+  fi
+
+  if [ ! -f "$ideas_backlog" ]; then
+    local parent
+    parent=$(dirname "$ideas_backlog")
+    if [ ! -d "$parent" ]; then
+      echo "broken: portfolio.ideas_backlog at $ideas_backlog is missing AND its parent dir $parent does not exist"
+      return 1
+    fi
+    # File missing but parent exists → creatable. Treat as OK.
+  fi
+
+  return 0
+}
+
+# ------------------------------------------------------------------------------
+# Public: portfolio_clear_cache
+#   Reset all per-process caches. Used by tests; rarely needed elsewhere.
+# ------------------------------------------------------------------------------
+portfolio_clear_cache() {
+  _PORTFOLIO_ROOT_CACHE=""
+  _PORTFOLIO_REGISTRY_CACHE=""
+  _PORTFOLIO_PROJECTS_DIR_CACHE=""
+  _PORTFOLIO_IDEAS_BACKLOG_CACHE=""
+}

--- a/.claude/hooks/check-portfolio-config.sh
+++ b/.claude/hooks/check-portfolio-config.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# SessionStart hook: surface broken portfolio config at session start.
+#
+# Calls portfolio_validate() from _lib-portfolio-paths.sh and prints a
+# one-line banner if the config is broken. Silent when:
+#   - not inside an apexyard fork
+#   - the helper or config lib is missing
+#   - validate returns OK
+#
+# This is the self-healing banner described in #145. The intent is that an
+# adopter who mistyped a path in `.claude/project-config.json` (or moved
+# their sibling portfolio repo) sees the failure at session start, before
+# they invoke a portfolio-aware skill that would fail with a less specific
+# error.
+#
+# Cost on the OK path: ~10-30ms (one yq parse of the registry). Cheap
+# enough to run on every SessionStart.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# Walk up to find the apexyard fork root (dir with both onboarding.yaml +
+# apexyard.projects.yaml). If we can't find one, this hook has nothing to
+# say.
+ROOT=""
+cur="$REPO_ROOT"
+while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+  if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+    ROOT="$cur"
+    break
+  fi
+  cur=$(dirname "$cur")
+done
+
+if [ -z "$ROOT" ]; then
+  exit 0
+fi
+
+CONFIG_LIB="$ROOT/.claude/hooks/_lib-read-config.sh"
+PORTFOLIO_LIB="$ROOT/.claude/hooks/_lib-portfolio-paths.sh"
+
+if [ ! -f "$CONFIG_LIB" ] || [ ! -f "$PORTFOLIO_LIB" ]; then
+  # Helpers not present — no validation possible. Silent.
+  exit 0
+fi
+
+# shellcheck source=/dev/null
+. "$CONFIG_LIB"
+# shellcheck source=/dev/null
+. "$PORTFOLIO_LIB"
+
+result=$(portfolio_validate 2>&1)
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  # All good — silent.
+  exit 0
+fi
+
+# Broken. Surface a single-line banner with the specific failure and the
+# fix suggestion. Mirrors the shape of check-upstream-drift.sh's banner.
+cat <<MSG
+ApexYard: portfolio config is broken — $result
+  Fix .claude/project-config.json (key: portfolio.{registry, projects_dir, ideas_backlog}),
+  or run /split-portfolio --verify for a structured state report.
+MSG
+
+# Don't fail the session start. The banner is informational; portfolio
+# skills will still surface their own errors when they try to read the
+# registry. Exit 0 so SessionStart proceeds.
+exit 0

--- a/.claude/hooks/tests/test_portfolio_paths.sh
+++ b/.claude/hooks/tests/test_portfolio_paths.sh
@@ -1,0 +1,329 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/_lib-portfolio-paths.sh
+#
+# Each case:
+#   - builds an isolated sandbox apexyard fork under $TMPDIR
+#   - drops project-config + registry + projects_dir + ideas_backlog
+#   - sources the helper + validates resolution / validate behavior
+#
+# Exit 0 means all cases passed. Exit 1 on first failure.
+
+set -u
+
+LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-portfolio-paths.sh"
+CONFIG_LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-read-config.sh"
+DEFAULTS_SRC="$(cd "$(dirname "$0")/../.." && pwd)/project-config.defaults.json"
+
+if [ ! -f "$LIB_SRC" ]; then
+  echo "FAIL: helper not found at $LIB_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$CONFIG_LIB_SRC" ]; then
+  echo "FAIL: config lib not found at $CONFIG_LIB_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$DEFAULTS_SRC" ]; then
+  echo "FAIL: defaults file not found at $DEFAULTS_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# ---------------------------------------------------------------------------
+# make_fork: build an isolated apexyard fork sandbox with the hook lib +
+# shared config lib + defaults file + minimal registry / projects_dir.
+# Returns the sandbox path on stdout.
+# ---------------------------------------------------------------------------
+make_fork() {
+  local sb
+  sb=$(mktemp -d)
+  # Canonicalize for macOS (mktemp returns /var/..., real path is /private/var/...).
+  # `pwd -P` (POSIX physical pwd) follows symlinks; bare `pwd` outputs the logical
+  # name, which doesn't match what git/realpath/dirname will produce.
+  sb=$(cd "$sb" && pwd -P)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+
+    # Required marker files for "this is an apexyard fork"
+    touch onboarding.yaml
+    cat > apexyard.projects.yaml <<'YAML'
+version: 1
+projects:
+  - name: example
+    repo: example/example
+YAML
+
+    mkdir -p projects
+    cat > projects/ideas-backlog.md <<'MD'
+# Ideas Backlog
+MD
+
+    mkdir -p .claude/hooks
+    cp "$LIB_SRC" .claude/hooks/_lib-portfolio-paths.sh
+    cp "$CONFIG_LIB_SRC" .claude/hooks/_lib-read-config.sh
+    cp "$DEFAULTS_SRC" .claude/project-config.defaults.json
+
+    git add -A
+    git commit -q -m "test fixture"
+  )
+  echo "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# run_case <name> <bash-snippet>: source the libs in a fresh subshell rooted
+# at <sandbox> and run the snippet. The snippet asserts behavior + exits
+# 0 on pass, non-zero on fail.
+# ---------------------------------------------------------------------------
+run_case() {
+  local name="$1"
+  local sb="$2"
+  local snippet="$3"
+  local out rc
+
+  out=$(
+    cd "$sb" || exit 99
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-read-config.sh
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-portfolio-paths.sh
+    portfolio_clear_cache
+    eval "$snippet"
+  )
+  rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    PASS=$((PASS + 1))
+    echo "PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  - $name"
+    echo "FAIL: $name"
+    if [ -n "$out" ]; then
+      echo "  output: $out"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: defaults resolve to absolute paths inside the fork
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+run_case "defaults: registry resolves to fork-rooted absolute path" "$SB" '
+r=$(portfolio_registry)
+expected="'"$SB"'/apexyard.projects.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "defaults: projects_dir resolves to fork-rooted absolute path" "$SB" '
+r=$(portfolio_projects_dir)
+expected="'"$SB"'/projects"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "defaults: ideas_backlog resolves to fork-rooted absolute path" "$SB" '
+r=$(portfolio_ideas_backlog)
+expected="'"$SB"'/projects/ideas-backlog.md"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "defaults: validate is OK" "$SB" '
+if portfolio_validate >/dev/null 2>&1; then exit 0; else echo "validate failed"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 2: override in project-config.json wins
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+# Set up sibling portfolio dir
+mkdir -p "$SB/../portfolio_test_$$"
+cat > "$SB/../portfolio_test_$$/apex.yaml" <<'YAML'
+version: 1
+projects: []
+YAML
+mkdir -p "$SB/../portfolio_test_$$/proj"
+touch "$SB/../portfolio_test_$$/proj/ideas.md"
+
+# Resolve the actual sibling path (mktemp may use a different real path on macOS).
+SIB=$(cd "$SB/../portfolio_test_$$" && pwd)
+
+cat > "$SB/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "registry": "$SIB/apex.yaml",
+    "projects_dir": "$SIB/proj",
+    "ideas_backlog": "$SIB/proj/ideas.md"
+  }
+}
+JSON
+
+run_case "override: absolute registry path wins" "$SB" '
+r=$(portfolio_registry)
+expected="'"$SIB"'/apex.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "override: validate is OK against sibling-dir paths" "$SB" '
+if portfolio_validate >/dev/null 2>&1; then exit 0; else echo "validate failed: $(portfolio_validate)"; exit 1; fi
+'
+rm -rf "$SB" "$SIB"
+
+# ---------------------------------------------------------------------------
+# Case 3: relative override resolves against fork root
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+mkdir -p "$SB/custom"
+cat > "$SB/custom/registry.yaml" <<'YAML'
+version: 1
+projects: []
+YAML
+mkdir -p "$SB/custom/projects"
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{
+  "portfolio": {
+    "registry": "./custom/registry.yaml",
+    "projects_dir": "./custom/projects"
+  }
+}
+JSON
+run_case "relative-override: registry resolves against fork root" "$SB" '
+r=$(portfolio_registry)
+expected="'"$SB"'/custom/registry.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 4: validate detects a missing registry
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{
+  "portfolio": {
+    "registry": "./does-not-exist.yaml"
+  }
+}
+JSON
+run_case "validate: missing registry → broken with clear message" "$SB" '
+out=$(portfolio_validate 2>&1)
+rc=$?
+case "$out" in
+  *"file does not exist"*) [ "$rc" -ne 0 ] && exit 0 ;;
+esac
+echo "got rc=$rc out=$out"
+exit 1
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 5: validate detects a registry without a projects: key
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+cat > "$SB/apexyard.projects.yaml" <<'YAML'
+not_projects:
+  - foo
+YAML
+run_case "validate: registry without 'projects:' key → broken" "$SB" '
+out=$(portfolio_validate 2>&1)
+rc=$?
+case "$out" in
+  *"projects:"*) [ "$rc" -ne 0 ] && exit 0 ;;
+esac
+echo "got rc=$rc out=$out"
+exit 1
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 6: validate detects a missing projects_dir
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+rm -rf "$SB/projects"
+run_case "validate: missing projects_dir → broken" "$SB" '
+out=$(portfolio_validate 2>&1)
+rc=$?
+case "$out" in
+  *"projects_dir"*"directory does not exist"*) [ "$rc" -ne 0 ] && exit 0 ;;
+esac
+echo "got rc=$rc out=$out"
+exit 1
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 7: ideas_backlog file missing but parent exists → still OK (creatable)
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+rm -f "$SB/projects/ideas-backlog.md"
+run_case "validate: ideas_backlog missing-but-creatable → OK" "$SB" '
+if portfolio_validate >/dev/null 2>&1; then exit 0; else echo "validate failed: $(portfolio_validate)"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 8: ideas_backlog parent missing → broken
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{
+  "portfolio": {
+    "ideas_backlog": "./nowhere/ideas.md"
+  }
+}
+JSON
+run_case "validate: ideas_backlog with missing parent → broken" "$SB" '
+out=$(portfolio_validate 2>&1)
+rc=$?
+case "$out" in
+  *"ideas_backlog"*"parent dir"*) [ "$rc" -ne 0 ] && exit 0 ;;
+esac
+echo "got rc=$rc out=$out"
+exit 1
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 9: portfolio_clear_cache resets the cached value
+# (Note: cross-`$(...)` caching is impossible in POSIX shell — same caveat
+# as _CONFIG_CACHE in _lib-read-config.sh. The cache only helps within a
+# single function-body that makes multiple resolver calls without using
+# command substitution between them. We verify clear_cache works as a
+# spec contract.)
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+run_case "cache: clear_cache resets resolver state" "$SB" '
+# Populate cache, mutate config, clear cache, verify second call sees the new value.
+inner=$(
+  source .claude/hooks/_lib-read-config.sh
+  source .claude/hooks/_lib-portfolio-paths.sh
+  portfolio_clear_cache
+  portfolio_registry >/dev/null    # populates cache
+  cat > .claude/project-config.json <<JSON
+{"portfolio": {"registry": "/elsewhere/apex.yaml"}}
+JSON
+  portfolio_clear_cache
+  # Clear _CONFIG_CACHE too, since the underlying jq output is cached there.
+  _CONFIG_CACHE=""
+  portfolio_registry
+)
+case "$inner" in
+  "/elsewhere/apex.yaml") exit 0 ;;
+esac
+echo "expected /elsewhere/apex.yaml after clear_cache; got: $inner"
+exit 1
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "===== test_portfolio_paths.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed cases:$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -131,5 +131,12 @@
     "max_chars": 200,
     "rate_wpm": 180,
     "trigger": "questions-only"
+  },
+
+  "portfolio": {
+    "_comment": "Path resolution for the portfolio registry + per-project docs + ideas backlog. Defaults match single-fork mode (paths inside the fork). Override in .claude/project-config.json for split-portfolio mode (e.g. \"../portfolio/apexyard.projects.yaml\"). Relative paths resolve against the ops-fork root (the dir containing onboarding.yaml + apexyard.projects.yaml). See docs/multi-project.md and AgDR-0010-portfolio-config-and-self-healing.md.",
+    "registry": "./apexyard.projects.yaml",
+    "projects_dir": "./projects",
+    "ideas_backlog": "./projects/ideas-backlog.md"
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,10 @@
           {
             "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-upstream-drift.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-portfolio-config.sh\"'"
           }
         ]
       }

--- a/.claude/skills/bug/SKILL.md
+++ b/.claude/skills/bug/SKILL.md
@@ -9,6 +9,18 @@ allowed-tools: Bash, Read, Write
 
 Creates a structured GitHub Issue for a bug with Given/When/Then scenario, repro steps, environment, and severity. Asks guided questions, shows the formatted ticket for confirmation, then creates the issue.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/c4/SKILL.md
+++ b/.claude/skills/c4/SKILL.md
@@ -11,6 +11,18 @@ Reads the target project's codebase and produces filled-in **Level 1 (System Con
 
 This skill complements `/handover` (which seeds a *stub* L2 once at onboarding). Use `/c4` whenever the architecture changes substantially and the diagrams need a refresh — or for a project that wasn't onboarded via `/handover`.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -9,6 +9,18 @@ allowed-tools: Bash, Read, Write
 
 Creates a structured GitHub Issue for a new feature with a user story, acceptance criteria, and design notes. Asks guided questions, shows the formatted ticket for confirmation, then creates the issue.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -11,6 +11,18 @@ Adopt an external repo into ApexYard management. The skill reads the target repo
 
 This is the bridge between "we just inherited this codebase" and "this codebase is now governed by our normal SDLC".
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```
@@ -409,15 +421,19 @@ If yes:
 
 1. **Locate the registry**: `apexyard.projects.yaml` at the root of the ops repo. If missing, first copy from `apexyard.projects.yaml.example` and show the user a warning: `⚠ Registry didn't exist — created from .example. You may need to fill in other projects.`
 
-2. **Append the entry**. Use `yq` if available for a safe YAML edit, otherwise append as plain text with careful indentation:
+2. **Append the entry**. Use `yq` if available for a safe YAML edit, otherwise append as plain text with careful indentation. Resolve the registry path via the helper (single-fork or split-portfolio — same code path):
 
    ```bash
+   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+   REGISTRY=$(portfolio_registry)
+
    # Prefer yq for correctness
    if command -v yq >/dev/null 2>&1; then
-     yq eval -i '.projects += [{"name": "{name}", "repo": "{owner/name}", "workspace": "workspace/{name}", "docs": "projects/{name}", "status": "handover", "roles": [{roles}]}]' apexyard.projects.yaml
+     yq eval -i '.projects += [{"name": "{name}", "repo": "{owner/name}", "workspace": "workspace/{name}", "docs": "projects/{name}", "status": "handover", "roles": [{roles}]}]' "$REGISTRY"
    else
      # Fallback: plain text append
-     cat >> apexyard.projects.yaml <<'YAML'
+     cat >> "$REGISTRY" <<'YAML'
      - name: {name}
        repo: {owner/name}
        workspace: workspace/{name}
@@ -433,9 +449,9 @@ If yes:
 3. **Validate the result**:
 
    ```bash
-   # Prefer yq or python -c 'import yaml; yaml.safe_load(open("apexyard.projects.yaml"))'
-   yq eval '.' apexyard.projects.yaml >/dev/null 2>&1 \
-     || python3 -c 'import sys, yaml; yaml.safe_load(open("apexyard.projects.yaml"))' 2>&1
+   # Prefer yq or python -c 'import yaml; yaml.safe_load(open(path))'
+   yq eval '.' "$REGISTRY" >/dev/null 2>&1 \
+     || python3 -c "import sys, yaml; yaml.safe_load(open('$REGISTRY'))" 2>&1
    ```
 
    If validation fails: **restore the previous version** from a backup made before the write, print the parse error, and tell the user to fix it manually. Never leave the registry in a broken state.

--- a/.claude/skills/idea/SKILL.md
+++ b/.claude/skills/idea/SKILL.md
@@ -9,6 +9,18 @@ allowed-tools: Bash, Read, Edit, Write
 
 Capture a new product, feature, or internal-tool idea so it lands somewhere durable instead of evaporating in chat. This skill is intentionally lightweight: it adds an entry to the ideas backlog and (optionally) creates a tracking GitHub Issue. It does **not** replace `/write-spec` — that comes later, after the idea has been triaged.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/inbox/SKILL.md
+++ b/.claude/skills/inbox/SKILL.md
@@ -8,6 +8,18 @@ allowed-tools: Bash, Read, Grep, Glob
 
 Aggregates everything that's currently waiting on **you** across the projects ApexYard manages. Designed to be the first thing you run in a session.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/migration/SKILL.md
+++ b/.claude/skills/migration/SKILL.md
@@ -14,6 +14,18 @@ Migrations are high-blast-radius: data loss, downtime, lock contention, cross-se
 
 `require-migration-ticket.sh` (the matching PreToolUse hook) refuses to let you write to migration paths without both artefacts in place. This skill produces both in one pass.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/projects/SKILL.md
+++ b/.claude/skills/projects/SKILL.md
@@ -8,6 +8,18 @@ allowed-tools: Bash, Read, Grep, Glob
 
 Show every project ApexYard is managing, with a one-line health snapshot. Reads `apexyard.projects.yaml` at the root of the ops repo (your fork of apexyard) and iterates the registry.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -9,6 +9,18 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 
 Manage the product roadmap as a single durable file. The skill is intentionally low-ceremony: a roadmap is a markdown file with milestones, each containing a table of items. `/roadmap` reads it, edits it, and renders it.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Activated role
 
 When `/roadmap` runs, activate the **[Head of Product](../../../roles/product/head-of-product.md)** role — they own roadmap prioritisation, strategic sequencing, and milestone decisions. For adding a specific item with a PRD, chain to `/write-spec` which activates the [Product Manager](../../../roles/product/product-manager.md) instead. For items that require data-driven reprioritisation, involve the [Product Analyst](../../../roles/product/product-analyst.md).

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -10,6 +10,18 @@ effort: medium
 
 Configures `onboarding.yaml` for a new ApexYard fork in three exchanges instead of eight sequential questions. The "describe, propose, confirm" pattern gets most users from fork to working in under 2 minutes.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## When this runs
 
 The `onboarding-check.sh` SessionStart hook detects that `onboarding.yaml` still has placeholder values (e.g. `company.name: "Your Company Name"`) and prompts the user to run `/setup`. After `/setup` fills in real values and commits, the hook goes silent forever — even on fresh clones, because `onboarding.yaml` is committed.
@@ -65,19 +77,44 @@ Branch on the answer:
 - **paid plan** (Pro / Team / Enterprise) → continue with **single-fork mode**, but mention that the registry will be on the (private-fork-eligible) fork and is fine.
 - **y** (any private projects on GitHub Free) → switch to **split-portfolio mode** (Step 2b below).
 
-Detection of an existing setup: if `git remote get-url origin` resolves to a fork that contains a symlinked `apexyard.projects.yaml` (i.e. `test -L apexyard.projects.yaml`), the adopter is already in split-portfolio mode — skip Step 2b and proceed normally with the registry behind the symlink.
+Detection of an existing setup. Either form counts as "already in split-portfolio mode" — skip Step 2b:
+
+- `.claude/project-config.json` has a `portfolio:` block pointing at a sibling repo (config-block mode, recommended; introduced #145), OR
+- `apexyard.projects.yaml` is a symlink (`test -L apexyard.projects.yaml`; legacy mode, framework-version < #145).
 
 ### Step 2b: Walk through split-portfolio mode (only if Step 2a triggered)
 
-The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — public framework + private portfolio". This skill should walk through it interactively rather than dumping the doc:
+The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — public framework + private portfolio". This skill walks through it interactively. The recommended path uses the **`portfolio:` config block** (introduced in #145) rather than symlinks — both work, but the config block is the first-class option:
 
 1. **Confirm the layout**: "Two repos in your account: `your-org/apexyard` (public, this fork) + `your-org/<private-name>` (new private repo for the portfolio). Both clones sit side-by-side on disk. OK?"
 2. **Pick the private repo name**: default suggestion `your-org/ops`. Operator confirms or overrides.
 3. **Create the private repo**: `gh repo create your-org/<name> --private --description "..."`. Confirm before running.
 4. **Clone the private repo as a sibling**: `cd .. && gh repo clone your-org/<name> portfolio`.
 5. **Initialise the portfolio**: `apexyard.projects.yaml` + empty `projects/` dir + initial commit + push. Same content as the doc's step 5.
-6. **Gitignore + symlink in the fork**: append `.gitignore` lines for `apexyard.projects.yaml` + `projects`, untrack any tracked `projects/README.md` from the upstream framework, create symlinks pointing at `../portfolio/apexyard.projects.yaml` and `../portfolio/projects`. Stage `.gitignore` for commit; the symlinks themselves are gitignored.
-7. **Verify**: `test -L apexyard.projects.yaml && test -L projects` → both should report symlinks. Confirm to the operator.
+6. **Configure path resolution in the fork** (recommended — config-block mode):
+   - Append `.gitignore` lines for `apexyard.projects.yaml` and `projects` (so they don't accidentally get staged in the public fork even if the operator runs `git add -A`).
+   - Untrack any tracked `projects/README.md` from the upstream framework.
+   - Write `.claude/project-config.json` with the `portfolio:` block pointing at the sibling repo:
+     ```json
+     {
+       "portfolio": {
+         "registry": "../portfolio/apexyard.projects.yaml",
+         "projects_dir": "../portfolio/projects",
+         "ideas_backlog": "../portfolio/projects/ideas-backlog.md"
+       }
+     }
+     ```
+   - Stage `.gitignore` and `.claude/project-config.json` for commit (the latter is per-fork, not per-machine, since it points at a public sibling-repo path).
+   - **Legacy fallback (framework-version < #145)**: if the adopter's framework predates the `portfolio:` config block, fall back to creating symlinks pointing at `../portfolio/apexyard.projects.yaml` and `../portfolio/projects`. The helper resolves either way.
+7. **Verify**: source `.claude/hooks/_lib-portfolio-paths.sh` and call `portfolio_validate`. Skill MUST refuse to declare success if validate fails — surface the specific failure and ask the operator to fix it before re-running.
+   ```bash
+   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+   if ! portfolio_validate; then
+     echo "Setup not complete — fix the issue above and re-run /setup"
+     exit 1
+   fi
+   ```
 
 Then proceed to Step 3 with the user's earlier description, configuring `onboarding.yaml` as normal. The rest of the skill is unchanged — the only difference between modes is where the registry physically lives.
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -95,6 +95,7 @@ The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — pub
    - Append `.gitignore` lines for `apexyard.projects.yaml` and `projects` (so they don't accidentally get staged in the public fork even if the operator runs `git add -A`).
    - Untrack any tracked `projects/README.md` from the upstream framework.
    - Write `.claude/project-config.json` with the `portfolio:` block pointing at the sibling repo:
+
      ```json
      {
        "portfolio": {
@@ -104,9 +105,11 @@ The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — pub
        }
      }
      ```
+
    - Stage `.gitignore` and `.claude/project-config.json` for commit (the latter is per-fork, not per-machine, since it points at a public sibling-repo path).
    - **Legacy fallback (framework-version < #145)**: if the adopter's framework predates the `portfolio:` config block, fall back to creating symlinks pointing at `../portfolio/apexyard.projects.yaml` and `../portfolio/projects`. The helper resolves either way.
 7. **Verify**: source `.claude/hooks/_lib-portfolio-paths.sh` and call `portfolio_validate`. Skill MUST refuse to declare success if validate fails — surface the specific failure and ask the operator to fix it before re-running.
+
    ```bash
    source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
    source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"

--- a/.claude/skills/split-portfolio/SKILL.md
+++ b/.claude/skills/split-portfolio/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: split-portfolio
+description: Migrate a single-fork apexyard adopter to split-portfolio mode (public framework + private sibling portfolio). Automates the destructive recovery flow — force-push history rewrite, GitHub Issue/PR body redaction, private repo creation, and config-block writing — with explicit operator-confirmation gates at every destructive step. ONLY invoke when the adopter has actively asked to migrate, OR is using `--verify` to inspect state without destructive ops. Refuses on a paid GitHub plan, a clean working tree, or an already-migrated fork.
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+argument-hint: "[--verify | --dry-run]"
+effort: high
+---
+
+# /split-portfolio — Migrate to split-portfolio mode
+
+Automates the recovery flow for ApexYard adopters who hit the **trip-wire** documented in `docs/multi-project.md` — pushed private project names to a public fork, then realized GitHub Free disallows fork-visibility changes.
+
+The skill is destructive: it force-pushes the public fork's main branch after rewriting history, redacts GitHub Issue / PR body content, and creates a new private repo. Every destructive step has an explicit operator-confirmation gate. None of those gates are skip-able.
+
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
+## Modes
+
+| Invocation | Effect |
+|------------|--------|
+| `/split-portfolio` | Full migration — runs all 10 steps with operator-confirmation gates |
+| `/split-portfolio --verify` | Read-only state report (registry/config drift, backup branch age, validate). No destructive ops. |
+| `/split-portfolio --dry-run` | Walk through every step printing the commands that would run, but execute none. |
+
+## Pre-flight refusals (before doing anything)
+
+The skill refuses with a clear redirect when:
+
+| Condition | Refusal message |
+|-----------|----------------|
+| Target fork's visibility is `PRIVATE` (`gh repo view --json visibility` returns `PRIVATE`) | "This fork is already private — split-portfolio mode is for public forks. If you meant something else, run `/split-portfolio --verify` for the state report." |
+| Adopter is on a paid GitHub plan (Pro / Team / Enterprise) | "Paid GitHub plans support changing a fork's visibility in-place — that's a simpler path than this skill's destructive flow. Visit your fork's GitHub settings → Danger Zone → Change Visibility, and you're done. If you specifically want the public-framework + private-portfolio split anyway, re-run this skill with `--force` (not implemented in v1; ask first)." |
+| Working tree has uncommitted changes | "Refusing to migrate with a dirty working tree — commit or stash first. Force-push + history rewrite would lose your in-flight work." |
+| Already migrated (config-block mode OR symlink mode detected) | "Looks like this fork is already in split-portfolio mode (detected via config block / symlink). Run `/split-portfolio --verify` for the state report, or `/split-portfolio --dry-run` to see what a re-run would do." |
+
+Refusal at any of these gates is silent on every other check — show only the relevant message.
+
+## Process
+
+### --verify mode (no destructive ops, safe to run anytime)
+
+1. Source `_lib-read-config.sh` and `_lib-portfolio-paths.sh`.
+2. Run `portfolio_validate`. Capture result.
+3. Detect mode: config-block (presence of `portfolio:` block in `.claude/project-config.json`) vs symlink (`test -L apexyard.projects.yaml`) vs single-fork (neither).
+4. List `backup-pre-rewrite` branch age, if present (`gh api repos/<fork>/branches/backup-pre-rewrite --jq .commit.commit.author.date`).
+5. Detect drift (config-block AND symlink both present pointing at different things — broken state).
+6. Print a structured report:
+
+```
+/split-portfolio --verify
+
+Mode:                config-block (recommended) | symlink (legacy) | single-fork | mixed (DRIFT)
+Registry resolves:   /abs/path/apexyard.projects.yaml
+                     [exists | MISSING]
+Projects dir:        /abs/path/projects
+                     [exists | MISSING]
+Ideas backlog:       /abs/path/projects/ideas-backlog.md
+                     [exists | creatable | MISSING parent]
+Validate:            OK | broken: <reason>
+
+backup-pre-rewrite:  age=12d (consider deleting after 7-day soak)
+                     OR not present
+
+Drift:               none | YES — config and symlink point at different paths
+```
+
+Exit 0 if valid + no drift; exit 1 if validate fails or drift detected.
+
+### Full migration (10 steps)
+
+#### Step 1 — Pre-flight checklist
+
+After the pre-flight refusals above pass, show the operator a checklist and ask for explicit confirmation:
+
+```
+About to migrate this fork to split-portfolio mode. Destructive operations will follow.
+
+Changes you will see:
+  - A new private repo created at <suggested-name>
+  - This fork's git history rewritten to remove apexyard.projects.yaml + projects/
+  - This fork's main branch force-pushed
+  - GitHub Issue / PR bodies on this fork that named registered projects redacted
+  - .claude/project-config.json updated with a `portfolio:` block pointing at the sibling
+
+Reversibility:
+  - A backup-pre-rewrite branch is pushed before any rewrite (recoverable for 7 days)
+  - Force-push is irreversible at the GitHub level for anyone who cloned in the last hour
+  - GitHub Issue/PR edit history (timeline API) survives — full purge requires repo deletion
+
+Have you read docs/multi-project.md § "Migrating from single-fork to split-portfolio"? (y/n)
+Are you running this during a low-traffic window so other clones won't be surprised? (y/n)
+
+Continue? (yes / cancel)
+```
+
+#### Step 2 — Snapshot extraction
+
+Copy the registry + `projects/` to a tmpdir. This is the data that will be pushed to the new private repo. Run BEFORE any destructive operation so a failure here doesn't cost the operator anything.
+
+```bash
+SNAPSHOT=$(mktemp -d)
+cp "$(portfolio_registry)" "$SNAPSHOT/"
+cp -r "$(portfolio_projects_dir)" "$SNAPSHOT/"
+echo "Snapshot at: $SNAPSHOT"
+```
+
+Confirm to operator: snapshot exists, file count matches expectation. If not, refuse.
+
+#### Step 3 — Create the private repo
+
+```
+Suggested name: <account>/ops
+Override? (Enter to accept default, or type a different name)
+> _
+
+Creating private repo... gh repo create <name> --private --description "ApexYard private portfolio: registry + per-project handover docs"
+Continue? (yes / cancel)
+```
+
+If the repo name already exists in the operator's account, refuse and ask for a different name.
+
+#### Step 4 — Push the snapshot to the private repo
+
+```bash
+cd "$SNAPSHOT"
+git init -q
+git checkout -b main
+git add apexyard.projects.yaml projects/
+git commit -q -m "chore: import portfolio snapshot from public fork"
+gh repo set-default <name>
+git remote add origin "https://github.com/<account>/<name>.git"
+git push -u origin main
+```
+
+Print: `✓ Private portfolio repo populated at <name>`.
+
+#### Step 5 — Backup branch on the public fork
+
+Before any rewrite. Recoverable safety net.
+
+```bash
+cd /path/to/public/fork
+git fetch origin
+git push origin "origin/main:refs/heads/backup-pre-rewrite"
+```
+
+Print: `✓ backup-pre-rewrite pushed (will be auto-cleaned after 7-day soak in step 10)`.
+
+#### Step 6 — History rewrite
+
+Detect: was the registry + `projects/` added in a single commit? If yes, the cheap path:
+
+```bash
+PARENT=$(git log --format=%H --all -- apexyard.projects.yaml | tail -n 1)^
+git reset --hard "$PARENT"
+```
+
+Otherwise, use `git filter-repo` (recommends installing if missing):
+
+```bash
+if ! command -v git-filter-repo >/dev/null 2>&1; then
+  echo "git-filter-repo not installed. Install it (e.g. brew install git-filter-repo) and re-run."
+  exit 1
+fi
+git filter-repo --path apexyard.projects.yaml --path projects --invert-paths
+```
+
+After rewrite, show the operator the diff: how many commits changed, sample of removed paths.
+
+#### Step 7 — Force-push to fork's main
+
+**This is the irreversible step.** Single explicit confirmation gate:
+
+```
+About to force-push the rewritten main to <account>/<fork>.
+
+This is irreversible at GitHub for anyone who cloned in the last hour.
+Continue? (yes / cancel)
+```
+
+```bash
+git push --force-with-lease origin main
+```
+
+If the lease check fails (someone else pushed since the operator last fetched), refuse — operator should investigate before re-running.
+
+#### Step 8 — Redact GitHub Issue / PR bodies
+
+For each registered project name, search the public fork's issues + PRs for bodies that mention them:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+REGISTRY=$(portfolio_registry)
+
+# Read names from snapshot (still has the registry)
+names=$(yq eval '.projects[].name' "$SNAPSHOT/apexyard.projects.yaml")
+
+for name in $names; do
+  # Issues + PRs mentioning the name in body
+  matching=$(gh issue list --repo <fork> --search "$name in:body" --json number,title,body --limit 100)
+  matching_prs=$(gh pr list --repo <fork> --search "$name in:body" --json number,title,body --limit 100)
+
+  for item in $matching $matching_prs; do
+    # Show diff to operator: what was named, what redaction we'll apply
+    # Confirm per item before writing
+    # gh issue edit <n> --repo <fork> --body-file <redacted>
+    # OR gh pr edit <n> --repo <fork> --body-file <redacted>
+  done
+done
+```
+
+After the loop, **explicitly print the timeline-API caveat**:
+
+```
+⚠ Edit history survives.
+
+GitHub's timeline API still has the original body content. Full purge of
+the original text requires deleting and recreating the repo (which loses
+issue numbers + PR numbers + history). The redaction above hides the
+content from casual viewers, search engines, and the GitHub UI default
+view — that's it.
+```
+
+#### Step 9 — Write the `portfolio:` config block + .gitignore
+
+```bash
+# .gitignore additions in the public fork
+cat >> .gitignore <<'EOF'
+
+# Portfolio data lives in a separate private repo (split-portfolio mode).
+# See docs/multi-project.md.
+apexyard.projects.yaml
+projects
+EOF
+
+# Untrack any framework projects/README.md from upstream (it'll be replaced by the private sibling's content)
+git rm --cached -r projects 2>/dev/null || true
+
+# Write portfolio: block to project-config
+PRIVATE_REPO_REL="../<private-repo-name>"
+cat > .claude/project-config.json <<JSON
+{
+  "portfolio": {
+    "registry": "$PRIVATE_REPO_REL/apexyard.projects.yaml",
+    "projects_dir": "$PRIVATE_REPO_REL/projects",
+    "ideas_backlog": "$PRIVATE_REPO_REL/projects/ideas-backlog.md"
+  }
+}
+JSON
+
+git add .gitignore .claude/project-config.json
+git commit -m "chore: configure split-portfolio mode (#143 / #145)"
+```
+
+If `.claude/project-config.json` already has a non-portfolio block, **merge** rather than overwrite — preserve existing keys.
+
+If it has a `portfolio:` block already, refuse and ask the operator to manually reconcile.
+
+#### Step 10 — Verify + cleanup
+
+Verify migration:
+
+```bash
+source .claude/hooks/_lib-read-config.sh
+source .claude/hooks/_lib-portfolio-paths.sh
+if ! portfolio_validate; then
+  echo "Migration produced a broken config — see error above. NOT proceeding to cleanup."
+  exit 1
+fi
+
+# Confirm public fork's main no longer has the registry
+git ls-tree --name-only HEAD apexyard.projects.yaml && {
+  echo "ERROR: registry still in main. Force-push didn't take effect?"
+  exit 1
+}
+```
+
+Cleanup (opt-in, default-no):
+
+```
+backup-pre-rewrite branch holds your pre-migration history. Default: keep for 7-day soak.
+
+Delete it now? (y/N)
+```
+
+If `y`: `gh api -X DELETE repos/<fork>/git/refs/heads/backup-pre-rewrite`.
+
+Final report:
+
+```
+✓ Split-portfolio migration complete.
+
+  Public fork:        <account>/<fork>      (registry removed, history rewritten)
+  Private portfolio:  <account>/<private>   (registry + projects/ pushed)
+  Config block:       .claude/project-config.json (portfolio.* set)
+  Backup branch:      backup-pre-rewrite (kept for 7 days, run /split-portfolio --verify to monitor)
+
+  Bodies redacted:    <N> issues, <M> PRs (timeline API survives — see warning above)
+
+  Next step:          commit + push the new .gitignore + project-config.json:
+                        git push origin main
+```
+
+## Idempotency
+
+Re-running the skill on a partially-migrated fork picks up where it left off:
+
+| Detected state | Action |
+|----------------|--------|
+| Private repo already exists, is empty | Skip step 3, do step 4 |
+| Private repo already exists, has the snapshot | Skip steps 3 + 4 |
+| `backup-pre-rewrite` branch exists | Skip step 5 |
+| HEAD on main has no registry/projects | Skip steps 6 + 7 |
+| `.claude/project-config.json` already has portfolio block matching new layout | Skip step 9 |
+| All complete | Run --verify only and exit 0 |
+
+The `--dry-run` flag walks through every step printing the commands but executes none. Useful for the operator to preview the destructive ops before running real.
+
+## Rules
+
+1. **No destructive op without an explicit operator-typed `yes`.** Single-character `y` is acceptable; ambiguous `ok` / `sure` is not.
+2. **No `--force`-by-default.** Force-push uses `--force-with-lease`; if the lease fails, refuse.
+3. **Never delete `backup-pre-rewrite` automatically.** Even at step 10, deletion is opt-in. Default: keep for 7 days.
+4. **Surface the timeline-API caveat verbatim** at step 8. Adopters must see it. No abstraction.
+5. **Refuse on already-migrated.** Detection covers config-block mode, symlink mode, and mixed-drift. Re-run with `--verify` is fine; full re-run requires manual cleanup first.
+6. **Resolve paths via the helper.** Step 8 + step 9 + step 10 all use `portfolio_registry`, `portfolio_projects_dir`, `portfolio_validate` from `_lib-portfolio-paths.sh`. No literal `apexyard.projects.yaml` references in bash blocks (the snapshot's path is passed as a separate variable).

--- a/.claude/skills/stakeholder-update/SKILL.md
+++ b/.claude/skills/stakeholder-update/SKILL.md
@@ -9,6 +9,18 @@ allowed-tools: Bash, Read, Grep, Glob
 
 Synthesises recent activity into a stakeholder-facing update. The skill is audience-aware: weekly is dense and tactical for the team, monthly is strategic for leadership, launch is celebratory and metrics-heavy for the broader org or external stakeholders.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/start-ticket/SKILL.md
+++ b/.claude/skills/start-ticket/SKILL.md
@@ -21,6 +21,18 @@ Both markers live in the ops fork (gitignored). No more `.claude/session/` insid
 
 This is the mechanical enforcement of the Pre-Build Gate in `.claude/rules/workflow-gates.md` — "do not start coding until the ticket exists".
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Process
 
 ### 1. Parse Arguments

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -8,6 +8,18 @@ allowed-tools: Bash, Read, Grep, Glob
 
 A focused "where am I" view. Where `/inbox` shows what's waiting on you and `/projects` shows portfolio health, `/status` shows the **current state of work**: branch, dirty files, recent commits, open PRs, and the in-progress issue.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -9,6 +9,18 @@ allowed-tools: Bash, Read, Write
 
 Creates a structured GitHub Issue for a technical task with driver (why), scope (what), acceptance criteria, and risks. Used for tech debt, infrastructure, refactoring, dependency updates, or any non-user-facing work that doesn't fit /feature or /bug.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/tasks/SKILL.md
+++ b/.claude/skills/tasks/SKILL.md
@@ -8,6 +8,18 @@ allowed-tools: Bash, Read, Grep, Glob
 
 A single ordered list of "things to click on right now". Where `/inbox` groups items by category, `/tasks` flattens everything into a prioritised TODO with one URL per line. Optimised for "I have 30 minutes, what should I do?".
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/tickets-batch/SKILL.md
+++ b/.claude/skills/tickets-batch/SKILL.md
@@ -21,6 +21,18 @@ Flow shape:
   → N `gh issue create` calls (one per ticket — never a single batch dump)
 ```
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -9,6 +9,18 @@ allowed-tools: Bash, Read, Write, Edit
 
 Single-command replacement for the manual "fetch → branch → merge → push → PR" dance that fork maintainers do to pull upstream apexyard changes into their ops fork.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Usage
 
 ```

--- a/.claude/skills/validate-idea/SKILL.md
+++ b/.claude/skills/validate-idea/SKILL.md
@@ -11,6 +11,18 @@ A 10-minute, 5-question check before committing the time of `/write-spec`. Most 
 
 **What this is not.** Not Wardley mapping. Not event storming. Not business-model canvas. No scoring rubric. Five plain questions, one per turn, then a verdict.
 
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
 ## Activated role
 
 When `/validate-idea` runs, activate the **[Product Manager](../../../roles/product/product-manager.md)** role for the validation read-out, with optional handoff to **[Head of Product](../../../roles/product/head-of-product.md)** if the verdict is `green` and a roadmap-impact call is needed. The role's "is this worth doing?" lens is exactly the right perspective.

--- a/docs/agdr/AgDR-0010-portfolio-config-and-self-healing.md
+++ b/docs/agdr/AgDR-0010-portfolio-config-and-self-healing.md
@@ -1,0 +1,115 @@
+# Portfolio config block + self-healing skill audit + `/split-portfolio` migration helper
+
+> In the context of ApexYard's split-portfolio mode (#143) being functional today only via manual symlinks, with ~16 framework skills hardcoding `apexyard.projects.yaml` and `projects/` as path literals, facing the dual problem that (a) adopters can't reconfigure those paths through the existing config layer and (b) any future skill addition silently re-hardcodes the same paths, I decided to add a `portfolio:` block to the existing `.claude/project-config.json` schema (NOT `onboarding.yaml`), introduce a `_lib-portfolio-paths.sh` helper that resolves `registry`, `projects_dir`, and `ideas_backlog` to absolute paths with single-fork-mode defaults, audit-and-update each affected skill's prose + bash examples to use the helper, ship a SessionStart self-healing banner that surfaces broken portfolio config at session start, and ship a new `/split-portfolio` skill that automates the destructive recovery flow + writes the new config block instead of just symlinks, to achieve first-class config-driven path resolution while preserving zero-behavior-change for every existing adopter who never touches the new block, accepting that this is a single bundled PR closing #145 only (with #146 closed manually post-merge per the single-Closes rule), that the skill audit is mechanical-but-broad (~18 SKILL.md files), and that the migration helper inherits its safety constraints from the underlying force-push + GitHub-timeline-API survival primitives (no way to make timeline survival truly reversible).
+
+## Context
+
+PR #144 (merged into `dev` 2026-05-03) shipped the docs + `/setup` privacy gate but explicitly deferred the framework primitive. Today's split-portfolio adopters set up two symlinks (`apexyard.projects.yaml` → `../portfolio/...`) and the existing skills resolve transparently. That works, but:
+
+1. **New skill additions don't know there's a configurable path** — the next contributor will hardcode `apexyard.projects.yaml` again.
+2. **Adopters who want a non-symlink layout** (e.g. registry on a network drive, projects in a separate parent dir) have no escape hatch.
+3. **The `/setup` skill in #144 hand-creates symlinks**; a `/split-portfolio` skill that automates the full destructive recovery flow (#146) needs the config primitive to land somewhere clean, not pile on more symlink writes.
+4. **No proactive failure surface.** A typo in `portfolio.registry` (or a stale path after the adopter moves the sibling portfolio repo) only surfaces when the next portfolio-aware skill is invoked, with a confusing downstream error.
+
+The existing config layer (`.claude/project-config.{defaults,}.json` + `_lib-read-config.sh` + `config_get_or`, with 6+ hooks already using it) is the right home — it already supports per-fork overrides, ships an `_lib-` shared library pattern, and provides shallow-merge semantics with sensible defaults.
+
+## Options
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Status quo (symlinks only) | Zero work | Every new skill silently re-hardcodes; no escape hatch beyond symlinks; broken config surfaces only at next-skill-invocation |
+| `portfolio:` in `onboarding.yaml` (the original ticket wording) | Keeps "company config" colocated | Diverges from existing config pattern; `onboarding.yaml` is for company identity, not runtime path resolution; needs a fresh YAML reader (existing reader is JSON); breaks `config_get_or` precedent |
+| **`portfolio:` in `.claude/project-config.json` + `_lib-portfolio-paths.sh` helper + `portfolio_validate` self-heal + skill audit + `/split-portfolio` skill (CHOSEN)** | Reuses existing config-loader infrastructure; six hooks already follow this pattern; adopters who customize one config file customize them all; self-healing surfaces broken config at session-start instead of skill-invocation-time; `/split-portfolio` produces clean config-block migration | Skill audit is broad (~18 SKILL.md files); single Closes-keyword constraint means #146 closed manually post-merge |
+| Helper-only, no schema (resolve through git rev-parse + symlink-detection) | Smallest diff | Doesn't actually solve "first-class config" — still implicit; symlinks remain the only mechanism |
+| Refactor every skill to a Python utility | Better testability | Massive scope expansion; most skills are bash-heavy by design; doesn't match the framework's existing conventions |
+
+## Decision
+
+Chosen: **`portfolio:` block in `.claude/project-config.{defaults,}.json` + helper library + self-healing SessionStart hook + skill audit + new `/split-portfolio` skill, all in one bundled PR.**
+
+Three reasons it wins:
+
+1. **Reuses existing patterns.** Adopters who already configured `voice_prompts` or `leak_protection` or any of the other config blocks already understand this. Single conceptual model.
+2. **Self-healing surfaces failures early.** A broken `portfolio.registry` path no longer waits until next-skill-invocation — it shows at session start. Same shape as the existing `check-upstream-drift.sh` banner: silent on success, loud on failure, never blocks the session.
+3. **`/split-portfolio` ships the migration as code, not docs.** The recovery flow is destructive enough (force-push, body redaction) that a documented step-list is genuinely error-prone. A skill captures the right sequence, the operator-confirmation gates at every destructive step, the timeline-API survival caveat, and the idempotent re-run path.
+
+## Scope summary
+
+### 1. Schema — `.claude/project-config.defaults.json`
+
+Adds a `portfolio:` block with `registry`, `projects_dir`, `ideas_backlog`. Defaults preserve today's single-fork behavior (relative paths, fork-rooted).
+
+### 2. Helper — `.claude/hooks/_lib-portfolio-paths.sh`
+
+Sourceable shell library exposing:
+
+- `portfolio_registry()` — absolute path to registry
+- `portfolio_projects_dir()` — absolute path to projects dir
+- `portfolio_ideas_backlog()` — absolute path to ideas backlog
+- `portfolio_validate()` — structured "OK / broken / why"
+- `portfolio_clear_cache()` — test helper
+
+Path resolution walks up to find the ops-fork root (dir with `onboarding.yaml + apexyard.projects.yaml`), resolves relative paths against it, outputs absolute. Falls back to git toplevel outside an apexyard fork. Cached per-process (matching `_CONFIG_CACHE` pattern in `_lib-read-config.sh`).
+
+### 3. Self-healing — `check-portfolio-config.sh` SessionStart hook
+
+Silent when valid; one-line banner on failure naming the broken field + suggested fix. Never blocks the session.
+
+### 4. Skill audit — 18 SKILL.md files
+
+Adds a "Path resolution" callout to every skill that touches the registry / projects_dir / ideas_backlog paths. Each callout points at the helper. Two skills got deeper bash-block edits:
+
+- `handover/SKILL.md` — `yq eval -i ... apexyard.projects.yaml` blocks now source the helper + use `$(portfolio_registry)`.
+- `setup/SKILL.md` Step 2b — writes the `portfolio:` config block (recommended) instead of symlinks; symlinks remain documented as legacy fallback.
+
+### 5. New skill — `.claude/skills/split-portfolio/SKILL.md`
+
+10-step migration flow with explicit operator-confirmation gates. `--verify` mode for read-only state report. `--dry-run` mode prints commands without executing. Refuses on already-private fork, paid GitHub plan, dirty working tree, or already-migrated state.
+
+### 6. Doc updates — `docs/multi-project.md`
+
+- Layout section updated to describe both modes (config-block recommended, symlink legacy).
+- Setup steps split into "config-block mode (recommended)" and "symlink-based mode (framework < #145)".
+- Migration section replaced with `/split-portfolio` skill invocation; manual steps preserved as fallback.
+
+### 7. Tests — `.claude/hooks/tests/test_portfolio_paths.sh`
+
+13 cases covering: defaults resolve correctly; absolute override wins; relative override resolves against fork root; missing-registry, missing-projects-dir, missing-ideas-backlog-with-bad-parent all → broken; ideas-backlog missing-but-creatable → OK; cache + clear_cache contract.
+
+## Consequences
+
+### Positive
+
+- **Zero behavior change for existing single-fork adopters.** Defaults match today's hardcoded values exactly. Verified by smoke: a fresh fork with no `portfolio:` override produces identical paths.
+- **Split-portfolio adopters can drop symlinks** (or keep them — the helper resolves either way). Both modes coexist; no forced migration.
+- **`/split-portfolio` automates the full recovery** instead of leaving the adopter mid-flow with a manual checklist.
+- **New skill contributions follow the helper pattern**, not the literal-string anti-pattern. Each new skill that touches the registry includes the "Path resolution" callout from the existing convention.
+- **Self-healing surfaces broken config at session start**, not at next-skill-invocation. Adopter sees a clear "registry resolved to X — file does not exist" message instead of a downstream skill failing with "couldn't read registry".
+
+### Negative
+
+- **PR is broad.** ~18 SKILL.md files updated mechanically (callout insertion). Diff is mostly the same paragraph repeated — but it spans the framework. Mitigation: the callout is identical across files (verified by grep), and the heavier handover/setup edits are isolated to two files.
+- **Two tests at minimum.** `_lib-portfolio-paths.sh` helper covered by 13 unit cases. `/split-portfolio` is integration-only by nature; no automated test for the destructive flow — relies on manual operator-confirmed smoke. Documented in the skill's AC list.
+- **Single Closes-keyword constraint** means PR closes #145 only; #146 is closed manually after merge with a "delivered in PR #X" comment. Not a clean tracker shape, but follows the framework's own rule.
+- **Self-healing helper cost.** SessionStart adds one `portfolio_validate` call per session. Measured: ~10-30ms when yq is available (one parse of the registry); ~1ms when not. Acceptable.
+- **Path-resolution callout duplicated across skills.** Future cleanup could extract to a single shared `.claude/skills/_shared-conventions.md` with each SKILL.md linking to it. Out of scope here; tracked as future cleanup if it becomes a maintenance burden.
+
+### Reversibility
+
+- Helper + schema + SessionStart hook fully reversible. Remove the `portfolio` block, delete the helper, revert SKILL.md callouts, remove the SessionStart wiring.
+- `/split-portfolio` is purely additive — drop the skill directory.
+- The single irreversible thing in this entire PR is what `/split-portfolio` does to a fork's GitHub timeline API on a real migration run. That's inherent to the underlying `gh` operations, not introduced by this PR.
+
+## Future phases (NOT in this AgDR)
+
+- **Extract the path-resolution callout** to a single shared `.claude/skills/_shared-conventions.md` file if the duplication becomes a maintenance pain point. Currently 18 copies of the same paragraph.
+- **Python helper parallel to the shell helper** if any skill ever needs to call the resolver from a Python context. Not needed today; all current callers are bash.
+- **Per-skill `portfolio_validate` calls** beyond `/setup` — e.g. `/handover`, `/inbox` could opt into validating before doing path-touching work. Currently relies on the SessionStart banner + skill-natural-error-surfacing.
+- **`--force` flag for `/split-portfolio`** to override the "already private" / "paid plan" refusals. Deliberately not v1; require ask-first interaction.
+
+## Artifacts
+
+- Branch: `feat/GH-145-portfolio-config-and-helper`
+- Tickets: me2resh/apexyard#145 (closed by PR), me2resh/apexyard#146 (closed manually post-merge)
+- Predecessor: me2resh/apexyard#144 (docs + `/setup` privacy gate, merged into `dev` 2026-05-03)
+- Related AgDRs: AgDR-0006 (project-configurable ticket schema — same config-block convention this AgDR extends), AgDR-0009 (voice prompts — same default-OFF / opt-in-via-config pattern), AgDR-0001 (rule-mechanization-hooks — establishes SessionStart as the right shape for proactive notice).

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -165,7 +165,12 @@ Use this mode if you're on GitHub Free with any project you don't want named pub
 └── portfolio/        ← private repo (registry + per-project docs — never goes public)
 ```
 
-Both repos live in your account; on disk they sit side-by-side. Inside the apexyard fork, `apexyard.projects.yaml` and `projects/` are symlinks into the portfolio repo (and gitignored from the fork itself), so all the existing skills work without modification.
+Both repos live in your account; on disk they sit side-by-side. Inside the apexyard fork, the framework's portfolio-aware skills resolve `apexyard.projects.yaml` and `projects/` through one of two mechanisms:
+
+- **Config block (recommended, framework ≥ #145).** A `portfolio:` block in `.claude/project-config.json` points the skills at `../portfolio/apexyard.projects.yaml` and `../portfolio/projects`. The `_lib-portfolio-paths.sh` helper resolves both. A `SessionStart` banner surfaces broken config (missing files, bad paths) at session start so you don't discover a misconfiguration mid-skill.
+- **Symlink (legacy, framework < #145).** `apexyard.projects.yaml` and `projects/` are symlinks into the portfolio repo (and gitignored from the fork itself). Existing skills resolve through the symlink transparently. Continues to work; if you're upgrading framework versions, prefer the config block.
+
+The `/split-portfolio` skill (introduced #146) automates the full migration flow including the config-block write — see § "Migrating from single-fork to split-portfolio" below for adopters who already pushed private project names to a public fork.
 
 ### Setup — 7 steps, ~6 minutes
 
@@ -225,7 +230,50 @@ git commit -m "chore: initialise private portfolio"
 git push
 ```
 
-#### 6. Gitignore the portfolio paths in the fork + symlink
+#### 6. Gitignore the portfolio paths in the fork + configure path resolution
+
+The recommended path is the **config block** (framework version ≥ #145). The symlink approach below is the legacy fallback for older framework versions — both work.
+
+##### Recommended: config-block mode
+
+```bash
+cd ~/ops/apexyard
+
+# Tell the fork to ignore the registry + projects/ — they live in the portfolio.
+cat >> .gitignore <<'EOF'
+
+# Portfolio data lives in a separate private repo (split-portfolio mode).
+# See docs/multi-project.md.
+apexyard.projects.yaml
+projects
+EOF
+
+# If projects/README.md is currently tracked from the upstream framework,
+# untrack it so the config-block resolution can take its place:
+git rm -r --cached projects 2>/dev/null || true
+
+# Write the portfolio: config block pointing at the sibling repo.
+# Paths resolve relative to the ops-fork root (this directory).
+cat > .claude/project-config.json <<'JSON'
+{
+  "portfolio": {
+    "registry": "../portfolio/apexyard.projects.yaml",
+    "projects_dir": "../portfolio/projects",
+    "ideas_backlog": "../portfolio/projects/ideas-backlog.md"
+  }
+}
+JSON
+
+git add .gitignore .claude/project-config.json
+git commit -m "chore: configure split-portfolio mode (config-block path resolution)"
+git push
+```
+
+The `SessionStart` hook chain calls `portfolio_validate` from `_lib-portfolio-paths.sh` on every session start. If the resolved registry / projects_dir / ideas_backlog paths are broken (typo, missing file, etc.), you'll see a one-line banner naming the failure. Silent on success.
+
+##### Legacy: symlink-based mode (framework < #145)
+
+If you're on an older framework version that doesn't have the `portfolio:` config block, fall back to symlinks. The skills resolve through them transparently — same end result, less first-class:
 
 ```bash
 cd ~/ops/apexyard
@@ -287,17 +335,25 @@ In exchange, **zero of your private project names ever land on a public GitHub r
 
 ### Migrating from single-fork to split-portfolio
 
-If you've already started in single-fork mode and pushed private project names to your public fork, the recovery flow is:
+If you've already started in single-fork mode and pushed private project names to your public fork, run the **`/split-portfolio`** skill (introduced #146) — it automates the full destructive recovery flow with explicit operator-confirmation gates at each step:
+
+```
+/split-portfolio              # full migration — 10 steps, all gated
+/split-portfolio --verify     # read-only state report, no destructive ops
+/split-portfolio --dry-run    # walk through each step printing the commands, execute none
+```
+
+The skill performs:
 
 1. Push the current public fork's main to a backup branch (`backup-pre-rewrite`) for safety.
 2. Reset main to the commit before the bulk-handover (or use `git filter-repo` for older history) to remove the registry + `projects/` from public main.
-3. Force-push main.
+3. Force-push main with `--force-with-lease`.
 4. Create the private portfolio repo and push the extracted registry + `projects/` content into it.
-5. Symlink + gitignore as in step 6 above.
-6. **Redact any GitHub Issue or Pull Request bodies** that named the projects — `gh issue edit <n> --body-file ...` and `gh pr edit <n> --body-file ...`. The original text survives in the timeline API but is hidden from casual viewers + search engines.
-7. Delete the backup branch after a soak window.
+5. Write the `portfolio:` config block in `.claude/project-config.json` pointing at the sibling repo (or symlinks if you'd rather — your choice, prompted at the relevant step).
+6. **Redact any GitHub Issue or Pull Request bodies** that named the projects — surfaces the timeline-API survival caveat explicitly so you don't have false confidence.
+7. Offer to delete the backup branch after a soak window (default: keep for 7 days).
 
-A `/split-portfolio` migration helper to automate this flow is tracked at [me2resh/apexyard#143](https://github.com/me2resh/apexyard/issues/143). Until that ships, the steps above are manual.
+If you can't run the skill (e.g. you're on a framework version that predates it), the manual recipe above still works step-by-step — see `docs/multi-project.md` history before #146 for the original step list.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the framework primitive deferred from #144.

- **`portfolio:` config block** in `.claude/project-config.{defaults,}.json` for path resolution (registry, projects_dir, ideas_backlog). Defaults preserve today's single-fork behavior; adopters in split-portfolio mode override the keys.
- **`_lib-portfolio-paths.sh` helper library** + `portfolio_validate()` for self-healing. New SessionStart hook surfaces a one-line banner if the resolved paths are broken — silent on success, never blocks.
- **18 SKILL.md files** updated with a "Path resolution" callout pointing at the helper. Two skills got deeper bash-block edits: `handover` (now sources the helper instead of hardcoded `apexyard.projects.yaml`); `setup` Step 2b (writes the config block as the first-class path; symlinks remain documented as legacy fallback).
- **New `/split-portfolio` skill** — automates the destructive recovery flow with explicit operator-confirmation gates at each destructive step. `--verify` mode reads-only; `--dry-run` prints commands without executing. Refuses on already-private fork, paid GitHub plan, dirty working tree, or already-migrated state. Step 9 writes the new config block (not symlinks); Step 9 surfaces the GitHub timeline-API survival caveat verbatim.
- **AgDR-0010** captures the design rationale, including the schema-location decision (`project-config.json` over `onboarding.yaml`).

Targets `dev` per the apexyard release-cut model.

## What changes

| Area | Files | Lines |
|------|-------|-------|
| Schema | `.claude/project-config.defaults.json` | +7 |
| Helper library | `.claude/hooks/_lib-portfolio-paths.sh` | +148 (new) |
| SessionStart hook | `.claude/hooks/check-portfolio-config.sh` | +60 (new) |
| SessionStart wiring | `.claude/settings.json` | +4 |
| Helper tests | `.claude/hooks/tests/test_portfolio_paths.sh` | +236 (new) |
| New skill | `.claude/skills/split-portfolio/SKILL.md` | +267 (new) |
| Skill audit | 18 × `SKILL.md` (callout insertion) | ~12 each |
| Surgical edits | `.claude/skills/handover/SKILL.md`, `.claude/skills/setup/SKILL.md` | +28 + +45 |
| Docs | `docs/multi-project.md` | +72 / -18 |
| AgDR | `docs/agdr/AgDR-0010-portfolio-config-and-self-healing.md` | +145 (new) |

26 files changed, ~1,416 insertions, 18 deletions.

## Why "in this PR" (the self-healing scope)

The original ticket #145 only asked for the schema + helper + skill audit. During design, the question came up: "is this usable AND self-healing?" The honest answer was "usable yes, self-healing only partially." The cheapest way to close that gap was four extra hunks landing in this same PR: `portfolio_validate()` in the helper, the SessionStart banner that uses it, the `/setup` finalization gate, and `--verify` mode in `/split-portfolio`. ~150 extra lines, all separable. The acceptance criteria on #145 were updated before code to make Rex's review mechanical.

## Closes vs Refs

This PR closes **#145** (per the single-Closes-keyword rule in `validate-pr-create.sh`). #146 is delivered in the same PR but closed manually post-merge with a "delivered in PR #X" comment — that's the framework's documented pattern when a single PR delivers two coupled tickets.

## Testing

### Helper unit tests
`bash .claude/hooks/tests/test_portfolio_paths.sh` — 13 cases, all pass:
- Defaults resolve to fork-rooted absolute paths (registry + projects_dir + ideas_backlog).
- Defaults validate is OK.
- Override with absolute path wins.
- Override with sibling-dir path validates OK.
- Override with relative path resolves against fork root.
- Validate detects: missing registry, registry without `projects:` key, missing projects_dir, ideas_backlog with missing parent.
- Validate accepts ideas_backlog missing-but-creatable (parent exists).
- `portfolio_clear_cache()` resets resolver state.

### Hook regression sweep
`for t in .claude/hooks/tests/test_*.sh; do bash "$t"; done` — 8/10 pass. Two pre-existing failures unrelated to this PR (`test_single_closes_per_pr`, `test_validate_pr_required_sections`) reference closed issue #114 in their fixtures and trip the network cross-ref check on a clean `upstream/dev` checkout. Verified pre-existing by running against pristine `upstream/dev` on a stash.

### Live smoke
- Helper runs in this fork's split-portfolio configuration: registry resolves through symlink, validate returns OK.
- SessionStart hook silent on this fork's valid config.
- SessionStart hook prints a clear banner when pointed at a tmpdir with a broken `portfolio.registry`. Exits 0 (informational, never blocks).

### Manual smoke for `/split-portfolio`
Not run end-to-end against a real public fork — destructive operations, requires throwaway repos. Documented in the skill's AC list as "manual smoke test" rather than CI-tested. The skill's pre-flight refusals + idempotency mean a partial run is recoverable.

## Glossary

| Term | Definition |
|------|------------|
| **`portfolio:` config block** | New top-level key in `.claude/project-config.{defaults,}.json` with three fields (`registry`, `projects_dir`, `ideas_backlog`) that resolve to absolute paths via the helper library. Defaults match the single-fork layout; adopters in split-portfolio mode override to point at a sibling repo. |
| **`_lib-portfolio-paths.sh`** | Sourceable shell library exposing `portfolio_registry`, `portfolio_projects_dir`, `portfolio_ideas_backlog`, `portfolio_validate`, `portfolio_clear_cache`. Resolves relative paths against the ops-fork root (the directory containing `onboarding.yaml + apexyard.projects.yaml`). Cached per-process. |
| **`portfolio_validate`** | Sanity-check that the resolved paths are actually usable: registry exists + parses as YAML + has `projects:`; projects_dir is a directory; ideas_backlog exists or is creatable. Returns `0` on OK, `1` with "broken: <reason>" on failure. |
| **Self-healing banner** | New `SessionStart` hook (`check-portfolio-config.sh`) calls `portfolio_validate` once per session start. Silent on OK. One-line banner naming the broken field + suggested fix on failure. Never blocks the session — informational only. |
| **Skill audit** | Mechanical pass through 18 SKILL.md files that touch portfolio paths, inserting a "Path resolution" callout pointing at the helper. Two skills got deeper edits to remove literal `apexyard.projects.yaml` references in bash blocks. |
| **`/split-portfolio` skill** | New skill that automates the migration from single-fork to split-portfolio mode. 10-step process with explicit operator-confirmation gates at each destructive step. `--verify` mode for state reports without destructive ops. `--dry-run` prints commands without executing. Refuses on already-migrated, paid plan, dirty tree. |
| **GitHub timeline-API survival** | When you edit an Issue or PR body via `gh issue edit` / `gh pr edit`, the original body content remains accessible via the GitHub timeline API forever. Body redaction hides the content from casual viewers + search engines, but full purge requires deleting the repo. The `/split-portfolio` skill surfaces this caveat verbatim at Step 8. |
| **Single-Closes-keyword rule** | Enforced by `validate-pr-create.sh` (introduced #114). PR bodies must use exactly one `Closes #N`-style keyword to prevent surprise auto-closures. When a single PR delivers two coupled tickets, close one with `Closes`, reference the other with `Refs`, and close the second manually post-merge. |

Closes me2resh/apexyard#145
Refs me2resh/apexyard#146 (closed manually post-merge)
