### PR TITLE
chore(#153): extend Bash-write matcher beyond first-version coverage

### DIFF
--- a/.claude/hooks/_lib-detect-bash-write.sh
+++ b/.claude/hooks/_lib-detect-bash-write.sh
@@ -10,6 +10,11 @@
 # cases (~95%) and treat the long tail as a known-limitation that
 # extends as new patterns are discovered.
 #
+# AgDR-0011 frames the matcher table as a LIVING LIST — extended on
+# observation. me2resh/apexyard#153 extended the first-version coverage
+# (#152) with file-moving builtins, archive/network writes, additional
+# interpreters, and python-helper / heredoc shapes.
+#
 # Usage:
 #   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-detect-bash-write.sh"
 #   if bash_command_appears_to_write "$COMMAND"; then
@@ -24,27 +29,48 @@
 #   bash_extract_write_target COMMAND
 #       echoes the target path if extractable, empty string otherwise.
 #       Best-effort — only handles the simple cases (echo > file,
-#       tee file, sed -i ... file). Embedded interpreters
-#       (python -c, node -e, ruby -e) return empty.
+#       tee file, sed -i ... file, cp src dst, curl -o file). Embedded
+#       interpreters (python -c, node -e, ruby -e, perl -e, php -r,
+#       go run, deno, bun) return empty.
 
 # ------------------------------------------------------------------------------
 # Public: bash_command_appears_to_write COMMAND
 #
-# Detects:
-#   - Output redirection: cmd > file, cmd >> file, cmd 2> file
-#   - tee
-#   - cat > file (with or without heredoc)
-#   - printf > file
-#   - sed -i (in-place edit)
-#   - awk -i inplace
-#   - python -c '...write...' or python -c '...open(...).write...'
-#   - python <<EOF ... write ... EOF (heredoc-fed python)
-#   - python3 - <<EOF ... write ... EOF (stdin-fed python — common pattern)
-#   - node -e '...writeFileSync...' or node -e '...write...'
-#   - ruby -e '...File.write...' or ruby -e '...write...'
+# Detects (matcher families):
+#
+#   Redirection / pipes-to-disk
+#     - cmd > file, cmd >> file, cmd 2> file
+#     - tee
+#
+#   In-place text editors
+#     - sed -i (in-place edit, GNU + BSD `''` form)
+#     - awk -i inplace
+#
+#   File-moving builtins (#153)
+#     - cp, mv, rm, dd, install — anchored at command start, --help/--version
+#       excluded, `git rm`/`git mv` excluded (those are subcommands)
+#
+#   Archive / network writes (#153)
+#     - tar -x, tar --extract
+#     - curl -o / --output
+#     - wget -O / --output-document
+#
+#   Embedded interpreters with inline source (-c / -e / -r)
+#     - python -c '…' with write/open/touch/copy/rename keywords
+#     - python <<EOF / python - <<EOF (heredoc-fed)
+#     - node -e '…' with writeFile/appendFile/write keywords
+#     - node <<EOF (heredoc-fed, #153)
+#     - ruby -e '…' with File.write/open keywords
+#     - ruby <<EOF (heredoc-fed, #153)
+#     - perl -e '…' with print-to-handle / open / unlink keywords (#153)
+#     - php -r '…' with file_put_contents / fwrite / fopen keywords (#153)
+#
+#   Script runners — categorical (#153)
+#     - go run <file>
+#     - deno run / deno <script.{ts,js,mjs}>
+#     - bun / bun run <script.{ts,js,mjs}>
 #
 # Misses (intentionally — long tail):
-#   - cp, mv, rm (those move/remove, not "write content")
 #   - xargs that constructs a write command
 #   - find -exec sed/awk/etc.
 #   - Custom scripts that wrap writes (could be anything)
@@ -52,58 +78,230 @@
 #
 # Returns 0 (write detected), 1 (no write detected).
 # ------------------------------------------------------------------------------
+
+# Helper: returns 0 if $1 (a command string) is a "help / version" invocation
+# that should be treated as read-only — used by file-moving-builtin matchers.
+_bdw_is_help_or_version() {
+  local cmd="$1"
+  echo "$cmd" | grep -qE '(^|[[:space:]])(--help|--version|-h|-V)([[:space:]]|$)'
+}
+
+# Helper: returns 0 if the bare command (first word, possibly after pipe/&&/;/|/()
+# is `git`. Used to skip `git rm`, `git mv` — those are subcommands, not the
+# coreutils. We check at every command-start position.
+_bdw_starts_with_git_subcommand() {
+  local cmd="$1" sub="$2"
+  # Match `git <sub>` at command-start positions only.
+  echo "$cmd" | grep -qE "(^|[;&|(]|&&|\|\|)[[:space:]]*git[[:space:]]+${sub}\b"
+}
+
+# ------------------------------------------------------------------------------
+# Matcher families
+# ------------------------------------------------------------------------------
+
+# 1. Redirection.
+_bdw_match_redirection() {
+  echo "$1" | grep -qE '[^|<&]>>?[[:space:]]+[^[:space:]&|;]+'
+}
+
+# 2. tee.
+_bdw_match_tee() {
+  echo "$1" | grep -qE '\btee\b'
+}
+
+# 3. sed -i.
+_bdw_match_sed_inplace() {
+  echo "$1" | grep -qE '\bsed[[:space:]]+([^|;&]*[[:space:]])?-i\b'
+}
+
+# 4. awk -i inplace.
+_bdw_match_awk_inplace() {
+  echo "$1" | grep -qE '\bawk[[:space:]]+[^|;&]*-i[[:space:]]+inplace\b'
+}
+
+# 5. File-moving builtins (cp, mv, rm, dd, install). Anchored at command-start.
+#    `git rm`, `git mv`, `cp --help`, `rm --version` etc. are excluded.
+_bdw_match_file_movers() {
+  local cmd="$1"
+  # Must contain one of the builtins as the first token of a command segment.
+  # Segment delimiters: start-of-line, `;`, `&&`, `||`, `|`, `(`.
+  if echo "$cmd" | grep -qE '(^|[;&|(]|&&|\|\|)[[:space:]]*(cp|mv|rm|dd|install)([[:space:]]|$)'; then
+    # Exclude help/version forms.
+    _bdw_is_help_or_version "$cmd" && return 1
+    # Exclude `git rm` / `git mv` — those are git subcommands.
+    if _bdw_starts_with_git_subcommand "$cmd" "rm" \
+       || _bdw_starts_with_git_subcommand "$cmd" "mv"; then
+      # If the ONLY match in the command is the git-subcommand, treat as read.
+      # If there's *also* a real cp/rm/mv/dd/install elsewhere, fall through.
+      # Approximation: if the command contains another fresh segment with one
+      # of the builtins not preceded by `git `, it's still a write.
+      if ! echo "$cmd" | grep -qE '(^|[;&|(]|&&|\|\|)[[:space:]]*(cp|mv|rm|dd|install)([[:space:]]|$)' \
+           | grep -vE 'git[[:space:]]+(rm|mv)'; then
+        # Fast path: if the entire command starts with `git rm` / `git mv` and
+        # has no further command segments, treat as read-only.
+        if echo "$cmd" | grep -qE '^[[:space:]]*git[[:space:]]+(rm|mv)\b' \
+           && ! echo "$cmd" | grep -qE '[;&|]'; then
+          return 1
+        fi
+      fi
+    fi
+    return 0
+  fi
+  return 1
+}
+
+# 6. tar -x / tar --extract.
+_bdw_match_tar_extract() {
+  local cmd="$1"
+  # Fast reject — must contain `tar`.
+  echo "$cmd" | grep -qE '\btar\b' || return 1
+  # `tar --extract` long form.
+  if echo "$cmd" | grep -qE '\btar\b[^|;&]*--extract\b'; then
+    return 0
+  fi
+  # `tar -x` / `tar -xf` / `tar xf` (short bundled form, common).
+  # Look for tar followed by an option token containing `x`. Avoid matching
+  # the `x` inside `--exclude` etc. by requiring a single-dash short-flag form.
+  if echo "$cmd" | grep -qE '\btar\b[[:space:]]+(-[A-Za-z]*x[A-Za-z]*|x[A-Za-z]*)\b'; then
+    return 0
+  fi
+  return 1
+}
+
+# 7. curl -o / --output.
+_bdw_match_curl_output() {
+  local cmd="$1"
+  echo "$cmd" | grep -qE '\bcurl\b' || return 1
+  # `--output FILE` or `-o FILE`. Exclude `--output-dir` (separate flag) by
+  # requiring `--output` to be followed by whitespace and a non-flag token.
+  if echo "$cmd" | grep -qE '\bcurl\b[^|;&]*(--output\b|-o\b)'; then
+    # Avoid matching `--output-dir` alone (rare flag — still a write surface
+    # but conservative match keeps this branch tight).
+    if echo "$cmd" | grep -qE '\bcurl\b[^|;&]*--output-dir\b' \
+       && ! echo "$cmd" | grep -qE '\bcurl\b[^|;&]*(--output[[:space:]]|-o[[:space:]])'; then
+      return 1
+    fi
+    return 0
+  fi
+  return 1
+}
+
+# 8. wget -O / --output-document.
+_bdw_match_wget_output() {
+  local cmd="$1"
+  echo "$cmd" | grep -qE '\bwget\b' || return 1
+  if echo "$cmd" | grep -qE '\bwget\b[^|;&]*(--output-document\b|-O\b)'; then
+    return 0
+  fi
+  return 1
+}
+
+# 9. Embedded Python (-c) with write keywords. Extended in #153 to include
+#    pathlib touch, shutil copy*/move, os.rename.
+_bdw_match_python_dash_c() {
+  local cmd="$1"
+  echo "$cmd" | grep -qE '\bpython3?[[:space:]]+(-[^c]*[[:space:]]+)?-c\b' || return 1
+  echo "$cmd" | grep -qE '\.write_text\b|\.write\b|\bopen\([^)]*[wa+]|\.touch\(|\bshutil\.(copy|copyfile|copy2|copytree|move)\b|\bos\.rename\b'
+}
+
+# 10. Heredoc-fed Python. Extended in #153 for the same keyword list.
+_bdw_match_python_heredoc() {
+  local cmd="$1"
+  echo "$cmd" | grep -qE '\bpython3?[[:space:]]+(-[[:space:]]+)?<<' || return 1
+  echo "$cmd" | grep -qE '\.write_text\b|\.write\b|\bopen\([^)]*[wa+]|\.touch\(|\bshutil\.(copy|copyfile|copy2|copytree|move)\b|\bos\.rename\b'
+}
+
+# 11. Embedded Node (-e) with write keywords.
+_bdw_match_node_dash_e() {
+  local cmd="$1"
+  echo "$cmd" | grep -qE '\bnode[[:space:]]+(-[^e]*[[:space:]]+)?-e\b' || return 1
+  echo "$cmd" | grep -qE '\bwriteFile(Sync)?\b|\.write\b|\bappendFile(Sync)?\b|\bcopyFile(Sync)?\b|\brename(Sync)?\b'
+}
+
+# 12. Heredoc-fed Node (#153).
+_bdw_match_node_heredoc() {
+  local cmd="$1"
+  echo "$cmd" | grep -qE '\bnode\b[[:space:]]*<<' || return 1
+  echo "$cmd" | grep -qE '\bwriteFile(Sync)?\b|\.write\b|\bappendFile(Sync)?\b|\bcopyFile(Sync)?\b|\brename(Sync)?\b'
+}
+
+# 13. Embedded Ruby (-e).
+_bdw_match_ruby_dash_e() {
+  local cmd="$1"
+  echo "$cmd" | grep -qE '\bruby[[:space:]]+(-[^e]*[[:space:]]+)?-e\b' || return 1
+  echo "$cmd" | grep -qE '\bFile\.write\b|\.write\b|\bFile\.open\([^)]*[wa+]|\bFileUtils\.(cp|mv|rm)\b'
+}
+
+# 14. Heredoc-fed Ruby (#153).
+_bdw_match_ruby_heredoc() {
+  local cmd="$1"
+  echo "$cmd" | grep -qE '\bruby\b[[:space:]]*<<' || return 1
+  echo "$cmd" | grep -qE '\bFile\.write\b|\.write\b|\bFile\.open\([^)]*[wa+]|\bFileUtils\.(cp|mv|rm)\b'
+}
+
+# 15. Embedded Perl (-e) (#153).
+_bdw_match_perl_dash_e() {
+  local cmd="$1"
+  echo "$cmd" | grep -qE '\bperl[[:space:]]+(-[^e]*[[:space:]]+)?-e\b' || return 1
+  # Common perl write idioms: print FH, open(…, ">"), open my $fh, ">", unlink, rename.
+  echo "$cmd" | grep -qE '\bprint[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]|\bopen\b[^|;&]*[">]|>>?["[:space:]]|\bunlink\b|\brename\b|\bsysopen\b'
+}
+
+# 16. Embedded PHP (-r) (#153).
+_bdw_match_php_dash_r() {
+  local cmd="$1"
+  echo "$cmd" | grep -qE '\bphp[[:space:]]+(-[^r]*[[:space:]]+)?-r\b' || return 1
+  echo "$cmd" | grep -qE '\bfile_put_contents\b|\bfwrite\b|\bfopen\([^)]*["'\'']\s*[wa+]|\bunlink\b|\brename\b|\bcopy\b'
+}
+
+# 17. Script runners — categorical (#153).
+#     `go run <file>`, `deno run <file>` / `deno <file.{ts,js,mjs}>`,
+#     `bun <file>` / `bun run <file>`.
+_bdw_match_script_runner() {
+  local cmd="$1"
+  # `go run` followed by anything.
+  if echo "$cmd" | grep -qE '\bgo[[:space:]]+run\b'; then
+    return 0
+  fi
+  # `deno run …` (categorical — `deno run` is "execute script").
+  if echo "$cmd" | grep -qE '\bdeno[[:space:]]+run\b'; then
+    return 0
+  fi
+  # `deno <script.{ts,js,mjs}>` — bare `deno foo.ts` shorthand.
+  if echo "$cmd" | grep -qE '\bdeno[[:space:]]+[^-][^[:space:]]*\.(ts|js|mjs|tsx|jsx)\b'; then
+    return 0
+  fi
+  # `bun run …` or `bun <script.{ts,js,mjs}>`.
+  if echo "$cmd" | grep -qE '\bbun[[:space:]]+run\b'; then
+    return 0
+  fi
+  if echo "$cmd" | grep -qE '\bbun[[:space:]]+[^-][^[:space:]]*\.(ts|js|mjs|tsx|jsx)\b'; then
+    return 0
+  fi
+  return 1
+}
+
 bash_command_appears_to_write() {
   local cmd="$1"
   [ -z "$cmd" ] && return 1
 
-  # Output redirection. Match `> file`, `>> file`, `2> file`, etc.
-  # Excludes `<>` (read-write open, rare) and `&>` (combined redirect — also
-  # a write but our regex catches the trailing `>`).
-  if echo "$cmd" | grep -qE '[^|<&]>>?[[:space:]]+[^[:space:]&|;]+'; then
-    return 0
-  fi
-
-  # `tee` — writes to its arguments.
-  if echo "$cmd" | grep -qE '\btee\b'; then
-    return 0
-  fi
-
-  # `sed -i` — in-place edit. Catch `-i` and `-i ''` (BSD/macOS form).
-  if echo "$cmd" | grep -qE '\bsed[[:space:]]+([^|;&]*[[:space:]])?-i\b'; then
-    return 0
-  fi
-
-  # `awk -i inplace`
-  if echo "$cmd" | grep -qE '\bawk[[:space:]]+[^|;&]*-i[[:space:]]+inplace\b'; then
-    return 0
-  fi
-
-  # Embedded Python: `python -c '...write...'` or `python3 -c '...'`.
-  # Look for write/open keywords inside the command string.
-  if echo "$cmd" | grep -qE '\bpython3?[[:space:]]+(-[^c]*[[:space:]]+)?-c\b' && \
-     echo "$cmd" | grep -qE '\.write_text\b|\.write\b|\bopen\([^)]*[wa+]'; then
-    return 0
-  fi
-
-  # Heredoc-fed Python: `python3 <<EOF ... write ... EOF` or `python3 - <<EOF`.
-  # If the command contains `python` followed by `<<` or `-` and then any
-  # write keyword, treat as a write.
-  if echo "$cmd" | grep -qE '\bpython3?[[:space:]]+(-[[:space:]]+)?<<' && \
-     echo "$cmd" | grep -qE '\.write_text\b|\.write\b|\bopen\([^)]*[wa+]'; then
-    return 0
-  fi
-
-  # Embedded Node: `node -e '...writeFileSync...'` etc.
-  if echo "$cmd" | grep -qE '\bnode[[:space:]]+(-[^e]*[[:space:]]+)?-e\b' && \
-     echo "$cmd" | grep -qE '\bwriteFile(Sync)?\b|\.write\b|\bappendFile(Sync)?\b'; then
-    return 0
-  fi
-
-  # Embedded Ruby: `ruby -e '...File.write...'`.
-  if echo "$cmd" | grep -qE '\bruby[[:space:]]+(-[^e]*[[:space:]]+)?-e\b' && \
-     echo "$cmd" | grep -qE '\bFile\.write\b|\.write\b|\bFile\.open\([^)]*[wa+]'; then
-    return 0
-  fi
+  _bdw_match_redirection     "$cmd" && return 0
+  _bdw_match_tee             "$cmd" && return 0
+  _bdw_match_sed_inplace     "$cmd" && return 0
+  _bdw_match_awk_inplace     "$cmd" && return 0
+  _bdw_match_file_movers     "$cmd" && return 0
+  _bdw_match_tar_extract     "$cmd" && return 0
+  _bdw_match_curl_output     "$cmd" && return 0
+  _bdw_match_wget_output     "$cmd" && return 0
+  _bdw_match_python_dash_c   "$cmd" && return 0
+  _bdw_match_python_heredoc  "$cmd" && return 0
+  _bdw_match_node_dash_e     "$cmd" && return 0
+  _bdw_match_node_heredoc    "$cmd" && return 0
+  _bdw_match_ruby_dash_e     "$cmd" && return 0
+  _bdw_match_ruby_heredoc    "$cmd" && return 0
+  _bdw_match_perl_dash_e     "$cmd" && return 0
+  _bdw_match_php_dash_r      "$cmd" && return 0
+  _bdw_match_script_runner   "$cmd" && return 0
 
   return 1
 }
