### PR TITLE
docs(#219): plan-mode usage rule — when to enter

### DIFF
--- a/.claude/rules/plan-mode.md
+++ b/.claude/rules/plan-mode.md
@@ -1,0 +1,52 @@
+# Plan Mode — When to Enter
+
+Claude Code ships **plan mode** — a harness state where the agent thinks through a multi-step approach and presents it for user approval *before* executing any tool calls that mutate state. This rule is the **trigger heuristic** — it defines when an agent should proactively enter plan mode instead of jumping straight into tool calls.
+
+A typical session jumps into execution on every request — even ones that decompose into several dependent steps with branching choices. The framework should make plan-mode-first the default for the cases where it pays off, not a pattern each user rediscovers by watching their agent thrash.
+
+## When to ENTER plan mode (proactively)
+
+Heuristic: enter plan mode when the user's request hits **any** of these:
+
+- **Multi-step coordination (≥ 4 dependent steps)** — the steps share state, ordering matters, and a wrong early step costs visible rework
+- **Unclear path** — there are 2+ plausible approaches and picking wrong means non-trivial backtracking
+- **Hard-to-reverse action upcoming** — destructive ops (force push, branch delete, schema migration), externally-visible writes (PR/issue creation, message sends), shared-state changes
+- **Validating a fan-out split** — before calling `/fan-out`, plan mode forces explicit articulation of the per-task scope so the parallel agents can't drift apart
+
+Examples that should trigger plan mode:
+
+- "Adopt repo X into the portfolio" (handover discovery — multi-step + branching on what the static read finds)
+- "Debug why the marketplace add is silently failing" (unclear path + multiple hypotheses to triage)
+- "Refactor module X from MVC to clean architecture" (multi-step + the file-move plan is the load-bearing decision)
+- "File these 5 tickets and open PRs against each" (externally-visible writes, want to confirm the batch before any `gh issue create` fires)
+
+## When NOT to enter plan mode
+
+- **Single read or single edit** — `Read X`, `grep for Y`, `change line 42 from foo to bar`. Plan mode adds latency without removing risk.
+- **Well-scoped patch with obvious next-action** — the user already named the file + the change, the change is reversible (one commit, one revert), and there's nothing to plan.
+- **Conversation has already established the plan** — the user just spent five turns discussing the approach with you. Re-entering plan mode to re-present what was just agreed is ceremony.
+- **Trivial work** — copy-paste edits, doc typos, label additions on a known issue. Same overhead-exceeds-gain calculus as `/fan-out` on three-line changes.
+
+## Self-check before responding
+
+Before answering a user request that involves tool calls, scan your planned response for:
+
+```
+[ ] Will this involve ≥ 4 dependent tool calls?
+[ ] Are there ≥ 2 plausible paths and I haven't committed to one?
+[ ] Am I about to do something hard-to-reverse (destructive, externally-visible, shared-state)?
+[ ] Am I about to spawn parallel agents via /fan-out without an explicit per-task scope?
+[ ] Did I write a multi-step plan in prose without entering plan mode?
+```
+
+If any box is checked and you didn't enter plan mode, you missed an opportunity. The last item — *"wrote a multi-step plan in prose"* — is the most common failure mode and the easiest to catch retroactively.
+
+## Prior art
+
+Anthropic's `opusplan` model alias is a related prior-art pattern: Opus runs during plan mode (deeper reasoning while the cost matters), Sonnet runs during execution (cheaper while the choices are mechanical). See [Claude Code model configuration](https://code.claude.com/docs/en/model-config) for the alias and tier-routing semantics. The `opusplan` shape implies plan mode is meant as a *deliberate, more-expensive thinking phase*, not a default-on ceremony — which lines up with the "when NOT to enter" list above.
+
+## Backstop
+
+This rule is **primarily self-discipline**. Mechanical enforcement isn't viable — plan mode is harness-owned (the harness owns `EnterPlanMode` / `ExitPlanMode`), so no shell hook can see "the agent should have entered plan mode but didn't" in assistant prose. Pair this rule with feedback memory: if the CEO has previously asked "why didn't you plan this first?", surface plan mode more aggressively next time.
+
+The cost of entering plan mode and being told "skip the plan, just do it" is a quick `ExitPlanMode`. The cost of jumping into tool calls on a multi-step task with an unclear path is the visible rework the user has to watch you do.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ Work on ONE ticket at a time. Complete fully before starting next. Each PR = one
 - **Code review required** before merge
 - **Explicit per-PR CEO approval required for every merge** -- plan-level "go" / "continue" / "ship it" does NOT authorize any `gh pr merge`. Stop before each merge and ask for a per-PR explicit nod. Mechanically enforced by `block-unreviewed-merge.sh` + the `/approve-merge` skill. Full rationale and examples: @.claude/rules/pr-workflow.md
 - **Tracker vocabulary is reserved** -- the words `Ticket`, `#N`, and dependency notation (`blocked by #N`, `depends on #N`) refer ONLY to real GitHub issues that exist in a tracker. Never apply them to in-conversation plan items. When decomposing work in chat, use `Step N` / `Item N` / plain bullets. Crossing the boundary from "plan item" to "tracker item" requires an explicit `gh issue create`. Full rule and anti-pattern example: @.claude/rules/ticket-vocabulary.md
+- **Plan mode for multi-step or risky work** -- enter plan mode when the task is ≥4 dependent steps, the path is unclear, or you're about to do something hard-to-reverse (force push, schema migration, batch PR/issue creation). Same self-discipline shape as parallel-work; harness-owned, no hook. Full heuristic: @.claude/rules/plan-mode.md
 - **No hardcoded secrets** -- use environment variables
 
 ### Code Review


### PR DESCRIPTION
## Summary

- New rule at `.claude/rules/plan-mode.md` mirroring `parallel-work.md`'s structure exactly (intro → when-to-enter → when-NOT-to → self-check → prior art → backstop).
- Closes the gap surfaced in #219: a grep across `.claude/`, `docs/`, `workflows/`, `CLAUDE.md` returned only one mention of plan mode (a spike doc referencing Anthropic's `opusplan` alias). Zero guidance for the agent.
- The rule fires on **any** of four triggers: ≥4 dependent steps, unclear path with ≥2 plausible approaches, hard-to-reverse upcoming action (force push, schema migration, batch tracker writes), or before `/fan-out` so per-task scope is explicit.
- Bullet added to `CLAUDE.md` § "Quality Rules" so the rule is surfaced inline next to `git-conventions`, `pr-workflow`, and `ticket-vocabulary` — same pattern those use.

## Why this matters

Plan mode is harness-owned and not visible to PreToolUse hooks — there's no mechanical way to enforce "should have planned first." The rule is the only available lever. Without it the agent falls back to its default of jumping into tool calls, which on multi-step tasks costs the operator visible rework time. The shape mirrors `parallel-work.md` deliberately: same primarily-self-discipline frame, same "cost of a missed call vs cost of one extra short message" framing.

The Prior Art section names `opusplan` (Opus during plan, Sonnet during execution) so a future operator reading the rule can connect the framework's heuristic to the model-routing pattern Anthropic ships natively.

## Testing

- [x] AC sanity check: all six required headings present in `plan-mode.md` (When to ENTER, When NOT, Self-check, Prior art, Backstop, harness-owned mention)
- [x] CLAUDE.md import: new bullet uses the `@.claude/rules/plan-mode.md` reference shape that matches the other rule references in the file
- [x] Structure mirrors `parallel-work.md` (same headings, same self-check checklist pattern, comparable length — 52 lines vs parallel-work's 60)
- [ ] Reviewer can skim `parallel-work.md` and `plan-mode.md` side-by-side and confirm the structural symmetry is intentional and clean
- [ ] Manual smoke test post-merge: a fresh session reading `CLAUDE.md` picks up the new rule and the agent can articulate the trigger heuristic when asked *"when should you use plan mode"*

## Glossary

| Term | Definition |
|---|---|
| Plan mode | Claude Code harness state where the agent presents a multi-step approach for user approval before executing any state-mutating tool calls. The harness owns `EnterPlanMode` / `ExitPlanMode` — hooks cannot see or enforce plan-mode entry. |
| `opusplan` | Anthropic model alias that runs Opus during plan mode and Sonnet during execution — deeper reasoning while choices matter, cheaper while choices are mechanical. Cited as prior art for tier-aware planning. |
| Agent-discipline rule | A rule documented in `.claude/rules/*.md` that's enforceable only by the agent's own self-check, with no shell hook backstop. Sibling rules: `parallel-work.md` (when to offer `/fan-out`). |
| Self-check checklist | The five-line `[ ]` block in each agent-discipline rule that the agent scans its planned response against before answering. The same pattern is used in `parallel-work.md`. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
