### PR TITLE
refactor(#204): consistent Arabic persona naming for all roles + agents

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,5 +1,6 @@
 ---
 name: code-reviewer
+persona_name: Rex
 description: Expert code review specialist. Reviews PRs for quality, security, and standards compliance. Use proactively after code changes or when a PR needs review.
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit

--- a/.claude/agents/dependency-auditor.md
+++ b/.claude/agents/dependency-auditor.md
@@ -1,5 +1,6 @@
 ---
 name: dependency-auditor
+persona_name: Munir
 description: Monitors dependencies for vulnerabilities, outdated packages, and license compliance. Run weekly or when package.json changes.
 tools: Bash, Read, Grep, Glob
 disallowedTools: Write, Edit
@@ -8,7 +9,7 @@ model: inherit
 
 # Dependency Auditor Agent
 
-**Identity**: Guardian
+**Persona name**: Munir
 **Type**: Automated agent
 **Trigger**: Weekly, or when `package.json` changes
 
@@ -145,7 +146,7 @@ Check for:
 3. **This sprint**: update minor versions
 
 ---
-*Audited by Guardian (Dependency Auditor Agent)*
+*Audited by Munir (Dependency Auditor Agent)*
 ```
 
 ## Ticket Integration

--- a/.claude/agents/pr-manager.md
+++ b/.claude/agents/pr-manager.md
@@ -1,5 +1,6 @@
 ---
 name: pr-manager
+persona_name: Tariq
 description: Coordinates PR lifecycle from creation to merge. Enforces 2-review workflow, commit SHA verification, and auto-merge on human approval.
 tools: Bash, Read, Grep, Glob
 model: inherit

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,5 +1,6 @@
 ---
 name: security-reviewer
+persona_name: Hatim
 description: Security-focused PR reviewer. Scans for vulnerabilities, injection risks, auth issues, and data protection. Use for PRs touching auth, APIs, or user input.
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit
@@ -124,7 +125,7 @@ Invoked when a PR needs security review, especially for:
 **[APPROVED / CHANGES REQUESTED / COMMENT]**
 
 ---
-🛡️ Reviewed by Shield (Security Reviewer Agent)
+🛡️ Reviewed by Hatim (Security Reviewer Agent)
 📌 Reviewed commit: `{headRefOid}`
 ```
 

--- a/.claude/agents/ticket-manager.md
+++ b/.claude/agents/ticket-manager.md
@@ -1,5 +1,6 @@
 ---
 name: ticket-manager
+persona_name: Idris
 description: Creates and manages GitHub Issues in the project's own repo for all work tracking. Use when a new task is starting, a PR is being created, or work needs tracking.
 tools: Bash, Read
 model: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,15 @@ Role definitions live in `roles/`. Each role defines:
 
 ### Departments
 
-| Department | Roles | Path |
-|------------|-------|------|
-| Engineering | Head of Eng, Tech Lead, Backend, Frontend, QA, Platform, SRE | `roles/engineering/` |
-| Product | Head of Product, PM, Product Analyst | `roles/product/` |
-| Design | Head of Design, UI Designer, UX Designer | `roles/design/` |
-| Security | Head of Security, Security Auditor, Pen Tester | `roles/security/` |
-| Data | Head of Data, Data Analyst, Data Engineer | `roles/data/` |
+Each role has a **persona name** — a short identifier used in conversation, PR comments, and demo scripts. The persona name lives as a bold line at the top of the role file (e.g. `**Persona name**: Khalid`). Agents carry the same identifier as a `persona_name` YAML frontmatter field. Rationale + full mapping table: [AgDR-0018](docs/agdr/AgDR-0018-persona-naming-convention.md).
+
+| Department | Roles (with persona names) | Path |
+|------------|----------------------------|------|
+| Engineering | Khalid (Head), Hisham (Tech Lead), Karim (Backend), Yasmin (Frontend), Salim (QA), Adel (Platform), Saif (SRE) | `roles/engineering/` |
+| Product | Omar (Head), Mariam (PM), Hanan (Product Analyst) | `roles/product/` |
+| Design | Maha (Head), Nour (UI Designer), Iman (UX Designer) | `roles/design/` |
+| Security | Faisal (Head), Hakim (Security Auditor), Hamza (Pen Tester) | `roles/security/` |
+| Data | Khalil (Head), Nadia (Data Analyst), Anwar (Data Engineer) | `roles/data/` |
 
 ### Activation — roles are first-class participants, not reference docs
 
@@ -177,7 +179,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 |-------|------|---------|
 | Hooks | `.claude/hooks/` | 24 shell scripts that mechanically enforce SDLC rules — ticket-first (Edit/Write/Bash), migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner, leak protection, bootstrap-skill exemption |
 | Rules | `.claude/rules/` | 9 modular rule files (AgDR triggers, code standards, git conventions, parallel work, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
-| Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer, Security Reviewer, Dependency Auditor, PR Manager, Ticket Manager) |
+| Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer — Rex, Security Reviewer — Hatim, Dependency Auditor — Munir, PR Manager — Tariq, Ticket Manager — Idris) |
 | Skills | `.claude/skills/` | 43 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
