### PR TITLE
fix(#194): validation hooks read git context from command, not $PWD

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -240,6 +240,57 @@ With that config, `wip: scratch work` is accepted and `refactor: cleanup` is rej
 
 **Enforces:** `.claude/rules/git-conventions.md § "Commit Message Format"` — was prose-only.
 
+## PWD-vs-command-context distinction
+
+The harness's `$PWD` at hook-invocation time is whatever directory the parent
+session was sitting in when it dispatched the tool call. For most single-shell
+sessions that happens to match the worktree the operator is editing — but it
+**does not have to**. Three failure modes recur:
+
+1. **Agent fan-out workers** — `/fan-out` (and direct `Agent` calls with
+   `isolation: "worktree"`) spawn parallel agents that `cd` into per-task
+   worktrees. The parent harness's `$PWD` may still point at a sibling
+   worktree or the ops-fork root.
+2. **Cross-repo shells** — operators routinely run `gh pr create --repo X`
+   from a clone of repo Y when bouncing between projects.
+3. **Backgrounded long-running shells** — a tool call dispatched from a
+   shell whose `cwd` has drifted since session start.
+
+The lesson from #194 (validation hooks) and #47 (the `gh api .../merge` bypass)
+is the same: **gate on the command's actual context, not on the harness's
+`$PWD`**. The command itself almost always carries the truth — `--head`,
+`--repo`, the push source-ref, the API path's `/pulls/<N>/merge` segment.
+Falling back to `$PWD`-derived state (`git branch --show-current`,
+`git rev-parse HEAD`, repo-root via parent-walk) is acceptable as a fallback
+when the command does not name the context, but it must never override what
+the command says.
+
+For hook authors:
+
+- Prefer the command-arg-first, fallback-to-local-context shape:
+  `BRANCH="${HEAD_FLAG:-$(git branch --show-current)}"`. The fallback
+  preserves backwards compatibility for shapes that don't pass the flag.
+- Centralise extraction in a `_lib-extract-*.sh` helper rather than reimplementing
+  the parsing inline in each hook — same pattern as `_lib-extract-pr.sh` for
+  the merge-gate hooks. One helper, one set of tests, all hooks safe.
+- Heredoc substitution (`-m "$(cat <<EOF...)"`) is a special case where the
+  command string the hook reads is **literal-pre-expansion** — the actual
+  message lives in the heredoc body and is invisible to the hook. Detect the
+  shape and skip validation rather than block; recommend the file-based
+  alternative (`git commit -F file`) in the INFO message so operators who
+  want full validation on multi-line content know where to go.
+
+Helpers that implement this convention:
+
+| Helper | Used by | What it parses |
+|--------|---------|----------------|
+| `_lib-extract-pr.sh` | `block-unreviewed-merge.sh`, `require-design-review-for-ui.sh`, `block-merge-on-red-ci.sh` | PR number from `gh pr merge` and `gh api .../pulls/<N>/merge` |
+| `_lib-extract-push-ref.sh` | `validate-branch-name.sh` | Source ref from `git push origin <ref>` (and refspec / -u / --set-upstream / --force-with-lease variants) |
+
+When you add a new hook that depends on git state, ask first: "is the answer
+already in the command string?" If yes, parse it from there. If no, falling
+back to local context is fine — but document the trade-off.
+
 ## Settings Ordering Note
 
 The new hooks are registered in `.claude/settings.json` alongside the existing ones on the same `Bash(git commit *)` / `Bash(gh pr merge *)` matchers. The Claude Code harness runs all matching hooks sequentially, and **any exit-2 blocks the tool call**. Order of registration within a matcher block is execution order. Current order (GH-13 additions shown in **bold**):

--- a/.claude/hooks/_lib-extract-push-ref.sh
+++ b/.claude/hooks/_lib-extract-push-ref.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Shared push-source-ref extraction for hooks that gate on `git push`.
+#
+# Not a hook itself (prefixed with `_lib-` so it's never wired as one). Sourced
+# by hooks via `. "$(dirname "$0")/_lib-extract-push-ref.sh"`.
+#
+# WHY THIS EXISTS
+# ---------------
+# Validation hooks like `validate-branch-name.sh` historically read the branch
+# from `git branch --show-current`, which resolves against the harness's $PWD.
+# When the harness $PWD is a sibling worktree of the worktree the operator
+# actually ran the command in (e.g. an Agent fan-out worker that `cd`'d into
+# its own worktree), the resolved branch is wrong — the hook reads the parent
+# session's branch, not the agent's.
+#
+# Fix: parse the actual command for the source ref. `git push origin <branch>`
+# carries the source ref directly; that's the ground truth, regardless of $PWD.
+# Falls back to no-op (caller uses local HEAD) when no ref is present in the
+# command (e.g. no-arg `git push` relying on upstream tracking).
+#
+# Same shape pattern as `_lib-extract-pr.sh` for the merge-gate hooks (#47):
+# gate on the command's actual context, not the harness's $PWD.
+#
+# USAGE
+# -----
+#   . "$(dirname "$0")/_lib-extract-push-ref.sh"
+#   PUSH_REF=$(extract_push_ref "$COMMAND")
+#   BRANCH="${PUSH_REF:-$(git branch --show-current)}"
+#
+# Refs: me2resh/apexyard#194
+
+# Echoes the source ref from a `git push` command, or empty if none found.
+#
+# Recognises:
+#   git push origin <branch>                           → <branch>
+#   git push origin <branch>:<remote-branch>           → <branch>  (LHS of refspec)
+#   git push -u origin <branch>                        → <branch>
+#   git push --set-upstream origin <branch>            → <branch>
+#   git push --force origin <branch>                   → <branch>
+#   git push --force-with-lease origin <branch>        → <branch>
+#   git push origin HEAD                               → empty (HEAD is not a ref name we can validate)
+#   git push                                           → empty (relies on upstream tracking)
+#   git push origin                                    → empty (no ref given)
+#   git push origin --delete <branch>                  → empty (deletion, no source-ref check)
+#
+# Returns: prints the ref to stdout (or empty), always exits 0.
+extract_push_ref() {
+  local cmd="$1"
+  local push_segment ref
+
+  # Bail on `--delete` / `-d` shapes — they don't have a source ref.
+  if echo "$cmd" | grep -qE '\bgit\s+push\b[^|;&]*(--delete\b|[[:space:]]-d\b)'; then
+    echo ""
+    return 0
+  fi
+
+  # Isolate the `git push ...` segment up to the first command separator
+  # (|, ;, &&, &) so `git push origin foo && echo bar` doesn't pick up `echo`
+  # tokens.
+  push_segment=$(echo "$cmd" | grep -oE '\bgit\s+push\b[^|;&]*' | head -1)
+  if [ -z "$push_segment" ]; then
+    echo ""
+    return 0
+  fi
+
+  # Strip the `git push` prefix so the remaining tokens are args/flags only.
+  # BSD sed (macOS) does not support `\b`, so use POSIX-only constructs.
+  # Since `git push` is always the first match for the segment we just
+  # extracted, a literal-prefix removal via parameter expansion is enough.
+  push_segment="${push_segment#*git}"
+  # Drop leading whitespace then the literal `push`.
+  push_segment="${push_segment#"${push_segment%%[![:space:]]*}"}"
+  push_segment="${push_segment#push}"
+
+  # Walk the remaining tokens, skipping flags + their values + the remote.
+  # The first non-flag, non-remote positional that isn't HEAD is the source ref.
+  #
+  # Recognised flags that consume a following value:
+  #   -o / --push-option, --recurse-submodules, --signed, --receive-pack /
+  #   --exec. The common short flags (-u, -f, -n, -v, -q, --force,
+  #   --force-with-lease, --tags, --follow-tags, --atomic, --dry-run,
+  #   --no-verify, --set-upstream, --prune, --mirror, --all) take no value.
+  #
+  # Recognised "remote" candidates: `origin`, `upstream`, or any single
+  # non-flag token that appears before the ref. We heuristically treat the
+  # FIRST non-flag positional as the remote and the SECOND as the ref.
+  # `git push <ref>` (one positional, no remote) is rare in scripts; if it
+  # happens, this returns empty and the caller falls back to local HEAD.
+  local positional_count=0
+  local skip_next=0
+  ref=""
+
+  # shellcheck disable=SC2086
+  for token in $push_segment; do
+    if [ "$skip_next" -eq 1 ]; then
+      skip_next=0
+      continue
+    fi
+
+    case "$token" in
+      # Flags that consume the next token as a value
+      -o|--push-option|--recurse-submodules|--signed|--receive-pack|--exec|--repo)
+        skip_next=1
+        continue
+        ;;
+      # `--<flag>=value` form — value is part of the same token, no skip needed.
+      --push-option=*|--recurse-submodules=*|--signed=*|--receive-pack=*|--exec=*|--repo=*)
+        continue
+        ;;
+      # Boolean flags — no value.
+      -[unfvq]|-[unfvq][unfvq]*|--force|--force-with-lease*|--tags|--follow-tags|--atomic|--dry-run|--no-verify|--set-upstream|--prune|--mirror|--all|--no-tags|--quiet|--verbose|--ipv4|--ipv6|--progress|--no-progress|--thin|--no-thin|--porcelain|--no-recurse-submodules)
+        continue
+        ;;
+      # Anything else starting with - is some other flag we don't know — skip
+      # to be safe (don't consume a following value, since most git push flags
+      # are boolean).
+      -*)
+        continue
+        ;;
+    esac
+
+    positional_count=$((positional_count + 1))
+    if [ "$positional_count" -eq 2 ]; then
+      ref="$token"
+      break
+    fi
+  done
+
+  if [ -z "$ref" ]; then
+    echo ""
+    return 0
+  fi
+
+  # `git push origin HEAD` — HEAD isn't a branch name we can validate; let the
+  # caller fall back to local HEAD resolution.
+  if [ "$ref" = "HEAD" ]; then
+    echo ""
+    return 0
+  fi
+
+  # Refspec form `<src>:<dst>` — the LHS is the branch the operator is pushing.
+  # Strip the colon-and-after so `feature/GH-1-x:main` → `feature/GH-1-x`.
+  ref="${ref%%:*}"
+
+  # Strip any leading `+` (force-update marker on a refspec).
+  ref="${ref#+}"
+
+  # Strip leading `refs/heads/` if present — leave just the branch shorthand.
+  ref="${ref#refs/heads/}"
+
+  echo "$ref"
+}

