### PR TITLE
feat(#206): mechanical role-trigger detection with non-blocking reminder injection

### DIFF
--- a/.claude/hooks/detect-role-trigger.sh
+++ b/.claude/hooks/detect-role-trigger.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+# Non-blocking advisory hook: detects role-trigger conditions per
+# .claude/rules/role-triggers.md and emits a system-reminder-style banner
+# naming the role + the file the agent should read before continuing.
+#
+# This hook converts the prose-only role-trigger rule into mechanical
+# enforcement — same shape as check-upstream-drift.sh (advisory banner,
+# exit 0 always). It does NOT block the underlying tool call.
+#
+# Triggers covered in v1 (acceptance criteria for me2resh/apexyard#206):
+#
+#   1. Label-based (Bash → `gh issue edit ... --add-label qa`)
+#        → QA Engineer
+#   2. Diff/path-based (Edit/Write/MultiEdit on auth / crypto / secrets /
+#      .env* paths)
+#        → Security Auditor
+#   3. Prompted (UserPromptSubmit "act as the X" / "as the X" /
+#      "put on your X hat")
+#        → matching role
+#
+# Additional path-based triggers wired up because they fall out of the
+# same plumbing for free:
+#
+#   - .github/workflows/**, golden-paths/pipelines/** → Platform Engineer
+#   - docs/agdr/**                                    → Tech Lead
+#
+# The banner is written to stderr; Claude Code surfaces hook stderr to
+# the assistant as a system-reminder-style note. For UserPromptSubmit,
+# both stdout and stderr are surfaced; we use stderr for consistency
+# with the other advisory hooks.
+#
+# Exit 0 in every path. The hook is purely advisory.
+
+set -u
+
+INPUT=$(cat)
+
+HOOK_EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null)
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+
+# ---------------------------------------------------------------------------
+# Helper: emit one banner line. Multiple triggers in a single call can
+# fire multiple banners.
+#
+# Args:
+#   $1 — role display name (e.g. "Security Auditor")
+#   $2 — role file path relative to repo root (e.g. roles/security/security-auditor.md)
+#   $3 — reason text (e.g. "PR diff touches **/auth/**")
+# ---------------------------------------------------------------------------
+emit_banner() {
+  local role="$1" file="$2" reason="$3"
+  printf 'ROLE TRIGGER: %s activates per .claude/rules/role-triggers.md (%s). Read %s and adopt the role before continuing.\n' \
+    "$role" "$reason" "$file" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Path-based detection (diff-driven triggers).
+#
+# Given a file path, emit banners for every role whose trigger patterns
+# match. Pattern matching uses shell case globs (`*` crosses `/`), which
+# is the same convention used by require-active-ticket.sh and the
+# migration-paths config.
+#
+# Patterns are kept narrow on purpose — over-triggering is acceptable
+# (security auditor can no-op cheaply) but under-triggering defeats the
+# whole point of mechanical enforcement.
+# ---------------------------------------------------------------------------
+detect_path_triggers() {
+  local path="$1"
+  [ -z "$path" ] && return 0
+
+  # Normalise: drop a leading ./ and any leading absolute prefix when it
+  # resolves under the current REPO_ROOT.
+  local rel="$path"
+  case "$rel" in
+    ./*) rel="${rel#./}" ;;
+  esac
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -n "$repo_root" ]; then
+    case "$rel" in
+      "$repo_root"/*) rel="${rel#$repo_root/}" ;;
+    esac
+  fi
+
+  # Security Auditor — auth / crypto / secrets / .env*
+  case "$rel" in
+    *auth/*|*auth|auth/*|*/auth/*|\
+    *crypto/*|*crypto|crypto/*|*/crypto/*|\
+    *secrets/*|*secrets|secrets/*|*/secrets/*|\
+    .env|.env.*|*/.env|*/.env.*)
+      emit_banner \
+        "Security Auditor" \
+        "roles/security/security-auditor.md" \
+        "edit touches security-sensitive path ($rel)"
+      ;;
+  esac
+
+  # Platform Engineer — CI/CD pipelines + golden-path templates
+  case "$rel" in
+    .github/workflows/*|*/.github/workflows/*|\
+    golden-paths/pipelines/*|*/golden-paths/pipelines/*)
+      emit_banner \
+        "Platform Engineer" \
+        "roles/engineering/platform-engineer.md" \
+        "edit touches CI/CD pipeline ($rel)"
+      ;;
+  esac
+
+  # Tech Lead — architecture decisions
+  case "$rel" in
+    docs/agdr/*|*/docs/agdr/*)
+      emit_banner \
+        "Tech Lead" \
+        "roles/engineering/tech-lead.md" \
+        "edit touches docs/agdr/ (architecture decision)"
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Label-based detection (gh-issue-edit triggers).
+#
+# Parses a Bash command for `gh issue edit ... --add-label <label>`
+# and fires the role attached to that label. The label arg can take
+# `--add-label foo` or `--add-label foo,bar` (comma list).
+# ---------------------------------------------------------------------------
+detect_label_triggers() {
+  local cmd="$1"
+  [ -z "$cmd" ] && return 0
+
+  # Only inspect `gh issue edit` shapes — keep the matcher narrow so
+  # `gh issue create --label qa` (a NEW ticket with the qa label) doesn't
+  # spuriously fire the QA Engineer trigger. (Trigger semantics from the
+  # role-triggers table: "ticket moved to qa label", i.e. transition, not
+  # initial create.)
+  if ! printf '%s' "$cmd" | grep -qE '\bgh[[:space:]]+issue[[:space:]]+edit\b'; then
+    return 0
+  fi
+
+  # Extract every `--add-label <value>` argument and split on commas.
+  # macOS-compatible: -oE for grep then sed for splitting.
+  local labels
+  labels=$(printf '%s' "$cmd" \
+    | grep -oE -- '--add-label[[:space:]=]+[^[:space:]]+' \
+    | sed -E 's/^--add-label[[:space:]=]+//; s/,/ /g' \
+    | tr '\n' ' ')
+  [ -z "$labels" ] && return 0
+
+  for label in $labels; do
+    case "$label" in
+      qa|QA)
+        emit_banner \
+          "QA Engineer" \
+          "roles/engineering/qa-engineer.md" \
+          "ticket moved to 'qa' label"
+        ;;
+    esac
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Prompted-activation detection (UserPromptSubmit).
+#
+# Scans the user's prompt for:
+#   - "act as the X"
+#   - "as the X"
+#   - "put on your X hat"
+# where X matches a known role name. Match is case-insensitive.
+#
+# The known-roles table is hard-coded here (not config-driven) — the role
+# files themselves are upstream framework, and the table mirrors the
+# Activation Table in .claude/rules/role-triggers.md.
+# ---------------------------------------------------------------------------
+ROLES_TABLE='
+qa engineer|roles/engineering/qa-engineer.md
+qa|roles/engineering/qa-engineer.md
+security auditor|roles/security/security-auditor.md
+penetration tester|roles/security/penetration-tester.md
+pen tester|roles/security/penetration-tester.md
+head of security|roles/security/head-of-security.md
+tech lead|roles/engineering/tech-lead.md
+head of engineering|roles/engineering/head-of-engineering.md
+backend engineer|roles/engineering/backend-engineer.md
+frontend engineer|roles/engineering/frontend-engineer.md
+platform engineer|roles/engineering/platform-engineer.md
+sre|roles/engineering/sre.md
+head of product|roles/product/head-of-product.md
+product manager|roles/product/product-manager.md
+product analyst|roles/product/product-analyst.md
+head of design|roles/design/head-of-design.md
+ui designer|roles/design/ui-designer.md
+ux designer|roles/design/ux-designer.md
+head of data|roles/data/head-of-data.md
+data analyst|roles/data/data-analyst.md
+data engineer|roles/data/data-engineer.md
+'
+
+detect_prompt_triggers() {
+  local prompt="$1"
+  [ -z "$prompt" ] && return 0
+
+  # Normalise: lowercase, replace common punctuation with spaces, then
+  # collapse whitespace. Done once up-front so each regex doesn't have
+  # to redo it. Punctuation→space lets "as the Security Auditor, please"
+  # match the trailing-space anchor used by the role patterns.
+  local norm
+  norm=$(printf '%s' "$prompt" \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr ',.;:!?()[]{}"'"'" ' ' \
+    | tr -s '[:space:]' ' ')
+
+  # Iterate the roles table. The first match wins per role; if the user
+  # mentions "QA Engineer" we'll fire on the longer phrase before the
+  # bare "qa" form catches it.
+  local fired=""
+  while IFS='|' read -r pattern file; do
+    [ -z "$pattern" ] && continue
+
+    # Skip roles we've already fired for in this prompt (de-dupe).
+    case "$fired" in *"|$file|"*) continue ;; esac
+
+    # Three phrase shapes the activation rule documents:
+    #   "act as the <role>"
+    #   "as the <role>"          (handles "review this as the security auditor")
+    #   "put on your <role> hat"
+    # All matched at word boundaries via spaces.
+    local hit=0
+    if printf ' %s ' "$norm" | grep -qE "[[:space:]]act as (the|a|an) ${pattern}[[:space:]]"; then
+      hit=1
+    elif printf ' %s ' "$norm" | grep -qE "[[:space:]]as (the|a|an) ${pattern}[[:space:]]"; then
+      hit=1
+    elif printf ' %s ' "$norm" | grep -qE "[[:space:]]put on (your|the) ${pattern} hat[[:space:]]"; then
+      hit=1
+    fi
+
+    if [ "$hit" = "1" ]; then
+      # Capitalise the pattern for the display name (simple title-case).
+      local display
+      display=$(printf '%s' "$pattern" | awk '{for(i=1;i<=NF;i++)$i=toupper(substr($i,1,1)) substr($i,2);print}')
+      emit_banner \
+        "$display" \
+        "$file" \
+        "prompted activation ('$pattern')"
+      fired="${fired}|$file|"
+    fi
+  done <<EOF
+$ROLES_TABLE
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch on hook event.
+# ---------------------------------------------------------------------------
+case "$HOOK_EVENT" in
+  UserPromptSubmit)
+    prompt=$(printf '%s' "$INPUT" | jq -r '.prompt // empty' 2>/dev/null)
+    detect_prompt_triggers "$prompt"
+    ;;
+  PreToolUse|PostToolUse|"")
+    # Hook event name was missing on some older harness versions — fall
+    # back to tool-name dispatch.
+    case "$TOOL_NAME" in
+      Edit|Write|MultiEdit)
+        FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+        detect_path_triggers "$FILE_PATH"
+        ;;
+      Bash)
+        COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+        detect_label_triggers "$COMMAND"
+        ;;
+    esac
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/detect-role-trigger.sh
+++ b/.claude/hooks/detect-role-trigger.sh
@@ -84,10 +84,11 @@ detect_path_triggers() {
   fi
 
   # Security Auditor — auth / crypto / secrets / .env*
+  # Patterns anchored to path boundaries to avoid matching e.g. "author.tsx" or "myauth".
   case "$rel" in
-    *auth/*|*auth|auth/*|*/auth/*|\
-    *crypto/*|*crypto|crypto/*|*/crypto/*|\
-    *secrets/*|*secrets|secrets/*|*/secrets/*|\
+    auth|auth/*|*/auth|*/auth/*|\
+    crypto|crypto/*|*/crypto|*/crypto/*|\
+    secrets|secrets/*|*/secrets|*/secrets/*|\
     .env|.env.*|*/.env|*/.env.*)
       emit_banner \
         "Security Auditor" \

