### PR TITLE
fix(#229): align merge gates + agent + skill on ops-fork marker path

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -237,22 +237,42 @@ If no handbooks loaded (e.g. the diff doesn't trigger any language handbooks and
 
 When your verdict is APPROVED, and ONLY then, write the approval marker file so the `block-unreviewed-merge.sh` hook can let the merge through.
 
+### Path: ops fork root, not git toplevel
+
+The marker MUST land at `<ops_fork_root>/.claude/session/reviews/{number}-rex.approved`. Inside `workspace/<project>/`, `git rev-parse --show-toplevel` returns the project clone — NOT the ops fork. Writing to a relative `.claude/session/reviews/` path from inside a workspace clone puts the marker where the merge-gate hook can't see it (the bug fix in me2resh/apexyard#229 + #230 aligned the merge gate with this path; this section is the agent-side counterpart).
+
+Resolve the ops fork root by walking up for `onboarding.yaml` + `apexyard.projects.yaml`:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+OPS_ROOT=""
+r="$REPO_ROOT"
+while [ -n "$r" ] && [ "$r" != "/" ]; do
+  if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
+    OPS_ROOT="$r"; break
+  fi
+  r=$(dirname "$r")
+done
+MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
+mkdir -p "$MARKER_HOME/.claude/session/reviews"
+```
+
 ### The command
 
-Use exactly one of these forms. Nothing else:
+Once `MARKER_HOME` is resolved (see above), use exactly one of these forms:
 
 ```bash
 # Option A — from the local HEAD of the PR branch
-git rev-parse HEAD > .claude/session/reviews/{number}-rex.approved
+git rev-parse HEAD > "$MARKER_HOME/.claude/session/reviews/{number}-rex.approved"
 
 # Option B — from the PR's HEAD on GitHub (preferred for cross-repo / detached HEAD)
-gh pr view {number} --json headRefOid --jq .headRefOid > .claude/session/reviews/{number}-rex.approved
+gh pr view {number} --json headRefOid --jq .headRefOid > "$MARKER_HOME/.claude/session/reviews/{number}-rex.approved"
 
 # Option C — literal SHA write (when you've already captured the SHA in a variable)
-printf '%s\n' "$SHA" > .claude/session/reviews/{number}-rex.approved
+printf '%s\n' "$SHA" > "$MARKER_HOME/.claude/session/reviews/{number}-rex.approved"
 ```
 
-Where `{number}` is the PR number and the file path is repo-relative from the repo root.
+Where `{number}` is the PR number.
 
 ### Content — MUST be bare SHA + newline
 
@@ -289,7 +309,7 @@ All of these fail the hook's whitespace-strip-then-compare check. The merge gate
 
 ### Where to write
 
-`.claude/session/reviews/` at the repo root. If running in a nested worktree, write to the worktree's reviews dir — that's where the merge-gate hook looks.
+`<ops_fork_root>/.claude/session/reviews/` per the MARKER_HOME resolution above. The merge-gate hook (`block-unreviewed-merge.sh`) resolves the same path via `_lib-ops-root.sh`. Inside a workspace clone (`workspace/<project>/`), this is NOT the project clone's `.claude/session/reviews/` — it's the ops fork above. If running in a nested worktree of the ops fork, the worktree shares the ops fork's session state (worktrees see the parent's tree below `.claude/`).
 
 ### On REQUEST CHANGES or COMMENT verdicts
 

--- a/.claude/hooks/_lib-ops-root.sh
+++ b/.claude/hooks/_lib-ops-root.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# _lib-ops-root.sh — shared OPS_ROOT discovery for hooks and skills.
+#
+# An "ops root" is the directory containing BOTH `onboarding.yaml` AND
+# `apexyard.projects.yaml` — i.e. a configured ApexYard ops fork.
+#
+# Hooks that write or read framework session state (`.claude/session/*`)
+# need this to resolve consistently regardless of cwd. The failure mode
+# is real: when the operator works inside a managed-project workspace
+# clone at `workspace/<project>/`, `git rev-parse --show-toplevel`
+# returns the project clone, NOT the ops fork. Hooks that wrote markers
+# under the ops fork (e.g. via `require-active-ticket.sh`'s OPS_ROOT
+# walk) ended up invisible to merge-gate hooks that resolved REPO_ROOT
+# via plain `git rev-parse`.
+#
+# This lib centralises the walk-up logic that 7+ existing hooks already
+# duplicate inline (#229 + #230 fixed the merge-gate hooks; the others
+# can be consolidated in a follow-up).
+#
+# Functions:
+#   resolve_ops_root [start_dir]
+#       Walks up from start_dir (default: $PWD) toward / looking for a
+#       directory with both onboarding.yaml AND apexyard.projects.yaml.
+#       Echoes the path on success; echoes nothing and returns 0 on miss
+#       (caller is expected to fall back to start_dir or a sensible
+#       default).
+#
+# Sourced by hooks; never executed directly.
+
+[ -n "${_LIB_OPS_ROOT_SOURCED:-}" ] && return 0
+_LIB_OPS_ROOT_SOURCED=1
+
+resolve_ops_root() {
+  local start="${1:-$PWD}"
+  local r="$start"
+  while [ -n "$r" ] && [ "$r" != "/" ]; do
+    if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
+      printf '%s' "$r"
+      return 0
+    fi
+    r=$(dirname "$r")
+  done
+  return 0
+}

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -79,7 +79,18 @@ if [ -z "$PR_NUMBER" ]; then
 fi
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-REVIEWS_DIR="${REPO_ROOT:-.}/.claude/session/reviews"
+# Resolve the ops fork root (where session markers live), not the
+# workspace clone's git toplevel. Inside `workspace/<project>/`,
+# REPO_ROOT is the project clone — markers live in the ops fork
+# above it. See me2resh/apexyard#229 + #230.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  OPS_ROOT=$(resolve_ops_root "$REPO_ROOT")
+fi
+MARKER_HOME="${OPS_ROOT:-${REPO_ROOT:-.}}"
+REVIEWS_DIR="${MARKER_HOME}/.claude/session/reviews"
 REX_APPROVAL="${REVIEWS_DIR}/${PR_NUMBER}-rex.approved"
 CEO_APPROVAL="${REVIEWS_DIR}/${PR_NUMBER}-ceo.approved"
 

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -64,6 +64,17 @@ if [ -z "$PR_NUMBER" ]; then
 fi
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+# Resolve the ops fork root (where session markers live), not the
+# workspace clone's git toplevel. Inside `workspace/<project>/`,
+# REPO_ROOT is the project clone — markers live in the ops fork
+# above it. See me2resh/apexyard#229 + #230.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  OPS_ROOT=$(resolve_ops_root "$REPO_ROOT")
+fi
+MARKER_HOME="${OPS_ROOT:-${REPO_ROOT:-.}}"
 
 # Default UI path patterns (regex). Note: .tsx$ / .jsx$ are EXACT — they must
 # not match plain .ts / .js, which are often backend/server files. The
@@ -111,7 +122,8 @@ if [ -z "$TOUCHED_UI" ]; then
 fi
 
 # UI PR detected — require a design approval marker
-APPROVAL="${REPO_ROOT:-.}/.claude/session/reviews/${PR_NUMBER}-design.approved"
+# Marker lives at the ops fork root (MARKER_HOME), not the workspace clone.
+APPROVAL="${MARKER_HOME}/.claude/session/reviews/${PR_NUMBER}-design.approved"
 
 if [ ! -f "$APPROVAL" ]; then
   cat >&2 <<MSG

--- a/.claude/hooks/tests/test_block_unreviewed_merge.sh
+++ b/.claude/hooks/tests/test_block_unreviewed_merge.sh
@@ -244,6 +244,35 @@ approval_summary="user said: 211 approved, ship it"
 EOF
 run_case "structured marker with quoted multi-word summary → allows" 0 "" "$sb" 211
 
+# 13. Workspace-clone scenario (apexyard#229 + #230). Sandbox simulates
+#     an ops fork at $sb (with onboarding.yaml + apexyard.projects.yaml
+#     + _lib-ops-root.sh) and a workspace clone underneath at
+#     $sb/workspace/demo/ (with its own .git/). Markers live in the OPS
+#     FORK's reviews dir. Hook runs with cwd = workspace clone. Should
+#     pass — the OPS_ROOT walk in the hook resolves up to the ops fork.
+sb=$(make_sandbox)
+# Add the apexyard.projects.yaml that resolve_ops_root requires.
+: > "$sb/apexyard.projects.yaml"
+# Copy _lib-ops-root.sh into the sandbox's hook dir.
+cp "$SRC_ROOT/.claude/hooks/_lib-ops-root.sh" "$sb/.claude/hooks/_lib-ops-root.sh"
+# Build a workspace clone underneath, with its own git toplevel.
+mkdir -p "$sb/workspace/demo"
+( cd "$sb/workspace/demo" && git init -q )
+# Markers exist at the OPS FORK's reviews dir (where the agent + skill write).
+write_rex_marker "$sb" 212
+write_ceo_marker_structured "$sb" 212
+# Run the hook from inside workspace/demo cwd (not the ops fork).
+input=$(jq -nc --arg c "gh pr merge 212 --repo me2resh/apexyard" '{tool_name:"Bash", tool_input:{command:$c}}')
+got_stderr=$(cd "$sb/workspace/demo" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash $sb/.claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
+  echo "PASS [workspace-clone cwd → resolves markers from ops fork (#229+#230)]"; PASS=$((PASS+1))
+else
+  echo "FAIL [workspace-clone cwd → resolves markers from ops fork (#229+#230)]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}workspace-clone-resolves-up "
+fi
+
 # --- Summary ----------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_ops_root.sh
+++ b/.claude/hooks/tests/test_ops_root.sh
@@ -68,7 +68,8 @@ case_1() {
   local sb
   sb=$(mktemp -d)
   build_sandbox "$sb"
-  ( . "$LIB"
+  ( # shellcheck source=/dev/null
+    . "$LIB"
     out=$(cd "$sb" && resolve_ops_root)
     [ "$out" = "$sb" ] || { mark_fail "$case_name" "expected '$sb', got '$out'"; return; }
     mark_pass "$case_name"
@@ -83,7 +84,8 @@ case_2() {
   local sb
   sb=$(mktemp -d)
   build_sandbox "$sb"
-  ( . "$LIB"
+  ( # shellcheck source=/dev/null
+    . "$LIB"
     out=$(cd "$sb/workspace/demo" && resolve_ops_root)
     [ "$out" = "$sb" ] || { mark_fail "$case_name" "expected '$sb', got '$out'"; return; }
     mark_pass "$case_name"
@@ -97,7 +99,8 @@ case_3() {
   local case_name="resolve_ops_root from non-ops dir → empty"
   local outside
   outside=$(mktemp -d)  # no onboarding.yaml / apexyard.projects.yaml
-  ( . "$LIB"
+  ( # shellcheck source=/dev/null
+    . "$LIB"
     out=$(cd "$outside" && resolve_ops_root)
     # /tmp may itself be inside something the resolver finds, but mktemp -d
     # places us in a fresh subdir — assert it's NOT $outside (we walked up).
@@ -126,7 +129,8 @@ case_4() {
   build_sandbox "$sb"
   local cwd_outside
   cwd_outside=$(mktemp -d)
-  ( . "$LIB"
+  ( # shellcheck source=/dev/null
+    . "$LIB"
     # cwd is outside; pass workspace clone as explicit start_dir.
     out=$(cd "$cwd_outside" && resolve_ops_root "$sb/workspace/demo")
     [ "$out" = "$sb" ] || { mark_fail "$case_name" "expected '$sb', got '$out'"; return; }
@@ -139,12 +143,14 @@ case_4() {
 # ---------------------------------------------------------------------------
 case_5() {
   local case_name="re-sourcing the lib is a no-op"
-  ( . "$LIB"
+  ( # shellcheck source=/dev/null
+    . "$LIB"
     if ! type resolve_ops_root >/dev/null 2>&1; then
       mark_fail "$case_name" "function not defined after first source"
       return
     fi
     # Re-source — should not error
+    # shellcheck source=/dev/null
     . "$LIB" 2>/dev/null
     if ! type resolve_ops_root >/dev/null 2>&1; then
       mark_fail "$case_name" "function gone after re-source"

--- a/.claude/hooks/tests/test_ops_root.sh
+++ b/.claude/hooks/tests/test_ops_root.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/_lib-ops-root.sh
+# (apexyard#229 + #230 — merge-gate marker-location mismatch fix)
+#
+# Each case:
+#   - builds an isolated sandbox under $TMPDIR with a synthetic ops-fork
+#     layout (onboarding.yaml + apexyard.projects.yaml at the root,
+#     optional workspace/<project>/ git clone underneath)
+#   - sources the lib
+#   - calls resolve_ops_root from various cwd contexts
+#   - asserts the returned path
+#
+# Cases covered:
+#   1. resolve_ops_root from inside the ops fork → returns ops fork path
+#   2. resolve_ops_root from inside workspace/<project>/ → returns OPS fork
+#      (this is the bug fix — without this, marker-resolution diverged
+#      between the agent and the merge gate)
+#   3. resolve_ops_root from outside any ops fork → returns empty string
+#   4. resolve_ops_root with explicit start_dir argument → walks from there
+#   5. Source-guard: re-sourcing the lib in the same shell is a no-op
+#      (no double-define of the function, no shell errors)
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+LIB="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
+
+if [ ! -f "$LIB" ]; then
+  echo "FAIL: lib not found at $LIB" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+mark_pass() { echo "  ✓ $1"; return 0; }
+mark_fail() { echo "  ✗ $1: $2" >&2; return 1; }
+
+run_case() {
+  local fn="$1"
+  if "$fn"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES $fn"
+  fi
+}
+
+# Builds a synthetic ops-fork layout under $1:
+#   $1/onboarding.yaml
+#   $1/apexyard.projects.yaml
+#   $1/workspace/demo/  (with its own .git/, simulating a managed-project clone)
+build_sandbox() {
+  local sb="$1"
+  mkdir -p "$sb/workspace/demo/.git"
+  : > "$sb/onboarding.yaml"
+  : > "$sb/apexyard.projects.yaml"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: from inside the ops fork
+# ---------------------------------------------------------------------------
+case_1() {
+  local case_name="resolve_ops_root from ops fork → ops fork path"
+  local sb
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  ( . "$LIB"
+    out=$(cd "$sb" && resolve_ops_root)
+    [ "$out" = "$sb" ] || { mark_fail "$case_name" "expected '$sb', got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: from inside workspace/<project>/ → returns ops fork (the bug fix)
+# ---------------------------------------------------------------------------
+case_2() {
+  local case_name="resolve_ops_root from workspace/<project>/ → ops fork"
+  local sb
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  ( . "$LIB"
+    out=$(cd "$sb/workspace/demo" && resolve_ops_root)
+    [ "$out" = "$sb" ] || { mark_fail "$case_name" "expected '$sb', got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: from outside any ops fork → empty string
+# ---------------------------------------------------------------------------
+case_3() {
+  local case_name="resolve_ops_root from non-ops dir → empty"
+  local outside
+  outside=$(mktemp -d)  # no onboarding.yaml / apexyard.projects.yaml
+  ( . "$LIB"
+    out=$(cd "$outside" && resolve_ops_root)
+    # /tmp may itself be inside something the resolver finds, but mktemp -d
+    # places us in a fresh subdir — assert it's NOT $outside (we walked up).
+    # The "miss" path returns empty.
+    if [ -z "$out" ]; then
+      mark_pass "$case_name"
+    elif [ "$out" = "$outside" ]; then
+      mark_fail "$case_name" "false-positive — returned start_dir without finding markers"
+    else
+      # Walked up and found markers somewhere above /tmp — also acceptable
+      # IF those markers actually exist (test environment varies).
+      [ -f "$out/onboarding.yaml" ] && [ -f "$out/apexyard.projects.yaml" ] \
+        && mark_pass "$case_name (walked up to ancestor ops fork: $out)" \
+        || mark_fail "$case_name" "returned '$out' but not a real ops fork"
+    fi
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: explicit start_dir argument
+# ---------------------------------------------------------------------------
+case_4() {
+  local case_name="resolve_ops_root <start_dir> walks from start_dir, not cwd"
+  local sb
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  local cwd_outside
+  cwd_outside=$(mktemp -d)
+  ( . "$LIB"
+    # cwd is outside; pass workspace clone as explicit start_dir.
+    out=$(cd "$cwd_outside" && resolve_ops_root "$sb/workspace/demo")
+    [ "$out" = "$sb" ] || { mark_fail "$case_name" "expected '$sb', got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: source-guard
+# ---------------------------------------------------------------------------
+case_5() {
+  local case_name="re-sourcing the lib is a no-op"
+  ( . "$LIB"
+    if ! type resolve_ops_root >/dev/null 2>&1; then
+      mark_fail "$case_name" "function not defined after first source"
+      return
+    fi
+    # Re-source — should not error
+    . "$LIB" 2>/dev/null
+    if ! type resolve_ops_root >/dev/null 2>&1; then
+      mark_fail "$case_name" "function gone after re-source"
+      return
+    fi
+    mark_pass "$case_name"
+  )
+}
+
+echo "Running ops-root lib tests..."
+for fn in case_1 case_2 case_3 case_4 case_5; do
+  run_case "$fn"
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -73,8 +73,20 @@ Sanity checks:
 The CEO approval is a stamp on top of a Rex-approved HEAD, not a standalone action.
 
 ```bash
+# Resolve the OPS FORK ROOT, not git toplevel. Inside workspace/<project>/,
+# git toplevel is the project clone; markers live in the ops fork above.
+# See me2resh/apexyard#229 + #230.
 REPO_ROOT=$(git rev-parse --show-toplevel)
-REX="$REPO_ROOT/.claude/session/reviews/<pr>-rex.approved"
+OPS_ROOT=""
+r="$REPO_ROOT"
+while [ -n "$r" ] && [ "$r" != "/" ]; do
+  if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
+    OPS_ROOT="$r"; break
+  fi
+  r=$(dirname "$r")
+done
+MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
+REX="$MARKER_HOME/.claude/session/reviews/<pr>-rex.approved"
 [ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "<headRefOid from step 3>" ]
 ```
 
@@ -107,17 +119,17 @@ Optional fields the gate stores but doesn't validate:
 | `approved_at=<ISO>` | Audit-log timestamp. Helpful when reviewing past merges. |
 | `approval_summary=<text>` | First ≤200 chars of the user's approval message, sanitised (no shell metachars). Audit trail for "what did the user say when they approved this." |
 
-Use the repo root as the path anchor — never a cwd-relative path:
+Use the **ops fork root** as the path anchor (NOT git toplevel — see #229 + #230 for the workspace-clone bug this avoids). Reuse the same MARKER_HOME computed in step 4:
 
 ```bash
-REPO_ROOT=$(git rev-parse --show-toplevel)
-mkdir -p "$REPO_ROOT/.claude/session/reviews"
+# (MARKER_HOME already resolved in step 4 — reuse it here.)
+mkdir -p "$MARKER_HOME/.claude/session/reviews"
 ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Sanitise: drop newlines, drop shell-special chars, truncate to 200.
 summary=$(echo "<user approval message>" | tr '\n' ' ' | tr -d '"`$\\' | cut -c1-200)
 
-cat > "$REPO_ROOT/.claude/session/reviews/<pr>-ceo.approved" <<EOF
+cat > "$MARKER_HOME/.claude/session/reviews/<pr>-ceo.approved" <<EOF
 sha=<headRefOid>
 approved_by=user
 approved_at=${ts}

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -326,6 +326,14 @@ cd ~/ops/apexyard-portfolio     # registry + project docs changes go here, push 
 
 Most ApexYard skills (`/projects`, `/inbox`, `/status`, `/tasks`, `/stakeholder-update`, `/handover`) work from the apexyard dir — they resolve paths through the symlinks. Skills that touch framework files only (`/update`, `/release`) operate on the apexyard dir alone.
 
+#### Where session-state files live
+
+Framework session state — active-ticket markers, code-review approvals, CEO approvals, the bootstrap-skill marker — always lives at `<ops_fork_root>/.claude/session/`. **Not** inside any `workspace/<project>/` clone.
+
+This matters when you `cd workspace/<project>/` to do project-specific work: even though `git rev-parse --show-toplevel` from inside the clone returns the project clone (not the ops fork), the framework's hooks, agents, and skills (Rex, `/start-ticket`, `/approve-merge`, the merge-gate hooks) all walk up to find the ops fork (looking for both `onboarding.yaml` AND `apexyard.projects.yaml`) and write/read session state from there. The `_lib-ops-root.sh` helper (added in me2resh/apexyard#229 + #230) centralises this walk so all components agree on the canonical path.
+
+You'll never need to manage session-state files by hand. If you ever see a "BLOCKED: PR has no recorded code-reviewer approval" error after the agent visibly approved, check that BOTH `onboarding.yaml` AND `apexyard.projects.yaml` exist at the ops fork root — the walk needs both files present to identify the fork.
+
 ### Upstream sync under split mode
 
 `/update` works the same. The upstream framework occasionally ships changes to `projects/README.md` (the framework's per-project docs convention). After the symlink, your fork's `projects/README.md` is replaced by the portfolio's own README. If a future upstream sync wants to update `projects/README.md`, you'll see a conflict; resolve by either accepting the upstream version (re-tracks the file, replacing the symlink behaviour for that one path) or keeping your symlink. Most upstream releases don't touch this file.


### PR DESCRIPTION
## Summary

- Closes the marker-location mismatch in #229 (and dup #230). Same root cause: merge-gate hooks resolved REPO_ROOT via `git rev-parse --show-toplevel`, which returns the workspace clone's git root when working inside `workspace/<project>/` — while Rex and the framework's other session-state hooks walk up to the ops fork. Result: marker invisible to the gate, merge blocked with *"no recorded code-reviewer approval"* even though the agent visibly approved seconds earlier.
- Per Option A (preferred in both bug reports): centralise on the ops fork. Extracts the walk-up pattern (look for both `onboarding.yaml` AND `apexyard.projects.yaml`) — already inline-duplicated in 6+ existing hooks — into a shared helper at `.claude/hooks/_lib-ops-root.sh`.
- Updates the 2 affected merge gates (`block-unreviewed-merge.sh`, `require-design-review-for-ui.sh`), the `/approve-merge` skill spec, and the code-reviewer agent (Rex) to use the helper. The third merge gate (`block-merge-on-red-ci.sh`) doesn't read marker paths and is unaffected.
- New `test_ops_root.sh` (5 cases) verifies the helper. Extended `test_block_unreviewed_merge.sh` with case 13 — the workspace-clone regression. All 13 tests pass.
- Doc note added to `docs/multi-project.md` § "Daily workflow under split mode" explaining the ops-fork invariant.

## Why this matters

Every framework-flow PR opened from inside a managed-project clone hit this bug. Workaround was a `cp` from the ops fork's reviews dir to the workspace clone's reviews dir before retrying the merge — fragile, undocumented, and easy to skip.

After this PR, the path is canonical: `<ops_fork_root>/.claude/session/reviews/<pr>-{rex,ceo,design}.approved`. All four touchpoints (Rex agent, `/approve-merge` skill, two merge-gate hooks) walk up to find the same path.

The walk is conservative: requires BOTH `onboarding.yaml` AND `apexyard.projects.yaml` at the candidate dir. False-positives (treating a non-ops dir as ops) are mechanically prevented. Misses fall back to REPO_ROOT silently, preserving single-fork behaviour with zero behaviour change for that path.

## Testing

- [x] `test_ops_root.sh` — 5 / 5 pass: from-ops-fork / from-workspace-clone / from-outside / explicit-start-dir / source-guard
- [x] `test_block_unreviewed_merge.sh` — 13 / 13 pass (12 existing regressions + 1 new workspace-clone case)
- [x] Backward-compat verified: existing test sandbox lacks `apexyard.projects.yaml` — `resolve_ops_root` returns empty, MARKER_HOME falls back to REPO_ROOT, all 12 existing tests still pass without modification
- [x] Hook source-guard: missing `_lib-ops-root.sh` is silent (`if [ -f ... ]` check), MARKER_HOME falls back to REPO_ROOT — single-fork mode keeps working even on the older lib-less layout
- [ ] Reviewer can spot-check that the walk-up condition (BOTH `onboarding.yaml` AND `apexyard.projects.yaml`) matches the convention used by `require-active-ticket.sh` (the existing inline pattern that this PR extracts)
- [ ] Reviewer can confirm the "out of scope" call is sensible — 6 other hooks have inline copies of the walk; this PR only refactors the 2 merge gates that are actually broken. Cleanup is filed mentally as a follow-up.
- [ ] Manual smoke test post-merge: open a PR from inside `workspace/<any-managed-project>/`, invoke Rex, then `/approve-merge` — both should succeed without manual marker copying

## Glossary

| Term | Definition |
|---|---|
| Ops fork root | The directory containing both `onboarding.yaml` AND `apexyard.projects.yaml` — i.e. a configured ApexYard ops fork. The walk-up condition requires both files to mechanically prevent false-positives. |
| MARKER_HOME | Per-hook variable: `OPS_ROOT` if found via the walk, else `REPO_ROOT` (single-fork fallback). All session-state paths in the affected hooks are rooted at `MARKER_HOME` after this PR. |
| Workspace clone | A managed-project repo cloned into `workspace/<project>/` under the ops fork (gitignored). `git rev-parse --show-toplevel` from inside this dir returns the project clone, NOT the ops fork. The bug fixed by this PR. |
| `_lib-ops-root.sh` | New shared helper that centralises the walk-up logic. Provides `resolve_ops_root [start_dir]`. Replaces inline duplicates in the 2 merge gates touched here; 6 other hooks still have inline copies (out of scope). |
| Source-guard | `[ -n "${_LIB_OPS_ROOT_SOURCED:-}" ] && return 0` pattern at the top of the lib — re-sourcing the lib in the same shell is a no-op. Standard `_lib-*.sh` shape used elsewhere in `.claude/hooks/`. |
| Workspace-clone regression test | Test case 13 in `test_block_unreviewed_merge.sh`: builds a sandbox with both ops-fork files at the root + a workspace clone underneath, writes markers in the ops fork's reviews dir, runs the hook from the workspace-clone cwd. Should pass. The test that proves the fix works end-to-end. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
