### PR TITLE
chore(#163): default split-portfolio sibling repo to <fork>-portfolio

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -103,27 +103,27 @@ Detection of an existing setup. Either form counts as "already in split-portfoli
 The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — public framework + private portfolio". This skill walks through it interactively. The recommended path uses the **`portfolio:` config block** (introduced in #145) rather than symlinks — both work, but the config block is the first-class option:
 
 1. **Confirm the layout**: "Two repos in your account: `your-org/apexyard` (public, this fork) + `your-org/<private-name>` (new private repo for the portfolio). Both clones sit side-by-side on disk. OK?"
-2. **Pick the private repo name**: default suggestion `your-org/ops`. Operator confirms or overrides.
+2. **Pick the private repo name**: default suggestion **`your-org/<fork>-portfolio`** (e.g. `your-org/apexyard-portfolio` if you kept the fork name; `your-org/cos-portfolio` if you renamed the fork to `cos`). Compute the `<fork>` part from the public-fork repo name (`gh repo view --json name -q .name`) so the suggestion is correct even when the fork was renamed. Operator confirms or overrides — any name works, the framework only cares about the local path.
 3. **Create the private repo**: `gh repo create your-org/<name> --private --description "..."`. Confirm before running.
-4. **Clone the private repo as a sibling**: `cd .. && gh repo clone your-org/<name> portfolio`.
+4. **Clone the private repo as a sibling**: `cd .. && gh repo clone your-org/<name>` (no second arg — the clone defaults to a directory named after the repo, so `your-org/apexyard-portfolio` clones into `apexyard-portfolio/`).
 5. **Initialise the portfolio**: `apexyard.projects.yaml` + empty `projects/` dir + initial commit + push. Same content as the doc's step 5.
 6. **Configure path resolution in the fork** (recommended — config-block mode):
    - Append `.gitignore` lines for `apexyard.projects.yaml` and `projects` (so they don't accidentally get staged in the public fork even if the operator runs `git add -A`).
    - Untrack any tracked `projects/README.md` from the upstream framework.
-   - Write `.claude/project-config.json` with the `portfolio:` block pointing at the sibling repo:
+   - Write `.claude/project-config.json` with the `portfolio:` block pointing at the sibling repo. Substitute the actual sibling-dir name the operator chose for `apexyard-portfolio` below:
 
      ```json
      {
        "portfolio": {
-         "registry": "../portfolio/apexyard.projects.yaml",
-         "projects_dir": "../portfolio/projects",
-         "ideas_backlog": "../portfolio/projects/ideas-backlog.md"
+         "registry": "../apexyard-portfolio/apexyard.projects.yaml",
+         "projects_dir": "../apexyard-portfolio/projects",
+         "ideas_backlog": "../apexyard-portfolio/projects/ideas-backlog.md"
        }
      }
      ```
 
    - Stage `.gitignore` and `.claude/project-config.json` for commit (the latter is per-fork, not per-machine, since it points at a public sibling-repo path).
-   - **Legacy fallback (framework-version < #145)**: if the adopter's framework predates the `portfolio:` config block, fall back to creating symlinks pointing at `../portfolio/apexyard.projects.yaml` and `../portfolio/projects`. The helper resolves either way.
+   - **Legacy fallback (framework-version < #145)**: if the adopter's framework predates the `portfolio:` config block, fall back to creating symlinks pointing at `../<sibling-dir>/apexyard.projects.yaml` and `../<sibling-dir>/projects`. The helper resolves either way.
 7. **Verify**: source `.claude/hooks/_lib-portfolio-paths.sh` and call `portfolio_validate`. Skill MUST refuse to declare success if validate fails — surface the specific failure and ask the operator to fix it before re-running.
 
    ```bash

--- a/.claude/skills/split-portfolio/SKILL.md
+++ b/.claude/skills/split-portfolio/SKILL.md
@@ -129,8 +129,10 @@ Confirm to operator: snapshot exists, file count matches expectation. If not, re
 
 #### Step 3 — Create the private repo
 
+The suggested default name is **`<account>/<fork>-portfolio`** — keeps the relationship to the public fork explicit on GitHub. Compute `<fork>` from the public-fork repo name (`gh repo view --json name -q .name`) so the suggestion is correct even when the fork was renamed (e.g. fork = `cos` → suggested portfolio = `cos-portfolio`).
+
 ```
-Suggested name: <account>/ops
+Suggested name: <account>/<fork>-portfolio    (e.g. <account>/apexyard-portfolio)
 Override? (Enter to accept default, or type a different name)
 > _
 

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -161,13 +161,15 @@ Use this mode if you're on GitHub Free with any project you don't want named pub
 
 ```
 ~/ops/
-├── apexyard/         ← public fork of me2resh/apexyard (framework code + tooling)
-└── portfolio/        ← private repo (registry + per-project docs — never goes public)
+├── apexyard/                ← public fork of me2resh/apexyard (framework code + tooling)
+└── apexyard-portfolio/      ← private repo (registry + per-project docs — never goes public)
 ```
+
+The default sibling-dir name is **`<fork>-portfolio`**, so the relationship between the two repos is self-documenting on disk and on GitHub. If you kept the fork name as `apexyard`, the sibling defaults to `apexyard-portfolio`. If you renamed the fork (e.g. `cos` for Chief-of-Staff), the sibling defaults to `cos-portfolio`. Pick something else if you'd prefer — the framework only cares about the local path you point the config block at.
 
 Both repos live in your account; on disk they sit side-by-side. Inside the apexyard fork, the framework's portfolio-aware skills resolve `apexyard.projects.yaml` and `projects/` through one of two mechanisms:
 
-- **Config block (recommended, framework ≥ #145).** A `portfolio:` block in `.claude/project-config.json` points the skills at `../portfolio/apexyard.projects.yaml` and `../portfolio/projects`. The `_lib-portfolio-paths.sh` helper resolves both. A `SessionStart` banner surfaces broken config (missing files, bad paths) at session start so you don't discover a misconfiguration mid-skill.
+- **Config block (recommended, framework ≥ #145).** A `portfolio:` block in `.claude/project-config.json` points the skills at `../apexyard-portfolio/apexyard.projects.yaml` and `../apexyard-portfolio/projects`. The `_lib-portfolio-paths.sh` helper resolves both. A `SessionStart` banner surfaces broken config (missing files, bad paths) at session start so you don't discover a misconfiguration mid-skill.
 - **Symlink (legacy, framework < #145).** `apexyard.projects.yaml` and `projects/` are symlinks into the portfolio repo (and gitignored from the fork itself). Existing skills resolve through the symlink transparently. Continues to work; if you're upgrading framework versions, prefer the config block.
 
 The `/split-portfolio` skill (introduced #146) automates the full migration flow including the config-block write — see § "Migrating from single-fork to split-portfolio" below for adopters who already pushed private project names to a public fork.
@@ -181,26 +183,26 @@ Same as single-fork mode. Visit [`github.com/me2resh/apexyard`](https://github.c
 #### 2. Create an empty private repo for your portfolio
 
 ```bash
-gh repo create your-org/ops --private \
+gh repo create your-org/apexyard-portfolio --private \
   --description "ApexYard private portfolio: registry + per-project handover docs"
 ```
 
-`your-org/ops` is the conventional name; pick whatever you like. The framework doesn't care about the name — only the local path.
+The default convention is **`<fork>-portfolio`** — keeps the relationship to the public fork clear on GitHub and on disk. If your fork is named `your-org/apexyard`, the portfolio is `your-org/apexyard-portfolio`. If you renamed the fork (`your-org/cos`, `your-org/apex`), use `<fork>-portfolio` accordingly. Pick a different name if you prefer — the framework only cares about the local path you point the config block at.
 
 #### 3. Clone both side-by-side
 
 ```bash
 mkdir ~/ops && cd ~/ops
 gh repo clone your-org/apexyard
-gh repo clone your-org/ops portfolio
+gh repo clone your-org/apexyard-portfolio
 ```
 
 Resulting layout:
 
 ```
 ~/ops/
-├── apexyard/         ← public fork
-└── portfolio/        ← private (currently empty)
+├── apexyard/                ← public fork
+└── apexyard-portfolio/      ← private (currently empty)
 ```
 
 #### 4. Add `upstream` for future updates
@@ -213,7 +215,7 @@ git remote add upstream https://github.com/me2resh/apexyard.git
 #### 5. Initialise the private portfolio
 
 ```bash
-cd ~/ops/portfolio
+cd ~/ops/apexyard-portfolio
 
 cat > apexyard.projects.yaml <<EOF
 version: 1
@@ -254,12 +256,14 @@ git rm -r --cached projects 2>/dev/null || true
 
 # Write the portfolio: config block pointing at the sibling repo.
 # Paths resolve relative to the ops-fork root (this directory).
+# If you used a different sibling-dir name than apexyard-portfolio,
+# substitute it in all three paths below.
 cat > .claude/project-config.json <<'JSON'
 {
   "portfolio": {
-    "registry": "../portfolio/apexyard.projects.yaml",
-    "projects_dir": "../portfolio/projects",
-    "ideas_backlog": "../portfolio/projects/ideas-backlog.md"
+    "registry": "../apexyard-portfolio/apexyard.projects.yaml",
+    "projects_dir": "../apexyard-portfolio/projects",
+    "ideas_backlog": "../apexyard-portfolio/projects/ideas-backlog.md"
   }
 }
 JSON
@@ -292,8 +296,8 @@ EOF
 git rm -r --cached projects 2>/dev/null || true
 
 # Symlink the registry and projects/ into the portfolio repo:
-ln -s ../portfolio/apexyard.projects.yaml apexyard.projects.yaml
-ln -s ../portfolio/projects projects
+ln -s ../apexyard-portfolio/apexyard.projects.yaml apexyard.projects.yaml
+ln -s ../apexyard-portfolio/projects projects
 
 git add .gitignore
 git commit -m "chore: configure split-portfolio mode (registry + projects/ in private sibling repo)"
@@ -309,13 +313,13 @@ cd ~/ops/apexyard
 /projects   # should resolve through the symlink and report 0 entries (or whatever's in your portfolio)
 ```
 
-Adopt your first project with `/handover` — it writes to `../portfolio/projects/<name>/` and appends to `../portfolio/apexyard.projects.yaml`, both committed only to the private portfolio repo. The public fork stays slim.
+Adopt your first project with `/handover` — it writes to `../apexyard-portfolio/projects/<name>/` and appends to `../apexyard-portfolio/apexyard.projects.yaml`, both committed only to the private portfolio repo. The public fork stays slim.
 
 ### Daily workflow under split mode
 
 ```bash
 cd ~/ops/apexyard      # framework changes go here, push to public fork
-cd ~/ops/portfolio     # registry + project docs changes go here, push to private repo
+cd ~/ops/apexyard-portfolio     # registry + project docs changes go here, push to private repo
 ```
 
 Most ApexYard skills (`/projects`, `/inbox`, `/status`, `/tasks`, `/stakeholder-update`, `/handover`) work from the apexyard dir — they resolve paths through the symlinks. Skills that touch framework files only (`/update`, `/release`) operate on the apexyard dir alone.
@@ -327,7 +331,7 @@ Most ApexYard skills (`/projects`, `/inbox`, `/status`, `/tasks`, `/stakeholder-
 ### What this mode trades off
 
 - **Two repos to maintain** instead of one. Both live in the same GitHub account; trivial overhead.
-- **Two clones on each machine.** Cross-machine setup is `gh repo clone your-org/apexyard && gh repo clone your-org/ops portfolio` instead of one clone.
+- **Two clones on each machine.** Cross-machine setup is `gh repo clone your-org/apexyard && gh repo clone your-org/apexyard-portfolio` instead of one clone.
 - **No automatic GitHub-UI fork-of-the-portfolio.** The portfolio repo is independent. Backups happen via your normal git push to your private GitHub repo.
 - **One conflict path on `/update`** (the `projects/README.md` case above). Resolved manually if it ever fires.
 


### PR DESCRIPTION
## Summary

Closes me2resh/apexyard#163. Defaults the split-portfolio sibling repo name to **`<fork>-portfolio`** (e.g. `your-org/apexyard-portfolio` for the canonical fork name). The previous default — `your-org/ops` plus a bare `portfolio/` directory — was too generic: adopters running multiple ops setups hit naming collisions, and a bare `portfolio/` dir gives no signal about which framework it belongs to.

The new default makes the relationship to the public fork self-documenting on disk and on GitHub. If the fork is renamed (`your-org/cos`, `your-org/apex`), the portfolio defaults to `cos-portfolio` / `apex-portfolio`. Adopters who picked a different name keep working — the `portfolio:` config block resolves whatever path they configured.

**Mechanism unchanged.** This is a default-suggestion + example-prose update only.

## Files changed

- `docs/multi-project.md` — split-portfolio layout diagrams, setup walkthrough, config-block / symlink examples, daily-workflow cd commands, cross-machine clone command. The two remaining `your-org/ops` references at lines 52 + 64 are FORK-rename examples (renaming the fork itself); those stay valid (renaming a fork to `ops` would just produce `ops-portfolio` for the sibling, still self-documenting).
- `.claude/skills/setup/SKILL.md` — Step 2b's "default suggestion" for the private repo name is now `your-org/<fork>-portfolio`, computed dynamically via `gh repo view --json name -q .name` so the suggestion stays correct even when the fork was renamed. Clone command drops the second arg (repo name IS the directory name now).
- `.claude/skills/split-portfolio/SKILL.md` — Step 3's suggested-name template is now `<account>/<fork>-portfolio` with the same dynamic-fork-name resolution.

## Testing

- [x] **Grep verification** — `grep -rn "your-org/ops" docs/ .claude/skills/` returns only the two intentional FORK-rename examples (`docs/multi-project.md:52`, `:64`, `docs/getting-started.md:20`). No prose references to `your-org/ops` remain in the split-portfolio walkthrough.
- [x] **Path consistency** — `grep -rn "../portfolio/" docs/ .claude/skills/` returns 0 matches. All split-portfolio config-block / symlink examples use `../apexyard-portfolio/`.
- [x] **AgDR-0010 unchanged** — historical decision record reference to "ops-fork" is generic terminology (the framework fork's role), not a name; kept as-is.
- [x] **`apexyard.projects.yaml.example` unchanged** — uses "ops repo" as generic terminology for the framework fork; not a name.
- [ ] **Visual review of the rendered docs** (manual) — confirm the layout diagrams + walkthrough flow read cleanly with the new naming.

## Glossary

| Term | Definition |
|------|------------|
| **`<fork>-portfolio`** | The new default sibling-repo / sibling-dir name for split-portfolio mode. `<fork>` is the public-fork repo name (e.g. `apexyard`, `cos`, `apex`). Both the GitHub repo and the local sibling-clone dir use this name. |
| **Dynamic fork-name resolution** | The skill computes `<fork>` at runtime via `gh repo view --json name -q .name`, so the suggestion is correct whether the fork is `apexyard` or has been renamed. Adopters never have to manually substitute. |
| **Mechanism unchanged** | The `portfolio:` config block in `.claude/project-config.json` still takes any path. Adopters with existing `ops/` setups keep working — only the default suggestion + example prose changes. |
| **Self-documenting on disk** | A directory listing of `~/Projects/<orgname>/` shows `apexyard/` and `apexyard-portfolio/` next to each other; the relationship is obvious without reading any docs. The previous bare `portfolio/` lost that signal as soon as another unrelated `portfolio/` dir landed nearby. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