--- a/.claude/hooks/tests/test_detect_role_trigger.sh
+++ b/.claude/hooks/tests/test_detect_role_trigger.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/detect-role-trigger.sh — verifies the
+# three trigger families called out in me2resh/apexyard#206:
+#
+#   1. Label-based  (Bash → gh issue edit ... --add-label qa)
+#   2. Diff/path    (Edit/Write/MultiEdit on **/auth/**, .env*, etc.)
+#   3. Prompted     (UserPromptSubmit "act as the X")
+#
+# Each case pipes a synthetic hook payload into the script and asserts:
+#   - exit code is 0 (non-blocking — advisory only)
+#   - stderr matches the expected ROLE TRIGGER banner (or is silent when
+#     no trigger applies)
+#
+# Test style matches the existing tests/*.sh — bash + jq + grep, no
+# external test framework.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK="$SRC_ROOT/.claude/hooks/detect-role-trigger.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook is not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED=""
+
+# run_case <label> <expected_rc> <expected_stderr_regex|""> <json_input>
+#
+# Empty regex string means "expect silent" — stderr must be empty.
+run_case() {
+  local label="$1" want_rc="$2" want_regex="$3" input="$4"
+  local got_stderr got_rc
+
+  got_stderr=$(printf '%s' "$input" | bash "$HOOK" 2>&1 >/dev/null)
+  got_rc=$?
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:200})" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "; return
+  fi
+
+  if [ -z "$want_regex" ]; then
+    if [ -n "$got_stderr" ]; then
+      echo "FAIL [$label]: expected silent, got: $got_stderr" >&2
+      FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "; return
+    fi
+    echo "PASS [$label] — silent"
+    PASS=$((PASS+1)); return
+  fi
+
+  if echo "$got_stderr" | grep -qE "$want_regex"; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1)); return
+  fi
+
+  echo "FAIL [$label]: stderr did not match /$want_regex/" >&2
+  echo "    stderr: $got_stderr" >&2
+  FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+}
+
+# --- (1) Label-based trigger — QA Engineer -----------------------------------
+
+# 1a. `gh issue edit --add-label qa` → QA Engineer banner.
+in=$(jq -nc \
+  --arg c "gh issue edit 42 --add-label qa" \
+  '{hook_event_name:"PreToolUse", tool_name:"Bash", tool_input:{command:$c}}')
+run_case "label trigger: qa label fires QA Engineer" 0 \
+  "ROLE TRIGGER: QA Engineer.*roles/engineering/qa-engineer\\.md" "$in"
+
+# 1b. `gh issue edit --add-label foo,qa,bar` → QA Engineer banner (comma list).
+in=$(jq -nc \
+  --arg c "gh issue edit 42 --add-label foo,qa,bar" \
+  '{hook_event_name:"PreToolUse", tool_name:"Bash", tool_input:{command:$c}}')
+run_case "label trigger: qa in comma list fires QA Engineer" 0 \
+  "ROLE TRIGGER: QA Engineer" "$in"
+
+# 1c. `gh issue edit --add-label bug` → silent (no role for bug label in v1).
+in=$(jq -nc \
+  --arg c "gh issue edit 42 --add-label bug" \
+  '{hook_event_name:"PreToolUse", tool_name:"Bash", tool_input:{command:$c}}')
+run_case "label trigger: non-mapped label is silent" 0 "" "$in"
+
+# 1d. `gh issue create --label qa` → silent (CREATE, not EDIT — trigger
+# semantics are transition only, see hook comment).
+in=$(jq -nc \
+  --arg c "gh issue create --label qa --title 'x' --body 'y'" \
+  '{hook_event_name:"PreToolUse", tool_name:"Bash", tool_input:{command:$c}}')
+run_case "label trigger: issue CREATE with qa label is silent (not a transition)" 0 "" "$in"
+
+# 1e. Non-gh command with the word 'qa' in it → silent.
+in=$(jq -nc \
+  --arg c "echo qa pass" \
+  '{hook_event_name:"PreToolUse", tool_name:"Bash", tool_input:{command:$c}}')
+run_case "label trigger: unrelated qa string is silent" 0 "" "$in"
+
+# --- (2) Diff/path-based trigger — Security Auditor --------------------------
+
+# 2a. Edit on src/auth/login.ts → Security Auditor banner.
+in=$(jq -nc \
+  --arg p "src/auth/login.ts" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "path trigger: src/auth/* fires Security Auditor" 0 \
+  "ROLE TRIGGER: Security Auditor.*roles/security/security-auditor\\.md" "$in"
+
+# 2b. Write on packages/api/src/auth/jwt.ts → Security Auditor.
+in=$(jq -nc \
+  --arg p "packages/api/src/auth/jwt.ts" \
+  '{hook_event_name:"PreToolUse", tool_name:"Write", tool_input:{file_path:$p}}')
+run_case "path trigger: deep auth/ path fires Security Auditor" 0 \
+  "ROLE TRIGGER: Security Auditor" "$in"
+
+# 2c. Edit on .env.production → Security Auditor.
+in=$(jq -nc \
+  --arg p ".env.production" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "path trigger: .env.* fires Security Auditor" 0 \
+  "ROLE TRIGGER: Security Auditor" "$in"
+
+# 2d. Edit on src/crypto/hash.ts → Security Auditor.
+in=$(jq -nc \
+  --arg p "src/crypto/hash.ts" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "path trigger: crypto/ fires Security Auditor" 0 \
+  "ROLE TRIGGER: Security Auditor" "$in"
+
+# 2e. Edit on src/utils/format.ts → silent (no security-sensitive segment).
+in=$(jq -nc \
+  --arg p "src/utils/format.ts" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "path trigger: ordinary path is silent" 0 "" "$in"
+
+# 2f. Edit on .github/workflows/ci.yml → Platform Engineer banner.
+in=$(jq -nc \
+  --arg p ".github/workflows/ci.yml" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "path trigger: .github/workflows/* fires Platform Engineer" 0 \
+  "ROLE TRIGGER: Platform Engineer.*roles/engineering/platform-engineer\\.md" "$in"
+
+# 2g. Edit on docs/agdr/AgDR-0007-something.md → Tech Lead.
+in=$(jq -nc \
+  --arg p "docs/agdr/AgDR-0099-test.md" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "path trigger: docs/agdr/* fires Tech Lead" 0 \
+  "ROLE TRIGGER: Tech Lead.*roles/engineering/tech-lead\\.md" "$in"
+
+# --- (3) Prompted-activation trigger -----------------------------------------
+
+# 3a. "Act as the QA Engineer …" → QA Engineer banner.
+in=$(jq -nc \
+  --arg prm "Act as the QA Engineer and verify ticket 42" \
+  '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
+run_case "prompt trigger: 'act as the QA Engineer' fires QA Engineer" 0 \
+  "ROLE TRIGGER: Qa Engineer.*roles/engineering/qa-engineer\\.md" "$in"
+
+# 3b. "As the Security Auditor …" → Security Auditor banner.
+in=$(jq -nc \
+  --arg prm "As the Security Auditor, please check this PR for OWASP issues" \
+  '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
+run_case "prompt trigger: 'as the Security Auditor' fires Security Auditor" 0 \
+  "ROLE TRIGGER: Security Auditor" "$in"
+
+# 3c. "Put on your Tech Lead hat …" → Tech Lead banner.
+in=$(jq -nc \
+  --arg prm "Put on your Tech Lead hat and review this PR" \
+  '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
+run_case "prompt trigger: 'put on your Tech Lead hat' fires Tech Lead" 0 \
+  "ROLE TRIGGER: Tech Lead" "$in"
+
+# 3d. Mixed case + extra whitespace → still fires.
+in=$(jq -nc \
+  --arg prm "  ACT  AS  THE  qa  engineer  please" \
+  '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
+run_case "prompt trigger: case + whitespace tolerant" 0 \
+  "ROLE TRIGGER: Qa Engineer" "$in"
+
+# 3e. Plain question — silent.
+in=$(jq -nc \
+  --arg prm "What is the weather today?" \
+  '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
+run_case "prompt trigger: unrelated prompt is silent" 0 "" "$in"
+
+# 3f. Mention of QA without activation phrase — silent.
+in=$(jq -nc \
+  --arg prm "The QA team asked about ticket 42" \
+  '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
+run_case "prompt trigger: passing mention is silent" 0 "" "$in"
+
+# --- Non-blocking guarantee --------------------------------------------------
+# Even when the hook fires, exit code is 0 — the underlying tool call
+# proceeds.
+in=$(jq -nc \
+  --arg p "src/auth/login.ts" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+got_rc=$(printf '%s' "$in" | bash "$HOOK" >/dev/null 2>&1; echo $?)
+if [ "$got_rc" = "0" ]; then
+  echo "PASS [non-blocking: hook exits 0 even on trigger]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [non-blocking: expected rc=0, got $got_rc]" >&2
+  FAIL=$((FAIL+1)); FAILED="${FAILED}non-blocking "
+fi
+
+# --- Summary -----------------------------------------------------------------
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/rules/role-triggers.md
+++ b/.claude/rules/role-triggers.md
@@ -105,3 +105,23 @@ Roles deliver concrete artefacts at each handoff point. These are the contracts 
 Before this rule existed, the 19 role files were passive markdown docs — no trigger, no activation, no automatic reference from workflows or skills. A user had to manually say *"please read `roles/engineering/qa-engineer.md` and act as the QA Engineer"* for anything to happen.
 
 This file closes that gap. When in a Claude Code session under apexyard, the trigger table drives which role activates, and the workflow and skill files now explicitly reference the role files at every phase boundary. Roles are now **first-class participants** in the SDLC, not reference material.
+
+### Mechanical backstop — `detect-role-trigger.sh`
+
+Self-discipline (the agent remembering to read the role file when the rule fires) is the primary mechanism. The framework also ships a mechanical backstop: `.claude/hooks/detect-role-trigger.sh` scans for trigger conditions on every relevant tool call and emits a system-reminder-style banner naming the role + the file to read.
+
+Same advisory shape as `check-upstream-drift.sh` — non-blocking, exit 0 always. The banner cannot force the agent to adopt the role, but it removes the "I forgot the rule applied here" failure mode.
+
+Triggers wired in v1 (me2resh/apexyard#206):
+
+| Trigger family | Hook event | Detection | Role |
+|----------------|------------|-----------|------|
+| Label-based  | `PreToolUse` on `Bash` (matcher: `gh issue edit *`) | `--add-label qa` (single or comma list) | QA Engineer |
+| Diff/path    | `PreToolUse` on `Edit` / `Write` / `MultiEdit` | path contains `auth/`, `crypto/`, `secrets/`, `.env*` | Security Auditor |
+| Diff/path    | same | path under `.github/workflows/` or `golden-paths/pipelines/` | Platform Engineer |
+| Diff/path    | same | path under `docs/agdr/` | Tech Lead |
+| Prompted     | `UserPromptSubmit` | "act as the X" / "as the X" / "put on your X hat" (case-insensitive, X matches any role in the activation table) | the named role |
+
+Triggers from the table above that are **not** yet mechanically detected (e.g. "production incident mentioned" → SRE, "new PRD drafted" → Product Manager) still rely on self-discipline; the hook can be extended without changing the surrounding wiring.
+
+Tests live at `.claude/hooks/tests/test_detect_role_trigger.sh` and cover the three trigger families the acceptance criteria call out.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,10 @@
           {
             "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
           }
         ]
       },
@@ -162,6 +166,21 @@
           {
             "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh issue edit *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Adds `.claude/hooks/detect-role-trigger.sh` — a non-blocking advisory hook (same shape as `check-upstream-drift.sh`) that detects role-trigger conditions per `.claude/rules/role-triggers.md` and emits a `ROLE TRIGGER:` banner naming the role + the file to read.
- Wired into `PreToolUse(Edit|Write|MultiEdit)`, `PreToolUse(Bash → gh issue edit *)`, and `UserPromptSubmit` so the three documented trigger families (diff-based, label-based, prompted) are all covered.
- Updates `.claude/rules/role-triggers.md` § "Aspirational → Real" to document the mechanical backstop and list the wired triggers.

## Testing

1. Run the new test suite: `bash .claude/hooks/tests/test_detect_role_trigger.sh` → 19 cases pass, including silent-on-unrelated-input for every trigger family.
2. Re-run the surrounding test suites (each `tests/test_*.sh`) to confirm no regression in adjacent hooks.
3. Manual smoke (optional):
   - `printf '{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"src/auth/login.ts"}}' | bash .claude/hooks/detect-role-trigger.sh 2>&1` → expect a Security Auditor banner, exit 0.
   - `printf '{"hook_event_name":"UserPromptSubmit","prompt":"Act as the QA Engineer"}' | bash .claude/hooks/detect-role-trigger.sh 2>&1` → expect a QA Engineer banner, exit 0.
   - `printf '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"gh issue edit 42 --add-label qa"}}' | bash .claude/hooks/detect-role-trigger.sh 2>&1` → expect a QA Engineer banner, exit 0.

## Acceptance criteria coverage

- [x] At least one new hook detects role-trigger conditions per the documented trigger table — `detect-role-trigger.sh`.
- [x] When a trigger fires, a system-reminder-style line is injected naming the role + the file to read — `ROLE TRIGGER: <Role> activates per .claude/rules/role-triggers.md (<reason>). Read <file> and adopt the role before continuing.`
- [x] Non-blocking — exit 0 always, regardless of whether a trigger fired. Mirrors the upstream-drift banner.
- [x] Test coverage for the three trigger families: label-based (QA), diff-based (Security Auditor on `**/auth/**`), prompted ("act as the X").
- [x] `.claude/rules/role-triggers.md` § "Aspirational → Real" updated.

## Out of scope (deliberate)

- Enforcing that the agent actually reads the role file after the banner fires (the AC explicitly excludes this — would require monitoring `Read` tool calls).
- Enforcing role CAN / CANNOT boundaries.
- Triggers from the table that aren't yet mechanically detectable from a tool-call payload alone (e.g. "production incident mentioned in conversation" → SRE). The hook is structured so additional triggers slot in without changing the wiring; v1 covers the three the AC names plus three more that fall out of the same plumbing for free (Platform Engineer on CI/CD diffs, Tech Lead on AgDR diffs).

## Glossary

| Term | Definition |
|------|------------|
| Role trigger | A condition documented in `.claude/rules/role-triggers.md` that, when met, should cause the main agent to read the corresponding role file in `roles/<dept>/<role>.md` and adopt that role's identity for the next stretch of work. |
| Auto-activation | A trigger that fires from a signal the framework can observe mechanically (label change, diff path, command shape) — the subject of this PR. |
| Prompted activation | A trigger driven by the user's prompt text ("act as the X" / "as the X" / "put on your X hat"). |
| Non-blocking advisory hook | A hook that emits a stderr banner but always exits 0, so the underlying tool call proceeds. `check-upstream-drift.sh` is the canonical precedent; this PR adds the second instance. |
| ROLE TRIGGER banner | The system-reminder-style line this hook prints when a trigger fires — names the role, the trigger reason, and the role file to read. |
| `UserPromptSubmit` | A Claude Code hook event that fires when the user submits a prompt, before the assistant processes it. Used here to catch prompted activation. |
| `PreToolUse` | A Claude Code hook event that fires before a tool call (Edit, Write, MultiEdit, Bash, …) is executed. Used here for diff-based and label-based triggers. |

Closes me2resh/apexyard#206