--- a/.claude/hooks/tests/test_validate_branch_name_pushref.sh
+++ b/.claude/hooks/tests/test_validate_branch_name_pushref.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Tests for validate-branch-name.sh's push-source-ref extraction (#194).
+#
+# Validates that the hook reads the branch from the actual `git push`
+# command's source ref when present, rather than from `git branch
+# --show-current` against the harness's $PWD. This is the worktree-safe
+# behaviour Agent fan-out workers depend on.
+#
+# Each case:
+#   - builds an isolated sandbox with the hook + helper
+#   - sets the sandbox to a "wrong" local branch that, if used, would FAIL
+#     validation (so we know the hook used the push-ref, not local HEAD)
+#   - pipes a synthetic PreToolUse JSON for a `git push` command containing
+#     the branch we actually want validated
+#   - asserts exit code (0 = pass, 2 = blocked)
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/validate-branch-name.sh"
+LIB_SRC="$SRC_ROOT/.claude/hooks/_lib-extract-push-ref.sh"
+LIB_CONFIG_SRC="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+
+for f in "$HOOK_SRC" "$LIB_SRC"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: required source missing: $f" >&2
+    exit 1
+  fi
+done
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# Build a sandbox where the LOCAL branch is intentionally NON-conforming.
+# If the hook resolves the branch from local HEAD, it will block (rc=2).
+# If the hook resolves from the push command's source ref, it will use
+# whatever the test passes in.
+make_sandbox_with_wrong_local_branch() {
+  local sb local_branch="${1:-not-conforming-branch-name}"
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    : > onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+    # Force the local branch to a name that fails the validator.
+    git checkout -q -B "$local_branch"
+  )
+  mkdir -p "$sb/.claude/hooks"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/validate-branch-name.sh"
+  cp "$LIB_SRC"  "$sb/.claude/hooks/_lib-extract-push-ref.sh"
+  if [ -f "$LIB_CONFIG_SRC" ]; then
+    cp "$LIB_CONFIG_SRC" "$sb/.claude/hooks/_lib-read-config.sh"
+  fi
+  if [ -f "$SRC_ROOT/.claude/project-config.defaults.json" ]; then
+    cp "$SRC_ROOT/.claude/project-config.defaults.json" "$sb/.claude/project-config.defaults.json"
+  fi
+  chmod +x "$sb/.claude/hooks/validate-branch-name.sh"
+  echo "$sb"
+}
+
+run_case() {
+  local label="$1" cmd="$2" want_rc="$3"
+  local sb; sb=$(make_sandbox_with_wrong_local_branch)
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_rc got_stderr
+  got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/validate-branch-name.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc" >&2
+    echo "    cmd: $cmd" >&2
+    echo "    stderr: ${got_stderr:0:300}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# -- Cases ---------------------------------------------------------------
+#
+# Local branch in every sandbox is `not-conforming-branch-name` (would fail
+# validation). The hook should use the push-ref from the COMMAND when present.
+
+# Conforming push refs → pass even though local branch is wrong.
+run_case "explicit ref: feature/GH-194-foo passes" \
+  "git push origin feature/GH-194-worktree-cwd-hooks" 0
+
+run_case "explicit ref: fix/ABC-123-bar passes" \
+  "git push origin fix/ABC-123-login-bug" 0
+
+run_case "with -u flag: -u origin <branch> passes" \
+  "git push -u origin feature/GH-194-foo" 0
+
+run_case "--set-upstream: passes" \
+  "git push --set-upstream origin feature/GH-194-foo" 0
+
+run_case "--force-with-lease: passes" \
+  "git push --force-with-lease origin feature/GH-194-foo" 0
+
+run_case "refspec form src:dst passes" \
+  "git push origin feature/GH-194-foo:feature/GH-194-foo" 0
+
+run_case "release branch shorthand (no ticket): passes via release exception" \
+  "git push origin release/v1.2.3" 0
+
+run_case "main is exempt as trunk" \
+  "git push origin main" 0
+
+run_case "dev is exempt as trunk (release-cut model)" \
+  "git push origin dev" 0
+
+# Non-conforming push refs → block (the push-ref is now the source of truth).
+run_case "explicit ref: bogus-branch blocks" \
+  "git push origin bogus-branch" 2
+
+run_case "explicit ref: feature/no-ticket blocks" \
+  "git push origin feature/no-ticket-id" 2
+
+# Fallback path: no source ref → falls back to local branch, which fails.
+run_case "no-arg push: falls back to local HEAD (which is wrong) → blocks" \
+  "git push" 2
+
+run_case "git push origin (no ref): falls back to local HEAD → blocks" \
+  "git push origin" 2
+
+# Delete shape — should not trigger the push-ref check; falls back to local
+# branch, which is non-conforming and blocks.
+run_case "git push --delete: falls back, blocks (local non-conforming)" \
+  "git push origin --delete bogus-branch" 2
+
+# Non-push commands → no-op.
+run_case "non-push command exits 0 silently" \
+  "git status" 0
+
+# ---- Summary ------------------------------------------------------------
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
+++ b/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# Tests for validate-commit-format.sh's heredoc-substitution skip (#194).
+#
+# When a commit is invoked as
+#   git commit -m "$(cat <<'EOF'
+#   subject
+#   body
+#   EOF
+#   )"
+# the harness sees the literal `$(cat <<'EOF' ... EOF )` string, not the
+# expanded message. The hook's regex over the `-m` value cannot validate
+# that string — it would always fail. Pre-194 the hook blocked these
+# commits as "malformed subject". Post-194 the hook detects the substitution
+# pattern and exits 0 with an INFO message suggesting `git commit -F file`
+# for full validation on multi-line messages.
+#
+# Each case:
+#   - builds an isolated sandbox with the hook + helpers
+#   - pipes a synthetic PreToolUse JSON for a `git commit ...` command
+#   - asserts exit code + (when relevant) stderr content
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/validate-commit-format.sh"
+LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    : > onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+  )
+  mkdir -p "$sb/.claude/hooks"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/validate-commit-format.sh"
+  if [ -f "$LIB_CFG" ]; then cp "$LIB_CFG" "$sb/.claude/hooks/_lib-read-config.sh"; fi
+  if [ -f "$DEFAULTS" ]; then cp "$DEFAULTS" "$sb/.claude/project-config.defaults.json"; fi
+  chmod +x "$sb/.claude/hooks/validate-commit-format.sh"
+  echo "$sb"
+}
+
+run_case() {
+  local label="$1" cmd="$2" want_rc="$3" want_stderr_regex="$4"
+  local sb; sb=$(make_sandbox)
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/validate-commit-format.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc" >&2
+    echo "    cmd: ${cmd:0:200}" >&2
+    echo "    stderr: ${got_stderr:0:300}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# -- Cases ---------------------------------------------------------------
+
+# Heredoc-substitution shape — pre-194 this blocked; post-194 it skips with INFO.
+HEREDOC_CMD='git commit -m "$(cat <<'\''EOF'\''
+feat(#194): subject line from heredoc
+
+body line 1
+body line 2
+EOF
+)"'
+run_case "heredoc-substitution: skip with INFO" \
+  "$HEREDOC_CMD" 0 "heredoc-substitution detected"
+
+# Variation: unquoted heredoc delimiter.
+HEREDOC_NOQ_CMD='git commit -m "$(cat <<EOF
+feat: subject
+EOF
+)"'
+run_case "heredoc-substitution unquoted delim: skip with INFO" \
+  "$HEREDOC_NOQ_CMD" 0 "heredoc-substitution detected"
+
+# Variation: <<- (tab-stripping heredoc).
+HEREDOC_DASH_CMD='git commit -m "$(cat <<-'\''EOF'\''
+	feat: subject
+	EOF
+)"'
+run_case "heredoc-substitution <<-: skip with INFO" \
+  "$HEREDOC_DASH_CMD" 0 "heredoc-substitution detected"
+
+# Plain non-substitution -m → still validated as before.
+run_case "plain -m valid subject: pass silently" \
+  'git commit -m "feat(#194): valid subject"' 0 ""
+
+run_case "plain -m bad subject: BLOCK" \
+  'git commit -m "not a valid subject line"' 2 "BLOCKED: Commit subject"
+
+run_case "plain -m '\''quoted'\'' valid subject: pass" \
+  "git commit -m 'fix: a fix'" 0 ""
+
+# -F file path → no heredoc substitution involved, full validation runs.
+# The skip pattern is anchored on `-m \$(cat <<` literally, so -F is never
+# affected.
+run_case "git commit -F (no -m): no heredoc skip applied" \
+  'git commit -F /nonexistent/path' 0 ""
+
+# A literal "$(cat <<" in a non--m position must NOT trigger the skip
+# (e.g. `git commit -m "feat: subject" --trailer '...'` with a comment
+# elsewhere). In practice this is hard to trigger without -m; this case
+# documents the negative.
+run_case "no heredoc-substitution: bad subject still blocks" \
+  'git commit -m "junk"' 2 "BLOCKED: Commit subject"
+
+# Non-commit command → no-op.
+run_case "non-commit command exits 0 silently" \
+  "git status" 0 ""
+
+# ---- Summary ------------------------------------------------------------
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_validate_pr_create_head.sh
+++ b/.claude/hooks/tests/test_validate_pr_create_head.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Tests for validate-pr-create.sh's --head flag handling (#194).
+#
+# Validates that the hook reads the branch from `gh pr create --head <branch>`
+# when present, rather than from `git branch --show-current` against the
+# harness's $PWD. This is the worktree-safe path Agent fan-out workers depend
+# on — the parent session's $PWD is often a sibling worktree, but the
+# command itself carries the truth via --head.
+#
+# Each case:
+#   - builds an isolated sandbox where the LOCAL branch is intentionally
+#     non-conforming (would fail the trailing branch-ID check if used)
+#   - mocks gh so the title's referenced issue resolves OPEN
+#   - pipes a synthetic `gh pr create --head <branch> ...` command
+#   - asserts exit code (0 = pass, 2 = blocked)
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/validate-pr-create.sh"
+LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+
+# shellcheck source=_lib-mock-gh.sh
+source "$(cd "$(dirname "$0")" && pwd)/_lib-mock-gh.sh"
+
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# Build a sandbox where the LOCAL branch is intentionally non-conforming.
+# If the hook resolves from local HEAD (the bug), the trailing branch-ID
+# check fires (rc=2 with "missing ticket ID"). If it resolves from --head,
+# the conforming branch passed via --head wins.
+make_sandbox() {
+  local sb local_branch="${1:-totally-bogus-host-branch}"
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    : > onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+    git checkout -q -B "$local_branch"
+  )
+  mkdir -p "$sb/.claude/hooks"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/validate-pr-create.sh"
+  if [ -f "$LIB_CFG" ]; then cp "$LIB_CFG" "$sb/.claude/hooks/_lib-read-config.sh"; fi
+  if [ -f "$DEFAULTS" ]; then cp "$DEFAULTS" "$sb/.claude/project-config.defaults.json"; fi
+  chmod +x "$sb/.claude/hooks/validate-pr-create.sh"
+  echo "$sb"
+}
+
+# A valid PR body — has Testing + Glossary so the body checks don't fire.
+BODY_OK="## Summary
+test
+
+## Testing
+1. unit tests pass
+
+## Glossary
+| Term | Definition |
+|------|------------|
+| GH-194 | the bug we're fixing |"
+
+run_case() {
+  local label="$1" cmd_extra_flags="$2" want_rc="$3" want_stderr_regex="$4"
+  local sb; sb=$(make_sandbox)
+  mock_gh_install "$sb"
+  local body_file="$sb/body.md"
+  printf '%s' "$BODY_OK" > "$body_file"
+
+  local cmd="gh pr create --repo me2resh/apexyard --title 'fix(#194): test' --body-file $body_file $cmd_extra_flags"
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/validate-pr-create.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc" >&2
+    echo "    extra: $cmd_extra_flags" >&2
+    echo "    stderr: ${got_stderr:0:300}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# -- Cases ---------------------------------------------------------------
+#
+# Local branch in every sandbox is `totally-bogus-host-branch` (no ticket
+# ID). The hook should use --head when present.
+
+# --head with conforming branch → pass.
+run_case "--head feature/GH-194-foo passes" \
+  "--head feature/GH-194-worktree-cwd-hooks" 0 ""
+
+run_case "--head fix/ABC-123-foo passes" \
+  "--head fix/ABC-123-login-bug" 0 ""
+
+# No --head → falls back to local HEAD which is non-conforming → block.
+run_case "no --head: falls back to local HEAD (no ticket ID) → blocks" \
+  "" 2 "missing ticket ID"
+
+# --head with non-conforming branch → blocks (the --head value is the truth).
+run_case "--head bogus-branch blocks (no ticket ID)" \
+  "--head bogus-branch" 2 "missing ticket ID"
+
+# --head with main → exempt (trunk-style branch).
+run_case "--head main is exempt (trunk)" \
+  "--head main" 0 ""
+
+# --head with master → exempt.
+run_case "--head master is exempt" \
+  "--head master" 0 ""
+
+# Make sure --head still works with other flags interleaved.
+run_case "--head later in command line still resolves" \
+  "--head feature/GH-194-foo --draft" 0 ""
+
+run_case "--head before --title still resolves" \
+  "--head feature/GH-194-foo --base dev" 0 ""
+
+# ---- Summary ------------------------------------------------------------
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -18,7 +18,28 @@ if ! echo "$COMMAND" | grep -qE '\bgit\s+push\b'; then
   exit 0
 fi
 
-CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+# Read the branch from the actual push command's source ref when present.
+# This is the worktree-safe path: when an Agent fan-out worker runs `git push
+# origin feature/GH-N-foo` from inside its own worktree, the harness $PWD may
+# be a sibling worktree, so `git branch --show-current` returns the wrong
+# branch. The push command itself carries the truth.
+#
+# Falls back to local HEAD when the push has no source ref (no-arg push,
+# `git push origin` with no ref, etc.) — preserves today's behaviour for
+# anyone not passing the ref explicitly. See me2resh/apexyard#194.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+PUSH_REF=""
+if [ -f "$HOOK_DIR/_lib-extract-push-ref.sh" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$HOOK_DIR/_lib-extract-push-ref.sh"
+  PUSH_REF=$(extract_push_ref "$COMMAND")
+fi
+
+if [ -n "$PUSH_REF" ]; then
+  CURRENT_BRANCH="$PUSH_REF"
+else
+  CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+fi
 
 # Allow trunk and shared integration branches.
 # Match the dev/main release model (apexyard#116) — dev is a valid trunk.

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -31,6 +31,33 @@ if ! echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
   exit 0
 fi
 
+# Heredoc-substitution short-circuit (#194):
+#
+#   git commit -m "$(cat <<'EOF'
+#   feat(#42): subject line
+#   ...
+#   EOF
+#   )"
+#
+# At hook-invocation time the shell hasn't expanded `$(cat <<...)` yet — the
+# hook sees the literal string `$(cat <<'EOF' ... EOF )` as the `-m` value,
+# which obviously can't match the conventional-commit subject regex. Skipping
+# validation here is the right call: the actual subject is in the heredoc
+# body, not in the `-m` argument string the hook can read. Operators who
+# want subject validation on a multi-line message should use the file-based
+# shape (`git commit -F path/to/msg`) — that path goes through the existing
+# -F branch below and gets full validation.
+#
+# Trade-off: this allows a malformed subject through if the heredoc body is
+# itself malformed. Acceptable bounded risk — the heredoc-substitution shape
+# is uncommon (mostly Claude Code's own commit-message authoring path), and
+# the more important goal is keeping the hook from misfiring on a legitimate
+# multi-line commit produced from within a worktree.
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+commit\b[^|;&]*-m\b[^|;&]*\$\(cat[[:space:]]+<<-?[[:space:]]*'\''?[A-Za-z_][A-Za-z0-9_]*'\''?'; then
+  echo "INFO: heredoc-substitution detected in -m; skipping subject validation. Use 'git commit -F <file>' for validation on multi-line messages." >&2
+  exit 0
+fi
+
 # Extract commit message (multi-line safe)
 COMMAND_FLAT=$(echo "$COMMAND" | tr '\n' ' ')
 MSG=""

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -267,8 +267,16 @@ EOF
   fi
 fi
 
-# Validate branch name has ticket ID
-CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+# Validate branch name has ticket ID.
+#
+# Read the branch from the `--head` flag when present, so this hook is
+# safe to run from a different worktree's $PWD (Agent fan-out workers
+# `cd` into their own worktree before running `gh pr create`, but the
+# harness $PWD may still be a sibling worktree's directory). Falls back
+# to local HEAD when `--head` isn't passed — preserves today's behaviour
+# for anyone using the implicit-branch shape. See me2resh/apexyard#194.
+HEAD_FLAG=$(echo "$COMMAND" | sed -nE 's/.*--head[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+CURRENT_BRANCH="${HEAD_FLAG:-$(git branch --show-current 2>/dev/null)}"
 if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "main" ] && [ "$CURRENT_BRANCH" != "master" ]; then
   # Release-cut branches are exempt — same recognition `validate-branch-name.sh`
   # added in me2resh/apexyard#168 / #169. Release branches don't carry a

--- a/docs/agdr/AgDR-0015-command-context-over-pwd-in-hooks.md
+++ b/docs/agdr/AgDR-0015-command-context-over-pwd-in-hooks.md
@@ -1,0 +1,103 @@
+# Resolve git context from the command, not from `$PWD`, in validation hooks
+
+> In the context of three validation hooks (`validate-branch-name.sh`,
+> `validate-pr-create.sh`, `validate-commit-format.sh`) that gate `git push`,
+> `gh pr create`, and `git commit` respectively, facing repeated misfires when
+> `/fan-out` workers ran from sibling worktrees while the harness's `$PWD` was
+> the parent session's directory, I decided to **resolve git context from the
+> command's own arguments first and fall back to `$PWD`-derived state only
+> when the command is silent**, to achieve worktree-safe validation, accepting
+> a small parsing-complexity tax in each hook plus one new shared helper.
+
+## Context
+
+Three independent agents in a recent fan-out session each tripped the same
+class of bug:
+
+- `validate-branch-name.sh` reads the branch from `git branch --show-current`,
+  which resolves against the harness's `$PWD`. A worker that `cd`'d into its
+  own worktree got blocked because the parent `$PWD` was a sibling worktree
+  whose branch happened not to match the convention.
+- `validate-pr-create.sh` did the same lookup for the trailing
+  branch-has-ticket-id check, with the same failure mode under fan-out.
+- `validate-commit-format.sh` blocked legitimate `git commit -m "$(cat <<'EOF'
+  ...EOF)"` heredoc-substitution invocations because the `-m` value the hook
+  read was literal-pre-expansion (`$(cat <<'EOF' ... EOF )`), which
+  obviously doesn't match the conventional-commit subject regex.
+
+Each agent invented a different workaround: branch-rename the host worktree,
+`git -C` to override resolution, drop a sentinel `onboarding.yaml` to satisfy
+the parent-walk, fall back to `gh api .../pulls` to bypass `gh pr create`.
+None of those should have been necessary — and the variety of workarounds
+demonstrates the cost: every agent re-discovers the bug, every workaround is
+invisible to Rex, the worked-around behavior ships, and the hook's enforcement
+is hollow.
+
+Same shape as the `gh api .../pulls/<N>/merge` bypass closed in
+[#47](https://github.com/me2resh/apexyard/issues/47): the hook read
+`$PWD`-derived state instead of parsing the command for the actual context,
+and a tool-surface change (or a new harness pattern like fan-out) silently
+undermined the rule.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Command-arg first, `$PWD` fallback** (chosen) | Worktree-safe in all observed cases. Backwards-compatible — silent-command shapes still resolve via `$PWD` exactly as before. Same shape as `_lib-extract-pr.sh` (#47), so future hook authors have a precedent to follow. Fits cleanly into existing hook structure (a small `extract_*` helper + one `${VAR:-fallback}` line in the hook). | One new helper + parsing tax in three hooks. Heredoc-substitution is a special case (the hook can't read the message; can only detect-and-skip). |
+| **B. Always trust the command, never fall back** | Simpler conceptual model. | Breaking change — silent commands (`git push` with no args, no-`--head` `gh pr create`) would suddenly stop validating. Not acceptable; that's the dominant shape today. |
+| **C. Walk up from FILE_PATH / refer-by-cwd-token** | Could let other hooks reuse the resolved repo root for downstream lookups. | These three hooks gate Bash commands, not Edit/Write/MultiEdit — there's no `FILE_PATH` to walk from. Doesn't apply. |
+| **D. Have the harness export the agent's worktree directory as a hook env var** | One-shot fix — every hook would inherit the right `$PWD` automatically. | Requires a Claude Code harness change, not a framework-side fix. We don't own the harness; can't mandate this. |
+| **E. Run hooks via `git -C "$resolved_root"` everywhere** | Forces all `git` calls to a known root. | Doesn't solve the fundamental problem — `$resolved_root` is computed from `$PWD`, so if `$PWD` is wrong, `$resolved_root` is wrong. Just moves the bug. |
+
+## Decision
+
+Chosen: **Option A — command-arg first, `$PWD` fallback**.
+
+Concretely:
+
+1. New shared helper `_lib-extract-push-ref.sh` parses the source ref out of a
+   `git push` command, returning empty when the command is silent.
+2. `validate-branch-name.sh` sources the helper, takes the push ref when
+   present, falls back to `git branch --show-current` otherwise.
+3. `validate-pr-create.sh` reads `--head` directly via a one-liner sed
+   extraction (the existing hook already does the same for `--repo` and
+   `--title`, so no helper warranted yet — promotable later if a fourth hook
+   needs the same parse).
+4. `validate-commit-format.sh` detects the `git commit -m "$(cat <<EOF ...)"`
+   heredoc-substitution pattern and exits 0 with an INFO message recommending
+   `git commit -F file` for full validation on multi-line subjects.
+
+Backwards compatibility is preserved: every shape that worked before still
+works. Only previously-broken shapes (worktree-isolated fan-out, heredoc
+substitution) move from blocked to allowed.
+
+## Consequences
+
+- Worktree-isolated fan-out workers can `git push`, `gh pr create`, and
+  `git commit -m "$(cat <<'EOF'...)"` without inventing local workarounds.
+  This unblocks the `/fan-out` skill and the parallel-work rule.
+- Future hook authors who write a Bash-gating validator should follow this
+  pattern by default. The README's new "PWD-vs-command-context distinction"
+  section calls this out and lists the existing helpers to centralise the
+  parsing.
+- The heredoc-substitution skip is a small (bounded) softening of
+  `validate-commit-format.sh` — a malformed heredoc body now slips through
+  the subject check. The bound is the heredoc-substitution shape itself; the
+  more common `git commit -F` shape still validates fully, and operators who
+  want validation on a multi-line message have a clear path. Trade-off
+  accepted; rationale in the hook's inline comment.
+- Two new test files (`test_validate_branch_name_pushref.sh`,
+  `test_validate_pr_create_head.sh`, `test_validate_commit_format_heredoc.sh`)
+  pin the new behaviour. The full hook test sweep stays green.
+- The new helper joins `_lib-extract-pr.sh` as a reusable parsing primitive.
+  Same pattern, same tests-co-located convention, same "any change here goes
+  here, not inline in the hooks" rule.
+
+## Artifacts
+
+- Issue: [me2resh/apexyard#194](https://github.com/me2resh/apexyard/issues/194)
+- Related: [me2resh/apexyard#47](https://github.com/me2resh/apexyard/issues/47) (`gh api .../merge` bypass — same root cause class)
+- Helper: `.claude/hooks/_lib-extract-push-ref.sh`
+- Patched hooks: `.claude/hooks/validate-branch-name.sh`, `.claude/hooks/validate-pr-create.sh`, `.claude/hooks/validate-commit-format.sh`
+- Tests: `.claude/hooks/tests/test_validate_branch_name_pushref.sh`, `.claude/hooks/tests/test_validate_pr_create_head.sh`, `.claude/hooks/tests/test_validate_commit_format_heredoc.sh`
+- Doc: `.claude/hooks/README.md` § "PWD-vs-command-context distinction"


### PR DESCRIPTION
## Summary

Validation hooks (`validate-branch-name.sh`, `validate-pr-create.sh`, `validate-commit-format.sh`) historically resolved git context against the harness's `$PWD` via `git branch --show-current` and inline `-m` extraction. Under `/fan-out`, each parallel agent's harness `$PWD` is typically a sibling worktree of the worktree the agent `cd`'d into for its own work — so the hooks read the wrong branch / wrong commit message and blocked legitimate operations with misleading errors. Three independent agents in a recent fan-out session each invented a different workaround (branch rename, `git -C`, sentinel `onboarding.yaml`, fall back to `gh api`).

Same root-cause class as the `gh api .../merge` bypass closed in #47: the hooks gated on `$PWD`-derived state instead of parsing the command for the actual context. Fix shape mirrors that one — **command-arg first, fallback to local context** — preserving today's behaviour for shapes that don't pass the new flags.

- New `_lib-extract-push-ref.sh` helper parses the source ref out of a `git push` command (supports `git push origin <ref>`, refspec form `<src>:<dst>`, `-u` / `--set-upstream`, `--force` / `--force-with-lease`, `HEAD` passthrough, `--delete` bail-out, no-ref fallback). Same shape as `_lib-extract-pr.sh` from #47.
- `validate-branch-name.sh` reads the branch from the helper when present, falls back to `git branch --show-current` otherwise.
- `validate-pr-create.sh` reads the branch from `--head` when present (one-liner sed extraction matching the existing `--repo` / `--title` style), falls back to local HEAD otherwise.
- `validate-commit-format.sh` detects the `git commit -m "$(cat <<'EOF'...)"` heredoc-substitution shape and exits 0 with an INFO message recommending `git commit -F file` for full validation on multi-line messages — the actual subject is in the heredoc body, invisible to the hook.
- `README.md` adds a "PWD-vs-command-context distinction" section so future hook authors have a written precedent (#47 + #194 are both surfaced).
- AgDR-0015 records the command-arg-first / fallback-to-local design call.

Backwards-compat is preserved: silent-command shapes (no `--head`, no source ref) still resolve via the existing `$PWD`-derived path. Only previously-broken shapes (worktree-isolated fan-out, heredoc substitution) move from blocked to allowed.

## Testing

1. Run the new test files:
   ```
   bash .claude/hooks/tests/test_validate_branch_name_pushref.sh   # 15 cases
   bash .claude/hooks/tests/test_validate_pr_create_head.sh        # 8 cases
   bash .claude/hooks/tests/test_validate_commit_format_heredoc.sh # 9 cases
   ```
2. Full hook test sweep: `for t in .claude/hooks/tests/test_*.sh; do bash "$t"; done` — 19 files, 0 failures locally.
3. End-to-end: this PR was pushed via `git push -u origin fix/GH-194-...` from a sibling-worktree harness `$PWD`. Pre-fix that path hard-blocked with the misleading "branch doesn't follow naming convention" message; post-fix the source ref carries the truth.

Closes #194

## Glossary

| Term | Definition |
|------|------------|
| Validation hook | A `PreToolUse` shell script in `.claude/hooks/` that gates a Bash command (`git push`, `gh pr create`, `git commit`) and blocks via exit code 2 when the command violates a rule. |
| Harness `$PWD` | The current working directory the Claude Code harness was sitting in when it dispatched the tool call. Often diverges from the directory the operator `cd`'d into for the actual command — particularly under `/fan-out` where parallel agents work in sibling worktrees. |
| Worktree | A linked checkout of a git repo that shares the same `.git/` storage but has its own branch and working directory. `/fan-out` uses worktrees to isolate parallel agents from each other. |
| Source ref | The local branch name in a `git push origin <ref>` command — what the operator is actually pushing, regardless of the harness's `$PWD`. |
| Heredoc substitution | The `git commit -m "$(cat <<'EOF' ... EOF)"` shape where the `-m` value is a shell command-substitution that hasn't yet expanded at hook-invocation time. The hook sees the literal substitution string, not the expanded message. |
| Fallback to local context | When the command itself doesn't carry the answer (e.g. `git push` with no args), resolving via `$PWD`-derived state (`git branch --show-current`) is the documented fallback — preserves backwards compatibility with shapes that never passed the now-recognised flags. |
