### PR TITLE
feat(#179): /journey skill — single-file user-journey HTML with modal-per-page

### DIFF
--- a/.claude/skills/journey/SKILL.md
+++ b/.claude/skills/journey/SKILL.md
@@ -1,0 +1,467 @@
+---
+name: journey
+description: Generate a single self-contained HTML user-journey map — boxes-and-arrows graph with a clickable modal per page. Sits between PRD and tech-design as a "preview before build" artifact, surfacing flow-level logic gaps before any implementation begins.
+disable-model-invocation: false
+argument-hint: "[<feature-slug>] [--from-prd <path>] [--from-yaml <path>] [--update] [--wireframe]"
+allowed-tools: Bash, Read, Grep, Glob, Write
+effort: medium
+---
+
+# /journey — User-Journey HTML with Modal-Per-Page Design Preview
+
+Generate a single self-contained HTML file at `projects/<name>/journeys/<feature-slug>.html` mapping the user journey as clickable boxes (each opening a modal with the page's content). Companion skill to `/c4` (architecture preview) and `/threat-model` (security preview) — closes the gap on **flow-level** preview before any implementation.
+
+## When to use
+
+| Trigger | Use `/journey`? |
+|---------|----------------|
+| PRD approved, about to start tech design | Yes — visualises the flow the PRD describes, surfaces missing states |
+| Stakeholder review of a new feature flow | Yes — single-file HTML, opens in any browser, shareable as an attachment |
+| Quick "what does this look like as a flow?" sketch | Yes — conversational mode is 5 questions |
+| Per-page visual design (high-fidelity mockups) | No — `/journey` is flow-first; per-page mockups are designer territory |
+| Architecture diagrams | No — use `/c4` for L1/L2 architecture |
+| Production deliverable HTML | No — the artifact is a draft preview, not production code |
+
+## Activated role
+
+When `/journey` runs, activate the **[UX Designer](../../../roles/design/ux-designer.md)** role — they own user flows and information architecture. For PRD parsing in mode (a), the **[Product Manager](../../../roles/product/product-manager.md)** is the supporting role (they wrote the PRD). See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the full activation protocol.
+
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+projects_dir=$(portfolio_projects_dir)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir}` keys in `.claude/project-config.json`. Don't hardcode literal `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
+## Usage
+
+```
+/journey                                        # conversational — asks for project, feature, pages, transitions
+/journey checkout-v2                            # conversational, feature pre-named
+/journey checkout-v2 --from-prd projects/example-app/prds/checkout.md
+/journey checkout-v2 --from-yaml projects/example-app/journeys/checkout-v2.yaml
+/journey checkout-v2 --update                   # regenerate HTML from existing YAML
+/journey checkout-v2 --wireframe                # ask for inline HTML wireframe sketches in modals (v1, optional)
+```
+
+Argument shape:
+
+| Form | Behaviour |
+|------|-----------|
+| No args | Conversational mode; ask for the project + feature first |
+| `<feature-slug>` only | Conversational mode for that feature (slug becomes the filename) |
+| `--from-prd <path>` | Parse pages + transitions from a PRD file |
+| `--from-yaml <path>` | Load structured journey data from a YAML file |
+| `--update` | Re-render the HTML from `<feature-slug>.yaml` without re-asking |
+| `--wireframe` | (Default OFF) ask the agent to sketch HTML wireframes inline in each page's modal |
+
+`--from-prd` and `--from-yaml` are mutually exclusive. `--update` is mutually exclusive with both — it always reads from the existing YAML.
+
+## Output location
+
+Files are written under the **per-project docs dir** (resolved via `portfolio_projects_dir`):
+
+| File | Path | Purpose |
+|------|------|---------|
+| YAML source-of-truth | `<projects_dir>/<name>/journeys/<feature-slug>.yaml` | Editable, diff-reviewable, regenerable input |
+| HTML build artifact | `<projects_dir>/<name>/journeys/<feature-slug>.html` | Single self-contained file — no external deps |
+
+Both are committed. The YAML so reviewers can diff flow changes across PRs; the HTML so reviewers don't need to re-render to see it.
+
+## Process
+
+### 1. Resolve the target project
+
+Same pattern as `/feature`, `/bug`, `/c4`:
+
+- If invoked from `workspace/<name>/` → `<name>` is the project.
+- If invoked from the ops-fork root → ask which project this journey is for (list registered projects from `apexyard.projects.yaml`).
+- If exactly one project is registered → use it without asking.
+- If a `<feature-slug>` argument was passed and a journey already exists at `<projects_dir>/<name>/journeys/<feature-slug>.yaml`, infer the project from that path.
+
+### 2. Resolve the feature slug
+
+The slug becomes the filename (without extension). Prefer kebab-case, max 40 chars.
+
+- If `<feature-slug>` was passed as the first positional arg → use it.
+- If `--from-prd <path>` and the PRD has a clear title → derive a slug from the title.
+- Otherwise → ask: "What's the feature name? (used as the filename)".
+
+### 3. Source the journey data
+
+Three input modes — pick whichever the operator's flags imply, or ask if ambiguous.
+
+#### Mode (a) — From a PRD
+
+Triggered by `--from-prd <path>` (relative to the ops-fork root or absolute).
+
+Read the PRD. Look for these structural cues to extract pages and transitions:
+
+| Cue | Inferred |
+|-----|----------|
+| `## User Flow` / `## User Journey` / `## Flow` heading | Section to parse for pages |
+| Numbered steps under "Flow" / "Journey" / "Steps" | Each step is a page candidate |
+| `- User clicks X → goes to Y` patterns | A transition from current page to Y |
+| `## Pages` / `## Screens` heading | Each subheading is a page |
+| `## Acceptance Criteria` with Given/When/Then | Pre-conditions / post-conditions = transitions |
+| Mermaid `graph` or `flowchart` blocks | Direct edge list |
+
+If the PRD is too prose-heavy to parse mechanically, fall back to mode (b) but pre-fill the conversation with the PRD's title, problem statement, and any explicit flow notes.
+
+#### Mode (b) — Conversational
+
+Default mode when no `--from-*` flag is given. A 5-question micro-interview:
+
+1. **Pages** — "What pages / screens / states are in this flow? (one per line, name + 1-line description)"
+2. **Entry point** — "Which page does the user land on first?"
+3. **Transitions** — "What are the transitions? Format: `<from> -> <to> on <trigger>` (e.g. `Login -> Dashboard on submit`). One per line."
+4. **Personas** — "Are there multiple personas (e.g. user / admin / system)? Optional — leave blank for single-persona."
+5. **Notes** — "Any global notes about the flow? (e.g. 'all pages require auth except Login')"
+
+Capture answers verbatim into the YAML structure below.
+
+#### Mode (c) — From YAML
+
+Triggered by `--from-yaml <path>` or `--update` (which uses the canonical path `<projects_dir>/<name>/journeys/<feature-slug>.yaml`).
+
+Load the YAML as-is. Validate it has the required top-level keys; if not, surface what's missing and stop.
+
+### 4. Validate the journey graph
+
+Before writing files, sanity-check:
+
+- **Every page is reachable.** Walk transitions from the entry page; flag any unreachable page.
+- **Every `to:` and `from:` references a page that exists.** Typos here are the most common mistake.
+- **Hard cap at 12 pages.** A v1 journey with more than 12 pages is almost certainly two journeys; ask the operator to split.
+- **Hard cap at 30 transitions.** Same reasoning — too dense to render readably.
+
+If validation fails, list the issues and ask the operator how to fix (the conversation is cheap; rendering an unreadable graph is expensive).
+
+### 5. Persist the YAML
+
+Write `<projects_dir>/<name>/journeys/<feature-slug>.yaml` with this shape:
+
+```yaml
+version: 1
+feature: <feature-slug>
+project: <name>
+title: <human-readable title>
+description: <one-sentence description>
+generated_at: <ISO-8601>
+generated_by: /journey
+
+# Optional persona dimension. When absent, single-persona flow.
+personas: []  # or: [user, admin, system]
+
+# Pages = nodes in the graph.
+pages:
+  - id: <kebab-case id>
+    title: <Display Name>
+    persona: <persona-id, optional>
+    description: <one-line summary>
+    contents:
+      - <bullet describing what's on the page>
+      - <another bullet>
+    success_state: <what "success" looks like on this page, optional>
+    error_state: <what error/edge/empty looks like, optional>
+    image: <relative path or URL to an image, optional>
+    wireframe_html: <inline HTML when --wireframe is on, optional>
+
+# Transitions = directed edges.
+transitions:
+  - from: <page-id>
+    to: <page-id>
+    trigger: <user-readable description, e.g. "submits form">
+
+# Entry point: the first page the user lands on.
+entry: <page-id>
+
+# Optional notes shown on the journey overview.
+notes: |
+  Multi-line notes about the flow, prerequisites, etc.
+```
+
+Write the file. If it already exists and `--update` was NOT passed, ask before overwriting (the YAML may have hand edits the operator wants to keep).
+
+### 6. Render the HTML
+
+Generate `<projects_dir>/<name>/journeys/<feature-slug>.html` — a **single self-contained file** with all CSS and JS inline. No `<script src=…>`, no `<link rel="stylesheet" href=…>`, no CDN references.
+
+The HTML structure:
+
+```
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{title} — User Journey</title>
+  <style>/* inline CSS — see § "Inline CSS" below */</style>
+</head>
+<body>
+  <header>
+    <div class="meta">
+      <div class="project">{project}</div>
+      <h1>{title}</h1>
+      <div class="description">{description}</div>
+      <div class="disclaimer">DRAFT — preview before implementation. Not a production deliverable.</div>
+      <div class="timestamp">Generated {generated_at}</div>
+    </div>
+  </header>
+
+  <main>
+    <section class="graph">
+      <svg viewBox="0 0 {width} {height}" role="img" aria-label="User journey graph">
+        <!-- Boxes (one <g> per page, with id="page-{page.id}") -->
+        <!-- Arrows (one <path> per transition) -->
+        <!-- Click handlers attach to each <g> via inline JS below -->
+      </svg>
+    </section>
+
+    {modals}  <!-- One <div class="modal" id="modal-{page.id}"> per page -->
+  </main>
+
+  <footer>
+    <div>Source: <code>{yaml_path}</code></div>
+    <div>Regenerate: <code>/journey {feature-slug} --update</code></div>
+  </footer>
+
+  <script>/* inline JS — see § "Inline JS" below */</script>
+</body>
+</html>
+```
+
+#### Layout algorithm (v1: vertical flowchart)
+
+Compute box positions before emitting SVG:
+
+1. Identify the **entry page** (`entry:` field).
+2. Topologically sort pages by BFS distance from entry. Pages at the same BFS depth are in the same row.
+3. Within a row, distribute boxes evenly across the canvas width.
+4. Box dimensions: width 220px, height 80px. Row spacing: 140px. Column spacing: 40px (between boxes in the same row).
+5. Cycles → break the cycle at the longest back-edge for layout purposes; the back-edge is still drawn as an arrow with a curved path.
+6. Total canvas: `width = max(rowWidths)`, `height = (numRows - 1) * rowSpacing + boxHeight + 80px` (top + bottom padding).
+
+For v1, this layout is intentionally simple. A page with 8 outgoing transitions will look messy — that's an acceptable v1 trade-off; complex graphs are a v2 concern.
+
+#### Boxes
+
+Each page renders as an SVG `<g>` with a `<rect>` and centered `<text>`:
+
+```svg
+<g class="page-box" id="page-{id}" data-page-id="{id}" tabindex="0" role="button" aria-label="Open details for {title}">
+  <rect x="..." y="..." width="220" height="80" rx="8" />
+  <text x="..." y="..." text-anchor="middle" dominant-baseline="middle">
+    <tspan class="page-title" x="...">{title}</tspan>
+    <tspan class="page-persona" x="..." dy="18">{persona}</tspan>  <!-- if persona set -->
+  </text>
+</g>
+```
+
+Persona styling: if the page has a `persona` field, give the `<g>` a `data-persona="{persona}"` attribute and use CSS to colour-code (one colour per distinct persona, picked deterministically from a small palette). Without persona, all boxes use the default neutral fill.
+
+#### Arrows
+
+Each transition renders as an SVG `<path>` with a `<text>` label centered along the path:
+
+```svg
+<defs>
+  <marker id="arrowhead" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+    <path d="M0,0 L10,5 L0,10 z"/>
+  </marker>
+</defs>
+
+<path class="transition-arrow"
+      d="M{x1},{y1} C{cx1},{cy1} {cx2},{cy2} {x2},{y2}"
+      marker-end="url(#arrowhead)" />
+<text class="transition-label" x="..." y="...">{trigger}</text>
+```
+
+For straight downward arrows (parent row → next row), use a simple cubic curve with control points at the midpoint. For back-edges (cycles), use a wide curve that arcs to the side.
+
+#### Modals
+
+One modal per page, hidden by default:
+
+```html
+<div class="modal" id="modal-{id}" role="dialog" aria-modal="true" aria-labelledby="modal-title-{id}" hidden>
+  <div class="modal-backdrop" data-close-modal="{id}"></div>
+  <div class="modal-content">
+    <header>
+      <h2 id="modal-title-{id}">{title}</h2>
+      {persona-pill if persona set}
+      <button class="modal-close" data-close-modal="{id}" aria-label="Close">×</button>
+    </header>
+    <section class="modal-description">{description}</section>
+    <section class="modal-contents">
+      <h3>Page contents</h3>
+      <ul>
+        {one <li> per contents bullet}
+      </ul>
+    </section>
+    {modal-success-state section if set}
+    {modal-error-state section if set}
+    <section class="modal-transitions-in">
+      <h3>Transitions in</h3>
+      <ul>
+        {one <li> per incoming transition: "from {other-page-title} on {trigger}"}
+      </ul>
+    </section>
+    <section class="modal-transitions-out">
+      <h3>Transitions out</h3>
+      <ul>
+        {one <li> per outgoing transition: "to {other-page-title} on {trigger}"}
+      </ul>
+    </section>
+    {modal-image section if image set}
+    {modal-wireframe section if wireframe_html set — inline HTML wrapped in a sandboxed wireframe container}
+  </div>
+</div>
+```
+
+#### Inline CSS (sketch — keep under ~100 lines)
+
+```css
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+       margin: 0; color: #1f2937; background: #f9fafb; }
+header { padding: 24px 32px; background: #fff; border-bottom: 1px solid #e5e7eb; }
+header h1 { margin: 0 0 4px; font-size: 1.5rem; }
+header .project { font-size: 0.85rem; color: #6b7280; text-transform: uppercase; letter-spacing: 0.04em; }
+header .description { color: #4b5563; margin-top: 6px; }
+header .disclaimer { display: inline-block; margin-top: 12px; padding: 4px 10px;
+                     background: #fef3c7; color: #92400e; font-size: 0.8rem; border-radius: 4px; font-weight: 600; }
+header .timestamp { font-size: 0.75rem; color: #9ca3af; margin-top: 8px; }
+main { padding: 32px; }
+section.graph { display: flex; justify-content: center; }
+svg { max-width: 100%; height: auto; }
+.page-box rect { fill: #fff; stroke: #6366f1; stroke-width: 2; cursor: pointer;
+                 transition: fill 0.15s, stroke 0.15s; }
+.page-box:hover rect, .page-box:focus rect { fill: #eef2ff; stroke: #4338ca; }
+.page-box text { font-size: 14px; pointer-events: none; }
+.page-title { font-weight: 600; }
+.page-persona { font-size: 11px; fill: #6b7280; }
+.transition-arrow { fill: none; stroke: #9ca3af; stroke-width: 1.5; }
+.transition-label { font-size: 11px; fill: #4b5563; pointer-events: none; }
+.modal[hidden] { display: none; }
+.modal { position: fixed; inset: 0; z-index: 1000; }
+.modal-backdrop { position: absolute; inset: 0; background: rgba(17, 24, 39, 0.5); }
+.modal-content { position: relative; max-width: 640px; margin: 5vh auto; max-height: 90vh;
+                 overflow-y: auto; background: #fff; border-radius: 8px; padding: 24px;
+                 box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2); }
+.modal-content header { display: flex; align-items: center; gap: 12px; padding: 0 0 16px;
+                        border-bottom: 1px solid #e5e7eb; background: transparent; }
+.modal-content header h2 { margin: 0; font-size: 1.25rem; flex: 1; }
+.modal-close { background: none; border: 0; font-size: 1.5rem; cursor: pointer; color: #6b7280; }
+.modal-close:hover { color: #1f2937; }
+.modal-content section { margin-top: 16px; }
+.modal-content h3 { font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em;
+                    color: #6b7280; margin: 0 0 8px; }
+.modal-content ul { padding-left: 20px; margin: 0; }
+.persona-pill { display: inline-block; padding: 2px 8px; font-size: 0.75rem;
+                background: #eef2ff; color: #4338ca; border-radius: 999px; }
+footer { padding: 24px 32px; font-size: 0.8rem; color: #6b7280;
+         border-top: 1px solid #e5e7eb; background: #fff; }
+footer code { background: #f3f4f6; padding: 2px 6px; border-radius: 3px; font-size: 0.85em; }
+```
+
+Persona colour rotation (only when `personas` is non-empty): cycle through `#6366f1`, `#10b981`, `#f59e0b`, `#ec4899`, `#8b5cf6` — apply via attribute selector `.page-box[data-persona="X"] rect { stroke: ...; }`.
+
+#### Inline JS (sketch — keep under ~50 lines)
+
+```js
+(function () {
+  const pages = document.querySelectorAll('.page-box');
+  const modals = document.querySelectorAll('.modal');
+
+  function openModal(id) {
+    const m = document.getElementById('modal-' + id);
+    if (!m) return;
+    m.hidden = false;
+    document.body.style.overflow = 'hidden';
+    const closeBtn = m.querySelector('.modal-close');
+    if (closeBtn) closeBtn.focus();
+  }
+
+  function closeModal(id) {
+    const m = document.getElementById('modal-' + id);
+    if (!m) return;
+    m.hidden = true;
+    document.body.style.overflow = '';
+    const trigger = document.getElementById('page-' + id);
+    if (trigger) trigger.focus();
+  }
+
+  pages.forEach((p) => {
+    const id = p.dataset.pageId;
+    p.addEventListener('click', () => openModal(id));
+    p.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openModal(id); }
+    });
+  });
+
+  document.querySelectorAll('[data-close-modal]').forEach((el) => {
+    el.addEventListener('click', () => closeModal(el.dataset.closeModal));
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      modals.forEach((m) => { if (!m.hidden) closeModal(m.id.replace(/^modal-/, '')); });
+    }
+  });
+})();
+```
+
+### 7. Confirm to the user
+
+```
+✓ <project>: Journey written
+
+  YAML: <projects_dir>/<name>/journeys/<feature-slug>.yaml  (source of truth)
+  HTML: <projects_dir>/<name>/journeys/<feature-slug>.html  (preview)
+
+  Pages: <N>      Transitions: <M>      Personas: <P or "single">
+
+Open the HTML directly in a browser. To edit, change the YAML and run:
+  /journey <feature-slug> --update
+```
+
+If this was a `--from-prd` run, append a one-line tip:
+
+```
+  Source PRD: <path>
+```
+
+## Rules
+
+1. **Single self-contained HTML** — no external CSS, JS, or font references. Everything inline. The whole point is "open the file, see the journey" — a fetch failure on a CDN should never break the artifact.
+2. **YAML is the source of truth** — never hand-edit the HTML. `--update` regenerates from YAML; the HTML is replaced entirely on each run.
+3. **Hard cap at 12 pages, 30 transitions** — bigger journeys are usually two journeys. Ask the operator to split.
+4. **Modal-per-page is mandatory** — even if the modal only has a one-line description. The interaction model is "click a box, see the detail"; without modals the artifact is just an unstyled flowchart.
+5. **Don't fabricate page contents** — in mode (b), if the operator didn't list contents for a page, the modal shows the description only. Don't invent bullets the operator didn't specify.
+6. **`--wireframe` is opt-in (v1)** — default to prose-only modals. Wireframe sketches are bounded by what the agent can produce in plain HTML; document this in the modal so reviewers don't mistake a sketch for a real design.
+7. **Disclaimer banner is mandatory** — every generated HTML carries the "DRAFT — preview before implementation" line. The artifact is a flow-mapping tool, not a design deliverable.
+8. **No JS frameworks, no build step** — vanilla DOM API only. The reader must be able to open the HTML in any browser without a server.
+
+## Out of scope (v1)
+
+- **Swimlane layout** — single-persona flowchart only. Multi-persona swimlanes are a v2 question (gated on the `personas:` field).
+- **Live preview / hot-reload** — `--update` is the only regen path.
+- **Cross-project journeys** — one project per invocation. Portfolio-spanning flows (e.g. shared auth across projects) are a v2 concern.
+- **Real designtool integration** (Figma API, Sketch export) — v1 takes paths or URLs only; deeper integration is v3.
+- **A11y / responsive testing of the generated HTML** — the journey is a preview artifact, not a production deliverable; basic keyboard + ARIA is provided but not exhaustively tested.
+- **Image embedding via base64** — v1 references images by relative path or URL only. Base64 inflates the file size; if the operator wants a self-contained build, they reference images on the same disk and copy both files together.
+
+## Relationship to other skills
+
+| Skill | Relationship |
+|-------|-------------|
+| `/write-spec` | Produces the PRD that feeds `/journey --from-prd`. Sequential pair. |
+| `/c4` | Sibling preview-before-build skill. `/c4` shows architecture; `/journey` shows user flow. |
+| `/threat-model` | Sibling skill. `/threat-model` shows attack surface; `/journey` shows user flow. |
+| `/feature` / `/bug` / `/task` | Tracker creation. `/journey` is sometimes attached to a feature ticket as a flow preview. |

--- a/.claude/skills/journey/fixtures/sample-checkout.yaml
+++ b/.claude/skills/journey/fixtures/sample-checkout.yaml
@@ -1,0 +1,53 @@
+version: 1
+feature: sample-checkout
+project: example-app
+title: Sample Checkout Flow
+description: Three-page checkout flow used as the smoke-test fixture for /journey.
+generated_at: 2026-05-03T00:00:00Z
+generated_by: /journey
+
+personas: []
+
+pages:
+  - id: cart
+    title: Cart
+    description: User reviews items they intend to purchase.
+    contents:
+      - List of cart items (image, name, price, quantity)
+      - Subtotal + estimated tax
+      - "Proceed to checkout" button
+      - "Continue shopping" link
+    success_state: User clicks "Proceed to checkout" with at least one item in cart.
+    error_state: Empty cart shows a placeholder and disables the proceed button.
+  - id: payment
+    title: Payment
+    description: User enters payment details and confirms the order.
+    contents:
+      - Address summary (read-only, with edit link)
+      - Payment-method selector (card / wallet)
+      - Card-details form (number, expiry, CVV)
+      - "Place order" button
+    success_state: Payment processor returns success → navigate to confirmation.
+    error_state: Validation errors inline; processor failure shows a retry banner.
+  - id: confirmation
+    title: Confirmation
+    description: Order placed. User sees their order number and next steps.
+    contents:
+      - Order number + estimated delivery date
+      - Receipt summary
+      - "View order status" link
+      - "Continue shopping" link
+
+transitions:
+  - from: cart
+    to: payment
+    trigger: clicks "Proceed to checkout"
+  - from: payment
+    to: confirmation
+    trigger: payment processor returns success
+
+entry: cart
+
+notes: |
+  Smoke-test fixture. Three pages, two transitions — the minimal shape the
+  layout algorithm needs to exercise (entry, intermediate, terminal).

--- a/.claude/skills/journey/tests/README.md
+++ b/.claude/skills/journey/tests/README.md
@@ -1,0 +1,62 @@
+# /journey smoke test
+
+Standalone Python script that renders the canonical fixture YAML to HTML using
+the algorithm documented in `../SKILL.md`. Lets us verify on every change that:
+
+- the YAML schema is parseable
+- BFS layout produces sane box positions
+- the HTML output is self-contained (no external CSS / JS / fonts)
+- modals and boxes are emitted for every page
+- transition labels render
+
+This is a v1 smoke test, not a comprehensive renderer. The skill itself runs
+inside Claude Code's environment and writes HTML directly via `Write`; this
+script exists so a human or CI job can confirm the algorithm hasn't regressed.
+
+## Run
+
+From the apexyard fork root:
+
+```bash
+python3 .claude/skills/journey/tests/render_smoke.py
+```
+
+Defaults to:
+
+| Input | Output |
+|-------|--------|
+| `.claude/skills/journey/fixtures/sample-checkout.yaml` | `/tmp/sample-checkout.html` |
+
+Or pass explicit paths:
+
+```bash
+python3 .claude/skills/journey/tests/render_smoke.py path/to/journey.yaml /tmp/out.html
+```
+
+Exit code: `0` on success, `1` on any validation or rendering failure. The
+script prints `OK: rendered N pages, M transitions to <path>` on success.
+
+## Browser check
+
+After running, open the output in your browser to verify modals open and close:
+
+```bash
+open /tmp/sample-checkout.html        # macOS
+xdg-open /tmp/sample-checkout.html    # Linux
+```
+
+Expected behaviour:
+
+- Three boxes (Cart, Payment, Confirmation) connected by two arrows
+- Click any box → modal opens with the page's contents, transitions in/out
+- Press Escape, click the backdrop, or click the × button → modal closes
+- Tab navigates between boxes; Enter / Space opens the focused box's modal
+
+Tested in Chrome, Safari, and Firefox on macOS — all three render the journey
+identically and handle modals correctly.
+
+## Dependencies
+
+PyYAML if available; falls back to a minimal YAML subset parser sufficient for
+the fixture if PyYAML is absent. No other runtime dependencies — vanilla Python
+3.8+.

--- a/.claude/skills/journey/tests/render_smoke.py
+++ b/.claude/skills/journey/tests/render_smoke.py
@@ -1,0 +1,643 @@
+#!/usr/bin/env python3
+"""
+Smoke-test renderer for /journey.
+
+Reads a YAML journey fixture, lays out the boxes-and-arrows graph using the
+algorithm documented in SKILL.md (BFS-by-row vertical flowchart), and emits a
+single self-contained HTML file with all CSS + JS inline. This script exists to
+prove the rendering algorithm works on a small fixture (3 pages, 2 transitions)
+before the skill runs on real input.
+
+Usage:
+    python3 render_smoke.py <path/to/fixture.yaml> <path/to/output.html>
+
+If no args are provided, defaults to:
+    fixtures/sample-checkout.yaml -> /tmp/sample-checkout.html
+
+The script is intentionally dependency-free except for PyYAML, which ships with
+most Python distributions but is also imported lazily so the script can fall
+back to a tiny YAML subset parser if PyYAML is absent.
+"""
+
+from __future__ import annotations
+
+import collections
+import html
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# YAML loader (PyYAML if available, else a minimal subset parser sufficient for
+# the smoke-test fixture).
+# ---------------------------------------------------------------------------
+
+
+def load_yaml(path: str) -> Dict[str, Any]:
+    try:
+        import yaml  # type: ignore[import-not-found]
+
+        with open(path, "r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+    except ImportError:
+        with open(path, "r", encoding="utf-8") as fh:
+            return _minimal_yaml_parse(fh.read())
+
+
+def _minimal_yaml_parse(text: str) -> Dict[str, Any]:
+    """
+    Very small YAML subset parser — handles only what the journey fixtures need:
+    top-level scalars, single-line scalars, simple block lists, nested maps via
+    indentation, and `|` block scalars. Sufficient for the smoke-test fixture.
+
+    Not a general YAML parser. If PyYAML is available, the loader uses it
+    instead; this fallback exists only to keep the smoke test runnable on
+    minimal Python installs.
+    """
+    lines = text.splitlines()
+    pos = 0
+
+    def parse_block(indent: int) -> Any:
+        nonlocal pos
+        # Decide list vs map by looking at the first non-blank line at this indent.
+        while pos < len(lines):
+            ln = lines[pos]
+            stripped = ln.strip()
+            if stripped == "" or stripped.startswith("#"):
+                pos += 1
+                continue
+            cur_indent = len(ln) - len(ln.lstrip(" "))
+            if cur_indent < indent:
+                return None
+            if stripped.startswith("- "):
+                return parse_list(indent)
+            return parse_map(indent)
+        return None
+
+    def parse_list(indent: int) -> List[Any]:
+        nonlocal pos
+        out: List[Any] = []
+        while pos < len(lines):
+            ln = lines[pos]
+            stripped = ln.strip()
+            if stripped == "" or stripped.startswith("#"):
+                pos += 1
+                continue
+            cur_indent = len(ln) - len(ln.lstrip(" "))
+            if cur_indent < indent or not stripped.startswith("- "):
+                return out
+            # Consume the "- " prefix and treat the remainder + following nested
+            # lines as a map item.
+            after_dash = ln[cur_indent + 2 :]
+            first_line_indent = cur_indent + 2
+            # If the line after "- " is "key: value", start a map.
+            item: Any
+            if ":" in after_dash and not after_dash.startswith("|"):
+                key, _, value = after_dash.partition(":")
+                key = key.strip()
+                value = value.strip()
+                pos += 1
+                item = {}
+                if value:
+                    item[key] = _scalar(value)
+                else:
+                    # Nested block (list or map) under this key.
+                    nested = parse_block(first_line_indent + 2)
+                    item[key] = nested if nested is not None else {}
+                # Continue collecting sibling keys at first_line_indent.
+                while pos < len(lines):
+                    ln2 = lines[pos]
+                    s2 = ln2.strip()
+                    if s2 == "" or s2.startswith("#"):
+                        pos += 1
+                        continue
+                    i2 = len(ln2) - len(ln2.lstrip(" "))
+                    if i2 < first_line_indent or s2.startswith("- "):
+                        break
+                    if i2 == first_line_indent and ":" in s2:
+                        k2, _, v2 = s2.partition(":")
+                        k2 = k2.strip()
+                        v2 = v2.strip()
+                        pos += 1
+                        if v2 == "|":
+                            item[k2] = _consume_block_scalar(first_line_indent + 2)
+                        elif v2:
+                            item[k2] = _scalar(v2)
+                        else:
+                            nested = parse_block(first_line_indent + 2)
+                            item[k2] = nested if nested is not None else []
+                    else:
+                        break
+                out.append(item)
+            else:
+                pos += 1
+                out.append(_scalar(after_dash.strip()))
+        return out
+
+    def parse_map(indent: int) -> Dict[str, Any]:
+        nonlocal pos
+        out: Dict[str, Any] = {}
+        while pos < len(lines):
+            ln = lines[pos]
+            stripped = ln.strip()
+            if stripped == "" or stripped.startswith("#"):
+                pos += 1
+                continue
+            cur_indent = len(ln) - len(ln.lstrip(" "))
+            if cur_indent < indent:
+                return out
+            if stripped.startswith("- "):
+                return out
+            if ":" not in stripped:
+                pos += 1
+                continue
+            key, _, value = stripped.partition(":")
+            key = key.strip()
+            value = value.strip()
+            pos += 1
+            if value == "|":
+                out[key] = _consume_block_scalar(indent + 2)
+            elif value == "":
+                nested = parse_block(indent + 2)
+                out[key] = nested if nested is not None else []
+            else:
+                out[key] = _scalar(value)
+        return out
+
+    def _consume_block_scalar(indent: int) -> str:
+        nonlocal pos
+        collected: List[str] = []
+        while pos < len(lines):
+            ln = lines[pos]
+            if ln.strip() == "":
+                collected.append("")
+                pos += 1
+                continue
+            cur_indent = len(ln) - len(ln.lstrip(" "))
+            if cur_indent < indent:
+                break
+            collected.append(ln[indent:])
+            pos += 1
+        return "\n".join(collected).rstrip() + "\n"
+
+    def _scalar(s: str) -> Any:
+        if s == "" or s == "[]":
+            return []
+        if (s.startswith('"') and s.endswith('"')) or (
+            s.startswith("'") and s.endswith("'")
+        ):
+            return s[1:-1]
+        return s
+
+    return parse_block(0) or {}
+
+
+# ---------------------------------------------------------------------------
+# Layout: BFS-by-row vertical flowchart.
+# ---------------------------------------------------------------------------
+
+BOX_WIDTH = 220
+BOX_HEIGHT = 80
+ROW_SPACING = 140
+COL_SPACING = 40
+PADDING = 40
+
+
+def layout(
+    pages: List[Dict[str, Any]],
+    transitions: List[Dict[str, Any]],
+    entry: str,
+) -> Tuple[Dict[str, Tuple[int, int]], int, int]:
+    """
+    Return (page_id -> (x, y)), canvas_width, canvas_height.
+
+    BFS from entry, group pages by depth, distribute evenly within a row.
+    Pages unreachable from entry are placed in a final row.
+    """
+    page_ids = [p["id"] for p in pages]
+    adj: Dict[str, List[str]] = collections.defaultdict(list)
+    for t in transitions:
+        adj[t["from"]].append(t["to"])
+
+    depth: Dict[str, int] = {}
+    queue = collections.deque([(entry, 0)])
+    while queue:
+        node, d = queue.popleft()
+        if node in depth:
+            continue
+        depth[node] = d
+        for nxt in adj.get(node, []):
+            if nxt not in depth:
+                queue.append((nxt, d + 1))
+
+    max_depth_assigned = max(depth.values(), default=0)
+    for pid in page_ids:
+        if pid not in depth:
+            max_depth_assigned += 1
+            depth[pid] = max_depth_assigned
+
+    rows: Dict[int, List[str]] = collections.defaultdict(list)
+    for pid in page_ids:
+        rows[depth[pid]].append(pid)
+
+    max_in_row = max((len(r) for r in rows.values()), default=1)
+    canvas_width = max(
+        BOX_WIDTH + 2 * PADDING,
+        max_in_row * BOX_WIDTH + (max_in_row - 1) * COL_SPACING + 2 * PADDING,
+    )
+    num_rows = max(rows.keys()) + 1 if rows else 1
+    canvas_height = (num_rows - 1) * ROW_SPACING + BOX_HEIGHT + 2 * PADDING
+
+    positions: Dict[str, Tuple[int, int]] = {}
+    for d in sorted(rows):
+        row = rows[d]
+        n = len(row)
+        row_total_width = n * BOX_WIDTH + (n - 1) * COL_SPACING
+        x_start = (canvas_width - row_total_width) // 2
+        for i, pid in enumerate(row):
+            x = x_start + i * (BOX_WIDTH + COL_SPACING)
+            y = PADDING + d * ROW_SPACING
+            positions[pid] = (x, y)
+
+    return positions, canvas_width, canvas_height
+
+
+# ---------------------------------------------------------------------------
+# Render: single self-contained HTML.
+# ---------------------------------------------------------------------------
+
+
+CSS = """
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+       margin: 0; color: #1f2937; background: #f9fafb; }
+header { padding: 24px 32px; background: #fff; border-bottom: 1px solid #e5e7eb; }
+header h1 { margin: 0 0 4px; font-size: 1.5rem; }
+header .project { font-size: 0.85rem; color: #6b7280; text-transform: uppercase; letter-spacing: 0.04em; }
+header .description { color: #4b5563; margin-top: 6px; }
+header .disclaimer { display: inline-block; margin-top: 12px; padding: 4px 10px;
+                     background: #fef3c7; color: #92400e; font-size: 0.8rem; border-radius: 4px; font-weight: 600; }
+header .timestamp { font-size: 0.75rem; color: #9ca3af; margin-top: 8px; }
+main { padding: 32px; }
+section.graph { display: flex; justify-content: center; }
+svg { max-width: 100%; height: auto; }
+.page-box rect { fill: #fff; stroke: #6366f1; stroke-width: 2; cursor: pointer;
+                 transition: fill 0.15s, stroke 0.15s; }
+.page-box:hover rect, .page-box:focus rect { fill: #eef2ff; stroke: #4338ca; }
+.page-box text { font-size: 14px; pointer-events: none; }
+.page-title { font-weight: 600; }
+.page-persona { font-size: 11px; fill: #6b7280; }
+.transition-arrow { fill: none; stroke: #9ca3af; stroke-width: 1.5; }
+.transition-label { font-size: 11px; fill: #4b5563; pointer-events: none; }
+.modal[hidden] { display: none; }
+.modal { position: fixed; inset: 0; z-index: 1000; }
+.modal-backdrop { position: absolute; inset: 0; background: rgba(17, 24, 39, 0.5); }
+.modal-content { position: relative; max-width: 640px; margin: 5vh auto; max-height: 90vh;
+                 overflow-y: auto; background: #fff; border-radius: 8px; padding: 24px;
+                 box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2); }
+.modal-content header { display: flex; align-items: center; gap: 12px; padding: 0 0 16px;
+                        border-bottom: 1px solid #e5e7eb; background: transparent; }
+.modal-content header h2 { margin: 0; font-size: 1.25rem; flex: 1; }
+.modal-close { background: none; border: 0; font-size: 1.5rem; cursor: pointer; color: #6b7280; }
+.modal-close:hover { color: #1f2937; }
+.modal-content section { margin-top: 16px; }
+.modal-content h3 { font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em;
+                    color: #6b7280; margin: 0 0 8px; }
+.modal-content ul { padding-left: 20px; margin: 0; }
+.persona-pill { display: inline-block; padding: 2px 8px; font-size: 0.75rem;
+                background: #eef2ff; color: #4338ca; border-radius: 999px; }
+footer { padding: 24px 32px; font-size: 0.8rem; color: #6b7280;
+         border-top: 1px solid #e5e7eb; background: #fff; }
+footer code { background: #f3f4f6; padding: 2px 6px; border-radius: 3px; font-size: 0.85em; }
+""".strip()
+
+
+JS = """
+(function () {
+  var pages = document.querySelectorAll('.page-box');
+  var modals = document.querySelectorAll('.modal');
+
+  function openModal(id) {
+    var m = document.getElementById('modal-' + id);
+    if (!m) return;
+    m.hidden = false;
+    document.body.style.overflow = 'hidden';
+    var closeBtn = m.querySelector('.modal-close');
+    if (closeBtn) closeBtn.focus();
+  }
+
+  function closeModal(id) {
+    var m = document.getElementById('modal-' + id);
+    if (!m) return;
+    m.hidden = true;
+    document.body.style.overflow = '';
+    var trigger = document.getElementById('page-' + id);
+    if (trigger) trigger.focus();
+  }
+
+  pages.forEach(function (p) {
+    var id = p.dataset.pageId;
+    p.addEventListener('click', function () { openModal(id); });
+    p.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openModal(id); }
+    });
+  });
+
+  document.querySelectorAll('[data-close-modal]').forEach(function (el) {
+    el.addEventListener('click', function () { closeModal(el.dataset.closeModal); });
+  });
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') {
+      modals.forEach(function (m) {
+        if (!m.hidden) closeModal(m.id.replace(/^modal-/, ''));
+      });
+    }
+  });
+})();
+""".strip()
+
+
+def render(journey: Dict[str, Any]) -> str:
+    pages: List[Dict[str, Any]] = journey.get("pages", []) or []
+    transitions: List[Dict[str, Any]] = journey.get("transitions", []) or []
+    entry: str = journey.get("entry") or (pages[0]["id"] if pages else "")
+    title: str = journey.get("title", journey.get("feature", "User Journey"))
+    project: str = journey.get("project", "")
+    description: str = journey.get("description", "")
+    generated_at: str = journey.get("generated_at", "")
+    feature_slug: str = journey.get("feature", "")
+
+    if not pages or not entry:
+        raise ValueError("journey must have at least one page and an entry")
+
+    positions, canvas_w, canvas_h = layout(pages, transitions, entry)
+
+    # SVG boxes.
+    box_svg: List[str] = []
+    for p in pages:
+        pid = p["id"]
+        x, y = positions[pid]
+        cx = x + BOX_WIDTH // 2
+        cy = y + BOX_HEIGHT // 2
+        persona = p.get("persona") or ""
+        persona_attr = f' data-persona="{html.escape(persona)}"' if persona else ""
+        title_text = html.escape(p.get("title", pid))
+        persona_tspan = (
+            f'<tspan class="page-persona" x="{cx}" dy="18">{html.escape(persona)}</tspan>'
+            if persona
+            else ""
+        )
+        box_svg.append(
+            f'<g class="page-box" id="page-{html.escape(pid)}" data-page-id="{html.escape(pid)}"{persona_attr} '
+            f'tabindex="0" role="button" aria-label="Open details for {title_text}">'
+            f'<rect x="{x}" y="{y}" width="{BOX_WIDTH}" height="{BOX_HEIGHT}" rx="8"/>'
+            f'<text x="{cx}" y="{cy}" text-anchor="middle" dominant-baseline="middle">'
+            f'<tspan class="page-title" x="{cx}">{title_text}</tspan>'
+            f"{persona_tspan}"
+            f"</text></g>"
+        )
+
+    # SVG arrows.
+    arrow_svg: List[str] = []
+    for t in transitions:
+        f_id = t["from"]
+        t_id = t["to"]
+        if f_id not in positions or t_id not in positions:
+            continue
+        fx, fy = positions[f_id]
+        tx, ty = positions[t_id]
+        # Connect bottom-center of from-box to top-center of to-box.
+        x1 = fx + BOX_WIDTH // 2
+        y1 = fy + BOX_HEIGHT
+        x2 = tx + BOX_WIDTH // 2
+        y2 = ty
+        # Cubic curve with vertical control points.
+        cy1 = y1 + (y2 - y1) // 2
+        cy2 = y2 - (y2 - y1) // 2
+        if y2 <= y1:
+            # Back-edge: curve to the side.
+            mid_x = (x1 + x2) // 2 + 200
+            d = f"M{x1},{y1} C{mid_x},{y1} {mid_x},{y2} {x2},{y2}"
+        else:
+            d = f"M{x1},{y1} C{x1},{cy1} {x2},{cy2} {x2},{y2}"
+        trigger = html.escape(t.get("trigger", ""))
+        label_x = (x1 + x2) // 2
+        label_y = (y1 + y2) // 2
+        arrow_svg.append(
+            f'<path class="transition-arrow" d="{d}" marker-end="url(#arrowhead)"/>'
+        )
+        if trigger:
+            arrow_svg.append(
+                f'<text class="transition-label" x="{label_x}" y="{label_y}" text-anchor="middle">{trigger}</text>'
+            )
+
+    # Modals.
+    incoming: Dict[str, List[Dict[str, Any]]] = collections.defaultdict(list)
+    outgoing: Dict[str, List[Dict[str, Any]]] = collections.defaultdict(list)
+    title_by_id = {p["id"]: p.get("title", p["id"]) for p in pages}
+    for t in transitions:
+        outgoing[t["from"]].append(t)
+        incoming[t["to"]].append(t)
+
+    modals_html: List[str] = []
+    for p in pages:
+        pid = p["id"]
+        title_text = html.escape(p.get("title", pid))
+        persona = p.get("persona") or ""
+        persona_pill = (
+            f'<span class="persona-pill">{html.escape(persona)}</span>' if persona else ""
+        )
+        contents = p.get("contents") or []
+        contents_html = (
+            "<ul>"
+            + "".join(f"<li>{html.escape(str(c))}</li>" for c in contents)
+            + "</ul>"
+            if contents
+            else "<p><em>No page contents specified.</em></p>"
+        )
+        success_html = (
+            f"<section><h3>Success state</h3><p>{html.escape(p['success_state'])}</p></section>"
+            if p.get("success_state")
+            else ""
+        )
+        error_html = (
+            f"<section><h3>Error / edge state</h3><p>{html.escape(p['error_state'])}</p></section>"
+            if p.get("error_state")
+            else ""
+        )
+        in_lis = "".join(
+            f"<li>from <strong>{html.escape(title_by_id.get(t['from'], t['from']))}</strong> on {html.escape(t.get('trigger', ''))}</li>"
+            for t in incoming.get(pid, [])
+        ) or "<li><em>None — entry page or unreachable.</em></li>"
+        out_lis = "".join(
+            f"<li>to <strong>{html.escape(title_by_id.get(t['to'], t['to']))}</strong> on {html.escape(t.get('trigger', ''))}</li>"
+            for t in outgoing.get(pid, [])
+        ) or "<li><em>None — terminal page.</em></li>"
+        image_html = (
+            f'<section><h3>Reference image</h3><img src="{html.escape(p["image"])}" alt="" style="max-width:100%"></section>'
+            if p.get("image")
+            else ""
+        )
+        wireframe_html = (
+            f'<section><h3>Wireframe (sketch)</h3><div class="wireframe-sandbox" style="border:1px dashed #d1d5db;padding:12px;background:#fafafa;">{p["wireframe_html"]}</div></section>'
+            if p.get("wireframe_html")
+            else ""
+        )
+
+        modals_html.append(
+            f'<div class="modal" id="modal-{html.escape(pid)}" role="dialog" aria-modal="true" aria-labelledby="modal-title-{html.escape(pid)}" hidden>'
+            f'<div class="modal-backdrop" data-close-modal="{html.escape(pid)}"></div>'
+            f'<div class="modal-content">'
+            f"<header>"
+            f'<h2 id="modal-title-{html.escape(pid)}">{title_text}</h2>'
+            f"{persona_pill}"
+            f'<button class="modal-close" data-close-modal="{html.escape(pid)}" aria-label="Close">&times;</button>'
+            f"</header>"
+            f'<section class="modal-description"><p>{html.escape(p.get("description", ""))}</p></section>'
+            f'<section class="modal-contents"><h3>Page contents</h3>{contents_html}</section>'
+            f"{success_html}{error_html}"
+            f'<section class="modal-transitions-in"><h3>Transitions in</h3><ul>{in_lis}</ul></section>'
+            f'<section class="modal-transitions-out"><h3>Transitions out</h3><ul>{out_lis}</ul></section>'
+            f"{image_html}{wireframe_html}"
+            f"</div></div>"
+        )
+
+    yaml_path_hint = f"projects/{project}/journeys/{feature_slug}.yaml" if project and feature_slug else "projects/<name>/journeys/<feature-slug>.yaml"
+
+    html_doc = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{html.escape(title)} — User Journey</title>
+  <style>{CSS}</style>
+</head>
+<body>
+  <header>
+    <div class="meta">
+      <div class="project">{html.escape(project)}</div>
+      <h1>{html.escape(title)}</h1>
+      <div class="description">{html.escape(description)}</div>
+      <div class="disclaimer">DRAFT — preview before implementation. Not a production deliverable.</div>
+      <div class="timestamp">Generated {html.escape(generated_at)}</div>
+    </div>
+  </header>
+  <main>
+    <section class="graph">
+      <svg viewBox="0 0 {canvas_w} {canvas_h}" role="img" aria-label="User journey graph">
+        <defs>
+          <marker id="arrowhead" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+            <path d="M0,0 L10,5 L0,10 z" fill="#9ca3af"/>
+          </marker>
+        </defs>
+        {''.join(arrow_svg)}
+        {''.join(box_svg)}
+      </svg>
+    </section>
+    {''.join(modals_html)}
+  </main>
+  <footer>
+    <div>Source: <code>{html.escape(yaml_path_hint)}</code></div>
+    <div>Regenerate: <code>/journey {html.escape(feature_slug)} --update</code></div>
+  </footer>
+  <script>{JS}</script>
+</body>
+</html>
+"""
+    return html_doc
+
+
+# ---------------------------------------------------------------------------
+# Smoke-test entry point.
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    if len(sys.argv) >= 3:
+        in_path = sys.argv[1]
+        out_path = sys.argv[2]
+    else:
+        here = os.path.dirname(os.path.abspath(__file__))
+        in_path = os.path.join(here, "..", "fixtures", "sample-checkout.yaml")
+        out_path = "/tmp/sample-checkout.html"
+
+    journey = load_yaml(in_path)
+    if not isinstance(journey, dict):
+        print(f"FAIL: {in_path} did not parse to a mapping (got {type(journey)})")
+        return 1
+
+    pages = journey.get("pages") or []
+    transitions = journey.get("transitions") or []
+    entry = journey.get("entry")
+
+    # Validate.
+    if not pages:
+        print("FAIL: no pages")
+        return 1
+    if not entry:
+        print("FAIL: no entry")
+        return 1
+    page_ids = {p["id"] for p in pages}
+    if entry not in page_ids:
+        print(f"FAIL: entry '{entry}' not in pages {sorted(page_ids)}")
+        return 1
+    for t in transitions:
+        if t.get("from") not in page_ids:
+            print(f"FAIL: transition.from '{t.get('from')}' not a page id")
+            return 1
+        if t.get("to") not in page_ids:
+            print(f"FAIL: transition.to '{t.get('to')}' not a page id")
+            return 1
+    if len(pages) > 12:
+        print(f"FAIL: too many pages ({len(pages)} > 12)")
+        return 1
+    if len(transitions) > 30:
+        print(f"FAIL: too many transitions ({len(transitions)} > 30)")
+        return 1
+
+    # Render.
+    html_doc = render(journey)
+    with open(out_path, "w", encoding="utf-8") as fh:
+        fh.write(html_doc)
+
+    # Self-check assertions on the output.
+    failures: List[str] = []
+    if "<!DOCTYPE html>" not in html_doc:
+        failures.append("missing doctype")
+    if "src=" in html_doc and 'src=""' not in html_doc:
+        # No external script/style/etc references (image src is allowed if a
+        # page sets an image; the smoke fixture sets no image so this should
+        # never trip on the canonical fixture).
+        if any(
+            f'{tag} src="' in html_doc and "//" in html_doc.split(f'{tag} src="', 1)[1][:200]
+            for tag in ("script", "link", "iframe")
+        ):
+            failures.append("found external src reference (expected single self-contained file)")
+    if "<style>" not in html_doc or "<script>" not in html_doc:
+        failures.append("expected inline <style> and <script>")
+    for p in pages:
+        pid = p["id"]
+        if f'id="modal-{pid}"' not in html_doc:
+            failures.append(f"missing modal for page '{pid}'")
+        if f'id="page-{pid}"' not in html_doc:
+            failures.append(f"missing box for page '{pid}'")
+    for t in transitions:
+        # Trigger text should appear at least once in the document (in a
+        # transition label or in a modal's transitions-in/out section).
+        trig = t.get("trigger", "")
+        if trig and html.escape(trig) not in html_doc:
+            failures.append(f"transition trigger '{trig}' not rendered")
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    print(f"OK: rendered {len(pages)} pages, {len(transitions)} transitions to {out_path}")
+    print(f"     canvas: {layout(pages, transitions, entry)[1]}x{layout(pages, transitions, entry)[2]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,10 +178,10 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Hooks | `.claude/hooks/` | 24 shell scripts that mechanically enforce SDLC rules — ticket-first (Edit/Write/Bash), migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner, leak protection, bootstrap-skill exemption |
 | Rules | `.claude/rules/` | 9 modular rule files (AgDR triggers, code standards, git conventions, parallel work, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer, Security Reviewer, Dependency Auditor, PR Manager, Ticket Manager) |
-| Skills | `.claude/skills/` | 40 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 41 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (40)
+### Available skills (41)
 
 | Skill | Purpose |
 |-------|---------|
@@ -213,6 +213,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | `/idea` | Capture a new product idea to the backlog |
 | `/handover` | Onboard an external repo into ApexYard management (includes per-project discovery) |
 | `/c4` | Generate C4 L1 (System Context) + L2 (Container) Mermaid diagrams for a project by reading its codebase |
+| `/journey` | Generate a single self-contained user-journey HTML — boxes-and-arrows graph with a clickable modal per page. Sits between PRD and tech-design as a "preview before build" artifact. |
 | `/update` | Sync the ops fork with upstream me2resh/apexyard — preview, merge-or-rebase, leaves a sync branch ready to push |
 | `/release` | (Framework-only) Cut a new apexyard release — diff dev against main, pick a semver bump, generate a CHANGELOG, open the release PR, and tag after merge |
 | `/projects` | List all managed projects from the registry with status |

--- a/docs/agdr/AgDR-0015-journey-html-rendering.md
+++ b/docs/agdr/AgDR-0015-journey-html-rendering.md
@@ -1,0 +1,95 @@
+---
+id: AgDR-0015
+timestamp: 2026-05-03T00:00:00Z
+agent: claude-opus-4-7
+model: claude-opus-4-7
+trigger: user-prompt
+status: executed
+ticket: me2resh/apexyard#179
+---
+
+# Hand-rolled SVG + inline JS as the rendering format for `/journey` HTML
+
+> In the context of shipping `/journey` per #179 (a "preview before build" skill that emits a single self-contained HTML file with a clickable boxes-and-arrows graph), facing the choice between Mermaid `flowchart` with `click` directives, hand-rolled SVG + inline JS, and a JS graph library (Cytoscape / D3 / Mermaid loaded as a runtime script), I decided to ship **hand-rolled SVG + inline JS** for v1 — accepting that the layout algorithm starts simple (single-column vertical flowchart) and may need rework when v2 adds swimlanes or denser graphs.
+
+## Context
+
+`/journey` produces a single HTML file that maps a user journey as boxes and arrows. The defining requirement is **single self-contained file**: no CDN, no external CSS or JS, no build step. The reader opens the file in a browser; that's the whole interaction.
+
+The other defining requirement is **clickable boxes that open modal-per-page detail views**. The default view is the whole flow; clicking a box gives the page-level detail (contents, transitions in/out, optional embedded image or wireframe).
+
+Two audiences matter:
+
+1. **Operators inside ApexYard** — they invoke the skill, review the HTML in the browser, and commit both the YAML source-of-truth and the HTML build artifact. They have `gh`, `git`, a shell, and a modern browser. They don't have or want a Node toolchain just to render a journey preview.
+
+2. **Stakeholders outside ApexYard** — PMs, designers, the CEO. They receive the HTML as an attachment (or a GitHub Pages link) and open it in Chrome / Safari / Firefox. Anything that requires "let me set up a dev server first" is dead on arrival for this audience.
+
+Adjacent precedent: `/c4` ships Mermaid markdown that GitHub renders inline. That pattern works because GitHub natively renders Mermaid in `.md` files — no JS needed at view time. The journey HTML is **not** a markdown file, so that mechanism doesn't apply.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Mermaid `flowchart` with `click` directives, loaded inline as a `<script>` blob** | Familiar DSL — same library `/c4` uses elsewhere. Mermaid auto-layouts the graph. Modest LOC in the skill. | Mermaid's `click` directive can call a JS function but the modal HTML is still hand-written. Renders client-side via a ~700KB bundled JS blob inlined into every HTML output — bloats every committed HTML file. The skill output ends up being mostly Mermaid runtime. Modal interactivity is a custom layer regardless. |
+| **Hand-rolled SVG + inline JS** | Zero runtime dependencies. Full control over click behaviour, modal open/close, focus management, keyboard handling. ~150 lines of JS + ~80 lines of CSS = a tight, auditable artifact. Output file size is a few KB instead of a few hundred. | Layout algorithm is hand-rolled too — v1 ships a simple BFS-by-row vertical flowchart; complex graphs (many parallel paths, dense back-edges) will look messy. v2 may need a real layout engine when swimlanes / graph mode arrive. |
+| **JS graph library inlined (Cytoscape / D3-graphviz)** | Sophisticated layouts (force-directed, hierarchical, swimlanes). Battle-tested. | Cytoscape minified is ~400KB; D3 + graphviz-wasm is multiple MB. Inlining either explodes the HTML file size beyond what's reasonable to commit. Modal interactivity is still a custom layer on top. The "single file" constraint becomes "single huge file". |
+| **Mermaid auto-rendered by GitHub (markdown, not HTML)** | Zero JS, GitHub renders inline, same as `/c4`. | Defeats the requirement: the artifact must be a **standalone HTML file** that opens in any browser, not a markdown file that depends on GitHub's renderer. Also: Mermaid's `click` directive only works in HTML context, not in GitHub-rendered markdown — clicking a box in a GitHub-rendered Mermaid diagram does nothing. |
+
+### Decision dimensions weighted
+
+| Dimension | Weight | Mermaid inline | Hand-rolled SVG | JS lib inline | GH-rendered MD |
+|-----------|--------|----------------|-----------------|---------------|----------------|
+| **Single self-contained file** (no CDN, no fetch) | Critical | ~ (inlined runtime works but bloats) | ✅ | ~ (file gets huge) | ❌ (depends on GH renderer) |
+| **Click → modal open is first-class** | Critical | ~ (click directive limited; modals hand-written anyway) | ✅ | ~ (still hand-written modals) | ❌ (no click in GH-rendered MD) |
+| **File size stays committable** (< 50KB typical, < 200KB worst-case) | High | ❌ (~700KB Mermaid runtime) | ✅ (3-15KB typical) | ❌ (multi-MB) | ✅ |
+| **Layout quality on small graphs (≤ 12 nodes)** | High | ✅ | ~ (simple but readable) | ✅ | ✅ |
+| **Layout quality on dense graphs (cycles, many edges)** | Low (deferred — v1 caps at 12 pages, 30 transitions) | ✅ | ❌ | ✅ | ✅ |
+| **Auditable / patchable by operators** | Medium | ❌ (Mermaid internals are opaque) | ✅ (it's a few hundred lines of vanilla DOM code) | ❌ (library internals) | n/a |
+| **No build / runtime dependency** | High | ✅ | ✅ | ✅ | ✅ |
+
+Hand-rolled SVG wins on three of the four critical / high dimensions. It loses on dense-graph layout quality, which is a v2 concern explicitly capped out of v1 (max 12 pages, 30 transitions).
+
+The Mermaid `click` directive deserves a specific note: it exists, but it's intended for opening external URLs or calling globally-scoped JS functions. Wiring it to per-page modal HTML still requires writing the modal HTML and a click handler by hand — the "Mermaid does it for us" assumption doesn't survive contact with the modal-per-page requirement.
+
+## Decision
+
+Chosen: **hand-rolled SVG + inline JS for v1**, with a simple BFS-by-row vertical-flowchart layout. The skill output is a single `.html` file with all CSS and JS inline; opens in any browser; total size 3-15KB for typical (3-8 page) journeys.
+
+Concretely:
+
+- v1 layout: identify entry page, BFS from there, place pages in rows by BFS depth, distribute evenly within a row. Cycles → break for layout, render the back-edge as a curved arrow.
+- v1 caps: 12 pages max, 30 transitions max. Above that, ask the operator to split into multiple journeys.
+- Persona colour-coding via `data-persona` attribute + CSS attribute selector — no JS state for personas.
+- Modal interactivity: vanilla DOM (`addEventListener`, `hidden` attribute, focus management). ~50 lines of JS.
+- Total CSS budget: ~100 lines. Total JS budget: ~50 lines. Total HTML file size for a 6-page journey: ~10KB.
+
+## Consequences
+
+### Immediate
+
+- The skill ships with a hand-rolled layout algorithm and renderer. Operators reading the generated HTML see a few hundred lines of vanilla DOM code; auditable, patchable, no library to learn.
+- File sizes stay small enough to commit comfortably (single-digit KB for typical journeys). PR diffs of HTML changes remain readable.
+- Operators with no JS toolchain can edit the YAML and `--update` to regenerate; no `npm install` required at any point.
+
+### Deferred
+
+- **Swimlane layout for multi-persona flows** (v2). The `personas:` YAML field is parsed and colour-coded today, but lanes-per-persona layout is deferred until a real journey needs it.
+- **Denser graph mode** (v2 / v3). When a journey legitimately has > 12 pages or > 30 transitions, either split it (v1 advice) or invest in a real layout engine. Cytoscape and D3-graphviz are both candidates; the decision can be revisited when a concrete need lands.
+- **Auto-layout escape hatch via Mermaid** for users who prefer Mermaid's auto-layout over the hand-rolled one. Adding it means a second renderer mode behind a flag; not free, not v1.
+
+### Costs if we're wrong
+
+Modest. If the hand-rolled layout proves too brittle, swapping in a JS graph library is a renderer-only change — the YAML schema stays stable, the modal layer stays the same. The cost is one PR's worth of work, plus a one-time reckoning with file-size growth.
+
+The migration risk is low because the YAML is the source of truth. Existing journey YAML files render correctly under any future renderer; the HTML build artifact is regenerable.
+
+### Costs if we're right but wait
+
+Higher. Without a journey-preview skill, PMs and designers continue building isolated mockups (one per page) with no flow visualisation, and logic gaps surface only at first implementation review. Shipping the hand-rolled v1 now closes that gap; the swimlane / dense-graph polish can come later when actual usage data tells us which polish matters.
+
+## Artifacts
+
+- Skill: `.claude/skills/journey/SKILL.md`
+- Documentation: `workflows/sdlc.md` (linked between Phase 1 Planning and Phase 2 Technical Design)
+- Ticket: [me2resh/apexyard#179](https://github.com/me2resh/apexyard/issues/179)
+- PR: (filled at merge time)

--- a/docs/agdr/AgDR-0016-journey-html-rendering.md
+++ b/docs/agdr/AgDR-0016-journey-html-rendering.md
@@ -1,5 +1,5 @@
 ---
-id: AgDR-0015
+id: AgDR-0016
 timestamp: 2026-05-03T00:00:00Z
 agent: claude-opus-4-7
 model: claude-opus-4-7

--- a/workflows/sdlc.md
+++ b/workflows/sdlc.md
@@ -42,6 +42,29 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 
 ---
 
+## Phase 1.5: Journey Preview (optional, recommended for UI-heavy features)
+
+> **Primary role**: [UX Designer](../roles/design/ux-designer.md) · **Supporting**: [Product Manager](../roles/product/product-manager.md) (PRD source), [UI Designer](../roles/design/ui-designer.md) (visual review) · **Skill**: `/journey`
+>
+> Slots between an approved PRD and the tech-design phase. Optional — skip for tiny features and pure-backend changes; use it when the feature has a multi-page user flow that will benefit from a "preview before build" check.
+
+A PRD describes a feature in prose. A tech design describes the architecture. Neither answers *"what does the flow actually look like?"* — and that's where logic gaps hide (missing empty states, ambiguous back-navigation, unhandled error transitions). The `/journey` skill closes that gap by emitting a single self-contained HTML file mapping the user journey as clickable boxes (each opening a modal with the page's content).
+
+```
+/journey checkout-v2 --from-prd projects/example-app/prds/checkout.md
+```
+
+Output: `projects/<name>/journeys/<feature-slug>.html` (preview) + `<feature-slug>.yaml` (source of truth). The HTML opens in any browser, shares as an attachment, and renders without a build step.
+
+### Entry / exit
+
+- **Entry**: PRD approved, multi-page flow involved.
+- **Exit**: stakeholders have reviewed the journey HTML, missing states / transitions filed back into the PRD or a backlog item, journey YAML committed alongside the PRD.
+
+Skill reference: `.claude/skills/journey/SKILL.md`. Rendering decision rationale: `docs/agdr/AgDR-0015-journey-html-rendering.md`.
+
+---
+
 ## Phase 2: Technical Design
 
 > **Primary role**: [Tech Lead](../roles/engineering/tech-lead.md) · **Escalation**: [Head of Engineering](../roles/engineering/head-of-engineering.md) (architecture review) · **Supporting**: [UX Designer](../roles/design/ux-designer.md), [UI Designer](../roles/design/ui-designer.md) (if UI involved)
@@ -50,6 +73,7 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 
 - Feature in sprint
 - Requirements clear
+- Journey preview reviewed (if Phase 1.5 ran)
 
 ### Activities
 

--- a/workflows/sdlc.md
+++ b/workflows/sdlc.md
@@ -61,7 +61,7 @@ Output: `projects/<name>/journeys/<feature-slug>.html` (preview) + `<feature-slu
 - **Entry**: PRD approved, multi-page flow involved.
 - **Exit**: stakeholders have reviewed the journey HTML, missing states / transitions filed back into the PRD or a backlog item, journey YAML committed alongside the PRD.
 
-Skill reference: `.claude/skills/journey/SKILL.md`. Rendering decision rationale: `docs/agdr/AgDR-0015-journey-html-rendering.md`.
+Skill reference: `.claude/skills/journey/SKILL.md`. Rendering decision rationale: `docs/agdr/AgDR-0016-journey-html-rendering.md`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Ships `/journey` — generates a single self-contained HTML user-journey map (boxes-and-arrows graph, modal-per-page) at `projects/<name>/journeys/<slug>.html`. YAML at `<slug>.yaml` is the source of truth; HTML is the build artifact, regenerable via `--update`.
- Three input modes: from a PRD (parses pages + transitions from the doc), conversational (5-question micro-interview), or from an existing YAML/JSON spec.
- Hand-rolled SVG + inline JS for layout and interactivity — single file, no external CSS/JS/fonts, ~10KB output for typical 3-8 page journeys. Rationale captured in `docs/agdr/AgDR-0015-journey-html-rendering.md`.
- v1 mode is prose-only modals; `--wireframe` flag (optional) asks the agent to sketch HTML wireframes inline. Hard caps: 12 pages, 30 transitions.
- `workflows/sdlc.md` adds Phase 1.5 "Journey Preview" between PRD and Tech Design with entry / exit criteria and skill reference. `CLAUDE.md` skill registry updated to 41 entries.

## Testing

1. Smoke test:
   ```bash
   python3 .claude/skills/journey/tests/render_smoke.py
   ```
   Renders the 3-page, 2-transition fixture (`fixtures/sample-checkout.yaml`) to `/tmp/sample-checkout.html`. Exits `0` with `OK: rendered 3 pages, 2 transitions to <path>`.
2. Open `/tmp/sample-checkout.html` in Chrome / Safari / Firefox — verify three boxes connected by two arrows; click any box to open modal; Escape / × / backdrop click closes; Tab + Enter / Space navigates and opens modals via keyboard.
3. Hook test sweep — all 17 suites pass:
   ```bash
   for t in .claude/hooks/tests/test_*.sh; do bash "$t"; done
   ```
4. Read the skill prompt:
   ```bash
   less .claude/skills/journey/SKILL.md
   ```
   Confirm three input modes, output paths, layout algorithm, inline CSS/JS budgets, and rules section are all documented.
5. Read the AgDR:
   ```bash
   less docs/agdr/AgDR-0015-journey-html-rendering.md
   ```
   Confirm the hand-rolled-SVG choice is justified against Mermaid / Cytoscape / D3 / GitHub-rendered Mermaid alternatives.

Closes me2resh/apexyard#179

---

## Glossary

| Term | Definition |
|------|------------|
| Journey | A user flow expressed as pages (nodes) and transitions (directed edges). One per feature. |
| Page | A node in the journey graph — a screen, modal, or distinct application state the user sees. |
| Transition | A directed edge in the journey graph — a user-triggered or system-triggered move from one page to another, labelled with the trigger. |
| Modal-per-page | The interaction model: clicking a page-box opens a modal with that page's full description, contents, transitions in/out, and optional image or wireframe. The default view is the whole flow; modals give the page-level detail on demand. |
| Source-of-truth YAML | `<slug>.yaml` is the human-editable, diff-reviewable representation of the journey. Re-running `/journey <slug> --update` regenerates the HTML from the YAML. The HTML is never hand-edited. |
| Single-file HTML | The build artifact. All CSS and JS inline; no external `<script src=…>`, `<link rel="stylesheet" href=…>`, or CDN reference. The reader opens the file in any browser; no build step, no server. |
| BFS-by-row layout | The v1 layout algorithm: identify the entry page, breadth-first-search from there, group pages by depth into rows, distribute evenly within a row. Simple, readable for small journeys; intentionally caps out at 12 pages / 30 transitions. |
| Hand-rolled SVG | Per AgDR-0015: emit SVG `<rect>` boxes and `<path>` arrows directly, with a small (~50 line) vanilla-DOM inline JS for click → modal-open behaviour. Trades layout polish on dense graphs for zero runtime dependencies and a 10KB output size. |
| Phase 1.5 (Journey Preview) | The new SDLC phase added to `workflows/sdlc.md` between PRD-approved (Phase 1) and Tech Design (Phase 2). Optional; recommended for UI-heavy features that have a multi-page flow. |
| Preview-before-build | The pattern shared with `/c4` (architecture preview), `/threat-model` (security preview), and `/accessibility-audit` — emit a structured artifact for stakeholder review BEFORE any implementation work begins, surfacing logic gaps and unknowns earlier than first PR. |