### PR TITLE
feat(#183): /launch-check historical trend tracking

### DIFF
--- a/.claude/hooks/tests/test_launch_check_trend.sh
+++ b/.claude/hooks/tests/test_launch_check_trend.sh
@@ -1,0 +1,278 @@
+#!/bin/bash
+# Smoke tests for .claude/skills/launch-check/render-trend.sh
+# (apexyard#183 — historical trend tracking)
+#
+# Each case:
+#   - builds an isolated runs/ dir under $TMPDIR
+#   - drops N synthetic run JSON files conforming to the apexyard#183 schema
+#   - invokes render-trend.sh against the dir
+#   - asserts exit code + stdout shape
+#
+# Cases covered (matches AC in apexyard#183):
+#   1. Single run        → no trend section emitted (silent, exit 0)
+#   2. Empty runs dir    → no trend section emitted (silent, exit 0)
+#   3. Missing runs dir  → no trend section emitted (silent, exit 0)
+#   4. Two runs          → trend section IS emitted (table + chart)
+#   5. Five runs         → trend table has 5 rows + chart spans 5 cols
+#   6. Trend mode read   → reading existing JSON produces trend-only output
+#                          (this is the "/launch-check trend" mode case —
+#                          the renderer doesn't run the audit, just reads
+#                          the existing history. So it's the same as case 5
+#                          with the assertion that no audit-side state was
+#                          written.)
+#   7. Auto-notes derive → "Security +N, Performance +M" string format
+#   8. Forward-compat     → run files with extra unknown fields still render
+#                          (schema is additive — apexyard#183 risk note)
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+RENDERER="$SRC_ROOT/.claude/skills/launch-check/render-trend.sh"
+
+if [ ! -x "$RENDERER" ]; then
+  echo "FAIL: renderer not found or not executable at $RENDERER" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not installed; render-trend.sh requires jq" >&2
+  exit 0
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+make_runs_dir() {
+  local sb
+  sb=$(mktemp -d)
+  mkdir -p "$sb/runs"
+  echo "$sb/runs"
+}
+
+# write_run <runs_dir> <ts> <scores_object_json> <verdict>
+# ts is ISO-8601; the filename uses ts with `:` replaced by `-`.
+write_run() {
+  local dir="$1" ts="$2" scores="$3" verdict="$4"
+  local fname
+  fname=$(echo "$ts" | tr ':' '-')
+  cat > "$dir/${fname}.json" <<EOF
+{
+  "ts": "$ts",
+  "branch": "main",
+  "commit": "abcdef0",
+  "scores": $scores,
+  "verdict": "$verdict",
+  "top_risks": []
+}
+EOF
+}
+
+# Same as write_run but with extra unknown fields — used to verify
+# forward-compatibility (apexyard#183 risk note: "adopters with existing
+# runs/ shouldn't lose them on framework upgrade").
+write_run_with_extras() {
+  local dir="$1" ts="$2" scores="$3" verdict="$4"
+  local fname
+  fname=$(echo "$ts" | tr ':' '-')
+  cat > "$dir/${fname}.json" <<EOF
+{
+  "ts": "$ts",
+  "branch": "main",
+  "commit": "abcdef0",
+  "scores": $scores,
+  "verdict": "$verdict",
+  "top_risks": [],
+  "future_field_v2": {"actor": "ci", "notes": "operator-supplied notes — v2 schema addition"},
+  "schema_version": 99
+}
+EOF
+}
+
+run_renderer() {
+  local dir="$1"
+  local out
+  out=$("$RENDERER" "$dir" 2>&1)
+  echo "$out"
+}
+
+assert_empty() {
+  local case_name="$1" out="$2"
+  if [ -z "$out" ]; then
+    PASS=$((PASS+1))
+    echo "PASS: $case_name"
+  else
+    FAIL=$((FAIL+1))
+    FAILED_CASES="$FAILED_CASES\n$case_name (expected empty output, got: $out)"
+    echo "FAIL: $case_name (expected empty output)"
+    echo "----- actual output -----"
+    echo "$out"
+    echo "-------------------------"
+  fi
+}
+
+assert_contains() {
+  local case_name="$1" out="$2" needle="$3"
+  if echo "$out" | grep -qF "$needle"; then
+    PASS=$((PASS+1))
+    echo "PASS: $case_name"
+  else
+    FAIL=$((FAIL+1))
+    FAILED_CASES="$FAILED_CASES\n$case_name (expected contains: $needle)"
+    echo "FAIL: $case_name (expected to contain: $needle)"
+    echo "----- actual output -----"
+    echo "$out"
+    echo "-------------------------"
+  fi
+}
+
+assert_not_contains() {
+  local case_name="$1" out="$2" needle="$3"
+  if echo "$out" | grep -qF "$needle"; then
+    FAIL=$((FAIL+1))
+    FAILED_CASES="$FAILED_CASES\n$case_name (expected NOT to contain: $needle)"
+    echo "FAIL: $case_name (expected to NOT contain: $needle)"
+    echo "----- actual output -----"
+    echo "$out"
+    echo "-------------------------"
+  else
+    PASS=$((PASS+1))
+    echo "PASS: $case_name"
+  fi
+}
+
+# Standard scores-object templates so cases below stay short.
+SCORES_LOW='{"security":50,"accessibility":70,"compliance":60,"analytics":60,"seo":65,"performance":60,"monitoring":60,"docs":70}'
+SCORES_MID='{"security":62,"accessibility":75,"compliance":65,"analytics":70,"seo":70,"performance":65,"monitoring":70,"docs":75}'
+SCORES_HI='{"security":75,"accessibility":80,"compliance":73,"analytics":80,"seo":75,"performance":70,"monitoring":75,"docs":85}'
+SCORES_HI2='{"security":78,"accessibility":82,"compliance":76,"analytics":82,"seo":78,"performance":72,"monitoring":78,"docs":88}'
+SCORES_HI3='{"security":80,"accessibility":85,"compliance":78,"analytics":85,"seo":80,"performance":75,"monitoring":82,"docs":90}'
+
+# ---------------------------------------------------------------------------
+# Case 1: single run -> no trend section
+# ---------------------------------------------------------------------------
+runs=$(make_runs_dir)
+write_run "$runs" "2026-04-20T10:00:00Z" "$SCORES_LOW" "no-go"
+out=$(run_renderer "$runs")
+assert_empty "case1: single run produces no trend section" "$out"
+
+# ---------------------------------------------------------------------------
+# Case 2: empty runs dir -> no trend section
+# ---------------------------------------------------------------------------
+runs=$(make_runs_dir)
+out=$(run_renderer "$runs")
+assert_empty "case2: empty runs dir produces no trend section" "$out"
+
+# ---------------------------------------------------------------------------
+# Case 3: missing runs dir -> no trend section
+# ---------------------------------------------------------------------------
+sb=$(mktemp -d)
+out=$(run_renderer "$sb/nonexistent")
+assert_empty "case3: missing runs dir produces no trend section" "$out"
+
+# ---------------------------------------------------------------------------
+# Case 4: two runs -> trend section IS emitted
+# ---------------------------------------------------------------------------
+runs=$(make_runs_dir)
+write_run "$runs" "2026-04-20T10:00:00Z" "$SCORES_LOW" "no-go"
+write_run "$runs" "2026-04-27T10:00:00Z" "$SCORES_MID" "conditional-go"
+out=$(run_renderer "$runs")
+assert_contains "case4a: 2 runs produces trend heading"        "$out" "## Trend (last 2 runs)"
+assert_contains "case4b: 2 runs produces table header"         "$out" "| Date       | Score | Verdict"
+assert_contains "case4c: 2 runs produces baseline note"        "$out" "Initial baseline"
+assert_contains "case4d: 2 runs produces ASCII chart heading"  "$out" "Score trend:"
+assert_contains "case4e: 2 runs produces this-run marker"      "$out" "(this run)"
+assert_contains "case4f: 2 runs renders earlier date"          "$out" "2026-04-20"
+assert_contains "case4g: 2 runs renders later date"            "$out" "2026-04-27"
+
+# ---------------------------------------------------------------------------
+# Case 5: five runs -> trend table has all five dates + chart spans 5 columns
+# ---------------------------------------------------------------------------
+runs=$(make_runs_dir)
+write_run "$runs" "2026-04-20T10:00:00Z" "$SCORES_LOW" "no-go"
+write_run "$runs" "2026-04-27T10:00:00Z" "$SCORES_MID" "conditional-go"
+write_run "$runs" "2026-05-04T10:00:00Z" "$SCORES_HI"  "conditional-go"
+write_run "$runs" "2026-05-05T10:00:00Z" "$SCORES_HI2" "conditional-go"
+write_run "$runs" "2026-05-06T10:00:00Z" "$SCORES_HI3" "conditional-go"
+out=$(run_renderer "$runs")
+assert_contains "case5a: 5 runs trend heading says 5 runs"   "$out" "## Trend (last 5 runs)"
+assert_contains "case5b: earliest run shows in table"        "$out" "2026-04-20"
+assert_contains "case5c: latest run shows in table"          "$out" "2026-05-06"
+assert_contains "case5d: middle run shows in table"          "$out" "2026-05-04"
+
+# ---------------------------------------------------------------------------
+# Case 6: trend mode reads existing JSON without writing audit state.
+# Verifies that running render-trend.sh twice in a row produces identical
+# output (idempotent / read-only).
+# ---------------------------------------------------------------------------
+out1=$(run_renderer "$runs")
+out2=$(run_renderer "$runs")
+if [ "$out1" = "$out2" ]; then
+  PASS=$((PASS+1))
+  echo "PASS: case6: trend renderer is idempotent (read-only)"
+else
+  FAIL=$((FAIL+1))
+  FAILED_CASES="$FAILED_CASES\ncase6: trend renderer produced different output on second run"
+  echo "FAIL: case6: trend renderer is not idempotent"
+fi
+
+# Also verify no new files were written into the runs dir.
+file_count_before=$(ls "$runs"/*.json | wc -l | tr -d ' ')
+run_renderer "$runs" >/dev/null
+file_count_after=$(ls "$runs"/*.json | wc -l | tr -d ' ')
+if [ "$file_count_before" = "$file_count_after" ]; then
+  PASS=$((PASS+1))
+  echo "PASS: case6b: trend renderer wrote no new run files"
+else
+  FAIL=$((FAIL+1))
+  FAILED_CASES="$FAILED_CASES\ncase6b: trend renderer wrote new files (was $file_count_before, now $file_count_after)"
+  echo "FAIL: case6b: trend renderer wrote new files"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 7: auto-notes column derives from score deltas
+# (e.g. "Security +12, Analytics +10")
+# ---------------------------------------------------------------------------
+runs=$(make_runs_dir)
+write_run "$runs" "2026-04-20T10:00:00Z" '{"security":50,"accessibility":70,"compliance":60,"analytics":60,"seo":65,"performance":60,"monitoring":60,"docs":70}' "no-go"
+write_run "$runs" "2026-04-27T10:00:00Z" '{"security":62,"accessibility":70,"compliance":60,"analytics":70,"seo":65,"performance":60,"monitoring":60,"docs":70}' "conditional-go"
+out=$(run_renderer "$runs")
+# Two changes: Security +12 (50→62) and Analytics +10 (60→70). Top 2 by abs delta.
+assert_contains "case7a: auto-notes shows Security +12"  "$out" "Security +12"
+assert_contains "case7b: auto-notes shows Analytics +10" "$out" "Analytics +10"
+
+# ---------------------------------------------------------------------------
+# Case 8: forward-compat — run files with extra unknown fields render fine.
+# Adopters with existing runs/ shouldn't lose them on framework upgrade
+# (apexyard#183 risk note).
+# ---------------------------------------------------------------------------
+runs=$(make_runs_dir)
+write_run_with_extras "$runs" "2026-04-20T10:00:00Z" "$SCORES_LOW" "no-go"
+write_run_with_extras "$runs" "2026-04-27T10:00:00Z" "$SCORES_MID" "conditional-go"
+out=$(run_renderer "$runs")
+assert_contains "case8a: extra fields don't break rendering"   "$out" "## Trend (last 2 runs)"
+assert_contains "case8b: extra fields — score still computed"  "$out" "Initial baseline"
+# Make sure unknown fields didn't bleed into the output.
+assert_not_contains "case8c: unknown fields not echoed"        "$out" "future_field_v2"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================"
+echo "test_launch_check_trend.sh: $PASS passed, $FAIL failed"
+echo "============================================"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Failed cases:"
+  printf '%b\n' "$FAILED_CASES"
+  exit 1
+fi
+
+exit 0

--- a/.claude/skills/launch-check/SKILL.md
+++ b/.claude/skills/launch-check/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: launch-check
-description: Production readiness audit — runs a multi-dimension sweep (security, accessibility, compliance, analytics, SEO, performance, monitoring, docs) and outputs a scored go/conditional-go/no-go verdict. Use at milestone boundaries, not on every PR.
+description: Production readiness audit — runs a multi-dimension sweep (security, accessibility, compliance, analytics, SEO, performance, monitoring, docs) and outputs a scored go/conditional-go/no-go verdict. Use at milestone boundaries, not on every PR. Persists each run to a per-project history store so the trend across runs is visible.
 disable-model-invocation: false
-argument-hint: "[project-path]"
+argument-hint: "[project-path] | trend [project-path]"
 effort: high
 ---
 
@@ -11,6 +11,11 @@ effort: high
 Runs an 8-dimension sweep against a project and outputs a one-page verdict. Designed for milestone boundaries — epic completion, release cuts, launch prep — not per-PR use.
 
 **Invoke from** the project's workspace directory (`cd workspace/<project>/`) or pass the path as an argument: `/launch-check workspace/my-app`.
+
+**Two modes:**
+
+- `/launch-check [project-path]` — full audit (default). Runs all 8 dimensions, persists results to the per-project history store, and renders a "Trend (last 5 runs)" section when ≥ 2 prior runs exist.
+- `/launch-check trend [project-path]` — read-only trend report. Renders just the trend section from existing run files. Useful for "are we trending up?" without burning the audit cost. See § "Trend-only mode" below.
 
 ## Deep-dive companions
 
@@ -216,9 +221,110 @@ Count PASS/WARN/FAIL, apply the verdict logic, format the output table.
 
 ### Step 5: Output
 
-Print the table exactly as shown in the "Output format" section above. Then stop and let the user decide what to do with the findings.
+Print the table exactly as shown in the "Output format" section above. Then continue to Step 6 to persist the run and render the trend section.
 
 **Do NOT auto-create tickets for the findings.** Offer: "Want me to create tickets for the blocking items?" — but let the user decide. The launch check is advisory.
+
+### Step 6: Persist the run + render the trend
+
+After the verdict table, persist this run to the project's history store and append a trend section if there are ≥ 2 prior runs.
+
+#### 6a. Resolve the project's launch-check directory
+
+Use the portfolio helper to resolve the projects dir — do NOT hardcode `projects/`:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+projects_dir=$(portfolio_projects_dir)
+lc_dir="$projects_dir/<project-name>/launch-check"
+runs_dir="$lc_dir/runs"
+mkdir -p "$runs_dir"
+```
+
+`<project-name>` is the project's registered name in `apexyard.projects.yaml`. If the project isn't registered (e.g. someone runs `/launch-check` on a directory that's never been onboarded), use the basename of the project path; tell the user the project should be `/handover`'d into the registry to make the trend persistent across machines.
+
+#### 6b. Write the per-run JSON
+
+Schema (apexyard#183):
+
+```json
+{
+  "ts": "2026-05-08T19:30:00Z",
+  "branch": "main",
+  "commit": "abc1234",
+  "scores": {
+    "security": 88,
+    "accessibility": 94,
+    "compliance": 76,
+    "analytics": 90,
+    "seo": 87,
+    "performance": 68,
+    "monitoring": 83,
+    "docs": 91
+  },
+  "verdict": "conditional-go",
+  "top_risks": ["No cookie consent banner", "Missing /health endpoint"]
+}
+```
+
+- `ts` — ISO-8601 UTC. Used for chronological sort.
+- `branch` / `commit` — `git rev-parse --abbrev-ref HEAD` and `git rev-parse --short HEAD` from the project's working tree.
+- `scores.*` — 0..100 per dimension. Map PASS → 95 ± project-specific finding-density, WARN → 70..85, FAIL → 30..55. Use your judgement based on the finding's severity. The headline score is the unweighted mean — adopters who want weighting can post-process.
+- `verdict` — one of `go`, `go-with-warnings`, `conditional-go`, `no-go`.
+- `top_risks` — the same blocking items you listed in the human-readable output.
+
+Write the file at `<runs_dir>/<ts>.json` with the timestamp safely encoded for filesystems (replace `:` with `-`, e.g. `2026-05-08T19-30-00Z.json`).
+
+**Forward-compatibility note:** the schema is open. Future framework versions may add fields (e.g. `notes`, `actor`, `weighting`); the trend renderer reads only `ts`, `scores`, `verdict`, so older run files continue to render correctly after framework upgrades.
+
+#### 6c. Render the trend section
+
+Run the trend renderer:
+
+```bash
+"$SKILL_DIR/render-trend.sh" "$runs_dir" 5
+```
+
+- With < 2 runs in the dir → prints nothing, exits 0. Skip the trend section in this run's output (this is correct on a project's first run).
+- With ≥ 2 runs → prints the trend markdown block (heading + table + ASCII chart) to stdout. Append it to this run's per-run summary markdown at `<lc_dir>/<ts>.md` and to the chat output.
+
+The `notes` column is auto-derived from the score-delta vs the previous run (e.g. "Security +12, Performance +5"). The most-recent row appends "(this run)". Operator-supplied notes are v2; v1 is auto-derived only.
+
+#### 6d. Opt-in commit (history-tracked marker)
+
+By default, history JSON files are gitignored. Most adopters do not want history bloat in the repo.
+
+Operator opt-in: a presence-only marker file at `<lc_dir>/.launch-check-history-tracked` flips this. When the marker exists, the skill emits a `.gitignore` for `<runs_dir>/` that *un-ignores* `*.json` files; when absent, the runs dir is fully gitignored.
+
+Concretely on first persist:
+
+- If `<lc_dir>/.launch-check-history-tracked` exists:
+  - Ensure `<lc_dir>/.gitignore` does NOT block runs JSON (delete or comment any `runs/` exclusion).
+- Otherwise:
+  - Ensure `<lc_dir>/.gitignore` contains `runs/` so JSON files don't accidentally get committed.
+
+Either way, leave it for the operator to `git add` when they want history committed; never auto-commit. The skill is read-only with respect to the working tree's commit state.
+
+To opt-in to committing history (for a project whose readiness trend the team wants archived in the repo):
+
+```bash
+touch projects/<name>/launch-check/.launch-check-history-tracked
+```
+
+To opt back out, delete the marker.
+
+## Trend-only mode — `/launch-check trend [project-path]`
+
+Read-only mode that produces just the trend section (no full audit, no per-dimension grep). Useful for "are we trending up?" without re-running the costly sweep.
+
+Process:
+
+1. Resolve the project's launch-check dir (same as Step 6a).
+2. If `<runs_dir>` doesn't exist or has < 2 JSON files, tell the operator there's no trend yet (run `/launch-check` first to establish baseline + at least one comparison point).
+3. Otherwise, run `render-trend.sh "$runs_dir" 5` and print the output.
+
+Do NOT run the 8-dimension sweep in this mode. Do NOT write any new JSON. This mode is purely for reviewing existing history.
 
 ## Rules
 
@@ -229,3 +335,15 @@ Print the table exactly as shown in the "Output format" section above. Then stop
 5. **Advisory, not blocking.** The user decides go/no-go based on the findings. The skill does NOT block deploys mechanically.
 6. **Don't create tickets unprompted.** Offer to create them. Let the user decide.
 7. **Run from the project directory.** The skill checks `workspace/<project>/`, not the ops repo.
+8. **Persist every run.** Step 6 always writes a JSON file under the project's `launch-check/runs/` (regardless of opt-in commit state). The `.launch-check-history-tracked` marker only controls whether those files are committed; it does NOT control whether they are written.
+9. **Resolve paths via the portfolio helper.** Don't hardcode `projects/` — adopters in split-portfolio mode have a different projects dir. Use `portfolio_projects_dir` from `_lib-portfolio-paths.sh`.
+
+## Implementation notes
+
+The persistence + trend logic ships as a small shell helper alongside this SKILL:
+
+| File | Purpose |
+|------|---------|
+| `render-trend.sh` | Reads `<runs_dir>` for `*.json` files, sorts by `ts`, emits the trend markdown block (heading + table + ASCII chart). Exits silently with no output when < 2 runs exist. |
+
+Design rationale (ASCII chart vs Mermaid, JSON schema choice, opt-in commit marker): see [`docs/agdr/AgDR-0014-launch-check-trend-tracking.md`](../../../docs/agdr/AgDR-0014-launch-check-trend-tracking.md).

--- a/.claude/skills/launch-check/render-trend.sh
+++ b/.claude/skills/launch-check/render-trend.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# render-trend.sh — render the "Trend (last N runs)" section for /launch-check.
+#
+# Reads the runs directory (one JSON file per run, schema below), sorts by
+# `ts`, takes the last N (default 5), and emits a markdown trend block:
+#   - heading
+#   - table (Date | Score | Verdict | Notes)
+#   - ASCII chart of scores over the same window
+#
+# Auto-notes column is derived from the score-delta vs the previous run
+# (e.g. "Security +12, Perf +5"). The most recent row notes "This run".
+# Operator-supplied notes are v2 (apexyard#183 v1 scope).
+#
+# Usage:
+#   render-trend.sh <runs_dir> [window]
+#
+# Behaviour:
+#   - Window defaults to 5.
+#   - With < 2 runs in the dir: prints nothing, exits 0. Callers (the
+#     /launch-check skill) suppress the trend section when there's no
+#     trend to show.
+#   - With >= 2 runs: prints the trend markdown block to stdout.
+#
+# JSON schema per run file (apexyard#183):
+#   {
+#     "ts": "2026-05-08T19:30:00Z",      # ISO-8601 UTC, used for sort
+#     "branch": "main",
+#     "commit": "abc1234",
+#     "scores": {
+#       "security": 88, "accessibility": 94, "compliance": 76,
+#       "analytics": 90, "seo": 87, "performance": 68,
+#       "monitoring": 83, "docs": 91
+#     },
+#     "verdict": "go" | "go-with-warnings" | "conditional-go" | "no-go",
+#     "top_risks": ["...", "..."]
+#   }
+#
+# The headline score is the unweighted mean of scores.* — rounded to int.
+# Forward-compatible: extra fields in the JSON are preserved as-is by
+# /launch-check (the skill writes the file; this script only reads), so
+# adopters with existing run files continue to work after framework upgrade.
+#
+# Dependencies: jq, sort, awk. No network calls.
+
+set -u
+
+RUNS_DIR="${1:-}"
+WINDOW="${2:-5}"
+
+if [ -z "$RUNS_DIR" ]; then
+  echo "usage: render-trend.sh <runs_dir> [window]" >&2
+  exit 2
+fi
+
+if [ ! -d "$RUNS_DIR" ]; then
+  # No runs dir => no trend. Treat as "first run".
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "render-trend.sh: jq is required (install via brew install jq / apt install jq)" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Collect run files, sort chronologically by `ts`.
+# Tab-separated: <ts>\t<path>. Sort by first column.
+# ---------------------------------------------------------------------------
+runs_tsv=$(
+  for f in "$RUNS_DIR"/*.json; do
+    [ -f "$f" ] || continue
+    ts=$(jq -r '.ts // ""' "$f" 2>/dev/null) || ts=""
+    [ -n "$ts" ] || continue
+    printf '%s\t%s\n' "$ts" "$f"
+  done | sort
+)
+
+run_count=$(printf '%s' "$runs_tsv" | grep -c . || true)
+if [ "${run_count:-0}" -lt 2 ]; then
+  # Fewer than 2 runs => no trend section (matches AC: "if 2+ prior runs exist").
+  exit 0
+fi
+
+# Take the last $WINDOW lines.
+window_tsv=$(printf '%s\n' "$runs_tsv" | tail -n "$WINDOW")
+
+# ---------------------------------------------------------------------------
+# Compute the headline score per run = round(mean(scores.*)).
+# Build parallel arrays: dates[], scores[], verdicts[], score_blobs[].
+# ---------------------------------------------------------------------------
+dates=()
+scores=()
+verdicts=()
+score_blobs=()  # full scores object per run, for delta computation
+
+while IFS=$'\t' read -r ts path; do
+  [ -n "$ts" ] || continue
+  date=$(printf '%s' "$ts" | cut -c1-10)  # YYYY-MM-DD
+  verdict=$(jq -r '.verdict // "?"' "$path")
+  blob=$(jq -c '.scores // {}' "$path")
+  # Mean of the values in .scores. If empty, score = 0.
+  mean=$(jq -r '
+    (.scores // {}) as $s
+    | ($s | to_entries | map(.value) ) as $v
+    | if ($v | length) == 0 then 0
+      else (($v | add) / ($v | length)) | round
+      end
+  ' "$path")
+  dates+=("$date")
+  scores+=("$mean")
+  verdicts+=("$verdict")
+  score_blobs+=("$blob")
+done <<< "$window_tsv"
+
+n=${#dates[@]}
+if [ "$n" -lt 2 ]; then
+  # Defensive — shouldn't happen given the count check above.
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Per-row notes: diff this run's scores against the previous run's.
+# Format: "Dim +N, Dim2 +M" for top 2 deltas by abs value. Negatives shown.
+# Last row gets "This run" appended.
+# ---------------------------------------------------------------------------
+notes=()
+for i in "${!dates[@]}"; do
+  if [ "$i" -eq 0 ]; then
+    notes+=("Initial baseline")
+    continue
+  fi
+  prev="${score_blobs[$((i-1))]}"
+  curr="${score_blobs[$i]}"
+  # jq computes deltas, sorts by abs desc, takes top 2, formats "Dim +N".
+  delta_str=$(jq -nr \
+    --argjson prev "$prev" --argjson curr "$curr" '
+    [ ($curr | to_entries[] )
+      | { dim: .key,
+          delta: (.value - ($prev[.key] // .value)) }
+    ]
+    | map(select(.delta != 0))
+    | sort_by(-( .delta | if . < 0 then -. else . end ))
+    | .[0:2]
+    | map(
+        ((.dim | .[0:1] | ascii_upcase) + (.dim | .[1:]))
+        + " "
+        + (if .delta > 0 then "+" else "" end)
+        + (.delta | tostring)
+      )
+    | join(", ")
+  ')
+  if [ -z "$delta_str" ]; then
+    delta_str="No change vs previous"
+  fi
+  if [ "$i" -eq $((n - 1)) ]; then
+    delta_str="${delta_str} (this run)"
+  fi
+  notes+=("$delta_str")
+done
+
+# ---------------------------------------------------------------------------
+# Render the trend section.
+# ---------------------------------------------------------------------------
+echo "## Trend (last ${n} runs)"
+echo ""
+echo "| Date       | Score | Verdict          | Notes |"
+echo "|------------|-------|------------------|-------|"
+for i in "${!dates[@]}"; do
+  printf '| %-10s | %5s | %-16s | %s |\n' \
+    "${dates[$i]}" "${scores[$i]}" "${verdicts[$i]}" "${notes[$i]}"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# ASCII chart — score vs time.
+# Y-axis: range derived from min/max scores in window, padded by 5.
+# X-axis: dates labeled below.
+# ---------------------------------------------------------------------------
+min=$(printf '%s\n' "${scores[@]}" | sort -n | head -1)
+max=$(printf '%s\n' "${scores[@]}" | sort -n | tail -1)
+# Pad and clamp to [0, 100].
+y_lo=$(( min - 5 )); [ "$y_lo" -lt 0 ] && y_lo=0
+y_hi=$(( max + 5 )); [ "$y_hi" -gt 100 ] && y_hi=100
+[ "$y_hi" -le "$y_lo" ] && y_hi=$(( y_lo + 10 ))
+
+# 5 horizontal grid lines, evenly spaced across [y_lo, y_hi].
+rows=5
+range=$(( y_hi - y_lo ))
+
+echo "Score trend:"
+echo ""
+# Column width = 6 chars per run (matches MM-DD label width + 1 space).
+COL_W=6
+for ((r = rows - 1; r >= 0; r--)); do
+  level=$(( y_lo + (range * r) / (rows - 1) ))
+  line=$(printf '%3d |' "$level")
+  for j in "${!scores[@]}"; do
+    s="${scores[$j]}"
+    # Map s to a row index in [0, rows-1].
+    row_for_s=$(( ((s - y_lo) * (rows - 1) + range / 2) / range ))
+    if [ "$row_for_s" -eq "$r" ]; then
+      line="${line}   ●  "  # 3 leading spaces + dot + 2 trailing = 6 cols
+    else
+      line="${line}      "
+    fi
+  done
+  echo "$line"
+done
+# X axis line.
+xaxis="    +"
+for _ in "${!scores[@]}"; do xaxis="${xaxis}------"; done
+echo "$xaxis"
+# Date labels — abbreviated MM-DD, 6 chars each so labels don't collide.
+labels="     "
+for d in "${dates[@]}"; do
+  short=$(printf '%s' "$d" | cut -c6-)  # MM-DD
+  labels="${labels}${short} "
+done
+echo "$labels"

--- a/docs/agdr/AgDR-0014-launch-check-trend-tracking.md
+++ b/docs/agdr/AgDR-0014-launch-check-trend-tracking.md
@@ -1,0 +1,63 @@
+# AgDR-0014 — `/launch-check` historical trend tracking (chart format, schema, opt-in)
+
+> In the context of making slide 13's "Readiness Trend (last 5 runs)" graph real, facing several non-obvious choices (chart rendering, JSON schema shape, commit-vs-gitignore default), I decided **ASCII chart embedded in the per-run markdown, open JSON schema, gitignored-by-default with a presence-only opt-in marker**, to achieve a low-friction trend feature that adopters can adopt or ignore with zero ceremony, accepting that the ASCII chart is less visually polished than a rendered SVG but renders identically in every Markdown viewer (terminal, GitHub, IDE, blog).
+
+## Context
+
+apexyard#183 asks for persistent run history + trend rendering for `/launch-check`, so marketing slide 13 ("Readiness Trend (last 5 runs)") becomes a real feature instead of a mockup. The acceptance criteria leave three things deliberately open:
+
+1. **Chart format** — "ASCII / Mermaid chart renders correctly in GitHub markdown preview"
+2. **History storage** — "opt-in per project — `.launch-check-history-tracked` file marker decides committed-vs-gitignored"
+3. **Schema** — sketched in the ticket but with no compatibility commitment
+
+Each of these becomes a load-bearing decision that shapes adoption — get any one wrong and the feature feels like ceremony rather than value. This AgDR documents the choices.
+
+## Options Considered
+
+### A. Chart format
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **ASCII chart** (chosen) | Renders identically in every viewer (terminal, GitHub, IDE, blog). Zero dependencies. Composable with the rest of the markdown report. Easy to test deterministically. | Less visually polished than a rendered chart. Coarse y-axis resolution (~5 rows). |
+| Mermaid pie/bar chart | Modern. GitHub renders it inline. Familiar to ApexYard users (already used in C4 diagrams). | Mermaid `xychart-beta` and `gantt` are awkward for time-series score data. Renders a "time" axis poorly when dates are coarse and irregular (the realistic /launch-check cadence). Doesn't render in the terminal at all — which is exactly where /launch-check output is read most often. |
+| Rendered PNG/SVG | Pretty. | Requires rendering at run time + a binary file in the repo. Cannot be regenerated trivially across machines. Defeats "trend lives in markdown" simplicity. |
+| GitHub Issues sparkline (UTF-8 block chars `▁▂▃▄▅▆▇█`) | One line; embeds in tables. | Less informative than the box-drawn ASCII chart. Loses the y-axis / date-axis context that makes the trend interpretable at a glance. |
+
+### B. JSON schema for run files
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Open schema, additive evolution** (chosen) | Forward-compatible — adopters who upgrade framework versions don't lose existing run files. Future fields (notes, actor, weighting) slot in without migration. | Not strictly typed; field-presence varies across run-file generations. |
+| Versioned schema (`"schema": 1` field + migration script) | Explicit compatibility story. | Heavyweight for a feature with O(N) trivial JSON files. The fields the renderer reads are stable (`ts`, `scores`, `verdict`); additions are additive; deletions don't happen. A version field would be ceremony. |
+| External schema file (JSON Schema validator) | Rigorous. | For an internal-only data store of <1KB files, ceremony exceeds value. Adopters who want strictness can lint locally — the framework doesn't impose it. |
+
+### C. Commit-vs-gitignore default
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Gitignored by default, presence-only marker file opts in** (chosen) | Most adopters won't want O(N) JSON files in the repo polluting diffs. Zero-config silence is the right default. Single-file opt-in is unambiguous. | Adopters who DO want trend history archived must remember to `touch .launch-check-history-tracked` once per project. |
+| Committed by default | Trend visible to teammates without setup. | Bloat for adopters who don't care about historical trend. PR diffs noisy on every audit run. Common case loses. |
+| Config-block toggle in `.claude/project-config.json` | Centralised. | Adopters managing multiple projects need to know which projects opted in; a per-project marker is more locally readable. |
+
+## Decision
+
+Chosen: **ASCII chart in the per-run markdown report, open additive JSON schema, gitignored-by-default with a presence-only `.launch-check-history-tracked` opt-in marker** — because:
+
+1. **ASCII** maximises portability. /launch-check output is read in terminals, IDEs, GitHub PR comments, and blog posts. ASCII renders identically in all four; Mermaid renders only in GitHub-rendered markdown and breaks on terminal copy-paste.
+2. **Open schema** matches the constraint in the ticket ("adopters with existing runs/ shouldn't lose them on framework upgrade"). The renderer reads only stable fields; additions are forward-compatible by construction.
+3. **Gitignored-by-default with presence-only marker** matches the ticket's risk note ("History bloat — JSON files are tiny but accumulate over a year"). Most adopters never need history in the repo; making them un-ignore feels right.
+
+## Consequences
+
+- The `render-trend.sh` helper is the single source of truth for trend rendering. It can be invoked standalone (e.g. by a CI job that posts trend updates to Slack) — not just from the SKILL.
+- The skill's per-run markdown summary at `<lc_dir>/<ts>.md` is the durable artefact; the JSON files are a build-input for the chart, not the user-facing artefact. Adopters who want a custom dashboard can read the JSON directly.
+- If a future framework version adds operator-supplied notes (apexyard#183 v2 scope), the schema absorbs the new field without migration; older `.json` files continue to render. The "Notes" column in the trend table will source from `notes` if present, fall back to the auto-derived score-delta string otherwise.
+- Adopters running on managed-project working trees inside `workspace/<name>/` should NOT confuse history files with project source. The launch-check dir lives under `projects/<name>/`, not in the project's own clone — a deliberate split that keeps audit history with the operator's docs, not the project's commit tree.
+- The decision to use ASCII over Mermaid is reversible — if a future iteration wants Mermaid output (e.g. for a web dashboard), `render-trend.sh` can grow a `--format=mermaid` flag without breaking existing callers.
+
+## Artifacts
+
+- PR: feature/GH-183-launch-check-trend → me2resh/apexyard#183
+- Skill: `.claude/skills/launch-check/SKILL.md`
+- Renderer: `.claude/skills/launch-check/render-trend.sh`
+- Test: `.claude/hooks/tests/test_launch_check_trend.sh`


### PR DESCRIPTION
## Summary

- Persist every `/launch-check` run as a JSON file under `<projects_dir>/<name>/launch-check/runs/<ISO-ts>.json` (timestamp + branch + commit + per-dimension scores + verdict + top_risks). Schema is forward-compatible — extra fields preserved on framework upgrade.
- Append a "Trend (last 5 runs)" section to the per-run summary when at least 2 prior runs exist: markdown table (Date | Score | Verdict | Notes) plus an ASCII score chart that renders identically in terminals, GitHub, and IDE markdown viewers.
- Add `/launch-check trend [project-path]` mode for read-only trend rendering (no full audit, no new run files written).
- Auto-derive the Notes column from the score-delta vs the previous run, e.g. "Security +12, Analytics +10". Operator-supplied notes are scoped to v2.
- Opt-in commit via `<lc_dir>/.launch-check-history-tracked` marker — gitignored by default to avoid history bloat in adopters' repos.
- Resolve the projects dir via `portfolio_projects_dir` from `_lib-portfolio-paths.sh` so split-portfolio adopters work transparently — no hardcoded `projects/` path.
- Ship a small `render-trend.sh` helper that does the heavy lifting (sort by `ts`, compute deltas, draw the chart). The skill markdown calls it; standalone callers (e.g. a CI Slack-poster) can use it directly.
- AgDR-0014 documents the chart-format / schema / opt-in choices (ASCII over Mermaid, open additive schema, gitignored-by-default).

Closes me2resh/apexyard#183

## Testing

1. `bash .claude/hooks/tests/test_launch_check_trend.sh` — 21 cases, covers single-run/empty/missing dirs (no output), 2-run / 5-run trend rendering, idempotency / read-only behaviour, auto-notes derivation, and forward-compat with extra unknown fields.
2. Full hook-test sweep — `bash .claude/hooks/tests/test_*.sh` — 213 cases across 13 test files all green; no regressions.
3. Visual smoke: synthesise 5 run JSON files matching the schema, run `.claude/skills/launch-check/render-trend.sh <runs_dir>`, eyeball the table + ASCII chart.

## Glossary

| Term | Definition |
|------|------------|
| Run history | Per-run JSON files under `<projects_dir>/<name>/launch-check/runs/`, one per `/launch-check` invocation, used as the input for trend rendering. |
| Trend window | Number of most-recent runs included in the trend table + chart. Default 5; configurable via the second argument to `render-trend.sh`. |
| Auto-notes | Derived "Dim ±N" string per row, generated from the score-delta vs the previous run. The most-recent row appends "(this run)". |
| Headline score | Unweighted mean of the per-dimension scores for a single run, rounded to int. The chart's Y-axis. |
| Opt-in commit marker | Presence-only file at `<lc_dir>/.launch-check-history-tracked`. Absent → runs JSON gitignored (default). Present → the skill un-ignores the runs dir so adopters who want history archived can `git add` the JSON files. |
| Forward-compatible schema | Open / additive — the renderer reads only `ts`, `scores`, `verdict`. Future framework versions can add fields (e.g. operator-supplied `notes`, `actor`, `weighting`) without breaking older run files. |
| Trend-only mode | `/launch-check trend [project-path]` — read-only rendering of existing run files, skipping the 8-dimension audit. Useful for "are we trending up?" without burning the audit cost. |
