### PR TITLE
docs(#189): document ENABLE_LSP_TOOL + per-language LSP plugin install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Getting Started | `docs/getting-started.md` |
 | Full setup guide | `docs/multi-project.md` |
 | Rule audit (every MUST → hook / advisory / deferred) | `docs/rule-audit.md` |
+| LSP-aware navigation (optional) | Set `ENABLE_LSP_TOOL=1` + install per-language plugins. See `docs/getting-started.md` § "Optional: LSP-aware code navigation" |
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,6 +135,107 @@ Create an AgDR.
 
 ---
 
+## Optional: LSP-aware code navigation
+
+Claude Code v2.0.74+ ships a built-in **LSP (Language Server Protocol) tool** that answers semantic queries — *"where is this defined?"*, *"where is this used?"*, *"what does this symbol resolve to?"* — by talking to a language server (`tsserver`, `pyright`, `gopls`, `rust-analyzer`, etc.) instead of grepping the file tree. It is **off by default** and **opt-in per session**.
+
+### Why turn it on?
+
+The LSP spike (PR #184, ticket #178) measured the input-token cost of three representative queries on a real TypeScript backend (~9,750 LOC). Shallow semantic queries — single-symbol lookups, find-references — came out **~3-15× cheaper** with LSP than with grep + Read. Multi-hop traces (chains of definitions across modules) saw a smaller ~1.4× win, because the irreducible cost is still reading prose to summarise behaviour.
+
+Concretely: a Code Reviewer agent run on a typical PR that does a handful of "where is this defined" lookups can come in at a quarter to a tenth of its grep-driven token bill, with the saved budget freed up for the actual review reasoning.
+
+### Opt-in path — two pieces
+
+LSP is enabled by **two** things in the same session:
+
+1. The environment variable `ENABLE_LSP_TOOL=1` (singular `_TOOL`, not plural).
+2. A per-language plugin that ships the LSP server binary and the `.lsp.json` wiring.
+
+Both are required. Setting only the env var without an installed plugin gives Claude Code nothing to talk to; installing only the plugin without the env var keeps the tool dormant.
+
+Set the env var for your session:
+
+```bash
+export ENABLE_LSP_TOOL=1
+claude
+```
+
+Or add it to your shell profile if you want it on by default. Plugins install through Claude Code's plugin marketplace — start at the [Claude Code plugins documentation](https://docs.claude.com/en/docs/claude-code/plugins) and search for the language you need.
+
+### Per-language install notes
+
+The framework actively encourages LSP for these four. Pick the languages your project uses; multi-language repos can install several plugins side-by-side and the LSP tool will dispatch per-file based on extension.
+
+#### TypeScript / JavaScript — `tsserver`
+
+`tsserver` ships bundled with the TypeScript compiler (`typescript` on npm), which most TS projects already have as a devDependency. No extra binary install if your repo has `node_modules`.
+
+```bash
+# Verify your project ships tsserver
+npx tsserver --version 2>/dev/null || npm ls typescript
+
+# Install the Claude Code plugin from the marketplace
+# (search "typescript" / "tsserver" in the marketplace UI)
+```
+
+#### Python — `pyright`
+
+```bash
+# Install pyright globally
+npm install -g pyright
+
+# Or per-project via uv / pip
+uv add --dev pyright
+# pip install pyright
+
+# Then install the Python plugin from the marketplace
+# (search "python" / "pyright")
+```
+
+`pyright` understands `pyproject.toml` and `pyrightconfig.json` for path resolution; if your repo uses a virtualenv the plugin needs to know where it lives — set `python.pythonPath` in `pyrightconfig.json`.
+
+#### Go — `gopls`
+
+```bash
+# Install gopls (the official Go language server)
+go install golang.org/x/tools/gopls@latest
+
+# Verify it's on $PATH
+which gopls
+
+# Then install the Go plugin from the marketplace
+# (search "go" / "gopls")
+```
+
+`gopls` requires Go 1.21+ and a `go.mod` at the repo root. Cold start on a large monorepo can take 30–90 seconds while the module graph builds.
+
+#### Rust — `rust-analyzer`
+
+`rust-analyzer` ships bundled with [rustup](https://rustup.rs/) — most Rust toolchains already have it.
+
+```bash
+# Add the component if it's missing
+rustup component add rust-analyzer
+
+# Verify
+rust-analyzer --version
+
+# Then install the Rust plugin from the marketplace
+# (search "rust" / "rust-analyzer")
+```
+
+Cargo workspaces with many crates have a slow first index — see the caveat below.
+
+### Caveats — what LSP does not solve
+
+- **Cold-start latency on large repos.** The first query against a fresh server pays the indexing cost: a few seconds for a small library, 30-90s for a Go monorepo or a large Rust workspace, sometimes longer for a TypeScript project with thousands of files. Subsequent queries in the same session are fast. Plan for the first call to be slow; budget for it in agent runs.
+- **Cross-project portfolio queries still need grep.** LSP indexes one project at a time. Skills that walk the whole portfolio (`/inbox`, `/tasks`, `/stakeholder-update`, anything that aggregates across `apexyard.projects.yaml`) read across many repos and stay on grep + Read regardless of LSP state.
+- **No new failure mode.** Skills that benefit from LSP (`/code-review`, `/threat-model`, `/security-review`) fall back to grep + Read transparently when LSP is absent. There is no "broken without LSP" path — only a faster one with it.
+- **Plugin marketplace links may move.** The plugin ecosystem is young. If a marketplace search turns up multiple options for one language, prefer the one maintained by the language's own community (e.g. official `tsserver` over a third-party wrapper).
+
+---
+
 ## Customization
 
 ### Adding a Custom Role

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -495,6 +495,12 @@ The same output appears when you run `/status --briefing` (or `/status -b`) insi
 
 Default `/status` (no flags) still produces the long per-project breakdown — `--briefing` only opts into the compact form.
 
+### LSP-aware skills inside a workspace
+
+If you've enabled the optional LSP tool (`ENABLE_LSP_TOOL=1` + a per-language plugin — see [`getting-started.md` § "Optional: LSP-aware code navigation"](getting-started.md#optional-lsp-aware-code-navigation)), code-aware skills like `/code-review`, `/threat-model`, and `/security-review` use semantic-index queries instead of grep when they run inside a cloned `workspace/<name>/`. The same skills fall back to grep + Read transparently when LSP is absent — there's no new failure mode, only optional speed.
+
+Cross-project portfolio skills (`/inbox`, `/tasks`, `/stakeholder-update`) walk the whole registry and stay on grep regardless, because no single LSP server has the full multi-repo view.
+
 ---
 
 ## Upgrades — pulling from upstream


### PR DESCRIPTION
## Summary

- Add an "Optional: LSP-aware code navigation" section to `docs/getting-started.md` covering the cost-benefit (~3-15× cheaper on shallow semantic queries per the Phase 1 spike numbers), the two-piece opt-in (`ENABLE_LSP_TOOL=1` env var + per-language plugin), per-language install notes for TypeScript / Python / Go / Rust, and the caveats (cold-start latency, cross-project queries still need grep).
- Add an LSP row to the Quick Reference table in `CLAUDE.md`.
- Add an "LSP-aware skills inside a workspace" subsection to the daily-workflow area of `docs/multi-project.md` noting the transparent fallback to grep when LSP is absent.
- Pure docs — no hooks / skills / settings touched. Closes me2resh/apexyard#189.

Plugin marketplace links: deliberately point at the [Claude Code plugins documentation](https://docs.claude.com/en/docs/claude-code/plugins) and tell readers to search the marketplace UI by language. Per the ticket's risk note, individual plugin URLs in the new ecosystem aren't yet stable enough to pin from a framework doc — better to link the search than rot a deep link.

## Testing

1. Open `docs/getting-started.md` and verify the new "Optional: LSP-aware code navigation" section reads end-to-end without dangling references — the cost-benefit, the two-piece opt-in, four per-language install blocks, and four caveats.
2. Open `CLAUDE.md` Quick Reference and confirm the LSP row appears at the bottom of the table.
3. Open `docs/multi-project.md` and search for "LSP-aware skills inside a workspace" — the new subsection sits between the `apexyard status` CLI briefing and the "Upgrades — pulling from upstream" section.
4. Run `gh issue view 189 --repo me2resh/apexyard` and tick off the four AC bullets against the diff.
5. (Optional, can't be automated here) On a workstation with an installed LSP plugin and `ENABLE_LSP_TOOL=1`, run `/code-review` against a small TS PR and confirm the latency / token cost matches the section's claim.

## Glossary

| Term | Definition |
|------|------------|
| LSP | Language Server Protocol — a JSON-RPC interface that lets a language-specific server answer semantic queries (definition, references, hover, diagnostics) about source code |
| LSP server | The language-specific binary (`tsserver`, `pyright`, `gopls`, `rust-analyzer`, …) that implements LSP over stdio for a given source tree |
| `ENABLE_LSP_TOOL` | Environment variable (singular `_TOOL`, not plural) that enables Claude Code's built-in LSP tool — off by default since v2.0.74 |
| Plugin (Claude Code) | A self-contained marketplace-installed directory that ships skills, agents, hooks, MCP servers, or **LSP servers** wired in via `.lsp.json` |
| `tsserver` | The TypeScript language server, bundled with the `typescript` npm package — typically already present in any TypeScript project's `node_modules` |
| `pyright` | A Microsoft-maintained Python type-checker that doubles as an LSP server; installable via npm or as a project devDependency |
| `gopls` | The official Go language server, installed via `go install golang.org/x/tools/gopls@latest` |
| `rust-analyzer` | The de-facto Rust LSP server, ships as a `rustup` component on most modern toolchains |
| Shallow vs multi-hop semantic query | Shallow: single symbol → single location lookup (definition, references). Multi-hop: chain across modules to summarise behaviour. LSP's input-token win is large on shallow queries, modest on multi-hop |
| Cold-start latency | The first-query indexing cost a language server pays when it opens a project — sub-second on small libraries, 30-90s on a Go monorepo or large Rust workspace |