### PR TITLE
feat(#232): adopter handbooks consumed by Rex during code review

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -9,7 +9,10 @@ model: inherit
 
 # Code Reviewer Agent
 
-You are an automated code reviewer. Your job is to review pull requests for quality, security, and adherence to the team's standards (see `.claude/rules/`).
+You are an automated code reviewer. Your job is to review pull requests for quality, security, and adherence to the team's standards. Two layers of standards apply, both consulted on every review:
+
+- **Framework rules** at `.claude/rules/*.md` — the generic ApexYard standards (code quality, PR workflow, AgDR requirements, etc.). Always loaded.
+- **Adopter handbooks** at `handbooks/**/*.md` — company-specific coding standards layered on top. Loaded per the discovery rules in [`handbooks/README.md`](../../handbooks/README.md). See § "Adopter handbooks" below for how to apply them in a review.
 
 ---
 
@@ -135,6 +138,76 @@ This PR cannot be merged until technical decisions are documented.
 3. **If an AgDR IS linked** → verify the linked AgDR covers the decisions in the code
 4. **If no decisions detected** → mark as N/A
 
+### 8. Adopter Handbooks
+
+Beyond the framework's generic rules, the adopter ships company-specific standards as **handbooks** at `handbooks/**/*.md`. Discover and apply them on every review.
+
+#### Discovery (path-convention)
+
+| Path glob | Load condition |
+|---|---|
+| `handbooks/architecture/*.md` | Always — every PR |
+| `handbooks/general/*.md` | Always — every PR |
+| `handbooks/language/<lang>/*.md` | When the PR diff includes files matching `<lang>`'s extensions: `typescript/` → `**/*.{ts,tsx}`, `python/` → `**/*.py`, `go/` → `**/*.go`, `rust/` → `**/*.rs`. Other directories under `language/` follow the same `<lang>/` → matching-extension convention. |
+| `handbooks/<other>/*.md` | Default to always-load if you don't recognise the directory; flag in your review that the directory convention is undocumented. |
+
+Discovery shape:
+
+```bash
+# Always-load buckets
+find handbooks/architecture handbooks/general -name '*.md' 2>/dev/null
+
+# Diff-matched language buckets
+gh pr diff <number> --name-only | (
+  grep -qE '\.(ts|tsx)$' && find handbooks/language/typescript -name '*.md' 2>/dev/null
+  grep -qE '\.py$'       && find handbooks/language/python     -name '*.md' 2>/dev/null
+  # ... etc per language
+)
+```
+
+Read each loaded handbook in full. They're flat markdown — no parser needed.
+
+#### Enforcement: advisory vs blocking
+
+Each handbook is **advisory** by default. A handbook is **blocking** if and only if its body contains the literal phrase `ENFORCEMENT: blocking` at the **top of the file** (typically as the first line, before the H1 title).
+
+| Type | If you find a violation | Effect on verdict |
+|---|---|---|
+| Advisory handbook | Surface as a `nit:` / `suggestion:` comment in the review. Cite the handbook by path. | Verdict unaffected — APPROVED / COMMENT still valid. |
+| Blocking handbook | Surface as a top-level finding in the review with the prefix `⛔ Handbook (blocking):`. Cite the handbook by path. | Verdict becomes **REQUEST CHANGES**. Do not write the approval marker. |
+
+#### What to surface
+
+For each loaded handbook:
+
+1. Read the "What Rex flags" section — that's the trigger pattern list.
+2. Read the "What's NOT a violation" section — that's the false-positive guard.
+3. Scan the diff for the trigger patterns; suppress matches that fall under the false-positive guard.
+4. For each genuine violation, surface a finding citing:
+   - The handbook path (e.g. `handbooks/architecture/clean-architecture-layers.md`)
+   - The file:line in the diff
+   - The specific rule violated (one-sentence summary)
+   - The mitigation, if the handbook suggests one
+
+#### Handbook section in the review output
+
+Add a `### Handbook Findings` section to the review (between the `### Issues Found` and `### Suggestions` sections from the existing output template). Group by handbook, severity (blocking first), then file:line:
+
+```markdown
+### Handbook Findings
+
+⛔ **Migration Safety (blocking)** — `handbooks/architecture/migration-safety.md`
+- `prisma/migrations/20260514_drop_role/migration.sql:3` drops `users.role_v1` which the previous release reads in `src/auth/role-resolver.ts:42`. Split into a deprecate-then-drop pair across two releases. (See handbook § "What Rex flags" #1.)
+
+⚠ **Clean Architecture Layers** — `handbooks/architecture/clean-architecture-layers.md`
+- `src/domain/order.ts:8` imports `@aws-sdk/client-dynamodb`. Move persistence to `src/infrastructure/`. (See handbook § "Sample finding".)
+
+⚠ **TypeScript Strict Mode** — `handbooks/language/typescript/strict-mode.md`
+- `src/handlers/user.ts:42` declares `function fetchUser(id: any)` — replace with `string` or a domain value object.
+```
+
+If no handbooks loaded (e.g. the diff doesn't trigger any language handbooks and no `architecture/` or `general/` files exist), omit the section entirely.
+
 ## Process
 
 ```
@@ -244,9 +317,13 @@ Report the failure in plain text with the exact command the caller needs to run.
 - ✅ Performance:               [Pass / Fail]
 - ✅ PR Description & Glossary: [Pass / Fail]
 - ✅ Technical Decisions (AgDR):[Pass / Fail / N/A]
+- ✅ Adopter Handbooks:         [Pass / Fail / N/A]   ← N/A if no handbooks loaded
 
 ### Issues Found
 [List any issues, or "None"]
+
+### Handbook Findings
+[Per-handbook list of violations, blocking-first. Omit this section if no handbooks loaded or no findings. See § "Adopter Handbooks" for the format.]
 
 ### Suggestions
 [Optional improvements, not blocking]
@@ -273,6 +350,7 @@ Report the failure in plain text with the exact command the caller needs to run.
    - List what needs to be documented
    - The PR author must run `/decide` and link the AgDR before re-review
 8. **Approval marker format is BLOCKING** — on APPROVED verdicts, write the marker at `.claude/session/reviews/{pr}-rex.approved` containing exactly the 40-char HEAD SHA + newline. No labels, no JSON, no extra text. See the "Approval marker — EXACT FORMAT REQUIRED" section above. A malformed marker blocks the merge and forces a rule-violating hand-edit, so getting the format right is as important as the review content.
+9. **Handbooks layer on top of framework rules** — discover and apply handbooks at `handbooks/**/*.md` per the path-convention rules in § 8. Advisory handbooks generate `nit:` / `suggestion:` comments; blocking handbooks (containing `ENFORCEMENT: blocking` at the top of the file) become REQUEST CHANGES verdicts. Adopters extend the standards by adding handbook files; you don't need a code change to teach Rex a new rule.
 
 ## Example Invocation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,8 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Layer | Path | Purpose |
 |-------|------|---------|
 | Hooks | `.claude/hooks/` | 24 shell scripts that mechanically enforce SDLC rules — ticket-first (Edit/Write/Bash), migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner, leak protection, bootstrap-skill exemption |
-| Rules | `.claude/rules/` | 9 modular rule files (AgDR triggers, code standards, git conventions, parallel work, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
+| Rules | `.claude/rules/` | 10 modular rule files (AgDR triggers, code standards, git conventions, parallel work, plan mode, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
+| Handbooks | `handbooks/` | Adopter-authored coding standards consumed by Rex during code review. Discovery by path-convention (`architecture/` + `general/` always-load; `language/<lang>/` loads on diff-match). Advisory by default; opt in to blocking via `ENFORCEMENT: blocking` marker. See [`handbooks/README.md`](handbooks/README.md). |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer — Rex, Security Reviewer — Hatim, Dependency Auditor — Munir, PR Manager — Tariq, Ticket Manager — Idris) |
 | Skills | `.claude/skills/` | 43 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
@@ -266,7 +267,8 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Workflows | `workflows/` |
 | Templates | `templates/` |
 | Hooks | `.claude/hooks/` |
-| Rules (modular) | `.claude/rules/` |
+| Rules (modular, framework-wide) | `.claude/rules/` |
+| **Adopter handbooks** (consumed by Rex during code review) | `handbooks/` — see [`handbooks/README.md`](handbooks/README.md) for the discovery + advisory/blocking conventions |
 | Agents | `.claude/agents/` |
 | Skills (40 slash commands) | `.claude/skills/` |
 | Hook wiring | `.claude/settings.json` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Layer | Path | Purpose |
 |-------|------|---------|
 | Hooks | `.claude/hooks/` | 24 shell scripts that mechanically enforce SDLC rules — ticket-first (Edit/Write/Bash), migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner, leak protection, bootstrap-skill exemption |
-| Rules | `.claude/rules/` | 10 modular rule files (AgDR triggers, code standards, git conventions, parallel work, plan mode, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
+| Rules | `.claude/rules/` | 11 modular rule files (AgDR triggers, code standards, git conventions, leak protection, parallel work, plan mode, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Handbooks | `handbooks/` | Adopter-authored coding standards consumed by Rex during code review. Discovery by path-convention (`architecture/` + `general/` always-load; `language/<lang>/` loads on diff-match). Advisory by default; opt in to blocking via `ENFORCEMENT: blocking` marker. See [`handbooks/README.md`](handbooks/README.md). |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer — Rex, Security Reviewer — Hatim, Dependency Auditor — Munir, PR Manager — Tariq, Ticket Manager — Idris) |
 | Skills | `.claude/skills/` | 43 slash commands — see the full list below |

--- a/docs/agdr/AgDR-0020-adopter-handbooks-for-rex.md
+++ b/docs/agdr/AgDR-0020-adopter-handbooks-for-rex.md
@@ -1,0 +1,84 @@
+# AgDR-0020 — Adopter handbooks consumed by Rex during code review: scope, discovery, format, enforcement
+
+> In the context of letting adopters layer company-specific coding standards on top of the framework's generic rules without forcing them to fork `.claude/rules/` (#232), facing five load-bearing choices (handbook scope, discovery mechanism, file format, sample-scaffold-per-feature, enforcement default), I decided **framework-level handbooks only (no per-project layering in v1), path-convention discovery (`architecture/` always-loads, `language/<lang>/` loads on diff match, `general/` always-loads), flat markdown without YAML frontmatter, ship 4 sample handbooks demonstrating each shape (no auto-scaffold per feature), and advisory-by-default with explicit `ENFORCEMENT: blocking` opt-in**, to achieve a low-friction handbook layer that grows organically with the framework while staying mechanically enforceable for the rules that genuinely warrant blocking, accepting that v1 has no per-project handbook scope and that the path-convention discovery requires authors to put files in the right directory.
+
+## Context
+
+[me2resh/apexyard#232](https://github.com/me2resh/apexyard/issues/232) introduces a new "handbook" concept — adopter-authored markdown files containing company-specific coding standards that Rex (the code-reviewer agent) consults during PR review, alongside the framework-wide rules in `.claude/rules/`. The CEO answered five design questions in conversation; this AgDR records those answers as the load-bearing decisions because each shapes how adopters interact with the layer.
+
+## Options Considered
+
+### A. Handbook scope: framework-level only vs per-project vs both layered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Framework-level only** (chosen) | Simple. Handbooks travel with the ops fork; one source of truth across all managed projects. Matches the way `.claude/rules/` already works — adopters know the pattern. | Adopters with truly project-specific patterns can't express them. Migration to per-project later is additive — no breaking change. |
+| Per-project only | Matches the per-project nature of audits + tickets. | Most coding standards are organisation-wide ("never use floats for currency", "API responses are camelCase") — forcing per-project duplication creates drift. Adopter has to author the handbook N times for N projects. |
+| Both, layered (project overrides framework) | Maximum flexibility. | The conflict-resolution rules (project wins? merge? warn-on-conflict?) become a design surface of their own. v1 should not carry that complexity until an adopter asks. |
+
+### B. Discovery mechanism: path-convention vs frontmatter targeting vs always-load
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Path-convention** (chosen): `architecture/` always-loads, `language/<lang>/` loads on diff match, `general/` always-loads | No format inspection — discovery is a glob over the file tree. Authors don't have to learn YAML. The directory IS the targeting metadata. Cheap to implement; cheap to audit. | Adopters with a handbook that doesn't fit the three buckets need to bend it (or ask for a fourth bucket via PR). |
+| YAML frontmatter (`applies_to: "**/*.tsx"`) | Maximally targeted — author specifies exactly which paths trigger loading. | Handbook authoring becomes "write YAML correctly". Discovery requires opening and parsing every file even when it won't apply. CEO answered "flat markdown" explicitly — frontmatter would contradict that. |
+| All handbooks always load | Trivial to implement. | Rex's review prompt grows linearly with handbook count. A 50-handbook adopter pays the full cost on every PR even when 49 are language-specific and don't apply. |
+
+### C. File format: flat markdown vs structured frontmatter vs YAML-only
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Flat markdown** (chosen) | Same as `.claude/rules/` — adopters already know the format. Rex reads as prose, no parser needed. Authors write English, not config. | No machine-readable metadata — discovery has to live in path conventions (which it does, per choice B). |
+| Markdown with YAML frontmatter | Captures `enforcement`, `applies_to`, `severity`, `version` as structured data. | Authors learn YAML. Discovery touches every file even when irrelevant. Every example handbook becomes a vehicle for documenting the schema. |
+| Pure YAML / JSON | Rex can introspect every field. | Handbook prose has nowhere to live; rules degenerate into one-liners that lose explanatory context (the WHY behind the rule). Loses the "Rex reads as prose" property that makes the layer trivial to extend. |
+
+### D. Sample-handbook-per-feature: auto-scaffold vs prompt-only vs ship-examples-only
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Ship sample handbooks; no per-feature scaffold** (chosen) | Adopters see the convention by example. New handbooks are written when an actual standard emerges, not on a feature-creation cadence. Avoids handbook bloat from speculative "this feature might need a rule someday" stubs. | No mechanical nudge to grow the handbook library; adopters must remember the layer exists. |
+| Auto-scaffold a draft handbook stub when `/feature` is run | Handbook coverage grows mechanically with feature count. | Most features don't need a new handbook entry. The scaffold becomes ceremony — adopters delete the stub or worse, leave empty stubs. Pollutes the handbook tree with noise. |
+| Prompt the operator (default-yes) inside `/feature` | Compromise — scaffold offered but skippable. | Still adds friction to every `/feature` run for the rare case where a handbook entry is warranted. CEO answered "just write an example for us" explicitly — no per-feature mechanism. |
+
+### E. Enforcement: advisory-only vs blocking-by-default vs hybrid with opt-in
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Advisory by default; blocking via `ENFORCEMENT: blocking` marker** (chosen) | Matches the existing rule mix (parallel-work + plan-mode are advisory; ticket-first + secret-scan are blocking). Authors decide per-rule whether the cost of false-positives outweighs the cost of false-negatives. Adopter-friendly first run — no day-1 blocking spree. | Marker phrase is a magic string; mistyping it silently downgrades to advisory. Mitigation: README documents the exact phrase + Rex agent docs cite it. |
+| Always blocking | Strongest enforcement signal. | Day-1 hostile to adopters — every false-positive blocks merges. Authors get ratio'd into removing rules instead of refining them. |
+| Always advisory | No false-positive risk. | Defeats half the value — the rules that should be blocking (e.g. "never log PII") become a polite suggestion. |
+
+## Decision
+
+Chosen — for all five:
+
+**A.** Framework-level handbooks only at `handbooks/` in the ops fork.
+**B.** Path-convention discovery (`architecture/` + `general/` always-load; `language/<lang>/` loads on diff-match).
+**C.** Flat markdown, no YAML frontmatter.
+**D.** Ship 4 sample handbooks demonstrating the four shapes; no auto-scaffold per `/feature` invocation.
+**E.** Advisory by default; opt in to blocking with the literal phrase `ENFORCEMENT: blocking` at the top of the file.
+
+Why this combination:
+
+1. **Path-convention + flat markdown is the only consistent pair.** YAML frontmatter would carry the metadata that path conventions carry; one or the other suffices. Flat markdown matches the framework's existing rule shape — adopters reach for the pattern they already know.
+2. **Framework-level first, per-project later if asked** matches the framework's adoption curve. Most company coding standards are organisation-wide; the v1 shape covers 95% of the use case at 50% of the complexity.
+3. **Sample handbooks demonstrate the shape** without imposing a workflow change to `/feature`. Adopters see four real examples and write their own when an actual standard emerges.
+4. **Advisory-by-default with blocking opt-in** mirrors the framework's existing rule mix and respects the principle that mechanical enforcement should match operator intent — not be the universal default.
+
+## Consequences
+
+- The four sample handbooks shipped in this PR are also the *recommended defaults*. Adopters who don't author their own get a non-trivial baseline of standards Rex enforces. Adopters who do author their own can keep, edit, or replace the samples freely.
+- Rex's review prompt grows by the loaded handbook count per PR. Diff-match for `language/<lang>/` keeps the per-PR cost bounded. If a future adopter has 50 architecture handbooks (always-load), follow-up work could add a `glob:` directive in handbook prose to narrow further — but v1 ships without it because no adopter has hit the limit yet.
+- The `ENFORCEMENT: blocking` marker is a magic phrase. If a future schema bump introduces a YAML frontmatter (reversal of choice C), the marker becomes a frontmatter field. The phrase is documented in `handbooks/README.md` and cited in `.claude/agents/code-reviewer.md` so the convention is discoverable.
+- Per-project handbook scope is filed as a follow-up consideration in the ticket's "Out of Scope" section. Adding it later is additive (introduce a `projects/<name>/handbooks/` resolution path; layer over framework handbooks) and reversible (remove the per-project arm if it doesn't get traction).
+- Handbook violations surface in Rex's existing review-comment shape — no new UI or output channel. Operators see them inline alongside framework-rule findings.
+- The `/handbook` authoring skill (interactive scaffold for new handbooks) is also out of scope. v1 expects adopters to copy a sample and edit. If authoring friction shows up, file a follow-up.
+
+## Artifacts
+
+- Ticket: [me2resh/apexyard#232](https://github.com/me2resh/apexyard/issues/232)
+- Implementation PR: feature/GH-232-adopter-handbooks (this branch)
+- Sample handbooks: `handbooks/architecture/clean-architecture-layers.md`, `handbooks/architecture/migration-safety.md` (blocking), `handbooks/language/typescript/strict-mode.md`, `handbooks/general/commit-message-quality.md`
+- Rex agent update: `.claude/agents/code-reviewer.md`
+- Index: `handbooks/README.md`
+- CLAUDE.md QUICK REFERENCE updated to surface `handbooks/`

--- a/handbooks/README.md
+++ b/handbooks/README.md
@@ -1,0 +1,121 @@
+# Handbooks — adopter coding standards consumed by Rex
+
+Handbooks are markdown files containing **company-specific coding standards** that the Code Reviewer agent (Rex) consults during PR review, alongside the framework's generic rules in `.claude/rules/`. Adopters customise this directory; the framework ships a small set of opinionated samples to demonstrate the convention.
+
+This is the place to encode the rules your team would otherwise enforce by Slack message, by lore, or by ad-hoc PR comments — *but only the ones that are stable enough to write down once and apply forever*.
+
+Decision rationale: [`docs/agdr/AgDR-0020-adopter-handbooks-for-rex.md`](../docs/agdr/AgDR-0020-adopter-handbooks-for-rex.md).
+
+## Discovery
+
+Rex finds handbooks by **path convention** — there is no YAML frontmatter, no `applies_to:` glob to maintain. The directory IS the targeting metadata.
+
+| Path | When Rex loads it |
+|---|---|
+| `handbooks/architecture/*.md` | **Always** — architecture standards apply to every PR |
+| `handbooks/general/*.md` | **Always** — cross-cutting rules (commit messages, comment density, naming) apply to every PR |
+| `handbooks/language/<lang>/*.md` | **On diff match** — only when the PR touches files of that language. `<lang>` matches by extension: `typescript/` → `**/*.{ts,tsx}`, `python/` → `**/*.py`, `go/` → `**/*.go`, `rust/` → `**/*.rs`, etc. |
+
+If you need a fourth bucket, add the directory and update Rex's discovery logic in `.claude/agents/code-reviewer.md`. The path convention is open — Rex falls back to "always-load" for any directory it doesn't have specific rules for.
+
+## File format
+
+Flat markdown. No YAML frontmatter required. Rex reads the file as prose during review and applies the rules conversationally.
+
+The recommended shape (mirrored across the four samples shipped with the framework):
+
+```markdown
+# Handbook: <Title>
+
+**Scope:** <which PRs this applies to, derived from the directory>
+**Enforcement:** advisory  (or: blocking — see below)
+
+## The rule
+
+<the rule in concrete, actionable language. Tables, bullet lists, and
+code snippets are fine. Aim for ≤ 50 lines per handbook — one rule
+cluster per file. Split into multiple files if a topic grows beyond
+that.>
+
+## Why
+
+<the load-bearing rationale. What problem does this rule prevent?
+What's the failure mode if it's ignored? Future-readers need to know
+why before they decide to keep / amend / drop it.>
+
+## What Rex flags
+
+<concrete patterns Rex looks for in the diff. Be specific about file
+paths, code patterns, and signal phrases. Vague rules generate vague
+findings.>
+
+## Sample finding
+
+<an example of how Rex should phrase the finding in a review comment.
+Format-by-example is the cheapest way to keep findings consistent.>
+
+## What's NOT a violation
+
+<the false-positive list. As load-bearing as the rule itself —
+without it, Rex over-reports and adopters tune him out.>
+```
+
+Other shapes are fine — Rex reads as prose. The shape above just keeps the four samples consistent.
+
+## Enforcement: advisory vs blocking
+
+**Default: advisory.** Rex surfaces the finding as a `nit:` / `suggestion:` comment in the review. The PR can still merge if other gates pass.
+
+**Opt in to blocking** by adding the literal phrase `ENFORCEMENT: blocking` at the **top of the file**, before any markdown content. Example:
+
+```markdown
+ENFORCEMENT: blocking
+
+# Handbook: Migration Safety
+
+...
+```
+
+When a blocking handbook is violated, Rex's overall review verdict becomes `request-changes` — the merge gate (Rex marker absent) blocks the PR until the violation is resolved or the handbook is amended via a separate PR.
+
+**Pick blocking sparingly.** A handbook that day-1 blocks every PR generates ratio'd revolts and eventually gets removed. Use blocking for rules where a violation has *material* downstream cost — data loss, security incident, irreversible production outage. Everything else is advisory.
+
+## Authoring conventions
+
+1. **One rule cluster per file.** A handbook on "TypeScript" is too broad; split into "strict-mode", "naming", "error-handling". Smaller files keep Rex's per-PR token cost bounded.
+2. **Be specific about the trigger.** "Use good types" is unenforceable. "`function fetchUser(id: any)` should declare `id: string` or `id: UserId`" is enforceable.
+3. **Include the false-positive list.** Every "What Rex flags" section should be paired with a "What's NOT a violation" section. Without it, Rex over-flags and operators tune the layer out.
+4. **Reference framework rules by `@.claude/rules/<file>.md` path** when a handbook extends or refines a generic framework rule. Don't duplicate; link.
+5. **Reference AgDRs** when a rule has a documented decision rationale. The handbook is the rule; the AgDR is the why.
+
+## Adding a new handbook
+
+```bash
+# Copy the shape of an existing sample
+cp handbooks/architecture/clean-architecture-layers.md handbooks/architecture/<your-new-rule>.md
+$EDITOR handbooks/architecture/<your-new-rule>.md
+
+# Commit alongside whatever PR introduced the need
+git add handbooks/architecture/<your-new-rule>.md
+git commit -m "docs(#NN): handbook on <your-new-rule>"
+```
+
+No skill scaffolding — handbook authoring is intentionally raw markdown editing in v1. If authoring friction shows up, file a ticket for a `/handbook` skill.
+
+## Out of scope (v1)
+
+- **Per-project handbooks** layered over framework handbooks. v1 is framework-level only — handbooks travel with the ops fork and apply to all managed projects. File a follow-up if your team needs project-specific handbooks.
+- **`/handbook` authoring skill.** Manual `cp` + edit is fine for v1.
+- **Handbook conflict resolution between framework rules and handbooks.** Defer until a real conflict surfaces; in v1 the framework rule wins.
+- **Cross-project handbook aggregation / dashboard.** Out of scope.
+
+## The four samples shipped with the framework
+
+| Path | Type | Enforcement | Rationale |
+|---|---|---|---|
+| `architecture/clean-architecture-layers.md` | Always-load architectural | Advisory | DDD layering — domain has no external deps; application doesn't import infrastructure |
+| `architecture/migration-safety.md` | Always-load architectural | **Blocking** | Schema migrations must be backwards-compatible for one release — production rollout safety |
+| `language/typescript/strict-mode.md` | Diff-matched language | Advisory | TS strict mode required; no bare `any` without justification |
+| `general/commit-message-quality.md` | Always-load cross-cutting | Advisory | Commits explain WHY, not WHAT — reduces future archaeology cost |
+
+Adopters can keep, edit, or replace any of these. They're not load-bearing for the framework — just demonstrative of the convention.

--- a/handbooks/architecture/clean-architecture-layers.md
+++ b/handbooks/architecture/clean-architecture-layers.md
@@ -1,0 +1,57 @@
+# Handbook: Clean Architecture Layering
+
+**Scope:** all PRs (handbook lives under `architecture/` — Rex always loads it).
+**Enforcement:** advisory.
+
+## The rule
+
+Code in this codebase is organised in three layers with a strict dependency direction:
+
+```
+domain  ←  application  ←  infrastructure
+```
+
+Dependencies point **inward**. The outer layers know about the inner; the inner layers do not know about the outer.
+
+| Layer | What lives there | What it CAN import | What it CANNOT import |
+|---|---|---|---|
+| `domain/` | Entities, value objects, domain events, business invariants | Other domain modules, standard library, primitive types | Anything from `application/`, `infrastructure/`, frameworks (HTTP, DB, message queues), env-var reads, network calls |
+| `application/` | Use cases, command/query handlers, orchestration of domain operations | `domain/`, ports/interfaces it owns | `infrastructure/` (concrete adapters, drivers, SDKs) |
+| `infrastructure/` | DB clients, HTTP handlers, queue producers/consumers, third-party SDK wrappers, config readers | `application/` (to call use cases), `domain/` (to construct entities), external libraries | (no restriction — this is the outermost layer) |
+
+## Why
+
+The dependency rule is what makes the domain testable without infrastructure mocks, swappable across deployments (DynamoDB → Postgres without changing business rules), and stable as the framework / hosting / vendor choices change underneath.
+
+When this gets violated — e.g. a domain entity importing the AWS SDK to fetch its own data — the domain becomes welded to the infrastructure. Test setup balloons. Refactoring the database becomes "rewrite the business logic". Three months in, the team stops touching the domain.
+
+## What Rex flags
+
+When reviewing a PR, surface a finding when:
+
+1. A file under `**/domain/**` imports from `**/infrastructure/**`, `**/application/**`, or any third-party framework module (e.g. `@aws-sdk/*`, `express`, `next`, `axios`, `prisma`).
+2. A file under `**/application/**` imports from `**/infrastructure/**` (the application layer should depend on ports/interfaces it owns, not on concrete adapters).
+3. A use case under `**/application/**` reads `process.env` directly (config should arrive as constructor arguments from infrastructure).
+4. A domain entity has a method that performs I/O — looks for `await fetch`, `await db.`, `await client.`, or imports of HTTP/DB clients inside the entity body.
+
+## Sample finding
+
+> **Layering** — `src/domain/order.ts` imports `@aws-sdk/client-dynamodb`. The domain layer must not depend on infrastructure SDKs. Move the persistence concern to `src/infrastructure/order-repository.ts` and let the use case in `src/application/place-order.ts` orchestrate the two.
+
+## What's NOT a violation
+
+- Type-only imports across layers (e.g. `import type { Order } from '../domain/order'` in `infrastructure/`) are fine — they're erased at compile time and don't create runtime coupling.
+- A domain module importing a small pure-function library (e.g. `date-fns`, `zod` for validation) is fine — these aren't infrastructure, they're extended primitives.
+- An adapter under `infrastructure/` importing `application/` to fulfil a port is the *correct* direction.
+
+## Refactor recipe
+
+If you spot a violation in code that's already shipped:
+
+1. Identify the offending import in `domain/`.
+2. Sketch the missing port — what *interface* does the domain need? Define it as an abstract class or TS interface inside `domain/` (no implementation).
+3. Move the concrete implementation to `infrastructure/` — make it implement the port.
+4. Wire it up in `application/` via constructor injection.
+5. Tests for the domain now mock the port, not the SDK.
+
+The refactor is mechanical once you see the shape. The hard part is noticing the violation in the first place — which is what this handbook is for.

--- a/handbooks/architecture/migration-safety.md
+++ b/handbooks/architecture/migration-safety.md
@@ -1,0 +1,74 @@
+ENFORCEMENT: blocking
+
+# Handbook: Migration Safety
+
+**Scope:** all PRs (handbook lives under `architecture/` — Rex always loads it).
+**Enforcement:** **blocking** — Rex requests changes if it detects a violation. PR cannot merge until resolved (or the handbook is amended via a separate PR).
+
+## The rule
+
+Database schema migrations must be **backwards-compatible for at least one release**. Any single migration that breaks the previous release's running code is a violation, even if the new code shipping in the same PR no longer needs the old shape.
+
+Concretely, a single migration **MUST NOT** do any of:
+
+| Action | Why it's blocked |
+|---|---|
+| `DROP COLUMN` or `DROP TABLE` on a column/table the previous release reads or writes | The previous release's deployed instances will crash mid-rollout. Use a two-step migration (deprecate-then-drop across releases) instead. |
+| `RENAME COLUMN` or `RENAME TABLE` in a single step | Same reason. Add the new name as a copy, dual-write for one release, drop the old name in a follow-up migration. |
+| `ALTER COLUMN` to a more restrictive type or NOT NULL without a default | Existing rows can violate the new constraint mid-migration; in-flight writes from the old code can fail validation. |
+| Drop or narrow an enum value the old code might emit | Old instances in a rolling deploy will fail to write. |
+| Reorder or change semantics of an existing column without a feature flag | Reads from old code interpret the new data wrong. |
+
+## Why
+
+Production rollouts are not atomic. During a deployment window — anywhere from 30 seconds (single instance) to 30 minutes (canary, regional, mobile-app-update lag) — both the old and new code are running against the same database. A migration that breaks the old code's expectations causes errors, lost writes, or data corruption during the window.
+
+The "backwards-compatible for one release" rule converts every breaking change into a planned two-step over two releases:
+
+```
+Release N:   add new column / table / value (additive). Old + new code both work.
+Release N+1: switch reads/writes to the new shape. Old code still works because the new shape is additive.
+Release N+2: drop the old column / table / value (destructive). Safe because no production code reads it any more.
+```
+
+This pattern is slow on purpose. The slowness is the safety.
+
+## What Rex flags
+
+When reviewing a PR, surface a **blocking** finding when:
+
+1. The diff includes a migration file (matches `**/migrate-*.{ts,js,py,sql}`, `**/migrations/**`, `prisma/schema.prisma`, `prisma/migrations/**`, `src/migrations/*.{ts,js}`, `alembic/versions/*.py`, `db/migrate/*.rb`) AND the migration content includes any of:
+   - SQL keywords: `DROP COLUMN`, `DROP TABLE`, `RENAME COLUMN`, `RENAME TABLE`, `ALTER COLUMN ... NOT NULL`, `ALTER COLUMN ... TYPE`, `ALTER TYPE ... DROP VALUE`, `DROP TYPE`
+   - Prisma schema changes: removed fields on existing models, removed models, narrowed types (String → Int, optional → required), removed enum values
+   - TypeORM / Drizzle migration calls: `dropColumn(`, `dropTable(`, `renameColumn(`, etc.
+
+2. AND there is no associated migration AgDR linked in the PR body (the framework's `require-migration-ticket.sh` hook normally enforces this; surface it here too as a defense-in-depth check).
+
+## Sample finding
+
+> ⛔ **Migration safety — BLOCKING**
+>
+> `prisma/migrations/20260514_drop_legacy_user_role/migration.sql` drops the `users.role_v1` column. The previous release still reads this column in `src/auth/role-resolver.ts:42`. A rolling deploy will cause the old instances to crash on every login request during the deployment window.
+>
+> **Required fix:** split into two PRs across two releases:
+> - This release: stop reading `role_v1` (use `role_v2`); leave the column in place. Add an AgDR documenting the deprecation.
+> - Next release: drop the column.
+
+## What's NOT a violation
+
+- **Adding** a column / table / enum value (additive — old code ignores it).
+- **Adding** an index, constraint that's NOT a NOT NULL or check on existing data, or extension.
+- A `DROP` on a column that was added AND deprecated in a prior release (verify by tracing the previous release's code — the column should have zero readers/writers).
+- A migration that's purely a data backfill (UPDATE / INSERT) with no schema change.
+- A migration on a table no other service touches and that the previous release didn't read (verify cross-service consumers).
+
+## Override
+
+If the violation is intentional and the team has weighed the risk (e.g. a planned downtime window, a column that's verifiably unused), the PR author **must** link a migration AgDR (per `templates/agdr-migration.md`) that explicitly documents:
+
+1. The breaking change being made
+2. Why backwards-compatibility is being skipped
+3. The downtime / rollback plan
+4. The cross-service consumer list verifying no other code reads the dropped shape
+
+With the AgDR linked, Rex marks this handbook check as N/A and the merge proceeds (the AgDR is the audit trail).

--- a/handbooks/architecture/migration-safety.md
+++ b/handbooks/architecture/migration-safety.md
@@ -51,6 +51,7 @@ When reviewing a PR, surface a **blocking** finding when:
 > `prisma/migrations/20260514_drop_legacy_user_role/migration.sql` drops the `users.role_v1` column. The previous release still reads this column in `src/auth/role-resolver.ts:42`. A rolling deploy will cause the old instances to crash on every login request during the deployment window.
 >
 > **Required fix:** split into two PRs across two releases:
+>
 > - This release: stop reading `role_v1` (use `role_v2`); leave the column in place. Add an AgDR documenting the deprecation.
 > - Next release: drop the column.
 

--- a/handbooks/general/commit-message-quality.md
+++ b/handbooks/general/commit-message-quality.md
@@ -1,0 +1,78 @@
+# Handbook: Commit Message Quality
+
+**Scope:** all PRs (handbook lives under `general/` — Rex always loads it).
+**Enforcement:** advisory.
+
+## The rule
+
+Commit messages explain **WHY**, not WHAT. The diff already shows what changed; the message is the only place the *reasoning* lives — and the only place future-readers (including future-you) can recover the context that motivated the change.
+
+| Required element | Detail |
+|---|---|
+| Subject line | `type(#TICKET): description` per `.claude/rules/git-conventions.md` (e.g. `feat(#218): add audit-history shared lib`). Imperative mood ("add", not "added"). Under 70 chars. No trailing period. |
+| Body | Present for any non-trivial change. Explains the WHY: what problem the change addresses, what alternatives were considered (briefly), what risks remain. Wrap at 72 cols. |
+| Ticket reference | `Closes #N` or `Refs #N` near the bottom of the body, single occurrence (the framework's hook blocks multi-Closes). |
+| Co-authorship | When pair-programming or AI-assisted, include `Co-Authored-By:` lines. |
+
+## Why
+
+Six months from now, someone will `git blame` the line you're about to write and read your commit message to understand WHY. The diff tells them what changed. The message is your only chance to tell them why.
+
+Commit messages that say "fixed bug", "update", or just `chore: cleanup` waste that opportunity. The reader has to dig through the PR (which may have been deleted), the linked ticket (which may have been closed and re-purposed), or the author's memory (which has moved on).
+
+A good commit message turns a 30-minute git-archaeology session into a 30-second read.
+
+## What Rex flags
+
+When reviewing a PR, surface a finding when:
+
+1. The PR has a commit whose subject is fewer than 10 characters of meaningful text after the `type(#N):` prefix (e.g. `chore(#42): fix`, `feat(#42): wip`, `refactor(#42): cleanup`).
+2. The PR has a commit with no body AND the diff is >50 lines (small fixes can get away with subject-only; substantive changes deserve a body).
+3. The commit body is a one-liner restating the subject (e.g. subject `feat(#42): add user export`, body `Adds user export.`). This is the WHAT-not-WHY pattern.
+4. The commit message contains placeholder text — `<description>`, `TODO`, `XXX`, `[fill in]`, etc.
+
+## Sample findings
+
+> **Commit-message quality** — Commit `abc1234` has subject `chore(#42): fix` and no body. The diff is 180 lines across 6 files. Add a body explaining what the fix addresses, what was tried before, and any follow-up considerations.
+
+> **Commit-message quality** — Commit `def5678` body says only `Adds user export feature.` — restating the subject line. Replace with the WHY: what user need does the export serve, what format / scope was chosen and why, what alternatives were considered.
+
+## What's NOT a violation
+
+- A trivial typo fix or a single-line docs change can ship as subject-only — the diff is self-evident.
+- A revert commit (`Revert "..."`) follows git's convention and doesn't need a hand-written body if the original had one.
+- A merge commit on a feature branch (rare with the framework's squash-merge default, but valid for stacked PRs).
+
+## Recipe — what a good body looks like
+
+The body has three rough sections:
+
+1. **What** — one sentence summary (yes, even though we said "WHY not WHAT" — this anchors the reader before the WHY).
+2. **Why** — the load-bearing paragraph. What problem does this solve? What was the trigger? Was there an incident, a metric, an AgDR, a customer ask?
+3. **Trade-offs** — anything notable. What this *doesn't* fix. Known limitations. Follow-up work that's filed as a separate ticket.
+
+Example:
+
+```
+fix(#218): handle empty findings array in audit_run_persist
+
+The lib's stats-derivation jq passed an empty findings array to
+`reduce` with no fallback, causing the persist to silently emit an
+empty stats object on first runs (no findings yet logged).
+
+A first-run with zero findings is the common case for a new project's
+first /threat-model invocation. The frontmatter would render with all
+severity buckets at 0, which is the right semantic but only by
+accident — the stats object should be present even when findings[]
+is empty.
+
+Fix: pre-seed the reduce accumulator with explicit zero buckets.
+
+Trade-off: the JSON file now always has a stats key even on first
+runs, slightly larger than before. The trend renderer was already
+defensive about a missing stats key; the change is forward-compatible.
+
+Refs #218
+```
+
+The diff alone wouldn't tell you why this matters. The message does.

--- a/handbooks/general/commit-message-quality.md
+++ b/handbooks/general/commit-message-quality.md
@@ -34,7 +34,7 @@ When reviewing a PR, surface a finding when:
 ## Sample findings
 
 > **Commit-message quality** — Commit `abc1234` has subject `chore(#42): fix` and no body. The diff is 180 lines across 6 files. Add a body explaining what the fix addresses, what was tried before, and any follow-up considerations.
-
+>
 > **Commit-message quality** — Commit `def5678` body says only `Adds user export feature.` — restating the subject line. Replace with the WHY: what user need does the export serve, what format / scope was chosen and why, what alternatives were considered.
 
 ## What's NOT a violation

--- a/handbooks/language/typescript/strict-mode.md
+++ b/handbooks/language/typescript/strict-mode.md
@@ -1,0 +1,57 @@
+# Handbook: TypeScript Strict Mode
+
+**Scope:** PRs touching `**/*.{ts,tsx}` files (handbook lives under `language/typescript/` — Rex loads it only when the PR diff includes TypeScript files).
+**Enforcement:** advisory.
+
+## The rule
+
+All TypeScript projects under this organisation enable strict mode and avoid `any` without an inline justification.
+
+| Required | Setting / pattern |
+|---|---|
+| `tsconfig.json` strict mode | `"strict": true` (which enables `strictNullChecks`, `noImplicitAny`, `strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`, `noImplicitThis`, `alwaysStrict`) |
+| Additional flags | `"noUncheckedIndexedAccess": true` (array access returns `T \| undefined`), `"noFallthroughCasesInSwitch": true` |
+| `any` usage | Only with an inline `// @ts-expect-error` or `// any: <reason>` comment on the same or preceding line, justifying why a typed shape isn't possible |
+| Type assertions (`as`) | Acceptable for narrowing union types after a runtime check; **not** acceptable as a way to silence a type error you don't understand |
+| `// @ts-ignore` | Forbidden. Use `// @ts-expect-error` instead — it errors out when the underlying issue is fixed, surfacing dead suppressions. |
+
+## Why
+
+TypeScript's type system is opt-in by design — every escape hatch (`any`, `as`, `@ts-ignore`) silences the compiler without explaining why. Without a discipline against unjustified escape hatches, the codebase rots into "TypeScript-shaped JavaScript" — types in the IDE, runtime errors in production.
+
+Strict mode catches the largest class of preventable bugs at compile time: accidental `null` / `undefined`, function-shape mismatches, uninitialised class fields. Once the project is on strict mode, *staying* on strict mode requires reviewers to push back on `any` (and friends) — that's what this handbook is for.
+
+## What Rex flags
+
+When reviewing a PR, surface a finding when:
+
+1. The PR adds OR modifies a `tsconfig.json` AND the resulting effective config doesn't enable `strict: true`.
+2. A `.ts` / `.tsx` file in the diff contains a bare `any` (function parameter, return type, variable annotation, type assertion `as any`) without an inline justification comment on the same or preceding line.
+3. A `.ts` / `.tsx` file in the diff uses `// @ts-ignore` (use `// @ts-expect-error` instead).
+4. A `.ts` / `.tsx` file in the diff uses `as` to narrow without a runtime check immediately preceding it. Heuristic: `as X` where `X` is a concrete type (not a union member after a `typeof`/`instanceof`/`in` check on the prior 1-3 lines).
+
+## Sample findings
+
+> **Strict mode** — `src/handlers/user.ts:42` declares `function fetchUser(id: any): Promise<User>`. The `id` parameter is implicitly stringly-typed; replace with `string` (or a `UserId` value object if one exists in the domain).
+
+> **Strict mode** — `src/lib/parse.ts:18` uses `// @ts-ignore`. Switch to `// @ts-expect-error` so the compiler tells us when the suppression becomes obsolete.
+
+> **Strict mode** — `src/api/order.ts:67` casts `req.body as CreateOrderRequest` without validating the shape. Add a runtime check (Zod / io-ts / hand-written guard) before the cast, or import a validated DTO from `domain/`.
+
+## What's NOT a violation
+
+- `any` with a clear inline justification: `function debug(x: any) { /* any: pretty-printer accepts arbitrary shapes */ console.dir(x) }`.
+- `unknown` — the safe alternative to `any`. Encouraged for boundaries where the shape isn't known until runtime.
+- `as` for genuinely safe narrowings: `const order = result as Order` *after* `if (result.kind === 'order')` etc.
+- Generated code with `any` (e.g. OpenAPI codegen) — out of scope; flag the codegen config instead if it produces too much `any`.
+
+## Refactor recipe
+
+If you spot bare `any`s in code you're already touching:
+
+1. Identify the shape the value actually has at the use site. Often it's a small union (`'pending' | 'shipped' | 'delivered'`) or a concrete domain type.
+2. If the value is genuinely dynamic, use `unknown` and narrow with a guard.
+3. If the boundary is external (HTTP body, message queue payload), define a Zod / io-ts schema and parse once at the boundary; the rest of the code holds a typed value.
+4. If the codebase has a domain value object that fits, use it (e.g. `UserId` instead of `string`).
+
+The first two are usually 30 seconds. The schema-at-boundary path takes 5 minutes per boundary but eliminates an entire class of "request shape changed and nobody noticed" bugs.

--- a/handbooks/language/typescript/strict-mode.md
+++ b/handbooks/language/typescript/strict-mode.md
@@ -33,9 +33,9 @@ When reviewing a PR, surface a finding when:
 ## Sample findings
 
 > **Strict mode** — `src/handlers/user.ts:42` declares `function fetchUser(id: any): Promise<User>`. The `id` parameter is implicitly stringly-typed; replace with `string` (or a `UserId` value object if one exists in the domain).
-
+>
 > **Strict mode** — `src/lib/parse.ts:18` uses `// @ts-ignore`. Switch to `// @ts-expect-error` so the compiler tells us when the suppression becomes obsolete.
-
+>
 > **Strict mode** — `src/api/order.ts:67` casts `req.body as CreateOrderRequest` without validating the shape. Add a runtime check (Zod / io-ts / hand-written guard) before the cast, or import a validated DTO from `domain/`.
 
 ## What's NOT a violation


### PR DESCRIPTION
## Summary

- New `handbooks/` directory at the ops fork root for adopter-authored coding standards consumed by Rex during PR review, layered on top of the framework's generic rules in `.claude/rules/`
- Discovery by **path-convention** (no YAML frontmatter): `handbooks/architecture/*.md` + `handbooks/general/*.md` always-load; `handbooks/language/<lang>/*.md` loads only when the PR diff includes files matching `<lang>`'s extensions
- Enforcement defaults to **advisory**; opt in to blocking with the literal phrase `ENFORCEMENT: blocking` at the top of a handbook file
- Four sample handbooks shipped, demonstrating each shape (always-load advisory architectural / always-load blocking architectural / diff-matched advisory language / always-load advisory cross-cutting)
- Rex agent definition (`.claude/agents/code-reviewer.md`) gains § 8 "Adopter Handbooks" with discovery rules, advisory/blocking convention, what-to-surface, and a `### Handbook Findings` section in the review output template
- `CLAUDE.md` Quick Reference and framework integration table updated to surface `handbooks/` next to `.claude/rules/`

## Why this matters

Before this PR, adopter coding standards lived in three places: ad-hoc Slack messages, wiki pages nobody re-reads, and inline PR comments that disappear with the PR. Rex enforced framework-wide rules but had no way to know about *your team's* patterns ("never use floats for currency", "all DB queries go through the repository layer", "Tailwind utility class order is alphabetised").

This PR closes that gap. Adopters drop a markdown file under `handbooks/`, Rex picks it up automatically on the next review, and the standard becomes enforced in CI rather than enforced by tribal memory. No code change needed to teach Rex a new rule — adopter authors a handbook, commits, done.

The four shapes (architecture/always-load, architecture/blocking, language/diff-matched, general/always-load) are the four shapes that cover most company coding standards. Per [AgDR-0020](docs/agdr/AgDR-0020-adopter-handbooks-for-rex.md), the design intentionally trades flexibility (no per-project layering, no YAML frontmatter, no per-feature scaffold) for adopter ergonomics — a one-file-and-done shape that authors can write without learning a schema.

## Testing

- [x] Directory structure created and 4 sample handbooks rendered with realistic content (DDD layering, migration safety with blocking marker, TS strict mode, commit-message quality)
- [x] Rex agent doc updated with § 8 "Adopter Handbooks" — discovery, advisory/blocking, what-to-surface, output template, new Rules entry #9
- [x] Section ordering in Rex agent doc verified: 1, 2, 3, 4, 5, 6, 7 (AgDR), 8 (Handbooks), then Process / Output Format / Rules
- [x] CLAUDE.md updated in two places (framework integration table + Quick Reference) to surface `handbooks/`
- [x] AgDR-0020 captures all five locked-in design decisions with options-considered tables
- [ ] Reviewer can spot-check the discovery shape in `.claude/agents/code-reviewer.md` § 8 — verify the path globs match the conventions described in `handbooks/README.md`
- [ ] Reviewer can confirm the blocking marker pattern (`ENFORCEMENT: blocking` at the top of `handbooks/architecture/migration-safety.md`) is the literal phrase Rex's prompt instructs him to look for
- [ ] Manual smoke test post-merge: open a real PR touching a `**/*.ts` file in any registered project, confirm Rex's review comment cites both framework rules AND the typescript-strict-mode handbook; open another PR touching only `**/*.py` files (no Python handbooks shipped yet), confirm Rex skips the typescript handbook

## Glossary

| Term | Definition |
|---|---|
| Handbook | A flat markdown file under `handbooks/` containing an adopter-authored coding standard. Consumed by Rex (the code-reviewer agent) during PR review alongside the framework's generic rules in `.claude/rules/`. |
| Path-convention discovery | Rex finds handbooks by globbing well-known paths — no YAML frontmatter, no `applies_to:` glob to maintain. The directory IS the targeting metadata. `architecture/` and `general/` always-load; `language/<lang>/` loads on diff match. |
| `ENFORCEMENT: blocking` marker | Literal phrase placed at the top of a handbook file (typically the first line) that opts the handbook in to blocking enforcement. When Rex finds a violation of a blocking handbook, his verdict becomes REQUEST CHANGES and the merge gate (Rex marker absent) blocks the PR. Default is advisory. |
| Advisory handbook | Default enforcement mode. Rex surfaces violations as `nit:` / `suggestion:` comments. Verdict unaffected — APPROVED / COMMENT still valid. |
| Blocking handbook | Opt-in enforcement mode. Surface format `⛔ Handbook (blocking):`. Verdict becomes REQUEST CHANGES. |
| Handbook Findings section | New `### Handbook Findings` section in Rex's review output, between `### Issues Found` and `### Suggestions`. Groups violations by handbook, severity (blocking first), then file:line. Omitted when no handbooks loaded. |
| Diff-matched language handbook | A handbook under `handbooks/language/<lang>/` that Rex loads only when the PR diff includes files of `<lang>`'s extensions. Keeps Rex's per-PR token cost bounded — Python-only PRs don't pay the TS handbook cost. |
| Sample handbooks | The four handbooks shipped with the framework demonstrating each shape: clean-architecture-layers (advisory architectural), migration-safety (blocking architectural), strict-mode (advisory language), commit-message-quality (advisory cross-cutting). Adopters can keep, edit, or replace them freely. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
