### PR TITLE
feat(#182): /status --briefing + bin/apexyard status CLI shim

### DIFF
--- a/.claude/hooks/tests/test_status_briefing.sh
+++ b/.claude/hooks/tests/test_status_briefing.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+# Tests for .claude/skills/status/briefing.sh — the helper that backs
+# /status --briefing and `apexyard status` (me2resh/apexyard#182).
+#
+# Each case:
+#   - builds an isolated sandbox apexyard fork containing onboarding.yaml,
+#     a minimal registry, the briefing helper itself, an optional
+#     workspace/<name>/, and an optional ticket marker
+#   - invokes briefing.sh with APEXYARD_OPS_ROOT, APEXYARD_CWD,
+#     APEXYARD_GH overrides so the test never touches the real fork or
+#     the real `gh` binary
+#   - asserts each output line matches an expected substring
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HELPER_SRC="$SRC_ROOT/.claude/skills/status/briefing.sh"
+
+if [ ! -f "$HELPER_SRC" ]; then
+  echo "FAIL: briefing helper not found at $HELPER_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# ---------------------------------------------------------------------------
+# make_fork: build an isolated apexyard fork sandbox.
+#   $1 (optional) — name of a workspace directory to create
+# Returns the sandbox absolute path on stdout.
+# ---------------------------------------------------------------------------
+make_fork() {
+  local sb workspace_name
+  workspace_name="${1:-}"
+  sb=$(mktemp -d)
+  # Canonicalize so paths match what `pwd -P` / dirname produce on macOS.
+  sb=$(cd "$sb" && pwd -P)
+
+  # Marker files for "this is an apexyard fork".
+  : > "$sb/onboarding.yaml"
+  cat > "$sb/apexyard.projects.yaml" <<YAML
+version: 1
+projects:
+  - name: example
+    repo: example/example
+YAML
+
+  # Copy the helper into the same relative path the real fork uses, so
+  # the shim's "find helper at \$ops_root/.claude/skills/status/briefing.sh"
+  # resolution works.
+  mkdir -p "$sb/.claude/skills/status" "$sb/.claude/session/tickets"
+  cp "$HELPER_SRC" "$sb/.claude/skills/status/briefing.sh"
+  chmod +x "$sb/.claude/skills/status/briefing.sh"
+
+  if [ -n "$workspace_name" ]; then
+    mkdir -p "$sb/workspace/$workspace_name"
+    (
+      cd "$sb/workspace/$workspace_name" || exit 1
+      git init -q -b "feature/test-branch"
+      git config user.email "test@example.com"
+      git config user.name "test"
+      : > .keep
+      git add .keep
+      git commit -q -m "init"
+    )
+  fi
+
+  printf '%s' "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# write_marker: drop a key=value ticket marker.
+#   $1 — sandbox root
+#   $2 — marker filename relative to .claude/session/ (e.g.
+#        "current-ticket" or "tickets/<workspace>")
+#   $3 — repo (e.g. "owner/repo")
+#   $4 — number
+#   $5 — title
+# ---------------------------------------------------------------------------
+write_marker() {
+  local sb="$1" rel="$2" repo="$3" number="$4" title="$5"
+  local path="$sb/.claude/session/$rel"
+  mkdir -p "$(dirname "$path")"
+  cat > "$path" <<EOF
+repo=$repo
+number=$number
+title=$title
+url=https://github.com/$repo/issues/$number
+suggested_branch=feature/test
+started_at=2026-05-03T00:00:00Z
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# run_case: execute the helper and assert each expected line is present.
+#   $1 — label
+#   $2 — sandbox path
+#   $3 — APEXYARD_CWD value (relative to sandbox, or absolute)
+#   $4 — APEXYARD_GH value (full path; empty disables gh)
+#   $5..$N — expected literal substrings (line-fragment match)
+# ---------------------------------------------------------------------------
+run_case() {
+  local label="$1" sb="$2" cwd="$3" gh_bin="$4"
+  shift 4
+
+  # Resolve relative cwd against the sandbox. Empty string → sandbox root
+  # itself (no trailing slash, so the equality check against ops_root passes).
+  if [ -z "$cwd" ]; then
+    cwd="$sb"
+  else
+    case "$cwd" in
+      /*) ;;
+      *)  cwd="$sb/$cwd" ;;
+    esac
+  fi
+
+  local out
+  out=$(APEXYARD_OPS_ROOT="$sb" APEXYARD_CWD="$cwd" APEXYARD_GH="$gh_bin" \
+        bash "$sb/.claude/skills/status/briefing.sh" 2>&1)
+  local rc=$?
+
+  rm -rf "$sb"
+
+  if [ "$rc" != "0" ]; then
+    echo "FAIL [$label]: helper exited rc=$rc" >&2
+    echo "    output: $out" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+
+  local expected
+  for expected in "$@"; do
+    if ! printf '%s' "$out" | grep -qF -- "$expected"; then
+      echo "FAIL [$label]: missing expected substring: '$expected'" >&2
+      echo "    output:" >&2
+      echo "$out" | sed 's/^/      /' >&2
+      FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+      return
+    fi
+  done
+
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# ---------------------------------------------------------------------------
+# 1. cwd at ops root → workspace = "(ops)", branch from no git → (no branch)
+# ---------------------------------------------------------------------------
+sb=$(make_fork)
+run_case "ops-root-workspace" "$sb" "" "" \
+  "Active workspace:" \
+  "(ops)" \
+  "(none)" \
+  "<none — inferred per task>"
+
+# ---------------------------------------------------------------------------
+# 2. cwd inside workspace/<name>/ → workspace = "<name>", branch from git
+# ---------------------------------------------------------------------------
+sb=$(make_fork "example-app")
+run_case "workspace-name" "$sb" "workspace/example-app" "" \
+  "Active workspace:  example-app" \
+  "Branch:" \
+  "feature/test-branch"
+
+# ---------------------------------------------------------------------------
+# 3. cwd outside ops_root → workspace = "(unknown)"
+# ---------------------------------------------------------------------------
+sb=$(make_fork)
+unrelated_dir=$(mktemp -d)
+unrelated_dir=$(cd "$unrelated_dir" && pwd -P)
+run_case "unknown-cwd" "$sb" "$unrelated_dir" "" \
+  "(unknown)"
+rm -rf "$unrelated_dir"
+
+# ---------------------------------------------------------------------------
+# 4. ops-fallback ticket marker — read from .claude/session/current-ticket
+# ---------------------------------------------------------------------------
+sb=$(make_fork)
+write_marker "$sb" "current-ticket" "me2resh/apexyard" "182" "[Feature] briefing slide"
+run_case "ops-ticket-fallback" "$sb" "" "" \
+  "Active ticket:" \
+  "#182 — [Feature] briefing slide"
+
+# ---------------------------------------------------------------------------
+# 5. per-project marker takes priority over ops fallback
+# ---------------------------------------------------------------------------
+sb=$(make_fork "demo-app")
+write_marker "$sb" "current-ticket"          "me2resh/apexyard"   "100" "ops-level title"
+write_marker "$sb" "tickets/demo-app"        "owner/demo-app"     "42"  "per-project title"
+run_case "per-project-priority" "$sb" "workspace/demo-app" "" \
+  "Active workspace:  demo-app" \
+  "#42 — per-project title"
+
+# ---------------------------------------------------------------------------
+# 6. role inference — ticket has `backend` label → role = backend
+#
+# Mock `gh` by writing a tiny shim script that prints a fixed JSON
+# blob whenever invoked with `issue view ... --json labels`.
+# ---------------------------------------------------------------------------
+sb=$(make_fork)
+write_marker "$sb" "current-ticket" "me2resh/apexyard" "200" "backend ticket"
+gh_shim="$sb/.gh-shim"
+cat > "$gh_shim" <<'SHIM'
+#!/usr/bin/env bash
+# Minimal mock: only handles `gh issue view N --repo R --json labels`.
+case "$1 $2" in
+  "issue view")
+    # Print labels JSON as gh would. Field set is what briefing.sh reads.
+    cat <<'JSON'
+{"labels":[{"name":"backend"},{"name":"P1"}]}
+JSON
+    ;;
+  *) exit 1 ;;
+esac
+SHIM
+chmod +x "$gh_shim"
+run_case "role-from-label-backend" "$sb" "" "$gh_shim" \
+  "Role set:" \
+  "backend"
+
+# ---------------------------------------------------------------------------
+# 7. role inference with no matching label → emit the explicit fallback
+# ---------------------------------------------------------------------------
+sb=$(make_fork)
+write_marker "$sb" "current-ticket" "me2resh/apexyard" "300" "label-less"
+gh_shim="$sb/.gh-shim"
+cat > "$gh_shim" <<'SHIM'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue view") echo '{"labels":[{"name":"P2"},{"name":"enhancement"}]}' ;;
+  *) exit 1 ;;
+esac
+SHIM
+chmod +x "$gh_shim"
+run_case "role-no-matching-label" "$sb" "" "$gh_shim" \
+  "Role set:" \
+  "<none — inferred per task>"
+
+# ---------------------------------------------------------------------------
+# 8. exactly four lines of output (every briefing has the same shape)
+# ---------------------------------------------------------------------------
+sb=$(make_fork)
+out=$(APEXYARD_OPS_ROOT="$sb" APEXYARD_CWD="$sb" APEXYARD_GH="" \
+      bash "$sb/.claude/skills/status/briefing.sh" 2>&1)
+rc=$?
+line_count=$(printf '%s' "$out" | grep -c '^')
+rm -rf "$sb"
+if [ "$rc" = "0" ] && [ "$line_count" = "4" ]; then
+  echo "PASS [four-line-shape]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [four-line-shape]: rc=$rc lines=$line_count" >&2
+  echo "$out" | sed 's/^/    /' >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}four-line-shape "
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Total: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -211,7 +211,7 @@ A compact 4-line "where am I" snapshot — workspace, ticket, branch, role. Desi
 Output shape (me2resh/apexyard#182):
 
 ```
-Active workspace:  curios-dog
+Active workspace:  example-app
 Active ticket:     #42 — Add CSV export
 Branch:            feature/GH-42-csv-export
 Role set:          backend

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -23,10 +23,14 @@ Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projec
 ## Usage
 
 ```
-/status
-/status --project example-app
-/status --verbose
+/status                       # full report (default)
+/status --project example-app # full report scoped to one project
+/status --verbose             # full report with extras
+/status --briefing            # 4-line "where am I" briefing (slide 6)
+/status -b                    # short form of --briefing
 ```
+
+When `--briefing` (or `-b`) is passed, skip every other section and shell out to `.claude/skills/status/briefing.sh`. The full default `/status` output is unchanged for invocations without the flag.
 
 ## Scope
 
@@ -199,6 +203,56 @@ Recent AgDRs:
 Warnings:
   ⚠ 1 untracked .env.local file (don't commit it)
 ```
+
+## Briefing mode (`--briefing` / `-b`)
+
+A compact 4-line "where am I" snapshot — workspace, ticket, branch, role. Designed to answer the orientation question in 2 seconds at the top of a session, instead of running 3 skills (`/projects`, `/inbox`, `/status`). This is the same output produced by `bin/apexyard status` (the CLI shim — see below), so the on-screen view in Claude Code and the shell view stay identical.
+
+Output shape (me2resh/apexyard#182):
+
+```
+Active workspace:  curios-dog
+Active ticket:     #42 — Add CSV export
+Branch:            feature/GH-42-csv-export
+Role set:          backend
+```
+
+Behaviour:
+
+| Field | Source |
+|-------|--------|
+| Active workspace | cwd: `<ops_root>/workspace/<name>/...` → `<name>`; `<ops_root>` exactly → `(ops)`; anywhere else → `(unknown)` |
+| Active ticket | `<ops_root>/.claude/session/tickets/<workspace>` first (only when workspace is a real name), then `<ops_root>/.claude/session/current-ticket`. Format: `#<number> — <title>`. No marker → `(none)` |
+| Branch | `git branch --show-current`, run inside the inferred workspace dir (or cwd if no workspace). Detached HEAD or no git repo → `(no branch)` |
+| Role set | Active ticket's labels — first match against the canonical list (`backend`, `frontend`, `qa`, `security`, `platform`, `sre`, `data`, `ux`, `ui`, `product`, `tech-lead`, plus the `-engineer` / `-auditor` / `-designer` / `-manager` / `-lead` long forms). No match (or no ticket) → `<none — inferred per task>` |
+
+Implementation: the logic lives in `.claude/skills/status/briefing.sh` so it's testable in isolation and runnable from a plain shell (no Claude Code dependency). Smoke tests at `.claude/hooks/tests/test_status_briefing.sh`.
+
+When invoked from inside Claude Code as `/status --briefing`, run the helper:
+
+```bash
+bash .claude/skills/status/briefing.sh
+```
+
+When invoked from a shell as `apexyard status`, the same helper runs via `bin/apexyard` (see § "CLI shim" below).
+
+### Role inference scope
+
+V1 ships **label-based inference only** — (a) on the trigger list in #182. The (b) recent-edits and (c) prompt-history strategies are explicit non-goals for v1; they land in a follow-up ticket if the basic version proves useful.
+
+### CLI shim — `apexyard status`
+
+`bin/apexyard` is a small bash script that exposes briefing mode at the shell:
+
+```bash
+# Install (one-time)
+ln -s "$(pwd)/bin/apexyard" ~/.local/bin/apexyard
+
+# Use from anywhere inside the fork or any workspace/<name>/ clone
+apexyard status
+```
+
+The shim walks up from `$PWD` looking for the apexyard fork root (`onboarding.yaml` + `apexyard.projects.yaml`), then runs the same briefing helper. No PATH-shadowing of the `claude` binary, no recursion into Claude Code — pure `bash` end-to-end.
 
 ## Rules
 

--- a/.claude/skills/status/briefing.sh
+++ b/.claude/skills/status/briefing.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# briefing.sh — compact 4-line "where am I" snapshot for /status --briefing
+# and the bin/apexyard status CLI shim.
+#
+# Output (slide 6 reality, me2resh/apexyard#182):
+#
+#   Active workspace:  <name|(ops)|(unknown)>
+#   Active ticket:     <#N — title|(none)>
+#   Branch:            <git branch --show-current|(no branch)>
+#   Role set:          <role-from-labels|<none — inferred per task>>
+#
+# Inputs (env, all optional — used by tests to bypass the real filesystem
+# and the real `gh` binary):
+#
+#   APEXYARD_OPS_ROOT     Override ops-fork root (skip the walk-up search).
+#   APEXYARD_CWD          Override the current working dir (workspace inference).
+#   APEXYARD_GH           Path to a `gh` shim (test-only). Defaults to `gh`.
+#
+# Exit codes:
+#   0 — output written. Even an empty / unknown briefing is a successful
+#       run; the briefing's job is to print "where you are right now" and
+#       a row of (none) is itself useful information.
+
+set -u
+
+# ---------------------------------------------------------------------------
+# 1. Resolve the ops-fork root.
+#
+# Same algorithm as _lib-portfolio-paths.sh (_portfolio_root) and as the
+# /start-ticket skill: walk up from the cwd / git toplevel until we find a
+# directory that contains BOTH onboarding.yaml AND apexyard.projects.yaml.
+#
+# Symlinked registry / projects (split-portfolio mode) is fine — the
+# `apexyard.projects.yaml` symlink in the fork still satisfies the test.
+# ---------------------------------------------------------------------------
+ops_root="${APEXYARD_OPS_ROOT:-}"
+if [ -z "$ops_root" ]; then
+  start=""
+  if [ -n "${APEXYARD_CWD:-}" ]; then
+    start="$APEXYARD_CWD"
+  elif r=$(git rev-parse --show-toplevel 2>/dev/null); then
+    start="$r"
+  else
+    start="$(pwd)"
+  fi
+
+  cur="$start"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -e "$cur/onboarding.yaml" ] && [ -e "$cur/apexyard.projects.yaml" ]; then
+      ops_root="$cur"
+      break
+    fi
+    cur=$(dirname "$cur")
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Active workspace from the cwd.
+#
+# Rules (from #182 AC):
+#   - cwd under <ops_root>/workspace/<name>/...   → workspace = "<name>"
+#   - cwd == <ops_root>                            → workspace = "(ops)"
+#   - anything else (or no ops_root)               → workspace = "(unknown)"
+# ---------------------------------------------------------------------------
+cwd="${APEXYARD_CWD:-$(pwd)}"
+workspace="(unknown)"
+
+if [ -n "$ops_root" ]; then
+  if [ "$cwd" = "$ops_root" ]; then
+    workspace="(ops)"
+  else
+    case "$cwd" in
+      "$ops_root"/workspace/*)
+        rel="${cwd#"$ops_root"/workspace/}"
+        # Take the first path segment as the workspace name. Survives
+        # trailing slashes and nested paths inside the workspace.
+        workspace="${rel%%/*}"
+        ;;
+    esac
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Active ticket — read marker.
+#
+# Per apexyard#41: per-project marker first if workspace is a real name,
+# then fall back to the ops-level current-ticket. Each marker is a
+# key=value file written by /start-ticket; we only need `number` and
+# `title` here.
+# ---------------------------------------------------------------------------
+read_marker_field() {
+  # Reads `key=value` lines, tolerating trailing CR. Outputs the value
+  # for the first matching key only. No grep/awk shell-injection risk —
+  # marker files are written by /start-ticket and never user-input.
+  local file="$1" key="$2" line v
+  [ -f "$file" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+    case "$line" in
+      "$key="*)
+        v="${line#"$key="}"
+        printf '%s' "$v"
+        return 0
+        ;;
+    esac
+  done < "$file"
+  return 1
+}
+
+ticket=""
+ticket_repo=""
+ticket_number=""
+
+if [ -n "$ops_root" ]; then
+  marker_paths=()
+  case "$workspace" in
+    "(ops)"|"(unknown)"|"")
+      ;;
+    *)
+      marker_paths+=("$ops_root/.claude/session/tickets/$workspace")
+      ;;
+  esac
+  marker_paths+=("$ops_root/.claude/session/current-ticket")
+
+  for m in "${marker_paths[@]}"; do
+    if [ -f "$m" ]; then
+      n=$(read_marker_field "$m" number || true)
+      t=$(read_marker_field "$m" title  || true)
+      r=$(read_marker_field "$m" repo   || true)
+      if [ -n "$n" ]; then
+        ticket_number="$n"
+        ticket_repo="$r"
+        if [ -n "$t" ]; then
+          ticket="#${n} — ${t}"
+        else
+          ticket="#${n}"
+        fi
+        break
+      fi
+    fi
+  done
+fi
+
+if [ -z "$ticket" ]; then
+  ticket="(none)"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Branch — git branch --show-current in the inferred workspace dir.
+#
+# If workspace is a real name, run git there; otherwise run in cwd.
+# Catches the "no current branch" case (detached HEAD, no git repo) and
+# substitutes "(no branch)" so the briefing always has 4 aligned lines.
+# ---------------------------------------------------------------------------
+branch_dir="$cwd"
+case "$workspace" in
+  "(ops)"|"(unknown)"|"") ;;
+  *)
+    if [ -n "$ops_root" ] && [ -d "$ops_root/workspace/$workspace" ]; then
+      branch_dir="$ops_root/workspace/$workspace"
+    fi
+    ;;
+esac
+
+branch=$(cd "$branch_dir" 2>/dev/null && git branch --show-current 2>/dev/null || true)
+[ -z "$branch" ] && branch="(no branch)"
+
+# ---------------------------------------------------------------------------
+# 5. Role set — v1 inference from active-ticket labels.
+#
+# Per #182 AC: v1 ships label-based inference only. (b) recent-edits and
+# (c) prompt-history inference are deferred. We pick the FIRST label that
+# matches one of the canonical role names; if none match, we emit the
+# explicit "<none — inferred per task>" string.
+# ---------------------------------------------------------------------------
+gh_bin="${APEXYARD_GH:-gh}"
+
+# Canonical role labels in priority order. The label match is exact
+# (case-insensitive) against the issue's labels. `qa-engineer` etc. are
+# accepted as an alternate spelling so role-files don't have to be
+# renamed if a project uses the long form.
+role_labels=(
+  backend         backend-engineer
+  frontend        frontend-engineer
+  qa              qa-engineer
+  security        security-auditor
+  platform        platform-engineer
+  sre
+  data            data-engineer
+  ux              ux-designer
+  ui              ui-designer
+  product         product-manager
+  techlead        tech-lead
+)
+
+role_set="<none — inferred per task>"
+
+if [ -n "$ticket_number" ] && [ -n "$ticket_repo" ] && command -v "$gh_bin" >/dev/null 2>&1; then
+  # `gh` may not be authed / online — failure here is silent. We only
+  # parse names, no shell-eval, so a malformed JSON is harmless.
+  labels_json=$("$gh_bin" issue view "$ticket_number" \
+                  --repo "$ticket_repo" \
+                  --json labels 2>/dev/null || true)
+
+  if [ -n "$labels_json" ]; then
+    # Extract label names: the JSON is `{"labels":[{"name":"x",...},...]}`.
+    # Use jq if available; otherwise fall back to a tolerant grep+sed.
+    if command -v jq >/dev/null 2>&1; then
+      label_lines=$(printf '%s' "$labels_json" \
+                      | jq -r '.labels[]?.name // empty' 2>/dev/null || true)
+    else
+      # Fallback: extract every "name":"…" inside the labels array. Good
+      # enough for the canonical gh output shape; jq is the supported path.
+      label_lines=$(printf '%s' "$labels_json" \
+                      | tr ',' '\n' \
+                      | sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    fi
+
+    if [ -n "$label_lines" ]; then
+      for candidate in "${role_labels[@]}"; do
+        while IFS= read -r lbl; do
+          [ -z "$lbl" ] && continue
+          # Case-insensitive equality match.
+          lbl_lower=$(printf '%s' "$lbl" | tr '[:upper:]' '[:lower:]')
+          if [ "$lbl_lower" = "$candidate" ]; then
+            role_set="$candidate"
+            break 2
+          fi
+        done <<< "$label_lines"
+      done
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Print.
+#
+# Field width matches slide 6 (column alignment to 19 chars after the
+# label) so every briefing renders identically regardless of values.
+# ---------------------------------------------------------------------------
+printf '%-18s %s\n' "Active workspace:" "$workspace"
+printf '%-18s %s\n' "Active ticket:"    "$ticket"
+printf '%-18s %s\n' "Branch:"           "$branch"
+printf '%-18s %s\n' "Role set:"         "$role_set"

--- a/bin/apexyard
+++ b/bin/apexyard
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# apexyard — tiny CLI shim that exposes a subset of ApexYard skills as
+# shell-runnable commands. Today: only `apexyard status` (slide 6).
+#
+# Install: symlink this script into a directory on your PATH.
+#
+#   ln -s "$(pwd)/bin/apexyard" ~/.local/bin/apexyard
+#
+# Usage:
+#   apexyard status [-b|--briefing]   # 4-line "where am I" briefing
+#   apexyard --help
+#
+# The script delegates to .claude/skills/status/briefing.sh inside the
+# nearest apexyard fork (it walks up from $PWD looking for a directory
+# that contains both onboarding.yaml AND apexyard.projects.yaml). This
+# means `apexyard status` works from anywhere inside the fork or any of
+# its workspace/<name>/ clones — the same scope rules as /start-ticket
+# and the portfolio-aware skills.
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Resolve the ops-fork root from $PWD by walking up until we find a dir
+# with onboarding.yaml AND apexyard.projects.yaml. Same algorithm as the
+# briefing helper itself; we replicate it here so the shim stays a single
+# self-contained file.
+# ---------------------------------------------------------------------------
+find_ops_root() {
+  local cur="$PWD"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -e "$cur/onboarding.yaml" ] && [ -e "$cur/apexyard.projects.yaml" ]; then
+      printf '%s' "$cur"
+      return 0
+    fi
+    cur=$(dirname "$cur")
+  done
+  return 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage: apexyard <command> [args]
+
+Commands:
+  status [-b|--briefing]   Compact "where am I" briefing — workspace, ticket,
+                           branch, role. Defaults to --briefing today (the
+                           full /status report runs inside Claude Code).
+
+Run from inside an apexyard fork or any of its workspace/<name>/ clones.
+EOF
+}
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+  ""|-h|--help|help)
+    usage
+    exit 0
+    ;;
+  status)
+    if ! ops_root=$(find_ops_root); then
+      echo "apexyard: not inside an apexyard fork (no onboarding.yaml + apexyard.projects.yaml found above $PWD)" >&2
+      exit 1
+    fi
+
+    helper="$ops_root/.claude/skills/status/briefing.sh"
+    if [ ! -x "$helper" ] && [ ! -f "$helper" ]; then
+      echo "apexyard: briefing helper not found at $helper" >&2
+      echo "  Update your fork: git pull upstream dev (or run /update)." >&2
+      exit 1
+    fi
+
+    # Today the only flag is --briefing/-b, which is also the default.
+    # We accept it explicitly for forward-compat with `apexyard status
+    # --full` etc. Anything unknown gets a helpful error.
+    case "${1:-}" in
+      ""|-b|--briefing) ;;
+      *)
+        echo "apexyard status: unknown flag '$1' (try --briefing)" >&2
+        exit 2
+        ;;
+    esac
+
+    exec bash "$helper"
+    ;;
+  *)
+    echo "apexyard: unknown command '$cmd'" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -466,11 +466,34 @@ Decision rationale (tool choice — Mermaid C4 over Structurizr DSL / PlantUML /
 A typical morning as a CTO / Chief of Staff using apexyard:
 
 1. **`cd ~/apexyard`** — into your fork
-2. **`/inbox`** — see everything waiting on you across every managed project
-3. **`/status`** — snapshot of git + CI health for each project
-4. Pick a ticket, **`cd workspace/<project>/`**, pick up the ticket as the appropriate role (see [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md))
-5. Work the ticket — the role file drives behaviour, the lifecycle demo in the hero of the landing site walks through the full flow
-6. Back at the fork root, **`/stakeholder-update weekly`** on Fridays to generate the summary
+2. **`apexyard status`** (or `/status --briefing` inside Claude Code) — 4-line "where am I" briefing: active workspace, active ticket, branch, role. Covers the orient-yourself question in one paragraph.
+3. **`/inbox`** — see everything waiting on you across every managed project
+4. **`/status`** — full snapshot of git + CI health for each project (verbose form when you want the per-project breakdown)
+5. Pick a ticket, **`cd workspace/<project>/`**, pick up the ticket as the appropriate role (see [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md))
+6. Work the ticket — the role file drives behaviour, the lifecycle demo in the hero of the landing site walks through the full flow
+7. Back at the fork root, **`/stakeholder-update weekly`** on Fridays to generate the summary
+
+### `apexyard status` — the CLI briefing
+
+`bin/apexyard` is a small bash shim that exposes the briefing at the shell. Install once by symlinking it onto your PATH:
+
+```bash
+ln -s "$(pwd)/bin/apexyard" ~/.local/bin/apexyard
+```
+
+Then from anywhere inside the fork or any `workspace/<name>/` clone:
+
+```bash
+$ apexyard status
+Active workspace:  example-app
+Active ticket:     #42 — Add CSV export
+Branch:            feature/GH-42-csv-export
+Role set:          backend
+```
+
+The same output appears when you run `/status --briefing` (or `/status -b`) inside Claude Code. The four fields all infer themselves: workspace from cwd, ticket from the per-project marker (`<ops_root>/.claude/session/tickets/<name>`) or the ops fallback (`<ops_root>/.claude/session/current-ticket`), branch from `git branch --show-current`, role from the active ticket's labels. Where any of those is unknown, the briefing prints an explicit `(none)` / `(unknown)` / `<none — inferred per task>` placeholder so the four-line shape is constant regardless of state.
+
+Default `/status` (no flags) still produces the long per-project breakdown — `--briefing` only opts into the compact form.
 
 ---
 


### PR DESCRIPTION
## Summary

- Make slide 6's `$ apexyard status` invocation real — adds a `--briefing` (`-b`) flag to `/status` and a `bin/apexyard` shell shim, so the marketing 4-line "where am I" briefing (active workspace / active ticket / branch / role-set) actually runs.
- The briefing logic lives in `.claude/skills/status/briefing.sh` so it's testable in isolation, runnable from a plain shell (no Claude Code dependency), and shared between `/status --briefing` and `apexyard status`. Default `/status` output is unchanged.
- Workspace, ticket, and role inference work the same way the rest of apexyard already does — walk up to the ops-fork root for workspace, read the per-project then ops-level session marker for the active ticket, and use the ticket's GitHub labels for v1 role inference (recent-edits and prompt-history strategies are explicit non-goals).

This is the smallest of three slide-reality tickets, demonstrating the marketing-to-implementation pattern before #181 / #183 land.

## Testing

1. From inside the fork:

   ```bash
   bash .claude/skills/status/briefing.sh
   ```

   Should print four lines (workspace / ticket / branch / role-set), each with the expected value or an explicit `(none)` / `(unknown)` / `<none — inferred per task>` placeholder.

2. From any `workspace/<name>/` clone (after symlinking `bin/apexyard` onto PATH):

   ```bash
   apexyard status
   ```

   Should print the same four lines, with `Active workspace:` resolved to `<name>` and `Branch:` resolved to that workspace's `git branch --show-current`.

3. Run the smoke tests:

   ```bash
   bash .claude/hooks/tests/test_status_briefing.sh
   ```

   8 cases pass — ops-root cwd, workspace cwd, unknown cwd, ops-fallback marker, per-project marker priority over ops-level, label-based role inference, no-matching-label, and the constant-four-line shape.

4. Full test sweep:

   ```bash
   for f in .claude/hooks/tests/*.sh; do bash "$f" >/dev/null 2>&1 && echo "PASS $(basename "$f")" || echo "FAIL $(basename "$f")"; done
   ```

   All 13 existing hook tests + the new test pass. No regressions.

Closes me2resh/apexyard#182

## Glossary

| Term | Definition |
|------|------------|
| Briefing | The compact 4-line "where am I" output — active workspace / active ticket / branch / role-set — designed to answer the orientation question in 2 seconds at the top of a session |
| Ops-fork root | The directory that contains BOTH `onboarding.yaml` and `apexyard.projects.yaml`, i.e. the apexyard fork itself (vs. a `workspace/<name>/` clone of a managed project) |
| Active workspace | The managed-project name derived from the cwd: `<ops_root>/workspace/<name>/...` → `<name>`; `<ops_root>` exactly → `(ops)`; anywhere else → `(unknown)` |
| Active ticket marker | The key-value file at `<ops_root>/.claude/session/tickets/<workspace>` (per-project, preferred when the workspace is a real name) or `<ops_root>/.claude/session/current-ticket` (ops-level fallback), written by `/start-ticket` |
| Role-set | The role inferred from the active ticket's GitHub labels — v1 recognises `backend`, `frontend`, `qa`, `security`, `platform`, `sre`, `data`, `ux`, `ui`, `product`, `tech-lead`, plus the long forms (`backend-engineer`, `qa-engineer`, etc.). No match emits the explicit `<none — inferred per task>` placeholder |
| CLI shim | `bin/apexyard` — a small bash script that exposes `apexyard status` at the shell, walking up to find the ops-fork root and delegating to the same briefing helper. Symlink onto PATH to install (`ln -s "$(pwd)/bin/apexyard" ~/.local/bin/apexyard`); does not shadow the `claude` binary |
