### PR TITLE
docs(#190): annotate LSP-aware skills with opt-in callouts

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -10,6 +10,12 @@ allowed-tools: Bash, Read, Grep, Glob
 
 Review a pull request for quality, security, and adherence to standards.
 
+## LSP-aware (optional, recommended)
+
+This skill performs semantic code navigation — finding definitions, walking references, tracing handlers across modules. With LSP enabled (`ENABLE_LSP_TOOL=1` + per-language plugin per `docs/getting-started.md`), queries are ~3-15× cheaper in token cost than grep + Read. Without LSP, the skill falls back to grep + Read transparently — no new failure mode, just optional speed.
+
+Per-language LSP plugins live in Claude Code's marketplace. Install once; the skill detects the active language and dispatches automatically.
+
 ## Activated agent + role
 
 When `/code-review` runs:

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -11,6 +11,12 @@ Adopt an external repo into ApexYard management. The skill reads the target repo
 
 This is the bridge between "we just inherited this codebase" and "this codebase is now governed by our normal SDLC".
 
+## LSP-aware (optional, recommended)
+
+The handover deep-dive — reading the codebase to populate the assessment — performs semantic code navigation: finding definitions, walking references, tracing handlers across modules. With LSP enabled (`ENABLE_LSP_TOOL=1` + per-language plugin per `docs/getting-started.md`) **and** the repo cloned locally (see the clone-first prompt from me2resh/apexyard#188), queries are ~3-15× cheaper in token cost than grep + Read on shallow lookups, and ~1.4-5× cheaper on multi-hop traces. Without LSP — or when only metadata is available — the skill falls back to grep + Read transparently. No new failure mode, just optional speed during the deep-dive phase.
+
+Per-language LSP plugins live in Claude Code's marketplace. Install once; the skill detects the active language and dispatches automatically.
+
 ## Path resolution
 
 Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -10,6 +10,12 @@ allowed-tools: Bash, Read, Grep, Glob
 
 Review a pull request specifically for security vulnerabilities and best practices.
 
+## LSP-aware (optional, recommended)
+
+This skill performs semantic code navigation — finding definitions, walking references, tracing handlers across modules. With LSP enabled (`ENABLE_LSP_TOOL=1` + per-language plugin per `docs/getting-started.md`), queries are ~3-15× cheaper in token cost than grep + Read. Without LSP, the skill falls back to grep + Read transparently — no new failure mode, just optional speed.
+
+Per-language LSP plugins live in Claude Code's marketplace. Install once; the skill detects the active language and dispatches automatically.
+
 ## Activated agent + role
 
 When `/security-review` runs:

--- a/.claude/skills/threat-model/SKILL.md
+++ b/.claude/skills/threat-model/SKILL.md
@@ -10,6 +10,12 @@ effort: high
 
 Deep-dive security analysis using the STRIDE framework. Produces a prioritized threat catalogue with mitigations. This is the expert companion to `/launch-check`'s security row — invoke it when security shows WARN or FAIL, or proactively before any launch.
 
+## LSP-aware (optional, recommended)
+
+This skill performs semantic code navigation — finding definitions, walking references, tracing handlers across modules. With LSP enabled (`ENABLE_LSP_TOOL=1` + per-language plugin per `docs/getting-started.md`), queries are ~3-15× cheaper in token cost than grep + Read on shallow lookups, and ~1.4-5× cheaper on multi-hop traces. Without LSP, the skill falls back to grep + Read transparently — no new failure mode, just optional speed.
+
+Per-language LSP plugins live in Claude Code's marketplace. Install once; the skill detects the active language and dispatches automatically.
+
 ## STRIDE Categories
 
 | Category | Question | What to look for |


### PR DESCRIPTION
## Summary

- Adds an "LSP-aware (optional, recommended)" callout near the top of the four code-aware SKILL.md files (`/code-review`, `/threat-model`, `/security-review`, `/handover`).
- Mechanical insertion: identical callout shape across all four files; the only variation is the per-skill token-savings number cited from the LSP spike (PR #184 / #178).
- Pure docs — no code, no behaviour change. Adopters who enable `ENABLE_LSP_TOOL=1` and install a per-language plugin get the speedup; adopters who don't keep using grep + Read transparently.

## Testing

1. `git diff upstream/dev -- .claude/skills/{code-review,threat-model,security-review,handover}/SKILL.md` — confirm the four files each gained an "LSP-aware (optional, recommended)" H2 just below the description and before the first existing H2.
2. Confirm the callout shape is identical across files; only the per-skill savings number varies (`/code-review` and `/security-review`: ~3-15× shallow; `/threat-model` and `/handover`: ~3-15× shallow + ~1.4-5× multi-hop).
3. Render each SKILL.md in any markdown viewer — confirm the new section reads cleanly and links to `docs/getting-started.md` (where the install steps live).

Closes me2resh/apexyard#190

## Glossary

| Term | Definition |
|------|------------|
| LSP | Language Server Protocol — IDE-style semantic queries (definitions, references, type info) that work across language toolchains via a uniform protocol. |
| `ENABLE_LSP_TOOL` | Environment flag the Claude Code harness reads to enable the LSP-backed code-navigation tool. Off by default; opt-in per the getting-started docs. |
| Semantic code navigation | Code queries answered by a language server (jump-to-definition, find-references, type-of) rather than by text search (grep). Cheaper per-answer when the language server is available. |
| Callout | A short, fixed-shape block of prose inserted at a known location in a doc to flag a cross-cutting capability without expanding the doc's main flow. |
| LSP spike | The measurement spike in apexyard#178 / PR #184 that quantified the token-cost ratio between LSP-backed queries and grep + Read across shallow vs multi-hop traces. The savings numbers cited in this PR come from that spike's Phase 1. |
