### PR TITLE
chore(#168): accept release/vN.N.N branches + release(...) PR titles

### DIFF
--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -26,6 +26,17 @@ if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ] || [ "$CUR
   exit 0
 fi
 
+# Allow release-cut branches (apexyard#116, AgDR-0007). The /release skill
+# prescribes `release/vN.N.N` (and optionally a `-rcN` suffix) as the
+# canonical name for the dev → main release PR's source branch. This is
+# a narrow, intentional exception to the standard {type}/{TICKET}-{desc}
+# shape — release branches don't carry a ticket-id because the release
+# itself is the ticket. See me2resh/apexyard#168 for why this exception
+# exists.
+if echo "$CURRENT_BRANCH" | grep -qE '^release/v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$'; then
+  exit 0
+fi
+
 # Load the branch-type whitelist from project config.
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 # shellcheck source=./_lib-read-config.sh

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -75,7 +75,8 @@
       "build",
       "ci",
       "chore",
-      "revert"
+      "revert",
+      "release"
     ],
     "required_sections": [
       "Testing",

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -82,7 +82,7 @@ Branch from `dev`: `release/vA.B.C`. Push to `upstream`. Open PR:
 
 - **Base**: `main`
 - **Head**: `release/vA.B.C`
-- **Title**: `release: vA.B.C`
+- **Title**: `release(#<release-ticket>): vA.B.C` — e.g. `release(#160): v1.2.0`. The release-cut ticket (filed via the standard ticket flow) is the natural scope, and `release` was added to the `pr.title_type_whitelist` in #168 so this title shape passes `validate-pr-create.sh` like every other PR title.
 - **Body**: the CHANGELOG draft + an explicit "this PR will tag `vA.B.C` on `main` after merge"
 
 The PR body should aggregate every `Closes #N` from the included commits so that merging the release PR auto-closes all of them on GitHub at once.


### PR DESCRIPTION
## Summary

Closes me2resh/apexyard#168. Fixes the contradiction between the `/release` skill's prescribed branch name + PR title and the framework's own validators. Surfaced cutting v1.2.0 — the first release under the dev/main model (AgDR-0007).

Three small changes:

1. **`.claude/hooks/validate-branch-name.sh`** — added an early-out clause that accepts `^release/v\d+\.\d+\.\d+(-rcN)?$` as a valid branch name. Narrow, intentional exception for the framework's release-cut convention; release branches don't carry a ticket-id because the release itself IS the ticket.

2. **`.claude/project-config.defaults.json`** — added `release` to `pr.title_type_whitelist` so a title like `release(#160): v1.2.0` passes `validate-pr-create.sh`'s existing regex unchanged.

3. **`.claude/skills/release/SKILL.md`** step 4 — corrected the prescribed PR title to `release(#<release-ticket>): vA.B.C` so future `/release` invocations produce a title that satisfies the validators by construction.

## Why now

Cutting v1.2.0 is blocked on this. The release-cut convention exists; the validators don't recognise it; the contradiction was invisible until the first release tried to land. Tiny scope (3 file edits), but blocks the v1.2.0 release.

## Testing

- [x] **Branch validator probes** against all relevant patterns:

  ```
  release/v1.2.0           → rc=0  (allowed, release-special-case)
  release/v1.2.0-rc1       → rc=0  (allowed, RC variant)
  release/v9.9.9           → rc=0  (allowed)
  release/foo              → rc=2  (correctly blocked)
  release/v1               → rc=2  (correctly blocked — no minor.patch)
  chore/GH-168-fix         → rc=0  (allowed, standard pattern)
  feature/GH-1-x           → rc=0  (allowed, standard pattern)
  ```

- [x] **Full hook test suite** — `for t in .claude/hooks/tests/test_*.sh; do bash "$t"; done` → **196/196 across 12 test files**. No regression.
- [x] **PR-title regex unchanged** — `validate-pr-create.sh` is untouched; only the type whitelist gets a new entry.
- [ ] **Live integration** — confirmed by the act of opening this PR (title `chore(#168): ...` passes the same regex it always did).

## Glossary

| Term | Definition |
|------|------------|
| **Release-cut convention** | The dev/main model adopted in AgDR-0007 / #116. Release PRs originate from `dev`, land on `main`, and get a semver tag on the merge commit. The `/release` skill automates this; the source branch's prescribed name is `release/vA.B.C`. |
| **Special-case branch exception** | A narrow, intentional bypass in `validate-branch-name.sh` for branches that match a known framework convention without fitting the standard `{type}/{TICKET-ID}-{description}` shape. Used here for `release/vN.N.N` because release branches are scoped by the release itself, not by a single ticket. |
| **PR-title type whitelist** | The `pr.title_type_whitelist` array in `.claude/project-config.{defaults,}.json`. Drives the `validate-pr-create.sh` regex's `${PR_TYPES}` capture group. Adding `release` lets `release(#N): vA.B.C` pass. |
| **Validator-by-construction** | A skill that produces output which satisfies the framework's validators without the operator having to manually massage it. The /release skill is now validator-by-construction for both the branch name and the PR title — earlier it produced names that the validators rejected. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
