### PR TITLE
feat(#177): /update detects deprecated config keys + offers cleanup

### DIFF
--- a/.claude/hooks/_lib-detect-deprecated-config.sh
+++ b/.claude/hooks/_lib-detect-deprecated-config.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# _lib-detect-deprecated-config.sh — detect override keys absent from defaults
+#
+# Source this library from the /update skill (or any other tool) to surface
+# top-level keys present in `.claude/project-config.json` (the adopter override)
+# that are NOT present in `.claude/project-config.defaults.json` (the upstream-
+# shipped defaults). The classic case is a config block removed upstream — for
+# example `voice_prompts` removed in me2resh/apexyard#157 — that lingers in the
+# adopter's override file as dead config.
+#
+# Output is ADVISORY ONLY. The helper never edits the override file. It just
+# emits a newline-separated list of deprecated key names on stdout. The caller
+# (a skill) decides what to do with that list — typically: prompt the operator
+# y / n / s, then on `y` edit the override JSON via jq.
+#
+# Usage:
+#   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-detect-deprecated-config.sh"
+#   deprecated=$(detect_deprecated_config_keys)
+#   for key in $deprecated; do echo "  - $key (no longer in upstream defaults)"; done
+#
+# Optional second arg lets callers point at non-default file paths (used by
+# tests). When omitted, paths are derived from the repo root.
+#
+# Whitelist: metadata keys whose name starts with `_` (e.g. `_comment`,
+# `_schema_version`) are always ignored. They're documentation / schema-version
+# fields, not deprecated config blocks. The whitelist is intentionally simple —
+# a leading underscore is the framework convention for non-config metadata.
+#
+# Custom-extension keys: an adopter may legitimately add their own top-level
+# keys to the override (custom hooks, in-house extensions). The helper surfaces
+# these the same way it surfaces upstream-removed keys — the caller's job is
+# to make the offer informational, not destructive. The skill prompts y/n/s
+# and the operator decides whether each flagged key is dead or load-bearing.
+
+# ---------------------------------------------------------------------------
+# Internal: resolve repo root when no explicit paths are passed.
+# ---------------------------------------------------------------------------
+_dep_repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Public: detect_deprecated_config_keys [defaults_path] [overrides_path]
+#
+# Emits one deprecated key name per line on stdout.
+# Exit codes:
+#   0 — completed (zero or more keys emitted)
+#   1 — jq missing, or required input file missing — caller should treat
+#       as "skip detection silently" rather than blocking the whole skill.
+#
+# Design notes:
+#   - Reads only TOP-LEVEL keys. The ticket explicitly scopes this to whole-
+#     block removals (e.g. `voice_prompts` as a whole), not to renamed keys
+#     within a still-existing block. That deeper schema-versioning concern
+#     is out of scope for v1 (see ticket § "Out of scope").
+#   - Whitelist is hard-coded to the leading-underscore convention. This is
+#     the simplest workable rule and matches every metadata field the
+#     framework currently ships (`_comment`, `_schema_version`,
+#     `_*_comment`). If the convention ever needs to broaden (adopter-added
+#     allowlist), the function below is the one obvious place to plumb a
+#     second argument.
+# ---------------------------------------------------------------------------
+detect_deprecated_config_keys() {
+  local defaults="${1:-}"
+  local overrides="${2:-}"
+
+  if [ -z "$defaults" ] || [ -z "$overrides" ]; then
+    local root
+    root=$(_dep_repo_root)
+    [ -z "$defaults" ] && defaults="$root/.claude/project-config.defaults.json"
+    [ -z "$overrides" ] && overrides="$root/.claude/project-config.json"
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "WARN: jq not installed; skipping deprecated-config detection." >&2
+    return 1
+  fi
+
+  if [ ! -f "$defaults" ]; then
+    # No defaults file — caller is not in an apexyard-shaped repo.
+    return 1
+  fi
+
+  if [ ! -f "$overrides" ]; then
+    # No override — by definition no deprecated keys to surface.
+    return 0
+  fi
+
+  # jq:
+  #   - keys: top-level key names in each file
+  #   - subtract default keys from override keys
+  #   - filter out leading-underscore metadata
+  #   - emit one per line, sorted for stable output
+  jq -r --slurpfile def "$defaults" '
+    [keys[]] as $okeys
+    | ($def[0] | keys) as $dkeys
+    | $okeys
+    | map(select(
+        (. as $k | $dkeys | index($k) | not)
+        and (startswith("_") | not)
+      ))
+    | sort
+    | .[]
+  ' "$overrides" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Public: show_deprecated_config_keys [defaults_path] [overrides_path]
+#
+# Pretty-prints each deprecated key name and its current value (truncated to
+# the first ~3 lines of jq's compact output) so the operator can decide
+# whether each is dead config or a custom extension before answering y/n.
+#
+# Used by the [s]how branch of the /update prompt.
+# ---------------------------------------------------------------------------
+show_deprecated_config_keys() {
+  local defaults="${1:-}"
+  local overrides="${2:-}"
+
+  if [ -z "$defaults" ] || [ -z "$overrides" ]; then
+    local root
+    root=$(_dep_repo_root)
+    [ -z "$defaults" ] && defaults="$root/.claude/project-config.defaults.json"
+    [ -z "$overrides" ] && overrides="$root/.claude/project-config.json"
+  fi
+
+  local keys
+  keys=$(detect_deprecated_config_keys "$defaults" "$overrides")
+  [ -z "$keys" ] && return 0
+
+  while IFS= read -r key; do
+    [ -z "$key" ] && continue
+    local value
+    value=$(jq --arg k "$key" '.[$k]' "$overrides" 2>/dev/null | head -n 5)
+    echo "  - $key:"
+    echo "$value" | sed 's/^/      /'
+  done <<<"$keys"
+}
+
+# ---------------------------------------------------------------------------
+# Public: remove_deprecated_config_keys [defaults_path] [overrides_path]
+#
+# Edits the override file in place to remove every deprecated top-level key.
+# Caller is expected to have already obtained explicit operator confirmation
+# (the skill's y/n/s prompt) — this function does NOT prompt and does NOT
+# commit. It just rewrites the JSON.
+#
+# Returns the count of removed keys on stdout (so the caller can report
+# "removed N keys" without re-running detection).
+# ---------------------------------------------------------------------------
+remove_deprecated_config_keys() {
+  local defaults="${1:-}"
+  local overrides="${2:-}"
+
+  if [ -z "$defaults" ] || [ -z "$overrides" ]; then
+    local root
+    root=$(_dep_repo_root)
+    [ -z "$defaults" ] && defaults="$root/.claude/project-config.defaults.json"
+    [ -z "$overrides" ] && overrides="$root/.claude/project-config.json"
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "0"
+    return 1
+  fi
+
+  local keys
+  keys=$(detect_deprecated_config_keys "$defaults" "$overrides")
+  if [ -z "$keys" ]; then
+    echo "0"
+    return 0
+  fi
+
+  # Build a jq filter that deletes each deprecated key.
+  #   del(.foo, .bar, .baz)
+  local filter="del("
+  local first=1
+  while IFS= read -r key; do
+    [ -z "$key" ] && continue
+    if [ "$first" -eq 1 ]; then
+      filter="${filter}.\"${key}\""
+      first=0
+    else
+      filter="${filter}, .\"${key}\""
+    fi
+  done <<<"$keys"
+  filter="${filter})"
+
+  local tmp
+  tmp=$(mktemp)
+  if jq "$filter" "$overrides" >"$tmp" 2>/dev/null; then
+    mv "$tmp" "$overrides"
+    # shellcheck disable=SC2126  # `wc -l` is fine here; keys are newline-separated
+    echo "$keys" | grep -c .
+  else
+    rm -f "$tmp"
+    echo "0"
+    return 1
+  fi
+}

--- a/.claude/hooks/tests/test_detect_deprecated_config.sh
+++ b/.claude/hooks/tests/test_detect_deprecated_config.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/_lib-detect-deprecated-config.sh
+#
+# Each case:
+#   - builds a tiny sandbox containing a defaults JSON + an override JSON
+#   - sources the helper and asserts behaviour
+#
+# Exit 0 means all cases passed. Exit 1 on first failure.
+
+set -u
+
+LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-detect-deprecated-config.sh"
+
+if [ ! -f "$LIB_SRC" ]; then
+  echo "FAIL: helper not found at $LIB_SRC" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not installed; skipping deprecated-config detection tests."
+  exit 0
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# ---------------------------------------------------------------------------
+# make_sandbox: build a tmp dir and write defaults + override JSON content
+# passed in $1 (defaults JSON literal) and $2 (override JSON literal).
+# ---------------------------------------------------------------------------
+make_sandbox() {
+  local defaults_json="$1"
+  local overrides_json="$2"
+  local sb
+  sb=$(mktemp -d)
+  sb=$(cd "$sb" && pwd -P)
+  printf '%s\n' "$defaults_json"  > "$sb/defaults.json"
+  printf '%s\n' "$overrides_json" > "$sb/overrides.json"
+  echo "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# run_case <name> <defaults> <overrides> <expected-newline-separated-keys>
+# ---------------------------------------------------------------------------
+run_case() {
+  local name="$1"
+  local defaults_json="$2"
+  local overrides_json="$3"
+  local expected="$4"
+
+  local sb actual
+  sb=$(make_sandbox "$defaults_json" "$overrides_json")
+
+  # shellcheck source=/dev/null
+  . "$LIB_SRC"
+  actual=$(detect_deprecated_config_keys "$sb/defaults.json" "$sb/overrides.json")
+
+  if [ "$actual" = "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  - $name"
+    echo "FAIL: $name"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual:   $(printf '%q' "$actual")"
+  fi
+
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: override has only a known-deprecated key (whole block removed
+# upstream, e.g. voice_prompts after #157) → flagged
+# ---------------------------------------------------------------------------
+run_case "single deprecated key flagged" \
+'{
+  "ticket": {"prefix_whitelist": ["Feature"]},
+  "branch": {"type_whitelist": ["feature"]}
+}' \
+'{
+  "voice_prompts": {"on_pause": "ping"}
+}' \
+'voice_prompts'
+
+# ---------------------------------------------------------------------------
+# Case 2: override has a custom-extension key that isn't in defaults →
+# surfaced (advisory). The detector's job is to flag *anything* not in
+# defaults; the skill's y/n/s prompt is what makes it informational rather
+# than destructive. So this case asserts the key IS surfaced — the
+# operator decides whether to keep it on the [s]how branch.
+# ---------------------------------------------------------------------------
+run_case "custom extension key is surfaced (advisory)" \
+'{
+  "ticket": {"prefix_whitelist": ["Feature"]}
+}' \
+'{
+  "ticket": {"prefix_whitelist": ["Feature", "Custom"]},
+  "my_team_extension": {"foo": "bar"}
+}' \
+'my_team_extension'
+
+# ---------------------------------------------------------------------------
+# Case 3: override has metadata keys (_comment, _schema_version) → NOT flagged
+# ---------------------------------------------------------------------------
+run_case "leading-underscore metadata keys are whitelisted" \
+'{
+  "ticket": {"prefix_whitelist": ["Feature"]}
+}' \
+'{
+  "_comment": "user notes about overrides",
+  "_schema_version": 1,
+  "_team_comment": "more notes",
+  "ticket": {"prefix_whitelist": ["Feature"]}
+}' \
+''
+
+# ---------------------------------------------------------------------------
+# Case 4: override matches defaults' top-level shape → no offer
+# ---------------------------------------------------------------------------
+run_case "override aligned with defaults yields no flags" \
+'{
+  "ticket": {"prefix_whitelist": ["Feature"]},
+  "branch": {"type_whitelist": ["feature"]},
+  "pr": {"required_sections": ["Glossary"]}
+}' \
+'{
+  "ticket": {"prefix_whitelist": ["Feature", "Bug"]},
+  "branch": {"type_whitelist": ["feature", "fix"]}
+}' \
+''
+
+# ---------------------------------------------------------------------------
+# Case 5: multiple deprecated keys are emitted sorted (stable output)
+# ---------------------------------------------------------------------------
+run_case "multiple deprecated keys emitted sorted" \
+'{
+  "ticket": {"prefix_whitelist": ["Feature"]}
+}' \
+'{
+  "voice_prompts": {"on_pause": "ping"},
+  "abandoned_block": {"x": 1},
+  "ticket": {"prefix_whitelist": ["Feature"]}
+}' \
+'abandoned_block
+voice_prompts'
+
+# ---------------------------------------------------------------------------
+# Case 6: missing override file → empty (no flags, no error to caller)
+# ---------------------------------------------------------------------------
+echo
+echo "Case 6: missing override file"
+SB6=$(mktemp -d)
+SB6=$(cd "$SB6" && pwd -P)
+cat > "$SB6/defaults.json" <<'JSON'
+{ "ticket": {"prefix_whitelist": ["Feature"]} }
+JSON
+. "$LIB_SRC"
+out6=$(detect_deprecated_config_keys "$SB6/defaults.json" "$SB6/missing.json")
+rc6=$?
+if [ -z "$out6" ] && [ "$rc6" -eq 0 ]; then
+  PASS=$((PASS + 1))
+  echo "PASS: missing override file -> empty output, exit 0"
+else
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  - missing override file"
+  echo "FAIL: missing override file (out='$out6', rc=$rc6)"
+fi
+rm -rf "$SB6"
+
+# ---------------------------------------------------------------------------
+# Case 7: remove_deprecated_config_keys actually deletes flagged keys
+# ---------------------------------------------------------------------------
+echo
+echo "Case 7: remove_deprecated_config_keys"
+SB7=$(mktemp -d)
+SB7=$(cd "$SB7" && pwd -P)
+cat > "$SB7/defaults.json" <<'JSON'
+{ "ticket": {"prefix_whitelist": ["Feature"]} }
+JSON
+cat > "$SB7/overrides.json" <<'JSON'
+{
+  "_comment": "keep me",
+  "voice_prompts": {"on_pause": "ping"},
+  "abandoned_block": {"x": 1},
+  "ticket": {"prefix_whitelist": ["Feature", "Bug"]}
+}
+JSON
+. "$LIB_SRC"
+removed=$(remove_deprecated_config_keys "$SB7/defaults.json" "$SB7/overrides.json")
+remaining=$(jq -r 'keys | join(",")' "$SB7/overrides.json" 2>/dev/null)
+if [ "$removed" = "2" ] && [ "$remaining" = "_comment,ticket" ]; then
+  PASS=$((PASS + 1))
+  echo "PASS: remove deletes deprecated keys, preserves whitelisted + active"
+else
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  - remove deletes flagged keys"
+  echo "FAIL: removed=$removed remaining=$remaining"
+fi
+rm -rf "$SB7"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "=========================================="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed cases:$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_detect_deprecated_config.sh
+++ b/.claude/hooks/tests/test_detect_deprecated_config.sh
@@ -156,6 +156,7 @@ SB6=$(cd "$SB6" && pwd -P)
 cat > "$SB6/defaults.json" <<'JSON'
 { "ticket": {"prefix_whitelist": ["Feature"]} }
 JSON
+# shellcheck source=/dev/null
 . "$LIB_SRC"
 out6=$(detect_deprecated_config_keys "$SB6/defaults.json" "$SB6/missing.json")
 rc6=$?
@@ -187,6 +188,7 @@ cat > "$SB7/overrides.json" <<'JSON'
   "ticket": {"prefix_whitelist": ["Feature", "Bug"]}
 }
 JSON
