### PR TITLE
feat(#188): /handover clone-first deep-dive prompt

### DIFF
--- a/.claude/hooks/tests/test_handover_clone_prompt.sh
+++ b/.claude/hooks/tests/test_handover_clone_prompt.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+# Smoke tests for /handover's clone-first deep-dive prompt
+# (me2resh/apexyard#188 — LSP spike Option 3).
+#
+# /handover is a markdown skill spec the model executes; this test
+# exercises two things:
+#
+#   1. SPEC SHAPE — the SKILL.md file contains the prompt text at the
+#      right location (after step 7 "Append to the portfolio registry",
+#      before what becomes the final summary), and surfaces the five
+#      cost-transparency facts the ticket's AC requires.
+#
+#   2. RUNTIME SHAPE — a small bash simulator that mirrors the clone
+#      branch the spec documents, exercised against an isolated sandbox
+#      with a mocked `git` binary so no network call ever fires. Verifies:
+#
+#        - operator response `n`     → no `git clone` invocation, exit clean
+#        - operator response `later` → no `git clone` invocation, exit clean
+#        - operator response `y`     → exactly one `git clone <url> workspace/<name>`
+#                                       invocation with the documented argument shape
+#        - workspace already exists  → no `git clone` invocation (skip-if-exists)
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SKILL_FILE="$SRC_ROOT/.claude/skills/handover/SKILL.md"
+
+if [ ! -f "$SKILL_FILE" ]; then
+  echo "FAIL: handover SKILL.md not found at $SKILL_FILE" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# ---------------------------------------------------------------------------
+# spec_assert <label> <expected literal substring> [grep-extended-regex flag]
+# ---------------------------------------------------------------------------
+spec_assert() {
+  local label="$1" needle="$2"
+  if grep -qF -- "$needle" "$SKILL_FILE"; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label]: missing literal substring in SKILL.md: '$needle'" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Spec-shape tests — verify the SKILL.md contains the documented prompt
+# at the documented location.
+# ---------------------------------------------------------------------------
+
+# 1. The new step exists, with a heading that names the clone-first option.
+spec_assert "spec-step-heading" \
+  "### 8. Offer the clone-first deep-dive option (recommended)"
+
+# 2. Insertion point — step 7 (registry append) still precedes step 8, and
+#    step 9 (validation) follows step 8. Catches accidental reordering.
+spec_assert "spec-step-7-still-registry"  \
+  "### 7. Append to the portfolio registry"
+spec_assert "spec-step-9-still-validation" \
+  "### 9. Offer validation (conditional, default-no)"
+spec_assert "spec-step-10-summary" \
+  "### 10. Return a summary"
+
+# 3. Five cost-transparency facts (AC #3 of the ticket).
+spec_assert "spec-cost-1-enable-lsp-tool"   "ENABLE_LSP_TOOL=1"
+spec_assert "spec-cost-2-plugin-install"    "plugin install is your problem"
+spec_assert "spec-cost-3-disk-and-gitignore" "gitignored"
+spec_assert "spec-cost-4-cross-project-grep" "Cross-project semantic queries still need grep"
+spec_assert "spec-cost-5-cold-start"         "Cold-start on large monorepos can be 30+ seconds"
+
+# 4. Three-option prompt response shape.
+spec_assert "spec-prompt-response-options" "[y / n / later]"
+
+# 5. Follow-up skill suggestion on success (AC #4 of the ticket).
+spec_assert "spec-followup-threat-model" \
+  "Want to run /threat-model against the new clone now?"
+
+# 6. Skip-if-exists branch is documented.
+spec_assert "spec-skip-if-exists" \
+  'if [ -d "workspace/<name>" ]; then'
+
+# 7. Decline path documented as silent (no side effects).
+spec_assert "spec-decline-silent" \
+  "Skip silently — no side effects"
+
+# ---------------------------------------------------------------------------
+# Runtime-shape simulator. Mirrors the bash logic the spec documents in
+# the "On `y`" branch. The simulator never touches the real `git`; we
+# point PATH at a mock that records its argv and exits 0.
+#
+# simulate <answer> <workspace-pre-exists?> <name> <repo-url>
+#   → echoes the recorded `git clone` argv to stdout (empty if no call)
+#   → returns simulator exit code
+# ---------------------------------------------------------------------------
+simulate() {
+  local answer="$1" pre_exists="$2" name="$3" repo_url="$4"
+  local sb log
+  sb=$(mktemp -d)
+  sb=$(cd "$sb" && pwd -P)
+  log="$sb/.git-clone-calls.log"
+  : > "$log"
+
+  # Mock `git` — only handles `git clone <url> <dest>`; for anything else,
+  # the simulator never calls it, so we just record + exit 0.
+  cat > "$sb/git" <<MOCK
+#!/usr/bin/env bash
+if [ "\$1" = "clone" ]; then
+  printf '%s\n' "\$*" >> "$log"
+  # Pretend the clone succeeded — make the destination dir so any
+  # subsequent skip-if-exists logic in a re-run sees a real workspace.
+  if [ -n "\$3" ]; then
+    mkdir -p "\$3"
+  fi
+  exit 0
+fi
+exit 0
+MOCK
+  chmod +x "$sb/git"
+
+  # Optionally pre-create workspace/<name>/ to exercise the skip branch.
+  if [ "$pre_exists" = "1" ]; then
+    mkdir -p "$sb/workspace/$name"
+  fi
+
+  # The simulator: a faithful translation of the spec's "On y" + skip
+  # branches. Lives inside this test on purpose — the spec is the source
+  # of truth, and any divergence between this and the spec is a test
+  # failure to triage. All status output goes to stderr; only the
+  # captured git-clone argv from $log lands on stdout.
+  (
+    cd "$sb" || exit 1
+    PATH="$sb:$PATH"
+    case "$answer" in
+      y|Y|yes)
+        if [ -d "workspace/$name" ]; then
+          echo "skip-existing" >&2
+        else
+          git clone "$repo_url" "workspace/$name" >/dev/null 2>&1
+          echo "cloned" >&2
+        fi
+        ;;
+      n|N|no|later|"")
+        echo "skipped" >&2
+        ;;
+      *)
+        # Unknown input → treat as `n` per the spec.
+        echo "skipped" >&2
+        ;;
+    esac
+  )
+  local rc=$?
+
+  # Echo whatever git invocations were captured.
+  if [ -s "$log" ]; then
+    cat "$log"
+  fi
+
+  rm -rf "$sb"
+  return $rc
+}
+
+# Case A: answer `n` → no clone, exit 0
+out=$(simulate "n" 0 "example-app" "https://github.com/example/example-app.git" 2>/dev/null)
+if [ -z "$out" ]; then
+  echo "PASS [runtime-decline-no]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [runtime-decline-no]: expected no git invocation, got: $out" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}runtime-decline-no "
+fi
+
+# Case B: answer `later` → no clone, exit 0
+out=$(simulate "later" 0 "example-app" "https://github.com/example/example-app.git" 2>/dev/null)
+if [ -z "$out" ]; then
+  echo "PASS [runtime-decline-later]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [runtime-decline-later]: expected no git invocation, got: $out" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}runtime-decline-later "
+fi
+
+# Case C: answer `y` → exactly one `git clone <url> workspace/<name>`
+out=$(simulate "y" 0 "example-app" "https://github.com/example/example-app.git" 2>/dev/null)
+expected="clone https://github.com/example/example-app.git workspace/example-app"
+if [ "$out" = "$expected" ]; then
+  echo "PASS [runtime-accept-y]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [runtime-accept-y]: argv mismatch" >&2
+  echo "    expected: $expected" >&2
+  echo "    got:      $out" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}runtime-accept-y "
+fi
+
+# Case D: workspace pre-exists → answer `y` skips the clone
+out=$(simulate "y" 1 "example-app" "https://github.com/example/example-app.git" 2>/dev/null)
+if [ -z "$out" ]; then
+  echo "PASS [runtime-skip-if-exists]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [runtime-skip-if-exists]: expected no git invocation when workspace exists, got: $out" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}runtime-skip-if-exists "
+fi
+
+# Case E: unknown input → treated as `n` (no clone)
+out=$(simulate "maybe" 0 "example-app" "https://github.com/example/example-app.git" 2>/dev/null)
+if [ -z "$out" ]; then
+  echo "PASS [runtime-unknown-input-no-clone]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [runtime-unknown-input-no-clone]: expected no git invocation, got: $out" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}runtime-unknown-input-no-clone "
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Total: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -495,7 +495,80 @@ Skipping the auto-append. If you want to add it later, copy this into apexyard.p
     roles: {derived list}
 ```
 
-### 8. Offer validation (conditional, default-no)
+### 8. Offer the clone-first deep-dive option (recommended)
+
+You've just produced a metadata-only handover. The next natural step is a deeper dive — security audit, threat model, code-quality assessment. Those skills benefit substantially from a local clone + LSP-aware tooling, so offer the clone-first path here, with the cost transparently disclosed. Default is **no clone** — the operator has to type `y` explicitly.
+
+#### What to ask
+
+Print a single offer block. Use the project name resolved earlier in the flow as `<name>`, and the registry's `repo` field (or the URL the operator gave in step 1) as `<repo-url>`. Don't paraphrase — the prompt below is the exact shape:
+
+```
+Want me to clone <name> into workspace/<name>/ now? It enables
+LSP-aware navigation in /code-review, /threat-model, /security-review
+and the post-handover discovery skills (~3-15× cheaper than grep on
+shallow semantic queries; ~1.4-5× on multi-hop traces).
+
+Cost: ~tens of MB on disk + a one-time clone. The clone is gitignored
+from your fork (workspace/*/).
+
+Note: LSP requires `ENABLE_LSP_TOOL=1` and a per-language Claude Code
+LSP plugin installed (the plugin install is your problem — it's not
+bundled). Cross-project semantic queries still need grep (LSP is
+per-workspace). Cold-start on large monorepos can be 30+ seconds.
+Decline now if you'd rather configure that first or skip the deep dive.
+
+[y / n / later]
+```
+
+#### Cost-transparency requirements
+
+The offer **must** explicitly disclose:
+
+1. **`ENABLE_LSP_TOOL=1`** — the env var the harness reads to enable LSP
+2. **Per-language plugin install is the adopter's problem** — don't pretend the clone alone enables LSP
+3. **Disk cost** (~tens of MB) and gitignored status (`workspace/*/`)
+4. **Cross-project queries still need grep** — LSP is per-workspace
+5. **Cold-start cost on large monorepos** — 30+ seconds is realistic per the spike
+
+If any of these aren't surfaced in the offer, the adopter accepts a deal they don't understand. Don't compress the prompt past these five.
+
+#### Branching
+
+**On `y`:**
+
+1. Resolve `<repo-url>`. If the registry already has the repo slug (`me2resh/<name>` form), translate to `https://github.com/<owner>/<name>.git`. If the operator gave a path in step 1 instead of a URL, fall back to asking for the clone URL — never invent one.
+
+2. Skip cleanly if `workspace/<name>/` already exists:
+
+   ```bash
+   if [ -d "workspace/<name>" ]; then
+     echo "✓ workspace/<name>/ already exists — skipping clone."
+   else
+     git clone <repo-url> workspace/<name>
+   fi
+   ```
+
+3. On clone failure (private repo without credentials, network error, repo moved): report the exit code, point at `gh auth login` or a manual `git clone` as the recovery, and continue to the final summary. Do **not** retry, do **not** fall back to a different URL — the operator picks up from there.
+
+4. On clone success, suggest the next skill as a single follow-up question:
+
+   ```
+   ✓ Cloned into workspace/<name>/.
+     Want to run /threat-model against the new clone now? (y/n)
+   ```
+
+   If the operator declines, mention `/code-review` and `/security-review` as the other natural follow-ups, then continue to the final summary. The skill never invokes follow-up skills automatically — the operator confirms each one.
+
+**On `n` or `later`:**
+
+Skip silently — no side effects, no further prompts. The adopter can clone manually anytime with `git clone <repo-url> workspace/<name>`. Continue to the final summary.
+
+**On any other input:**
+
+Treat as `n` (no clone). Don't loop the prompt — the offer is one-shot.
+
+### 9. Offer validation (conditional, default-no)
 
 If the project looks **dormant** by the heuristic — last commit > 90 days ago AND zero open PRs AND no recent issue activity (rough thresholds, the skill can probe `gh repo view` + `gh pr list` + `gh issue list` to compute) — ask:
 
@@ -508,12 +581,13 @@ If the user accepts, hand off to `/validate-idea {name}` (which reads the just-w
 
 If the project is healthy (recent commits, active PRs/issues), skip the prompt entirely. Don't ask "should I validate?" on every handover — only when the dormancy signal warrants it.
 
-### 9. Return a summary
+### 10. Return a summary
 
 ```
 Handover assessment written: projects/{name}/handover-assessment.md
 Architecture stub:           projects/{name}/architecture/container.md ({written | preserved | skipped})
 Registry updated:            apexyard.projects.yaml ({added | skipped})
+Workspace clone:             workspace/{name}/ ({cloned | preserved | skipped (declined) | skipped (later) | failed: <reason>})
 Validation:                  {"completed — verdict <GREEN|YELLOW|RED>" | "skipped" | "not offered (project is active)"}
 
 Tech stack: {one-liner}
@@ -534,7 +608,7 @@ Top 3 next steps:
 4. **Auto-append to the registry** (with confirmation) — don't leave the user to copy-paste a snippet. Propose the append, validate the resulting YAML, roll back on failure.
 5. **Derive roles from the stack** — don't hard-code `[tech-lead, backend-engineer]`. The roles list depends on the actual tech stack, CI config, and security surface detected in step 3.
 6. **Derive next steps from the risks** — don't emit generic placeholders. Every "Next Step" must correspond to a specific finding from the Quality Risks section of the assessment.
-7. **Never auto-clone** — ask for the path.
+7. **Never auto-clone** — ask for the path in step 1, and offer (default-no) the optional clone in step 8. Clone only happens on an explicit operator `y`; `n` / `later` / unrecognised input all skip cleanly.
 8. **Never store secrets** — if `.env` is found, list its presence but never read its contents.
 9. **Status starts at `handover`** — moves to `active` only after the integration plan is executed.
 10. **Never break the registry** — if the YAML append breaks the file, restore the previous version and ask the user to edit manually.

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -127,7 +127,9 @@ projects/example-app/
 └── roadmap.md     ← project-specific roadmap (optional)
 ```
 
-Or run `/handover example-app` and the skill will generate a real assessment and seed the README. Then optionally clone the live working copy:
+Or run `/handover example-app` and the skill will generate a real assessment and seed the README. At the end of its flow, `/handover` also **offers (default-no) to clone the project into `workspace/<name>/`** — accept if you intend to follow up with `/code-review`, `/threat-model`, or `/security-review` and want the LSP-aware deep-dive path; decline if you'd rather configure `ENABLE_LSP_TOOL=1` + the per-language plugin first, or skip the deep dive entirely. The prompt surfaces the disk cost, the gitignored status (`workspace/*/`), and the LSP plugin caveats explicitly so the cost is owned, not assumed.
+
+If you'd rather clone manually:
 
 ```bash
 git clone github.com/your-org/example-app workspace/example-app
@@ -431,7 +433,7 @@ Every portfolio skill reads `apexyard.projects.yaml` and iterates the registry.
 | `/idea` | Appends to `projects/ideas-backlog.md` at the fork root (one shared backlog for all projects) |
 | `/roadmap` | Reads `projects/<name>/roadmap.md`; asks which project if ambiguous |
 | `/stakeholder-update` | Portfolio rollup with a section per project |
-| `/handover` | Writes to `projects/<name>/handover-assessment.md` and appends the project to the registry |
+| `/handover` | Writes to `projects/<name>/handover-assessment.md`, appends the project to the registry, and offers (default-no) to clone the project into `workspace/<name>/` for an LSP-aware deep-dive follow-up (`/code-review`, `/threat-model`, `/security-review`). The clone offer surfaces the cost (disk, gitignored status, `ENABLE_LSP_TOOL=1` + per-language plugin install) explicitly. |
 | `/c4` | Reads a project's codebase and writes filled-in C4 L1 + L2 Mermaid diagrams (location depends on invocation context — see `.claude/skills/c4/SKILL.md`) |
 
 Skills that aren't portfolio-aware (`/decide`, `/write-spec`, `/code-review`, `/security-review`, `/audit-deps`) operate on the current working directory — `cd workspace/<name>/` first if you want them to run against a specific project's code.


### PR DESCRIPTION
## Summary
- Add Step 8 to `/handover` (between registry-append and validation) that offers (default-no) to clone the project into `workspace/<name>/` for the LSP-aware deep-dive path used by `/code-review`, `/threat-model`, and `/security-review`.
- Cost transparency in the prompt: `ENABLE_LSP_TOOL=1`, per-language plugin install (the adopter's problem — not bundled), disk cost (~tens of MB), gitignored status (`workspace/*/`), cross-project queries still need grep, and 30+s cold-start on large monorepos.
- Branching: `y` runs `git clone <repo-url> workspace/<name>`, skips if the workspace already exists, and offers `/threat-model` as the natural next step. `n` / `later` / unrecognised input all skip silently with no side effects.
- Doc note in `docs/multi-project.md` covering both the seed-per-project step and the skill-behaviour table row.

Implements me2resh/apexyard#188 (LSP spike Phase 3 recommendation, Option 3 — interactive clone-first prompt).

## Testing
1. `bash .claude/hooks/tests/test_handover_clone_prompt.sh` — 18 cases pass:
   - 13 spec-shape assertions on `SKILL.md` (heading at the right step number, the five cost-transparency facts, three-option `[y / n / later]` shape, follow-up `/threat-model` suggestion, skip-if-exists branch, decline-silent semantics).
   - 5 runtime-shape cases against a mocked `git` binary: `n` -> no invocation, `later` -> no invocation, `y` -> exactly one `git clone <url> workspace/<name>`, `y` with pre-existing workspace -> no invocation, unknown input -> no invocation.
2. `for t in .claude/hooks/tests/test_*.sh; do bash "$t"; done` — full hook test sweep, all 16 suites pass with no regressions.
3. Smoke (manual): the actual `/handover` skill invocation against a public sample repo with the three operator paths (`y`, `n`, `later`) is the AC's smoke test and runs at adoption time — covered by the deterministic simulator in (1) for CI.

## Glossary
| Term | Definition |
|------|------------|
| LSP | Language Server Protocol — gives editors and tools structured semantic queries (definitions, references, types) instead of grep-style text matching. Per-workspace scope by design. |
| `ENABLE_LSP_TOOL=1` | Env var the Claude Code harness reads to enable the LSP-backed code-navigation tool. Off by default; opting in requires the per-language plugin to be installed separately. |
| Deep-dive skills | `/code-review`, `/threat-model`, `/security-review` — skills that benefit from LSP-aware navigation because they need to follow definitions and call sites across files. |
| `workspace/<name>/` | The per-project live working copy directory inside an apexyard fork. Each entry is a git clone of the project's own repo and is gitignored from the fork itself (`workspace/*/`). |
| Default-no prompt | An interactive offer where the operator must type `y` explicitly to proceed; any other input (including silence / Enter / `n` / `later` / unrecognised) is treated as decline. The opposite shape from a default-yes prompt. |
| Skip-if-exists | The clone path's idempotency safeguard: if `workspace/<name>/` already contains a clone, the skill prints a confirmation and continues without re-cloning, avoiding a destructive overwrite. |
| Spec-shape test | A test that asserts a markdown skill spec contains specific literal substrings at specific section ordinals. The skill itself is executed by the model, so the SKILL.md *is* the source of truth and content drift is the regression we catch. |
| Runtime-shape test | A test that exercises a small bash simulator faithful to the spec's documented branches, against a mocked binary, to verify the operator-input -> side-effect contract holds without making any real network or filesystem changes. |

Closes me2resh/apexyard#188
