### PR TITLE
chore(#170): exempt release/vN.N.N from validate-pr-create's branch-id check

### DIFF
--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -270,7 +270,12 @@ fi
 # Validate branch name has ticket ID
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
 if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "main" ] && [ "$CURRENT_BRANCH" != "master" ]; then
-  if ! echo "$CURRENT_BRANCH" | grep -qE '[A-Z]{2,10}-[0-9]+|GH-[0-9]+|#[0-9]+'; then
+  # Release-cut branches are exempt — same recognition `validate-branch-name.sh`
+  # added in me2resh/apexyard#168 / #169. Release branches don't carry a
+  # ticket-id because the release itself is the ticket.
+  if echo "$CURRENT_BRANCH" | grep -qE '^release/v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$'; then
+    :  # release branch, exempt — fall through to the rest of the validator
+  elif ! echo "$CURRENT_BRANCH" | grep -qE '[A-Z]{2,10}-[0-9]+|GH-[0-9]+|#[0-9]+'; then
     ERRORS="${ERRORS}Branch '$CURRENT_BRANCH' missing ticket ID.\n"
   fi
 fi


### PR DESCRIPTION
## Summary

Closes me2resh/apexyard#170. Completes the work started in #169 (closing #168). The release-pattern exemption was applied to `validate-branch-name.sh` but the secondary branch-id check inside `validate-pr-create.sh` (line 273) was missed; this PR adds the same exemption there.

One file edit, ~6 lines. Same regex (`^release/v\d+\.\d+\.\d+(-rc\d+)?$`), same rationale ("release branches don't carry a ticket-id because the release itself is the ticket").

#168's AC 3 was checked off based on the title regex alone; the second branch-id check inside the same file was missed. This PR closes that gap.

## Why now

Same chain as #168. The v1.2.0 release PR can't open without this fix.

## Testing

- [x] **Validator probes** against all relevant patterns:

  ```
  release/v1.2.0     → rc=0  (allowed, exempt)
  release/v1.2.0-rc1 → rc=0  (allowed, RC variant)
  chore/GH-1-fix     → rc=0  (allowed, has ticket-id)
  release/foo        → rc=2  (correctly blocked, missing ticket-id)
  chore/no-ticket    → rc=2  (correctly blocked, missing ticket-id)
  ```

- [x] **No regression** — full hook test suite still passes; `validate-pr-create.sh`'s other branches (Closes-keyword check, sections check, title regex check, issue-state check) are untouched.
- [x] **PR title + body format** — title `chore(#170): ...`, body has Summary / Why now / Testing / Glossary, single `Closes me2resh/apexyard#170` keyword.

## Glossary

| Term | Definition |
|------|------------|
| **Incomplete fix** | #168's AC catalogued the test cases but only patched one of two validators in the same chain. Rex's review of #169 verified the AC's letter (the title regex change) but didn't notice the secondary branch-id check living in the same `validate-pr-create.sh` file. This PR completes that fix. |
| **Release-pattern exemption** | The narrow `^release/vN.N.N(-rcN)?$` regex that recognises the framework's release-cut convention (AgDR-0007). Now applied identically in two validators (`validate-branch-name.sh` from #169, `validate-pr-create.sh` from this PR). |
| **Branch-id check** | The validator's verification that any non-trunk branch contains a substring matching a ticket-id pattern (`[A-Z]{2,10}-[0-9]+`, `GH-[0-9]+`, `#[0-9]+`). Independent of the branch-name format check. |
| **Discoverability of related checks** | Two semantically-related checks living in different validator files (and different lines of the same file) made #168 easy to underestimate. A future tightening would consolidate the release-pattern exemption into a shared helper, so adding a new validator can call into the same recognition. Out of scope for this fix; worth a separate ticket. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
