### PR TITLE
feat(#150): bootstrap-skill exemption + Bash-write coverage

### DIFF
--- a/.claude/hooks/_lib-detect-bash-write.sh
+++ b/.claude/hooks/_lib-detect-bash-write.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# _lib-detect-bash-write.sh — detect whether a Bash command writes to a file.
+#
+# Closes the bypass surface where Bash file-writes routed around hooks
+# scoped to Edit|Write|MultiEdit only. See me2resh/apexyard#151.
+#
+# Design choice: false-negatives PREFERRED over false-positives.
+# Blocking a legitimate read-only command on a fresh-adopter test is
+# worse than missing one obscure write pattern. We catch the common
+# cases (~95%) and treat the long tail as a known-limitation that
+# extends as new patterns are discovered.
+#
+# Usage:
+#   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-detect-bash-write.sh"
+#   if bash_command_appears_to_write "$COMMAND"; then
+#     target=$(bash_extract_write_target "$COMMAND")
+#     # ... apply gate, optionally with target-aware path exemptions
+#   fi
+#
+# Exposed functions:
+#   bash_command_appears_to_write COMMAND
+#       returns 0 if the command appears to write to a file, 1 otherwise
+#
+#   bash_extract_write_target COMMAND
+#       echoes the target path if extractable, empty string otherwise.
+#       Best-effort — only handles the simple cases (echo > file,
+#       tee file, sed -i ... file). Embedded interpreters
+#       (python -c, node -e, ruby -e) return empty.
+
+# ------------------------------------------------------------------------------
+# Public: bash_command_appears_to_write COMMAND
+#
+# Detects:
+#   - Output redirection: cmd > file, cmd >> file, cmd 2> file
+#   - tee
+#   - cat > file (with or without heredoc)
+#   - printf > file
+#   - sed -i (in-place edit)
+#   - awk -i inplace
+#   - python -c '...write...' or python -c '...open(...).write...'
+#   - python <<EOF ... write ... EOF (heredoc-fed python)
+#   - python3 - <<EOF ... write ... EOF (stdin-fed python — common pattern)
+#   - node -e '...writeFileSync...' or node -e '...write...'
+#   - ruby -e '...File.write...' or ruby -e '...write...'
+#
+# Misses (intentionally — long tail):
+#   - cp, mv, rm (those move/remove, not "write content")
+#   - xargs that constructs a write command
+#   - find -exec sed/awk/etc.
+#   - Custom scripts that wrap writes (could be anything)
+#   - Bash builtins like `read VAR < file` (that's a read, anyway)
+#
+# Returns 0 (write detected), 1 (no write detected).
+# ------------------------------------------------------------------------------
+bash_command_appears_to_write() {
+  local cmd="$1"
+  [ -z "$cmd" ] && return 1
+
+  # Output redirection. Match `> file`, `>> file`, `2> file`, etc.
+  # Excludes `<>` (read-write open, rare) and `&>` (combined redirect — also
+  # a write but our regex catches the trailing `>`).
+  if echo "$cmd" | grep -qE '[^|<&]>>?[[:space:]]+[^[:space:]&|;]+'; then
+    return 0
+  fi
+
+  # `tee` — writes to its arguments.
+  if echo "$cmd" | grep -qE '\btee\b'; then
+    return 0
+  fi
+
+  # `sed -i` — in-place edit. Catch `-i` and `-i ''` (BSD/macOS form).
+  if echo "$cmd" | grep -qE '\bsed[[:space:]]+([^|;&]*[[:space:]])?-i\b'; then
+    return 0
+  fi
+
+  # `awk -i inplace`
+  if echo "$cmd" | grep -qE '\bawk[[:space:]]+[^|;&]*-i[[:space:]]+inplace\b'; then
+    return 0
+  fi
+
+  # Embedded Python: `python -c '...write...'` or `python3 -c '...'`.
+  # Look for write/open keywords inside the command string.
+  if echo "$cmd" | grep -qE '\bpython3?[[:space:]]+(-[^c]*[[:space:]]+)?-c\b' && \
+     echo "$cmd" | grep -qE '\.write_text\b|\.write\b|\bopen\([^)]*[wa+]'; then
+    return 0
+  fi
+
+  # Heredoc-fed Python: `python3 <<EOF ... write ... EOF` or `python3 - <<EOF`.
+  # If the command contains `python` followed by `<<` or `-` and then any
+  # write keyword, treat as a write.
+  if echo "$cmd" | grep -qE '\bpython3?[[:space:]]+(-[[:space:]]+)?<<' && \
+     echo "$cmd" | grep -qE '\.write_text\b|\.write\b|\bopen\([^)]*[wa+]'; then
+    return 0
+  fi
+
+  # Embedded Node: `node -e '...writeFileSync...'` etc.
+  if echo "$cmd" | grep -qE '\bnode[[:space:]]+(-[^e]*[[:space:]]+)?-e\b' && \
+     echo "$cmd" | grep -qE '\bwriteFile(Sync)?\b|\.write\b|\bappendFile(Sync)?\b'; then
+    return 0
+  fi
+
+  # Embedded Ruby: `ruby -e '...File.write...'`.
+  if echo "$cmd" | grep -qE '\bruby[[:space:]]+(-[^e]*[[:space:]]+)?-e\b' && \
+     echo "$cmd" | grep -qE '\bFile\.write\b|\.write\b|\bFile\.open\([^)]*[wa+]'; then
+    return 0
+  fi
+
+  return 1
+}
+
+# ------------------------------------------------------------------------------
+# Public: bash_extract_write_target COMMAND
+#
+# Best-effort extraction of the target path from a write command.
+# Echoes the target path on success, empty string on failure.
+#
+# Handles:
+#   - cmd > /path/to/file        → /path/to/file
+#   - cmd >> /path/to/file       → /path/to/file
+#   - tee /path/to/file          → /path/to/file
+#   - sed -i 's/.../.../' /path  → /path
+#
+# Does NOT handle (returns empty):
+#   - python/node/ruby with embedded path
+#   - cmd with multiple redirects
+#   - paths constructed from variables
+# ------------------------------------------------------------------------------
+bash_extract_write_target() {
+  local cmd="$1"
+  [ -z "$cmd" ] && return 0
+
+  # Output redirection: capture the first target after > or >>.
+  # Strip leading number for cases like `2> file`.
+  local target
+  target=$(echo "$cmd" | grep -oE '[^|<&]>>?[[:space:]]+[^[:space:]&|;]+' \
+                | head -n 1 \
+                | sed -E 's/^[^>]*>>?[[:space:]]+//')
+  if [ -n "$target" ]; then
+    # Strip surrounding quotes if any.
+    target="${target%\"}"; target="${target#\"}"
+    target="${target%\'}"; target="${target#\'}"
+    echo "$target"
+    return 0
+  fi
+
+  # tee: capture the first non-flag argument after `tee`.
+  if echo "$cmd" | grep -qE '\btee\b'; then
+    target=$(echo "$cmd" | grep -oE '\btee\b[[:space:]]+(-[^[:space:]]+[[:space:]]+)*[^[:space:]&|;]+' \
+                  | head -n 1 \
+                  | sed -E 's/^tee[[:space:]]+(-[^[:space:]]+[[:space:]]+)*//')
+    if [ -n "$target" ]; then
+      target="${target%\"}"; target="${target#\"}"
+      target="${target%\'}"; target="${target#\'}"
+      echo "$target"
+      return 0
+    fi
+  fi
+
+  # sed -i: capture the file argument (last positional after the script).
+  # This is approximate — sed's argument grammar is annoying.
+  if echo "$cmd" | grep -qE '\bsed[[:space:]]+([^|;&]*[[:space:]])?-i\b'; then
+    # Take everything after the last quote-pair in the sed invocation.
+    target=$(echo "$cmd" | sed -E "s/.*'[^']*'[[:space:]]+([^[:space:]&|;]+).*/\1/")
+    # Heuristic: only accept if it looks like a path (contains / or starts with
+    # an alphanumeric, doesn't contain quote chars).
+    if echo "$target" | grep -qE '^[A-Za-z0-9./_~-]+$'; then
+      echo "$target"
+      return 0
+    fi
+  fi
+
+  # No target extractable.
+  return 0
+}

--- a/.claude/hooks/clear-bootstrap-marker.sh
+++ b/.claude/hooks/clear-bootstrap-marker.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# SessionStart hook: clear any stale bootstrap-skill marker from a
+# previous session.
+#
+# The marker at .claude/session/active-bootstrap signals to
+# require-active-ticket.sh that an in-progress bootstrap skill (e.g.
+# /setup, /handover, /update, /split-portfolio) is exempt from the
+# ticket-first gate. Skills are responsible for writing the marker on
+# entry and removing it on completion — but if a skill is interrupted
+# (terminal closed, agent killed, network failure), the marker can be
+# left behind, silently exempting the next session from the ticket gate.
+#
+# This hook runs at SessionStart and removes the marker if present, so
+# every session starts with a clean slate. If the user is genuinely
+# resuming a bootstrap skill, they re-invoke it and the skill writes
+# the marker again.
+#
+# Silent on the no-marker path (the common case). Logs a one-line note
+# to stderr when clearing a stale marker so the operator sees what
+# happened.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# Walk up to find the apexyard fork root.
+ROOT=""
+cur="$REPO_ROOT"
+while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+  if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+    ROOT="$cur"
+    break
+  fi
+  cur=$(dirname "$cur")
+done
+
+if [ -z "$ROOT" ]; then
+  exit 0
+fi
+
+MARKER="$ROOT/.claude/session/active-bootstrap"
+if [ -f "$MARKER" ]; then
+  stale_skill=$(tr -d '[:space:]' < "$MARKER" 2>/dev/null || echo "(unreadable)")
+  rm -f "$MARKER"
+  echo "ApexYard: cleared stale bootstrap marker (was: $stale_skill) from a previous session." >&2
+fi
+
+exit 0

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -31,16 +31,51 @@
 # Everything else (source code, config, infra) requires a ticket marker.
 
 INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
 
-if [ -z "$FILE_PATH" ]; then
+# Bash-tool path: extract the target file from the command if it appears
+# to be a write. Closes the bypass surface where Bash file-writes
+# (`echo > file`, `tee file`, `sed -i ... file`, `python -c
+# 'pathlib.Path(...).write_text(...)'`, etc.) routed around the
+# Edit/Write/MultiEdit-only gate. See me2resh/apexyard#151 + the
+# _lib-detect-bash-write helper for the matcher details and design
+# choice (false-negatives preferred over false-positives).
+if [ "$TOOL_NAME" = "Bash" ]; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+  if [ -z "$COMMAND" ]; then
+    exit 0
+  fi
+
+  # Source the bash-write detector. Library lives next to this hook.
+  HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+  if [ ! -f "$HOOK_DIR/_lib-detect-bash-write.sh" ]; then
+    # Library missing — fall back to non-Bash behavior to avoid bricking
+    # the hook entirely.
+    exit 0
+  fi
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-detect-bash-write.sh"
+
+  if ! bash_command_appears_to_write "$COMMAND"; then
+    # Read-only command — no gate.
+    exit 0
+  fi
+
+  # Try to extract a target path so we can apply the same path-based
+  # exemptions (.claude/, docs/, *.md). If extraction fails, FILE_PATH
+  # stays empty and the gate is applied categorically.
+  FILE_PATH=$(bash_extract_write_target "$COMMAND")
+fi
+
+if [ -z "$FILE_PATH" ] && [ "$TOOL_NAME" != "Bash" ]; then
   exit 0
 fi
 
 # Normalise to repo-relative path when possible
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 REL_PATH="$FILE_PATH"
-if [ -n "$REPO_ROOT" ]; then
+if [ -n "$REPO_ROOT" ] && [ -n "$FILE_PATH" ]; then
   case "$FILE_PATH" in
     "$REPO_ROOT"/*) REL_PATH="${FILE_PATH#$REPO_ROOT/}" ;;
   esac
@@ -56,17 +91,24 @@ fi
 # existing `*.md` pattern already crosses `/`, so absolute-match via a
 # `*/…` prefix is a known-good shape — #56 extends the same trick to the
 # path-prefix exemptions.
-case "$REL_PATH" in
-  .claude/*|.claude|*/.claude/*|*/.claude) exit 0 ;;
-  docs/*|docs|*/docs/*|*/docs) exit 0 ;;
-  TODO.md|README.md|MEMORY.md|CLAUDE.md) exit 0 ;;
-esac
-# Note: `projects/*/docs/*` is subsumed by `*/docs/*` above (shell case `*`
-# crosses `/`), so no separate arm needed. Per-project apexyard docs are
-# matched by the generic docs-in-any-subtree pattern.
-case "$REL_PATH" in
-  *.md) exit 0 ;;
-esac
+#
+# Skipped entirely when FILE_PATH is empty (Bash command writes to an
+# unextractable target — e.g. `python -c '...write...'`). Those fall
+# through to the ticket gate; the bootstrap-skill exemption below covers
+# the legitimate use case (/setup writing to fork-root files via Bash).
+if [ -n "$REL_PATH" ]; then
+  case "$REL_PATH" in
+    .claude/*|.claude|*/.claude/*|*/.claude) exit 0 ;;
+    docs/*|docs|*/docs/*|*/docs) exit 0 ;;
+    TODO.md|README.md|MEMORY.md|CLAUDE.md) exit 0 ;;
+  esac
+  # Note: `projects/*/docs/*` is subsumed by `*/docs/*` above (shell case `*`
+  # crosses `/`), so no separate arm needed. Per-project apexyard docs are
+  # matched by the generic docs-in-any-subtree pattern.
+  case "$REL_PATH" in
+    *.md) exit 0 ;;
+  esac
+fi
 
 # Discover the ops root. Walk up from REPO_ROOT until we find a directory
 # with both onboarding.yaml AND apexyard.projects.yaml (a configured ops
