### PR TITLE
chore(#223): add Data Flow Diagram section to threat-model template

### DIFF
--- a/.claude/skills/threat-model/SKILL.md
+++ b/.claude/skills/threat-model/SKILL.md
@@ -31,6 +31,8 @@ Per-language LSP plugins live in Claude Code's marketplace. Install once; the sk
 
 ### Step 1: Map the attack surface
 
+**Populate the Data Flow Diagram first** in this run's per-run artefact (per `templates/audits/threat-model.md` § Data Flow Diagram) — replace the Mermaid skeleton's placeholders with the system's actual external entities, processes, data stores, and trust boundaries, and label every arrow with the data that crosses it. The STRIDE walk in Step 2 then iterates the DFD's trust-boundary crossings rather than inventing threats ad-hoc.
+
 Read the codebase and identify:
 
 - **Entry points**: API routes, form handlers, WebSocket endpoints, file upload handlers

--- a/templates/audits/threat-model.md
+++ b/templates/audits/threat-model.md
@@ -2,6 +2,43 @@
 
 > Persisted by `/threat-model` via `_lib-audit-history.sh`. Frontmatter (above) is structured; the body is freeform per dimension. Edit the body freely; keep the frontmatter parseable. See `docs/agdr/AgDR-0019-audit-artefact-persistence.md` for the schema rationale.
 
+## Data Flow Diagram
+
+A Data Flow Diagram (DFD) is the natural input to STRIDE — each crossing of a trust boundary is where threats apply most acutely, and the STRIDE walk in the table below should iterate the boundary crossings rather than invent threats ad-hoc. Replace the placeholders below with your system's actual entities; keep trust boundaries as dashed `subgraph` blocks and label every arrow with the data that crosses it (auth tokens, PII, transaction records, etc.). Mermaid-template choice rationale: see `docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md`.
+
+```mermaid
+flowchart LR
+    user([External user])
+
+    subgraph internet ["Trust boundary: public internet"]
+        web[Web frontend]
+    end
+
+    subgraph backend ["Trust boundary: backend network"]
+        api[API service]
+        db[(Primary data store)]
+    end
+
+    subgraph thirdparty ["Trust boundary: third-party service"]
+        ext[External service<br/>e.g. payment / email / SSO]
+    end
+
+    user -->|credentials, form input| web
+    web -->|auth token, user PII| api
+    api -->|user PII, transaction record| db
+    db -->|query results| api
+    api -->|webhook / API call, redacted payload| ext
+    ext -->|callback, signed response| api
+    api -->|session cookie, view model| web
+    web -->|rendered HTML, JSON| user
+
+    style internet stroke-dasharray: 5 5
+    style backend stroke-dasharray: 5 5
+    style thirdparty stroke-dasharray: 5 5
+```
+
+Replace placeholders with your system's actual entities. **Each arrow that CROSSES a trust boundary is where STRIDE threats apply most acutely** — drive the table below from the boundary crossings, not from a free-form brainstorm.
+
 ## Attack surface
 
 - **Entry points**: {N} (HTTP routes, form handlers, WebSocket endpoints, file uploaders)


### PR DESCRIPTION
## Summary

- Add a `## Data Flow Diagram` section to `templates/audits/threat-model.md` (between the H1 and the existing `## Attack surface`). The section ships a Mermaid `flowchart LR` skeleton with three trust boundaries drawn as dashed `subgraph` blocks (public internet, backend network, third-party service), realistic node placeholders (external user, web frontend, API service, primary data store, external service), and labelled arrows naming the data that crosses each boundary (auth tokens, user PII, transaction records, callbacks).
- Update `.claude/skills/threat-model/SKILL.md` Step 1 ("Map the attack surface") to instruct the operator to populate the DFD section of the per-run artefact first, and to drive the Step 2 STRIDE walk from the DFD's trust-boundary crossings rather than inventing threats ad-hoc.
- Why: proper STRIDE analysis starts with a DFD identifying trust boundaries — without one the threat catalogue is per-run improvisation. Mermaid is the framework's chosen diagram language per AgDR-0003 (`templates/architecture/c4-context.md` and `c4-container.md` already use it), so adopters render the skeleton in any GitHub markdown view with zero build step.

## Testing

1. Open `templates/audits/threat-model.md` in GitHub's rendered preview (or a Mermaid-aware viewer like <https://mermaid.live/>) and confirm the Mermaid block parses without errors.
2. Confirm three subgraphs render with **dashed** outlines (the `style <id> stroke-dasharray: 5 5` declarations apply to each boundary).
3. Confirm every cross-boundary arrow displays its data label (e.g. `auth token, user PII`).
4. Edit the skeleton — replace placeholders with a real system's entities — and re-render to confirm the structure is editable, not just decorative.
5. Open `.claude/skills/threat-model/SKILL.md` and confirm Step 1 now leads with the DFD-population instruction and references the template section by name.

## Glossary

| Term | Definition |
|------|------------|
| **DFD (Data Flow Diagram)** | The canonical input artefact for STRIDE: a graph of external entities, processes, data stores, and the data flowing between them, partitioned by trust boundary. STRIDE iterates the DFD's elements rather than free-form brainstorming, which is what makes the resulting catalogue systematic. |
| **STRIDE** | Microsoft-originated threat-modelling taxonomy: Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege. Each STRIDE category has a natural target element class on a DFD (e.g. spoofing applies most acutely to external entities and processes; tampering applies to data flows and stores). |
| **Trust boundary** | A border in a DFD across which the level of trust changes — e.g. public internet ↔ backend network, backend ↔ third-party service. Threats apply most acutely to data crossing a trust boundary, because the data leaves a context where assumptions hold and enters one where they don't. |
| **Mermaid `flowchart`** | A text-based diagram language renderable in any GitHub markdown view without a build step. The framework chose Mermaid over Structurizr DSL / PlantUML / D2 in [AgDR-0003](docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md); the C4 architecture templates already use it, so this PR keeps diagram tooling consistent. |
| **`stroke-dasharray: 5 5`** | An SVG/CSS stroke attribute that renders the line as 5px-on / 5px-off dashes. Mermaid passes this through `style <node_or_subgraph_id> ...` — the convention the apexyard `c4-container.md` template already uses for soft (logical) boundaries. Used here to visually distinguish trust boundaries from the system's internal structure. |
| **Per-run artefact** | The output Markdown file `/threat-model` writes via `_lib-audit-history.sh` for each invocation. Each run gets its own artefact stamped with a timestamp; the trend across runs is visible via `audit_render_trend`. The DFD section lives in this artefact (one DFD per run), not in a global doc, so it captures the system's shape at the SHA the threat model was run against. |

Closes #223