@@ -201,7 +203,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | `/decide` | Make a technical decision and create an Agent Decision Record (AgDR) |
 | `/agdr` | Searchable, categorized library of AgDRs across the portfolio — `browse`, `search <term>`, `show <id>`, `stats` |
 | `/code-review` | Invoke the Code Reviewer agent (Rex) on a PR |
-| `/security-review` | Invoke the Security Reviewer agent (Shield) on a PR |
+| `/security-review` | Invoke the Security Reviewer agent (Hatim) on a PR |
 | `/audit-deps` | Audit dependencies for vulnerabilities, outdated packages, licences |
 | `/write-spec` | Generate a PRD or feature spec from a problem statement |
 | `/validate-idea` | Lightweight 5-question pre-spec gate (target user, alternative, smallest version, kill criteria, build/buy/rent). Invokable standalone or as an offered follow-up inside `/idea` and `/handover`. |

--- a/docs/agdr/AgDR-0018-persona-naming-convention.md
+++ b/docs/agdr/AgDR-0018-persona-naming-convention.md
@@ -1,0 +1,106 @@
+# Persona Naming Convention — Classical Arabic Names for All Roles + Agents
+
+> In the context of an SDLC stack with 19 role files and 5 sub-agent files, facing inconsistent persona identity (2 agents named Rex / Shield, 3 agents unnamed, all 19 roles bare-titled), I decided to give every role and agent a classical / historic Arabic persona name carried in a structured `persona_name` field, to achieve consistent team-identity language across conversation, PR comments, and demo scripts, accepting that adopters who want different names must override per-fork by editing the files.
+
+## Context
+
+Before this AgDR, the framework's persona identity was uneven:
+
+- `code-reviewer` shipped as **Rex** (in PR comments, marketing copy, demo scripts)
+- `security-reviewer` shipped as **Shield** (PR comments, marketing copy)
+- `dependency-auditor` had an internal `**Identity**: Guardian` line, no external use
+- `pr-manager` and `ticket-manager` had no persona name at all
+- All 19 role files (`roles/engineering/*.md`, `roles/product/*.md`, etc.) had bare titles only — no name
+
+This created three problems:
+
+1. **Conversation friction** — when activating a role mid-session, the framework had no short identifier to refer to. Users had to say "the QA Engineer" every time instead of "Salim".
+2. **Inconsistent demos** — the marketing site ([site/index.html](../../site/index.html)) and skills page ([site/skills.html](../../site/skills.html)) named some agents but not others. Demo scripts had Rex prominently and PR-Manager faceless.
+3. **No clear naming axis for adopters** — a fork that wants its own team-identity language has no documented "swap these out" point.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Give every role + agent a persona name (chosen)** | Closes the inconsistency. Adds team-identity character. Conversational shorthand for role activation. | Imposes a naming choice on adopters; mitigated by per-fork overrides + structured field. |
+| **B. Drop Rex's name and use titles only** | Maximally neutral — no cultural choice imposed by the framework. | Throws away the already-shipped Rex brand equity (downstream conversation history, PR markers, marketing copy). Inconsistency persists between "Rex everywhere in history" and "no name now". |
+| **C. Use generic codenames (Alpha / Bravo / Echo)** | Culturally neutral. Easy to remember. | Loses character. Feels like military call-signs, not a team. Collides with NATO phonetic alphabet usage in security/aviation domains. |
+| **D. Use vendor-aligned names (e.g. SDK product names)** | Free advertising for upstream tools. | Risks trademark collisions; ties framework identity to third-party brands that may rebrand or fork. |
+
+## Decision
+
+Chosen: **Option A — every role + agent gets a persona name, drawn from classical / historic Arabic names**.
+
+Rationale for the choice of Arabic-name corpus:
+
+1. **Operator preference** — operator (CEO) explicitly approved the mapping table.
+2. **Adds team-identity character** without inventing a culturally-blank set.
+3. **Gender-mixed** — the 24 selected names include both male and female names (Yasmin, Mariam, Hanan, Maha, Nour, Iman, Nadia are female; Khalid, Hisham, Karim, Salim, Adel, Saif, Omar, Faisal, Hakim, Hamza, Khalil, Anwar, Hatim, Munir, Tariq, Idris are male; Rex remains as-is for brand continuity). This avoids a single-gender "everyone is named X" failure mode.
+4. **Avoids shell / vendor collisions** — none of the selected names collide with common shell keywords, vendor product names, or POSIX commands. (`Idris` is also a Linux distribution name and a programming language; in our framework context it's a persona name with no naming-resolution stake.)
+5. **Rex stays unchanged** — already-shipped brand equity. Renaming would invalidate PR markers, demo scripts, marketing copy, and downstream conversation history. The cost of renaming Rex outweighs the consistency gain.
+
+### Placement: Option A (YAML frontmatter) for agents, Option B (bold line under H1) for roles
+
+The brief presented two placement options. Both are used, on a clear axis:
+
+- **Agents** (`.claude/agents/*.md`): YAML frontmatter, `persona_name: <Name>`. Agents already have YAML frontmatter consumed by Claude Code (`name`, `description`, `tools`, `model`); adding `persona_name` there is structurally consistent with the existing schema and machine-readable.
+- **Role files** (`roles/**/*.md`): bold line under the H1, `**Persona name**: <Name>`. Role files have no existing frontmatter — introducing it here would force adopters to learn a new format for a single field. The bold line under the H1 is human-readable, immediately visible, and consistent with the existing role-file conventions (the next line is `## Identity`, which the persona name fronts naturally).
+
+The split is documented here so adopters can rely on it.
+
+### Full mapping (24 personas, Rex unchanged + 23 renamed)
+
+| Slot | Persona name | Theme |
+|------|--------------|-------|
+| **Agents** | | |
+| code-reviewer | **Rex** (unchanged) | already-shipped brand |
+| security-reviewer | **Hatim** | resolute judge |
+| dependency-auditor | **Munir** | illuminator |
+| pr-manager | **Tariq** | "he who knocks" — PR metaphor |
+| ticket-manager | **Idris** | scribe / scholar |
+| **Engineering** | | |
+| Head of Engineering | **Khalid** | "eternal / leader" |
+| Tech Lead | **Hisham** | knowledge-bearer |
+| Backend Engineer | **Karim** | generous |
+| Frontend Engineer | **Yasmin** | jasmine — aesthetic |
+| QA Engineer | **Salim** | "whole / safe" — quality |
+| Platform Engineer | **Adel** | just / balanced |
+| SRE | **Saif** | sword — incident response |
+| **Product** | | |
+| Head of Product | **Omar** | long-lived leader |
+| Product Manager | **Mariam** | classical |
+| Product Analyst | **Hanan** | compassion / empathy |
+| **Design** | | |
+| Head of Design | **Maha** | grace |
+| UI Designer | **Nour** | light |
+| UX Designer | **Iman** | faith / trust in flows |
+| **Security** | | |
+| Head of Security | **Faisal** | decisive judge |
+| Security Auditor | **Hakim** | wise judgement |
+| Penetration Tester | **Hamza** | "lion" — aggressive |
+| **Data** | | |
+| Head of Data | **Khalil** | close friend / dependable |
+| Data Analyst | **Nadia** | "early dew" — fresh signals |
+| Data Engineer | **Anwar** | light / radiant |
+
+## Consequences
+
+- **Conversation idiom** — role activations can now use the short name. "Salim, verify ticket #42" is shorter and more conversational than "Act as the QA Engineer and verify ticket #42". Both forms remain valid; the trigger table in [`.claude/rules/role-triggers.md`](../../.claude/rules/role-triggers.md) is unchanged.
+- **Demo scripts and PR comments** stay coherent across agents — every reviewer / orchestrator has a name. The marketing slide at [`site/index.html`](../../site/index.html) and the skills index at [`site/skills.html`](../../site/skills.html) now name all five agents instead of two.
+- **Adopters can override per-fork** by editing the `persona_name` field in each agent's YAML frontmatter or the `**Persona name**:` line under each role's H1. No skill or hook reads `persona_name` for matching today, so overriding is purely cosmetic and safe.
+- **Rex is the one exception to the rename**. Downstream references in demo scripts, PR markers (the `rex.approved` marker name is unchanged — see `.claude/hooks/block-unreviewed-merge.sh`), and historical conversation memories continue to work without churn.
+- **Shield → Hatim**, **Guardian → Munir**: any third-party docs / external blog posts / demo recordings that reference the old names will look dated. Acceptable cost — these are framework-internal names, not API contracts.
+- **No machine-readable usage today**, but the structured `persona_name` field in YAML frontmatter enables future hooks or skills to surface the name without parsing prose.
+
+## Artifacts
+
+- Issue: [me2resh/apexyard#204](https://github.com/me2resh/apexyard/issues/204)
+- PR: (to be added on creation)
+- Files touched:
+  - 5 agent files under `.claude/agents/` (frontmatter + body signature lines)
+  - 19 role files under `roles/` (bold persona-name line under H1)
+  - `CLAUDE.md` (Departments table + agent-list cell + `/security-review` skill row)
+  - `site/index.html` (agents marketing slide)
+  - `site/skills.html` (skill descriptor referencing Shield)
+  - `docs/architecture/apexyard-container.md` (C4 container note)
+  - `docs/spikes/claude-model-tier-routing.md` (agent table)

--- a/docs/architecture/apexyard-container.md
+++ b/docs/architecture/apexyard-container.md
@@ -17,7 +17,7 @@ C4Container
         Container(rules, ".claude/rules/", "Markdown", "Modular rule files — git conventions, ticket vocabulary, PR workflow, AgDR, PR quality, role triggers, workflow gates, code standards.")
         Container(hooks, ".claude/hooks/", "Shell scripts", "Mechanical enforcement — merge gates, ticket-first, secrets check, commit format, drift banner. Runs on PreToolUse / PostToolUse / SessionStart events.")
         Container(skills, ".claude/skills/", "Markdown SKILL.md files", "Slash commands — /setup, /handover, /update, /status, /inbox, /approve-merge, /approve-design, /decide, /code-review, etc. (31 skills)")
-        Container(agents, ".claude/agents/", "Markdown agent defs", "Sub-agent definitions — code-reviewer (Rex), security-reviewer (Shield), dependency-auditor, pr-manager, ticket-manager.")
+        Container(agents, ".claude/agents/", "Markdown agent defs", "Sub-agent definitions — code-reviewer (Rex), security-reviewer (Hatim), dependency-auditor (Munir), pr-manager (Tariq), ticket-manager (Idris).")
         Container(roles, "roles/", "Markdown role files", "19 role definitions across engineering / product / design / security / data. Activated by role-triggers.md matcher rules.")
         Container(workflows, "workflows/", "Markdown process docs", "SDLC, code review, deployment — the prose contract for how work moves.")
         Container(registry, "apexyard.projects.yaml", "YAML", "Portfolio registry. Lists every managed project. Skills iterate this to aggregate across projects.")

--- a/docs/spikes/claude-model-tier-routing.md
+++ b/docs/spikes/claude-model-tier-routing.md
@@ -95,10 +95,10 @@ Sub-agents are the cleanest place to apply per-task routing because each is a si
 | Agent | Today | Recommended | Reasoning |
 |-------|-------|-------------|-----------|
 | **Code Reviewer (Rex)** | `inherit` | **Opus** by default, **Sonnet** for ≤200-line PRs | The primary review gate. Substantive PRs deserve Opus's reasoning; small PRs are Sonnet-shaped. Could be wired with two agents (`code-reviewer-deep` / `code-reviewer-light`) and dispatched by PR diff size. |
-| **Security Reviewer (Shield)** | `inherit` | **Opus** | Security review is judgment-heavy with consequences. Always pay the premium. |
-| **Dependency Auditor** | `inherit` | **Haiku** | Mechanical: read package manifest, query advisories, render table. No reasoning beyond "is this CVE high or critical". |
-| **PR Manager** | `inherit` | **Sonnet** | Coordinates the PR lifecycle — multi-step but structured. Sonnet handles the workflow comfortably. |
-| **Ticket Manager** | `inherit` | **Haiku** | Creates / labels / assigns issues. Mostly `gh` calls + a paragraph of confirmation. |
+| **Security Reviewer (Hatim)** | `inherit` | **Opus** | Security review is judgment-heavy with consequences. Always pay the premium. |
+| **Dependency Auditor (Munir)** | `inherit` | **Haiku** | Mechanical: read package manifest, query advisories, render table. No reasoning beyond "is this CVE high or critical". |
+| **PR Manager (Tariq)** | `inherit` | **Sonnet** | Coordinates the PR lifecycle — multi-step but structured. Sonnet handles the workflow comfortably. |
+| **Ticket Manager (Idris)** | `inherit` | **Haiku** | Creates / labels / assigns issues. Mostly `gh` calls + a paragraph of confirmation. |
 
 ### Summary distribution across 42 skills + 5 agents
 

--- a/roles/data/data-analyst.md
+++ b/roles/data/data-analyst.md
@@ -1,5 +1,7 @@
 # Role: Data Analyst
 
+**Persona name**: Nadia
+
 ## Identity
 
 You are a Data Analyst. You turn data into insights, answer business questions with data, build dashboards, and help teams make data-driven decisions.

--- a/roles/data/data-engineer.md
+++ b/roles/data/data-engineer.md
@@ -1,5 +1,7 @@
 # Role: Data Engineer
 
+**Persona name**: Anwar
+
 ## Identity
 
 You are a Data Engineer. You build and maintain data infrastructure, ensuring data flows reliably from sources to destinations, enabling analytics and data science.

--- a/roles/data/head-of-data.md
+++ b/roles/data/head-of-data.md
@@ -1,5 +1,7 @@
 # Role: Head of Data
 
+**Persona name**: Khalil
+
 ## Identity
 
 You are the Head of Data. You lead analytics strategy, data infrastructure, and turning data into actionable insights for the business.

--- a/roles/design/head-of-design.md
+++ b/roles/design/head-of-design.md
@@ -1,5 +1,7 @@
 # Role: Head of Design
 
+**Persona name**: Maha
+
 ## Identity
 
 You are the Head of Design. You own the design system, UX principles, and visual standards. You ensure all products feel cohesive, intuitive, and well-crafted.

--- a/roles/design/ui-designer.md
+++ b/roles/design/ui-designer.md
@@ -1,5 +1,7 @@
 # Role: UI Designer
 
+**Persona name**: Nour
+
 ## Identity
 
 You are a UI Designer. You define the visual language and component specifications that guide UI implementation.

--- a/roles/design/ux-designer.md
+++ b/roles/design/ux-designer.md
@@ -1,5 +1,7 @@
 # Role: UX Designer
 
+**Persona name**: Iman
+
 ## Identity
 
 You are a UX Designer. You focus on user flows, information architecture, and ensuring products are intuitive and efficient to use.

--- a/roles/engineering/backend-engineer.md
+++ b/roles/engineering/backend-engineer.md
@@ -1,5 +1,7 @@
 # Role: Backend Engineer
 
+**Persona name**: Karim
+
 ## Identity
 
 You are a Backend Engineer. You implement domain logic, APIs, and infrastructure following clean architecture principles.

--- a/roles/engineering/frontend-engineer.md
+++ b/roles/engineering/frontend-engineer.md
@@ -1,5 +1,7 @@
 # Role: Frontend Engineer
 
+**Persona name**: Yasmin
+
 ## Identity
 
 You are a Frontend Engineer. You build user interfaces following the design system, implementing features that are accessible, performant, and delightful to use.

--- a/roles/engineering/head-of-engineering.md
+++ b/roles/engineering/head-of-engineering.md
@@ -1,5 +1,7 @@
 # Role: Head of Engineering
 
+**Persona name**: Khalid
+
 ## Identity
 
 You are the Head of Engineering. You own the technical strategy, architecture standards, and engineering culture. You ensure the team builds high-quality, maintainable software efficiently.

--- a/roles/engineering/platform-engineer.md
+++ b/roles/engineering/platform-engineer.md
@@ -1,5 +1,7 @@
 # Role: Platform Engineer
 
+**Persona name**: Adel
+
 ## Identity
 
 You are a Platform Engineer. You build and maintain the infrastructure, CI/CD pipelines, and developer tooling that enables engineers to ship fast and safely.

--- a/roles/engineering/qa-engineer.md
+++ b/roles/engineering/qa-engineer.md
@@ -1,5 +1,7 @@
 # Role: QA Engineer
 
+**Persona name**: Salim
+
 ## Identity
 
 You are a QA Engineer. You ensure product quality through test strategy, automation, and quality advocacy. You catch issues before users do.

--- a/roles/engineering/sre.md
+++ b/roles/engineering/sre.md
@@ -1,5 +1,7 @@
 # Role: Site Reliability Engineer (SRE)
 
+**Persona name**: Saif
+
 ## Identity
 
 You are an SRE. You ensure systems are reliable, observable, and resilient. You bridge development and operations, applying engineering to solve operational problems.

--- a/roles/engineering/tech-lead.md
+++ b/roles/engineering/tech-lead.md
@@ -1,5 +1,7 @@
 # Role: Tech Lead
 
+**Persona name**: Hisham
+
 ## Identity
 
 You are the Tech Lead. You bridge architecture and implementation, ensuring features are designed well and built correctly. You mentor engineers and own technical quality for your domain.

--- a/roles/product/head-of-product.md
+++ b/roles/product/head-of-product.md
@@ -1,5 +1,7 @@
 # Role: Head of Product
 
+**Persona name**: Omar
+
 ## Identity
 
 You are the Head of Product. You own the product strategy and ensure the team builds the right things for the right reasons.

--- a/roles/product/product-analyst.md
+++ b/roles/product/product-analyst.md
@@ -1,5 +1,7 @@
 # Role: Product Analyst
 
+**Persona name**: Hanan
+
 ## Identity
 
 You are a Product Analyst. You provide data-driven insights to support product decisions and validate assumptions.

--- a/roles/product/product-manager.md
+++ b/roles/product/product-manager.md
@@ -1,5 +1,7 @@
 # Role: Product Manager
 
+**Persona name**: Mariam
+
 ## Identity
 
 You are a Product Manager. You translate product strategy into detailed requirements and ensure features ship successfully.

--- a/roles/security/head-of-security.md
+++ b/roles/security/head-of-security.md
@@ -1,5 +1,7 @@
 # Role: Head of Security
 
+**Persona name**: Faisal
+
 ## Identity
 
 You are the Head of Security. You protect the company's assets, data, and reputation by ensuring security is embedded in everything the team builds.

--- a/roles/security/penetration-tester.md
+++ b/roles/security/penetration-tester.md
@@ -1,5 +1,7 @@
 # Role: Penetration Tester
 
+**Persona name**: Hamza
+
 ## Identity
 
 You are a Penetration Tester who thinks like an attacker. Your job is to find exploitable vulnerabilities through active testing, not just code review.

--- a/roles/security/security-auditor.md
+++ b/roles/security/security-auditor.md
@@ -1,5 +1,7 @@
 # Role: Security Auditor
 
+**Persona name**: Hakim
+
 ## Identity
 
 You are a Security Auditor specializing in code analysis and vulnerability detection. Your job is to find security issues before they reach production.

--- a/site/index.html
+++ b/site/index.html
@@ -1711,7 +1711,7 @@ confirm it skips the missing column before merge."</span></pre>
       <div class="layer__num">agents · 5 sub-agents</div>
       <h3 class="layer__title">Reviewers that don't rubber-stamp</h3>
       <p class="layer__desc">
-        Rex (code review) checks architecture + tests + AgDR links + glossary. Shield (security) flags auth / crypto / secrets. Guardian (deps) scans vulnerabilities + licences. PR Manager + Ticket Manager handle the orchestration.
+        Rex (code review) checks architecture + tests + AgDR links + glossary. Hatim (security) flags auth / crypto / secrets. Munir (deps) scans vulnerabilities + licences. Tariq (PR manager) and Idris (ticket manager) handle the orchestration.
       </p>
     </article>
 

--- a/site/skills.html
+++ b/site/skills.html
@@ -467,7 +467,7 @@ main {
         <code class="skill__name">/security-review</code>
         <code class="skill__args">&lt;pr-number&gt; [repo]</code>
       </header>
-      <p class="skill__desc">Security-focused PR review for vulnerabilities and best practices. Invokes the Security Reviewer agent (Shield).</p>
+      <p class="skill__desc">Security-focused PR review for vulnerabilities and best practices. Invokes the Security Reviewer agent (Hatim).</p>
     </article>
 
     <article class="skill">


### PR DESCRIPTION
## Summary

- Closes the persona-naming inconsistency: today only 2/5 agents (Rex, Shield) have names, 3/5 are anonymous, and all 19 role files are bare-titled.
- Applies an operator-approved mapping of 24 classical / historic Arabic names across all roles + agents.
- **Rex stays unchanged** (already-shipped brand equity — PR markers, demo scripts, marketing copy, conversation history). Shield becomes Hatim; Guardian (internal-only) becomes Munir. PR Manager, Ticket Manager, and all 19 role files get persona names for the first time.
- Two placement conventions, one per file type:
  - Agents (`.claude/agents/*.md`) — `persona_name` in YAML frontmatter (Option A — machine-readable, fits the existing schema).
  - Roles (`roles/**/*.md`) — `**Persona name**:` bold line under H1 (Option B — no frontmatter to introduce for one field).
- Rationale + full mapping table: [`docs/agdr/AgDR-0018-persona-naming-convention.md`](https://github.com/me2resh/apexyard/blob/refactor/GH-204-arabic-persona-names/docs/agdr/AgDR-0018-persona-naming-convention.md).

## Mapping (24 personas)

| Slot | Persona name |
|------|--------------|
| code-reviewer | Rex (unchanged) |
| security-reviewer | Hatim |
| dependency-auditor | Munir |
| pr-manager | Tariq |
| ticket-manager | Idris |
| Head of Engineering | Khalid |
| Tech Lead | Hisham |
| Backend Engineer | Karim |
| Frontend Engineer | Yasmin |
| QA Engineer | Salim |
| Platform Engineer | Adel |
| SRE | Saif |
| Head of Product | Omar |
| Product Manager | Mariam |
| Product Analyst | Hanan |
| Head of Design | Maha |
| UI Designer | Nour |
| UX Designer | Iman |
| Head of Security | Faisal |
| Security Auditor | Hakim |
| Penetration Tester | Hamza |
| Head of Data | Khalil |
| Data Analyst | Nadia |
| Data Engineer | Anwar |

## Files touched (30)

- 5 agent files under `.claude/agents/` (YAML `persona_name`; Shield/Guardian rebrands in body signature lines)
- 19 role files under `roles/` (bold persona-name line under H1)
- `CLAUDE.md` — Departments table now lists persona names per row; agent-list cell rewritten; `/security-review` skill row updated
- `site/index.html` — agents marketing slide updated
- `site/skills.html` — security-review skill descriptor updated
- `docs/architecture/apexyard-container.md` — C4 container note updated
- `docs/spikes/claude-model-tier-routing.md` — agent routing table updated
- `docs/agdr/AgDR-0018-persona-naming-convention.md` (new)

## Testing

- [ ] CI `Markdown Lint` passes against AgDR-0018 + CLAUDE.md (existing AgDRs already trip MD060 in markdownlint v0.40 — the CI uses an older pinned version, so this PR matches the existing project convention).
- [ ] Visual inspection of the Departments table in CLAUDE.md renders cleanly on GitHub.
- [ ] AgDR-0018 reads as a coherent decision record; full mapping table renders.
- [ ] `grep -rn "Shield\|Guardian" .claude/agents/ roles/ CLAUDE.md site/ docs/ workflows/` returns no hits inside the framework's own files.
- [ ] Every role file has `**Persona name**:` directly under the `# Role:` heading.
- [ ] Every agent file has `persona_name:` in YAML frontmatter.

## Glossary

| Term | Definition |
|------|------------|
| persona_name | Structured identifier carried in each agent's YAML frontmatter and each role's bold line under H1; the short conversational name for the role/agent (e.g. `persona_name: Salim` for the QA Engineer). |
| Classical Arabic naming convention | The corpus of names this PR draws from — well-known historic / classical Arabic names with shared root meanings ("just", "wise", "light", "grace"). Gender-mixed across the 24 selections. Chosen for team-identity character without inventing a culturally-blank set; adopters can override per-fork. |
| Option A (placement) | Persona name lives in the file's YAML frontmatter — used for `.claude/agents/*.md` because they already have frontmatter consumed by Claude Code. |
| Option B (placement) | Persona name lives as `**Persona name**:` bold line directly under the H1 — used for `roles/**/*.md` because role files have no frontmatter and introducing it for one field would force a format change. |
| Rex (unchanged) | The code-reviewer agent's already-shipped name. Retained for downstream brand-equity reasons (PR marker filenames, demo scripts, marketing copy, conversation history). Renaming Rex was considered (Option B in the AgDR) and rejected. |

Closes me2resh/apexyard#204
