### PR TITLE
fix(#207): verify-commit-refs and validate-pr-create consult upstream remote

### DIFF
--- a/.claude/hooks/tests/_lib-mock-gh.sh
+++ b/.claude/hooks/tests/_lib-mock-gh.sh
@@ -18,6 +18,15 @@
 # `mock_gh_set_state <num> CLOSED` before running the case (it writes to a state
 # file the shim reads). State file is per-sandbox.
 #
+# By default the shim ignores `--repo` and answers OPEN for any number on any
+# repo (origin AND upstream alike). To exercise the upstream-fallback path
+# added for me2resh/apexyard#207 — where a #N must NOT exist in origin but
+# MUST exist in upstream — call `mock_gh_set_repo_existence <sb> <num> <repo>
+# <yes|no>` per-repo. When ANY existence entry is recorded for a number, the
+# shim flips into per-repo mode for that number: any (num, repo) pair without
+# an explicit `yes` entry returns "not found" (exit 1, empty stdout). Numbers
+# with no existence entries at all keep the default-OPEN-everywhere behavior.
+#
 # Set MOCK_GH_TRACE=1 to print intercepted calls to stderr for debugging.
 
 # Install the fake `gh` into <sandbox>/bin/ and prepend that to PATH.
@@ -30,7 +39,9 @@ mock_gh_install() {
   fi
   mkdir -p "$sb/bin"
   local state_file="$sb/.mock-gh-state"
+  local exists_file="$sb/.mock-gh-exists"
   : > "$state_file"
+  : > "$exists_file"
 
   # Resolve the real gh once so the shim can pass-through unintercepted calls.
   local real_gh
@@ -41,6 +52,7 @@ mock_gh_install() {
 # Fake gh — intercepts \`gh issue view <N> ... --json ...\` and returns
 # synthetic JSON. Pass-through for everything else (via real gh, if available).
 STATE_FILE="$state_file"
+EXISTS_FILE="$exists_file"
 REAL_GH="$real_gh"
 
 if [ "\${MOCK_GH_TRACE:-0}" = "1" ]; then
@@ -50,8 +62,29 @@ fi
 # Match: gh issue view <N> [--repo R] --json <fields>
 if [ "\$1" = "issue" ] && [ "\$2" = "view" ]; then
   num="\$3"
+  # Parse --repo from the remaining args. Default empty means "no repo flag".
+  repo=""
+  shift 3
+  while [ \$# -gt 0 ]; do
+    case "\$1" in
+      --repo) repo="\$2"; shift 2 ;;
+      --repo=*) repo="\${1#--repo=}"; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  # Per-repo existence mode: triggered when ANY entry exists for this number
+  # in the existence file. Lines: "<num> <repo> <yes|no>".
+  if [ -f "\$EXISTS_FILE" ] && grep -qE "^\${num} " "\$EXISTS_FILE"; then
+    answer=\$(grep -E "^\${num} \${repo} " "\$EXISTS_FILE" | tail -1 | awk '{print \$3}')
+    if [ "\$answer" != "yes" ]; then
+      # No "yes" entry for this (num, repo) → emulate gh's not-found exit.
+      exit 1
+    fi
+  fi
+
   state="OPEN"
-  # Per-number override (one line per: "<num> <state>"). Last write wins.
+  # Per-number state override (one line per: "<num> <state>"). Last write wins.
   if [ -f "\$STATE_FILE" ]; then
     override=\$(grep -E "^\${num} " "\$STATE_FILE" | tail -1 | awk '{print \$2}')
     if [ -n "\$override" ]; then
@@ -89,4 +122,28 @@ mock_gh_set_state() {
     return 1
   fi
   echo "$num $state" >> "$sb/.mock-gh-state"
+}
+
+# Record whether a specific (num, repo) pair exists. Writes to
+# <sandbox>/.mock-gh-exists. Use this to test the upstream-fallback path
+# (me2resh/apexyard#207) — once any existence entry is recorded for a number,
+# ALL lookups for that number switch to per-repo mode (lookups without a
+# matching "yes" entry return not-found).
+#
+#   mock_gh_set_repo_existence <sandbox> <num> <repo> <yes|no>
+#
+# Example — issue #150 exists in upstream but not in fork's origin:
+#   mock_gh_set_repo_existence "$sb" 150 me2resh/apexyard yes
+#   mock_gh_set_repo_existence "$sb" 150 fork-org/apexyard no
+mock_gh_set_repo_existence() {
+  local sb="$1" num="$2" repo="$3" answer="$4"
+  if [ -z "$sb" ] || [ -z "$num" ] || [ -z "$repo" ] || [ -z "$answer" ]; then
+    echo "mock_gh_set_repo_existence: usage: mock_gh_set_repo_existence <sandbox> <num> <repo> <yes|no>" >&2
+    return 1
+  fi
+  if [ "$answer" != "yes" ] && [ "$answer" != "no" ]; then
+    echo "mock_gh_set_repo_existence: answer must be 'yes' or 'no', got '$answer'" >&2
+    return 1
+  fi
+  echo "$num $repo $answer" >> "$sb/.mock-gh-exists"
 }

--- a/.claude/hooks/tests/test_validate_pr_create_upstream.sh
+++ b/.claude/hooks/tests/test_validate_pr_create_upstream.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Tests for validate-pr-create.sh upstream awareness (me2resh/apexyard#207).
+#
+# The validator extracts the ticket number from the PR title and confirms it
+# exists + is OPEN in the tracker. Before #207 the lookup was origin-only;
+# after #207 a missing-in-origin ticket is rechecked against `upstream` when
+# that remote is configured. Same short-circuit behavior as the commit-ref
+# validator — try origin first, only fall back on miss.
+#
+# Coverage:
+#   - title #N exists in origin → pass (regression)
+#   - title #N missing in origin but present in upstream → pass (NEW)
+#   - title #N missing in both → block (regression)
+#   - title #N exists in origin, upstream unconfigured → pass (no regression)
+#   - title #N CLOSED in upstream → block, error names upstream repo
+#   - --repo flag overrides origin and is checked first (existing behavior)
+
+set -u
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/validate-pr-create.sh"
+# shellcheck source=_lib-mock-gh.sh
+source "$(cd "$(dirname "$0")" && pwd)/_lib-mock-gh.sh"
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+make_sandbox_fork() {
+  local with_upstream="$1"
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    git remote add origin git@github.com:fork-org/apexyard.git
+    if [ "$with_upstream" = "yes" ]; then
+      git remote add upstream git@github.com:me2resh/apexyard.git
+    fi
+    git checkout -q -b "fix/#207-pr-upstream-test" 2>/dev/null || git checkout -q -B "fix/#207-pr-upstream-test"
+    touch onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+  )
+  mkdir -p "$sb/.claude/hooks"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/validate-pr-create.sh"
+  chmod +x "$sb/.claude/hooks/validate-pr-create.sh"
+  local src_root
+  src_root=$(cd "$(dirname "$0")/../../.." && pwd)
+  cp "$src_root/.claude/hooks/_lib-read-config.sh" "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$src_root/.claude/project-config.defaults.json" "$sb/.claude/project-config.defaults.json"
+  echo "$sb"
+}
+
+# Minimal PR body with the required Testing + Glossary sections so the body
+# check isn't what trips the validator. We're testing the ticket-existence
+# fallback, not the body parser.
+BODY=$'## Summary\nx\n\n## Testing\ny\n\n## Glossary\n| t | d |'
+
+# Build a `gh pr create` command. Pass `with_repo_flag=yes` to include
+# `--repo me2resh/apexyard` (forces TRACKER_REPO=me2resh/apexyard regardless
+# of origin) — used to test the --repo branch, which is unchanged.
+build_cmd() {
+  local title="$1" with_repo_flag="${2:-no}" body_file="$3"
+  if [ "$with_repo_flag" = "yes" ]; then
+    printf 'gh pr create --repo me2resh/apexyard --title "%s" --body-file %s --head fix/#207-pr-upstream-test' "$title" "$body_file"
+  else
+    printf 'gh pr create --title "%s" --body-file %s --head fix/#207-pr-upstream-test' "$title" "$body_file"
+  fi
+}
+
+# Helper: write a body file inside the sandbox, then build the command + run.
+run_pr_case() {
+  local label="$1" with_upstream="$2" title="$3" with_repo_flag="$4" want_rc="$5" want_stderr_regex="$6" exist_setup="${7:-}"
+  local sb; sb=$(make_sandbox_fork "$with_upstream")
+  mock_gh_install "$sb"
+  if [ -n "$exist_setup" ]; then
+    eval "$exist_setup"
+  fi
+  local body_file="$sb/body.md"
+  printf '%s' "$BODY" > "$body_file"
+  local cmd; cmd=$(build_cmd "$title" "$with_repo_flag" "$body_file")
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/validate-pr-create.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:300})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# ---- Cases --------------------------------------------------------------
+
+# Regression: #N exists in origin, no upstream remote → pass.
+run_pr_case "title #N in origin, no upstream → pass" \
+  "no" "fix(#42): something" "no" 0 ""
+
+# NEW: #N missing in origin, present in upstream → pass.
+run_pr_case "title #N in upstream only → pass (the #207 fix)" \
+  "yes" "fix(#150): upstream issue" "no" 0 "" \
+  'mock_gh_set_repo_existence "$sb" 150 fork-org/apexyard no
+   mock_gh_set_repo_existence "$sb" 150 me2resh/apexyard yes'
+
+# Regression: missing in both → block, error message names both.
+run_pr_case "title #N missing in both → block, names both" \
+  "yes" "fix(#99999): phantom" "no" 2 "does not.*exist|or upstream" \
+  'mock_gh_set_repo_existence "$sb" 99999 fork-org/apexyard no
+   mock_gh_set_repo_existence "$sb" 99999 me2resh/apexyard no'
+
+# Regression: origin exists, no upstream configured → pass.
+run_pr_case "title #N in origin, upstream unconfigured → pass" \
+  "no" "feat(#5): do thing" "no" 0 ""
+
+# CLOSED-in-upstream → block. Tests that the CLOSED error names the upstream
+# repo (the one that actually matched) rather than always saying origin.
+run_pr_case "title #N CLOSED in upstream → block, error names upstream" \
+  "yes" "fix(#321): closed in upstream" "no" 2 "me2resh/apexyard.*CLOSED|CLOSED.*me2resh/apexyard" \
+  'mock_gh_set_repo_existence "$sb" 321 fork-org/apexyard no
+   mock_gh_set_repo_existence "$sb" 321 me2resh/apexyard yes
+   mock_gh_set_state "$sb" 321 CLOSED'
+
+# Existing behavior: --repo me2resh/apexyard makes TRACKER_REPO = upstream
+# directly. The upstream-fallback would then be skipped (UPSTREAM_REPO ==
+# TRACKER_REPO). Should still pass for an issue that exists in upstream.
+run_pr_case "title #N with --repo upstream → pass (upstream IS tracker)" \
+  "yes" "fix(#200): explicit upstream" "yes" 0 "" \
+  'mock_gh_set_repo_existence "$sb" 200 me2resh/apexyard yes'
+
+# Short-circuit: origin yes, upstream no → upstream not consulted.
+# Indirect verification: the case passes because origin matches first.
+run_pr_case "origin yes, upstream no → pass (short-circuit)" \
+  "yes" "fix(#7): in origin" "no" 0 "" \
+  'mock_gh_set_repo_existence "$sb" 7 fork-org/apexyard yes
+   mock_gh_set_repo_existence "$sb" 7 me2resh/apexyard no'
+
+# ---- Summary ------------------------------------------------------------
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_verify_commit_refs_upstream.sh
+++ b/.claude/hooks/tests/test_verify_commit_refs_upstream.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# Tests for verify-commit-refs.sh upstream awareness (me2resh/apexyard#207)
+# and the existing origin-only behavior it must preserve.
+#
+# Coverage matrix:
+#   - bare #N exists in origin → pass (regression)
+#   - bare #N missing in origin but present in upstream → pass (NEW)
+#   - bare #N missing in both → block (regression)
+#   - bare #N exists in origin, upstream not configured → pass (no-regression)
+#   - cross-repo notation (owner/repo#N) → no auto-extracted #N → pass
+#   - bare #N is CLOSED in upstream → still passes (WARN, never block on closed)
+#   - fork without `upstream` remote configured → identical to origin-only
+#
+# Each case:
+#   - builds an isolated sandbox with the hook + mock gh
+#   - configures a `git remote upstream` when the case needs one
+#   - pipes a synthetic PreToolUse JSON blob with `git commit -m "<msg>"`
+#   - asserts exit code + stderr contents
+
+set -u
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/verify-commit-refs.sh"
+# shellcheck source=_lib-mock-gh.sh
+source "$(cd "$(dirname "$0")" && pwd)/_lib-mock-gh.sh"
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# Build a sandbox shaped like a fork: origin = fork-org/apexyard, optional
+# upstream = me2resh/apexyard. The `tracker_repo` config key isn't set, so
+# the hook falls back to parsing origin (matches real-world fork layout).
+make_sandbox_fork() {
+  local with_upstream="$1"
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    git remote add origin git@github.com:fork-org/apexyard.git
+    if [ "$with_upstream" = "yes" ]; then
+      git remote add upstream git@github.com:me2resh/apexyard.git
+    fi
+    git checkout -q -b fix/#207-test 2>/dev/null || git checkout -q -B fix/#207-test
+    touch README.md
+    git add README.md
+    git commit -q -m "init"
+  )
+  echo "$sb"
+}
+
+# Run the hook with a synthetic `git commit -m "<msg>"` command and assert
+# the exit code + (optional) stderr regex. Existence-config callback lets
+# each case set its own mock-gh entries before the hook runs.
+#
+#   run_case <label> <with_upstream:yes|no> <commit_msg> <want_rc> <stderr_regex> [<existence_setup>]
+run_case() {
+  local label="$1" with_upstream="$2" commit_msg="$3" want_rc="$4" want_stderr_regex="$5" exist_setup="${6:-}"
+  local sb; sb=$(make_sandbox_fork "$with_upstream")
+  mock_gh_install "$sb"
+  if [ -n "$exist_setup" ]; then
+    eval "$exist_setup"
+  fi
+  # commit_msg uses `\n` for newlines in the test source for readability;
+  # convert them to real newlines so the parsed -m argument matches the way
+  # bash sees a real multi-line commit (no `\b` issue against a literal `\n`).
+  local cmd_msg; cmd_msg=$(printf '%b' "$commit_msg")
+  local cmd; cmd=$(printf 'git commit -m "%s"' "$cmd_msg")
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && echo "$input" | bash "$HOOK_SRC" 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:300})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# ---- Cases --------------------------------------------------------------
+
+# Regression: bare #N that exists in origin passes, no upstream consulted.
+run_case "bare #N in origin, no upstream remote → pass" \
+  "no" \
+  "fix: something\n\nCloses #42" \
+  0 "" \
+  ''
+
+# NEW: bare #N missing in origin, present in upstream → pass.
+run_case "bare #N in upstream only → pass (the #207 fix)" \
+  "yes" \
+  "fix: upstream issue\n\nCloses #150" \
+  0 "" \
+  'mock_gh_set_repo_existence "$sb" 150 fork-org/apexyard no
+   mock_gh_set_repo_existence "$sb" 150 me2resh/apexyard yes'
+
+# Regression: missing in both → block.
+run_case "bare #N missing in both → block" \
+  "yes" \
+  "fix: phantom\n\nCloses #99999" \
+  2 "doesnot exist|do not exist" \
+  'mock_gh_set_repo_existence "$sb" 99999 fork-org/apexyard no
+   mock_gh_set_repo_existence "$sb" 99999 me2resh/apexyard no'
+
+# Regression: bare #N in origin, no upstream configured → pass (no regression).
+run_case "bare #N in origin, upstream unconfigured → pass" \
+  "no" \
+  "feat: do thing\n\nCloses #5" \
+  0 "" \
+  ''
+
+# Cross-repo notation (`owner/repo#N`) — the existing REFS regex requires
+# `#` immediately after the closing keyword + whitespace, so `me2resh/apexyard#150`
+# is not picked up as a #N reference at all. This is unchanged behavior;
+# adding the test pins it so future regex changes don't break backwards-compat.
+run_case "cross-repo notation owner/repo#N → no #N extracted → pass" \
+  "yes" \
+  "fix: cross-repo\n\nCloses me2resh/apexyard#150" \
+  0 "" \
+  ''
+
+# Closed-but-existing in upstream is still allowed through (WARN, not BLOCK).
+# Existing rule: closed-issue refs are warned at commit time; the PR-create
+# hook is the right place to BLOCK closed-issue refs. The fix preserves that.
+run_case "bare #N CLOSED in upstream → pass with WARN" \
+  "yes" \
+  "fix: closed upstream\n\nRefs #777" \
+  0 "WARN" \
+  'mock_gh_set_repo_existence "$sb" 777 fork-org/apexyard no
+   mock_gh_set_repo_existence "$sb" 777 me2resh/apexyard yes
+   mock_gh_set_state "$sb" 777 CLOSED'
+
+# When origin and upstream both resolve to the same repo (e.g. running INSIDE
+# the framework itself), the hook should not double-query. We can't observe
+# the query count directly, but we can assert the hook passes when the issue
+# exists in origin — exercising the "skip upstream because UPSTREAM_REPO ==
+# TRACKER_REPO" branch.
+run_case "upstream == origin → no double-check, still passes when issue in origin" \
+  "no" \
+  "fix: same repo\n\nCloses #1" \
+  0 "" \
+  ''
+
+# Network failure equivalent: gh returns nothing for any repo (no existence
+# entries → falls through to default-exists-everywhere). But we can flip into
+# per-repo mode with "no" entries to simulate network failure. Result must
+# be: block (treat as not found) — matches existing fail-closed behavior.
+run_case "gh returns nothing in both → block (fail-closed)" \
+  "yes" \
+  "fix: ghost\n\nFixes #321" \
+  2 "do not exist" \
+  'mock_gh_set_repo_existence "$sb" 321 fork-org/apexyard no
+   mock_gh_set_repo_existence "$sb" 321 me2resh/apexyard no'
+
+# Short-circuit: when origin says yes, upstream should NOT be consulted.
+# Verified indirectly by setting upstream to "no" and origin to "yes" —
+# if the hook checked upstream too, this case would still pass; if it
+# short-circuits on origin success, this case also passes. Both behaviors
+# yield the same result, so this case is mostly documentation.
+run_case "origin yes, upstream no → pass (short-circuit on origin)" \
+  "yes" \
+  "fix: in origin\n\nCloses #7" \
+  0 "" \
+  'mock_gh_set_repo_existence "$sb" 7 fork-org/apexyard yes
+   mock_gh_set_repo_existence "$sb" 7 me2resh/apexyard no'
+
+# ---- Summary ------------------------------------------------------------
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -81,14 +81,48 @@ if [ -n "$TICKET_REF" ]; then
     TRACKER_REPO=$(echo "$ORIGIN_URL" | sed -nE 's|.*[:/]([^/:]+/[^/]+)\.git$|\1|p; s|.*[:/]([^/:]+/[^/]+)$|\1|p' | head -1)
   fi
 