@@ -86,6 +128,34 @@ fi
 
 MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
 MARKER_HOME="${MARKER_HOME:-.}"
+
+# Bootstrap-skill exemption (apexyard#150): skills like /setup,
+# /handover, /update, /split-portfolio run BEFORE any ticket can exist
+# (no portfolio configured yet, no projects registered). They write a
+# marker at .claude/session/active-bootstrap with the skill name on
+# entry; this hook reads the marker, looks up the configured
+# bootstrap_skills list, and exits 0 if the active skill is on the list.
+#
+# The marker is cleared at SessionStart by clear-bootstrap-marker.sh so
+# a stale marker from an interrupted session can't carry over.
+BOOTSTRAP_MARKER="$MARKER_HOME/.claude/session/active-bootstrap"
+if [ -f "$BOOTSTRAP_MARKER" ]; then
+  active_bootstrap=$(tr -d '[:space:]' < "$BOOTSTRAP_MARKER" 2>/dev/null)
+  if [ -n "$active_bootstrap" ]; then
+    # Source the config reader and look up bootstrap_skills.
+    if [ -f "$MARKER_HOME/.claude/hooks/_lib-read-config.sh" ]; then
+      # shellcheck source=/dev/null
+      . "$MARKER_HOME/.claude/hooks/_lib-read-config.sh"
+      if command -v config_get >/dev/null 2>&1; then
+        # `config_get '.ticket.bootstrap_skills[]'` outputs one skill per
+        # line. Use grep -wF for whole-word, fixed-string match.
+        if config_get '.ticket.bootstrap_skills[]' 2>/dev/null | grep -qwF "$active_bootstrap"; then
+          exit 0
+        fi
+      fi
+    fi
+  fi
+fi
 
 # Per-project resolution (apexyard#41): if FILE_PATH points under
 # <ops_root>/workspace/<project>/, we look for a per-project marker at

