### PR TITLE
chore(#173): sync CHANGELOG.md from main to dev (post-v1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,89 @@
 
 All notable changes to ApexYard are documented here.
 
+## [1.2.0] — 2026-05-04
+
+### Mechanical-enforcement hardening + portfolio polish + landing-site refresh
+
+v1.2.0 doubles down on apexyard's "rule-as-code, not advisory prose" thesis. Nine new hooks plus two upgrades wire the SDLC's safety claims tighter to the runtime; four new skills (`/debug`, `/validate-idea`, `/tickets-batch`, `/fan-out`) extend the operator surface; portfolio mode ships a first-class config block plus a destructive-migration helper; and the landing site picks up a multi-tab terminal demo, a full skills reference page, and a permanent changelog link.
+
+Two adopter-visible behaviour changes worth reading before you sync — the `/approve-merge` flow now auto-merges in the same turn (with a structured marker that's harder to forge), and `Bash` file writes (`echo > file`, `tee`, `python -c '...write_text...'`, etc.) are now gated by the same ticket-first hook that already covered `Edit` / `Write` / `MultiEdit`. See "Notable behaviour changes" below.
+
+### Highlights
+
+- **Bootstrap-skill exemption + Bash-write coverage** close the ticket-first gate's two known failure modes (#150 + #151, AgDR-0011)
+- **`/approve-merge` hardened + streamlined** — structured CEO marker prevents `echo SHA > file` bypass; default flow auto-merges in the same turn (#132 + #48, AgDR-0012)
+- **Portfolio mode polish** — `portfolio:` config block, `/split-portfolio` migration helper, self-healing path resolution (#143 + #145, AgDR-0010)
+- **Four new skills** — `/debug` (structured hypothesis-driven debugging), `/validate-idea` (pre-spec gate), `/tickets-batch` (bulk-file flow), `/fan-out` (parallel agents)
+- **Release-cut branch model adopted** — framework now uses `dev` for daily PRs, `main` for release tags only (#116, AgDR-0007)
+- **Landing site refresh** — multi-tab terminal demo (`one ticket / /handover / /setup / /fan-out`), full 39-skill reference page at `/skills.html`, persistent `changelog →` link in the nav
+
+### Added
+
+- `feat(#108)` `/tickets-batch` — bulk-file 5–20 structured tickets in one flow with shared-context micro-interview (#127)
+- `feat(#117)` `/fan-out` — spawn N parallel `Agent` calls in one assistant message, optional worktree isolation, foreground / background mode (#128)
+- `feat(#130)` `/validate-idea` — lightweight 5-question pre-spec gate (#131)
+- `feat(#141)` `/debug` — structured hypothesis-driven debugging that forces architecture-first reading and evidence-before-fix (#142)
+- `feat(#145)` Portfolio config block (`portfolio.{registry,projects_dir,ideas_backlog}`) + self-healing SessionStart banner + `/split-portfolio` migration helper (#147, AgDR-0010)
+- `feat(#150)` Bootstrap-skill exemption — `/setup`, `/handover`, `/update`, `/split-portfolio` write `.claude/session/active-bootstrap` markers; `require-active-ticket.sh` exempts them. Plus Bash-write coverage in `require-active-ticket.sh` and `require-migration-ticket.sh` (#152, AgDR-0011)
+- `feat(#132)` `/approve-merge` writes a structured CEO marker (`sha=`, `approved_by=user`, `skill_version=2`) AND runs `gh pr merge --squash --delete-branch` in the same turn by default; `--no-merge` opt-out preserves the deferred case; bare-SHA legacy markers rejected by the merge gate (#158, AgDR-0012)
+- `feat(#160)` Multi-tab terminal demo on the landing site — four flows (`one ticket`, `/handover`, `/setup`, `/fan-out`) with auto-advance + click-to-jump (#162)
+- `feat(#165)` Skills reference page at `site/skills.html` covering all 39 skills + permanent `changelog →` link in the homepage nav (#167)
+
+### Fixed
+
+- `fix(#106)` CHANGELOG fallback in upstream-drift hook for squash-merged forks (#129)
+
+### Changed
+
+- `chore(#107)` `validate-issue-structure.sh` PreToolUse hook — issue-body schema verified at create time (#122)
+- `chore(#109)` Project-configurable ticket / branch / commit / PR schema in `.claude/project-config.{defaults,}.json` (#118)
+- `chore(#110)` `block-private-refs-in-public-repos.sh` — leak protection on outgoing PR / issue / comment bodies (#119)
+- `chore(#111)` `pre-push-gate` upgraded from advisory reminder to blocking check-runner (#121)
+- `chore(#112)` `require-agdr-for-arch-pr.sh` — flag arch-class PRs that don't link an AgDR (#123)
+- `chore(#113)` `## Testing` section now required in PR body, project-configurable (#124)
+- `chore(#114)` Single `Closes #N` keyword per PR body enforced (#125)
+- `chore(#115)` `warn-stale-review-markers.sh` PostToolUse hook — surfaces stale review markers after pushes (#120)
+- `chore(#116)` Release-cut branch model — `dev` for daily PRs, `main` for release tags only. Framework-only; managed projects stay trunk-based (#126, AgDR-0007)
+- `chore(#153)` Extended Bash-write matcher beyond first-version coverage — additional patterns for archive / network / interpreter shapes (#155)
+- `chore(#163)` Default the split-portfolio sibling repo name to `<fork>-portfolio` (e.g. `your-org/apexyard-portfolio`) instead of generic `your-org/ops` (#164)
+- `chore(#77)` Hook + skill counts in `CHANGELOG.md` and `CLAUDE.md` corrected to current reality (24 hooks, 39 skills) (#161)
+- `chore(#168)` `validate-branch-name.sh` now recognises the `release/vN.N.N(-rcN)?` pattern as a valid branch name; `release` added to `pr.title_type_whitelist` so a PR title `release(#160): v1.2.0` passes the validator (#169)
+- `chore(#170)` `validate-pr-create.sh`'s independent branch-id check now also exempts `release/vN.N.N` (completes the #168 fix) (#171)
+
+### Tests
+
+- `test(#154)` Mock `gh` in test sandboxes — removes live-tracker dependency from `test_single_closes_per_pr.sh` and `test_validate_pr_required_sections.sh` (#156)
+
+### Docs
+
+- `docs(#143)` Document split-portfolio mode (public framework + private sibling portfolio) + add the `/setup` privacy gate (#144)
+- `docs(#148)` Correct privacy-gate wording — adopter action, not framework auto-publish (#149)
+
+### Notable behaviour changes (read before upgrade)
+
+1. **`/approve-merge` auto-merges by default.** The skill now writes the CEO marker AND runs `gh pr merge --squash --delete-branch` in the same turn. Use `/approve-merge <pr> --no-merge` to preserve the old "stop after marker" flow. AgDR-0012 has the rationale.
+2. **Legacy bare-SHA CEO markers are rejected.** Any in-flight `<pr>-ceo.approved` written by the pre-#48 skill must be re-issued via `/approve-merge` (one re-run per stale marker). The new format is structured key/value (`sha=`, `approved_by=user`, `skill_version=2`).
+3. **Bash file writes are gated.** `echo > file`, `tee`, `sed -i`, `python -c '...write_text...'`, `node -e '...writeFileSync...'`, `ruby -e '...File.write...'` now hit `require-active-ticket.sh` / `require-migration-ticket.sh` when no ticket is active. Bootstrap skills get an exemption via the active-bootstrap marker.
+4. **PR body must include `## Testing` section.** PR creation is blocked otherwise. Override via `.claude/project-config.json` → `pr.required_sections` if your team uses different conventions.
+5. **Single `Closes #N` per PR body / commit message.** Multi-Closes is blocked. Use `Refs #N` for cross-references; release PRs use the `<!-- multi-close: approved -->` skip marker.
+6. **Release-cut branch model.** The framework's `main` now only receives release PRs from `dev`. Adopter forks stay trunk-based on `main`.
+
+### Stats
+
+- **24 hooks** wired in `.claude/settings.json` (up from 18 in v1.1.0)
+- **39 skills** available as slash commands (up from 35 in v1.1.0)
+- **10 modular rule files** in `.claude/rules/`
+- **13 AgDRs total** (AgDR-0006 through AgDR-0013 — eight new AgDRs added in this cycle)
+- **Test coverage**: 196+ cases across 12 hook test files
+
+### Migration notes
+
+- **Stale CEO markers** — re-run `/approve-merge` on any in-flight PR with a pre-#48 marker. One re-run each.
+- **Custom `/approve-merge` invocation** — if you customised the skill to skip the merge, pass `--no-merge` to preserve that behaviour.
+- **PR body templates** — make sure your local templates include `## Testing` and `## Glossary` sections (the two `pr.required_sections` enforced by `validate-pr-create.sh`; `## Summary` is conventional but not validator-enforced). See [`pr-quality.md`](.claude/rules/pr-quality.md).
+- **Bash bypass paths** — any tooling that relied on `echo > file` to circumvent the ticket-first gate now needs a real active ticket via `/start-ticket`. Bootstrap skills (`/setup`, `/handover`, `/update`, `/split-portfolio`) are exempt automatically.
+
 ## [1.1.0] — 2026-04-19
 
 ### Tag-based upstream drift detection


### PR DESCRIPTION
## Summary

Closes me2resh/apexyard#173. Single-file commit syncing `dev`'s `CHANGELOG.md` to match `main` after the v1.2.0 release cut.

The release-cut model (AgDR-0007 / #116) squash-merges `release/vN.N.N → main`, which means the v1.2.0 CHANGELOG section that landed on main via PR #172 was never propagated back to dev. Without this sync, the next release PR cut from dev would build a v1.3.0 section on top of v1.1.0, silently dropping v1.2.0 from dev's running history.

## Implementation

```bash
git fetch upstream main
git show upstream/main:CHANGELOG.md > CHANGELOG.md
```

The diff is exactly the v1.2.0 entry being prepended; no other lines change.

## Follow-up — out of scope here

The skill-level fix (option B in the ticket) — updating `/release` to source the previous CHANGELOG from `upstream/main` so this drift can't recur — is filed as the same ticket's "next step" but not done in this PR. Worth a separate ticket once we've shipped a couple more releases under the dev/main flow and confirmed the right shape.

## Testing

- [x] **`dev`'s CHANGELOG.md now matches `main`'s** — `git diff upstream/main:CHANGELOG.md HEAD:CHANGELOG.md` returns empty
- [x] **v1.2.0 section is present and at the top** — `head -8 CHANGELOG.md` confirms `## [1.2.0] — 2026-05-04`
- [x] **No voice mentions in the v1.2.0 section** — `awk '/^## \[1\.2\.0\]/,/^## \[1\.1\.0\]/' CHANGELOG.md | grep -ci voice` → 0 (per AgDR-0013)
- [x] **Single-file diff** — only `CHANGELOG.md` changed; nothing else moved
- [x] **Markdownlint clean** — passed locally

## Glossary

| Term | Definition |
|------|------------|
| **Release-cut drift (CHANGELOG flavour)** | The corollary of the dev/main release-cut model: when a release PR squash-merges to main with the new CHANGELOG entry, that entry never propagates back to dev. dev's CHANGELOG is perpetually one version behind main unless explicitly synced. |
| **One-shot sync** | This PR copies main's CHANGELOG.md verbatim onto dev. Adopters who want this sync to be automatic should track the follow-up ticket for the skill-level fix to `/release`. |
| **AgDR-0007 corollary** | A side-effect of the release-cut decision that wasn't captured in the original AgDR. Filed as #173 as documentation of "what we missed when we adopted dev/main." |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