+# shellcheck source=/dev/null
 . "$LIB_SRC"
 removed=$(remove_deprecated_config_keys "$SB7/defaults.json" "$SB7/overrides.json")
 remaining=$(jq -r 'keys | join(",")' "$SB7/overrides.json" 2>/dev/null)

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -257,7 +257,70 @@ git checkout main
 git branch -D "$BRANCH"
 ```
 
-### 8. Final state + next steps
+### 8. Detect deprecated config keys (advisory)
+
+After the merge / rebase has applied (so the new `.claude/project-config.defaults.json` is on disk), scan the adopter's `.claude/project-config.json` for **top-level keys that no longer exist in defaults** — typically a config block removed upstream (e.g. `voice_prompts` removed in me2resh/apexyard#157) that still lingers in the override as dead config.
+
+This is **advisory only**. Custom-extension keys an adopter has added (their own hooks, in-house extensions) are also surfaced — the detector cannot tell them apart from upstream-removed keys, and only the operator can. The y/n/s offer below is the human-in-the-loop step that disambiguates.
+
+#### Detection
+
+Source the helper and read the deprecated key list:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-detect-deprecated-config.sh"
+DEPRECATED=$(detect_deprecated_config_keys)
+```
+
+Return values:
+
+- Empty → nothing to surface, skip to step 9.
+- One or more newline-separated key names → continue.
+
+The helper:
+
+- Reads only **top-level** keys (whole-block removals; sub-key renames are out of scope per the ticket).
+- Whitelists metadata keys with a leading underscore (`_comment`, `_schema_version`, `_team_comment`, etc.) — those aren't deprecated config blocks.
+- Returns silently with exit 1 if `jq` is missing or defaults file is absent (skill should skip detection in that case, not fail).
+
+#### Offer
+
+If `DEPRECATED` is non-empty, format and print:
+
+```
+ApexYard /update detected N config block(s) in .claude/project-config.json
+that no longer exist in upstream defaults:
+
+  - voice_prompts
+  - abandoned_block
+
+These keys may be:
+  (a) dead config from a block the framework removed upstream (e.g.
+      voice_prompts after #157), or
+  (b) custom extension keys you've added intentionally.
+
+The detector can't tell them apart — choose:
+
+  [y] yes, remove the listed keys from .claude/project-config.json
+  [n] no, leave them alone (they're harmless; you can clean up later)
+  [s] show me the keys + their current values before deciding
+```
+
+Read the operator's reply.
+
+| Reply | Action |
+|-------|--------|
+| `y` | Run `remove_deprecated_config_keys` (edits `.claude/project-config.json` in place, no commit), then `git add .claude/project-config.json` to stage the change for the operator's review. Print `Removed N keys. Staged for review — diff with: git diff --staged .claude/project-config.json`. |
+| `n` | Print `Leaving override untouched. Re-run /update later if you change your mind.` and continue to step 9. |
+| `s` | Run `show_deprecated_config_keys` (prints each key + current value), then re-prompt with the same y/n options (no `s` recursion). |
+
+The skill **never auto-removes without explicit `y`**. The skill **never auto-commits** — staging is the contract, the operator owns the commit.
+
+#### Why advisory, not destructive
+
+A custom-extension key indistinguishable from an upstream-removed key is a real possibility (e.g. an adopter who's ahead of defaults with their own block). The cost of incorrectly removing a custom block is much higher than the cost of one extra prompt — the y/n/s pattern matches the rest of `/update`'s "operator owns each material change" stance.
+
+### 9. Final state + next steps
 
 On clean completion, print:
 
@@ -307,7 +370,7 @@ BODY
 Skill done. No remote state changed.
 ```
 
-### 9. Edge cases
+### 10. Edge cases
 
 | Situation | Handling |
 |-----------|----------|
@@ -319,6 +382,9 @@ Skill done. No remote state changed.
 | User chose rebase but has 50+ local commits | Warn about rewriting many SHAs, re-confirm |
 | Merge conflict the user aborts | Restore original branch state, delete sync branch, exit 1 |
 | Tracking issue for the sync doesn't exist | Offer to create one via `gh issue create`, get number, continue |
+| `jq` not installed (deprecated-config detection) | Skip step 8 silently; print one-line warning. The sync itself still completes. |
+| `.claude/project-config.json` missing (no override) | Skip step 8 silently — by definition no deprecated keys to surface. |
+| Operator answered `s` (show) | Print key + value, then re-prompt y/n (no `s` recursion). |
 
 ## Design notes
 

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -531,7 +531,7 @@ Every few weeks, pull the latest apexyard improvements into your fork. The easy 
 /update --dry-run    # preview only, no state change
 ```
 
-`/update` does the work of the manual flow below: fetches `upstream`, previews the commit delta, creates a sync branch (because `block-main-push.sh` forbids direct pushes to `main`), merges or rebases, walks through any conflicts with per-file options, and leaves the branch ready to push as a PR. See `.claude/skills/update/SKILL.md` for the full process.
+`/update` does the work of the manual flow below: fetches `upstream`, previews the commit delta, creates a sync branch (because `block-main-push.sh` forbids direct pushes to `main`), merges or rebases, walks through any conflicts with per-file options, surfaces any **deprecated config keys** in your `.claude/project-config.json` that no longer exist in upstream defaults (advisory y/n/s offer — see step 8 of the skill), and leaves the branch ready to push as a PR. See `.claude/skills/update/SKILL.md` for the full process.
 
 If you prefer the raw commands:
 


### PR DESCRIPTION
## Summary

- Extends `/update` (the upstream-sync skill) with a new step 8 that detects **top-level config keys** present in `.claude/project-config.json` but absent from `.claude/project-config.defaults.json` — typically a config block the framework removed upstream (e.g. `voice_prompts` removed in #157) that lingers in the override as dead config.
- Adds `_lib-detect-deprecated-config.sh` with three pure functions: `detect_deprecated_config_keys` (returns the newline-separated list), `show_deprecated_config_keys` (prints each key + current value for the `[s]how` branch), and `remove_deprecated_config_keys` (in-place jq edit, no auto-commit).
- Whitelists leading-underscore metadata keys (`_comment`, `_schema_version`, `_team_comment`, etc.) so they're never flagged.
- The skill offers operator `y / n / s`. `y` removes the keys and stages the change for the operator's review — never auto-commits. `n` leaves the override untouched. `s` shows current values, then re-prompts y/n.
- Detection is **advisory only**. The detector cannot tell upstream-removed keys apart from custom-extension keys an adopter has added intentionally — the human-in-the-loop offer is what disambiguates.

Closes #177

## Testing

1. Run the new test suite — covers seven cases (single deprecated key flagged, custom-extension key surfaced advisorily, metadata whitelist, fully-aligned override produces no offer, multi-key sorted output, missing override file, remove + preserve):
   ```bash
   bash .claude/hooks/tests/test_detect_deprecated_config.sh
   # expect: PASS: 7  FAIL: 0
   ```
2. Run the full hook test sweep to confirm no regressions:
   ```bash
   for t in .claude/hooks/tests/test_*.sh; do echo "=== $(basename $t) ==="; bash "$t" 2>&1 | tail -3; done
   # expect: every test file reports zero failures
   ```
3. Spot-check the helper end-to-end against this fork's own files:
   ```bash
   source .claude/hooks/_lib-detect-deprecated-config.sh
   detect_deprecated_config_keys
   # expect: empty (no override on dev), or just the keys the operator legitimately added
   ```
4. Read the new step 8 in `.claude/skills/update/SKILL.md` and confirm the y/n/s prompt copy matches the ticket AC.

## Glossary

| Term | Definition |
|------|------------|
| deprecated config key | A top-level key in `.claude/project-config.json` that no longer exists in `.claude/project-config.defaults.json`, typically because the framework removed the corresponding block in a release |
| override file | `.claude/project-config.json` — the adopter's per-fork customisation layer, shallow-merged on top of `project-config.defaults.json` |
| advisory detection | A check that surfaces candidates for the operator to confirm, never auto-removing — sibling shape to the rest of `/update`'s "operator owns each material change" stance |
| metadata key | A non-config field whose name starts with `_` (e.g. `_comment`, `_schema_version`); always whitelisted by the detector |
| custom-extension key | A top-level key an adopter has added to the override for their own hooks/skills, indistinguishable from an upstream-removed key without operator input |