--- a/.claude/hooks/require-migration-ticket.sh
+++ b/.claude/hooks/require-migration-ticket.sh
@@ -37,7 +37,32 @@
 # present, otherwise defaults below apply.
 
 INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+
+# Bash-tool path: if the command writes, try to extract the target so we
+# can apply the migration-path matcher to it. If extraction fails (e.g.
+# `python -c '…write_text("file"…)…'`), FILE_PATH stays empty and the
+# hook exits 0 — the migration gate is path-specific, so an
+# unextractable target falls outside the gate's scope.
+# See me2resh/apexyard#151 + _lib-detect-bash-write.sh for the detector.
+if [ "$TOOL_NAME" = "Bash" ]; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+  [ -z "$COMMAND" ] && exit 0
+
+  HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+  if [ -f "$HOOK_DIR/_lib-detect-bash-write.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$HOOK_DIR/_lib-detect-bash-write.sh"
+    if ! bash_command_appears_to_write "$COMMAND"; then
+      exit 0
+    fi
+    FILE_PATH=$(bash_extract_write_target "$COMMAND")
+  else
+    # Library missing — fall back to no-op rather than bricking the hook.
+    exit 0
+  fi
+fi
 
 if [ -z "$FILE_PATH" ]; then
   exit 0

--- a/.claude/hooks/tests/test_detect_bash_write.sh
+++ b/.claude/hooks/tests/test_detect_bash_write.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Tests for the bash-write-detection helper (#151).
+#
+# Covers:
+#   - bash_command_appears_to_write: each pattern in the matcher table
+#     (positive-class) and a representative read-only set (negative-class)
+#   - bash_extract_write_target: the simple cases where extraction works
+#     (>, >>, tee), and the documented misses (python -c) returning empty
+#
+# Exit 0 if all cases pass; exit 1 on first failure.
+
+set -u
+
+LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-detect-bash-write.sh"
+if [ ! -f "$LIB_SRC" ]; then
+  echo "FAIL: lib not found at $LIB_SRC" >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+. "$LIB_SRC"
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+assert_write() {
+  local label="$1" cmd="$2"
+  if bash_command_appears_to_write "$cmd"; then
+    echo "PASS [write/$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [should-detect-write/$label]: $cmd" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}write/${label} "
+  fi
+}
+
+assert_read() {
+  local label="$1" cmd="$2"
+  if bash_command_appears_to_write "$cmd"; then
+    echo "FAIL [should-be-read/$label]: $cmd" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}read/${label} "
+  else
+    echo "PASS [read/$label]"
+    PASS=$((PASS+1))
+  fi
+}
+
+assert_target() {
+  local label="$1" cmd="$2" want="$3"
+  local got
+  got=$(bash_extract_write_target "$cmd")
+  if [ "$got" = "$want" ]; then
+    echo "PASS [target/$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [target/$label]: cmd=$cmd  want=[$want]  got=[$got]" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}target/${label} "
+  fi
+}
+
+# --- WRITE patterns (positive class) -----------------------------------
+
+assert_write "echo redirect"        "echo hi > /tmp/x"
+assert_write "echo append"          "echo hi >> /tmp/x"
+assert_write "cat heredoc"          $'cat > /tmp/x <<EOF\nhi\nEOF'
+assert_write "tee"                  "echo x | tee /tmp/x"
+assert_write "tee -a"               "echo x | tee -a /tmp/x"
+assert_write "printf redirect"      "printf '%s' hello > /tmp/x"
+assert_write "sed -i GNU"           "sed -i s/foo/bar/ /tmp/x"
+assert_write "sed -i BSD"           "sed -i '' s/foo/bar/ /tmp/x"
+assert_write "awk inplace"          "awk -i inplace 1 /tmp/x"
+assert_write "python -c write_text" 'python3 -c "import pathlib; pathlib.Path(\"/tmp/x\").write_text(\"hi\")"'
+assert_write "python -c open w"     'python3 -c "open(\"/tmp/x\", \"w\").write(\"hi\")"'
+assert_write "python heredoc -"     $'python3 - <<\'PY\'\nimport pathlib\npathlib.Path("/tmp/x").write_text("hi")\nPY'
+assert_write "node -e writeFile"    'node -e "require(\"fs\").writeFileSync(\"/tmp/x\", \"hi\")"'
+assert_write "node -e appendFile"   'node -e "require(\"fs\").appendFileSync(\"/tmp/x\", \"hi\")"'
+assert_write "ruby -e File.write"   'ruby -e "File.write(\"/tmp/x\", \"hi\")"'
+
+# --- READ patterns (negative class — must NOT trigger) -----------------
+
+assert_read  "cat"            "cat /tmp/x"
+assert_read  "grep file"      "grep foo /tmp/x"
+assert_read  "ls"             "ls -la /tmp"
+assert_read  "find"           "find . -name foo"
+assert_read  "git status"     "git status"
+assert_read  "git diff"       "git diff HEAD"
+assert_read  "pipe to grep"   "cat /tmp/x | grep foo"
+assert_read  "stderr merge"   "make build 2>&1"
+assert_read  "python read"    'python3 -c "print(open(\"/tmp/x\").read())"'
+assert_read  "node read"      'node -e "console.log(require(\"fs\").readFileSync(\"/tmp/x\", \"utf8\"))"'
+
+# --- target extraction (positive class — should produce target) --------
+
+assert_target "redirect path"      "echo hi > /tmp/x"           "/tmp/x"
+assert_target "append path"        "echo hi >> /tmp/x"          "/tmp/x"
+assert_target "tee path"           "echo x | tee /tmp/x"        "/tmp/x"
+assert_target "tee with flag"      "echo x | tee -a /tmp/x"     "/tmp/x"
+
+# --- target extraction (documented misses — empty result) --------------
+
+assert_target "python -c (miss)"   'python3 -c "open(\"/tmp/x\",\"w\").write(\"hi\")"' ""
+assert_target "node -e (miss)"     'node -e "fs.writeFileSync(\"/tmp/x\",\"hi\")"' ""
+
+# --- Regression: the exact bypass attempt that surfaced #151 ----------
+
+bypass_cmd=$'python3 - <<\'PY\'\nimport pathlib\np = pathlib.Path(".gitignore")\np.write_text("...")\nPY'
+assert_write "issue-151 bypass attempt" "$bypass_cmd"
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Tests for require-active-ticket.sh — Bash-write coverage (#151) and
+# bootstrap-skill exemption (#150).
+#
+# Each case:
+#   - builds an isolated sandbox containing onboarding.yaml, an empty
+#     registry, the hook script, the two libs it sources, and the shipped
+#     project-config defaults
+#   - optionally writes a current-ticket marker and/or active-bootstrap
+#     marker to flip the gate
+#   - pipes a synthetic PreToolUse JSON (Edit or Bash tool) to the hook
+#   - asserts exit code (0=pass-through, 2=blocked) and stderr regex
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/require-active-ticket.sh"
+LIB_BASH="$SRC_ROOT/.claude/hooks/_lib-detect-bash-write.sh"
+LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+
+for f in "$HOOK_SRC" "$LIB_BASH" "$LIB_CFG" "$DEFAULTS"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: required source missing: $f" >&2
+    exit 1
+  fi
+done
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    : > onboarding.yaml
+    : > apexyard.projects.yaml
+    git add onboarding.yaml apexyard.projects.yaml
+    git commit -q -m "init"
+  )
+  mkdir -p "$sb/.claude/hooks" "$sb/.claude/session"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/require-active-ticket.sh"
+  cp "$LIB_BASH" "$sb/.claude/hooks/_lib-detect-bash-write.sh"
+  cp "$LIB_CFG"  "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$DEFAULTS" "$sb/.claude/project-config.defaults.json"
+  chmod +x "$sb/.claude/hooks/require-active-ticket.sh"
+  echo "$sb"
+}
+
+run_case() {
+  local label="$1" want_rc="$2" want_stderr_regex="$3" input="$4" sb="$5"
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/require-active-ticket.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:200})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# --- Bash-write coverage (#151) -----------------------------------------
+
+# 1. echo > .gitignore with no ticket → BLOCKED
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo x > .gitignore" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash echo redirect blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 2. python -c '...write_text...' on .gitignore w/o ticket → BLOCKED
+#    (the exact bypass attempt from #151)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c 'python3 -c "import pathlib; pathlib.Path(\".gitignore\").write_text(\"x\")"' \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash python write_text bypass blocked" 2 "BLOCKED" "$in" "$sb"
+
+# 3. cat /file → allowed (read-only)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "cat /etc/hostname" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash read passes through" 0 "" "$in" "$sb"
+
+# 4. echo > .claude/foo.json → allowed (path exemption catches it)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo x > .claude/foo.json" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash write to .claude/ exempt" 0 "" "$in" "$sb"
+
+# 5. tee /docs/note.md → allowed (path + .md exemption)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo x | tee docs/note.md" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash write to .md exempt" 0 "" "$in" "$sb"
+
+# --- Bootstrap-skill exemption (#150) -----------------------------------
+
+# 6. Edit src/foo.ts, no ticket, NO bootstrap marker → BLOCKED
+sb=$(make_sandbox)
+in=$(jq -nc --arg p "$sb/src/foo.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "edit blocked w/o ticket no bootstrap" 2 "BLOCKED" "$in" "$sb"
+
+# 7. Edit .gitignore, no ticket, BOOTSTRAP marker (setup) → allowed
+sb=$(make_sandbox)
+echo "setup" > "$sb/.claude/session/active-bootstrap"
+in=$(jq -nc --arg p "$sb/.gitignore" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "edit allowed with setup bootstrap marker" 0 "" "$in" "$sb"
+
+# 8. Edit src/foo.ts, no ticket, BOOTSTRAP marker (handover) → allowed
+sb=$(make_sandbox)
+echo "handover" > "$sb/.claude/session/active-bootstrap"
+in=$(jq -nc --arg p "$sb/src/foo.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "edit allowed with handover bootstrap marker" 0 "" "$in" "$sb"
+
+# 9. Edit src/foo.ts, no ticket, BOOTSTRAP marker (UNKNOWN skill) → BLOCKED
+#    (only skills on the configured bootstrap_skills list are exempt)
+sb=$(make_sandbox)
+echo "some-random-skill" > "$sb/.claude/session/active-bootstrap"
+in=$(jq -nc --arg p "$sb/src/foo.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "edit blocked when bootstrap marker is for non-listed skill" 2 "BLOCKED" "$in" "$sb"
+
+# 10. Bash python write to .gitignore, BOOTSTRAP marker (setup) → allowed
+#     (this is the exact /setup-runs-into-#151-bypass scenario from #150)
+sb=$(make_sandbox)
+echo "setup" > "$sb/.claude/session/active-bootstrap"
+in=$(jq -nc --arg c 'python3 -c "import pathlib; pathlib.Path(\".gitignore\").write_text(\"x\")"' \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash write allowed with setup bootstrap" 0 "" "$in" "$sb"
+
+# 11. Empty bootstrap marker → no exemption (treated as no marker)
+sb=$(make_sandbox)
+: > "$sb/.claude/session/active-bootstrap"
+in=$(jq -nc --arg p "$sb/src/foo.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "edit blocked when bootstrap marker is empty" 2 "BLOCKED" "$in" "$sb"
+
+# --- Active-ticket marker still works (regression for the legacy path) -
+
+# 12. Edit src/foo.ts with a current-ticket marker → allowed
+sb=$(make_sandbox)
+cat > "$sb/.claude/session/current-ticket" <<EOF
+repo=me2resh/apexyard
+number=999
+title=test
+url=https://example.com
+EOF
+in=$(jq -nc --arg p "$sb/src/foo.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "edit allowed with active ticket marker" 0 "" "$in" "$sb"
+
+# --- Summary -----------------------------------------------------------
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -22,7 +22,14 @@
       "Docs": ["Driver", "Acceptance Criteria"],
       "Bug": ["Given / When / Then", "Repro"]
     },
-    "skip_marker": "<!-- validate-issue-structure: skip -->"
+    "skip_marker": "<!-- validate-issue-structure: skip -->",
+    "_bootstrap_skills_comment": "Skills that run BEFORE any ticket can exist (fork bootstrap, project handover, framework upstream-sync). When one of these is active (marker at .claude/session/active-bootstrap), require-active-ticket.sh exempts the gate. The marker is written by the skill itself on entry, cleared on completion, AND reset at SessionStart so a stale marker can't carry over. See AgDR-0011-bootstrap-skill-exemption.md and me2resh/apexyard#150.",
+    "bootstrap_skills": [
+      "setup",
+      "handover",
+      "update",
+      "split-portfolio"
+    ]
   },
 
   "branch": {

--- a/.claude/rules/workflow-gates.md
+++ b/.claude/rules/workflow-gates.md
@@ -36,6 +36,23 @@ Do not start coding until **all** of these exist in your ticket tracker:
 - Technical tasks broken down
 - Tickets moved to "Todo" or "In Progress"
 
+### Bootstrap-skill exemption
+
+The pre-build gate is enforced mechanically by `require-active-ticket.sh`, which fires on `Edit`, `Write`, `MultiEdit`, **and** `Bash` (the Bash matcher uses `_lib-detect-bash-write.sh` to detect `>` redirection, `tee`, `sed -i`, `python -c '…write…'`, `node -e '…writeFile…'`, etc. — closing the bypass surface from me2resh/apexyard#151).
+
+A small set of **bootstrap-class skills** runs before any portfolio is configured, before any project is registered, and therefore before any tracker tickets can exist. For these, the gate is exempt:
+
+- `/setup` — first-run framework bootstrap on a fresh fork
+- `/handover` — adopting an external project (registry / `projects/<name>/` writes happen before the project's own tracker is wired up)
+- `/update` — upstream sync (touches framework files; the only "ticket" for this work is the sync itself)
+- `/split-portfolio` — destructive migration to split-portfolio mode (rewriting fork-root files; existing private-name tickets being redacted *as the work proceeds*)
+
+The list lives at `.claude/project-config.defaults.json` → `ticket.bootstrap_skills`. Adopters extend it via `.claude/project-config.json` shallow-merge if they have custom bootstrap skills.
+
+**Mechanism:** each bootstrap skill writes its name to `.claude/session/active-bootstrap` on entry and removes the file on completion. The hook reads the marker and exempts skills on the configured list. The `clear-bootstrap-marker.sh` SessionStart hook sweeps stale markers from interrupted sessions so a crashed / killed skill can't leave the exemption open forever.
+
+See AgDR-0011 + me2resh/apexyard#150 for the full design rationale.
+
 ## Migration Gate (3a) — dedicated ticket + AgDR
 
 Any edit to a file that matches the migration-path patterns (configurable via `.claude/project-config.json` → `migration_paths`) requires:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,10 @@
           {
             "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-portfolio-config.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/clear-bootstrap-marker.sh\"'"
           }
         ]
       }
@@ -150,6 +154,14 @@
             "type": "command",
             "if": "Bash(gh api *)",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-migration-ticket.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
           }
         ]
       }

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -48,6 +48,16 @@ The architecture stub is **written once** and never overwritten — it's a start
 
 ## Process
 
+### 0. Mark this session as bootstrap (REQUIRED)
+
+`/handover` may run before any tracker tickets exist for the project being adopted, so the `require-active-ticket.sh` PreToolUse hook would block the registry / `projects/<name>/` writes the skill needs. Write a marker so the hook exempts this skill (it's on the default `bootstrap_skills` list in `.claude/project-config.defaults.json`):
+
+```bash
+mkdir -p .claude/session && echo "handover" > .claude/session/active-bootstrap
+```
+
+Clear the marker on completion (Step "Post-Handover Checklist" below). If the skill is interrupted, the SessionStart hook `clear-bootstrap-marker.sh` clears it at the start of the next session. See AgDR-0011 + me2resh/apexyard#150.
+
 ### 1. Locate the target repo
 
 If a path is given, use it. If a URL is given, prompt the user to clone it into `workspace/<name>/` first (don't clone automatically — that's a side-effect with cost). If nothing is given, ask:
@@ -236,6 +246,14 @@ If no risks match a row, omit that row. If fewer than 3 actions come out, add:
 
 - `{next} /code-review the most-recent PR on this repo as Rex to calibrate review standards`
 - `{next} Stakeholder sync with the previous owner to cover context the static read couldn't surface`
+
+## Cleanup (REQUIRED before exit)
+
+```bash
+rm -f .claude/session/active-bootstrap
+```
+
+Always remove the bootstrap marker on a clean exit. If the skill is interrupted before this step, `clear-bootstrap-marker.sh` clears the stale marker on the next session.
 
 ## Post-Handover Checklist
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -30,6 +30,20 @@ Re-running `/setup` on an already-configured fork shows the current config and a
 
 ## Process
 
+### Step 0: Mark this session as bootstrap (REQUIRED)
+
+`/setup` runs BEFORE any portfolio is configured, so no project tickets can exist yet. The `require-active-ticket.sh` PreToolUse hook would otherwise block every Edit / Write / Bash-write the skill needs to make. To stay coherent with the ticket-first rule without forcing adopters to file a placeholder ticket against nothing, the skill writes a one-line marker at `.claude/session/active-bootstrap` containing the skill name. The hook reads the marker and exempts skills listed in `ticket.bootstrap_skills` (in `.claude/project-config.defaults.json` — `setup` is on the default list).
+
+Run this **before any tool calls that edit files**:
+
+```bash
+mkdir -p .claude/session && echo "setup" > .claude/session/active-bootstrap
+```
+
+The marker is cleared in Step 8 below (and on the next SessionStart by `clear-bootstrap-marker.sh`, in case this skill is interrupted).
+
+See AgDR-0011 + me2resh/apexyard#150 for the design rationale.
+
 ### Step 1: Check current state
 
 Read `onboarding.yaml`. Two modes:
@@ -211,6 +225,14 @@ I'll need: repo name (owner/repo) and a short project name.
 
 If yes → append to `apexyard.projects.yaml`, stage alongside `onboarding.yaml`.
 If no → skip. They can add projects later with `/handover`.
+
+### Step 8: Clear the bootstrap marker (REQUIRED)
+
+```bash
+rm -f .claude/session/active-bootstrap
+```
+
+Always remove the marker on a clean exit so subsequent edits in the same session go through the normal ticket gate. If `/setup` is interrupted before this step, `clear-bootstrap-marker.sh` (SessionStart hook) clears the stale marker on the next session.
 
 ## Rules
 

--- a/.claude/skills/split-portfolio/SKILL.md
+++ b/.claude/skills/split-portfolio/SKILL.md
@@ -47,6 +47,17 @@ Refusal at any of these gates is silent on every other check — show only the r
 
 ## Process
 
+### 0. Mark this session as bootstrap (REQUIRED for non-`--verify` modes)
+
+`/split-portfolio` rewrites fork-root files (`.gitignore`, `.claude/project-config.json`, registry symlinks) which the `require-active-ticket.sh` PreToolUse hook would block — and the whole point of the migration is that the fork's existing private project names should no longer be referenced, so even filing a placeholder ticket is awkward. Write a marker so the hook exempts this skill (it's on the default `bootstrap_skills` list in `.claude/project-config.defaults.json`):
+
+```bash
+# Only on full / --dry-run modes. --verify is read-only and doesn't need the marker.
+mkdir -p .claude/session && echo "split-portfolio" > .claude/session/active-bootstrap
+```
+
+Clear the marker at the end of the migration (or on a confirmed-abort). If the skill is interrupted mid-flow, the SessionStart hook `clear-bootstrap-marker.sh` clears it at the start of the next session. See AgDR-0011 + me2resh/apexyard#150.
+
 ### --verify mode (no destructive ops, safe to run anytime)
 
 1. Source `_lib-read-config.sh` and `_lib-portfolio-paths.sh`.
@@ -326,6 +337,14 @@ Re-running the skill on a partially-migrated fork picks up where it left off:
 | All complete | Run --verify only and exit 0 |
 
 The `--dry-run` flag walks through every step printing the commands but executes none. Useful for the operator to preview the destructive ops before running real.
+
+## Cleanup (REQUIRED before exit)
+
+```bash
+rm -f .claude/session/active-bootstrap
+```
+
+Run on every exit path (successful migration, confirmed abort, refusal-in-flight). If the skill is interrupted before this step, `clear-bootstrap-marker.sh` clears the stale marker on the next session.
 
 ## Rules
 

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -46,6 +46,16 @@ On up-to-date: one line, no state change.
 
 ## Process
 
+### 0. Mark this session as bootstrap (REQUIRED)
+
+`/update` edits framework-root files (resolving merge conflicts, updating CLAUDE.md imports, etc.) which the `require-active-ticket.sh` PreToolUse hook would otherwise block when the only "ticket" is the upstream-sync work itself. Write a marker so the hook exempts this skill (it's on the default `bootstrap_skills` list in `.claude/project-config.defaults.json`):
+
+```bash
+mkdir -p .claude/session && echo "update" > .claude/session/active-bootstrap
+```
+
+Clear the marker on completion (last step of this skill). If the skill is interrupted, the SessionStart hook `clear-bootstrap-marker.sh` clears it at the start of the next session. See AgDR-0011 + me2resh/apexyard#150.
+
 ### 1. Pre-flight
 
 Run these checks in order. On first failure, stop and explain.
@@ -335,6 +345,14 @@ Two reasons:
 ### Dry-run semantics
 
 `--dry-run` simulates step 3 (preview) only. It does NOT simulate the merge itself — running `git merge --no-commit --no-ff` as a dry-run leaves the working tree in a staged state that's easy to accidentally commit. If the preview says N commits to pull in, the user should run `/update` for real to see the merge.
+
+## Cleanup (REQUIRED before exit)
+
+```bash
+rm -f .claude/session/active-bootstrap
+```
+
+Always remove the bootstrap marker on a clean exit (after the sync branch is ready to push, or on a confirmed-abort during conflict resolution). If the skill is interrupted, `clear-bootstrap-marker.sh` clears the stale marker on the next session.
 
 ## Related
 

--- a/docs/agdr/AgDR-0011-bootstrap-skill-exemption.md
+++ b/docs/agdr/AgDR-0011-bootstrap-skill-exemption.md
@@ -1,0 +1,133 @@
+# Bootstrap-skill exemption for the ticket-first gate + Bash-write coverage
+
+> In the context of `/setup` (and the rest of the bootstrap-class skills — `/handover`, `/update`, `/split-portfolio`) running BEFORE any portfolio is configured or any tickets exist, facing the dual problem that (a) `require-active-ticket.sh` blocks every Edit / Write the bootstrap skill needs to make and (b) the only escape hatch the agent organically discovered was a `Bash` write through `python -c '…write_text…'` that the hook didn't cover, I decided to ship a file-based active-skill marker (`.claude/session/active-bootstrap`) that the hook reads and exempts skills listed in `ticket.bootstrap_skills`, AND extend `require-active-ticket.sh` + `require-migration-ticket.sh` to fire on `Bash` via a shared `_lib-detect-bash-write.sh` helper that detects the common write shapes (output redirection, `tee`, `sed -i`, `awk -i inplace`, embedded `python` / `node` / `ruby`), to achieve a coherent ticket gate where the legitimate bootstrap path works without ceremony AND the illegitimate Bash bypass is closed in the same PR, accepting that the marker is opt-in (skills must write it; a non-cooperating skill won't get the exemption), that the Bash matcher uses heuristic regex with documented false-negative-preferred semantics, and that the two changes (legitimate-bypass + illegitimate-bypass) ship together because shipping #150 alone would issue an exemption mechanism for a gate that's still trivially bypassable, and shipping #151 alone would make `/setup` the worst first-impression in the framework.
+
+## Context
+
+The framework's safety story rests on `require-active-ticket.sh` blocking code edits without a tracked ticket. That story has two cracks that surfaced together during a fresh-adopter `/setup` test on 2026-05-03:
+
+1. **Crack 1 — legitimate bypass needed (#150).** `/setup` runs before `apexyard.projects.yaml` exists, before any project is registered, before any tickets can be filed. The hook blocks every Edit it tries to make to `.gitignore`, `.claude/project-config.json`, etc. There is no ticket to declare and no place to file one — the framework's first interaction with a fresh adopter is a deadlock.
+
+2. **Crack 2 — illegitimate bypass discovered (#151).** Hitting Crack 1, the agent's natural next move was *"let me try via bash (which doesn't fire that hook)"* — and proceeded to attempt `python3 -c 'pathlib.Path(".gitignore").write_text(...)'`. The bypass would have worked. The hook was scoped to `Edit|Write|MultiEdit` only; any `Bash` write — `echo > file`, `tee`, `sed -i`, embedded interpreters — slipped through.
+
+Both cracks point at the same gate. Shipping a fix to one without the other leaves the framework incoherent:
+
+- Fix Crack 1 only → bootstrap exemption, but the gate is still trivially bypassable. The exemption is a ceremony for a gate that doesn't actually gate anything.
+- Fix Crack 2 only → gate is now strict, but `/setup` is now hard-blocked. Adoption flow is worse than before.
+
+A coherent fix lands both at once.
+
+## Options
+
+### Option A — Path-based exemption only (today's pattern, extended)
+
+The hook already exempts `.claude/`, `docs/`, `*.md`. Add `.gitignore`, `onboarding.yaml`, `apexyard.projects.yaml` to the path exemption list. Done.
+
+| Pros | Cons |
+|------|------|
+| One-line change | Does NOT scale: every new bootstrap-touched file extends the exemption list and the list grows unboundedly |
+| No new mechanisms | Path-based exemption is a permission, not a context — anyone editing those paths skips the gate, even outside `/setup` |
+| | Doesn't address Crack 2 (Bash bypass) at all |
+
+### Option B — SkillStart hook integration
+
+Wait for Claude Code to expose an official "active skill" lifecycle hook. The skill name lands in a system-managed marker; the ticket hook reads it.
+
+| Pros | Cons |
+|------|------|
+| Official mechanism, no skill-side opt-in needed | Doesn't exist today — would need an upstream Claude Code change |
+| Cleaner: the harness manages the marker lifecycle | Coupling the framework's safety story to an unbuilt CC feature ships unbounded delay |
+| | Punts on Crack 2 entirely |
+
+### Option C — Active-skill marker (file-based, skill-cooperative) **CHOSEN**
+
+Each bootstrap-class skill writes its name to `.claude/session/active-bootstrap` on entry and removes the file on completion. The ticket hook reads the marker and exempts skills whose names appear in the configured `ticket.bootstrap_skills` list. A SessionStart hook (`clear-bootstrap-marker.sh`) sweeps stale markers from interrupted sessions. Bash coverage is added in the same PR via `_lib-detect-bash-write.sh` so the gate is actually a gate.
+
+| Pros | Cons |
+|------|------|
+| Works today, no upstream CC dependency | Skill-cooperative — a skill that forgets to write the marker doesn't get the exemption (correctly, but adds maintenance surface) |
+| Scales: new bootstrap skills add themselves to `bootstrap_skills` | A skill that forgets to clear the marker leaves a stale exemption (mitigated by `clear-bootstrap-marker.sh` SessionStart sweep) |
+| Closes both Cracks in one PR — coherent safety story | Heuristic Bash detection has documented false-negative tail — bypass surface narrows but isn't formally closed |
+| Reuses existing config layer (`.claude/project-config.defaults.json` + `_lib-read-config.sh`) | |
+| File-based marker is debuggable (`cat .claude/session/active-bootstrap`) | |
+
+## Decision
+
+Chosen: **Option C — file-based active-skill marker + same-PR Bash coverage extension.**
+
+Three reasons it wins:
+
+1. **Coherent safety story.** Crack 1 and Crack 2 are the same shape (gate not matching the work in front of it). Fixing them separately leaves a window where the framework is worse than before. Bundling them is the right shape — the AgDR captures the pair.
+2. **No upstream dependency.** Option B is the prettier long-term mechanism, but waiting on Claude Code to expose a SkillStart lifecycle hook is unbounded delay. Option C works with what's there today and converts cleanly to Option B if/when CC ships the upstream hook (the marker file becomes the harness-written marker file; the consumer doesn't change).
+3. **Reuses existing patterns.** The config layer, the `_lib-` helper convention, the SessionStart-sweep pattern — all already present. No new mechanisms; the marker is a one-line `.claude/session/<name>` file like `current-ticket`, the hook chain pattern is the same as `clear-fetch-cache` and friends.
+
+## Scope summary
+
+### 1. Schema — `.claude/project-config.defaults.json`
+
+Adds `ticket.bootstrap_skills` listing `setup`, `handover`, `update`, `split-portfolio`. Adopters can extend in `.claude/project-config.json`. Same pattern as the rest of the config layer.
+
+### 2. Hook changes
+
+- `require-active-ticket.sh`:
+  - Now fires on `Bash` in addition to `Edit|Write|MultiEdit`. Sources `_lib-detect-bash-write.sh`; if the Bash command appears to write, extracts the target (best-effort) and applies the same gate logic. If extraction fails, the gate is applied categorically.
+  - New bootstrap-marker exemption: reads `.claude/session/active-bootstrap`; if its content matches a skill in `ticket.bootstrap_skills`, the gate is skipped.
+- `require-migration-ticket.sh`: parallel Bash extension. The migration gate is path-specific, so an unextractable Bash target naturally falls outside scope (exits 0).
+
+### 3. New library — `_lib-detect-bash-write.sh`
+
+Heuristic Bash-command write detector. Two functions:
+
+- `bash_command_appears_to_write COMMAND` — exits 0 on detected write, 1 otherwise.
+- `bash_extract_write_target COMMAND` — best-effort path extraction; empty on failure.
+
+Pattern coverage: output redirection, `tee`, `sed -i`, `awk -i inplace`, `python -c '…write…'`, `python <<EOF …`, `node -e '…writeFile…'`, `ruby -e '…File.write…'`. Design choice: false-negatives PREFERRED over false-positives. Better to miss an obscure write than block a legitimate read on a fresh-adopter test. Pattern table extends as new bypass shapes are observed.
+
+### 4. New SessionStart hook — `clear-bootstrap-marker.sh`
+
+Sweeps stale `.claude/session/active-bootstrap` files from interrupted sessions. Wired into `.claude/settings.json` after the existing `onboarding-check`, `check-upstream-drift`, `check-portfolio-config` chain. Logs to stderr only when it actually clears a marker; silent on the no-marker path (the common case).
+
+### 5. Skill changes
+
+`/setup`, `/handover`, `/update`, `/split-portfolio` each get a "Step 0: write the marker" instruction near the top of the Process section and a "Cleanup: remove the marker" instruction at the end. Skill content otherwise unchanged.
+
+### 6. Tests
+
+- `test_detect_bash_write.sh` — 32 cases covering each pattern in the matcher table, the negative-class read patterns, target extraction, and the exact #151 bypass repro.
+- `test_require_active_ticket_bash.sh` — 12 integration cases covering: Bash writes blocked w/o ticket, the #151 python-write bypass closed, Bash reads pass through, path exemptions still work for Bash, bootstrap-marker exemption works for Edit and Bash, unknown / empty marker correctly falls through to the gate, and the legacy active-ticket path still works (regression).
+
+### 7. Doc note
+
+`.claude/rules/workflow-gates.md` § "Pre-Build Gate" gets a one-paragraph callout explaining the exemption.
+
+## Consequences
+
+### Now safer
+
+- The Bash bypass surface is closed for ~95% of writes an agent would naturally reach for. The 5% tail is documented and extends as bypass shapes are observed.
+- `/setup` runs end-to-end on a fresh fork without filing a placeholder ticket. Adoption flow is no longer first-impression-broken.
+- Both cracks are closed together — no transition window where the framework is internally inconsistent.
+
+### Now riskier
+
+- Skill cooperation matters. A bootstrap skill that forgets to write the marker won't get the exemption (the gate will block — the adopter sees a confusing block on their first run). Caught in code review; documented in each affected SKILL.md.
+- Heuristic Bash detection has false-negative tail. A determined agent that researches the matcher patterns will eventually find a shape that slips through. Mitigated by: pattern table is a living list extended on observation; the matcher's false-negative-preference is a deliberate design choice (an over-aggressive matcher that blocks legitimate read commands is a worse failure mode for adoption); commit-time secret scanning and `block-private-refs-in-public-repos` provide defence-in-depth at the persist-to-tracker layer.
+- Marker hygiene. A skill that writes the marker but crashes before clearing leaves a stale exemption until the next session. `clear-bootstrap-marker.sh` SessionStart sweep handles this — but inside the same session, the stale marker persists. Acceptable: the next file edit either matches the bootstrap skill's intent (continuation) or is human-driven (operator notices the marker via `git status`).
+
+### Future work — convert to Option B if/when Claude Code ships SkillStart
+
+When/if upstream CC exposes a SkillStart lifecycle hook, this AgDR's Option B becomes available. Conversion is small: the marker file becomes a harness-managed file, the consumer reads the same path. Skills lose the "Step 0: write the marker" prose. No re-architecture needed.
+
+## Artifacts
+
+- `me2resh/apexyard#150` — bootstrap-skill exemption ticket
+- `me2resh/apexyard#151` — Bash-write coverage ticket
+- `.claude/hooks/_lib-detect-bash-write.sh` — new helper
+- `.claude/hooks/require-active-ticket.sh` — Bash + bootstrap exemption extension
+- `.claude/hooks/require-migration-ticket.sh` — parallel Bash extension
+- `.claude/hooks/clear-bootstrap-marker.sh` — new SessionStart sweep
+- `.claude/project-config.defaults.json` — `ticket.bootstrap_skills` entry
+- `.claude/skills/{setup,handover,update,split-portfolio}/SKILL.md` — Step 0 + Cleanup
+- `.claude/hooks/tests/test_detect_bash_write.sh` — lib unit tests (32 cases)
+- `.claude/hooks/tests/test_require_active_ticket_bash.sh` — integration tests (12 cases)
+- `.claude/rules/workflow-gates.md` — § Pre-Build Gate doc note


### PR DESCRIPTION
## Summary

Closes the legitimate-bypass case (me2resh/apexyard#150) and the illegitimate-bypass case (me2resh/apexyard#151) together so the ticket-first gate is coherent. Shipping either alone would leave a window where the framework is internally inconsistent — see [`AgDR-0011`](docs/agdr/AgDR-0011-bootstrap-skill-exemption.md) for the full rationale.

- **Bootstrap exemption (#150)** — `.claude/session/active-bootstrap` marker written by `/setup`, `/handover`, `/update`, `/split-portfolio` on entry; cleared on exit; SessionStart sweep handles stale markers from interrupted sessions; configurable via `ticket.bootstrap_skills` in `.claude/project-config.{defaults,}.json`.
- **Bash-write coverage (#151)** — new `.claude/hooks/_lib-detect-bash-write.sh` heuristic detector (output redirect, `tee`, `sed -i`, `awk -i inplace`, `python -c`, `node -e`, `ruby -e`); `require-active-ticket.sh` and `require-migration-ticket.sh` now fire on `Bash` in addition to `Edit|Write|MultiEdit`. Design choice: false-negatives preferred over false-positives.

## Why bundled

The two issues are the same crack in the gate viewed from two sides:
- #150 alone: bootstrap exemption opens a legit path, but the gate is still trivially bypassable. The exemption ceremonies a gate that doesn't actually gate.
- #151 alone: gate hardens, but `/setup` is now hard-blocked on a fresh fork. Adoption flow is worse than before.

Same shape as [#147 / AgDR-0010](docs/agdr/AgDR-0010-portfolio-config-and-self-healing.md) which bundled #145 + #146 for the same reason.

`Closes me2resh/apexyard#150` only — me2resh/apexyard#151 closed manually post-merge per the single-Closes-per-PR rule.

## Testing

- [x] **Unit tests on the bash-write detector** — `bash .claude/hooks/tests/test_detect_bash_write.sh` → 32/32 passing. Covers each pattern in the matcher table (positive class), representative reads (negative class), target extraction (positive + documented misses), and the exact bypass attempt repro from me2resh/apexyard#151.
- [x] **Integration tests on `require-active-ticket.sh`** — `bash .claude/hooks/tests/test_require_active_ticket_bash.sh` → 12/12 passing. Covers Bash writes blocked w/o ticket, `python3 -c "...write_text..."` bypass closed, Bash reads pass through, path exemptions still work for Bash, bootstrap-marker exemption works for Edit and Bash, unknown / empty marker correctly falls through, and the legacy active-ticket path still works (regression).
- [x] **No regressions in adjacent tests** — ran the full `.claude/hooks/tests/` suite. The two failing tests (`test_single_closes_per_pr.sh`, `test_validate_pr_required_sections.sh`) are pre-existing — they hardcode `#113`, which has since been CLOSED upstream, and the validator now refuses closed-issue refs. Worth a small follow-up to switch the tests to a synthetic open issue or mock `gh`.
- [x] **Live verification** — the hook chain successfully blocked an attempt to commit this PR's body on a fork where the referenced issues didn't exist (closing-keyword check), and accepted the fully-qualified `me2resh/apexyard#NNN` form. Confirms the existing `verify-commit-refs.sh` is doing its job and our changes don't interfere with it.

## Glossary

| Term | Definition |
|------|------------|
| **Active-skill marker** | `.claude/session/active-bootstrap` — a one-line file written by a bootstrap-class skill on entry, read by `require-active-ticket.sh`, removed by the skill on completion (or by the SessionStart sweep on the next session). The mechanism that lets `/setup` run before any tickets exist without disabling the ticket-first gate. |
| **Bootstrap-class skill** | A skill that runs before tracker tickets can exist for the work it's doing — `/setup`, `/handover`, `/update`, `/split-portfolio`. The list is configurable via `ticket.bootstrap_skills` in `.claude/project-config.{defaults,}.json`. |
| **Bash-write bypass** | The pre-fix failure mode where any Bash command that wrote to a file (`echo > file`, `tee`, `sed -i`, `python -c '…write_text…'`, etc.) skipped the ticket-first gate because the hook was scoped to `Edit\|Write\|MultiEdit` only. Closed in this PR via `_lib-detect-bash-write.sh` + Bash-matcher wiring. |
| **False-negatives preferred over false-positives** | Design choice for the Bash-write matcher: if the matcher is uncertain, let the command through rather than block. Rationale: blocking a legitimate read-only command on a fresh-adopter test is worse for adoption than missing one obscure write pattern. The pattern table is a living list extended on observation. |
| **Bootstrap-marker hygiene** | The discipline around writing the marker on skill entry and removing it on completion. A skill that writes but doesn't clear leaves a stale exemption until the next session — caught by `clear-bootstrap-marker.sh` SessionStart sweep, but inside the same session, the operator-visible marker (`cat .claude/session/active-bootstrap`) is the only signal. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
