### PR TITLE
feat(#205): role-activation visibility markers — prose convention with persona-name awareness

### DIFF
--- a/.claude/rules/role-triggers.md
+++ b/.claude/rules/role-triggers.md
@@ -46,6 +46,32 @@ Head of Product → Product Manager → Head of Design / UX Designer / UI Design
 
 Each handoff is explicit. The handing-off role delivers the artefact defined in its role file (PRD, tech design, PR, test plan, etc.); the receiving role reads it and moves forward.
 
+### How to signal activation
+
+When you activate, hand off, or exit a role, print a single-line marker at the top of your response. The reader sees who's driving the work right now.
+
+**Activation** — when entering a role:
+
+```
+▸ Activating Salim (QA Engineer) for #42 (trigger: ticket labeled `qa`)
+```
+
+**Handoff** — when one role hands off to another:
+
+```
+▸ Salim (QA Engineer) → Mariam (Product Manager) (handoff: acceptance criteria signed off)
+```
+
+**Exit** — when finishing a role and returning to ambient mode:
+
+```
+▸ Salim (QA Engineer) task complete — returning to ambient mode
+```
+
+The persona name comes from the `persona_name` field added in [#204](https://github.com/me2resh/apexyard/issues/204). If a future role doesn't have a persona name (custom adopter role), drop the name and use just the title (e.g. `▸ Activating QA Engineer for #42 …`). The triangle prefix (`▸`) makes the marker visually scannable.
+
+This is a **prose convention**, not a mechanically-enforced format. The sibling hook (`detect-role-trigger.sh`, from [#206](https://github.com/me2resh/apexyard/issues/206)) already injects an advisory reminder banner when a trigger fires; this convention adds the agent's response side so operators can see the transition in the conversation.
+
 ## Trigger Types
 
 **Auto-activation** — a role should activate automatically when its condition is detected in conversation context:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ When a role activates:
 3. Follow the handoff rules in the role file — who you receive from, who you deliver to
 4. Stay in the role until the task completes or a different trigger activates a different role
 
+When you activate, hand off, or exit a role, print a single-line marker (e.g. `▸ Activating Salim (QA Engineer) for #42 (trigger: ticket labeled qa)`) so operators can see who's driving the work — full marker convention in [`.claude/rules/role-triggers.md`](.claude/rules/role-triggers.md) § "How to signal activation".
+
 Full trigger table and handoff artefacts: @.claude/rules/role-triggers.md
 
 ---

--- a/roles/data/data-analyst.md
+++ b/roles/data/data-analyst.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Nadia
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Nadia (Data Analyst) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are a Data Analyst. You turn data into insights, answer business questions with data, build dashboards, and help teams make data-driven decisions.

--- a/roles/data/data-engineer.md
+++ b/roles/data/data-engineer.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Anwar
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Anwar (Data Engineer) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are a Data Engineer. You build and maintain data infrastructure, ensuring data flows reliably from sources to destinations, enabling analytics and data science.

--- a/roles/data/head-of-data.md
+++ b/roles/data/head-of-data.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Khalil
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Khalil (Head of Data) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are the Head of Data. You lead analytics strategy, data infrastructure, and turning data into actionable insights for the business.

--- a/roles/design/head-of-design.md
+++ b/roles/design/head-of-design.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Maha
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Maha (Head of Design) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are the Head of Design. You own the design system, UX principles, and visual standards. You ensure all products feel cohesive, intuitive, and well-crafted.

--- a/roles/design/ui-designer.md
+++ b/roles/design/ui-designer.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Nour
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Nour (UI Designer) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are a UI Designer. You define the visual language and component specifications that guide UI implementation.

--- a/roles/design/ux-designer.md
+++ b/roles/design/ux-designer.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Iman
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Iman (UX Designer) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are a UX Designer. You focus on user flows, information architecture, and ensuring products are intuitive and efficient to use.

--- a/roles/engineering/backend-engineer.md
+++ b/roles/engineering/backend-engineer.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Karim
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Karim (Backend Engineer) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are a Backend Engineer. You implement domain logic, APIs, and infrastructure following clean architecture principles.

--- a/roles/engineering/frontend-engineer.md
+++ b/roles/engineering/frontend-engineer.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Yasmin
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Yasmin (Frontend Engineer) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are a Frontend Engineer. You build user interfaces following the design system, implementing features that are accessible, performant, and delightful to use.

--- a/roles/engineering/head-of-engineering.md
+++ b/roles/engineering/head-of-engineering.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Khalid
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Khalid (Head of Engineering) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are the Head of Engineering. You own the technical strategy, architecture standards, and engineering culture. You ensure the team builds high-quality, maintainable software efficiently.

--- a/roles/engineering/platform-engineer.md
+++ b/roles/engineering/platform-engineer.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Adel
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Adel (Platform Engineer) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are a Platform Engineer. You build and maintain the infrastructure, CI/CD pipelines, and developer tooling that enables engineers to ship fast and safely.

--- a/roles/engineering/qa-engineer.md
+++ b/roles/engineering/qa-engineer.md
@@ -2,6 +2,26 @@
 
 **Persona name**: Salim
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Salim (QA Engineer) for #<ticket> (trigger: <reason>)`.
+
+If activated for ticket #42 (label `qa`), the first line of your response is:
+
+```
+▸ Activating Salim (QA Engineer) for #42 (trigger: ticket labeled `qa`)
+```
+
+When handing off to the Product Manager after acceptance-criteria verification:
+
+```
+▸ Salim (QA Engineer) → Mariam (Product Manager) (handoff: acceptance criteria signed off)
+```
+
+When you finish the QA task and return to ambient mode:
+
+```
+▸ Salim (QA Engineer) task complete — returning to ambient mode
+```
+
 ## Identity
 
 You are a QA Engineer. You ensure product quality through test strategy, automation, and quality advocacy. You catch issues before users do.

--- a/roles/engineering/sre.md
+++ b/roles/engineering/sre.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Saif
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Saif (Site Reliability Engineer (SRE)) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are an SRE. You ensure systems are reliable, observable, and resilient. You bridge development and operations, applying engineering to solve operational problems.

--- a/roles/engineering/tech-lead.md
+++ b/roles/engineering/tech-lead.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Hisham
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Hisham (Tech Lead) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are the Tech Lead. You bridge architecture and implementation, ensuring features are designed well and built correctly. You mentor engineers and own technical quality for your domain.

--- a/roles/product/head-of-product.md
+++ b/roles/product/head-of-product.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Omar
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Omar (Head of Product) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are the Head of Product. You own the product strategy and ensure the team builds the right things for the right reasons.

--- a/roles/product/product-analyst.md
+++ b/roles/product/product-analyst.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Hanan
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Hanan (Product Analyst) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are a Product Analyst. You provide data-driven insights to support product decisions and validate assumptions.

--- a/roles/product/product-manager.md
+++ b/roles/product/product-manager.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Mariam
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Mariam (Product Manager) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are a Product Manager. You translate product strategy into detailed requirements and ensure features ship successfully.

--- a/roles/security/head-of-security.md
+++ b/roles/security/head-of-security.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Faisal
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Faisal (Head of Security) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are the Head of Security. You protect the company's assets, data, and reputation by ensuring security is embedded in everything the team builds.

--- a/roles/security/penetration-tester.md
+++ b/roles/security/penetration-tester.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Hamza
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Hamza (Penetration Tester) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are a Penetration Tester who thinks like an attacker. Your job is to find exploitable vulnerabilities through active testing, not just code review.

--- a/roles/security/security-auditor.md
+++ b/roles/security/security-auditor.md
@@ -2,6 +2,8 @@
 
 **Persona name**: Hakim
 
+**Signalling activation**: when activated, print the marker convention from `.claude/rules/role-triggers.md` § "How to signal activation". Example: `▸ Activating Hakim (Security Auditor) for #<ticket> (trigger: <reason>)`.
+
 ## Identity
 
 You are a Security Auditor specializing in code analysis and vulnerability detection. Your job is to find security issues before they reach production.

--- a/workflows/code-review.md
+++ b/workflows/code-review.md
@@ -6,7 +6,7 @@ Ensure code quality, share knowledge, and catch issues before they reach product
 
 ## Roles
 
-Code review is a **role-activated** workflow. The roles below activate automatically when a PR is opened, per [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md).
+Code review is a **role-activated** workflow. The roles below activate automatically when a PR is opened, per [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md). When you activate one of these roles for a review, signal it with the single-line marker convention from [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md) § "How to signal activation" — e.g. `▸ Activating Hakim (Security Auditor) for PR #42 (trigger: diff touches **/auth/**)`.
 
 | Role | Responsibility | Role file |
 |------|----------------|-----------|

--- a/workflows/sdlc.md
+++ b/workflows/sdlc.md
@@ -341,7 +341,7 @@ In Progress --> In Review --> QA --> Done
 
 ## Roles Summary
 
-Every phase has a primary role that activates automatically when the phase starts. Full trigger table: [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md).
+Every phase has a primary role that activates automatically when the phase starts. Full trigger table: [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md). When you activate, hand off, or exit a phase's role, print the single-line marker from [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md) § "How to signal activation" (e.g. `▸ Activating Hisham (Tech Lead) for #42 (trigger: planning phase)`) so operators can see the phase transition in the conversation.
 
 | Phase | Primary role | Supporting roles |
 |-------|--------------|------------------|


### PR DESCRIPTION
## Summary

- Add a prose-only convention (no new enforcement hook) for the main agent to print a single-line marker when activating, handing off, or exiting a role — the reader sees who's driving the work right now.
- Marker shape: `▸ Activating <persona> (<role title>) for #<ticket> (trigger: <reason>)` — degrades to title-only when a custom adopter role lacks a `persona_name` field (added in #204).
- Sibling enforcement is already in `detect-role-trigger.sh` (merged via #209 against #206) — that hook injects the *trigger-side* reminder banner; this PR adds the *response-side* convention so transitions are visible in the conversation.

## Testing

Visual inspection only — this is a documentation / convention change with no shell, no test framework, and no runtime behaviour.

- [ ] `.claude/rules/role-triggers.md` carries a new `### How to signal activation` subsection under Activation Protocol, with Activation / Handoff / Exit example blocks and the persona-name-fallback note.
- [ ] `CLAUDE.md` "Activation — roles are first-class participants" subsection has a one-line pointer to the new marker convention.
- [ ] `workflows/sdlc.md` "Roles Summary" intro mentions the marker convention with an example using the Tech Lead persona.
- [ ] `workflows/code-review.md` "## Roles" intro mentions the marker convention with an example using the Security Auditor persona.
- [ ] All 19 role files under `roles/**/*.md` carry one consistent additive paragraph immediately after their `**Persona name**:` line and before `## Identity`, naming the rule and showing an example with that role's own persona + title baked in. The `**Persona name**:` line is preserved untouched.
- [ ] `roles/engineering/qa-engineer.md` additionally carries a worked-example block (Activation / Handoff / Exit) as a cosmetic adopter aid — proves the pattern reads naturally end-to-end.
- [ ] `markdownlint-cli2` reports no new MD031 / MD032 / MD040 violations introduced by this PR (the pre-existing MD060 noise is unchanged).

## Glossary

| Term | Definition |
|------|------------|
| **Activation marker** | The single-line `▸ Activating …` banner the main agent prints at the top of its response when entering a role. Lets operators see who's driving the work without scanning prose. |
| **Ambient mode** | The default state of the main agent — not embodying any specific role. Returned to via the exit marker (`▸ <persona> (<role>) task complete — returning to ambient mode`). |
| **▸ prefix** | BLACK RIGHT-POINTING SMALL TRIANGLE (U+25B8). Chosen for the marker because it's visually distinct from prose, renders cleanly in both monospace and proportional fonts, and is already conventional in CLI tools for "active item" / "you are here" indicators. |
| **Handoff marker** | The single-line `▸ <from-persona> (<from-role>) → <to-persona> (<to-role>) (handoff: <artefact>)` banner emitted when one role finishes its part of an SDLC chain and hands the artefact (PRD, tech design, PR, test plan) to the next role. Pairs with the Handoff Artefacts table in `.claude/rules/role-triggers.md`. |
| **Exit marker** | The `▸ <persona> (<role>) task complete — returning to ambient mode` line printed when a role finishes its task and the agent returns to ambient mode. |
| **persona_name** | The bold-line identifier (e.g. `**Persona name**: Salim`) added by #204 to every role file and as a YAML field to every agent. Provides a stable, human-friendly identifier for each role independent of the role title. |

## Notes

- v1 is **prose-only**. No new hook, no validation, no tests. Mechanical enforcement on the trigger side is already in `detect-role-trigger.sh` (from #206); a future PR could add a `Stop` / `PostToolUse` hook that scans assistant text for the marker, but that's a different surface and out of scope here.
- The ▸ prefix choice is documented in the commit body rather than as a separate AgDR — small enough decision and the rationale (visually distinct, prose-only, sibling-hook backstop) is captured there.
- All Edits touch markdown only — no role's CAN / CANNOT boundaries, no responsibilities, no handoff tables changed. Additive only.

Closes me2resh/apexyard#205