### PR TITLE
test(#154): mock gh in test sandboxes to remove live-tracker dependency

### DIFF
--- a/.claude/hooks/tests/_lib-mock-gh.sh
+++ b/.claude/hooks/tests/_lib-mock-gh.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# _lib-mock-gh.sh — install a fake `gh` on PATH for hook test sandboxes.
+#
+# Why: validate-pr-create.sh calls `gh issue view <N> --repo <repo> --json number,state`
+# to verify the PR title's referenced issue exists and is OPEN. If the test relies on a
+# real upstream issue, every closed/renamed/deleted issue retroactively breaks the suite.
+# The shim removes that live-tracker dependency: any `gh issue view <N> ... --json ...`
+# call returns synthetic JSON with state=OPEN by default, regardless of N.
+#
+# Usage in a test file:
+#
+#     source "$(dirname "$0")/_lib-mock-gh.sh"
+#     sb=$(make_sandbox)
+#     mock_gh_install "$sb"
+#     # ... build the input + run the hook from inside $sb ...
+#
+# By default state=OPEN for any number. To exercise the CLOSED branch, call
+# `mock_gh_set_state <num> CLOSED` before running the case (it writes to a state
+# file the shim reads). State file is per-sandbox.
+#
+# Set MOCK_GH_TRACE=1 to print intercepted calls to stderr for debugging.
+
+# Install the fake `gh` into <sandbox>/bin/ and prepend that to PATH.
+# Returns: nothing. Side effect: PATH is modified for the calling shell.
+mock_gh_install() {
+  local sb="$1"
+  if [ -z "$sb" ] || [ ! -d "$sb" ]; then
+    echo "mock_gh_install: bad sandbox dir: $sb" >&2
+    return 1
+  fi
+  mkdir -p "$sb/bin"
+  local state_file="$sb/.mock-gh-state"
+  : > "$state_file"
+
+  # Resolve the real gh once so the shim can pass-through unintercepted calls.
+  local real_gh
+  real_gh=$(command -v gh 2>/dev/null || true)
+
+  cat > "$sb/bin/gh" <<EOF
+#!/bin/bash
+# Fake gh — intercepts \`gh issue view <N> ... --json ...\` and returns
+# synthetic JSON. Pass-through for everything else (via real gh, if available).
+STATE_FILE="$state_file"
+REAL_GH="$real_gh"
+
+if [ "\${MOCK_GH_TRACE:-0}" = "1" ]; then
+  echo "[mock-gh] \$*" >&2
+fi
+
+# Match: gh issue view <N> [--repo R] --json <fields>
+if [ "\$1" = "issue" ] && [ "\$2" = "view" ]; then
+  num="\$3"
+  state="OPEN"
+  # Per-number override (one line per: "<num> <state>"). Last write wins.
+  if [ -f "\$STATE_FILE" ]; then
+    override=\$(grep -E "^\${num} " "\$STATE_FILE" | tail -1 | awk '{print \$2}')
+    if [ -n "\$override" ]; then
+      state="\$override"
+    fi
+  fi
+  # Emit JSON shaped like \`gh issue view --json number,state\`. The validator
+  # only reads .number and .state; extra keys are harmless.
+  printf '{"number":%s,"state":"%s"}\n' "\$num" "\$state"
+  exit 0
+fi
+
+# Pass-through for anything we don't intercept.
+if [ -n "\$REAL_GH" ]; then
+  exec "\$REAL_GH" "\$@"
+fi
+echo "[mock-gh] no real gh found and call not intercepted: \$*" >&2
+exit 127
+EOF
+  chmod +x "$sb/bin/gh"
+  PATH="$sb/bin:$PATH"
+  export PATH
+}
+
+# Override the synthetic state for a specific issue number in a sandbox.
+# Call AFTER mock_gh_install. Writes to <sandbox>/.mock-gh-state.
+#
+#   mock_gh_set_state <sandbox> <num> <state>
+#
+# Example: mock_gh_set_state "$sb" 999 CLOSED
+mock_gh_set_state() {
+  local sb="$1" num="$2" state="$3"
+  if [ -z "$sb" ] || [ -z "$num" ] || [ -z "$state" ]; then
+    echo "mock_gh_set_state: usage: mock_gh_set_state <sandbox> <num> <state>" >&2
+    return 1
+  fi
+  echo "$num $state" >> "$sb/.mock-gh-state"
+}

--- a/.claude/hooks/tests/test_single_closes_per_pr.sh
+++ b/.claude/hooks/tests/test_single_closes_per_pr.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 # Tests for the single-Closes-keyword check in validate-pr-create.sh (#114).
+#
+# Note: the PR title in each case (`chore(#114): test`) references issue #114 in
+# me2resh/apexyard. Rather than depend on that issue staying OPEN forever, the
+# sandbox installs a fake `gh` on PATH (see _lib-mock-gh.sh) that returns a
+# synthetic OPEN response for any `gh issue view`. Removes the live-tracker
+# dependency from the suite. See me2resh/apexyard#154.
 
 set -u
 
 HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/validate-pr-create.sh"
+# shellcheck source=_lib-mock-gh.sh
+source "$(cd "$(dirname "$0")" && pwd)/_lib-mock-gh.sh"
 PASS=0
 FAIL=0
 FAILED_CASES=""
@@ -34,6 +42,7 @@ make_sandbox() {
 run_case() {
   local label="$1" body_content="$2" want_rc="$3" want_stderr_regex="$4" extra_config="${5-}"
   local sb; sb=$(make_sandbox)
+  mock_gh_install "$sb"
   # Body must satisfy the required-sections check so we're only testing the close-count logic.
   local body_file="$sb/body.md"
   printf '%s\n\n## Testing\nfoo\n\n## Glossary\n| t | d |\n' "$body_content" > "$body_file"

--- a/.claude/hooks/tests/test_validate_pr_required_sections.sh
+++ b/.claude/hooks/tests/test_validate_pr_required_sections.sh
@@ -7,11 +7,18 @@
 #   - pipes a synthetic PreToolUse JSON blob with `gh pr create --body-file <path>`
 #   - asserts exit code + stderr contents
 #
+# The sandbox installs a fake `gh` on PATH (see _lib-mock-gh.sh) so the
+# validator's `gh issue view` call against the PR-title's referenced issue
+# returns synthetic OPEN data — no live-tracker dependency. See
+# me2resh/apexyard#154.
+#
 # Exit 0 if all cases pass; exit 1 on first failure.
 
 set -u
 
 HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/validate-pr-create.sh"
+# shellcheck source=_lib-mock-gh.sh
+source "$(cd "$(dirname "$0")" && pwd)/_lib-mock-gh.sh"
 if [ ! -x "$HOOK_SRC" ]; then
   echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
   exit 1
@@ -47,6 +54,7 @@ make_sandbox() {
 run_case() {
   local label="$1" body_content="$2" want_rc="$3" want_stderr_regex="$4"
   local sb; sb=$(make_sandbox)
+  mock_gh_install "$sb"
   local body_file="$sb/body.md"
   printf '%s' "$body_content" > "$body_file"
   local cmd="gh pr create --repo me2resh/apexyard --title 'chore(#113): test' --body-file $body_file"


### PR DESCRIPTION
## Summary

- Adds `.claude/hooks/tests/_lib-mock-gh.sh` — a tiny gh-shim helper that intercepts `gh issue view <N> ... --json ...` calls inside hook test sandboxes and returns synthetic `{"number":N,"state":"OPEN"}`. Pass-through for any `gh` call it doesn't intercept.
- Wires the shim into `test_single_closes_per_pr.sh` and `test_validate_pr_required_sections.sh`. Both previously failed **every** case (0/13 and 0/8) because their PR titles reference `#114` / `#113`, which `validate-pr-create.sh` rejects when those issues are CLOSED — and they are now closed upstream.
- The shim's `mock_gh_set_state <sb> <num> <state>` helper is available for future tests that need to exercise the CLOSED-issue branch of the validator. Not used in this PR — neither test was scoped to that branch originally.

Closes #154.

## Testing

```bash
bash .claude/hooks/tests/test_single_closes_per_pr.sh
# PASS: 13   FAIL: 0

bash .claude/hooks/tests/test_validate_pr_required_sections.sh
# PASS: 8    FAIL: 0

# Full suite — all 12 test files green
for t in .claude/hooks/tests/test_*.sh; do bash "$t" 2>&1 | tail -2; done
```

To trace intercepted shim calls during debug: `MOCK_GH_TRACE=1 bash .claude/hooks/tests/test_single_closes_per_pr.sh`.

## Glossary

| Term | Definition |
|------|------------|
| gh-shim | A fake `gh` binary placed on `PATH` that intercepts a known subset of subcommands and returns synthetic responses. Real `gh` is `exec`'d for everything not intercepted. |
| Live-tracker dependency | A test that calls a real network API (here, GitHub Issues) and so changes pass/fail status when the remote state changes — even though no test code or system-under-test code changed. |
| Sandbox | A `mktemp`'d directory each test case populates with a minimal git repo, the hook under test, and supporting libs, then runs the hook against. Isolates filesystem state between cases. |
| `validate-pr-create.sh` | Hook that runs on `PreToolUse` for `gh pr create` and refuses when the PR title references an issue that doesn't exist OR is CLOSED in the tracker repo. |
