### PR TITLE
feat(#218): audit-skill artefact persistence + canonical structure

### DIFF
--- a/.claude/hooks/_lib-audit-history.sh
+++ b/.claude/hooks/_lib-audit-history.sh
@@ -1,0 +1,385 @@
+#!/bin/bash
+# _lib-audit-history.sh — shared persistence + trend rendering for audit skills.
+#
+# Generalises the per-run JSON + per-run MD + opt-in commit marker
+# convention that /launch-check has shipped since #183 (see AgDR-0014).
+# Other audit skills (/threat-model, /security-review, /compliance-check,
+# /accessibility-audit, /performance-audit, /seo-audit, /monitoring-audit,
+# /docs-audit, /analytics-audit) consume this lib so their per-run
+# artefacts share the same on-disk shape and the trend across runs is
+# legible.
+#
+# Design + decision rationale:
+#   docs/technical-designs/audit-artefact-persistence.md
+#   docs/agdr/AgDR-0019-audit-artefact-persistence.md
+#
+# Functions (sourced; do not exec this file directly):
+#   audit_resolve_dir <project_name> <dimension>
+#       Echoes <projects_dir>/<project_name>/audits/<dimension>/. Creates
+#       it if missing.
+#
+#   audit_run_persist <project_name> <dimension> <ts> <verdict> <score> <body_file>
+#       Reads a JSON payload from stdin (must contain a findings[] array,
+#       optionally a stats{} object). Writes two artefacts:
+#         <dim_dir>/runs/<ts_safe>.json    (the stdin JSON, augmented with
+#                                           top-level ts/dimension/verdict/score)
+#         <dim_dir>/<ts_safe>.md           (skill-provided body prefixed with
+#                                           generated YAML frontmatter)
+#       Updates <dim_dir>/.gitignore based on .audit-history-tracked
+#       marker presence.
+#
+#   audit_run_list <project_name> <dimension> [limit]
+#       Prints filenames of last <limit> JSON runs (default 10), sorted
+#       by ts ascending. Reads the canonical path AND the legacy
+#       launch-check path (projects/<name>/launch-check/runs/) when
+#       <dimension> is "launch-check" — non-destructive backward compat
+#       per AgDR-0019.
+#
+#   audit_render_trend <project_name> <dimension> [window]
+#       Loads the last <window> JSON runs (default 5), emits a markdown
+#       trend block (heading + table + ASCII chart) to stdout. Silent
+#       (exit 0) when fewer than 2 runs exist.
+#
+# Dependencies: jq, awk, sort, mkdir. No network calls.
+# Sourced by audit-skill SKILL.md flows; never invoked as a standalone
+# command.
+
+# Don't run twice in the same shell.
+[ -n "${_LIB_AUDIT_HISTORY_SOURCED:-}" ] && return 0
+_LIB_AUDIT_HISTORY_SOURCED=1
+
+# Locate the lib's own dir so we can source siblings (read-config, portfolio-paths).
+_AUDIT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -f "$_AUDIT_LIB_DIR/_lib-read-config.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$_AUDIT_LIB_DIR/_lib-read-config.sh"
+fi
+if [ -f "$_AUDIT_LIB_DIR/_lib-portfolio-paths.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$_AUDIT_LIB_DIR/_lib-portfolio-paths.sh"
+fi
+
+# Render-trend.sh ships next to /launch-check; the trend rendering logic
+# is currently launch-check-shaped. Until #218 absorbs render-trend.sh
+# fully, we shell out to it for the launch-check dimension and use a
+# generic findings-shaped renderer for everything else.
+_AUDIT_RENDER_TREND_SH=""
+if [ -n "$_AUDIT_LIB_DIR" ]; then
+  _candidate="$(cd "$_AUDIT_LIB_DIR/.." 2>/dev/null && pwd)/skills/launch-check/render-trend.sh"
+  [ -f "$_candidate" ] && _AUDIT_RENDER_TREND_SH="$_candidate"
+fi
+
+# ---------------------------------------------------------------------------
+# audit_resolve_dir <project_name> <dimension>
+# Echoes the canonical audit dir for the given project + dimension.
+# Creates it if missing.
+# ---------------------------------------------------------------------------
+audit_resolve_dir() {
+  local project_name="$1"
+  local dimension="$2"
+  if [ -z "$project_name" ] || [ -z "$dimension" ]; then
+    echo "audit_resolve_dir: project_name and dimension required" >&2
+    return 2
+  fi
+
+  local projects_dir
+  if command -v portfolio_projects_dir >/dev/null 2>&1; then
+    projects_dir=$(portfolio_projects_dir)
+  else
+    # Fallback: assume single-fork layout from the ops root.
+    projects_dir="$(git rev-parse --show-toplevel 2>/dev/null)/projects"
+  fi
+
+  local dim_dir="$projects_dir/$project_name/audits/$dimension"
+  mkdir -p "$dim_dir/runs"
+  printf '%s' "$dim_dir"
+}
+
+# ---------------------------------------------------------------------------
+# Internal: convert ISO-8601 ts to filesystem-safe form (colons → dashes).
+# ---------------------------------------------------------------------------
+_audit_ts_safe() {
+  printf '%s' "$1" | tr ':' '-'
+}
+
+# ---------------------------------------------------------------------------
+# Internal: write/refresh the dim's .gitignore based on opt-in marker.
+# Marker present     → un-ignore *.json under runs/  (history committed)
+# Marker absent      → ignore everything under runs/ (history local-only)
+# ---------------------------------------------------------------------------
+_audit_apply_marker() {
+  local dim_dir="$1"
+  local marker="$dim_dir/.audit-history-tracked"
+  local gitignore="$dim_dir/.gitignore"
+  if [ -f "$marker" ]; then
+    cat > "$gitignore" <<'EOF'
+# audit history is committed for this dimension
+# (.audit-history-tracked marker is present)
+!runs/
+!runs/*.json
+EOF
+  else
+    cat > "$gitignore" <<'EOF'
+# audit history is local-only for this dimension
+# (touch .audit-history-tracked to opt in to committed history)
+runs/
+EOF
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# audit_run_persist <project_name> <dimension> <ts> <verdict> <score> <body_file>
+# JSON payload from stdin. Writes JSON + MD pair.
+# ---------------------------------------------------------------------------
+audit_run_persist() {
+  local project_name="$1"
+  local dimension="$2"
+  local ts="$3"
+  local verdict="$4"
+  local score="$5"
+  local body_file="$6"
+
+  if [ -z "$project_name" ] || [ -z "$dimension" ] || [ -z "$ts" ] \
+     || [ -z "$verdict" ] || [ -z "$score" ] || [ -z "$body_file" ]; then
+    echo "audit_run_persist: requires project_name, dimension, ts, verdict, score, body_file" >&2
+    return 2
+  fi
+  if [ ! -f "$body_file" ]; then
+    echo "audit_run_persist: body_file does not exist: $body_file" >&2
+    return 2
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "audit_run_persist: jq is required" >&2
+    return 2
+  fi
+
+  local dim_dir
+  dim_dir=$(audit_resolve_dir "$project_name" "$dimension") || return $?
+  local ts_safe
+  ts_safe=$(_audit_ts_safe "$ts")
+
+  # Read stdin JSON. Augment with top-level metadata, derive stats from
+  # findings[] if absent.
+  local json_path="$dim_dir/runs/$ts_safe.json"
+  jq --arg ts "$ts" --arg dim "$dimension" --arg v "$verdict" --argjson s "$score" '
+    . as $in
+    | (.findings // []) as $f
+    | (.stats // null) as $existing_stats
+    | (
+        $f
+        | reduce .[] as $x ({"by_severity":{},"by_status":{}};
+            .by_severity[$x.severity] = ((.by_severity[$x.severity] // 0) + 1)
+            | .by_status[$x.status]   = ((.by_status[$x.status]   // 0) + 1)
+          )
+      ) as $derived_stats
+    | $in
+      + { ts: $ts, dimension: $dim, verdict: $v, score: $s,
+          schema_version: ($in.schema_version // 1),
+          stats: ($existing_stats // $derived_stats) }
+  ' > "$json_path" || {
+    echo "audit_run_persist: jq failed writing JSON" >&2
+    return 1
+  }
+
+  # Build frontmatter from the just-written JSON, then concatenate with body.
+  local md_path="$dim_dir/$ts_safe.md"
+  local fm
+  fm=$(jq -r '
+    "---",
+    "date: " + (.ts // "" | .[0:10]),
+    "ts: " + (.ts // ""),
+    "dimension: " + (.dimension // ""),
+    "verdict: " + (.verdict // ""),
+    "score: " + ((.score // 0) | tostring),
+    "schema_version: " + ((.schema_version // 1) | tostring),
+    "findings_summary:",
+    "  critical: " + (((.stats // {}).by_severity.critical // 0) | tostring),
+    "  high: "     + (((.stats // {}).by_severity.high     // 0) | tostring),
+    "  medium: "   + (((.stats // {}).by_severity.medium   // 0) | tostring),
+    "  low: "      + (((.stats // {}).by_severity.low      // 0) | tostring),
+    "  info: "     + (((.stats // {}).by_severity.info     // 0) | tostring),
+    "---",
+    ""
+  ' "$json_path") || {
+    echo "audit_run_persist: jq failed building frontmatter" >&2
+    return 1
+  }
+
+  {
+    printf '%s\n' "$fm"
+    cat "$body_file"
+  } > "$md_path" || return 1
+
+  _audit_apply_marker "$dim_dir"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# audit_run_list <project_name> <dimension> [limit]
+# Prints up to <limit> JSON paths sorted by ts ascending (oldest → newest).
+# For dimension=launch-check, ALSO reads the legacy
+# projects/<name>/launch-check/runs/*.json path so adopters' existing
+# trend history is not orphaned.
+# ---------------------------------------------------------------------------
+audit_run_list() {
+  local project_name="$1"
+  local dimension="$2"
+  local limit="${3:-10}"
+
+  if [ -z "$project_name" ] || [ -z "$dimension" ]; then
+    echo "audit_run_list: project_name and dimension required" >&2
+    return 2
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "audit_run_list: jq required" >&2
+    return 2
+  fi
+
+  local dim_dir
+  dim_dir=$(audit_resolve_dir "$project_name" "$dimension") || return $?
+
+  local projects_dir
+  if command -v portfolio_projects_dir >/dev/null 2>&1; then
+    projects_dir=$(portfolio_projects_dir)
+  else
+    projects_dir="$(git rev-parse --show-toplevel 2>/dev/null)/projects"
+  fi
+
+  # Candidate runs dirs: canonical, plus legacy launch-check path.
+  local candidates=("$dim_dir/runs")
+  if [ "$dimension" = "launch-check" ]; then
+    local legacy="$projects_dir/$project_name/launch-check/runs"
+    [ -d "$legacy" ] && candidates+=("$legacy")
+  fi
+
+  # Build tab-separated <ts>\t<path>, sort by ts ascending, take last <limit>.
+  {
+    for d in "${candidates[@]}"; do
+      [ -d "$d" ] || continue
+      for f in "$d"/*.json; do
+        [ -f "$f" ] || continue
+        local ts
+        ts=$(jq -r '.ts // ""' "$f" 2>/dev/null) || ts=""
+        [ -n "$ts" ] || continue
+        printf '%s\t%s\n' "$ts" "$f"
+      done
+    done
+  } | sort | tail -n "$limit" | awk -F '\t' '{print $2}'
+}
+
+# ---------------------------------------------------------------------------
+# audit_render_trend <project_name> <dimension> [window]
+# Renders the trend section to stdout. Silent when <2 runs.
+#
+# For dimension=launch-check, dispatch to the existing render-trend.sh
+# (preserves byte-equal output for the regression test). For everything
+# else, render a generic findings-based trend (table + ASCII chart of
+# the .score field).
+# ---------------------------------------------------------------------------
+audit_render_trend() {
+  local project_name="$1"
+  local dimension="$2"
+  local window="${3:-5}"
+
+  if [ -z "$project_name" ] || [ -z "$dimension" ]; then
+    echo "audit_render_trend: project_name and dimension required" >&2
+    return 2
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "audit_render_trend: jq required" >&2
+    return 2
+  fi
+
+  # Collect runs (ts-sorted ascending paths).
+  local runs
+  runs=$(audit_run_list "$project_name" "$dimension" "$window")
+  local n
+  n=$(printf '%s\n' "$runs" | grep -c . || true)
+  if [ "${n:-0}" -lt 2 ]; then
+    return 0
+  fi
+
+  # launch-check dispatches to the legacy renderer for byte-equal output
+  # of the existing chart (mean of scores.* on Y-axis). render-trend.sh
+  # takes a single dir argument, but audit_run_list above already merged
+  # old + new paths — so stage the merged file set into a tmp dir before
+  # invoking it. This preserves adopters' existing history on first
+  # post-refactor run, no manual `mv` required.
+  if [ "$dimension" = "launch-check" ] && [ -n "$_AUDIT_RENDER_TREND_SH" ]; then
+    local staged
+    staged=$(mktemp -d)
+    while IFS= read -r f; do
+      [ -f "$f" ] && cp "$f" "$staged/" 2>/dev/null
+    done <<< "$runs"
+    "$_AUDIT_RENDER_TREND_SH" "$staged" "$window"
+    local rc=$?
+    rm -rf "$staged"
+    return $rc
+  fi
+
+  # Generic renderer: parallel arrays of date / score / verdict.
+  local dates=() scores=() verdicts=()
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    local ts date verdict score
+    ts=$(jq -r '.ts // ""' "$path")
+    date=$(printf '%s' "$ts" | cut -c1-10)
+    verdict=$(jq -r '.verdict // "?"' "$path")
+    score=$(jq -r '(.score // 0) | tostring' "$path")
+    dates+=("$date")
+    scores+=("$score")
+    verdicts+=("$verdict")
+  done <<< "$runs"
+
+  echo "## Trend (last ${#dates[@]} runs)"
+  echo ""
+  echo "| Date       | Score | Verdict     |"
+  echo "|------------|-------|-------------|"
+  local i
+  for ((i=0; i<${#dates[@]}; i++)); do
+    printf '| %-10s | %5s | %-11s |\n' \
+      "${dates[$i]}" "${scores[$i]}" "${verdicts[$i]}"
+  done
+  echo ""
+
+  # ASCII chart, same shape as render-trend.sh (5 rows, 6 col-width).
+  local min max y_lo y_hi range rows
+  min=$(printf '%s\n' "${scores[@]}" | sort -n | head -1)
+  max=$(printf '%s\n' "${scores[@]}" | sort -n | tail -1)
+  y_lo=$(( min - 5 )); [ "$y_lo" -lt 0 ] && y_lo=0
+  y_hi=$(( max + 5 )); [ "$y_hi" -gt 100 ] && y_hi=100
+  [ "$y_hi" -le "$y_lo" ] && y_hi=$(( y_lo + 10 ))
+  rows=5
+  range=$(( y_hi - y_lo ))
+  [ "$range" -le 0 ] && range=10
+
+  echo "Score trend:"
+  echo ""
+  local r j
+  for ((r = rows - 1; r >= 0; r--)); do
+    local level line
+    level=$(( y_lo + (range * r) / (rows - 1) ))
+    line=$(printf '%3d |' "$level")
+    for j in "${!scores[@]}"; do
+      local s row_for_s
+      s="${scores[$j]}"
+      row_for_s=$(( ((s - y_lo) * (rows - 1) + range / 2) / range ))
+      if [ "$row_for_s" -eq "$r" ]; then
+        line="${line}   ●  "
+      else
+        line="${line}      "
+      fi
+    done
+    echo "$line"
+  done
+  local xaxis="    +"
+  for _ in "${!scores[@]}"; do xaxis="${xaxis}------"; done
+  echo "$xaxis"
+  local labels="     "
+  local d
+  for d in "${dates[@]}"; do
+    labels="${labels}$(printf '%s' "$d" | cut -c6-) "
+  done
+  echo "$labels"
+}

--- a/.claude/hooks/tests/test_audit_history.sh
+++ b/.claude/hooks/tests/test_audit_history.sh
@@ -1,0 +1,370 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/_lib-audit-history.sh
+# (apexyard#218 — audit-skill artefact persistence + canonical structure)
+#
+# Each case:
+#   - builds an isolated sandbox under $TMPDIR
+#   - overrides portfolio_projects_dir to point at the sandbox
+#   - exercises the lib function under test
+#   - asserts file presence, JSON shape, frontmatter shape, or stdout shape
+#
+# Cases covered (matches AC in apexyard#218):
+#   1. audit_resolve_dir creates the dim dir + runs/ subdir
+#   2. audit_run_persist writes both JSON + MD with augmented top-level fields
+#   3. audit_run_persist derives stats.by_severity from findings[]
+#   4. audit_run_persist preserves explicit stats{} when caller provides them
+#   5. audit_run_persist applies .gitignore based on .audit-history-tracked marker
+#   6. audit_run_list returns paths sorted by ts ascending
+#   7. audit_run_list reads legacy launch-check/runs/ path for the launch-check dim
+#   8. audit_render_trend silent (<2 runs)
+#   9. audit_render_trend emits table + chart (>=2 runs) for a generic dimension
+#  10. audit_render_trend for launch-check dispatches to legacy render-trend.sh
+#  11. audit_render_trend for launch-check merges old + new history (regression
+#      test for AC: "/launch-check refactored without behaviour change")
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+LIB="$SRC_ROOT/.claude/hooks/_lib-audit-history.sh"
+
+if [ ! -f "$LIB" ]; then
+  echo "FAIL: lib not found at $LIB" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not installed; lib requires jq" >&2
+  exit 0
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# ---------------------------------------------------------------------------
+# Sandbox + lib loader. Each call creates a fresh sandbox, defines a stub
+# portfolio_projects_dir pointing at it, and sources the lib (after the
+# stub so the lib's later use of `command -v portfolio_projects_dir` finds
+# our stub via shell function name resolution).
+# ---------------------------------------------------------------------------
+fresh_sandbox() {
+  mktemp -d
+}
+
+source_lib_with_projects_dir() {
+  local sb="$1"
+  # Define stub BEFORE sourcing — but the lib re-sources real portfolio
+  # paths if available. Workaround: source the lib first (using guard
+  # already), then redefine the function in our shell. Bash will use the
+  # latest definition for subsequent calls.
+  # shellcheck source=/dev/null
+  . "$LIB"
+  portfolio_projects_dir() { printf '%s' "$1/projects"; }
+  # Force re-export by binding to a local var via closure-style trick:
+  # since bash dynamic-scopes function bodies, we redefine using the sb
+  # value baked into a string.
+  eval "portfolio_projects_dir() { printf '%s' '$sb/projects'; }"
+}
+
+# write_payload_json <findings_json>
+# Echoes a payload JSON containing only the findings array (lib derives
+# stats from it).
+write_payload_json() {
+  local findings="$1"
+  printf '{"findings": %s}\n' "$findings"
+}
+
+# write_payload_with_stats <findings_json> <stats_json>
+# Echoes a payload with explicit stats (lib should preserve, not derive).
+write_payload_with_stats() {
+  local findings="$1" stats="$2"
+  printf '{"findings": %s, "stats": %s}\n' "$findings" "$stats"
+}
+
+mark_pass() { echo "  ✓ $1"; return 0; }
+mark_fail() { echo "  ✗ $1: $2" >&2; return 1; }
+# Each case_N runs in a subshell (so the lib's function-redefinition
+# trickery doesn't leak between cases). Subshells can't mutate the
+# parent's PASS/FAIL counters, so the runner aggregates via $? from
+# each case invocation.
+run_case() {
+  local fn="$1"
+  if "$fn"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES $fn"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: audit_resolve_dir creates dirs
+# ---------------------------------------------------------------------------
+case_1() {
+  local case_name="audit_resolve_dir creates dim + runs/"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    out=$(audit_resolve_dir "demo" "threat-model")
+    expected="$sb/projects/demo/audits/threat-model"
+    [ "$out" = "$expected" ] || { mark_fail "$case_name" "wrong path: $out"; return; }
+    [ -d "$expected/runs" ] || { mark_fail "$case_name" "runs/ not created"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: audit_run_persist writes JSON + MD pair
+# ---------------------------------------------------------------------------
+case_2() {
+  local case_name="audit_run_persist writes JSON + MD"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    body=$(mktemp)
+    echo "## Body" > "$body"
+    findings='[{"id":"T1","severity":"high","status":"open","summary":"x"}]'
+    write_payload_json "$findings" \
+      | audit_run_persist "demo" "threat-model" "2026-05-11T20:30:00Z" "fail" 65 "$body"
+    [ -f "$sb/projects/demo/audits/threat-model/runs/2026-05-11T20-30-00Z.json" ] \
+      || { mark_fail "$case_name" "JSON not written"; return; }
+    [ -f "$sb/projects/demo/audits/threat-model/2026-05-11T20-30-00Z.md" ] \
+      || { mark_fail "$case_name" "MD not written"; return; }
+    rm -f "$body"
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: derived stats.by_severity
+# ---------------------------------------------------------------------------
+case_3() {
+  local case_name="audit_run_persist derives stats from findings"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    body=$(mktemp); echo "x" > "$body"
+    findings='[
+      {"id":"T1","severity":"high","status":"open","summary":"a"},
+      {"id":"T2","severity":"high","status":"open","summary":"b"},
+      {"id":"T3","severity":"medium","status":"mitigated","summary":"c"}
+    ]'
+    write_payload_json "$findings" \
+      | audit_run_persist "demo" "threat-model" "2026-05-11T20:30:00Z" "fail" 50 "$body"
+    json="$sb/projects/demo/audits/threat-model/runs/2026-05-11T20-30-00Z.json"
+    high=$(jq -r '.stats.by_severity.high' "$json")
+    medium=$(jq -r '.stats.by_severity.medium' "$json")
+    [ "$high" = "2" ]   || { mark_fail "$case_name" "high count: $high"; return; }
+    [ "$medium" = "1" ] || { mark_fail "$case_name" "medium count: $medium"; return; }
+    rm -f "$body"
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: explicit stats preserved
+# ---------------------------------------------------------------------------
+case_4() {
+  local case_name="audit_run_persist preserves caller-provided stats"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    body=$(mktemp); echo "x" > "$body"
+    findings='[]'
+    stats='{"by_severity":{"critical":7,"high":2},"by_status":{"open":5}}'
+    write_payload_with_stats "$findings" "$stats" \
+      | audit_run_persist "demo" "threat-model" "2026-05-11T20:30:00Z" "fail" 30 "$body"
+    json="$sb/projects/demo/audits/threat-model/runs/2026-05-11T20-30-00Z.json"
+    critical=$(jq -r '.stats.by_severity.critical' "$json")
+    [ "$critical" = "7" ] || { mark_fail "$case_name" "explicit stats lost: $critical"; return; }
+    rm -f "$body"
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: gitignore semantics from .audit-history-tracked marker
+# ---------------------------------------------------------------------------
+case_5() {
+  local case_name="audit_run_persist applies marker-driven .gitignore"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    body=$(mktemp); echo "x" > "$body"
+    payload='{"findings":[]}'
+
+    # First run: marker absent → .gitignore should suppress runs/
+    printf '%s' "$payload" \
+      | audit_run_persist "demo" "threat-model" "2026-05-11T20:30:00Z" "pass" 100 "$body"
+    gi="$sb/projects/demo/audits/threat-model/.gitignore"
+    grep -q '^runs/$' "$gi" \
+      || { mark_fail "$case_name" "marker absent: gitignore should ignore runs/"; return; }
+
+    # Drop the marker, persist again → .gitignore should un-ignore *.json
+    touch "$sb/projects/demo/audits/threat-model/.audit-history-tracked"
+    printf '%s' "$payload" \
+      | audit_run_persist "demo" "threat-model" "2026-05-11T21:00:00Z" "pass" 100 "$body"
+    grep -q '!runs/\*\.json' "$gi" \
+      || { mark_fail "$case_name" "marker present: gitignore should un-ignore *.json"; return; }
+    rm -f "$body"
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 6: audit_run_list sorts by ts ascending
+# ---------------------------------------------------------------------------
+case_6() {
+  local case_name="audit_run_list sorts by ts ascending"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    body=$(mktemp); echo "x" > "$body"
+    for ts in "2026-05-11T20:30:00Z" "2026-04-15T14:22:00Z" "2026-05-01T09:00:00Z"; do
+      printf '{"findings":[]}' \
+        | audit_run_persist "demo" "threat-model" "$ts" "pass" 90 "$body"
+    done
+    out=$(audit_run_list "demo" "threat-model" 10)
+    first=$(echo "$out" | head -1)
+    last=$(echo "$out" | tail -1)
+    echo "$first" | grep -q "2026-04-15" \
+      || { mark_fail "$case_name" "first should be Apr-15: $first"; return; }
+    echo "$last"  | grep -q "2026-05-11" \
+      || { mark_fail "$case_name" "last should be May-11: $last"; return; }
+    rm -f "$body"
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 7: audit_run_list reads legacy launch-check path
+# ---------------------------------------------------------------------------
+case_7() {
+  local case_name="audit_run_list reads legacy launch-check/runs/"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    # Drop a legacy-shape run JSON in projects/demo/launch-check/runs/
+    legacy_dir="$sb/projects/demo/launch-check/runs"
+    mkdir -p "$legacy_dir"
+    cat > "$legacy_dir/2026-04-01T00-00-00Z.json" <<'EOF'
+{"ts":"2026-04-01T00:00:00Z","scores":{"security":80,"performance":75},"verdict":"go"}
+EOF
+    out=$(audit_run_list "demo" "launch-check" 10)
+    echo "$out" | grep -q "launch-check/runs/2026-04-01" \
+      || { mark_fail "$case_name" "legacy file not surfaced. out=$out"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 8: audit_render_trend silent on <2 runs
+# ---------------------------------------------------------------------------
+case_8() {
+  local case_name="audit_render_trend silent on <2 runs"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    body=$(mktemp); echo "x" > "$body"
+    printf '{"findings":[]}' \
+      | audit_run_persist "demo" "threat-model" "2026-05-11T20:30:00Z" "pass" 90 "$body"
+    out=$(audit_render_trend "demo" "threat-model" 5)
+    [ -z "$out" ] || { mark_fail "$case_name" "expected empty, got: $out"; return; }
+    rm -f "$body"
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 9: audit_render_trend emits trend on >=2 runs (generic dim)
+# ---------------------------------------------------------------------------
+case_9() {
+  local case_name="audit_render_trend emits trend on 2+ runs"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    body=$(mktemp); echo "x" > "$body"
+    for ts in "2026-04-15T14:22:00Z" "2026-05-11T20:30:00Z"; do
+      printf '{"findings":[]}' \
+        | audit_run_persist "demo" "threat-model" "$ts" "pass" 90 "$body"
+    done
+    out=$(audit_render_trend "demo" "threat-model" 5)
+    echo "$out" | grep -q "## Trend (last 2 runs)" \
+      || { mark_fail "$case_name" "no trend heading. out=$out"; return; }
+    echo "$out" | grep -q "Score trend:" \
+      || { mark_fail "$case_name" "no score-trend chart. out=$out"; return; }
+    rm -f "$body"
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 10: audit_render_trend dispatches to render-trend.sh for launch-check
+# ---------------------------------------------------------------------------
+case_10() {
+  local case_name="audit_render_trend dispatches to legacy renderer for launch-check"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    runs_dir="$sb/projects/demo/audits/launch-check/runs"
+    mkdir -p "$runs_dir"
+    for i in 1 2; do
+      ts="2026-05-0${i}T12-00-00Z"
+      cat > "$runs_dir/$ts.json" <<EOF
+{"ts":"2026-05-0${i}T12:00:00Z","scores":{"security":80,"performance":7${i}},"verdict":"go"}
+EOF
+    done
+    out=$(audit_render_trend "demo" "launch-check" 5)
+    # The legacy renderer emits "Score trend:" too; assert it ran (heading present).
+    echo "$out" | grep -q "## Trend (last 2 runs)" \
+      || { mark_fail "$case_name" "legacy renderer didn't fire. out=$out"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Run all cases
+# ---------------------------------------------------------------------------
+echo "Running audit-history lib tests..."
+# ---------------------------------------------------------------------------
+# Case 11: launch-check trend merges old + new path histories (regression test
+# for the "without behaviour change" AC). One run in legacy path, one run in
+# canonical path; trend should render with BOTH dates visible in the chart.
+# ---------------------------------------------------------------------------
+case_11() {
+  local case_name="audit_render_trend merges legacy + canonical for launch-check"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    legacy_dir="$sb/projects/demo/launch-check/runs"
+    canon_dir="$sb/projects/demo/audits/launch-check/runs"
+    mkdir -p "$legacy_dir" "$canon_dir"
+    cat > "$legacy_dir/2026-04-01T00-00-00Z.json" <<'EOF'
+{"ts":"2026-04-01T00:00:00Z","scores":{"security":80,"performance":75},"verdict":"go"}
+EOF
+    cat > "$canon_dir/2026-05-01T00-00-00Z.json" <<'EOF'
+{"ts":"2026-05-01T00:00:00Z","scores":{"security":85,"performance":80},"verdict":"go","dimension":"launch-check","score":82,"schema_version":1}
+EOF
+    out=$(audit_render_trend "demo" "launch-check" 5)
+    # Both dates should appear in the rendered table.
+    echo "$out" | grep -q "2026-04-01" \
+      || { mark_fail "$case_name" "legacy date missing from trend. out=$out"; return; }
+    echo "$out" | grep -q "2026-05-01" \
+      || { mark_fail "$case_name" "canonical date missing from trend. out=$out"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+for fn in case_1 case_2 case_3 case_4 case_5 case_6 case_7 case_8 case_9 case_10 case_11; do
+  run_case "$fn"
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/skills/launch-check/SKILL.md
+++ b/.claude/skills/launch-check/SKILL.md
@@ -227,92 +227,99 @@ Print the table exactly as shown in the "Output format" section above. Then cont
 
 ### Step 6: Persist the run + render the trend
 
-After the verdict table, persist this run to the project's history store and append a trend section if there are ≥ 2 prior runs.
+After the verdict table, persist this run to the project's history store via the shared audit-history lib and append a trend section if there are ≥ 2 prior runs.
 
-#### 6a. Resolve the project's launch-check directory
+This step was refactored as part of #218 to consume `_lib-audit-history.sh` (the same lib that powers `/threat-model`, `/security-review`, and the other audit skills). Behaviour is preserved: the JSON schema is the same superset shape, the chart is rendered by the same `render-trend.sh` (dispatched from inside the lib), and adopters' existing run-history at the legacy path is still picked up by the trend renderer.
 
-Use the portfolio helper to resolve the projects dir — do NOT hardcode `projects/`:
+#### 6a. Resolve project name + score + verdict
+
+`<project-name>` is the project's registered name in `apexyard.projects.yaml`. If the project isn't registered (e.g. someone runs `/launch-check` on a directory that's never been onboarded), use the basename of the project path; tell the operator to `/handover` it for cross-machine trend continuity.
+
+The headline score is the unweighted mean of `scores.*`, rounded to int. The verdict is one of `go` / `go-with-warnings` / `conditional-go` / `no-go` (launch-check-specific four-state vocabulary, preserved from the existing skill).
+
+#### 6b. Build payload + body, persist via the lib
+
+The lib's `audit_run_persist` accepts arbitrary stdin JSON and augments it with top-level `ts` / `dimension` / `verdict` / `score` fields, then writes both a JSON file and an MD file. For launch-check the JSON payload is a SUPERSET — it includes the legacy `scores{}` map (for `render-trend.sh` to plot) AND a derived `findings[]` array (for the canonical schema):
 
 ```bash
-source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
-source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
-projects_dir=$(portfolio_projects_dir)
-lc_dir="$projects_dir/<project-name>/launch-check"
-runs_dir="$lc_dir/runs"
-mkdir -p "$runs_dir"
-```
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-audit-history.sh"
 
-`<project-name>` is the project's registered name in `apexyard.projects.yaml`. If the project isn't registered (e.g. someone runs `/launch-check` on a directory that's never been onboarded), use the basename of the project path; tell the user the project should be `/handover`'d into the registry to make the trend persistent across machines.
-
-#### 6b. Write the per-run JSON
-
-Schema (apexyard#183):
-
-```json
+# Map each scored dimension to a Finding for the canonical schema.
+# Severity from score: ≥85 info, 70-84 low, 55-69 medium, 40-54 high, <40 critical.
+payload=$(mktemp); cat > "$payload" <<'EOF'
 {
-  "ts": "2026-05-08T19:30:00Z",
+  "schema_version": 1,
   "branch": "main",
   "commit": "abc1234",
   "scores": {
-    "security": 88,
-    "accessibility": 94,
-    "compliance": 76,
-    "analytics": 90,
-    "seo": 87,
-    "performance": 68,
-    "monitoring": 83,
-    "docs": 91
+    "security": 88, "accessibility": 94, "compliance": 76,
+    "analytics": 90, "seo": 87, "performance": 68,
+    "monitoring": 83, "docs": 91
   },
-  "verdict": "conditional-go",
-  "top_risks": ["No cookie consent banner", "Missing /health endpoint"]
+  "top_risks": ["No cookie consent banner", "Missing /health endpoint"],
+  "findings": [
+    {"id": "compliance",  "severity": "low",    "status": "open", "summary": "compliance score 76 — cookie consent banner missing"},
+    {"id": "performance", "severity": "medium", "status": "open", "summary": "performance score 68 — bundle > 250KB"}
+  ]
 }
+EOF
+
+# Body: the human-readable per-run summary launch-check already produces.
+body=$(mktemp); cat > "$body" <<'EOF'
+## Launch-check verdict: conditional-go
+
+| Dimension       | Score | Status |
+|-----------------|-------|--------|
+| Security        | 88    | PASS   |
+| Accessibility   | 94    | PASS   |
+| Compliance      | 76    | WARN   |
+| ...             | ...   | ...    |
+
+## Top risks
+
+1. No cookie consent banner
+2. Missing /health endpoint
+
+## Recommendations
+
+(...)
+EOF
+
+ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+audit_run_persist "<project-name>" "launch-check" "$ts" "conditional-go" 84 "$body" < "$payload"
+rm -f "$payload" "$body"
 ```
 
-- `ts` — ISO-8601 UTC. Used for chronological sort.
-- `branch` / `commit` — `git rev-parse --abbrev-ref HEAD` and `git rev-parse --short HEAD` from the project's working tree.
-- `scores.*` — 0..100 per dimension. Map PASS → 95 ± project-specific finding-density, WARN → 70..85, FAIL → 30..55. Use your judgement based on the finding's severity. The headline score is the unweighted mean — adopters who want weighting can post-process.
-- `verdict` — one of `go`, `go-with-warnings`, `conditional-go`, `no-go`.
-- `top_risks` — the same blocking items you listed in the human-readable output.
+`audit_run_persist` writes:
 
-Write the file at `<runs_dir>/<ts>.json` with the timestamp safely encoded for filesystems (replace `:` with `-`, e.g. `2026-05-08T19-30-00Z.json`).
+- `projects/<name>/audits/launch-check/runs/<ts>.json` — JSON with everything the lib added on top of the payload (top-level `ts`, `dimension: launch-check`, `verdict`, `score`, `schema_version`) AND everything in the original payload (`scores{}`, `branch`, `commit`, `top_risks[]`, `findings[]`, derived `stats{}`)
+- `projects/<name>/audits/launch-check/<ts>.md` — frontmatter + the body above
+- `projects/<name>/audits/launch-check/.gitignore` — driven by the per-dim `.audit-history-tracked` marker presence
 
-**Forward-compatibility note:** the schema is open. Future framework versions may add fields (e.g. `notes`, `actor`, `weighting`); the trend renderer reads only `ts`, `scores`, `verdict`, so older run files continue to render correctly after framework upgrades.
+**JSON schema is a SUPERSET.** The canonical fields (`ts`, `dimension`, `verdict`, `score`, `findings[]`, `stats{}`, `schema_version`) coexist with the launch-check-specific fields (`scores{}`, `branch`, `commit`, `top_risks[]`). The legacy `render-trend.sh` reads `ts` / `scores` / `verdict` and works unchanged. The new generic `audit_render_trend` reads `ts` / `score` / `verdict` and works for the rest of the audit family.
 
 #### 6c. Render the trend section
 
-Run the trend renderer:
-
 ```bash
-"$SKILL_DIR/render-trend.sh" "$runs_dir" 5
+audit_render_trend "<project-name>" "launch-check" 5
 ```
 
-- With < 2 runs in the dir → prints nothing, exits 0. Skip the trend section in this run's output (this is correct on a project's first run).
-- With ≥ 2 runs → prints the trend markdown block (heading + table + ASCII chart) to stdout. Append it to this run's per-run summary markdown at `<lc_dir>/<ts>.md` and to the chat output.
-
-The `notes` column is auto-derived from the score-delta vs the previous run (e.g. "Security +12, Performance +5"). The most-recent row appends "(this run)". Operator-supplied notes are v2; v1 is auto-derived only.
+- The lib internally dispatches to `render-trend.sh` for the `launch-check` dimension — byte-equal output to the pre-#218 chart (mean of `scores.*` on Y-axis, score-delta notes, ASCII chart).
+- Crucially, the lib's `audit_run_list` merges JSON from the canonical path (`projects/<name>/audits/launch-check/runs/`) AND the legacy path (`projects/<name>/launch-check/runs/`) — so adopters' existing history continues to render across the migration. No `mv` required.
+- Output is a markdown trend block (heading + table + ASCII chart). Append it to this run's MD artefact and to the chat output.
 
 #### 6d. Opt-in commit (history-tracked marker)
 
-By default, history JSON files are gitignored. Most adopters do not want history bloat in the repo.
-
-Operator opt-in: a presence-only marker file at `<lc_dir>/.launch-check-history-tracked` flips this. When the marker exists, the skill emits a `.gitignore` for `<runs_dir>/` that *un-ignores* `*.json` files; when absent, the runs dir is fully gitignored.
-
-Concretely on first persist:
-
-- If `<lc_dir>/.launch-check-history-tracked` exists:
-  - Ensure `<lc_dir>/.gitignore` does NOT block runs JSON (delete or comment any `runs/` exclusion).
-- Otherwise:
-  - Ensure `<lc_dir>/.gitignore` contains `runs/` so JSON files don't accidentally get committed.
-
-Either way, leave it for the operator to `git add` when they want history committed; never auto-commit. The skill is read-only with respect to the working tree's commit state.
-
-To opt-in to committing history (for a project whose readiness trend the team wants archived in the repo):
+The per-dimension marker (`.audit-history-tracked`) sits inside the dimension's audit dir and controls whether `runs/*.json` files are gitignored:
 
 ```bash
-touch projects/<name>/launch-check/.launch-check-history-tracked
+# Opt in to commit launch-check history
+touch projects/<name>/audits/launch-check/.audit-history-tracked
 ```
 
-To opt back out, delete the marker.
+The lib re-evaluates the marker on every persist; toggling is free. The MD artefact at `<dim_dir>/<ts>.md` is committed regardless — that's the durable human-readable artefact.
+
+**Migration note for adopters with existing history:** the legacy marker at `projects/<name>/launch-check/.launch-check-history-tracked` continues to apply to that path's `runs/`. To consolidate trees, `mv projects/<name>/launch-check/* projects/<name>/audits/launch-check/` after backing up; the lib's renderer will read the consolidated tree on the next run. Consolidation is optional — the read-merge happens transparently if you leave both trees in place.
 
 ## Trend-only mode — `/launch-check trend [project-path]`
 
@@ -320,9 +327,9 @@ Read-only mode that produces just the trend section (no full audit, no per-dimen
 
 Process:
 
-1. Resolve the project's launch-check dir (same as Step 6a).
-2. If `<runs_dir>` doesn't exist or has < 2 JSON files, tell the operator there's no trend yet (run `/launch-check` first to establish baseline + at least one comparison point).
-3. Otherwise, run `render-trend.sh "$runs_dir" 5` and print the output.
+1. Source `_lib-audit-history.sh` (same as Step 6).
+2. Call `audit_render_trend "<project-name>" "launch-check" 5`. The lib reads both the canonical path AND the legacy path; if the merged set has < 2 runs the call is silent and you tell the operator there's no trend yet.
+3. Print the renderer's output.
 
 Do NOT run the 8-dimension sweep in this mode. Do NOT write any new JSON. This mode is purely for reviewing existing history.
 
@@ -335,15 +342,18 @@ Do NOT run the 8-dimension sweep in this mode. Do NOT write any new JSON. This m
 5. **Advisory, not blocking.** The user decides go/no-go based on the findings. The skill does NOT block deploys mechanically.
 6. **Don't create tickets unprompted.** Offer to create them. Let the user decide.
 7. **Run from the project directory.** The skill checks `workspace/<project>/`, not the ops repo.
-8. **Persist every run.** Step 6 always writes a JSON file under the project's `launch-check/runs/` (regardless of opt-in commit state). The `.launch-check-history-tracked` marker only controls whether those files are committed; it does NOT control whether they are written.
-9. **Resolve paths via the portfolio helper.** Don't hardcode `projects/` — adopters in split-portfolio mode have a different projects dir. Use `portfolio_projects_dir` from `_lib-portfolio-paths.sh`.
+8. **Persist every run via the lib.** Step 6 always calls `audit_run_persist`, regardless of opt-in commit state. The `.audit-history-tracked` marker only controls whether the JSON files are committed; the MD artefacts are committed unconditionally and persistence happens on every run.
+9. **Resolve paths via the lib.** `audit_resolve_dir` (inside `_lib-audit-history.sh`) calls `portfolio_projects_dir` for you — the SKILL doesn't need to source the portfolio helper directly any more.
 
 ## Implementation notes
 
-The persistence + trend logic ships as a small shell helper alongside this SKILL:
+Persistence + trend logic ships as a shared shell helper that all audit skills consume:
 
 | File | Purpose |
 |------|---------|
-| `render-trend.sh` | Reads `<runs_dir>` for `*.json` files, sorts by `ts`, emits the trend markdown block (heading + table + ASCII chart). Exits silently with no output when < 2 runs exist. |
+| `.claude/hooks/_lib-audit-history.sh` | Audit-history library shared with /threat-model, /security-review, etc. (4 functions: `audit_resolve_dir`, `audit_run_persist`, `audit_run_list`, `audit_render_trend`) |
+| `render-trend.sh` (this skill's dir) | Legacy chart renderer for the launch-check dimension; the lib's `audit_render_trend` dispatches to it when the dimension is `launch-check` so the chart shape stays byte-equal across the #218 refactor |
 
-Design rationale (ASCII chart vs Mermaid, JSON schema choice, opt-in commit marker): see [`docs/agdr/AgDR-0014-launch-check-trend-tracking.md`](../../../docs/agdr/AgDR-0014-launch-check-trend-tracking.md).
+Design rationale:
+- ASCII chart vs Mermaid, JSON schema choice, opt-in commit marker: see [`docs/agdr/AgDR-0014-launch-check-trend-tracking.md`](../../../docs/agdr/AgDR-0014-launch-check-trend-tracking.md)
+- Audit-history lib shape, JSON+MD pair, launch-check backward-compat strategy: see [`docs/agdr/AgDR-0019-audit-artefact-persistence.md`](../../../docs/agdr/AgDR-0019-audit-artefact-persistence.md) and [`docs/technical-designs/audit-artefact-persistence.md`](../../../docs/technical-designs/audit-artefact-persistence.md)

--- a/.claude/skills/launch-check/SKILL.md
+++ b/.claude/skills/launch-check/SKILL.md
@@ -355,5 +355,6 @@ Persistence + trend logic ships as a shared shell helper that all audit skills c
 | `render-trend.sh` (this skill's dir) | Legacy chart renderer for the launch-check dimension; the lib's `audit_render_trend` dispatches to it when the dimension is `launch-check` so the chart shape stays byte-equal across the #218 refactor |
 
 Design rationale:
+
 - ASCII chart vs Mermaid, JSON schema choice, opt-in commit marker: see [`docs/agdr/AgDR-0014-launch-check-trend-tracking.md`](../../../docs/agdr/AgDR-0014-launch-check-trend-tracking.md)
 - Audit-history lib shape, JSON+MD pair, launch-check backward-compat strategy: see [`docs/agdr/AgDR-0019-audit-artefact-persistence.md`](../../../docs/agdr/AgDR-0019-audit-artefact-persistence.md) and [`docs/technical-designs/audit-artefact-persistence.md`](../../../docs/technical-designs/audit-artefact-persistence.md)

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -103,3 +103,97 @@ Posts a GitHub review with:
 - Verdict
 
 Invokes: Security Reviewer Agent (Shield)
+
+## Persist the run + render trend
+
+After the Security Reviewer agent posts the GitHub review, persist a structured artefact via the shared audit-history lib so the security-review trend across PRs becomes legible. See `docs/agdr/AgDR-0019-audit-artefact-persistence.md` for the schema rationale.
+
+### 1. Resolve project name + score + verdict
+
+`<project-name>` is the project's registered name in `apexyard.projects.yaml`, derived from the PR's repo. If the project isn't registered, use the basename of the repo and tell the operator to `/handover` it for cross-machine trend continuity.
+
+Compute a single headline score from the severity distribution of the findings in the review:
+
+```
+score = max(0, 100 - 25*critical - 10*high - 3*medium - 1*low)
+```
+
+Compute the verdict by the worst-severity rule:
+
+| Worst severity present | Verdict |
+|---|---|
+| critical or high       | `fail` |
+| medium only            | `conditional` |
+| low only / none        | `pass` |
+
+### 2. Build payload + body, persist via the lib
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-audit-history.sh"
+
+# Lowercase severity in the payload — the lib's stats derivation expects
+# critical / high / medium / low / info. The visible review on the PR
+# can use whatever capitalisation reads best.
+payload=$(mktemp); cat > "$payload" <<'EOF'
+{
+  "schema_version": 1,
+  "findings": [
+    {"id": "F1", "severity": "critical", "status": "open", "summary": "Unsanitised user input in SQL"},
+    {"id": "F2", "severity": "high",     "status": "open", "summary": "JWT signature not verified"}
+  ]
+}
+EOF
+
+# Body: a markdown summary of the security review for this PR, formatted
+# per templates/audits/security-review.md. Include the diff scope, findings
+# table, dependency vulnerabilities, secrets-scan results, and recommendations.
+body=$(mktemp); cat > "$body" <<'EOF'
+## Scope
+
+PR <number>; reviewed `<branch>..main` (X files, Y +/- lines).
+
+## Findings
+
+| # | Severity | OWASP class | Finding | File:Line | Status |
+|---|---|---|---|---|---|
+| F1 | critical | A03 Injection | Unsanitised user input concatenated into SQL | `src/users.ts:42` | open |
+| F2 | high | A07 Auth failure | JWT signature not verified | `src/auth.ts:18` | open |
+
+## Dependency vulnerabilities
+
+(... output of `npm audit` or `pip audit` for critical+high ...)
+
+## Secrets scan
+
+(... checks per templates/audits/security-review.md ...)
+
+## Recommendations
+
+1. F1 — fix injection vector before merge
+2. F2 — verify JWT signatures
+EOF
+
+ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+audit_run_persist "<project-name>" "security-review" "$ts" "fail" 50 "$body" < "$payload"
+rm -f "$payload" "$body"
+```
+
+### 3. Render the trend section
+
+```bash
+audit_render_trend "<project-name>" "security-review" 5
+```
+
+- < 2 prior runs → silent (no trend section). Don't append anything.
+- ≥ 2 prior runs → prints a markdown trend block (heading + table + ASCII chart of `score` over time) to stdout. Append it to this run's MD artefact so the PR-by-PR security trend is visible.
+
+### 4. Opt-in commit (history-tracked marker)
+
+By default the dimension's runs/ JSON files are gitignored. The lib applies a `.gitignore` based on the presence of the marker:
+
+```bash
+# Opt in to commit security-review history for this project
+touch projects/<name>/audits/security-review/.audit-history-tracked
+```
+
+The MD artefacts at `<dim_dir>/<ts>.md` are committed regardless — they are the durable human-readable artefact of every PR's security review.

--- a/.claude/skills/threat-model/SKILL.md
+++ b/.claude/skills/threat-model/SKILL.md
@@ -81,9 +81,102 @@ After the STRIDE sweep, explicitly check for:
 - Security misconfiguration (CORS *, debug mode, default credentials?)
 - Using components with known vulnerabilities (`npm audit` / `pip audit`)
 
+### Step 5: Persist the run + render trend
+
+After printing the human-readable catalogue (Step 3) and OWASP check (Step 4), persist a structured artefact via the shared audit-history lib so the threat-model trend across runs becomes legible. See `docs/agdr/AgDR-0019-audit-artefact-persistence.md` for the schema rationale.
+
+#### 5a. Resolve project name + score + verdict
+
+`<project-name>` is the project's registered name in `apexyard.projects.yaml`. If the project isn't registered, use the basename of the project path and tell the operator to `/handover` it for cross-machine trend continuity.
+
+Compute a single headline score from the severity distribution:
+
+```
+score = max(0, 100 - 25*critical - 10*high - 3*medium - 1*low)
+```
+
+Compute the verdict by the worst-severity rule:
+
+| Worst severity present | Verdict |
+|---|---|
+| critical or high       | `fail` |
+| medium only            | `conditional` |
+| low only / none        | `pass` |
+
+#### 5b. Build payload + body, persist via the lib
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-audit-history.sh"
+
+# Lowercase severity in the payload — the lib's stats derivation expects
+# critical / high / medium / low / info. The visible catalogue from Step 3
+# can keep whatever capitalisation reads best.
+payload=$(mktemp); cat > "$payload" <<'EOF'
+{
+  "schema_version": 1,
+  "findings": [
+    {"id": "T1", "severity": "high",   "status": "open", "summary": "No rate limit on /auth/login"},
+    {"id": "T2", "severity": "medium", "status": "open", "summary": "Stack traces in prod errors"},
+    {"id": "T3", "severity": "high",   "status": "open", "summary": "No CSRF on state-changing forms"}
+  ]
+}
+EOF
+
+# Body = the catalogue table + OWASP cross-check (per templates/audits/threat-model.md).
+body=$(mktemp); cat > "$body" <<'EOF'
+## Attack surface
+
+3 entry points, 1 data store, 0 external integrations.
+
+## Threats by STRIDE category
+
+| # | Category | Threat | Severity | Entry point | Mitigation |
+|---|---|---|---|---|---|
+| T1 | Spoofing | No rate limit on /auth/login | high | POST /auth/login | Add rate limiter (5/min/IP) |
+| T2 | Info Disclosure | Stack traces in prod errors | medium | Global error handler | Strip when NODE_ENV=production |
+| T3 | Tampering | No CSRF on state-changing forms | high | POST /settings | Add CSRF middleware |
+
+## Recommended priority
+
+1. T1 — rate limit on /auth/login
+2. T3 — CSRF middleware
+3. T2 — strip stack traces
+
+## OWASP cross-check
+
+(... per Step 4 results ...)
+EOF
+
+ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+audit_run_persist "<project-name>" "threat-model" "$ts" "fail" 65 "$body" < "$payload"
+rm -f "$payload" "$body"
+```
+
+#### 5c. Render the trend section
+
+```bash
+audit_render_trend "<project-name>" "threat-model" 5
+```
+
+- < 2 prior runs → silent (no trend section). Don't append anything.
+- ≥ 2 prior runs → prints a markdown trend block (heading + table + ASCII chart of `score` over time) to stdout. Append it to this run's MD artefact and to the chat output.
+
+#### 5d. Opt-in commit (history-tracked marker)
+
+By default the dimension's runs/ JSON files are gitignored — most adopters don't want audit history bloat in the repo. The lib applies a `.gitignore` based on the presence of the marker:
+
+```bash
+# Opt in to commit threat-model history (per-project, per-dimension)
+touch projects/<name>/audits/threat-model/.audit-history-tracked
+```
+
+The lib re-evaluates the marker on every persist; the operator can toggle freely. The MD artefacts at `<dim_dir>/<ts>.md` are committed regardless — they are the durable human-readable artefact.
+
 ## Rules
 
 1. **Lead with the summary table.** Details (code snippets, exploit scenarios) go AFTER the table, organized by severity.
 2. **Be specific about mitigations.** "Add auth" is not a mitigation. "Add JWT verification middleware to routes /api/admin/* using the existing authMiddleware.ts" is.
 3. **Don't cry wolf.** Only flag threats that are realistic for this codebase. A static site doesn't need CSRF protection.
 4. **Adapt scope to project type.** API-only? Focus on auth, input validation, rate limiting. Full-stack? Add XSS, CSRF, cookie security. Library? Focus on supply chain and input handling.
+5. **Always persist.** Step 5 always writes a JSON + MD pair via `audit_run_persist`, regardless of opt-in commit state. The marker only controls whether the JSON is committed; persistence is unconditional so the trend is visible across runs.
+6. **Severity vocabulary in the JSON is lowercase.** The lib's `stats.by_severity` derivation expects `critical` / `high` / `medium` / `low` / `info`. The human-readable Step 3 table can use whatever capitalisation reads best.

--- a/docs/agdr/AgDR-0019-audit-artefact-persistence.md
+++ b/docs/agdr/AgDR-0019-audit-artefact-persistence.md
@@ -1,0 +1,75 @@
+# AgDR-0019 — Audit-skill artefact persistence: schema shape, lib API, launch-check backward-compat
+
+> In the context of generalising `/launch-check`'s persistence convention to the other nine audit skills (#218), facing four load-bearing choices (single vs paired artefact files, findings-shape rigidity, path-segment for launch-check, and lib-API surface), I decided **paired JSON+MD artefacts (preserving launch-check's existing pair pattern), a rigid common-denominator findings shape with per-dimension extension via the MD body, a new `audits/<dim>/` path root with launch-check's existing `launch-check/` path preserved (read-merged not migrated), and a four-function bash lib (`audit_resolve_dir` / `audit_run_persist` / `audit_run_list` / `audit_render_trend`)**, to achieve consistent on-disk structure across all nine audit dimensions without breaking launch-check's existing trend-history adopters, accepting that the rigid findings shape pushes per-dimension nuance into the MD body and the dual-path read for launch-check adds one branch to the trend reader.
+
+## Context
+
+[me2resh/apexyard#218](https://github.com/me2resh/apexyard/issues/218) asks for canonical structure + persistence for the audit-skill family so trend rendering becomes possible across `/threat-model`, `/security-review`, `/compliance-check`, `/accessibility-audit`, `/performance-audit`, `/seo-audit`, `/monitoring-audit`, `/docs-audit`, and `/analytics-audit` — currently only `/launch-check` persists. The technical design lives at [`docs/technical-designs/audit-artefact-persistence.md`](../technical-designs/audit-artefact-persistence.md).
+
+Four decisions in the design needed an explicit airing because each has a viable alternative that would shape adoption differently. None are recoverable for free once shipped.
+
+## Options Considered
+
+### A. Single artefact file (MD-with-frontmatter) vs paired JSON+MD
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Paired JSON + MD** (chosen) | Matches `/launch-check`'s existing pattern (`runs/*.json` + per-run `<ts>.md`) — zero behaviour change for that skill. JSON is parser-friendly for trend renderers, dashboards, and ad-hoc `jq` queries; MD is the human artefact. Each format is good at exactly one job. | Two files per run instead of one. Slight duplication risk if frontmatter and JSON drift (mitigated by writing both from a single in-memory representation in `audit_run_persist`). |
+| Single MD-with-frontmatter | One file per run. Frontmatter (YAML) is parseable. AgDRs and PRDs already use this shape — pattern is familiar. | `/launch-check` would need to migrate its existing JSON history — destructive op for adopters with committed run history. YAML frontmatter is awkward to query with `jq`-class tools; needs a YAML parser. Trend renderer becomes file-grep-and-extract instead of clean JSON load. |
+| Single JSON-with-prose | Machine-friendly. | Operators who edit artefacts by hand (adding context to a finding) get JSON-string-escaped prose. Awful UX. |
+
+### B. Findings shape: rigid common denominator vs per-dimension extensible schema
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Rigid common denominator** `{id, severity, status, summary}` (chosen) | Trend renderer can compare runs across all nine dimensions with one code path. Frontmatter stays small and parseable. Per-dimension extras live in the MD body where they belong. | Some per-dimension nuance (STRIDE category, OWASP class, WCAG criterion) doesn't fit the common shape and has to live in the body — slightly worse for programmatic per-category queries. |
+| Per-dimension extensible (each dim adds its own fields) | Captures everything programmatically. | Trend renderer needs per-dim adapters (9 paths). The "common" structure becomes an empty interface. Adopters writing dashboards face a fragmented schema. |
+| Hybrid (common required fields + a `dim_specific: {}` dict) | Best of both, in theory. | In practice the dict becomes a junk drawer. Dashboards still need per-dim awareness to read it; common-denominator queries get cluttered with `if dim_specific.X` checks. |
+
+### C. Launch-check backward compatibility: migrate paths or read both
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Read both paths, write only to new** (chosen) | Zero destruction of adopters' existing `projects/<name>/launch-check/runs/` history. New runs land in the canonical `audits/launch-check/` tree. Trend reader merges chronologically. Adopters can manually `mv` the old dir to consolidate when ready. | Trend reader has one extra branch (try old path, try new path, merge). Two-tree state for adopters who never migrate manually. |
+| Migrate on first new write | Single-tree state for everyone going forward. | First post-upgrade `/launch-check` run becomes destructive (file moves). Risk of mid-migration crash leaving a half-moved tree. Operators who had `git`-tracked their launch-check history get noisy diffs. |
+| Leave launch-check's path alone, only generalise for the new dimensions | Zero risk for launch-check. | Inconsistency forever — `audits/threat-model/` next to `launch-check/` on the same project. Defeats the "canonical structure" half of the ticket title. |
+
+### D. Lib API surface: four functions vs one omnibus
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Four discrete functions** (chosen): `audit_resolve_dir`, `audit_run_persist`, `audit_run_list`, `audit_render_trend` | Each has one job; each is testable in isolation. Skills only call what they need (e.g. trend-only mode skips `_persist`). Mirrors the `_lib-portfolio-paths.sh` / `_lib-read-config.sh` shape adopters already know. | Four functions to learn instead of one. |
+| One omnibus `audit_run` with subcommands (`audit_run persist …`, `audit_run trend …`) | Single entry point. Looks like `git`. | Bash subcommand dispatch is awkward; arg parsing duplicates work. Tests harder to scope. Doesn't match the existing lib conventions in `.claude/hooks/`. |
+| Skip the lib, copy-paste persistence into each skill | Zero coupling; each skill controls its own destiny. | Defeats the whole ticket. Drift across nine skills is exactly what the ticket is preventing. |
+
+## Decision
+
+Chosen — for all four:
+
+**A.** Paired JSON + MD per run (preserves `/launch-check` exactly).
+**B.** Rigid common-denominator `findings[]` shape; per-dimension extras in the MD body via per-dim templates.
+**C.** Read launch-check's old + new paths, write only to new — no destructive migration.
+**D.** Four-function shell lib at `.claude/hooks/_lib-audit-history.sh`.
+
+Why this combination:
+
+1. **Pair preserves launch-check** — the existing JSON history of every adopter on `/launch-check` keeps working with zero migration. The change is additive: future runs land in the canonical tree; old runs are still readable.
+2. **Rigid findings shape keeps the trend renderer simple** — one code path across all nine dimensions. The MD body is the right place for per-dimension nuance because operators read those by hand; the structured layer only needs what the trend cares about.
+3. **Dual-path read is one extra branch in one function** — `audit_run_list` checks both `projects/<name>/audits/launch-check/runs/*.json` and `projects/<name>/launch-check/runs/*.json` for that one dimension. ~5 lines of bash. Cheap insurance against orphaning adopter history.
+4. **Four discrete functions** match the existing `_lib-*.sh` shape — adopters reading the source recognise the pattern from `_lib-portfolio-paths.sh`. Onboarding cost ≈ zero.
+
+## Consequences
+
+- The `/launch-check` skill keeps its four-state vocabulary (`go` / `go-with-warnings` / `conditional-go` / `no-go`) in its own stdout and MD body, but its frontmatter `verdict` field maps to the generic three-state (`pass` / `conditional` / `fail`) so trend comparisons across mixed-dimension data are coherent.
+- Adopters with committed `projects/<name>/launch-check/.launch-check-history-tracked` markers get a follow-up choice on first post-upgrade run: keep the old marker (works for old path) and add `projects/<name>/audits/launch-check/.audit-history-tracked` (works for new path), or run the manual `mv` consolidation. Documented in launch-check's SKILL.md upgrade note.
+- Per-dimension templates at `templates/audits/<dim>.md` are *reference material*, not auto-loaded by the skill. Each retrofitted skill embeds the body shape it produces inline; the template is a copy-paste starting point for adopters writing new audit-class skills (or for the seven follow-up retrofits).
+- Schema versioning is explicit (`schema_version: 1` in both JSON and MD frontmatter). v2 won't ship until there's a forcing function; the renderer dispatches per version with v1 as the fallback reader.
+- Cross-project audit aggregation (a portfolio-wide "every audit's latest verdict") becomes trivially possible — walk the registry, glob `projects/*/audits/*/<latest>.json`, render. Out of scope for #218; this AgDR records that the chosen shape doesn't block it.
+- The follow-up ticket retrofitting the remaining seven dimensions (`/compliance-check`, `/accessibility-audit`, `/performance-audit`, `/seo-audit`, `/monitoring-audit`, `/docs-audit`, `/analytics-audit`) is mechanical: drop in the same `audit_run_persist` call, write a per-dim template, done. Each takes ~30 minutes once the lib + pilots are in place.
+
+## Artifacts
+
+- Ticket: [me2resh/apexyard#218](https://github.com/me2resh/apexyard/issues/218)
+- Technical design: [`docs/technical-designs/audit-artefact-persistence.md`](../technical-designs/audit-artefact-persistence.md)
+- Prior-art AgDR: [`AgDR-0014 — /launch-check trend tracking`](AgDR-0014-launch-check-trend-tracking.md)
+- Existing skill (model for the convention): `.claude/skills/launch-check/SKILL.md` + `render-trend.sh`

--- a/docs/technical-designs/audit-artefact-persistence.md
+++ b/docs/technical-designs/audit-artefact-persistence.md
@@ -1,0 +1,340 @@
+# Technical Design — Audit-Skill Artefact Persistence + Canonical Structure
+
+**Status**: Draft
+**Author**: Hisham (Tech Lead) — drafted via Claude Code session
+**Date**: 2026-05-11
+**Ticket**: [me2resh/apexyard#218](https://github.com/me2resh/apexyard/issues/218)
+**Related AgDR**: [AgDR-0019 — Audit-skill artefact persistence schema and lib](../agdr/AgDR-0019-audit-artefact-persistence.md)
+**Prior art**: [AgDR-0014 — `/launch-check` historical trend tracking](../agdr/AgDR-0014-launch-check-trend-tracking.md), `.claude/skills/launch-check/`
+
+---
+
+## Overview
+
+### Summary
+
+Generalise `/launch-check`'s existing per-run artefact convention (per-run JSON for chart data + per-run markdown for the human report + opt-in commit marker) into a shared library that the other nine audit skills (`/threat-model`, `/security-review`, `/compliance-check`, `/accessibility-audit`, `/performance-audit`, `/seo-audit`, `/monitoring-audit`, `/docs-audit`, `/analytics-audit`) consume, so every audit run produces a structurally consistent persisted artefact and the trend across runs becomes readable.
+
+### Goals
+
+- One shared shell library (`.claude/hooks/_lib-audit-history.sh`) handles persistence + trend rendering for all audit skills
+- Consistent on-disk shape: `projects/<name>/audits/<dimension>/runs/<ts>.json` + `projects/<name>/audits/<dimension>/<ts>.md`
+- Common frontmatter contract: `date`, `sha`, `dimension`, `verdict`, `findings[]` — extensible per-dimension via the markdown body
+- Pilot retrofit of `/threat-model` and `/security-review`; follow-up ticket retrofits the remaining seven dimensions
+- `/launch-check` refactored to consume the shared lib without behaviour change — its existing `runs/*.json` files continue to render correctly
+
+### Non-Goals
+
+- Migrating existing free-form audit outputs — there's no historical persisted output for the seven non-launch-check dimensions; the trend starts at the first post-feature run
+- Cross-project audit aggregation (a portfolio-wide "every audit's latest verdict across all managed projects" view) — useful, but separate ticket
+- Changing what each audit *checks* — purely about persistence, structure, trend rendering. Audit-content changes are out of scope
+- Replacing the stdout summary that operators see in the terminal — the persisted artefact is *additional* output, not a substitute
+
+---
+
+## Domain Model
+
+### Entities
+
+```
+AuditRun
+├── id: <ts>                (e.g. 2026-05-11T20-30-00Z — colons replaced for FS safety)
+├── dimension: AuditDimension
+├── repo: { branch, commit }
+├── verdict: Verdict
+├── findings: Finding[]
+└── Methods:
+    ├── persist()            → writes JSON + MD pair
+    └── render_summary()     → markdown for stdout
+
+AuditHistory (per dimension, per project)
+├── runs: AuditRun[]
+├── Methods:
+    ├── load_recent(n)
+    ├── append(run)
+    └── render_trend(n)      → markdown table + ASCII chart
+```
+
+### Value Objects
+
+| Value Object | Fields | Purpose |
+|---|---|---|
+| `AuditDimension` | `name` (string, e.g. `threat-model`, `security-review`) | Identifies which audit produced the run; drives the `audits/<dimension>/` path segment |
+| `Verdict` | one of `pass` / `conditional` / `fail` (alias map preserves launch-check's `go` / `go-with-warnings` / `conditional-go` / `no-go`) | Headline outcome |
+| `Finding` | `id` (string), `severity` (`critical`/`high`/`medium`/`low`/`info`), `status` (`open`/`mitigated`/`accepted`), `summary` (string) | The common denominator across all dimensions; per-dimension extras live in the MD body |
+| `RunTimestamp` | `value` (ISO-8601 UTC), `fs_safe()` (colons → dashes for filesystem) | Used as run id and filename |
+
+### Why this common denominator works
+
+Every audit emits findings with a severity and a status. The free-form context (STRIDE category for threat-model, OWASP class for security-review, WCAG criterion for accessibility) lives in the MD body — the structured frontmatter only carries what the trend renderer needs to compare runs.
+
+---
+
+## Architecture
+
+### C4 Level 3 — Component Diagram
+
+```mermaid
+C4Component
+    title Audit-Skill Artefact Persistence — Component View
+
+    Person(operator, "Operator", "Runs /threat-model, /security-review, /launch-check, etc.")
+
+    System_Boundary(audits, "Audit subsystem inside ApexYard ops fork") {
+        Container_Boundary(skills, "Audit Skills") {
+            Component(threatModel, "/threat-model", "SKILL.md + STRIDE walker", "Produces threat catalogue")
+            Component(secReview, "/security-review", "SKILL.md + OWASP walker", "Produces security findings")
+            Component(launchCheck, "/launch-check", "SKILL.md + 8-dim sweep", "Produces multi-dim verdict")
+            Component(others, "(7 other audit skills)", "SKILL.md per dimension", "compliance, a11y, perf, seo, monitoring, docs, analytics")
+        }
+
+        Container_Boundary(lib, "Shared Audit-History Library") {
+            Component(libWrite, "audit_run_persist", "_lib-audit-history.sh", "Writes JSON + MD pair to canonical path")
+            Component(libRead, "audit_run_list", "_lib-audit-history.sh", "Lists last N runs sorted by ts")
+            Component(libTrend, "audit_render_trend", "_lib-audit-history.sh", "Renders table + ASCII chart")
+            Component(libPath, "audit_resolve_dir", "_lib-audit-history.sh", "Resolves projects/<name>/audits/<dim>/")
+        }
+
+        Container_Boundary(templates, "Per-Dimension Templates") {
+            Component(tplThreatModel, "audits/threat-model.md", "Template", "Body skeleton for threat-model artefact")
+            Component(tplSecReview, "audits/security-review.md", "Template", "Body skeleton for security-review artefact")
+            Component(tplOthers, "(7 other templates)", "Template", "One per dimension")
+        }
+    }
+
+    System_Boundary(storage, "Per-project storage") {
+        ContainerDb(diskMd, "Per-run MD artefact", "projects/<name>/audits/<dim>/<ts>.md", "Frontmatter + human-readable body")
+        ContainerDb(diskJson, "Per-run JSON data", "projects/<name>/audits/<dim>/runs/<ts>.json", "Trend renderer's input")
+        ContainerDb(marker, "Opt-in commit marker", ".audit-history-tracked", "Presence-only file flips gitignore")
+    }
+
+    Rel(operator, threatModel, "Runs")
+    Rel(operator, secReview, "Runs")
+    Rel(operator, launchCheck, "Runs")
+    Rel(operator, others, "Runs")
+
+    Rel(threatModel, libWrite, "Calls with findings")
+    Rel(threatModel, tplThreatModel, "Uses for body")
+    Rel(secReview, libWrite, "Calls with findings")
+    Rel(secReview, tplSecReview, "Uses for body")
+    Rel(launchCheck, libWrite, "Calls (replaces inline persistence)")
+    Rel(others, libWrite, "Calls with findings (post-retrofit)")
+
+    Rel(libWrite, libPath, "Resolves output dir")
+    Rel(libWrite, diskMd, "Writes")
+    Rel(libWrite, diskJson, "Writes")
+    Rel(libWrite, marker, "Reads — controls gitignore semantics")
+
+    Rel(threatModel, libTrend, "After persist, render trend")
+    Rel(secReview, libTrend, "After persist, render trend")
+    Rel(launchCheck, libTrend, "After persist, render trend")
+    Rel(others, libTrend, "After persist, render trend")
+
+    Rel(libTrend, libRead, "Reads last N")
+    Rel(libRead, diskJson, "Loads")
+```
+
+### Data Flow Diagram
+
+```mermaid
+flowchart LR
+    A[Audit-skill SKILL.md<br/>e.g. /threat-model] -->|run results:<br/>findings + verdict| B[Frontmatter generator]
+    B -->|YAML header| C[Per-run MD writer]
+    B -->|structured data| D[Per-run JSON writer]
+
+    C -->|projects/&lt;name&gt;/audits/<br/>&lt;dim&gt;/&lt;ts&gt;.md| E[(MD artefact)]
+    D -->|projects/&lt;name&gt;/audits/<br/>&lt;dim&gt;/runs/&lt;ts&gt;.json| F[(JSON data)]
+
+    G[.audit-history-tracked<br/>marker] -->|presence?| H[Gitignore writer]
+    H -->|writes/skips<br/>.gitignore in dim dir| I{committed?}
+
+    F -->|all runs| J[Trend renderer<br/>last N]
+    J -->|markdown table<br/>+ ASCII chart| K[Stdout + appended<br/>to current MD]
+
+    A -.->|stdout summary<br/>—unchanged—| K
+
+    style E fill:#dfd
+    style F fill:#dfd
+    style K fill:#fdd
+```
+
+The skill's stdout summary (the human-readable verdict + findings table the operator sees in the terminal) is **unchanged** — persisted artefact is additional output, not a replacement. This is the load-bearing UX promise.
+
+---
+
+## API Design
+
+### Shared library — `.claude/hooks/_lib-audit-history.sh`
+
+Sourced by audit skills via:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-audit-history.sh"
+```
+
+Exposes four shell functions. Each is a thin shell wrapper — no heavy logic, easily testable.
+
+| Function | Signature | Purpose |
+|---|---|---|
+| `audit_resolve_dir <project_name> <dimension>` | echoes path | Resolves `<projects_dir>/<project_name>/audits/<dimension>/` via `portfolio_projects_dir`. Creates the dir if missing. |
+| `audit_run_persist <project_name> <dimension> <ts> <verdict> <json_payload> <md_body>` | exit 0 / 1 | Writes both the JSON file (under `runs/`) and the MD file (frontmatter generated from `<verdict>` + `<ts>` + `<dimension>` + `<json_payload>`'s `findings` array, body = `<md_body>`). Updates `.gitignore` semantics based on `.audit-history-tracked` marker. |
+| `audit_run_list <project_name> <dimension> [limit]` | prints filenames sorted by ts desc | Used by trend renderer + adopters writing custom dashboards. Limit defaults to 10. |
+| `audit_render_trend <project_name> <dimension> [n]` | prints markdown trend block to stdout | Loads last N JSON files, sorts by ts, emits the trend section (heading + table + ASCII chart). Silent when < 2 runs. Calls into existing `render-trend.sh` logic, generalised for dimension. |
+
+### Per-run JSON schema
+
+```json
+{
+  "schema_version": 1,
+  "ts": "2026-05-11T20:30:00Z",
+  "dimension": "threat-model",
+  "branch": "main",
+  "commit": "abc1234",
+  "verdict": "fail",
+  "findings": [
+    {
+      "id": "T1",
+      "severity": "high",
+      "status": "open",
+      "summary": "No rate limit on /auth/login"
+    }
+  ],
+  "stats": {
+    "by_severity": { "critical": 0, "high": 3, "medium": 5, "low": 2 },
+    "by_status":   { "open": 8, "mitigated": 1, "accepted": 1 }
+  }
+}
+```
+
+`stats` is derived from `findings` at write time (saves the trend renderer from re-aggregating on every read). `schema_version` is the explicit version field — bumped on breaking schema changes; renderer reads any version it knows.
+
+### Per-run MD frontmatter
+
+```markdown
+---
+date: 2026-05-11
+sha: abc1234
+dimension: threat-model
+verdict: fail
+schema_version: 1
+findings_summary:
+  critical: 0
+  high: 3
+  medium: 5
+  low: 2
+---
+
+# Threat Model — <project> @ abc1234
+
+(human-readable body, including the per-dimension specifics that don't fit the
+generic `findings[]` shape — e.g. STRIDE category groupings for threat-model,
+WCAG criterion mappings for a11y. Each dimension's template at
+`templates/audits/<dim>.md` provides the body skeleton.)
+```
+
+The frontmatter has the load-bearing structured fields; the body is freeform per dimension.
+
+---
+
+## Data Model
+
+### Storage layout
+
+```
+projects/<name>/audits/
+├── threat-model/
+│   ├── 2026-05-11T20-30-00Z.md         ← per-run MD (the durable artefact)
+│   ├── 2026-04-15T14-22-00Z.md
+│   ├── runs/
+│   │   ├── 2026-05-11T20-30-00Z.json   ← per-run JSON (trend renderer input)
+│   │   └── 2026-04-15T14-22-00Z.json
+│   ├── .gitignore                       ← per-dim, written by lib based on marker presence
+│   └── .audit-history-tracked           ← presence-only opt-in marker (per-dim)
+├── security-review/
+│   └── (same shape)
+└── launch-check/                        ← post-refactor; existing data preserved
+    ├── 2026-05-08T19-30-00Z.md          ← already exists, unchanged
+    └── runs/
+        └── 2026-05-08T19-30-00Z.json    ← already exists, unchanged
+```
+
+The opt-in commit marker is **per-dimension** — adopters might want trend history archived for security audits but not for accessibility. `.audit-history-tracked` lives next to the dimension's runs, not at the project root.
+
+### Backward compatibility with `/launch-check`
+
+`/launch-check` currently writes to `projects/<name>/launch-check/` (no `audits/` segment) and uses different scoring (`scores{}` map of 8 dimensions, not generic `findings[]`). The refactor:
+
+1. **Path migration** — write new artefacts to `projects/<name>/audits/launch-check/` going forward; leave existing `projects/<name>/launch-check/` files where they are. The trend reader looks at both paths and merges chronologically. Operators can manually `mv` the old dir under `audits/` if they want a single tree.
+2. **Schema mapping** — the existing `scores{}` map maps cleanly onto the generic shape via a per-launch-check adapter: each scored dimension becomes a `Finding` with `severity` derived from score (≥85 = info, 70-84 = low, 55-69 = medium, 40-54 = high, <40 = critical) and `status` always `open`. The original `scores{}` is preserved in the JSON for the trend chart's score-axis rendering.
+3. **Verdict alias** — `go` / `go-with-warnings` / `conditional-go` / `no-go` map to `pass` / `pass` / `conditional` / `fail` for the generic frontmatter; the launch-check skill's own output continues to use the four-state vocabulary in its body.
+
+---
+
+## Implementation Plan
+
+### Tasks
+
+| # | Task | Estimate | Dependencies |
+|---|---|---|---|
+| 1 | Write `.claude/hooks/_lib-audit-history.sh` (4 functions, ~150 LOC bash) | 3h | — |
+| 2 | Write `.claude/hooks/tests/test_audit_history.sh` (write/read/trend/marker) | 2h | 1 |
+| 3 | Write canonical templates: `templates/audits/threat-model.md`, `templates/audits/security-review.md` | 1h | — |
+| 4 | Retrofit `/threat-model` SKILL — Step 3 calls lib for persistence + appends trend | 1h | 1, 3 |
+| 5 | Retrofit `/security-review` SKILL — same shape | 1h | 1, 3 |
+| 6 | Refactor `/launch-check` to consume the shared lib (preserves existing JSON path + adds new MD path) | 2h | 1 |
+| 7 | Regression test: run `/launch-check` against an existing run history, confirm trend output unchanged | 1h | 6 |
+| 8 | Write follow-up ticket for the remaining 7 audit skills' retrofit | 0.5h | — |
+
+**Total estimate:** ~11h. Single PR — the lib + pilot retrofit + launch-check refactor ship together so nothing references a half-built API.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `/launch-check` refactor breaks existing trend rendering | Medium | High | Task 7 is a regression test against the live history store. Lib-internal — no behaviour change visible to operators. If broken, revert is one commit. |
+| Findings shape too rigid → squeezes per-dimension nuance into a generic frame that loses meaning | Medium | Medium | Frontmatter only carries the trend-renderer needs (`severity`, `status`); dimension-specific structure lives in the MD body via per-dim templates. AgDR-0019 records this trade-off. |
+| Adopters' existing `/launch-check` history gets orphaned by path change | Low | Medium | Reader merges old + new paths chronologically. Migration is opt-in (`mv` the old dir manually if you want one tree). No silent destruction. |
+| Bash-detection in `_lib-detect-bash-write.sh` flags lib's own writes during testing → blocks tests | Low | Low | Tests run from `bootstrap_skills` exemption context. Pattern proven in launch-check's existing tests. |
+| Schema bump (v1 → v2) breaks adopters mid-flight | Low | Medium | `schema_version` field is explicit; renderer dispatches per version and falls back to v1 reader for older files. v2 is N-quarters away. |
+
+---
+
+## Security Considerations
+
+- [x] No secrets in artefacts — frontmatter and body are operator-readable text only
+- [x] Path resolution via `portfolio_projects_dir` — same boundary the rest of the framework uses; no new attack surface
+- [x] Opt-in commit marker is presence-only — no parsable content, no injection vector
+- [x] No external network calls — purely local file I/O
+- [x] No PII in audit artefacts (audits are about *the codebase*, not about users)
+
+---
+
+## Testing Strategy
+
+| Type | Coverage | Notes |
+|---|---|---|
+| Bash unit tests | All four lib functions | `test_audit_history.sh` mirrors `test_launch_check_trend.sh` pattern. Mocks `gh` for project resolution. |
+| Integration | `/threat-model` end-to-end: invoke skill → confirm artefacts written → confirm trend rendered on second run | Manual smoke during PR; no live tracker dependency |
+| Regression | `/launch-check` post-refactor against fixture history of 5 runs → trend output byte-equal to pre-refactor baseline | Snapshot test |
+
+---
+
+## Open Questions
+
+| Question | Owner | Status |
+|---|---|---|
+| Should `audit_run_persist` accept `findings[]` as JSON-on-stdin or as a temp-file path? Bash quoting on multi-line JSON via argv is fiddly. | Hisham | Open — leaning stdin for clean quoting |
+| For `/launch-check`'s post-refactor MD artefact, is the `findings_summary.{critical,high,...}` count driven from the score-derived severity mapping above, or do we leave launch-check's frontmatter score-shaped instead? | Hisham + Khalid | Open — favouring score-shaped (preserves what the trend chart already plots) |
+| Should the per-dimension templates at `templates/audits/<dim>.md` be auto-loaded by the skill, or does each skill embed its own body inline? Auto-load is DRY but couples the skill to a template path that may move. | Hisham | Open — small enough that either works; lean toward inline body, template is just reference |
+
+---
+
+## Approvals
+
+| Role | Name | Date | Status |
+|---|---|---|---|
+| Tech Lead | Hisham (drafter) | 2026-05-11 | Author |
+| Head of Engineering | Khalid | | Pending — requested for the launch-check backward-compat call |
+| Security | Faisal (Head of Security) | | Skip — no security surface added |

--- a/templates/audits/security-review.md
+++ b/templates/audits/security-review.md
@@ -1,0 +1,43 @@
+# Security Review — {project} @ {short-sha}
+
+> Persisted by `/security-review` via `_lib-audit-history.sh`. Frontmatter (above) is structured; the body is freeform per dimension. Edit the body freely; keep the frontmatter parseable. See `docs/agdr/AgDR-0019-audit-artefact-persistence.md` for the schema rationale.
+
+## Scope
+
+- Diff reviewed: `{branch}..main` ({N} files, {M} +/- lines)
+- Review focus: code-class findings (auth, input validation, secrets handling, dependencies)
+- Out of scope: architecture-level threat modelling — that belongs in `/threat-model`
+
+## Findings
+
+| # | Severity | OWASP class | Finding | File:Line | Status |
+|---|---|---|---|---|---|
+| F1 | critical | A03 Injection | (e.g. unsanitised user input concatenated into SQL) | `src/users.ts:42` | open |
+| F2 | high | A07 Auth failure | (e.g. JWT signature not verified) | `src/auth.ts:18` | open |
+| F3 | medium | A05 Misconfig | (e.g. CORS `Access-Control-Allow-Origin: *`) | `src/server.ts:8` | open |
+
+## Dependency vulnerabilities
+
+| Package | Current | Patched | Severity | Advisory |
+|---|---|---|---|---|
+| (e.g. axios) | 0.21.1 | 1.6.0 | high | CVE-XXXX-NNNN |
+
+Run `npm audit` / `pip audit` and capture critical+high here.
+
+## Secrets scan
+
+- [ ] `.env*` files in repo? (`git ls-files | grep -E '^.env'`)
+- [ ] API keys / tokens hardcoded? (`grep -rE '(api[_-]?key|secret|token)\s*[=:]\s*["'\'']'`)
+- [ ] Cloud account IDs / ARNs in source?
+
+## Recommendations
+
+Order by severity:
+
+1. F1 — fix injection vector before any new feature work
+2. F2 — verify JWT signatures
+3. (lower-severity items after)
+
+## Notes
+
+(Context: prior incidents in this area, why specific findings are higher-severity than they look, links to related AgDRs.)

--- a/templates/audits/threat-model.md
+++ b/templates/audits/threat-model.md
@@ -1,0 +1,41 @@
+# Threat Model — {project} @ {short-sha}
+
+> Persisted by `/threat-model` via `_lib-audit-history.sh`. Frontmatter (above) is structured; the body is freeform per dimension. Edit the body freely; keep the frontmatter parseable. See `docs/agdr/AgDR-0019-audit-artefact-persistence.md` for the schema rationale.
+
+## Attack surface
+
+- **Entry points**: {N} (HTTP routes, form handlers, WebSocket endpoints, file uploaders)
+- **Data stores**: {N} (databases, caches, file systems, env vars)
+- **External integrations**: {N} (third-party APIs, webhooks, SDKs)
+
+## Threats by STRIDE category
+
+| # | Category | Threat | Severity | Entry point | Mitigation |
+|---|---|---|---|---|---|
+| T1 | Spoofing | (e.g. no rate limit on login) | high | POST /auth/login | Add rate limiter |
+| T2 | Tampering | (e.g. no CSRF token on state-changing forms) | high | POST /settings | Add CSRF middleware |
+| T3 | Repudiation | (e.g. no audit log on admin actions) | medium | Admin panel | Add structured action log |
+| T4 | Information Disclosure | (e.g. stack traces in prod) | medium | Global error handler | Strip traces when NODE_ENV=production |
+| T5 | Denial of Service | (e.g. unbounded list endpoint) | medium | GET /items | Add pagination + cap |
+| T6 | Elevation of Privilege | (e.g. role check missing on /admin/*) | high | Admin routes | Verify role on every admin handler |
+
+## Recommended priority
+
+Order by severity, then ease-of-fix:
+
+1. T1 — rate limit on /auth/login
+2. T2 — CSRF middleware
+3. T6 — admin role checks
+4. (lower-severity items after)
+
+## OWASP cross-check
+
+- [ ] SQL/NoSQL injection — parameterised queries / ORM throughout?
+- [ ] XSS — `dangerouslySetInnerHTML` / `v-html` / template literals in HTML?
+- [ ] Insecure deserialization — `JSON.parse` on untrusted input without validation?
+- [ ] Security misconfiguration — CORS `*`, debug mode, default credentials?
+- [ ] Components with known vulnerabilities — `npm audit` / `pip audit` clean?
+
+## Notes
+
+(Free space for context the table doesn't capture — bounded contexts, trust boundaries, threat-actor assumptions, etc.)


### PR DESCRIPTION
## Summary

- New shared library `.claude/hooks/_lib-audit-history.sh` (4 functions: `audit_resolve_dir`, `audit_run_persist`, `audit_run_list`, `audit_render_trend`) generalises `/launch-check`'s existing per-run persistence convention to the whole audit-skill family
- Pilot retrofits on `/threat-model` and `/security-review` — both now persist a JSON + MD pair per run and render the trend section after each invocation
- `/launch-check` refactored to consume the lib without behaviour change. JSON is a superset preserving the legacy `scores{}` map (so the existing chart renderer plots the same shape) plus the canonical generic fields (so the lib's trend renderer reads it). Adopters' existing history at the legacy path is read-merged transparently — no `mv` required, no destructive migration
- 11 lib tests covering write/read/derive/preserve/marker/sort/legacy-path/silent/render/dispatch/regression-merge — all passing
- Per-dim canonical templates at `templates/audits/threat-model.md` and `templates/audits/security-review.md` (reference material; per-skill bodies are inline per AgDR-0019)
- Follow-up #221 filed for the remaining 7 audit skills (compliance-check, accessibility-audit, performance-audit, seo-audit, monitoring-audit, docs-audit, analytics-audit) — mechanical retrofit per the pattern proven here

## Why this matters

Before this PR the audit family was inconsistent: `/launch-check` persisted (since #183) and rendered a trend chart; the other nine audit skills wrote only to stdout and disappeared as soon as the terminal scrolled. Comparing two threat models from a quarter apart was an exercise in reading two different free-form essays. After this PR every audit run produces a structurally consistent on-disk artefact with parseable frontmatter, and the trend renderer renders identically across all dimensions.

The launch-check refactor is the load-bearing piece: it changes how persistence happens (lib-driven instead of inline) without changing what operators see (chart shape unchanged, existing history preserved). The regression test (case 11) confirms the legacy + canonical path merge keeps adopters' existing history visible on the first post-refactor run.

The decision airing in [AgDR-0019](docs/agdr/AgDR-0019-audit-artefact-persistence.md) covers the four load-bearing calls (paired JSON+MD, rigid common-denominator findings shape, non-destructive backward compat, four discrete shell functions). The technical design at [docs/technical-designs/audit-artefact-persistence.md](docs/technical-designs/audit-artefact-persistence.md) embeds a Mermaid C4 L3 component diagram and a Mermaid DFD showing the audit subsystem boundaries.

## Testing

- [x] Lib tests: `bash .claude/hooks/tests/test_audit_history.sh` → 11 passed, 0 failed
- [x] Lib syntax: `bash -n .claude/hooks/_lib-audit-history.sh` → OK
- [x] Regression test for launch-check (case 11): one run in legacy path + one run in canonical path → both dates appear in the rendered chart
- [x] Stats derivation (case 3): payload with 2 high + 1 medium → `stats.by_severity.high=2, .medium=1`
- [x] Marker semantics (case 5): absent → `runs/` ignored; present → `!runs/*.json` un-ignored
- [ ] Reviewer can spot-check the lib's jq invocations (the schema-augmentation jq in `audit_run_persist` and the frontmatter-generation jq next to it are the two non-trivial pieces)
- [ ] Reviewer can confirm the launch-check Step 6 rewrite preserves the JSON superset shape (legacy `scores{}` / `branch` / `commit` / `top_risks[]` AND new `dimension` / `score` / `findings[]` / `stats{}` / `schema_version`)
- [ ] Manual smoke test post-merge: invoke `/threat-model` against any registered project, confirm `projects/<name>/audits/threat-model/<ts>.md` is written with valid frontmatter

## Glossary

| Term | Definition |
|---|---|
| Audit-history lib | `.claude/hooks/_lib-audit-history.sh` — shared shell library with four functions handling persistence + trend rendering for all audit skills. Sourced by SKILL.md flows. |
| Per-run JSON | The trend-renderer's input file at `projects/<name>/audits/<dimension>/runs/<ts>.json`. Schema includes `ts`, `dimension`, `verdict`, `score`, `findings[]`, `stats{}`, plus dimension-specific extras (e.g. launch-check preserves `scores{}` + `branch` + `commit` + `top_risks[]`). |
| Per-run MD | The durable human-readable artefact at `projects/<name>/audits/<dimension>/<ts>.md`. Frontmatter is generated by the lib from the JSON; body is freeform per dimension. |
| Findings shape | The common denominator across all nine audit dimensions: `{id, severity, status, summary}` per finding. Per-dimension nuance (STRIDE category, OWASP class, WCAG criterion) lives in the MD body via per-dim templates. |
| Headline score | A single 0-100 number per run plotted on the trend chart's Y-axis. Generic skills derive it from severity-weighted finding count; `/launch-check` keeps its existing `mean(scores.*)` derivation for byte-equal chart output. |
| Legacy + canonical merge | `audit_run_list` reads JSON files from BOTH `projects/<name>/audits/<dim>/runs/` (canonical) AND `projects/<name>/launch-check/runs/` (legacy, launch-check only) so adopters' existing trend history isn't orphaned by the path change. |
| Opt-in commit marker | `.audit-history-tracked` — presence-only file inside the dimension's audit dir that flips the `runs/` `.gitignore` from "ignore everything" to "un-ignore *.json". MD artefacts are committed unconditionally. |
| Verdict | One of `pass` / `conditional` / `fail` (generic vocabulary). `/launch-check` keeps its four-state vocabulary (`go` / `go-with-warnings` / `conditional-go` / `no-go`) in its body, but maps to the generic three-state in the frontmatter for cross-dim consistency. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
