### PR TITLE
feat(#181): /agdr skill — searchable AgDR library across the portfolio

### DIFF
--- a/.claude/hooks/tests/test_agdr_skill.sh
+++ b/.claude/hooks/tests/test_agdr_skill.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+# Smoke tests for the /agdr skill's parsing + indexing logic.
+#
+# The skill itself is a markdown spec the model executes; this test
+# exercises the parser the spec specifies (frontmatter extraction,
+# category bucketing, search match) against a synthetic portfolio
+# fixture so a regression in the spec — or in any future helper
+# extracted from the spec — fails loudly.
+#
+# Each case:
+#   - builds a sandbox portfolio with multiple synthetic AgDRs
+#   - runs the parsing logic the skill specifies
+#   - asserts the resulting index matches expectations
+#
+# Exit 0 means all cases passed. Exit 1 on first failure.
+
+set -u
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# ---------------------------------------------------------------------------
+# parse_frontmatter <file>
+# Mirrors the awk parser in .claude/skills/agdr/SKILL.md § "Parse frontmatter".
+# Echoes only the lines between the leading --- / --- block.
+# ---------------------------------------------------------------------------
+parse_frontmatter() {
+  local file="$1"
+  awk '
+    BEGIN { in_fm = 0; fm_done = 0 }
+    NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; next }
+    in_fm && /^---[[:space:]]*$/ { in_fm = 0; fm_done = 1; next }
+    in_fm { print }
+    fm_done && /./ { exit }
+  ' "$file"
+}
+
+# ---------------------------------------------------------------------------
+# extract_category <file>
+# Returns the literal category value, or "other" when missing.
+# Mirrors the bucket-on-missing-frontmatter rule from the skill spec.
+# ---------------------------------------------------------------------------
+extract_category() {
+  local file="$1"
+  local fm cat
+  fm=$(parse_frontmatter "$file")
+  cat=$(printf '%s\n' "$fm" | awk -F': *' '/^category:/{print $2; exit}')
+  if [ -z "$cat" ]; then
+    echo "other"
+  else
+    # Strip surrounding quotes / whitespace / inline comments.
+    echo "$cat" | sed -e 's/[[:space:]]*#.*$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/^["'"'"']//' -e 's/["'"'"']$//'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# extract_id <file>
+# Returns the AgDR-NNNN id, or empty if no id field found.
+# ---------------------------------------------------------------------------
+extract_id() {
+  local file="$1"
+  local fm
+  fm=$(parse_frontmatter "$file")
+  printf '%s\n' "$fm" | awk -F': *' '/^id:/{print $2; exit}'
+}
+
+# ---------------------------------------------------------------------------
+# make_portfolio
+# Builds a sandbox apexyard fork with three synthetic AgDRs:
+#   - AgDR-0001: full frontmatter, category: architecture
+#   - AgDR-0002: legacy (no frontmatter) — should bucket as `other`
+#   - AgDR-0003: full frontmatter, category: security
+# ---------------------------------------------------------------------------
+make_portfolio() {
+  local sb
+  sb=$(mktemp -d)
+  sb=$(cd "$sb" && pwd -P)
+
+  mkdir -p "$sb/docs/agdr"
+
+  cat > "$sb/docs/agdr/AgDR-0001-clean-architecture.md" <<'MD'
+---
+id: AgDR-0001
+timestamp: 2026-05-01T10:00:00Z
+agent: claude
+status: executed
+category: architecture
+---
+
+# Adopt clean architecture
+
+> In the context of a growing API tier, facing creeping framework lock-in,
+> I decided to adopt a hexagonal layout, accepting the upfront refactor cost.
+
+## Decision
+
+Chosen: **hexagonal**, because the rate-limit middleware can be swapped without
+touching the domain layer.
+MD
+
+  cat > "$sb/docs/agdr/AgDR-0002-legacy-no-frontmatter.md" <<'MD'
+# Legacy AgDR with no frontmatter
+
+This file predates the `/agdr` skill and lacks any frontmatter at all.
+It should still be indexable — bucketed as `other` by default.
+
+## Decision
+
+Chosen: **option X**, because reasons.
+MD
+
+  cat > "$sb/docs/agdr/AgDR-0003-mfa-required.md" <<'MD'
+---
+id: AgDR-0003
+timestamp: 2026-05-02T10:00:00Z
+agent: claude
+status: executed
+category: security
+projects: [example-app, billing-api]
+---
+
+# Require MFA on admin login
+
+> In the context of a portfolio-wide admin surface, facing credential-stuffing
+> reports, I decided to require MFA on admin login, accepting the friction.
+
+## Decision
+
+Chosen: **TOTP MFA**, because hardware keys are over-engineering for this tier.
+MD
+
+  echo "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# run_case <name> <command...>
+# Run a snippet, capture stdout+stderr, compare to expected via $assert_*.
+# ---------------------------------------------------------------------------
+assert_eq() {
+  local name="$1"
+  local got="$2"
+  local expected="$3"
+  if [ "$got" = "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  - $name (got=[$got] expected=[$expected])"
+    echo "FAIL: $name"
+    echo "  got:      [$got]"
+    echo "  expected: [$expected]"
+  fi
+}
+
+assert_contains() {
+  local name="$1"
+  local haystack="$2"
+  local needle="$3"
+  case "$haystack" in
+    *"$needle"*)
+      PASS=$((PASS + 1))
+      echo "PASS: $name"
+      ;;
+    *)
+      FAIL=$((FAIL + 1))
+      FAILED_CASES="$FAILED_CASES\n  - $name (needle=[$needle] missing from haystack)"
+      echo "FAIL: $name"
+      echo "  needle:   [$needle]"
+      echo "  haystack: [$haystack]"
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Build fixture portfolio
+# ---------------------------------------------------------------------------
+SB=$(make_portfolio)
+A1="$SB/docs/agdr/AgDR-0001-clean-architecture.md"
+A2="$SB/docs/agdr/AgDR-0002-legacy-no-frontmatter.md"
+A3="$SB/docs/agdr/AgDR-0003-mfa-required.md"
+
+# ---------------------------------------------------------------------------
+# Case 1: parse_frontmatter extracts only the leading --- block
+# ---------------------------------------------------------------------------
+fm=$(parse_frontmatter "$A1")
+assert_contains "parse_frontmatter A1: contains category" "$fm" "category: architecture"
+assert_contains "parse_frontmatter A1: contains id" "$fm" "id: AgDR-0001"
+
+# Should NOT include body lines (everything after the closing ---).
+case "$fm" in
+  *"# Adopt clean"*)
+    FAIL=$((FAIL + 1))
+    echo "FAIL: parse_frontmatter A1 leaked body content"
+    ;;
+  *)
+    PASS=$((PASS + 1))
+    echo "PASS: parse_frontmatter A1: body excluded"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Case 2: legacy AgDR with no frontmatter → empty parse output
+# ---------------------------------------------------------------------------
+fm2=$(parse_frontmatter "$A2")
+assert_eq "parse_frontmatter A2 (legacy): empty output" "$fm2" ""
+
+# ---------------------------------------------------------------------------
+# Case 3: extract_category bucketing
+# ---------------------------------------------------------------------------
+assert_eq "extract_category A1: architecture" "$(extract_category "$A1")" "architecture"
+assert_eq "extract_category A2: other (legacy default)" "$(extract_category "$A2")" "other"
+assert_eq "extract_category A3: security" "$(extract_category "$A3")" "security"
+
+# ---------------------------------------------------------------------------
+# Case 4: extract_id reads from frontmatter
+# ---------------------------------------------------------------------------
+assert_eq "extract_id A1" "$(extract_id "$A1")" "AgDR-0001"
+assert_eq "extract_id A3" "$(extract_id "$A3")" "AgDR-0003"
+assert_eq "extract_id A2 (no frontmatter): empty" "$(extract_id "$A2")" ""
+
+# ---------------------------------------------------------------------------
+# Case 5: stats — count by category across the fixture
+# Mirrors what /agdr stats does in aggregate.
+# ---------------------------------------------------------------------------
+# Use a flat counter file rather than associative arrays — keeps the test
+# portable across bash versions (some macOS shells ship bash 3, no -A).
+counts_file=$(mktemp)
+total=0
+for f in "$A1" "$A2" "$A3"; do
+  c=$(extract_category "$f")
+  echo "$c" >> "$counts_file"
+  total=$((total + 1))
+done
+
+count_arch=$(grep -c '^architecture$' "$counts_file" || true)
+count_sec=$(grep -c '^security$' "$counts_file" || true)
+count_other=$(grep -c '^other$' "$counts_file" || true)
+rm -f "$counts_file"
+
+assert_eq "stats: architecture count" "$count_arch" "1"
+assert_eq "stats: security count" "$count_sec" "1"
+assert_eq "stats: other count (legacy bucket)" "$count_other" "1"
+assert_eq "stats: total" "$total" "3"
+
+# ---------------------------------------------------------------------------
+# Case 6: search — case-insensitive grep across bodies finds matches
+# Mirrors the /agdr search <term> path.
+# ---------------------------------------------------------------------------
+# grep -li returns matching filenames, one per line. Counting lines gives
+# the file-match count directly. -i is case-insensitive (matches the skill
+# spec); the term is treated as a fixed string via -F to avoid regex traps
+# in the test inputs ("." in "rate.limit" was eating the space).
+matches=$(grep -liF "rate-limit" "$A1" "$A2" "$A3" 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "search 'rate-limit': 1 file matches" "$matches" "1"
+
+mfa_matches=$(grep -liF "mfa" "$A1" "$A2" "$A3" 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "search 'mfa': 1 file matches" "$mfa_matches" "1"
+
+zero_matches=$(grep -liF "kubernetes" "$A1" "$A2" "$A3" 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "search 'kubernetes': 0 file matches" "$zero_matches" "0"
+
+# ---------------------------------------------------------------------------
+# Case 7: an AgDR id appears in the filename even when frontmatter lacks it.
+# Filename-derived id is the fallback show-resolver path.
+# ---------------------------------------------------------------------------
+fname_id=$(basename "$A2" | grep -oE '^AgDR-[0-9]+')
+assert_eq "filename id fallback for legacy AgDR" "$fname_id" "AgDR-0002"
+
+# ---------------------------------------------------------------------------
+# Cleanup + summary
+# ---------------------------------------------------------------------------
+rm -rf "$SB"
+
+echo
+echo "----------------------------------------"
+echo "Total: $((PASS + FAIL))  Passed: $PASS  Failed: $FAIL"
+echo "----------------------------------------"
+
+if [ "$FAIL" -gt 0 ]; then
+  printf "Failed cases:%b\n" "$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/skills/agdr/SKILL.md
+++ b/.claude/skills/agdr/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: agdr
+description: Searchable, categorized library of Agent Decision Records (AgDRs) across the portfolio. Walks the registry, reads each project's docs/agdr/*.md (locally or via `gh api`), parses YAML frontmatter, and answers browse / search / show / stats queries. Use when you want to recall "have we decided this before?" without grepping every project.
+argument-hint: "[browse|search <term>|show <id>|stats] [--project <name>] [--category <cat>] [--no-cache]"
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# /agdr — AgDR Library across the portfolio
+
+Walks `apexyard.projects.yaml`, collects every `docs/agdr/*.md` from every managed project (local clone if available, otherwise `gh api`), parses the optional YAML frontmatter for `category` + `projects`, and answers four queries:
+
+| Subcommand | Purpose |
+|------------|---------|
+| `/agdr browse` | List every AgDR across the portfolio, grouped by category |
+| `/agdr search <term>` | Full-text grep across all AgDR bodies; returns `<project>/AgDR-NNNN-<slug>.md` paths plus the matching paragraph |
+| `/agdr show <id>` | Print a specific AgDR (`AgDR-0007` or `<project>/AgDR-0007`) regardless of which project it lives in |
+| `/agdr stats` | Counts per category — the "AgDR Library" tile from the marketing slides, but real |
+
+This is the data layer behind "AgDR Library" in the marketing slides. Before this skill, AgDRs were loose markdown files searchable only by `grep` per project. Now they're a portfolio-wide index with category metadata.
+
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
+## Usage
+
+```
+/agdr browse                            # all projects, all categories
+/agdr browse --category security        # only security AgDRs
+/agdr browse --project example-app      # only one project's AgDRs
+/agdr search "rate limit"               # full-text across all bodies
+/agdr search rate --category patterns   # narrow by category
+/agdr show AgDR-0007                    # disambiguates if id is unique
+/agdr show example-app/AgDR-0007        # explicit when the id appears in two projects
+/agdr stats                             # category counts (tabular)
+/agdr stats --json                      # machine-readable counts
+```
+
+Add `--no-cache` to bypass the per-session cache (useful right after writing a new AgDR).
+
+## Categories — the canonical 6
+
+```
+architecture     System / service shape, layering, bounded contexts
+tech-stack       Language / framework / database / runtime choices
+security         Auth, authz, secrets handling, threat-model outcomes
+patterns         Design / implementation patterns adopted across the codebase
+integrations     Third-party APIs, providers, vendors
+other            Anything that doesn't fit; default for legacy AgDRs without frontmatter
+```
+
+These six are what `/agdr stats` aggregates and what the AgDR template's frontmatter offers as the choice set. Treat them as a stable taxonomy — operators occasionally want a seventh, but the cost of taxonomy drift across a portfolio is high; resist new categories without an AgDR justifying the addition.
+
+## Frontmatter schema
+
+The optional block at the top of each AgDR markdown file:
+
+```yaml
+---
+id: AgDR-NNNN
+timestamp: 2026-05-03T10:30:00Z
+agent: claude
+model: claude-opus-4-7
+trigger: user-prompt
+status: executed
+category: architecture | tech-stack | security | patterns | integrations | other
+projects: [example-app, billing-api]   # optional — defaults to the AgDR's containing project
+---
+```
+
+The skill reads only `category` and `projects`. Everything else (id, timestamp, agent, etc.) is descriptive and not used for retrieval. Missing frontmatter or missing `category:` → categorise as `other`.
+
+## Process
+
+### 1. Resolve the portfolio
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+projects_dir=$(portfolio_projects_dir)
+
+# Read project list. yq if available, otherwise a yaml-aware fallback.
+if command -v yq >/dev/null 2>&1; then
+  yq -r '.projects[] | .name + "|" + (.repo // "") + "|" + (.workspace // "")' "$registry"
+else
+  # Minimal fallback — good enough for the canonical example.yaml shape
+  awk '/^  - name:/{name=$3} /^    repo:/{repo=$2} /^    workspace:/{ws=$2} \
+       /^  - name:/ && name { if (prev) print prev; prev=name"|"repo"|"ws } \
+       END{ if (prev) print prev }' "$registry"
+fi
+```
+
+If the registry doesn't parse or contains no `projects:` key → print a friendly error pointing at `apexyard.projects.yaml.example` and stop.
+
+### 2. Collect AgDRs per project
+
+For each project entry, decide the read path:
+
+| Source | When to use | Read command |
+|--------|-------------|--------------|
+| Local workspace | `workspace/<name>/docs/agdr/*.md` exists | `find workspace/<name>/docs/agdr -name 'AgDR-*.md' -type f` |
+| Local fork docs | This is the apexyard fork itself (its own AgDRs in `docs/agdr/`) | `find docs/agdr -name 'AgDR-*.md' -type f` (only when iterating the fork's own decisions) |
+| GitHub API | No local clone | `gh api repos/<owner>/<repo>/contents/docs/agdr --jq '.[].name'` then `gh api repos/<owner>/<repo>/contents/docs/agdr/<file> --jq '.content' \| base64 -d` |
+
+The fork's own `docs/agdr/` is included as a synthetic project entry named `apexyard` (or whatever the fork is named) — it carries the framework's own decisions, not a managed-project's, and they belong in the index.
+
+Cache results per-session at `.claude/session/agdr-index.cache.json` keyed by registry mtime. Subsequent invocations within the same session re-read from cache; `--no-cache` forces a refresh. The cache is small (~1 KB per AgDR — id, path, category, project, body-snippet) and rebuilt in well under a second for typical portfolios.
+
+### 3. Parse frontmatter
+
+Each AgDR file is read once, and the leading `---\n…\n---` block is parsed:
+
+```bash
+parse_frontmatter() {
+  local file="$1"
+  awk '
+    BEGIN { in_fm = 0; fm_done = 0 }
+    NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; next }
+    in_fm && /^---[[:space:]]*$/ { in_fm = 0; fm_done = 1; next }
+    in_fm { print }
+    fm_done && /./ { exit }       # short-circuit once frontmatter parsed
+  ' "$file"
+}
+```
+
+Extract `category:` and `projects:`. If either is absent:
+
+- Missing `category:` → `category=other`
+- Missing `projects:` → `projects=[<containing project>]`
+
+Files with no frontmatter at all (legacy AgDRs predating this skill) are still indexed — they just land in the `other` bucket.
+
+### 4. Build the in-memory index
+
+```
+{
+  "AgDR-0001": {
+    "id": "AgDR-0001",
+    "title": "Rule mechanization via hooks",
+    "path": "apexyard/docs/agdr/AgDR-0001-rule-mechanization-hooks.md",
+    "project": "apexyard",
+    "category": "patterns",
+    "projects_field": ["apexyard"]
+  },
+  ...
+}
+```
+
+The index is built fresh per invocation (or once per session with `--no-cache` to bust). For typical portfolio sizes (5-20 projects, 5-30 AgDRs each) this is well under a second.
+
+### 5. Answer the query
+
+#### `/agdr browse [--category C] [--project P]`
+
+Group by category (or by project if `--project` is set), sorted within each group by id:
+
+```
+ARCHITECTURE (3)
+  apexyard/AgDR-0007  Adopt release-cut branch model
+  apexyard/AgDR-0010  Portfolio config and self-healing
+  example-app/AgDR-0004 Hexagonal layout for the API tier
+
+TECH-STACK (2)
+  apexyard/AgDR-0003  Mermaid C4 over Structurizr DSL
+  example-app/AgDR-0001 Postgres over MySQL for transactional data
+
+…
+
+OTHER (4)                      ← legacy AgDRs without category frontmatter
+  apexyard/AgDR-0002  Warning-to-blocker upgrade
+  apexyard/AgDR-0005  Tag-based upstream drift
+  apexyard/AgDR-0006  Project-configurable ticket schema
+  apexyard/AgDR-0008  CHANGELOG fallback for squash-merged forks
+
+13 AgDRs across 3 projects · 6 categories
+3 lack `category:` frontmatter — run `/agdr migrate` (TODO) or edit manually.
+```
+
+The trailing migration prompt only appears if at least one AgDR is in `other` due to missing frontmatter (not because operator chose `other` deliberately — those are detected by the literal `category: other` value being absent).
+
+#### `/agdr search <term> [--category C] [--project P]`
+
+Case-insensitive grep across the bodies (title + content, not just frontmatter). One result block per match:
+
+```
+example-app/AgDR-0004 — Hexagonal layout for the API tier
+  category: architecture
+  …adopt a hexagonal architecture so that the **rate limiting** middleware
+  can be replaced without touching the domain layer…
+
+apexyard/AgDR-0011 — Bootstrap-skill exemption
+  category: patterns
+  …bootstrap skills like /setup write before any **rate limiting** is wired
+  up; they shouldn't trip the active-ticket gate…
+
+2 matches across 2 projects.
+```
+
+Match snippets are the paragraph containing the hit, trimmed to ~3 lines. Multiple hits per file collapse to one result block (with one snippet — the first hit). If 0 matches: print "0 matches for `<term>`" and exit cleanly.
+
+#### `/agdr show <id>`
+
+Print the resolved AgDR file's full content. Disambiguation:
+
+- `AgDR-0007` → resolves uniquely if exactly one project has it; otherwise prompt for `<project>/AgDR-0007`
+- `<project>/AgDR-0007` → resolves directly; errors if the project or id doesn't exist
+- Numeric-only inputs (`7`, `0007`) → expanded to `AgDR-0007` and resolved as above
+
+Output is the raw markdown — frontmatter included so the reader sees the full record.
+
+#### `/agdr stats [--json]`
+
+```
+| Category       | Count |
+|----------------|-------|
+| architecture   |    12 |
+| tech-stack     |     8 |
+| security       |     6 |
+| patterns       |     7 |
+| integrations   |     5 |
+| other          |     4 |
+| **Total**      |    42 |
+
+Across 5 managed projects + the apexyard fork itself.
+```
+
+`--json` flips this to:
+
+```json
+{
+  "categories": {
+    "architecture": 12,
+    "tech-stack": 8,
+    "security": 6,
+    "patterns": 7,
+    "integrations": 5,
+    "other": 4
+  },
+  "total": 42,
+  "projects": 6,
+  "uncategorised": 4
+}
+```
+
+`uncategorised` counts AgDRs that landed in `other` because frontmatter was missing — distinct from operator-chosen `category: other`. Useful for a "migrate these" follow-up.
+
+### 6. Caching
+
+Per-session cache at `.claude/session/agdr-index.cache.json`:
+
+```json
+{
+  "registry_mtime": 1714752000,
+  "built_at": "2026-05-03T10:30:00Z",
+  "entries": [ { "id": "AgDR-0007", "project": "apexyard", "category": "architecture", "title": "...", "path": "..." }, ... ]
+}
+```
+
+Invalidation:
+
+- `--no-cache` → ignore and rebuild
+- Cache file's `registry_mtime` differs from the registry's actual mtime → rebuild (catches new project added)
+- Cache file is older than 1 hour → rebuild (catches AgDRs added since the cache was built)
+
+The cache stores enough metadata for browse/stats but not full bodies — search always reads bodies fresh because reading 30 small markdown files is cheaper than maintaining a body cache.
+
+## Errors and edge cases
+
+| Condition | Behaviour |
+|-----------|-----------|
+| `apexyard.projects.yaml` missing | Print friendly error pointing at `.example` + `docs/multi-project.md` |
+| Registry parses but has 0 projects | Skill still indexes the apexyard fork's own `docs/agdr/`; prints a note that no managed projects are registered |
+| A project has no `docs/agdr/` dir | Silently skip — not an error, just zero contribution |
+| `gh api` fails for a non-cloned project | Print a one-line warning per project, continue with the rest; mark that project as `(unreachable)` in browse |
+| AgDR file has malformed frontmatter (unclosed `---`) | Treat as no-frontmatter (category=other); print one-line warning to stderr |
+| Two AgDRs share the same id within one project | Index both; flag in `/agdr browse` as a duplicate row |
+| `<id>` passed to `/agdr show` doesn't exist | List the closest matches by Levenshtein-ish prefix; exit 1 |
+
+## Performance notes
+
+- Typical portfolio: 5–20 projects × 5–30 AgDRs = 25–600 files. ~1 ms per file to read + parse → 25–600 ms total.
+- Network reads via `gh api` add ~100 ms per non-cloned project (one directory listing + N small file fetches). Cache aggressively.
+- Cache hit path is ~10 ms (read JSON, filter, render). Cold-start without cache and without local clones is ~3–5 s for a 10-project portfolio.
+- v2 (out of scope of this skill): a `projects/agdr-index.md` rebuilt by a post-commit hook would make even cold starts ~10 ms. Left for a follow-up if the cache-per-session approach proves too slow.
+
+## Rules
+
+1. **Read-only** — never modifies any AgDR, never writes to `docs/agdr/` of any project. Cache writes go to `.claude/session/` only.
+2. **Tolerant of missing frontmatter** — legacy AgDRs are first-class citizens, just bucketed as `other`.
+3. **No new categories without an AgDR** — the 6-category taxonomy is the contract. Operators wanting a 7th category should write an AgDR justifying it; this skill rejects unknown categories and reports them as `other` with a one-line stderr warning so drift is visible.
+4. **Doesn't mutate the registry** — pure consumer of `apexyard.projects.yaml`.
+5. **`gh api` is the cross-org fallback, not the primary** — local clones are read first when available, both for speed and because `gh api` has rate limits on busy days.
+6. **Apexyard's own AgDRs are included** — the fork's `docs/agdr/` is treated as a synthetic project so the framework's decisions show up alongside the portfolio's.
+
+## When to use this
+
+| Trigger | Use `/agdr`? |
+|---------|--------------|
+| "Have we decided X before?" mid-design | Yes — `/agdr search X` |
+| Onboarding a new engineer to the portfolio | Yes — `/agdr browse` is the orientation |
+| Pre-PRD: "what's our auth pattern across projects?" | Yes — `/agdr browse --category security` |
+| Producing a marketing/sales deck with category counts | Yes — `/agdr stats --json` feeds the slide |
+| Recording a NEW decision | No — that's `/decide`, which writes the AgDR. `/agdr` only reads. |
+| Tracking a single decision's lineage | Use `git log -p docs/agdr/AgDR-NNNN…` directly — `/agdr` is portfolio-level, not history-level |
+
+## Related skills
+
+- `/decide` — writes AgDRs (the producer; this skill is the consumer)
+- `/projects` — same registry walk; project-level rather than AgDR-level view
+- `/handover` — onboarding flow that may produce an early batch of AgDRs
+
+## Out of scope (v1)
+
+- **Persistent index file** (`projects/agdr-index.md` auto-regenerated on commit) — deferred until cache-per-session proves insufficient
+- **Frontmatter migration helper** (`/agdr migrate`) — currently the skill prints "N AgDRs lack `category:`" and the operator edits manually; a guided migrator is a separate ticket
+- **Cross-AgDR linking** — "AgDR-0007 supersedes AgDR-0003" relationships aren't surfaced; the schema doesn't carry them yet
+- **Full-text relevance ranking** — current search is grep-style match presence, not BM25/TF-IDF; fine for portfolios in the hundreds, not thousands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,10 +178,10 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Hooks | `.claude/hooks/` | 24 shell scripts that mechanically enforce SDLC rules — ticket-first (Edit/Write/Bash), migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner, leak protection, bootstrap-skill exemption |
 | Rules | `.claude/rules/` | 9 modular rule files (AgDR triggers, code standards, git conventions, parallel work, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer, Security Reviewer, Dependency Auditor, PR Manager, Ticket Manager) |
-| Skills | `.claude/skills/` | 39 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 40 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (39)
+### Available skills (40)
 
 | Skill | Purpose |
 |-------|---------|
@@ -199,6 +199,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | `/approve-merge` | Record per-PR CEO approval for a specific merge (required by merge gate) |
 | `/approve-design` | Record per-PR design-review approval for UI PRs (required by design gate) |
 | `/decide` | Make a technical decision and create an Agent Decision Record (AgDR) |
+| `/agdr` | Searchable, categorized library of AgDRs across the portfolio — `browse`, `search <term>`, `show <id>`, `stats` |
 | `/code-review` | Invoke the Code Reviewer agent (Rex) on a PR |
 | `/security-review` | Invoke the Security Reviewer agent (Shield) on a PR |
 | `/audit-deps` | Audit dependencies for vulnerabilities, outdated packages, licences |
@@ -256,7 +257,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Hooks | `.claude/hooks/` |
 | Rules (modular) | `.claude/rules/` |
 | Agents | `.claude/agents/` |
-| Skills (39 slash commands) | `.claude/skills/` |
+| Skills (40 slash commands) | `.claude/skills/` |
 | Hook wiring | `.claude/settings.json` |
 | **Per-project docs** | `projects/<name>/` |
 | **Live working copies** (gitignored) | `workspace/<name>/` |

--- a/templates/agdr.md
+++ b/templates/agdr.md
@@ -6,6 +6,10 @@ model: {model-id}
 session: {session-id}
 trigger: {user-prompt | hook | automation}
 status: {executed | rolled-back | superseded by AgDR-NNNN}
+# Optional — read by /agdr for portfolio-wide indexing. Safe to omit;
+# legacy AgDRs without this field land in the `other` bucket.
+# category: architecture | tech-stack | security | patterns | integrations | other
+# projects: [<project-name>]   # optional; defaults to the AgDR's containing project
 ---
 
 # {Short Title}

--- a/workflows/sdlc.md
+++ b/workflows/sdlc.md
@@ -60,6 +60,8 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 | Break into tasks | Tech Lead | Task list with estimates |
 | Identify risks | Tech Lead | Risk register |
 
+> **"Have we decided this before?"** Before drafting a design, run `/agdr search <term>` (or `/agdr browse --category architecture`) to scan the portfolio's existing Agent Decision Records. The skill walks every managed project and the apexyard fork itself, so prior calls on auth, data layers, or vendor choices surface in seconds rather than getting silently re-litigated.
+
 ### Exit Criteria
 
 - Technical design approved


### PR DESCRIPTION
## Summary

Adds `/agdr` — a portfolio-wide index for Agent Decision Records that delivers the "AgDR Library" concept from the marketing slides as a real feature.

- **`.claude/skills/agdr/SKILL.md`** — new skill with four subcommands: `browse` (grouped by category), `search <term>` (full-text across bodies), `show <id>` (cross-project lookup with disambiguation), `stats` (category counts, with optional `--json`). Walks the registry via the `portfolio_*` helpers; reads each project's `docs/agdr/*.md` from the local clone if available, else falls back to `gh api repos/<owner>/<repo>/contents/docs/agdr/`. Per-session cache at `.claude/session/agdr-index.cache.json` keyed by registry mtime.
- **`templates/agdr.md`** — adds an optional `category:` (and optional `projects:`) line to the existing frontmatter block. The 6-category taxonomy: `architecture | tech-stack | security | patterns | integrations | other`. **Backwards-compatible**: legacy AgDRs without the field bucket as `other` and remain first-class; the change is additive only.
- **`workflows/sdlc.md`** — note in Phase 2 (Technical Design) pointing at `/agdr search` for "have we decided this before?" lookups before drafting a design.
- **`CLAUDE.md`** — skills count + table updated to include `/agdr`.
- **`.claude/hooks/tests/test_agdr_skill.sh`** — smoke test exercising the parser the spec specifies (frontmatter extraction, category bucketing including the legacy default-to-`other` path, id reading, stats aggregation, search match counts). 18 assertions.

The skill is read-only against AgDRs and the registry. It complements `/decide` (writer) without overlapping it.

## Testing

1. `bash .claude/hooks/tests/test_agdr_skill.sh` — 18 assertions, all green.
2. Full hook test sweep: `for t in .claude/hooks/tests/test_*.sh; do bash "$t"; done` — 12 pre-existing suites still green, no regressions.
3. End-to-end manual smoke (recommended after merge): on a fork with the apexyard `docs/agdr/` populated, run `/agdr stats`, `/agdr browse`, `/agdr search "branch model"`, `/agdr show AgDR-0007`. Expect counts matching the directory and a hit on AgDR-0007 for the search.
4. Backwards-compatibility check: existing AgDRs without `category:` should still be readable and should bucket into `other` — covered by the test fixture's `AgDR-0002-legacy-no-frontmatter.md` case.

## Backwards compatibility

The template change is **additive only**. The new `category:` and `projects:` fields are optional, commented out by default, and the skill defaults missing values to `category: other` / `projects: [<containing project>]`. Every existing AgDR in every fork remains valid without modification. No data migration required.

## Glossary

| Term | Definition |
|------|------------|
| AgDR | Agent Decision Record — a structured markdown record of why a technical or process choice was made. Lives at `docs/agdr/AgDR-NNNN-<slug>.md` per project. Apexyard's analogue to ADR, optimised for AI-agent provenance. |
| Frontmatter | The YAML block delimited by `---` lines at the top of a markdown file. Used here for metadata (id, timestamp, category) without polluting the rendered body. |
| Portfolio | The set of repos governed by one apexyard fork. Listed in `apexyard.projects.yaml` (the registry). Each entry can be a managed repo or the framework fork itself. |
| Registry | `apexyard.projects.yaml` — the file that lists every project under apexyard governance. Resolved via `portfolio_registry` from `.claude/hooks/_lib-portfolio-paths.sh`. |
| Category | One of six labels (`architecture`, `tech-stack`, `security`, `patterns`, `integrations`, `other`) that the skill aggregates AgDRs by. Stable taxonomy — additions go through their own AgDR. |
| Per-session cache | A small JSON file at `.claude/session/agdr-index.cache.json` that stores the index built during one shell session, keyed by registry mtime. Skips re-walking the portfolio on repeat invocations within the same session. |
| `gh api` fallback | When a registered project isn't cloned locally, the skill reads its `docs/agdr/` via the GitHub Contents API instead. Slower than local reads (~100 ms per project) but means the skill works without requiring every managed repo to be cloned. |

Closes #181