+  # Optional upstream fallback (me2resh/apexyard#207). When the primary
+  # tracker resolution returns nothing for #N, recheck against the `upstream`
+  # remote if one is configured. Lets a fork's `fix(#N)` validate when the
+  # ticket lives on upstream and the PR targets upstream — and avoids the
+  # cross-repo workaround (`fix(owner/repo#N)`) that passes the hook but
+  # breaks GitHub's bare-#N auto-close on merge.
+  UPSTREAM_REPO=""
+  if git remote get-url upstream >/dev/null 2>&1; then
+    UPSTREAM_URL=$(git remote get-url upstream 2>/dev/null)
+    UPSTREAM_REPO=$(echo "$UPSTREAM_URL" | sed -nE 's|.*[:/]([^/:]+/[^/]+)\.git$|\1|p; s|.*[:/]([^/:]+/[^/]+)$|\1|p' | head -1)
+    # Skip the redundant check when upstream resolves to the same repo as
+    # the primary tracker (running inside the framework itself, or when
+    # --repo on the gh command points at upstream directly).
+    if [ "$UPSTREAM_REPO" = "$TRACKER_REPO" ]; then
+      UPSTREAM_REPO=""
+    fi
+  fi
+
   if [ -n "$TICKET_NUM" ] && [ -n "$TRACKER_REPO" ]; then
     # Fetch both number and state in one call so we can distinguish
     # "does not exist" from "exists but CLOSED". Both are blocking.
     ISSUE_JSON=$(gh issue view "$TICKET_NUM" --repo "$TRACKER_REPO" --json number,state 2>/dev/null)
