### PR TITLE
feat(#224): add architecture vision + DFD + sequence templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,9 @@ Template: @templates/agdr.md
 | Migration AgDR | Recording migration decisions (rollback, downtime, consumers, observability) | `templates/agdr-migration.md` |
 | C4 Context (L1) | System + external actors (one per project) | `templates/architecture/c4-context.md` |
 | C4 Container (L2) | Deployable units inside the system | `templates/architecture/c4-container.md` |
+| Architecture Vision | Target-state architecture + multi-quarter migration path + explicit anti-scope | `templates/architecture/vision.md` |
+| Data Flow Diagram (DFD) | Trust boundaries + data crossings (input to STRIDE threat model) | `templates/architecture/dfd.md` |
+| Sequence Diagram | Time-ordered request-flow walkthrough (auth handshake, payment flow, etc.) | `templates/architecture/sequence.md` |
 
 ---
 

--- a/templates/architecture/README.md
+++ b/templates/architecture/README.md
@@ -1,0 +1,45 @@
+# Architecture Templates
+
+ApexYard ships five architecture-document templates. All diagrams are [Mermaid](https://mermaid.js.org/) — GitHub renders them inline, no build step. Decision rationale: [AgDR-0003](../../docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md).
+
+## When to use which
+
+| I want to document… | Use this template |
+|---------------------|-------------------|
+| The system + its external actors (as-is) | [`c4-context.md`](c4-context.md) |
+| Deployable units inside the system (as-is) | [`c4-container.md`](c4-container.md) |
+| Target-state architecture + migration path | [`vision.md`](vision.md) |
+| Trust boundaries + data flows (input to STRIDE) | [`dfd.md`](dfd.md) |
+| A request-flow walkthrough over time | [`sequence.md`](sequence.md) |
+
+## One-line summary per template
+
+- **[`c4-context.md`](c4-context.md)** — C4 Level 1. The system as a single box surrounded by people and external systems. One per project; updated when external relationships change (rare — once or twice a year).
+- **[`c4-container.md`](c4-container.md)** — C4 Level 2. The system zoomed in to its deployable units (web, API, worker, DB, cache, queue). One per project; updated when containers are added / split / merged.
+- **[`vision.md`](vision.md)** — North-star architecture. Target state + current-vs-target gap table + multi-quarter migration path + explicit anti-scope ("things we chose NOT to build"). Reviewed quarterly.
+- **[`dfd.md`](dfd.md)** — Data flow diagram with dashed-line trust boundaries. Designed to feed a STRIDE threat model — every boundary crossing is a candidate for spoofing / tampering / repudiation / disclosure / DoS / elevation analysis.
+- **[`sequence.md`](sequence.md)** — Time-ordered request-flow walkthrough. Use when *the order of interactions* is the load-bearing detail (auth handshake, payment flow, webhook callback). Includes an `alt` / `else` failure-path block + a failure-modes table.
+
+## Where to put filled-in diagrams
+
+Same split as every other doc — *"would this follow the code if the project spun out tomorrow?"* If yes → put it in the project's own repo. If no → put it in your fork's portfolio docs.
+
+| Scope | Location |
+|-------|----------|
+| Framework-wide (ApexYard itself) | `docs/architecture/` in the ops fork |
+| ApexYard's view of a managed project | `projects/<name>/architecture/` in the ops fork |
+| Internal to a project's own repo | `docs/architecture/` in that project's repo (via `workspace/<name>/docs/architecture/`) |
+
+## How they relate
+
+```
+                                ┌─ vision.md      (where are we going?)
+                                │
+   c4-context.md (L1, as-is) ───┼─ dfd.md         (what crosses trust boundaries?)
+                                │
+   c4-container.md (L2, as-is) ─┴─ sequence.md    (in what order do things happen?)
+```
+
+The two C4 templates describe **what is**. `vision.md` describes **what will be**. `dfd.md` and `sequence.md` are **lenses** on the same components — DFD asks "where are the security-relevant data crossings?", sequence asks "what happens, in what order, when this flow runs?".
+
+You don't need all five for every project. A small project ships happy with just a `c4-context.md`. Add `c4-container.md` once you have ≥ 3 deployable units. Add `vision.md` when there's a target-state delta worth coordinating around. Add `dfd.md` before the first STRIDE pass. Add `sequence.md` for the flows you'd want to read at 2 AM during an incident.

--- a/templates/architecture/dfd.md
+++ b/templates/architecture/dfd.md
@@ -1,0 +1,93 @@
+# Data Flow Diagram — {Project Name / Feature}
+
+> **Use a DFD when you need to identify trust boundaries + data crossings** — most often as input to a STRIDE threat model (see [`../audits/threat-model.md`](../audits/threat-model.md)). Sibling: [`c4-context.md`](c4-context.md) for L1 system context (different shape, less data-flow-focused).
+>
+> Audience: tech leads, security auditor, threat-model facilitator. One DFD per system *or* per high-value flow (auth handshake, payment flow, admin export — each typically benefits from its own DFD when threat-modelled).
+
+## Diagram
+
+```mermaid
+flowchart LR
+    %% Actors and stores live OUTSIDE all trust boundaries
+    user([External User])
+    external_api[("External Service<br/>(e.g. Stripe, SendGrid)")]
+
+    subgraph public_zone["Public Zone (untrusted)"]
+        frontend["Frontend App<br/>(SPA / SSR)"]
+    end
+
+    subgraph trusted_backend["Trusted Backend Zone"]
+        api["API Service"]
+        worker["Background Worker"]
+    end
+
+    subgraph data_zone["Data Zone (most-trusted)"]
+        primary_db[("Primary Store<br/>(Postgres)")]
+        secrets_store[("Secrets Store<br/>(Vault / Secrets Manager)")]
+    end
+
+    user -->|credentials, form data| frontend
+    frontend -->|auth token, user PII| api
+    api -->|user PII, query results| frontend
+    api -->|read/write user records| primary_db
+    api -->|read API keys| secrets_store
+    api -->|enqueue job + payload| worker
+    worker -->|outbound webhook payload| external_api
+    external_api -->|callback payload + signature| api
+
+    %% Trust boundaries are dashed
+    style public_zone stroke-dasharray: 5 5
+    style trusted_backend stroke-dasharray: 5 5
+    style data_zone stroke-dasharray: 5 5
+```
+
+The dashed subgraph borders mark **trust boundaries**. Every arrow that crosses a boundary is a candidate for STRIDE analysis — that's where authentication, authorisation, and data-classification rules apply most acutely. Annotate every arrow with the data it carries (`|auth token|`, `|user PII|`, `|callback payload + signature|`) — unlabelled arrows lose half their value.
+
+Replace the placeholders with your real actors, services, stores, and external systems. Keep external systems and external users **outside all subgraphs** — they belong to other people's trust zones.
+
+---
+
+## Trust boundaries
+
+| From | To | Authentication mechanism | Data classification |
+|------|-----|--------------------------|---------------------|
+| External User → Frontend | (browser session) | None at the network edge — TLS only | Credentials (in flight only), form input |
+| Frontend → API | TLS + bearer token (JWT / session cookie) | OAuth 2 / OIDC bearer | Auth token, user PII, request body |
+| API → Frontend | TLS (server auth via cert) | n/a (server is trusted by the client) | User PII, query results |
+| API → Primary Store | mTLS or VPC-internal + DB credentials from secrets store | DB user/password | All persistent user records — highest sensitivity |
+| API → Secrets Store | IAM role / service identity | mTLS + IAM | API keys, tokens — secrets-class |
+| API → Worker | Internal queue (auth via shared transport credentials) | Queue ACL | Job payload — may contain user PII |
+| Worker → External Service | TLS + API key | API key from secrets store | Outbound webhook payload — sanitise before sending |
+| External Service → API | TLS + signed callback | HMAC signature verified per call | Callback payload — never trust the body without verifying the signature first |
+
+Add / remove rows to match your real arrows. The four columns are deliberate:
+
+- **Authentication mechanism** — what *proves identity* on this hop. "TLS only" is not authentication.
+- **Data classification** — what *category of data* crosses this hop. Use whatever scheme your org uses (PII / Credentials / Secrets / Public / Internal). Threat-modelling output will weight risks against this.
+
+---
+
+## Notes
+
+Each crossing of a trust boundary is where STRIDE threats apply most acutely:
+
+- **Spoofing** — can the source's identity be forged on this hop?
+- **Tampering** — can the data be modified in transit / at the receiver?
+- **Repudiation** — can the sender deny having sent this?
+- **Information disclosure** — what leaks if this hop is intercepted?
+- **Denial of service** — what's the failure mode if this hop is overwhelmed?
+- **Elevation of privilege** — does crossing this boundary grant additional permissions, and are those bounded correctly?
+
+The DFD is meant to be **re-drawn as the system evolves** — don't treat it as one-shot. New actor → new arrow → new STRIDE pass. New trust zone (e.g. introducing a third-party data processor) → new dashed subgraph → new boundary row.
+
+Pair this DFD with a STRIDE threat model in [`../audits/threat-model.md`](../audits/threat-model.md) so the boundary table feeds directly into a per-arrow threat enumeration. The DFD without a threat model is just a picture; the threat model without a DFD has no anchor.
+
+---
+
+## References
+
+- [`c4-context.md`](c4-context.md) — L1 system context (sibling: less data-flow-focused, no trust-boundary semantics)
+- [`../audits/threat-model.md`](../audits/threat-model.md) — STRIDE threat model template that consumes this DFD
+- [Mermaid `flowchart` syntax](https://mermaid.js.org/syntax/flowchart.html)
+- [STRIDE — Microsoft Security Development Lifecycle](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats)
+- [AgDR-0003: Mermaid C4 for diagrams](../../docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md) — why every architecture diagram in apexyard is Mermaid

--- a/templates/architecture/sequence.md
+++ b/templates/architecture/sequence.md
@@ -1,0 +1,91 @@
+# Sequence Diagram — {Flow Name}
+
+> **Use a sequence diagram for request-flow walkthroughs** (auth handshake, payment flow, webhook callback, async job dispatch, etc.) where the *time-ordered interaction between components* is the load-bearing detail. Sibling: [`c4-container.md`](c4-container.md) for static container topology — same components, different question (*who talks to whom* vs *in what order*).
+>
+> Audience: tech leads, on-call engineers, anyone debugging this flow at 2 AM. One sequence diagram per non-trivial request flow — don't draw one for a CRUD GET.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant Frontend as Frontend (SPA)
+    participant API as API Service
+    participant Auth as Auth Provider
+    participant DB as Primary Store
+
+    User->>Frontend: 1. Submit credentials
+    Frontend->>API: 2. POST /auth/login {email, password}
+    API->>Auth: 3. validateCredentials(email, password)
+
+    alt Credentials valid
+        Auth-->>API: 4a. {user_id, claims}
+        API->>DB: 5a. SELECT user record + permissions
+        DB-->>API: 6a. user + permissions
+        API-->>Frontend: 7a. 200 OK + session token (HttpOnly cookie)
+        Frontend-->>User: 8a. Redirect to /dashboard
+    else Credentials invalid
+        Auth-->>API: 4b. 401 Unauthorized
+        API-->>Frontend: 5b. 401 + generic error message
+        Frontend-->>User: 6b. Show "Invalid email or password"
+    else Auth provider unreachable (timeout > 3s)
+        Auth--xAPI: 4c. (timeout)
+        API-->>Frontend: 5c. 503 Service Unavailable
+        Frontend-->>User: 6c. Show "Service temporarily unavailable, please retry"
+    end
+```
+
+Replace the actors and messages with your real flow. Conventions:
+
+- **`autonumber`** numbers messages so failure-mode rows can reference them by index.
+- **`actor` vs `participant`** — `actor` for human / external systems, `participant` for internal components.
+- **Solid arrow `->>`** = synchronous call. **Dashed arrow `-->>`** = response. **Dashed-X `--x`** = timeout / dropped message.
+- **`alt` / `else` blocks** model branching paths. Cover at least one failure branch — the happy path alone is rarely the load-bearing knowledge.
+- Keep to **5–9 messages per `alt` branch**. More than that and you're either drawing two flows in one diagram or pasting code logic into a picture.
+
+---
+
+## When this flow runs
+
+- [Trigger 1 — e.g. user submits the login form on the marketing site]
+- [Trigger 2 — e.g. session expires and the SPA receives a 401 from any protected endpoint, redirecting to /login]
+- [Trigger 3 — e.g. SSO callback from the identity provider lands on /auth/callback]
+
+If a flow has only one trigger, say so explicitly. If a flow has many, list them all — that surfaces shared-flow risk (a bug in this sequence affects every entry-point).
+
+---
+
+## Failure modes
+
+| # | Branch | Cause | Detection | Recovery |
+|---|--------|-------|-----------|----------|
+| 4b | Credentials invalid | User typo, brute-force attempt, password reset not yet propagated | Counter on `auth.login.invalid` metric; lockout after N consecutive failures per IP / per user | User retries; on Nth failure, throttle + show "reset password" CTA |
+| 4c | Auth provider unreachable | Provider outage, network partition, expired CA certificate | `auth.provider.timeout` metric + synthetic check on `/auth/health` | Frontend shows degraded-mode message; on-call paged if synthetic fails for > 5 min; failover to backup IdP if configured |
+| 5a | DB unavailable | Primary failover, connection pool exhausted | `db.query.error_rate` metric > threshold | Retry with exponential backoff (max 3); fail closed with 503 if pool exhausted |
+| 7a | Cookie set but request races a navigation | User clicked twice / cookie domain mismatch on staging | Browser-side error logger picks up `auth.cookie.missing` after redirect | Frontend re-attempts the auth check on /dashboard once before bouncing back to /login |
+
+Add one row per `else` branch in the diagram, plus one per silent failure that doesn't show in the diagram (DB error mid-happy-path, etc.). The four columns are deliberate:
+
+- **Cause** — what went wrong (root cause, not symptom)
+- **Detection** — how you find out it went wrong (metric, log, synthetic, user report)
+- **Recovery** — what the system / user does to recover (automatic retry, human runbook, accept-and-degrade)
+
+---
+
+## Notes
+
+- **Idempotency.** This flow [is / is not] idempotent. If the user double-clicks "Submit", the second call [returns the same session / creates a duplicate record / no-ops via idempotency key]. Document the actual behaviour, not the aspirational one.
+- **Retry semantics.** The Frontend [retries automatically on 5xx with backoff / does not retry / shows a manual retry button]. The API [is safe to retry / requires an idempotency key / must not be retried because step N is non-idempotent].
+- **Observability hooks.** Each numbered message emits a structured log line with `trace_id`, `user_id`, and `flow=auth.login`. Latencies are bucketed in the `auth.login.duration_ms` histogram. The full trace is queryable in [link to your APM tool] by `trace_id`.
+
+Keep this section to 1–2 sentences per concern. If it grows past a paragraph, the answer is probably its own page (a runbook, a separate AgDR), not more text here.
+
+---
+
+## References
+
+- [`c4-container.md`](c4-container.md) — static container topology (sibling: same components, different question)
+- [`dfd.md`](dfd.md) — data-flow diagram (sibling: trust-boundary view of the same components, useful when sequence diagrams cross security boundaries)
+- [Mermaid `sequenceDiagram` syntax](https://mermaid.js.org/syntax/sequenceDiagram.html)
+- [AgDR-0003: Mermaid C4 for diagrams](../../docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md) — why every architecture diagram in apexyard is Mermaid

--- a/templates/architecture/vision.md
+++ b/templates/architecture/vision.md
@@ -1,0 +1,121 @@
+# Architecture Vision — {Project Name}
+
+> **North-star architecture.** Use `vision.md` for *target-state* + the *current → target migration path*. Use [`c4-context.md`](c4-context.md) for the as-is system context. Use [`c4-container.md`](c4-container.md) for the as-is container topology. Vision is the only template here that explicitly addresses *where the architecture is going* and *what we are choosing not to build*.
+>
+> Audience: tech leads, head of engineering, the CTO. Reviewed every quarter (default cadence — see § Review cadence below). One vision per system / domain.
+
+## Scope
+
+[One short paragraph: which system or domain this vision covers, and why it needs a north-star call now. Example: *"Covers the customer-facing web platform — the user-onboarding journey, billing, and account self-service. Excludes the internal admin console (separate vision) and the data warehouse (owned by the data team)."*]
+
+---
+
+## Principles
+
+5–10 architectural principles that constrain every future call. Keep each one a one-liner. Examples (delete and replace):
+
+1. **Bounded contexts own their data** — no cross-context DB joins. Cross-context reads go through a published API.
+2. **Failures are caller-handled, not provider-swallowed** — services surface failures as typed errors; callers decide retry / fallback / degrade.
+3. **Idempotency by default** — every state-changing endpoint accepts an idempotency key.
+4. **Observability is a feature, not an add-on** — every service ships with structured logs, metrics, and one synthetic check before it leaves staging.
+5. **Strict-typed boundaries** — every public interface (HTTP, queue, gRPC) has a versioned schema; breaking changes go through a deprecation window.
+6. **Async over sync where the contract allows** — prefer eventual consistency through events; reserve synchronous calls for read-paths the user blocks on.
+7. **Stateless compute, stateful storage** — compute units are restart-safe; durable state lives only in named persistence layers (DB, object store, queue).
+8. **Single source of truth per concept** — duplication is a migration, not a permanent state.
+
+---
+
+## Target-state architecture
+
+```mermaid
+C4Context
+    title Target-state System Context for {Project Name}
+
+    Person(user, "User", "Primary human actor")
+    Person(admin, "Admin", "Internal operator — remove if N/A")
+
+    System(main, "{Project Name}", "Target-state description (one sentence)")
+
+    System_Ext(auth, "Auth Provider", "Target choice — e.g. Auth0, Clerk")
+    System_Ext(payments, "Payment Processor", "Target choice — remove if N/A")
+    System_Ext(events, "Event Bus", "Target choice — e.g. Kafka, NATS")
+    System_Ext(observability, "Observability Platform", "Target choice — e.g. Datadog, Honeycomb")
+
+    Rel(user, main, "Uses", "HTTPS")
+    Rel(admin, main, "Administers", "HTTPS")
+    Rel(main, auth, "Authenticates via", "OIDC")
+    Rel(main, payments, "Charges + webhooks", "HTTPS + webhook")
+    Rel(main, events, "Publishes / consumes", "Async")
+    Rel(main, observability, "Emits telemetry", "OpenTelemetry")
+```
+
+Replace placeholders with the **target** state — not today's state. If today is monolith and target is event-driven, draw the event-driven version here. The current state belongs in the table below.
+
+For deeper detail, link a target-state container diagram (`vision-container.md`) using the [`c4-container.md`](c4-container.md) template structure — keep this page L1.
+
+---
+
+## Current state vs target state
+
+| Dimension | Today | Target | Gap |
+|-----------|-------|--------|-----|
+| Data layer | [Today, e.g. shared Postgres across services] | [Target, e.g. one Postgres per bounded context] | [Gap, e.g. extract billing tables into a billing-owned DB] |
+| Auth | [Today, e.g. session cookies + custom RBAC] | [Target, e.g. OIDC + claims-based authz] | [Gap, e.g. migrate session store to OIDC tokens, replace RBAC table with claim resolver] |
+| Deployment | [Today, e.g. EC2 + manual deploy script] | [Target, e.g. ECS + GitHub Actions] | [Gap, e.g. containerise services, build IaC] |
+| Observability | [Today, e.g. CloudWatch logs only] | [Target, e.g. structured logs + metrics + traces in Datadog] | [Gap, e.g. instrument with OpenTelemetry, configure exporters] |
+| Async messaging | [Today, e.g. cron-driven polling] | [Target, e.g. event-driven via SNS/SQS] | [Gap, e.g. introduce event bus, migrate cron jobs to consumers] |
+| Frontend | [Today, e.g. server-rendered Rails views] | [Target, e.g. Next.js + RSC] | [Gap, e.g. extract API layer, port pages incrementally] |
+| Secrets management | [Today, e.g. .env files in deploy bundles] | [Target, e.g. AWS Secrets Manager + IAM-scoped reads] | [Gap, e.g. inventory secrets, migrate per-service] |
+
+Add / remove rows to fit the system. The Gap column is what gets sequenced into the migration path below.
+
+---
+
+## Migration path
+
+Multi-quarter milestones. Each milestone is concrete enough to verify ("by Q3, we will have moved X to Y") and small enough to deliver inside a single quarter without freezing other work.
+
+| Quarter | Milestone | Owner | Done when |
+|---------|-----------|-------|-----------|
+| Q1 26 | [e.g. Extract billing tables into a dedicated billing DB] | [Tech Lead — billing] | [e.g. all billing reads/writes go through the billing service; cross-context join queries fail in staging] |
+| Q2 26 | [e.g. Introduce event bus + migrate the welcome-email cron to a consumer] | [Tech Lead — platform] | [e.g. welcome email triggered by `UserRegistered` event; old cron disabled in prod] |
+| Q3 26 | [e.g. OIDC migration for the customer-facing web] | [Tech Lead — auth] | [e.g. session cookies retired; web app reads claims from OIDC tokens; admin console still on legacy (separate ticket)] |
+| Q4 26 | [e.g. Frontend port — first 5 pages on Next.js] | [Tech Lead — frontend] | [e.g. 5 named pages live on Next.js behind a feature flag; performance budget within 10% of legacy] |
+
+Group dependent milestones into the same quarter only if you can fund both in parallel. If a milestone slips, the *vision* doesn't change — only the date does. Update this table at every quarterly review.
+
+---
+
+## Things we explicitly chose NOT to build
+
+This is the section that prevents wishful-architecture drift. List the patterns, technologies, or capabilities the team has consciously declined — and the rationale, so the next person to suggest one knows we already considered it.
+
+- **[e.g. Microservices below the bounded-context level]** — *Rationale: a 10-service monolith-of-microservices is more painful than a well-bounded modular monolith at our scale. Reconsider when org > 50 engineers OR a bounded context's deploy frequency demands per-service independence.*
+- **[e.g. Multi-region active-active]** — *Rationale: the customer base is single-region today; the operational and data-residency cost of active-active outweighs the latency win. Reconsider when expansion lands in a second geographic region with > 100 ms inter-region latency tolerance.*
+- **[e.g. Custom authn — building our own OIDC provider]** — *Rationale: identity is not a differentiator; vendor lock-in is acceptable. Reconsider only on a vendor exit event.*
+- **[e.g. GraphQL gateway in front of REST APIs]** — *Rationale: aggregator complexity exceeds the over-fetching cost we'd save. Reconsider when we have ≥ 3 client surfaces with materially different field needs.*
+
+The "reconsider when" clause is load-bearing — it prevents the section from rotting into "this was forbidden in 2026 and the rationale is lost".
+
+---
+
+## Review cadence
+
+This vision is reviewed **quarterly** by default (Tech Lead + Head of Engineering + at least one engineer who has shipped against the current state). The review checks:
+
+- Have the migration milestones from the previous quarter shipped? If not, what blocked them?
+- Does the target state still match the business direction, or has the business shifted?
+- Has anything in "Things we explicitly chose NOT to build" hit its "reconsider when" trigger?
+- Are there new gaps to surface in the current-vs-target table?
+
+A quarterly review that produces zero changes is fine — it's still a record that the vision was checked and remains valid.
+
+---
+
+## References
+
+- [`c4-context.md`](c4-context.md) — L1 system context (as-is)
+- [`c4-container.md`](c4-container.md) — L2 container view (as-is)
+- [`dfd.md`](dfd.md) — data-flow diagram (input to threat modelling)
+- [`sequence.md`](sequence.md) — request-flow walkthroughs
+- [AgDR-0003: Mermaid C4 for diagrams](../../docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md) — why every architecture diagram in apexyard is Mermaid

--- a/templates/technical-design.md
+++ b/templates/technical-design.md
@@ -56,13 +56,23 @@
 
 ### Component Diagram
 
+For anything beyond a trivial design, prefer one of the dedicated architecture templates over an ad-hoc ASCII sketch — they're index-aware (`templates/architecture/README.md`) and render as Mermaid on GitHub:
+
+- **As-is system context**: copy [`architecture/c4-context.md`](architecture/c4-context.md) (C4 L1).
+- **As-is container topology**: copy [`architecture/c4-container.md`](architecture/c4-container.md) (C4 L2).
+- **Target-state + migration path**: copy [`architecture/vision.md`](architecture/vision.md).
+- **Trust boundaries + data flows** (input to a STRIDE threat model): copy [`architecture/dfd.md`](architecture/dfd.md).
+- **Time-ordered request flow** (auth handshake, payment flow, webhook callback): copy [`architecture/sequence.md`](architecture/sequence.md).
+
+For a trivial design where one of those is overkill, the ASCII fallback below is fine.
+
 ```
 [Draw your architecture here using text/ASCII]
 ```
 
 ### Data Flow
 
-[Describe how data flows through the system]
+[Describe how data flows through the system. For non-trivial flows, link a [`architecture/dfd.md`](architecture/dfd.md) (data flow + trust boundaries) and/or a [`architecture/sequence.md`](architecture/sequence.md) (time-ordered walkthrough) instead of describing it inline.]
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds three new Mermaid-based architecture templates to `templates/architecture/`:
  - `vision.md` — north-star architecture (target state + current-vs-target gap table + multi-quarter migration path + explicit anti-scope + quarterly review cadence)
  - `dfd.md` — data-flow diagram with dashed-subgraph trust boundaries, labelled cross-boundary arrows, trust-boundaries table, and STRIDE primer
  - `sequence.md` — autonumbered `sequenceDiagram` with `alt` / `else` failure branches, failure-modes table, and idempotency / retry / observability notes
- Adds `templates/architecture/README.md` — one-page index with a decision table and a relationship sketch covering all five templates (the two existing C4 ones plus the three new ones).
- Updates `CLAUDE.md` § TEMPLATES — appends three rows for the new templates next to the existing C4 L1 / L2 rows; existing table rendering is preserved.
- Updates `templates/technical-design.md` § Architecture — points at the four sibling architecture templates as the preferred path; keeps the ASCII fallback for trivial designs.

The Mermaid diagram choice follows [AgDR-0003](../docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md) — every architecture diagram in apexyard is Mermaid because GitHub renders it inline, no build step.

## Why

Tech leads drafting designs hit a blank page when they need a target-state vision, a DFD for STRIDE input, or a sequence-of-events walkthrough. The gap surfaced when the threat-model and tech-design flows started referencing DFD / sequence artefacts that had no corresponding template — engineers were copy-pasting Mermaid blocks ad-hoc each time.

## Testing

1. **Render check** — open each new template on the GitHub PR file view; the `flowchart`, `sequenceDiagram`, and `C4Context` blocks render cleanly.
   - `templates/architecture/vision.md` — C4 L1 (target state)
   - `templates/architecture/dfd.md` — `flowchart LR` with three dashed-line subgraphs (public / trusted-backend / data zones) and labelled cross-boundary arrows
   - `templates/architecture/sequence.md` — `sequenceDiagram` with `autonumber` and an `alt` / `else` block covering valid creds, invalid creds, and auth-provider timeout
2. **Cross-reference check** — every link in the four templates resolves:
   - `vision.md` → `c4-context.md`, `c4-container.md`, `dfd.md`, `sequence.md`, AgDR-0003
   - `dfd.md` → `c4-context.md`, `../audits/threat-model.md` (one-way reference, sibling task), AgDR-0003
   - `sequence.md` → `c4-container.md`, `dfd.md`, AgDR-0003
   - `README.md` → all four template files
3. **README index check** — `templates/architecture/README.md` decision table covers all five templates and renders the relationship ASCII sketch correctly.
4. **`CLAUDE.md` table integrity** — TEMPLATES table renders as a single contiguous markdown table with three new rows appended (no broken pipes, no header re-render).
5. **Branch + PR title format** — `feature/GH-224-arch-vision-templates` and `feat(#224): ...` both pass `validate-branch-name.sh` / `validate-pr-create.sh`.

## Glossary

| Term | Definition |
|------|------------|
| C4 Model | Architecture-diagramming approach with four levels of zoom: System Context (L1), Container (L2), Component (L3), Code (L4). ApexYard ships templates for L1 and L2 only. |
| Mermaid | Markdown-friendly diagram-as-code language. GitHub renders it inline, no build step. Choice rationale: AgDR-0003. |
| DFD | Data Flow Diagram — shows actors, processes, data stores, and data flows, with trust boundaries marked. Designed to feed a STRIDE threat model. |
| STRIDE | Microsoft threat-modelling framework: Spoofing, Tampering, Repudiation, Information disclosure, Denial of service, Elevation of privilege. Each crossing of a trust boundary in a DFD is a candidate for STRIDE analysis. |
| Trust boundary | A line in a DFD across which the trust assumptions change — e.g. user → frontend (untrusted → less-untrusted), frontend → API (auth required), API → secrets store (most-trusted). Rendered as a dashed-line subgraph in the template. |
| `alt` / `else` block | Mermaid `sequenceDiagram` syntax for branching paths. Used in `sequence.md` to model the happy path alongside failure branches (invalid creds, auth provider timeout, etc.). |
| Anti-scope | Architectural decisions about what we explicitly chose **not** to build, with the rationale and a "reconsider when" trigger. Prevents wishful-architecture drift. The load-bearing section of `vision.md`. |
| AgDR | Agent Decision Record — apexyard's flavour of ADR for capturing technical decisions made by an agent. Stored at `docs/agdr/AgDR-NNNN-<slug>.md`. |

Closes #224