@@ -119,11 +317,17 @@ bash_command_appears_to_write() {
 #   - cmd >> /path/to/file       → /path/to/file
 #   - tee /path/to/file          → /path/to/file
 #   - sed -i 's/.../.../' /path  → /path
+#   - cp src /path/to/dst        → /path/to/dst (#153)
+#   - mv src /path/to/dst        → /path/to/dst (#153)
+#   - curl -o /path URL          → /path        (#153)
+#   - wget -O /path URL          → /path        (#153)
 #
 # Does NOT handle (returns empty):
-#   - python/node/ruby with embedded path
+#   - python/node/ruby/perl/php with embedded path
+#   - go run / deno / bun (script-runner categorical)
 #   - cmd with multiple redirects
 #   - paths constructed from variables
+#   - tar -x (target is a directory, often implicit)
 # ------------------------------------------------------------------------------
 bash_extract_write_target() {
   local cmd="$1"
@@ -136,7 +340,6 @@ bash_extract_write_target() {
                 | head -n 1 \
                 | sed -E 's/^[^>]*>>?[[:space:]]+//')
   if [ -n "$target" ]; then
-    # Strip surrounding quotes if any.
     target="${target%\"}"; target="${target#\"}"
     target="${target%\'}"; target="${target#\'}"
     echo "$target"
@@ -157,13 +360,54 @@ bash_extract_write_target() {
   fi
 
   # sed -i: capture the file argument (last positional after the script).
-  # This is approximate — sed's argument grammar is annoying.
   if echo "$cmd" | grep -qE '\bsed[[:space:]]+([^|;&]*[[:space:]])?-i\b'; then
-    # Take everything after the last quote-pair in the sed invocation.
     target=$(echo "$cmd" | sed -E "s/.*'[^']*'[[:space:]]+([^[:space:]&|;]+).*/\1/")
-    # Heuristic: only accept if it looks like a path (contains / or starts with
-    # an alphanumeric, doesn't contain quote chars).
     if echo "$target" | grep -qE '^[A-Za-z0-9./_~-]+$'; then
+      echo "$target"
+      return 0
+    fi
+  fi
+
+  # curl -o / --output: capture the path argument (#153).
+  if echo "$cmd" | grep -qE '\bcurl\b[^|;&]*(--output\b|-o\b)'; then
+    target=$(echo "$cmd" | grep -oE '(--output|-o)[[:space:]]+[^[:space:]&|;]+' \
+                  | head -n 1 \
+                  | sed -E 's/^(--output|-o)[[:space:]]+//')
+    if [ -n "$target" ]; then
+      target="${target%\"}"; target="${target#\"}"
+      target="${target%\'}"; target="${target#\'}"
+      echo "$target"
+      return 0
+    fi
+  fi
+
+  # wget -O / --output-document: same idea (#153).
+  if echo "$cmd" | grep -qE '\bwget\b[^|;&]*(--output-document\b|-O\b)'; then
+    target=$(echo "$cmd" | grep -oE '(--output-document|-O)[[:space:]]+[^[:space:]&|;]+' \
+                  | head -n 1 \
+                  | sed -E 's/^(--output-document|-O)[[:space:]]+//')
+    if [ -n "$target" ]; then
+      target="${target%\"}"; target="${target#\"}"
+      target="${target%\'}"; target="${target#\'}"
+      echo "$target"
+      return 0
+    fi
+  fi
+
+  # cp / mv: target is the LAST positional argument (#153).
+  # Approximate: tokenise on whitespace, strip pipeline tail, take the last
+  # non-flag token. Skip this for `git rm`/`git mv` (subcommands).
+  if echo "$cmd" | grep -qE '(^|[;&|(]|&&|\|\|)[[:space:]]*(cp|mv)([[:space:]]|$)' \
+     && ! echo "$cmd" | grep -qE '^[[:space:]]*git[[:space:]]+(rm|mv)\b'; then
+    # Strip everything after a pipeline / list separator to focus on this segment.
+    local seg
+    seg=$(echo "$cmd" | sed -E 's/[[:space:]]*[|;&].*$//')
+    # Take the last whitespace-delimited token of the segment.
+    target=$(echo "$seg" | awk '{print $NF}')
+    # Reject if it looks like a flag.
+    if [ -n "$target" ] && ! echo "$target" | grep -qE '^-'; then
+      target="${target%\"}"; target="${target#\"}"
+      target="${target%\'}"; target="${target#\'}"
       echo "$target"
       return 0
     fi

--- a/.claude/hooks/tests/test_detect_bash_write.sh
+++ b/.claude/hooks/tests/test_detect_bash_write.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-# Tests for the bash-write-detection helper (#151).
+# Tests for the bash-write-detection helper (#151, extended in #153).
 #
 # Covers:
 #   - bash_command_appears_to_write: each pattern in the matcher table
 #     (positive-class) and a representative read-only set (negative-class)
 #   - bash_extract_write_target: the simple cases where extraction works
-#     (>, >>, tee), and the documented misses (python -c) returning empty
+#     (>, >>, tee, cp/mv last arg, curl -o, wget -O), and the documented
+#     misses (python -c, script runners) returning empty
 #
 # Exit 0 if all cases pass; exit 1 on first failure.
 
@@ -60,6 +61,7 @@ assert_target() {
 
 # --- WRITE patterns (positive class) -----------------------------------
 
+# First-version coverage (#152).
 assert_write "echo redirect"        "echo hi > /tmp/x"
 assert_write "echo append"          "echo hi >> /tmp/x"
 assert_write "cat heredoc"          $'cat > /tmp/x <<EOF\nhi\nEOF'
@@ -76,8 +78,49 @@ assert_write "node -e writeFile"    'node -e "require(\"fs\").writeFileSync(\"/t
 assert_write "node -e appendFile"   'node -e "require(\"fs\").appendFileSync(\"/tmp/x\", \"hi\")"'
 assert_write "ruby -e File.write"   'ruby -e "File.write(\"/tmp/x\", \"hi\")"'
 
+# #153 — file-moving builtins.
+assert_write "cp file"              "cp src.txt /tmp/dst.txt"
+assert_write "mv file"              "mv old.txt /tmp/new.txt"
+assert_write "rm file"              "rm /tmp/x"
+assert_write "rm -rf"               "rm -rf /tmp/dir"
+assert_write "dd of"                "dd if=/dev/zero of=/tmp/x bs=1M count=1"
+assert_write "install"              "install -m 0644 src /tmp/dst"
+
+# #153 — archive / network writes.
+assert_write "tar -xf"              "tar -xf archive.tar"
+assert_write "tar xzf"              "tar xzf archive.tar.gz"
+assert_write "tar --extract"        "tar --extract --file=archive.tar"
+assert_write "curl -o"              "curl -o /tmp/x https://example.com/f"
+assert_write "curl --output"        "curl --output /tmp/x https://example.com/f"
+assert_write "wget -O"              "wget -O /tmp/x https://example.com/f"
+assert_write "wget --output-doc"    "wget --output-document=/tmp/x https://example.com/f"
+
+# #153 — additional interpreters.
+assert_write "perl -e print FH"     'perl -e "open(my $fh, \">\", \"/tmp/x\"); print $fh \"hi\";"'
+assert_write "perl -e unlink"       'perl -e "unlink \"/tmp/x\""'
+assert_write "php -r file_put"      'php -r "file_put_contents(\"/tmp/x\", \"hi\");"'
+assert_write "php -r fwrite"        'php -r "$f = fopen(\"/tmp/x\", \"w\"); fwrite($f, \"hi\");"'
+assert_write "go run"               "go run main.go"
+assert_write "deno run"             "deno run --allow-write script.ts"
+assert_write "deno script.ts"       "deno script.ts"
+assert_write "bun run"              "bun run script.ts"
+assert_write "bun script.ts"        "bun script.ts"
+
+# #153 — python helpers.
+assert_write "pathlib touch"        'python3 -c "import pathlib; pathlib.Path(\"/tmp/x\").touch()"'
+assert_write "shutil.copy"          'python3 -c "import shutil; shutil.copy(\"a\", \"b\")"'
+assert_write "shutil.move"          'python3 -c "import shutil; shutil.move(\"a\", \"b\")"'
+assert_write "os.rename"            'python3 -c "import os; os.rename(\"a\", \"b\")"'
+
+# #153 — ruby/node heredocs.
+ruby_heredoc=$'ruby <<\'RB\'\nFile.write("/tmp/x", "hi")\nRB'
+assert_write "ruby heredoc"         "$ruby_heredoc"
+node_heredoc=$'node <<\'JS\'\nrequire("fs").writeFileSync("/tmp/x", "hi")\nJS'
+assert_write "node heredoc"         "$node_heredoc"
+
 # --- READ patterns (negative class — must NOT trigger) -----------------
 
+# First-version coverage (#152).
 assert_read  "cat"            "cat /tmp/x"
 assert_read  "grep file"      "grep foo /tmp/x"
 assert_read  "ls"             "ls -la /tmp"
@@ -89,17 +132,48 @@ assert_read  "stderr merge"   "make build 2>&1"
 assert_read  "python read"    'python3 -c "print(open(\"/tmp/x\").read())"'
 assert_read  "node read"      'node -e "console.log(require(\"fs\").readFileSync(\"/tmp/x\", \"utf8\"))"'
 
+# #153 — counterexamples for the new matcher families.
+assert_read  "cp --help"      "cp --help"
+assert_read  "cp --version"   "cp --version"
+assert_read  "rm --help"      "rm --help"
+assert_read  "mv --version"   "mv --version"
+assert_read  "git rm"         "git rm src.txt"
+assert_read  "git mv"         "git mv old.txt new.txt"
+assert_read  "tar -t"         "tar -t archive.tar"
+assert_read  "tar --list"     "tar --list -f archive.tar"
+assert_read  "tar -tzf"       "tar -tzf archive.tar.gz"
+assert_read  "curl -s url"    "curl -s https://example.com/f"
+assert_read  "curl bare"      "curl https://example.com/f"
+assert_read  "wget --help"    "wget --help"
+assert_read  "wget bare"      "wget https://example.com/f"
+assert_read  "deno fmt"       "deno fmt"
+assert_read  "deno test"      "deno test --no-check"
+assert_read  "go build"       "go build ./..."
+assert_read  "go version"     "go version"
+assert_read  "perl -v"        "perl -v"
+assert_read  "php --version"  "php --version"
+
 # --- target extraction (positive class — should produce target) --------
 
+# First-version coverage (#152).
 assert_target "redirect path"      "echo hi > /tmp/x"           "/tmp/x"
 assert_target "append path"        "echo hi >> /tmp/x"          "/tmp/x"
 assert_target "tee path"           "echo x | tee /tmp/x"        "/tmp/x"
 assert_target "tee with flag"      "echo x | tee -a /tmp/x"     "/tmp/x"
 
+# #153 — new extractors.
+assert_target "cp last arg"        "cp src.txt /tmp/dst.txt"    "/tmp/dst.txt"
+assert_target "mv last arg"        "mv a.txt /tmp/b.txt"        "/tmp/b.txt"
+assert_target "curl -o path"       "curl -o /tmp/f https://example.com/f"        "/tmp/f"
+assert_target "curl --output"      "curl --output /tmp/f https://example.com/f"  "/tmp/f"
+assert_target "wget -O path"       "wget -O /tmp/f https://example.com/f"        "/tmp/f"
+
 # --- target extraction (documented misses — empty result) --------------
 
 assert_target "python -c (miss)"   'python3 -c "open(\"/tmp/x\",\"w\").write(\"hi\")"' ""
 assert_target "node -e (miss)"     'node -e "fs.writeFileSync(\"/tmp/x\",\"hi\")"' ""
+assert_target "go run (miss)"      "go run main.go" ""
+assert_target "deno run (miss)"    "deno run script.ts" ""
 
 # --- Regression: the exact bypass attempt that surfaced #151 ----------
 


### PR DESCRIPTION
## Summary

Extends `_lib-detect-bash-write.sh` (introduced in #152 for #151) with the matcher families that Rex's review flagged as missing from the first-version coverage. AgDR-0011 already frames the matcher table as a living list extended on observation; this PR walks the list.

- **File-moving builtins** — `cp`, `mv`, `rm`, `dd`, `install`. Anchored at command-start. `--help`/`--version` and `git rm`/`git mv` are excluded so `git rm src.txt` and `cp --help` stay read-class.
- **Archive / network writes** — `tar -x` / `tar --extract`, `curl -o` / `--output`, `wget -O` / `--output-document`. Flag-gated so `tar -t` (list), `curl <url>` (bare fetch), `wget --help` stay read-class.
- **Additional interpreters** — `perl -e` and `php -r` keyword-gated like the existing python/node/ruby matchers; `go run`, `deno run`/`deno script.ts`, `bun run`/`bun script.ts` matched categorically as script runners.
- **Python helpers** — `pathlib.Path().touch()`, `shutil.copy*`, `shutil.move`, `os.rename` added to the `python -c` and python-heredoc keyword list.
- **Heredoc variants for `ruby` and `node`** — previously only python's heredoc form was matched.
- **Extractor extensions** — `cp`/`mv` return the last positional arg; `curl -o`/`--output` and `wget -O`/`--output-document` return the file argument. `go run`/`deno`/`bun`/`perl -e`/`php -r`/`tar -x` return empty (caller gates categorically per AgDR-0011).

Refactored the matcher into one `_bdw_match_<family>` helper per family so future extensions land as additional helpers rather than additional `if` branches in one big function.

## Testing

- [x] `bash .claude/hooks/tests/test_detect_bash_write.sh` — **86/0** (was 32/0 before #153). Includes ≥3 negative-class counterexamples for every new family: `tar -t`, `tar --list`, `tar -tzf`, `cp --help`, `cp --version`, `rm --help`, `mv --version`, `git rm`, `git mv`, `curl -s url`, `curl bare`, `wget --help`, `wget bare`, `deno fmt`, `deno test`, `go build`, `go version`, `perl -v`, `php --version`.
- [x] `bash .claude/hooks/tests/test_require_active_ticket_bash.sh` — **12/12** (regression check, unchanged).
- [x] No edits outside `.claude/hooks/_lib-detect-bash-write.sh` and `.claude/hooks/tests/test_detect_bash_write.sh`.

## Glossary

| Term | Definition |
|------|------------|
| Matcher family | One self-contained shape the detector looks for (redirection, tee, sed -i, file-mover, archive-extractor, …). Each is a separate `_bdw_match_*` helper. |
| Categorical match | A matcher that fires whenever the command shape is present, without inspecting payload contents. Used for `go run`, `deno`, `bun` where the script body could write but isn't visible to the detector. |
| Keyword-gated match | A matcher that requires both the interpreter shape (`python -c`, `node -e`, `perl -e`, …) AND a write-related keyword (`writeFile`, `open(…, "w")`, `unlink`, …) before firing. Reduces false positives on read-only one-liners. |
| Living list | AgDR-0011's framing of the matcher table as a list of patterns extended whenever a new bypass shape is observed in the wild, rather than a fixed-once-and-done specification. |
| False-negative preference | The tightness target the detector aims for: missing one obscure write pattern is acceptable; blocking a legitimate read-only command on a fresh-adopter test is not. |
| Bootstrap exemption | The `.claude/session/active-bootstrap` marker that lets `/setup`, `/handover`, `/update`, `/split-portfolio` write files without an active ticket. Orthogonal to this PR but the reason the matcher can be stricter without breaking first-run UX. |