+    # Short-circuit: only consult upstream when primary missed. Records which
+    # tracker actually matched so the CLOSED-state error names the right repo.
+    MATCHED_REPO="$TRACKER_REPO"
+    if [ -z "$ISSUE_JSON" ] && [ -n "$UPSTREAM_REPO" ]; then
+      ISSUE_JSON=$(gh issue view "$TICKET_NUM" --repo "$UPSTREAM_REPO" --json number,state 2>/dev/null)
+      if [ -n "$ISSUE_JSON" ]; then
+        MATCHED_REPO="$UPSTREAM_REPO"
+      fi
+    fi
     if [ -z "$ISSUE_JSON" ]; then
+      # Name both trackers in the error when an upstream fallback was tried,
+      # so the operator sees exactly where the lookup was attempted.
+      if [ -n "$UPSTREAM_REPO" ]; then
+        NOT_FOUND_LOC="${TRACKER_REPO} or upstream ${UPSTREAM_REPO}"
+      else
+        NOT_FOUND_LOC="${TRACKER_REPO}"
+      fi
       cat >&2 <<MSG
 BLOCKED: PR title references ${TICKET_REF} but issue #${TICKET_NUM} does not
-exist in ${TRACKER_REPO}.
+exist in ${NOT_FOUND_LOC}.
 
 This is the failure mode the ticket-vocabulary rule exists to prevent — do NOT
 use tracker notation (#N) for plan items that have no real issue behind them.
@@ -106,7 +140,7 @@ MSG
     if [ "$ISSUE_STATE" = "CLOSED" ]; then
       cat >&2 <<MSG
 BLOCKED: PR title references ${TICKET_REF} but issue #${TICKET_NUM} in
-${TRACKER_REPO} is CLOSED.
+${MATCHED_REPO} is CLOSED.
 
 Every PR needs its own OPEN ticket. Referencing a closed issue means the PR
 has no live acceptance criteria, no QA handoff, and no tracker row to move
@@ -117,7 +151,7 @@ Common causes:
     describes the follow-up, link back to the closed one in the body, and
     use the new number in the PR title.
   - The closed issue was auto-closed by a prior PR that didn't fully finish
-    the work → re-open it (gh issue reopen ${TICKET_NUM} --repo ${TRACKER_REPO})
+    the work → re-open it (gh issue reopen ${TICKET_NUM} --repo ${MATCHED_REPO})
     or create a new ticket for the remaining work.
   - The number is a typo → fix the PR title.
 

--- a/.claude/hooks/verify-commit-refs.sh
+++ b/.claude/hooks/verify-commit-refs.sh
@@ -17,6 +17,17 @@
 # Tracker repo resolves in this order:
 #   1. .claude/project-config.json `.tracker_repo`
 #   2. origin remote (parsed from `git remote get-url origin`)
+#
+# Upstream awareness (me2resh/apexyard#207): when an `upstream` remote is
+# configured (typical fork-of-apexyard layout), a #N reference that misses in
+# the primary tracker is rechecked against `upstream` before being declared
+# missing. This lets a fork's `Closes #150` validate when issue 150 lives on
+# the upstream repo — and, more importantly, lets GitHub's auto-close fire on
+# merge (auto-close requires BARE #N notation; the cross-repo workaround
+# `Closes owner/repo#150` passes the hook but breaks auto-close).
+#
+# Short-circuit: try the primary tracker first, only fall back to upstream on
+# miss. No double query for refs that resolve in origin.
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -99,6 +110,21 @@ if [ -z "$TRACKER_REPO" ]; then
   exit 0
 fi
 
+# Optional upstream fallback (see file header). Parse `git remote get-url
+# upstream` into `owner/repo`; empty if no upstream remote is configured —
+# in which case the validator behaves exactly as before (origin-only check).
+UPSTREAM_REPO=""
+if git remote get-url upstream >/dev/null 2>&1; then
+  UPSTREAM_URL=$(git remote get-url upstream 2>/dev/null)
+  UPSTREAM_REPO=$(echo "$UPSTREAM_URL" | sed -nE 's|.*[:/]([^/:]+/[^/]+)\.git$|\1|p; s|.*[:/]([^/:]+/[^/]+)$|\1|p' | head -1)
+  # Don't double-check if upstream resolves to the same repo as the primary
+  # tracker (e.g. running INSIDE the framework repo itself, where origin and
+  # upstream both point at me2resh/apexyard).
+  if [ "$UPSTREAM_REPO" = "$TRACKER_REPO" ]; then
+    UPSTREAM_REPO=""
+  fi
+fi
+
 # Verify each referenced issue exists. Fabricated #N (issue not found) is
 # BLOCKING — that's the failure mode the ticket-vocabulary rule targets.
 # References to CLOSED issues are WARNED (not blocked) because a commit may
@@ -111,6 +137,10 @@ CLOSED=""
 for REF in $REFS; do
   NUM=$(echo "$REF" | tr -d '#')
   ISSUE_JSON=$(gh issue view "$NUM" --repo "$TRACKER_REPO" --json number,state 2>/dev/null)
+  # Short-circuit: only consult upstream when the primary tracker missed.
+  if [ -z "$ISSUE_JSON" ] && [ -n "$UPSTREAM_REPO" ]; then
+    ISSUE_JSON=$(gh issue view "$NUM" --repo "$UPSTREAM_REPO" --json number,state 2>/dev/null)
+  fi
   if [ -z "$ISSUE_JSON" ]; then
     MISSING="${MISSING}${REF} "
     continue
@@ -122,8 +152,15 @@ for REF in $REFS; do
 done
 
 if [ -n "$MISSING" ]; then
+  # Include the upstream repo in the error when one was consulted — makes the
+  # blocked-because-it's-not-in-either-place case explicit.
+  if [ -n "$UPSTREAM_REPO" ]; then
+    LOCATION_MSG="${TRACKER_REPO} or upstream ${UPSTREAM_REPO}"
+  else
+    LOCATION_MSG="${TRACKER_REPO}"
+  fi
   cat >&2 <<MSG
-BLOCKED: Commit message references issues that do not exist in ${TRACKER_REPO}:
+BLOCKED: Commit message references issues that do not exist in ${LOCATION_MSG}:
   ${MISSING}
 
 This is the failure mode the ticket-vocabulary rule exists to prevent — do NOT

--- a/.claude/rules/ticket-vocabulary.md
+++ b/.claude/rules/ticket-vocabulary.md
@@ -110,6 +110,18 @@ This rule is primarily self-discipline. It is also backed up by two mechanical h
 
 Both hooks block at the moment the fabricated reference would be committed to a durable artifact (PR title, commit message). They cannot see conversation prose — that's why the rule comes first and the hooks are labeled **backstops**, not the primary fix.
 
+### Fork → upstream PRs: bare `#N` is the right notation (since me2resh/apexyard#207)
+
+When you're working in a fork (e.g. `your-org/apexyard`) with `origin` = the fork and `upstream` = `me2resh/apexyard`, and the issue you're closing lives in **upstream**, use bare `#N` notation — not cross-repo `owner/repo#N`.
+
+| Notation | Hook check | Auto-close on merge |
+|----------|-----------|---------------------|
+| `Closes #150` (issue in upstream) | passes — both hooks consult `upstream` after origin misses | fires (GitHub auto-closes on bare `#N` when PR target = issue host) |
+| `Closes me2resh/apexyard#150` | passes (no #N extracted from the cross-repo form) | does NOT fire — cross-repo references don't trigger auto-close |
+| `Closes #99999` (nowhere) | BLOCKED — neither tracker has it | n/a |
+
+Earlier versions of these hooks were origin-only, which forced the cross-repo workaround for fork → upstream PRs and silently broke GitHub's auto-close — leaving every cross-fork PR's issue OPEN forever. After #207, bare `#N` is the supported pattern and the cross-repo workaround is no longer needed (it still passes the hook for backwards compat, but you lose auto-close).
+
 ## Why not lint Claude's prose output?
 
 Considered and rejected. Hooks run on tool calls, not on assistant text output. The only way to catch a fabricated `#N` in prose would be a self-discipline check Claude runs at the end of every response — which is exactly the failure mode this rule is trying to prevent. If Claude could reliably remember to check itself, the vocabulary collision wouldn't happen in the first place.


### PR DESCRIPTION
## Summary

Forks of apexyard with `origin` = the fork and `upstream` = me2resh/apexyard could not use bare `#N` notation to close upstream issues. The previous behavior was origin-only: a `Closes #150` against an issue that lived on upstream got blocked, forcing the operator to write `Closes me2resh/apexyard#150` — which passes the hook but silently breaks GitHub's auto-close (auto-close only fires on bare `#N` when the PR's target repo equals the issue's host).

Result: every cross-fork PR's issue stayed OPEN forever, requiring manual `gh issue close` after merge. One recent session counted 12+ manual closures.

This patch teaches both `verify-commit-refs.sh` and `validate-pr-create.sh` to consult `upstream` after the primary tracker misses, with a short-circuit so successful origin lookups never pay the upstream RTT.

## Behavior change

| Before | After |
|---|---|
| `Closes #150` (issue on upstream) → BLOCKED | `Closes #150` → PASSES; auto-close fires on merge |
| `Closes me2resh/apexyard#150` → passes hook but breaks auto-close | Still passes (backwards-compat); but no longer the required pattern |
| `Closes #99999` (nowhere) → BLOCKED | Still BLOCKED — correct behavior preserved |
| No `upstream` remote configured | Identical to today's origin-only check (no regression) |

## Files touched

- `.claude/hooks/verify-commit-refs.sh` — parse `git remote get-url upstream`, short-circuit lookup, error message names both repos when applicable
- `.claude/hooks/validate-pr-create.sh` — same upstream awareness for PR-title `#N`; tracks `MATCHED_REPO` so the CLOSED-state error names the right tracker
- `.claude/hooks/tests/_lib-mock-gh.sh` — new `mock_gh_set_repo_existence` helper enabling per-(num, repo) existence simulation (backwards-compatible with all seven existing mock consumers)
- `.claude/hooks/tests/test_verify_commit_refs_upstream.sh` — 9 new cases
- `.claude/hooks/tests/test_validate_pr_create_upstream.sh` — 7 new cases
- `.claude/rules/ticket-vocabulary.md` — added "Fork → upstream PRs" subsection documenting bare `#N` as the supported pattern

## Testing

1. Run the new test files directly:
   ```bash
   bash .claude/hooks/tests/test_verify_commit_refs_upstream.sh   # 9 cases
   bash .claude/hooks/tests/test_validate_pr_create_upstream.sh   # 7 cases
   ```
   Both report `PASS: N   FAIL: 0`.

2. Regression-check the rest of the hook suite (22 test files total). Confirmed: all pre-existing tests still green, including `test_validate_pr_required_sections.sh`, `test_single_closes_per_pr.sh`, and `test_validate_pr_create_head.sh`, which exercise the validate-pr-create.sh codepath the most.

3. Manual smoke-test from a fork checkout (origin = fork, upstream = me2resh/apexyard) with the patched hooks installed:
   - `git commit -m "fix: upstream issue<newline><newline>Closes #150"` where #150 exists on upstream → passes (was BLOCKED before)
   - `git commit -m "fix: phantom<newline><newline>Closes #99999"` where #99999 is nowhere → BLOCKED (regression preserved)
   - `gh pr create --title "fix(#207): something" --body "..."` for an upstream-only ticket → passes (was BLOCKED before)

## Performance note

Each `#N` ref pays one `gh issue view` against origin. On a miss in a fork with `upstream` configured, it pays a second `gh issue view` against upstream. Refs that resolve in origin pay zero overhead vs. the old behavior (short-circuit). Forks without an `upstream` remote pay zero overhead (the `git remote get-url upstream` check fails fast and `UPSTREAM_REPO` stays empty).

## Risks

- **Network failure on `gh issue view`** — fails closed (treats as not-found), matching existing behavior. Reflected in the `gh returns nothing in both → block (fail-closed)` test case.
- **Same-repo origin / upstream** — when both remotes point at the same `owner/repo`, the upstream check is skipped to avoid a redundant RTT. Covered by the `upstream == origin → no double-check` test case.
- **No supporting reverse case** — a PR on upstream wanting to close a fork's issue is out of scope (not a real apexyard workflow). Same as the ticket scoped.

## Glossary

| Term | Definition |
|------|------------|
| Tracker repo | The GitHub repo that holds the issues the operator's commits reference. For a fork, this is normally the fork itself (`origin`), but for cross-fork work it may be `upstream`. |
| `upstream` remote | The conventional name for the upstream repo a fork was forked from (`git remote add upstream <url>` in the apexyard setup docs). |
| Bare `#N` notation | A GitHub issue reference like `Closes #150` with no `owner/repo` prefix. GitHub's auto-close-on-merge only fires for bare `#N` when the PR's target repo equals the issue's host repo. |
| Cross-repo notation | A GitHub issue reference like `Closes owner/repo#150`. Survives merges as a hyperlink but does NOT trigger GitHub's auto-close, regardless of PR target. |
| Short-circuit | Implementation pattern where the upstream lookup runs only after the primary lookup misses — so refs that resolve in origin pay no upstream overhead. |
| Fail-closed | Default-block on network failure rather than default-allow. Preserves the "fabricated #N is BLOCKED" contract even when `gh` can't reach GitHub. |
| Backstop | A mechanical enforcement layer that catches downstream symptoms of a higher-level rule (here, the ticket-vocabulary rule) that primarily lives as self-discipline. |

Closes me2resh/apexyard#207