### PR TITLE
feat(#242): split-portfolio v2 — workspace + onboarding to private repo

### DIFF
--- a/.claude/hooks/_lib-ops-root.sh
+++ b/.claude/hooks/_lib-ops-root.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 # _lib-ops-root.sh — shared OPS_ROOT discovery for hooks and skills.
 #
-# An "ops root" is the directory containing BOTH `onboarding.yaml` AND
-# `apexyard.projects.yaml` — i.e. a configured ApexYard ops fork.
+# An "ops root" is the directory containing one of:
+#
+#   1. a `.apexyard-fork` marker file (v2 layout, framework ≥ #242), OR
+#   2. BOTH `onboarding.yaml` AND `apexyard.projects.yaml` (legacy v1
+#      layout — pre-v2 single-fork OR pre-v2 split-portfolio adopters).
 #
 # Hooks that write or read framework session state (`.claude/session/*`)
 # need this to resolve consistently regardless of cwd. The failure mode
@@ -13,14 +16,19 @@
 # walk) ended up invisible to merge-gate hooks that resolved REPO_ROOT
 # via plain `git rev-parse`.
 #
-# This lib centralises the walk-up logic that 7+ existing hooks already
-# duplicate inline (#229 + #230 fixed the merge-gate hooks; the others
-# can be consolidated in a follow-up).
+# Why a marker file: split-portfolio v2 (#242) moves both `onboarding.yaml`
+# AND `apexyard.projects.yaml` to the private sibling repo. The legacy
+# walk-up condition (BOTH files at the candidate dir) is no longer
+# satisfied by the public fork, so we need a presence-only anchor that
+# survives the move. `.apexyard-fork` is written by `/setup` at first
+# run and by `/update` during the v2 migration. Single-fork adopters
+# also benefit from the marker (set by `/setup`) but the legacy walk
+# remains a fallback for un-migrated forks.
 #
 # Functions:
 #   resolve_ops_root [start_dir]
 #       Walks up from start_dir (default: $PWD) toward / looking for a
-#       directory with both onboarding.yaml AND apexyard.projects.yaml.
+#       directory that satisfies either anchor condition.
 #       Echoes the path on success; echoes nothing and returns 0 on miss
 #       (caller is expected to fall back to start_dir or a sensible
 #       default).
@@ -34,6 +42,14 @@ resolve_ops_root() {
   local start="${1:-$PWD}"
   local r="$start"
   while [ -n "$r" ] && [ "$r" != "/" ]; do
+    # v2 anchor (preferred): the explicit .apexyard-fork marker file.
+    # Presence-only — content is ignored. Cheapest test runs first.
+    if [ -f "$r/.apexyard-fork" ]; then
+      printf '%s' "$r"
+      return 0
+    fi
+    # Legacy v1 anchor: both fork-root files present. Covers
+    # un-migrated single-fork AND un-migrated split-portfolio adopters.
     if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
       printf '%s' "$r"
       return 0

--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -2,9 +2,10 @@
 # _lib-portfolio-paths.sh — resolve portfolio paths from project-config.
 #
 # Source this library from any hook or skill that reads/writes the
-# portfolio registry, per-project docs dir, or ideas backlog. Reads the
-# `portfolio` block from .claude/project-config.{defaults,}.json (via
-# _lib-read-config.sh's `config_get_or`).
+# portfolio registry, per-project docs dir, ideas backlog, the
+# onboarding config, or the workspace dir. Reads the `portfolio` block
+# from .claude/project-config.{defaults,}.json (via _lib-read-config.sh's
+# `config_get_or`).
 #
 # Usage:
 #   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
@@ -12,25 +13,37 @@
 #   registry=$(portfolio_registry)
 #   projects_dir=$(portfolio_projects_dir)
 #   ideas_backlog=$(portfolio_ideas_backlog)
+#   onboarding=$(portfolio_onboarding_path)         # framework ≥ #242
+#   workspace_dir=$(portfolio_workspace_dir)        # framework ≥ #242
 #   portfolio_validate || echo "broken: $(portfolio_validate)"
 #
 # All resolvers output absolute paths. Relative config values resolve
-# against the ops-fork root (dir containing both onboarding.yaml and
-# apexyard.projects.yaml). Outside an apexyard fork the resolvers fall
-# back to the current git toplevel; outside any git repo they output
-# the relative literal so callers can detect the no-fork state.
+# against the ops-fork root. The ops-fork root is identified by EITHER:
+#
+#   - a `.apexyard-fork` marker file (split-portfolio v2 layout, where
+#     onboarding.yaml + apexyard.projects.yaml live in the private
+#     sibling repo), OR
+#   - both `onboarding.yaml` AND `apexyard.projects.yaml` (legacy
+#     single-fork OR un-migrated split-portfolio v1 layout)
+#
+# Outside an apexyard fork the resolvers fall back to the current git
+# toplevel; outside any git repo they output the relative literal so
+# callers can detect the no-fork state.
 #
 # Defaults (when config is missing entirely):
 #   registry      → ./apexyard.projects.yaml
 #   projects_dir  → ./projects
 #   ideas_backlog → ./projects/ideas-backlog.md
+#   onboarding    → ./onboarding.yaml
+#   workspace_dir → ./workspace
 #
 # Caching: results cached per-process in shell vars to avoid repeat jq
 # calls. Same pattern as _CONFIG_CACHE in _lib-read-config.sh.
 
 # ------------------------------------------------------------------------------
-# Internal: resolve the ops-fork root (dir with onboarding.yaml AND
-# apexyard.projects.yaml). Walks up from the git toplevel.
+# Internal: resolve the ops-fork root. Walks up from the git toplevel
+# looking for the v2 marker (`.apexyard-fork`) first, falling back to
+# the legacy v1 anchor (onboarding.yaml + apexyard.projects.yaml).
 # Falls back to git toplevel if not inside an apexyard fork.
 # ------------------------------------------------------------------------------
 _PORTFOLIO_ROOT_CACHE=""
@@ -49,6 +62,13 @@ _portfolio_root() {
 
   local cur="$r"
   while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    # v2 anchor first (cheap presence test).
+    if [ -f "$cur/.apexyard-fork" ]; then
+      _PORTFOLIO_ROOT_CACHE="$cur"
+      echo "$cur"
+      return 0
+    fi
+    # Legacy v1 anchor.
     if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
       _PORTFOLIO_ROOT_CACHE="$cur"
       echo "$cur"
@@ -151,6 +171,47 @@ portfolio_ideas_backlog() {
 }
 
 # ------------------------------------------------------------------------------
+# Public: portfolio_onboarding_path
+#   Resolves the path to onboarding.yaml. In single-fork mode this is
+#   inside the fork; in split-portfolio v2 mode it lives in the private
+#   sibling repo (e.g. ../<fork>-portfolio/onboarding.yaml).
+#
+#   Default: ./onboarding.yaml (relative to ops-fork root)
+# ------------------------------------------------------------------------------
+_PORTFOLIO_ONBOARDING_CACHE=""
+portfolio_onboarding_path() {
+  if [ -n "$_PORTFOLIO_ONBOARDING_CACHE" ]; then
+    echo "$_PORTFOLIO_ONBOARDING_CACHE"
+    return 0
+  fi
+  local raw
+  raw=$(_portfolio_get '.portfolio.onboarding' './onboarding.yaml')
+  _PORTFOLIO_ONBOARDING_CACHE=$(_portfolio_resolve "$raw")
+  echo "$_PORTFOLIO_ONBOARDING_CACHE"
+}
+
+# ------------------------------------------------------------------------------
+# Public: portfolio_workspace_dir
+#   Resolves the path to the workspace dir (where managed-project clones
+#   live). In single-fork mode this is inside the fork; in split-portfolio
+#   v2 mode it lives in the private sibling repo (e.g.
+#   ../<fork>-portfolio/workspace).
+#
+#   Default: ./workspace (relative to ops-fork root)
+# ------------------------------------------------------------------------------
+_PORTFOLIO_WORKSPACE_DIR_CACHE=""
+portfolio_workspace_dir() {
+  if [ -n "$_PORTFOLIO_WORKSPACE_DIR_CACHE" ]; then
+    echo "$_PORTFOLIO_WORKSPACE_DIR_CACHE"
+    return 0
+  fi
+  local raw
+  raw=$(_portfolio_get '.portfolio.workspace_dir' './workspace')
+  _PORTFOLIO_WORKSPACE_DIR_CACHE=$(_portfolio_resolve "$raw")
+  echo "$_PORTFOLIO_WORKSPACE_DIR_CACHE"
+}
+
+# ------------------------------------------------------------------------------
 # Public: portfolio_validate
 #   Sanity-check that resolved paths are actually usable.
 #   On success: prints nothing, returns 0.
@@ -166,10 +227,12 @@ portfolio_ideas_backlog() {
 #   SessionStart hooks without measurable session-start lag.
 # ------------------------------------------------------------------------------
 portfolio_validate() {
-  local registry projects_dir ideas_backlog
+  local registry projects_dir ideas_backlog onboarding workspace_dir
   registry=$(portfolio_registry)
   projects_dir=$(portfolio_projects_dir)
   ideas_backlog=$(portfolio_ideas_backlog)
+  onboarding=$(portfolio_onboarding_path)
+  workspace_dir=$(portfolio_workspace_dir)
 
   if [ ! -f "$registry" ]; then
     echo "broken: portfolio.registry resolved to $registry — file does not exist"
@@ -215,6 +278,41 @@ portfolio_validate() {
     # File missing but parent exists → creatable. Treat as OK.
   fi
 
+  # onboarding.yaml: validate ONLY when the resolved path is OUTSIDE the
+  # ops-fork root (i.e. an explicit override pointing at a sibling repo,
+  # split-portfolio v2 mode). When the resolved path is the in-fork
+  # default, the onboarding-check.sh hook already handles the
+  # missing/placeholder case with a more specific message; double-flagging
+  # would be noisy on fresh forks before /setup runs.
+  local root
+  root=$(_portfolio_root)
+  case "$onboarding" in
+    "$root"/*|"$root")
+      # In-fork path — leave it to onboarding-check.sh.
+      ;;
+    *)
+      if [ ! -f "$onboarding" ]; then
+        echo "broken: portfolio.onboarding resolved to $onboarding — file does not exist"
+        return 1
+      fi
+      ;;
+  esac
+
+  # workspace_dir: same shape — only validate explicit overrides. The
+  # in-fork default may legitimately not exist yet (no managed projects
+  # cloned). Callers that need the dir should mkdir on demand.
+  case "$workspace_dir" in
+    "$root"/*|"$root")
+      # In-fork path — optional; skip.
+      ;;
+    *)
+      if [ ! -d "$workspace_dir" ]; then
+        echo "broken: portfolio.workspace_dir resolved to $workspace_dir — directory does not exist"
+        return 1
+      fi
+      ;;
+  esac
+
   return 0
 }
 
@@ -227,4 +325,19 @@ portfolio_clear_cache() {
   _PORTFOLIO_REGISTRY_CACHE=""
   _PORTFOLIO_PROJECTS_DIR_CACHE=""
   _PORTFOLIO_IDEAS_BACKLOG_CACHE=""
+  _PORTFOLIO_ONBOARDING_CACHE=""
+  _PORTFOLIO_WORKSPACE_DIR_CACHE=""
+}
+
+# ------------------------------------------------------------------------------
+# Public: portfolio_is_v2
+#   Returns 0 if the ops fork is configured with the v2 layout (the
+#   `.apexyard-fork` marker is present at the resolved root), 1 otherwise.
+#   Useful for skills that want to branch behaviour on the layout (e.g.
+#   `/update`'s migration step, `/setup`'s split-portfolio init).
+# ------------------------------------------------------------------------------
+portfolio_is_v2() {
+  local root
+  root=$(_portfolio_root)
+  [ -n "$root" ] && [ -f "$root/.apexyard-fork" ]
 }

--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -310,6 +310,14 @@ portfolio_validate() {
         echo "broken: portfolio.workspace_dir resolved to $workspace_dir — directory does not exist"
         return 1
       fi
+      # Writability check — read-only mounts (NFS / SMB / nested-container
+      # bind-mounts that drop write perms) would otherwise silent-fail when
+      # /handover or the v2 migration tries to write into workspace/.
+      # Surface the failure here so SessionStart catches it.
+      if [ ! -w "$workspace_dir" ]; then
+        echo "broken: portfolio.workspace_dir at $workspace_dir is not writable"
+        return 1
+      fi
       ;;
   esac
 

--- a/.claude/hooks/check-portfolio-config.sh
+++ b/.claude/hooks/check-portfolio-config.sh
@@ -23,18 +23,33 @@ if [ -z "$REPO_ROOT" ]; then
   exit 0
 fi
 
-# Walk up to find the apexyard fork root (dir with both onboarding.yaml +
-# apexyard.projects.yaml). If we can't find one, this hook has nothing to
-# say.
-ROOT=""
-cur="$REPO_ROOT"
-while [ -n "$cur" ] && [ "$cur" != "/" ]; do
-  if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
-    ROOT="$cur"
-    break
-  fi
-  cur=$(dirname "$cur")
-done
+# Walk up to find the apexyard fork root. After framework #242 the v1
+# anchor (onboarding.yaml + apexyard.projects.yaml at the candidate dir)
+# is no longer satisfied by split-portfolio v2 forks (both files live in
+# the private sibling repo). Use the shared resolver which honours BOTH
+# the v2 `.apexyard-fork` marker AND the legacy v1 anchor.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  ROOT=$(resolve_ops_root "$REPO_ROOT")
+else
+  # Library missing — fall back to the legacy inline walk so the hook
+  # still works on un-migrated forks.
+  ROOT=""
+  cur="$REPO_ROOT"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/.apexyard-fork" ]; then
+      ROOT="$cur"
+      break
+    fi
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      ROOT="$cur"
+      break
+    fi
+    cur=$(dirname "$cur")
+  done
+fi
 
 if [ -z "$ROOT" ]; then
   exit 0

--- a/.claude/hooks/clear-bootstrap-marker.sh
+++ b/.claude/hooks/clear-bootstrap-marker.sh
@@ -26,16 +26,28 @@ if [ -z "$REPO_ROOT" ]; then
   exit 0
 fi
 
-# Walk up to find the apexyard fork root.
+# Walk up to find the apexyard fork root. Honours both the v2
+# `.apexyard-fork` marker and the legacy v1 anchor.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT=""
-cur="$REPO_ROOT"
-while [ -n "$cur" ] && [ "$cur" != "/" ]; do
-  if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
-    ROOT="$cur"
-    break
-  fi
-  cur=$(dirname "$cur")
-done
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  ROOT=$(resolve_ops_root "$REPO_ROOT")
+else
+  cur="$REPO_ROOT"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/.apexyard-fork" ]; then
+      ROOT="$cur"
+      break
+    fi
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      ROOT="$cur"
+      break
+    fi
+    cur=$(dirname "$cur")
+  done
+fi
 
 if [ -z "$ROOT" ]; then
   exit 0

--- a/.claude/hooks/onboarding-check.sh
+++ b/.claude/hooks/onboarding-check.sh
@@ -1,18 +1,43 @@
 #!/bin/bash
 # SessionStart hook: checks whether this ApexYard fork has been configured.
 #
-# Detection: reads onboarding.yaml and checks if company.name is still the
-# placeholder value "Your Company Name". If so, the fork hasn't been set up
-# yet and the user should run /setup.
+# Detection: reads the resolved onboarding.yaml path (via
+# portfolio_onboarding_path — handles both single-fork mode where
+# onboarding.yaml lives in the fork AND split-portfolio v2 mode where it
+# lives in the private sibling repo) and checks if company.name is still
+# the placeholder value "Your Company Name". If so, the fork hasn't been
+# set up yet and the user should run /setup.
 #
-# Why onboarding.yaml and not a session marker: onboarding.yaml is COMMITTED,
-# so the setup state persists across clones and team members. A fresh clone
-# of a configured fork already has real values — no per-machine marker needed.
+# Why onboarding.yaml and not a session marker: onboarding.yaml is COMMITTED
+# (to the fork in single-fork mode, to the private portfolio repo in
+# split-portfolio v2 mode), so the setup state persists across clones and
+# team members. A fresh clone of a configured fork already has real
+# values — no per-machine marker needed.
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-CONFIG="${REPO_ROOT:-.}/onboarding.yaml"
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
 
-# No onboarding.yaml at all — not an apexyard fork, skip silently
+# Resolve onboarding path through the portfolio helper so split-portfolio
+# v2 adopters (onboarding.yaml in the private sibling repo) get the right
+# file. Falls back to the in-fork default for single-fork mode.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG=""
+if [ -f "$HOOK_DIR/_lib-portfolio-paths.sh" ] && [ -f "$HOOK_DIR/_lib-read-config.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-read-config.sh"
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-portfolio-paths.sh"
+  CONFIG=$(portfolio_onboarding_path 2>/dev/null)
+fi
+if [ -z "$CONFIG" ]; then
+  CONFIG="$REPO_ROOT/onboarding.yaml"
+fi
+
+# No onboarding.yaml at the resolved path — not an apexyard fork (or
+# split-portfolio v2 misconfigured); skip silently. check-portfolio-config.sh
+# handles broken paths.
 if [ ! -f "$CONFIG" ]; then
   exit 0
 fi

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -110,24 +110,51 @@ if [ -n "$REL_PATH" ]; then
   esac
 fi
 
-# Discover the ops root. Walk up from REPO_ROOT until we find a directory
-# with both onboarding.yaml AND apexyard.projects.yaml (a configured ops
-# fork). Stop at /. If not found, OPS_ROOT stays empty and we treat the
-# REPO_ROOT itself as the marker home (pre-#41 behaviour).
+# Discover the ops root. Walk up from REPO_ROOT looking for either the
+# v2 `.apexyard-fork` marker (split-portfolio v2 layout) OR the legacy
+# v1 anchor (onboarding.yaml + apexyard.projects.yaml). Stop at /. If
+# not found, OPS_ROOT stays empty and we treat the REPO_ROOT itself as
+# the marker home (pre-#41 behaviour).
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 OPS_ROOT=""
 if [ -n "$REPO_ROOT" ]; then
-  r="$REPO_ROOT"
-  while [ -n "$r" ] && [ "$r" != "/" ]; do
-    if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
-      OPS_ROOT="$r"
-      break
-    fi
-    r=$(dirname "$r")
-  done
+  if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$HOOK_DIR/_lib-ops-root.sh"
+    OPS_ROOT=$(resolve_ops_root "$REPO_ROOT")
+  else
+    r="$REPO_ROOT"
+    while [ -n "$r" ] && [ "$r" != "/" ]; do
+      if [ -f "$r/.apexyard-fork" ]; then
+        OPS_ROOT="$r"
+        break
+      fi
+      if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
+        OPS_ROOT="$r"
+        break
+      fi
+      r=$(dirname "$r")
+    done
+  fi
 fi
 
 MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
 MARKER_HOME="${MARKER_HOME:-.}"
+
+# Resolve the workspace dir for the per-project marker resolution below.
+# Defaults to $OPS_ROOT/workspace; split-portfolio v2 adopters override
+# via portfolio.workspace_dir to point at their private sibling repo.
+WORKSPACE_DIR="$OPS_ROOT/workspace"
+if [ -n "$OPS_ROOT" ] && [ -f "$HOOK_DIR/_lib-portfolio-paths.sh" ] && [ -f "$HOOK_DIR/_lib-read-config.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-read-config.sh"
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-portfolio-paths.sh"
+  resolved_ws=$(portfolio_workspace_dir 2>/dev/null)
+  if [ -n "$resolved_ws" ]; then
+    WORKSPACE_DIR="$resolved_ws"
+  fi
+fi
 
 # Bootstrap-skill exemption (apexyard#150): skills like /setup,
 # /handover, /update, /split-portfolio run BEFORE any ticket can exist
@@ -157,14 +184,29 @@ if [ -f "$BOOTSTRAP_MARKER" ]; then
   fi
 fi
 
-# Per-project resolution (apexyard#41): if FILE_PATH points under
-# <ops_root>/workspace/<project>/, we look for a per-project marker at
+# Per-project resolution (apexyard#41): if FILE_PATH points under the
+# resolved workspace dir, we look for a per-project marker at
 # .claude/session/tickets/<project>. This keeps per-project session state
 # keyed by the managed-project name and localised in the ops fork
 # (gitignored), instead of the pre-#41 scheme that relied on a
 # .claude/session/ inside each managed-project clone.
+#
+# Split-portfolio v2 (#242): WORKSPACE_DIR may resolve to a sibling
+# private repo path (e.g. ../<fork>-portfolio/workspace) instead of the
+# default $OPS_ROOT/workspace; both shapes are handled here.
 PROJECT=""
-if [ -n "$OPS_ROOT" ]; then
+if [ -n "$WORKSPACE_DIR" ]; then
+  case "$FILE_PATH" in
+    "$WORKSPACE_DIR"/*)
+      tail="${FILE_PATH#$WORKSPACE_DIR/}"
+      PROJECT="${tail%%/*}"
+      ;;
+  esac
+fi
+# Belt-and-suspenders: also recognise the literal $OPS_ROOT/workspace/
+# shape, in case workspace_dir is overridden but a tool produced an
+# absolute path under the in-fork legacy location.
+if [ -z "$PROJECT" ] && [ -n "$OPS_ROOT" ]; then
   case "$FILE_PATH" in
     "$OPS_ROOT"/workspace/*)
       tail="${FILE_PATH#$OPS_ROOT/workspace/}"

--- a/.claude/hooks/require-agdr-for-arch-changes.sh
+++ b/.claude/hooks/require-agdr-for-arch-changes.sh
@@ -110,16 +110,31 @@ fi
 # See .claude/rules/workflow-gates.md § Spike work.
 # ---------------------------------------------------------------------------
 spike_commit_exempt() {
-  # Walk up from REPO_ROOT to find the ops root.
+  # Walk up from REPO_ROOT to find the ops root. Honours both the v2
+  # `.apexyard-fork` marker and the legacy v1 anchor.
   local marker_home="$REPO_ROOT"
-  local r="$REPO_ROOT"
-  while [ -n "$r" ] && [ "$r" != "/" ]; do
-    if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
-      marker_home="$r"
-      break
-    fi
-    r=$(dirname "$r")
-  done
+  local hook_dir
+  hook_dir="$(cd "$(dirname "$0")" && pwd)"
+  if [ -f "$hook_dir/_lib-ops-root.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$hook_dir/_lib-ops-root.sh"
+    local resolved
+    resolved=$(resolve_ops_root "$REPO_ROOT")
+    [ -n "$resolved" ] && marker_home="$resolved"
+  else
+    local r="$REPO_ROOT"
+    while [ -n "$r" ] && [ "$r" != "/" ]; do
+      if [ -f "$r/.apexyard-fork" ]; then
+        marker_home="$r"
+        break
+      fi
+      if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
+        marker_home="$r"
+        break
+      fi
+      r=$(dirname "$r")
+    done
+  fi
 
   if [ -f "$marker_home/.claude/session/current-ticket" ]; then
     if grep -qE '^title=\[Spike\]' "$marker_home/.claude/session/current-ticket" 2>/dev/null; then

--- a/.claude/hooks/require-agdr-for-arch-pr.sh
+++ b/.claude/hooks/require-agdr-for-arch-pr.sh
@@ -133,15 +133,30 @@ spike_pr_exempt() {
 
   # (b) active ticket marker has [Spike] prefix
   local marker_home="${REPO_ROOT}"
-  # Walk up to find the ops root (has both onboarding.yaml + apexyard.projects.yaml)
-  local r="$REPO_ROOT"
-  while [ -n "$r" ] && [ "$r" != "/" ]; do
-    if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
-      marker_home="$r"
-      break
-    fi
-    r=$(dirname "$r")
-  done
+  # Walk up to find the ops root. Honours both the v2 `.apexyard-fork`
+  # marker and the legacy v1 anchor (onboarding.yaml + apexyard.projects.yaml).
+  local hook_dir
+  hook_dir="$(cd "$(dirname "$0")" && pwd)"
+  if [ -f "$hook_dir/_lib-ops-root.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$hook_dir/_lib-ops-root.sh"
+    local resolved
+    resolved=$(resolve_ops_root "$REPO_ROOT")
+    [ -n "$resolved" ] && marker_home="$resolved"
+  else
+    local r="$REPO_ROOT"
+    while [ -n "$r" ] && [ "$r" != "/" ]; do
+      if [ -f "$r/.apexyard-fork" ]; then
+        marker_home="$r"
+        break
+      fi
+      if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
+        marker_home="$r"
+        break
+      fi
+      r=$(dirname "$r")
+    done
+  fi
 
   if [ -f "$marker_home/.claude/session/current-ticket" ]; then
     if grep -qE '^title=\[Spike\]' "$marker_home/.claude/session/current-ticket" 2>/dev/null; then

--- a/.claude/hooks/require-migration-ticket.sh
+++ b/.claude/hooks/require-migration-ticket.sh
@@ -79,20 +79,45 @@ esac
 # crosses `/`), so no separate arm is needed.
 
 # --------- Discover ops root ---------
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 OPS_ROOT=""
 if [ -n "$REPO_ROOT" ]; then
-  r="$REPO_ROOT"
-  while [ -n "$r" ] && [ "$r" != "/" ]; do
-    if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
-      OPS_ROOT="$r"
-      break
-    fi
-    r=$(dirname "$r")
-  done
+  if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$HOOK_DIR/_lib-ops-root.sh"
+    OPS_ROOT=$(resolve_ops_root "$REPO_ROOT")
+  else
+    r="$REPO_ROOT"
+    while [ -n "$r" ] && [ "$r" != "/" ]; do
+      if [ -f "$r/.apexyard-fork" ]; then
+        OPS_ROOT="$r"
+        break
+      fi
+      if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
+        OPS_ROOT="$r"
+        break
+      fi
+      r=$(dirname "$r")
+    done
+  fi
 fi
 MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
 MARKER_HOME="${MARKER_HOME:-.}"
+
+# Resolve the workspace dir (defaults to $OPS_ROOT/workspace; v2
+# split-portfolio adopters point at the private sibling repo).
+WORKSPACE_DIR="$OPS_ROOT/workspace"
+if [ -n "$OPS_ROOT" ] && [ -f "$HOOK_DIR/_lib-portfolio-paths.sh" ] && [ -f "$HOOK_DIR/_lib-read-config.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-read-config.sh"
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-portfolio-paths.sh"
+  resolved_ws=$(portfolio_workspace_dir 2>/dev/null)
+  if [ -n "$resolved_ws" ]; then
+    WORKSPACE_DIR="$resolved_ws"
+  fi
+fi
 
 # --------- Load project-config overrides ---------
 MIGRATION_LABEL="migration"
@@ -156,10 +181,19 @@ if ! is_migration_path "$FILE_PATH"; then
 fi
 
 # --------- Gate 1: active ticket marker ---------
-# Reuse the #41 resolution: per-project marker if FILE_PATH is under
-# ops_root/workspace/<project>/, otherwise the ops-level fallback.
+# Reuse the #41 resolution: per-project marker if FILE_PATH is under the
+# resolved workspace dir, otherwise the ops-level fallback. The resolved
+# workspace dir may live in the private sibling repo for v2 adopters.
 PROJECT=""
-if [ -n "$OPS_ROOT" ]; then
+if [ -n "$WORKSPACE_DIR" ]; then
+  case "$FILE_PATH" in
+    "$WORKSPACE_DIR"/*)
+      tail="${FILE_PATH#$WORKSPACE_DIR/}"
+      PROJECT="${tail%%/*}"
+      ;;
+  esac
+fi
+if [ -z "$PROJECT" ] && [ -n "$OPS_ROOT" ]; then
   case "$FILE_PATH" in
     "$OPS_ROOT"/workspace/*)
       tail="${FILE_PATH#$OPS_ROOT/workspace/}"

--- a/.claude/hooks/tests/test_handover_clone_prompt.sh
+++ b/.claude/hooks/tests/test_handover_clone_prompt.sh
@@ -82,9 +82,14 @@ spec_assert "spec-prompt-response-options" "[y / n / later]"
 spec_assert "spec-followup-threat-model" \
   "Want to run /threat-model against the new clone now?"
 
-# 6. Skip-if-exists branch is documented.
+# 6. Skip-if-exists branch is documented. After framework #242 the skill
+# resolves the workspace dir via portfolio_workspace_dir (split-portfolio
+# v2 may point it at a sibling private repo), so the literal becomes
+# `$WORKSPACE_DIR/<name>` rather than `workspace/<name>`. The shape of
+# the skip branch (an `if [ -d ... ]; then` guard around `git clone`)
+# is what the spec test pins.
 spec_assert "spec-skip-if-exists" \
-  'if [ -d "workspace/<name>" ]; then'
+  'if [ -d "$WORKSPACE_DIR/<name>" ]; then'
 
 # 7. Decline path documented as silent (no side effects).
 spec_assert "spec-decline-silent" \

--- a/.claude/hooks/tests/test_ops_root.sh
+++ b/.claude/hooks/tests/test_ops_root.sh
@@ -49,7 +49,7 @@ run_case() {
   fi
 }
 
-# Builds a synthetic ops-fork layout under $1:
+# Builds a synthetic ops-fork layout under $1 (legacy v1 layout):
 #   $1/onboarding.yaml
 #   $1/apexyard.projects.yaml
 #   $1/workspace/demo/  (with its own .git/, simulating a managed-project clone)
@@ -58,6 +58,17 @@ build_sandbox() {
   mkdir -p "$sb/workspace/demo/.git"
   : > "$sb/onboarding.yaml"
   : > "$sb/apexyard.projects.yaml"
+}
+
+# Builds a synthetic split-portfolio v2 ops-fork layout under $1:
+#   $1/.apexyard-fork                            (v2 anchor — presence-only)
+#   $1/workspace_local/demo/  (placeholder workspace dir for clone path)
+# NOTE: no onboarding.yaml or apexyard.projects.yaml at this root —
+# v2 moves both to a private sibling repo.
+build_v2_sandbox() {
+  local sb="$1"
+  mkdir -p "$sb/workspace_local/demo/.git"
+  : > "$sb/.apexyard-fork"
 }
 
 # ---------------------------------------------------------------------------
@@ -160,8 +171,61 @@ case_5() {
   )
 }
 
+# ---------------------------------------------------------------------------
+# Case 6 (v2): from inside a split-portfolio v2 fork with .apexyard-fork
+# marker but NO onboarding.yaml / apexyard.projects.yaml at the root
+# ---------------------------------------------------------------------------
+case_6() {
+  local case_name="resolve_ops_root v2: .apexyard-fork marker is enough"
+  local sb
+  sb=$(mktemp -d)
+  build_v2_sandbox "$sb"
+  ( # shellcheck source=/dev/null
+    . "$LIB"
+    out=$(cd "$sb" && resolve_ops_root)
+    [ "$out" = "$sb" ] || { mark_fail "$case_name" "expected '$sb', got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 7 (v2): from inside workspace clone in a v2 fork → returns ops fork
+# ---------------------------------------------------------------------------
+case_7() {
+  local case_name="resolve_ops_root v2: from workspace_local/demo → v2 ops fork"
+  local sb
+  sb=$(mktemp -d)
+  build_v2_sandbox "$sb"
+  ( # shellcheck source=/dev/null
+    . "$LIB"
+    out=$(cd "$sb/workspace_local/demo" && resolve_ops_root)
+    [ "$out" = "$sb" ] || { mark_fail "$case_name" "expected '$sb', got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 8 (v2): v2 marker takes precedence over a legacy anchor when both
+# happen to be present (during migration, before legacy files are removed)
+# ---------------------------------------------------------------------------
+case_8() {
+  local case_name="resolve_ops_root: v2 marker takes precedence over legacy anchor"
+  local sb
+  sb=$(mktemp -d)
+  build_v2_sandbox "$sb"
+  # Add legacy anchor too — should still resolve to this dir (no ambiguity).
+  : > "$sb/onboarding.yaml"
+  : > "$sb/apexyard.projects.yaml"
+  ( # shellcheck source=/dev/null
+    . "$LIB"
+    out=$(cd "$sb" && resolve_ops_root)
+    [ "$out" = "$sb" ] || { mark_fail "$case_name" "expected '$sb', got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
 echo "Running ops-root lib tests..."
-for fn in case_1 case_2 case_3 case_4 case_5; do
+for fn in case_1 case_2 case_3 case_4 case_5 case_6 case_7 case_8; do
   run_case "$fn"
 done
 

--- a/.claude/hooks/tests/test_portfolio_paths.sh
+++ b/.claude/hooks/tests/test_portfolio_paths.sh
@@ -316,6 +316,132 @@ exit 1
 rm -rf "$SB"
 
 # ---------------------------------------------------------------------------
+# Case 10 (v2): portfolio_onboarding_path resolves to in-fork default
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+run_case "v2: portfolio_onboarding_path defaults to in-fork onboarding.yaml" "$SB" '
+r=$(portfolio_onboarding_path)
+expected="'"$SB"'/onboarding.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 11 (v2): portfolio_workspace_dir resolves to in-fork default
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+run_case "v2: portfolio_workspace_dir defaults to in-fork workspace" "$SB" '
+r=$(portfolio_workspace_dir)
+expected="'"$SB"'/workspace"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 12 (v2): explicit override for onboarding + workspace_dir wins
+# (split-portfolio v2 mode — both keys point at sibling private repo)
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+mkdir -p "$SIB/workspace"
+cat > "$SIB/onboarding.yaml" <<'YAML'
+company:
+  name: "Test Co"
+YAML
+cat > "$SB/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "onboarding": "$SIB/onboarding.yaml",
+    "workspace_dir": "$SIB/workspace"
+  }
+}
+JSON
+run_case "v2: portfolio_onboarding_path override → sibling repo path" "$SB" '
+r=$(portfolio_onboarding_path)
+expected="'"$SIB"'/onboarding.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "v2: portfolio_workspace_dir override → sibling repo path" "$SB" '
+r=$(portfolio_workspace_dir)
+expected="'"$SIB"'/workspace"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "v2: validate is OK against sibling-dir onboarding + workspace" "$SB" '
+if portfolio_validate >/dev/null 2>&1; then exit 0; else echo "validate failed: $(portfolio_validate)"; exit 1; fi
+'
+rm -rf "$SB" "$SIB"
+
+# ---------------------------------------------------------------------------
+# Case 13 (v2): override pointing at non-existent onboarding → broken
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{
+  "portfolio": {
+    "onboarding": "/nowhere/onboarding.yaml"
+  }
+}
+JSON
+run_case "v2: validate catches missing onboarding override" "$SB" '
+out=$(portfolio_validate 2>&1)
+rc=$?
+case "$out" in
+  *"onboarding"*"file does not exist"*) [ "$rc" -ne 0 ] && exit 0 ;;
+esac
+echo "got rc=$rc out=$out"
+exit 1
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 14 (v2): override pointing at non-existent workspace_dir → broken
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{
+  "portfolio": {
+    "workspace_dir": "/nowhere/workspace"
+  }
+}
+JSON
+run_case "v2: validate catches missing workspace_dir override" "$SB" '
+out=$(portfolio_validate 2>&1)
+rc=$?
+case "$out" in
+  *"workspace_dir"*"directory does not exist"*) [ "$rc" -ne 0 ] && exit 0 ;;
+esac
+echo "got rc=$rc out=$out"
+exit 1
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 15 (v2): missing in-fork workspace dir is OK (no managed projects yet)
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+# Default workspace dir is $SB/workspace; don't create it.
+run_case "v2: validate tolerates missing in-fork workspace (creatable)" "$SB" '
+if portfolio_validate >/dev/null 2>&1; then exit 0; else echo "validate failed: $(portfolio_validate)"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 16 (v2): portfolio_is_v2 detects the .apexyard-fork marker
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+# Without marker — should be v1.
+run_case "v2: portfolio_is_v2 returns false without .apexyard-fork marker" "$SB" '
+if portfolio_is_v2; then echo "expected non-zero exit"; exit 1; else exit 0; fi
+'
+# Add the marker — now v2.
+touch "$SB/.apexyard-fork"
+run_case "v2: portfolio_is_v2 returns true when .apexyard-fork present" "$SB" '
+if portfolio_is_v2; then exit 0; else echo "expected zero exit"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo

--- a/.claude/hooks/tests/test_split_portfolio_v2_migration.sh
+++ b/.claude/hooks/tests/test_split_portfolio_v2_migration.sh
@@ -215,7 +215,7 @@ WS_KEY=$(jq -r '.portfolio.workspace_dir // empty' "$SB/public/.claude/project-c
 
 # Validate the post-state
 (
-  cd "$SB/public"
+  cd "$SB/public" || exit 1
   # shellcheck source=/dev/null
   . .claude/hooks/_lib-read-config.sh
   # shellcheck source=/dev/null

--- a/.claude/hooks/tests/test_split_portfolio_v2_migration.sh
+++ b/.claude/hooks/tests/test_split_portfolio_v2_migration.sh
@@ -1,0 +1,300 @@
+#!/bin/bash
+# Smoke test for the split-portfolio v2 migration logic in /update.
+#
+# Builds a synthetic pre-v2 split-portfolio layout (sibling private repo
+# + public fork with onboarding.yaml + workspace/ still in-fork), runs
+# the move steps the /update skill would run, and asserts the post-state
+# matches the v2 layout (onboarding + workspace in sibling, marker
+# present in public, gitignore updated, project-config.json carries the
+# new keys, portfolio_validate happy).
+#
+# This is a SHELL test of the migration recipe — it doesn't drive the
+# /update skill itself (skills are markdown). The recipe lives inside
+# the skill's step 8a; this test pins the bash to ensure the recipe
+# stays runnable.
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+LIB_OPS="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
+LIB_PORT="$SRC_ROOT/.claude/hooks/_lib-portfolio-paths.sh"
+LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+
+for f in "$LIB_OPS" "$LIB_PORT" "$LIB_CFG" "$DEFAULTS"; do
+  [ -f "$f" ] || { echo "FAIL: missing $f" >&2; exit 1; }
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not installed; migration logic uses jq" >&2
+  exit 0
+fi
+
+PASS=0
+FAIL=0
+FAILED=""
+
+mark_pass() { echo "  ✓ $1"; PASS=$((PASS+1)); }
+mark_fail() { echo "  ✗ $1: $2" >&2; FAIL=$((FAIL+1)); FAILED="$FAILED\n  - $1"; }
+
+# Builds a synthetic pre-v2 split-portfolio layout under $1:
+#   $1/public/                 ← public fork
+#   $1/public/onboarding.yaml
+#   $1/public/workspace/demo/  (committed sample workspace)
+#   $1/public/.claude/...      (libs + project-config.json with v1 portfolio block)
+#   $1/private/                ← sibling private repo
+#   $1/private/apexyard.projects.yaml
+#   $1/private/projects/
+#   $1/private/projects/ideas-backlog.md
+build_pre_v2() {
+  local sb="$1"
+  mkdir -p "$sb/public/.claude/hooks" "$sb/public/workspace/demo"
+  mkdir -p "$sb/private/projects"
+
+  # Public fork — pre-v2 has onboarding.yaml + workspace/ here
+  cat > "$sb/public/onboarding.yaml" <<'YAML'
+company:
+  name: "Test Co"
+YAML
+  echo "demo workspace content" > "$sb/public/workspace/demo/README.md"
+
+  # Public fork has copies of the libs (production setup mirror)
+  cp "$LIB_OPS" "$sb/public/.claude/hooks/_lib-ops-root.sh"
+  cp "$LIB_PORT" "$sb/public/.claude/hooks/_lib-portfolio-paths.sh"
+  cp "$LIB_CFG" "$sb/public/.claude/hooks/_lib-read-config.sh"
+  mkdir -p "$sb/public/.claude"
+  cp "$DEFAULTS" "$sb/public/.claude/project-config.defaults.json"
+
+  # v1 split-portfolio config: portfolio block points at sibling repo
+  # but only for registry / projects_dir / ideas_backlog (no v2 keys).
+  cat > "$sb/public/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "registry": "../private/apexyard.projects.yaml",
+    "projects_dir": "../private/projects",
+    "ideas_backlog": "../private/projects/ideas-backlog.md"
+  }
+}
+JSON
+
+  # Initial .gitignore (no v2 entries yet)
+  cat > "$sb/public/.gitignore" <<'IGNORE'
+node_modules/
+*.log
+IGNORE
+
+  # Init the public fork as a git repo so portfolio_root finds toplevel
+  ( cd "$sb/public" && git init -q && git config user.email "t@t.t" && git config user.name "t" \
+    && git add -A && git commit -q -m "pre-v2 fixture" )
+
+  # Sibling private repo
+  cat > "$sb/private/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: demo
+    repo: example/demo
+YAML
+  cat > "$sb/private/projects/ideas-backlog.md" <<'MD'
+# Ideas Backlog
+MD
+}
+
+# Run the migration recipe from /update step 8a in a subshell rooted at
+# the public fork. Uses the same bash that the skill prescribes.
+run_migration() {
+  local public="$1"
+  (
+    cd "$public" || exit 99
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-read-config.sh
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-portfolio-paths.sh
+
+    SIBLING_ROOT=$(dirname "$(jq -r '.portfolio.registry' .claude/project-config.json)")
+
+    # Move onboarding.yaml
+    if [ -f onboarding.yaml ] && [ ! -f "$SIBLING_ROOT/onboarding.yaml" ]; then
+      mv onboarding.yaml "$SIBLING_ROOT/onboarding.yaml"
+    fi
+
+    # Move workspace contents
+    if [ -d workspace ] && [ "$(ls -A workspace 2>/dev/null)" ]; then
+      mkdir -p "$SIBLING_ROOT/workspace"
+      for entry in workspace/*; do
+        [ -e "$entry" ] || continue
+        name=$(basename "$entry")
+        if [ -e "$SIBLING_ROOT/workspace/$name" ]; then continue; fi
+        mv "$entry" "$SIBLING_ROOT/workspace/$name"
+      done
+    fi
+
+    # Update .gitignore
+    NEEDS=()
+    grep -qxF onboarding.yaml .gitignore 2>/dev/null || NEEDS+=(onboarding.yaml)
+    grep -qxF workspace .gitignore 2>/dev/null || NEEDS+=(workspace)
+    if [ "${#NEEDS[@]}" -gt 0 ]; then
+      {
+        echo ""
+        echo "# Split-portfolio v2 (framework ≥ #242)"
+        for n in "${NEEDS[@]}"; do echo "$n"; done
+      } >> .gitignore
+    fi
+
+    # Write the .apexyard-fork marker
+    if [ ! -f .apexyard-fork ]; then
+      echo "# v2 anchor" > .apexyard-fork
+    fi
+
+    # Update project-config.json
+    PCONFIG=.claude/project-config.json
+    TMP=$(mktemp)
+    jq --arg onb "$SIBLING_ROOT/onboarding.yaml" \
+       --arg ws  "$SIBLING_ROOT/workspace" \
+       '.portfolio.onboarding = (.portfolio.onboarding // $onb)
+        | .portfolio.workspace_dir = (.portfolio.workspace_dir // $ws)' \
+       "$PCONFIG" > "$TMP" && mv "$TMP" "$PCONFIG"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: end-to-end migration produces v2 layout
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d)
+SB=$(cd "$SB" && pwd -P)
+build_pre_v2 "$SB"
+
+# Sanity pre-checks
+if [ ! -f "$SB/public/onboarding.yaml" ]; then
+  mark_fail "pre-state" "expected onboarding.yaml in public fork"; rm -rf "$SB"; exit 1
+fi
+if [ ! -d "$SB/public/workspace/demo" ]; then
+  mark_fail "pre-state" "expected workspace/demo in public fork"; rm -rf "$SB"; exit 1
+fi
+
+run_migration "$SB/public"
+
+# Post-checks
+[ ! -f "$SB/public/onboarding.yaml" ] \
+  && mark_pass "onboarding.yaml moved out of public fork" \
+  || mark_fail "onboarding moved" "still present in public fork"
+
+[ -f "$SB/private/onboarding.yaml" ] \
+  && mark_pass "onboarding.yaml landed in sibling private repo" \
+  || mark_fail "onboarding landed" "missing in sibling repo"
+
+[ ! -d "$SB/public/workspace/demo" ] \
+  && mark_pass "workspace/demo moved out of public fork" \
+  || mark_fail "workspace moved" "still present in public fork"
+
+[ -d "$SB/private/workspace/demo" ] && [ -f "$SB/private/workspace/demo/README.md" ] \
+  && mark_pass "workspace/demo landed in sibling private repo" \
+  || mark_fail "workspace landed" "missing or incomplete in sibling repo"
+
+[ -f "$SB/public/.apexyard-fork" ] \
+  && mark_pass ".apexyard-fork marker written in public fork" \
+  || mark_fail "marker present" ".apexyard-fork missing"
+
+grep -qxF onboarding.yaml "$SB/public/.gitignore" \
+  && mark_pass "onboarding.yaml added to public-fork .gitignore" \
+  || mark_fail "gitignore onboarding" "not added"
+
+grep -qxF workspace "$SB/public/.gitignore" \
+  && mark_pass "workspace added to public-fork .gitignore" \
+  || mark_fail "gitignore workspace" "not added"
+
+ONB_KEY=$(jq -r '.portfolio.onboarding // empty' "$SB/public/.claude/project-config.json")
+WS_KEY=$(jq -r '.portfolio.workspace_dir // empty' "$SB/public/.claude/project-config.json")
+[ -n "$ONB_KEY" ] \
+  && mark_pass "portfolio.onboarding key added to project-config.json (=$ONB_KEY)" \
+  || mark_fail "config key onboarding" "not added"
+[ -n "$WS_KEY" ] \
+  && mark_pass "portfolio.workspace_dir key added to project-config.json (=$WS_KEY)" \
+  || mark_fail "config key workspace_dir" "not added"
+
+# Validate the post-state
+(
+  cd "$SB/public"
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-read-config.sh
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-portfolio-paths.sh
+  portfolio_clear_cache
+  if portfolio_validate >/dev/null 2>&1; then
+    exit 0
+  else
+    err=$(portfolio_validate 2>&1)
+    echo "validate failed: $err" >&2
+    exit 1
+  fi
+)
+if [ "$?" -eq 0 ]; then
+  mark_pass "portfolio_validate happy on post-migration v2 layout"
+else
+  mark_fail "validate post-state" "see error above"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: re-running the migration is a no-op (idempotence)
+# ---------------------------------------------------------------------------
+# Capture state, re-run, compare.
+PRE_LIST=$(find "$SB/public" "$SB/private" -type f 2>/dev/null | sort)
+run_migration "$SB/public"
+POST_LIST=$(find "$SB/public" "$SB/private" -type f 2>/dev/null | sort)
+
+# .gitignore should have exactly one entry per v2 file class even after re-run.
+GI_ONB=$(grep -cxF onboarding.yaml "$SB/public/.gitignore" 2>/dev/null || echo 0)
+GI_WS=$(grep -cxF workspace "$SB/public/.gitignore" 2>/dev/null || echo 0)
+if [ "$GI_ONB" -eq 1 ] && [ "$GI_WS" -eq 1 ]; then
+  mark_pass "idempotence: .gitignore has exactly one entry per file class"
+else
+  mark_fail "idempotence gitignore" "got onboarding=$GI_ONB workspace=$GI_WS (expected 1 each)"
+fi
+
+if [ "$PRE_LIST" = "$POST_LIST" ]; then
+  mark_pass "idempotence: file listing unchanged on re-run"
+else
+  mark_fail "idempotence files" "file listing changed on re-run"
+  diff <(echo "$PRE_LIST") <(echo "$POST_LIST") | head -20 >&2
+fi
+
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 3: ops-root walk finds the v2 fork via .apexyard-fork marker
+# (proves the v2 layout works even though onboarding+apexyard.projects.yaml
+#  are no longer in the public fork)
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d)
+SB=$(cd "$SB" && pwd -P)
+build_pre_v2 "$SB"
+run_migration "$SB/public"
+
+(
+  # shellcheck source=/dev/null
+  . "$LIB_OPS"
+  out=$(cd "$SB/public" && resolve_ops_root)
+  [ "$out" = "$SB/public" ] || { echo "ops_root expected $SB/public got $out" >&2; exit 1; }
+  exit 0
+)
+if [ "$?" -eq 0 ]; then
+  mark_pass "post-v2: resolve_ops_root finds the public fork via .apexyard-fork"
+else
+  mark_fail "post-v2 ops_root" "see error above"
+fi
+
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "===== test_split_portfolio_v2_migration.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed cases:$FAILED"
+  exit 1
+fi
+exit 0

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -137,9 +137,11 @@
   ],
 
   "portfolio": {
-    "_comment": "Path resolution for the portfolio registry + per-project docs + ideas backlog. Defaults match single-fork mode (paths inside the fork). Override in .claude/project-config.json for split-portfolio mode (e.g. \"../portfolio/apexyard.projects.yaml\"). Relative paths resolve against the ops-fork root (the dir containing onboarding.yaml + apexyard.projects.yaml). See docs/multi-project.md and AgDR-0010-portfolio-config-and-self-healing.md.",
+    "_comment": "Path resolution for the portfolio registry + per-project docs + ideas backlog + onboarding config + workspace dir. Defaults match single-fork mode (paths inside the fork). Override in .claude/project-config.json for split-portfolio mode (e.g. \"../portfolio/apexyard.projects.yaml\"). Relative paths resolve against the ops-fork root (the dir containing the .apexyard-fork marker, or the legacy onboarding.yaml + apexyard.projects.yaml pair). See docs/multi-project.md and AgDR-0010-portfolio-config-and-self-healing.md. The `onboarding` and `workspace_dir` keys were added in framework #242 (split-portfolio v2) — see docs/multi-project.md § 'Split-portfolio mode'.",
     "registry": "./apexyard.projects.yaml",
     "projects_dir": "./projects",
-    "ideas_backlog": "./projects/ideas-backlog.md"
+    "ideas_backlog": "./projects/ideas-backlog.md",
+    "onboarding": "./onboarding.yaml",
+    "workspace_dir": "./workspace"
   }
 }

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -545,22 +545,29 @@ If any of these aren't surfaced in the offer, the adopter accepts a deal they do
 
 1. Resolve `<repo-url>`. If the registry already has the repo slug (`me2resh/<name>` form), translate to `https://github.com/<owner>/<name>.git`. If the operator gave a path in step 1 instead of a URL, fall back to asking for the clone URL — never invent one.
 
-2. Skip cleanly if `workspace/<name>/` already exists:
+2. Resolve the workspace dir via the portfolio helper, then skip cleanly if the project clone already exists:
 
    ```bash
-   if [ -d "workspace/<name>" ]; then
-     echo "✓ workspace/<name>/ already exists — skipping clone."
+   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+   WORKSPACE_DIR=$(portfolio_workspace_dir)
+   mkdir -p "$WORKSPACE_DIR"
+
+   if [ -d "$WORKSPACE_DIR/<name>" ]; then
+     echo "✓ $WORKSPACE_DIR/<name>/ already exists — skipping clone."
    else
-     git clone <repo-url> workspace/<name>
+     git clone <repo-url> "$WORKSPACE_DIR/<name>"
    fi
    ```
+
+   In single-fork mode `WORKSPACE_DIR` resolves to `<ops-root>/workspace`; in split-portfolio v2 mode it resolves to the sibling private repo (e.g. `../<fork>-portfolio/workspace`). Don't hardcode `workspace/<name>/`.
 
 3. On clone failure (private repo without credentials, network error, repo moved): report the exit code, point at `gh auth login` or a manual `git clone` as the recovery, and continue to the final summary. Do **not** retry, do **not** fall back to a different URL — the operator picks up from there.
 
 4. On clone success, suggest the next skill as a single follow-up question:
 
    ```
-   ✓ Cloned into workspace/<name>/.
+   ✓ Cloned into $WORKSPACE_DIR/<name>/.
      Want to run /threat-model against the new clone now? (y/n)
    ```
 
@@ -568,7 +575,7 @@ If any of these aren't surfaced in the offer, the adopter accepts a deal they do
 
 **On `n` or `later`:**
 
-Skip silently — no side effects, no further prompts. The adopter can clone manually anytime with `git clone <repo-url> workspace/<name>`. Continue to the final summary.
+Skip silently — no side effects, no further prompts. The adopter can clone manually anytime with `git clone <repo-url> "$WORKSPACE_DIR/<name>"`. Continue to the final summary.
 
 **On any other input:**
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -131,10 +131,13 @@ The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — pub
      }
      ```
 
-   - **Write the `.apexyard-fork` marker** at the public-fork root. This is the v2 ops-fork anchor — `_lib-ops-root.sh` and every hook that walks up to find the ops fork looks for this marker first (with the legacy `onboarding.yaml + apexyard.projects.yaml` pair as fallback). The marker is presence-only; content is ignored. A short identifying line is fine for human-grep purposes:
+   - **Write the `.apexyard-fork` marker** at the public-fork root. This is the v2 ops-fork anchor — `_lib-ops-root.sh` and every hook that walks up to find the ops fork looks for this marker first (with the legacy `onboarding.yaml + apexyard.projects.yaml` pair as fallback). **Spec: presence-only — readers MUST ignore content; only file presence matters.** Writers MAY include a single explanatory line so `head .apexyard-fork` is informative for operators encountering it the first time. See [AgDR-0021](../../../docs/agdr/AgDR-0021-split-portfolio-v2-path-resolution.md) § B for the rationale.
 
      ```bash
+     # Either form is valid — both are presence-only as far as readers are concerned:
      echo "# This file marks the directory as an ApexYard ops fork (split-portfolio v2)." > .apexyard-fork
+     # OR (strictly empty, also valid):
+     # touch .apexyard-fork
      ```
 
    - Stage `.gitignore`, `.claude/project-config.json`, and `.apexyard-fork` for commit. All three are per-fork, not per-machine.

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -107,24 +107,38 @@ The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — pub
 2. **Pick the private repo name**: default suggestion **`your-org/<fork>-portfolio`** (e.g. `your-org/apexyard-portfolio` if you kept the fork name; `your-org/cos-portfolio` if you renamed the fork to `cos`). Compute the `<fork>` part from the public-fork repo name (`gh repo view --json name -q .name`) so the suggestion is correct even when the fork was renamed. Operator confirms or overrides — any name works, the framework only cares about the local path.
 3. **Create the private repo**: `gh repo create your-org/<name> --private --description "..."`. Confirm before running.
 4. **Clone the private repo as a sibling**: `cd .. && gh repo clone your-org/<name>` (no second arg — the clone defaults to a directory named after the repo, so `your-org/apexyard-portfolio` clones into `apexyard-portfolio/`).
-5. **Initialise the portfolio**: `apexyard.projects.yaml` + empty `projects/` dir + initial commit + push. Same content as the doc's step 5.
-6. **Configure path resolution in the fork** (recommended — config-block mode):
-   - Append `.gitignore` lines for `apexyard.projects.yaml` and `projects` (so they don't accidentally get staged in the public fork even if the operator runs `git add -A`).
-   - Untrack any tracked `projects/README.md` from the upstream framework.
-   - Write `.claude/project-config.json` with the `portfolio:` block pointing at the sibling repo. Substitute the actual sibling-dir name the operator chose for `apexyard-portfolio` below:
+5. **Initialise the portfolio (v2 layout)**: in the private repo, create:
+   - `apexyard.projects.yaml` with `version: 1`, `projects: []`, `defaults: {status: active, ticket_prefix: GH}`
+   - empty `projects/` dir (with a `.gitkeep` so the dir survives the initial commit)
+   - empty `workspace/` dir (with a `.gitkeep`) — managed-project clones land here
+   - **`onboarding.yaml`** seeded from the framework template — split-portfolio v2 (#242) moves company/team/stack config to the private repo too, so the public fork stays slim
+   - `.gitignore` with `workspace/*/` so the inner clones don't get double-tracked in the private repo either
+   - initial commit + push
+6. **Configure path resolution in the fork** (recommended — v2 config-block mode):
+   - Append `.gitignore` lines for `apexyard.projects.yaml`, `projects`, `onboarding.yaml`, AND `workspace` so none of them get accidentally staged in the public fork even on a stray `git add -A`. (The first two cover registry + per-project docs; the last two are the v2 additions.)
+   - Untrack any tracked `projects/README.md`, `onboarding.yaml`, or `workspace/README.md` from the upstream framework: `git rm --cached -r projects onboarding.yaml workspace 2>/dev/null || true`.
+   - Write `.claude/project-config.json` with the v2 `portfolio:` block pointing at the sibling repo. Substitute the actual sibling-dir name the operator chose for `apexyard-portfolio` below:
 
      ```json
      {
        "portfolio": {
          "registry": "../apexyard-portfolio/apexyard.projects.yaml",
          "projects_dir": "../apexyard-portfolio/projects",
-         "ideas_backlog": "../apexyard-portfolio/projects/ideas-backlog.md"
+         "ideas_backlog": "../apexyard-portfolio/projects/ideas-backlog.md",
+         "onboarding": "../apexyard-portfolio/onboarding.yaml",
+         "workspace_dir": "../apexyard-portfolio/workspace"
        }
      }
      ```
 
-   - Stage `.gitignore` and `.claude/project-config.json` for commit (the latter is per-fork, not per-machine, since it points at a public sibling-repo path).
-   - **Legacy fallback (framework-version < #145)**: if the adopter's framework predates the `portfolio:` config block, fall back to creating symlinks pointing at `../<sibling-dir>/apexyard.projects.yaml` and `../<sibling-dir>/projects`. The helper resolves either way.
+   - **Write the `.apexyard-fork` marker** at the public-fork root. This is the v2 ops-fork anchor — `_lib-ops-root.sh` and every hook that walks up to find the ops fork looks for this marker first (with the legacy `onboarding.yaml + apexyard.projects.yaml` pair as fallback). The marker is presence-only; content is ignored. A short identifying line is fine for human-grep purposes:
+
+     ```bash
+     echo "# This file marks the directory as an ApexYard ops fork (split-portfolio v2)." > .apexyard-fork
+     ```
+
+   - Stage `.gitignore`, `.claude/project-config.json`, and `.apexyard-fork` for commit. All three are per-fork, not per-machine.
+   - **Legacy fallback (framework-version < #145)**: if the adopter's framework predates the `portfolio:` config block, fall back to creating symlinks pointing at `../<sibling-dir>/apexyard.projects.yaml` and `../<sibling-dir>/projects`. The helper resolves either way. v2 (`onboarding` / `workspace_dir` / `.apexyard-fork`) requires framework ≥ #242 — older forks should run `/update` first to pick up the v2 plumbing before going through this branch.
 7. **Verify**: source `.claude/hooks/_lib-portfolio-paths.sh` and call `portfolio_validate`. Skill MUST refuse to declare success if validate fails — surface the specific failure and ask the operator to fix it before re-running.
 
    ```bash
@@ -461,16 +475,44 @@ Include the Step 2c.7 status line verbatim if Step 2c ran. If `/setup --enable-l
 
 Don't loop more than twice. If the user keeps correcting, switch to "tell me exactly what to change" direct-edit mode.
 
-### Step 6: Write onboarding.yaml
+### Step 6: Write onboarding.yaml + the .apexyard-fork marker
 
-Read the current `onboarding.yaml` template, replace placeholder values with the confirmed config, and write back. Preserve the file's structure and comments — the comments are documentation for future readers.
+Read the current `onboarding.yaml` template (in single-fork mode this is at the fork root; in v2 split-portfolio mode it lives in the private sibling repo, resolved via `portfolio_onboarding_path`), replace placeholder values with the confirmed config, and write back. Preserve the file's structure and comments — the comments are documentation for future readers.
 
 **Important:** use `Edit` tool to modify in-place, not `Write` to overwrite — this preserves comments and structure that the user didn't touch.
+
+In **single-fork mode** also write the `.apexyard-fork` marker at the fork root if it doesn't already exist (idempotent — content is ignored, presence is the signal):
+
+```bash
+if [ ! -f .apexyard-fork ]; then
+  echo "# This file marks the directory as an ApexYard ops fork." > .apexyard-fork
+  git add .apexyard-fork
+fi
+```
+
+The marker is the v2 ops-fork anchor — every hook that walks up to find the ops fork looks for it first. Single-fork adopters benefit from the same anchor (cheaper presence test, and consistency with v2 split-portfolio adopters). The legacy `onboarding.yaml + apexyard.projects.yaml` walk remains as a fallback for un-migrated forks (so existing tests + un-migrated single-fork installs keep working without a migration).
+
+In **split-portfolio v2 mode** the marker was already written in Step 2b — skip the bash above.
 
 After writing:
 
 ```bash
-git add onboarding.yaml
+# In single-fork mode: stage the in-fork onboarding.yaml.
+# In v2 mode: stage the SIBLING repo's onboarding.yaml.
+ONBOARDING=$(portfolio_onboarding_path)
+case "$ONBOARDING" in
+  "$(git rev-parse --show-toplevel)"/*)
+    git add onboarding.yaml
+    ;;
+  *)
+    # v2 mode — onboarding lives in the sibling repo. Stage it there
+    # so the user can `git -C ../<sibling> diff --cached` before committing.
+    sibling_root=$(git -C "$(dirname "$ONBOARDING")" rev-parse --show-toplevel 2>/dev/null)
+    if [ -n "$sibling_root" ]; then
+      (cd "$sibling_root" && git add onboarding.yaml)
+    fi
+    ;;
+esac
 ```
 
 Stage but do NOT commit — let the user review the diff and commit when ready. Tell them:
@@ -479,6 +521,8 @@ Stage but do NOT commit — let the user review the diff and commit when ready. 
 onboarding.yaml updated and staged. Review with `git diff --cached` and
 commit when you're happy: git commit -m "chore: configure apexyard for <company>"
 ```
+
+(In v2 mode point them at the sibling repo for the diff + commit.)
 
 ### Step 7: Optionally seed the project registry
 

--- a/.claude/skills/status/briefing.sh
+++ b/.claude/skills/status/briefing.sh
@@ -28,9 +28,15 @@ set -u
 #
 # Same algorithm as _lib-portfolio-paths.sh (_portfolio_root) and as the
 # /start-ticket skill: walk up from the cwd / git toplevel until we find a
-# directory that contains BOTH onboarding.yaml AND apexyard.projects.yaml.
+# directory satisfying one of the apexyard-fork anchors:
 #
-# Symlinked registry / projects (split-portfolio mode) is fine — the
+#   - the v2 `.apexyard-fork` marker file (split-portfolio v2, where
+#     onboarding.yaml + apexyard.projects.yaml live in the private
+#     sibling repo and aren't present at the public fork root); OR
+#   - both onboarding.yaml AND apexyard.projects.yaml (legacy v1 layout —
+#     single-fork OR un-migrated split-portfolio).
+#
+# Symlinked registry / projects (split-portfolio v1 mode) is fine — the
 # `apexyard.projects.yaml` symlink in the fork still satisfies the test.
 # ---------------------------------------------------------------------------
 ops_root="${APEXYARD_OPS_ROOT:-}"
@@ -46,6 +52,12 @@ if [ -z "$ops_root" ]; then
 
   cur="$start"
   while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    # v2 anchor (cheap presence test).
+    if [ -e "$cur/.apexyard-fork" ]; then
+      ops_root="$cur"
+      break
+    fi
+    # Legacy v1 anchor.
     if [ -e "$cur/onboarding.yaml" ] && [ -e "$cur/apexyard.projects.yaml" ]; then
       ops_root="$cur"
       break
@@ -58,22 +70,45 @@ fi
 # 2. Active workspace from the cwd.
 #
 # Rules (from #182 AC):
-#   - cwd under <ops_root>/workspace/<name>/...   → workspace = "<name>"
+#   - cwd under <workspace_dir>/<name>/...         → workspace = "<name>"
 #   - cwd == <ops_root>                            → workspace = "(ops)"
 #   - anything else (or no ops_root)               → workspace = "(unknown)"
+#
+# In split-portfolio v2 mode the workspace dir lives in the private sibling
+# repo (e.g. ../<fork>-portfolio/workspace) — resolve via the portfolio
+# helper so v2 cwds map to the right workspace name. The literal
+# $ops_root/workspace/ shape stays as a belt-and-suspenders fallback for
+# legacy v1 forks.
 # ---------------------------------------------------------------------------
 cwd="${APEXYARD_CWD:-$(pwd)}"
 workspace="(unknown)"
 
+# Resolve workspace_dir via the portfolio helper if available.
+workspace_dir=""
+if [ -n "$ops_root" ] && [ -f "$ops_root/.claude/hooks/_lib-portfolio-paths.sh" ] && [ -f "$ops_root/.claude/hooks/_lib-read-config.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$ops_root/.claude/hooks/_lib-read-config.sh" 2>/dev/null
+  # shellcheck source=/dev/null
+  . "$ops_root/.claude/hooks/_lib-portfolio-paths.sh" 2>/dev/null
+  if command -v portfolio_workspace_dir >/dev/null 2>&1; then
+    workspace_dir=$(portfolio_workspace_dir 2>/dev/null)
+  fi
+fi
+[ -z "$workspace_dir" ] && [ -n "$ops_root" ] && workspace_dir="$ops_root/workspace"
+
 if [ -n "$ops_root" ]; then
   if [ "$cwd" = "$ops_root" ]; then
     workspace="(ops)"
-  else
+  elif [ -n "$workspace_dir" ]; then
     case "$cwd" in
+      "$workspace_dir"/*)
+        rel="${cwd#"$workspace_dir"/}"
+        workspace="${rel%%/*}"
+        ;;
       "$ops_root"/workspace/*)
+        # Belt-and-suspenders fallback for v1 forks where workspace_dir
+        # may not be the literal $ops_root/workspace.
         rel="${cwd#"$ops_root"/workspace/}"
-        # Take the first path segment as the workspace name. Survives
-        # trailing slashes and nested paths inside the workspace.
         workspace="${rel%%/*}"
         ;;
     esac
@@ -156,7 +191,9 @@ branch_dir="$cwd"
 case "$workspace" in
   "(ops)"|"(unknown)"|"") ;;
   *)
-    if [ -n "$ops_root" ] && [ -d "$ops_root/workspace/$workspace" ]; then
+    if [ -n "$workspace_dir" ] && [ -d "$workspace_dir/$workspace" ]; then
+      branch_dir="$workspace_dir/$workspace"
+    elif [ -n "$ops_root" ] && [ -d "$ops_root/workspace/$workspace" ]; then
       branch_dir="$ops_root/workspace/$workspace"
     fi
     ;;

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -320,6 +320,178 @@ The skill **never auto-removes without explicit `y`**. The skill **never auto-co
 
 A custom-extension key indistinguishable from an upstream-removed key is a real possibility (e.g. an adopter who's ahead of defaults with their own block). The cost of incorrectly removing a custom block is much higher than the cost of one extra prompt — the y/n/s pattern matches the rest of `/update`'s "operator owns each material change" stance.
 
+### 8a. Migrate to split-portfolio v2 layout (advisory, default-yes)
+
+Detection. After the merge / rebase has applied the new `_lib-portfolio-paths.sh` + `_lib-ops-root.sh`, source the helper and check for **two** conditions that together identify a pre-v2 split-portfolio adopter:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+
+# Already v2 (or single-fork) — no migration needed.
+if portfolio_is_v2; then
+  V2_NEEDED=0
+elif ! jq -e '.portfolio.registry' .claude/project-config.json >/dev/null 2>&1; then
+  # No portfolio block at all → single-fork mode → no migration.
+  V2_NEEDED=0
+else
+  # Has a portfolio block (split-portfolio) but no .apexyard-fork marker
+  # → pre-v2 split-portfolio adopter. Migration applies.
+  V2_NEEDED=1
+fi
+```
+
+If `V2_NEEDED=0` → skip this step entirely and continue to step 9.
+
+If `V2_NEEDED=1`, present the offer:
+
+```
+ApexYard /update detected your fork is in split-portfolio mode (v1 layout):
+
+  - apexyard.projects.yaml     → resolved to a sibling private repo (good)
+  - projects/                  → resolved to a sibling private repo (good)
+  - onboarding.yaml            → still in this public fork (v1 layout)
+  - workspace/                 → still in this public fork (v1 layout)
+
+Split-portfolio v2 (introduced in framework #242) moves onboarding.yaml
+AND workspace/ to the private sibling repo too, so the public fork holds
+ONLY framework files + your customisations to skills/hooks/rules.
+
+Migrate now? This will:
+  - Move onboarding.yaml to the sibling private repo
+  - Move workspace/<name>/ contents to the sibling private repo
+  - Add gitignore entries for both in the public fork
+  - Write a .apexyard-fork marker (the v2 ops-fork anchor)
+  - Add portfolio.{onboarding,workspace_dir} keys to .claude/project-config.json
+
+Files MOVED, not copied — destructive. Idempotent — if interrupted, re-run.
+
+[Y / n / dry-run — show commands, don't execute]
+```
+
+If `--dry-run` was passed to `/update`, force the dry-run branch automatically (print the commands the migration would run, do not execute, then continue to step 9).
+
+Per-file-class confirmation — ask separately for `onboarding.yaml` and `workspace/`, so the operator can move one and defer the other:
+
+```
+Move onboarding.yaml? [Y/n]
+Move workspace/? [Y/n]   # surfaces the disk size: du -sh workspace
+```
+
+#### Migration steps
+
+For each file class the operator confirmed, run the moves below. Resolve the sibling repo dir from the existing `portfolio.registry` path (the parent dir of the registry file is the sibling repo root):
+
+```bash
+SIBLING_ROOT=$(dirname "$(jq -r '.portfolio.registry' .claude/project-config.json)")
+# e.g. SIBLING_ROOT=../apexyard-portfolio
+```
+
+##### Move onboarding.yaml
+
+```bash
+if [ -f onboarding.yaml ] && [ ! -f "$SIBLING_ROOT/onboarding.yaml" ]; then
+  mv onboarding.yaml "$SIBLING_ROOT/onboarding.yaml"
+  (cd "$SIBLING_ROOT" && git add onboarding.yaml)
+elif [ -f "$SIBLING_ROOT/onboarding.yaml" ] && [ -f onboarding.yaml ]; then
+  # Both present — surface the conflict and stop. The operator picks.
+  echo "WARNING: onboarding.yaml exists in BOTH the public fork and the sibling repo."
+  echo "  Resolve manually before re-running /update."
+  return 1
+fi
+```
+
+Idempotence: if `onboarding.yaml` is already only in the sibling repo, this block is a no-op.
+
+##### Move workspace/
+
+```bash
+if [ -d workspace ] && [ "$(ls -A workspace 2>/dev/null)" ]; then
+  mkdir -p "$SIBLING_ROOT/workspace"
+  # Move each entry individually so we don't trip on `mv` of a populated dir
+  # to an existing dir (some shells refuse).
+  for entry in workspace/*; do
+    [ -e "$entry" ] || continue
+    name=$(basename "$entry")
+    if [ -e "$SIBLING_ROOT/workspace/$name" ]; then
+      echo "WARNING: workspace/$name exists in BOTH locations — skipped."
+      continue
+    fi
+    mv "$entry" "$SIBLING_ROOT/workspace/$name"
+  done
+  # workspace/README.md (committed framework file) stays in the public fork.
+fi
+```
+
+Idempotence: empty `workspace/` (no entries to move) is a no-op.
+
+##### Update .gitignore
+
+```bash
+NEEDS=()
+grep -qxF onboarding.yaml .gitignore 2>/dev/null || NEEDS+=(onboarding.yaml)
+grep -qxF workspace .gitignore 2>/dev/null || NEEDS+=(workspace)
+
+if [ "${#NEEDS[@]}" -gt 0 ]; then
+  {
+    echo ""
+    echo "# Split-portfolio v2 (framework ≥ #242): onboarding + workspace live in the private sibling repo."
+    for n in "${NEEDS[@]}"; do echo "$n"; done
+  } >> .gitignore
+  git add .gitignore
+fi
+```
+
+##### Write the .apexyard-fork marker
+
+```bash
+if [ ! -f .apexyard-fork ]; then
+  echo "# This file marks the directory as an ApexYard ops fork (split-portfolio v2)." > .apexyard-fork
+  git add .apexyard-fork
+fi
+```
+
+##### Update .claude/project-config.json
+
+Add the two new keys to the `portfolio` block, pointing at the sibling repo. Use `jq` to merge so existing keys are preserved:
+
+```bash
+PCONFIG=.claude/project-config.json
+if [ -f "$PCONFIG" ]; then
+  TMP=$(mktemp)
+  jq --arg onb "$SIBLING_ROOT/onboarding.yaml" \
+     --arg ws "$SIBLING_ROOT/workspace" \
+     '.portfolio.onboarding = (.portfolio.onboarding // $onb)
+      | .portfolio.workspace_dir = (.portfolio.workspace_dir // $ws)' \
+     "$PCONFIG" > "$TMP" && mv "$TMP" "$PCONFIG"
+  git add "$PCONFIG"
+fi
+```
+
+Idempotence: `// $onb` short-circuits if the operator already added the key by hand.
+
+##### Final verification
+
+```bash
+portfolio_clear_cache
+if portfolio_validate >/dev/null 2>&1; then
+  echo "✓ Migration to split-portfolio v2 layout complete."
+  echo "  Files moved to: $SIBLING_ROOT"
+  echo "  Public-fork changes staged for review (git diff --cached)."
+  echo "  Don't forget to commit + push the sibling repo as well:"
+  echo "    cd $SIBLING_ROOT && git status"
+else
+  echo "✗ Migration left portfolio_validate broken — fix manually:"
+  portfolio_validate
+fi
+```
+
+The skill **does not commit** — staging is the contract; the operator owns both the public-fork commit AND the sibling-repo commit.
+
+#### Why advisory, not silent
+
+The migration moves real files between repos. If the operator has a custom workflow built on top of the in-fork `workspace/` location, an automatic move would silently break it. The y/n/dry-run pattern matches the deprecated-config-key offer in step 8 — operator owns each material change.
+
 ### 9. Final state + next steps
 
 On clean completion, print:

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -395,9 +395,13 @@ if [ -f onboarding.yaml ] && [ ! -f "$SIBLING_ROOT/onboarding.yaml" ]; then
   (cd "$SIBLING_ROOT" && git add onboarding.yaml)
 elif [ -f "$SIBLING_ROOT/onboarding.yaml" ] && [ -f onboarding.yaml ]; then
   # Both present — surface the conflict and stop. The operator picks.
-  echo "WARNING: onboarding.yaml exists in BOTH the public fork and the sibling repo."
-  echo "  Resolve manually before re-running /update."
-  return 1
+  # `exit 1` (not `return 1`) — this snippet runs at top-level in the
+  # operator's shell when invoked from the skill; `return` would fail
+  # outside a function. Wrap the whole step 8a in `( ... )` if you want
+  # the exit contained to a subshell.
+  printf 'WARNING: onboarding.yaml exists in BOTH the public fork and the sibling repo.\n' >&2
+  printf '  Resolve manually before re-running /update.\n' >&2
+  exit 1
 fi
 ```
 
@@ -413,13 +417,19 @@ if [ -d workspace ] && [ "$(ls -A workspace 2>/dev/null)" ]; then
   for entry in workspace/*; do
     [ -e "$entry" ] || continue
     name=$(basename "$entry")
+    # workspace/README.md is a committed framework artefact explaining the
+    # workspace/*/ convention — it stays in the public fork (matches the
+    # manual recipe in docs/multi-project.md § "What if you want to migrate
+    # by hand?"). See AgDR-0021 § G for the rationale.
+    if [ "$name" = "README.md" ]; then
+      continue
+    fi
     if [ -e "$SIBLING_ROOT/workspace/$name" ]; then
       echo "WARNING: workspace/$name exists in BOTH locations — skipped."
       continue
     fi
     mv "$entry" "$SIBLING_ROOT/workspace/$name"
   done
-  # workspace/README.md (committed framework file) stays in the public fork.
 fi
 ```
 
@@ -443,6 +453,8 @@ fi
 ```
 
 ##### Write the .apexyard-fork marker
+
+The marker is **presence-only**: readers (every ops-root walk) MUST ignore content; only file presence matters. Writers MAY include a single explanatory line so `head .apexyard-fork` is informative — both `echo "# comment" > .apexyard-fork` and `touch .apexyard-fork` are valid. See [AgDR-0021](../../../docs/agdr/AgDR-0021-split-portfolio-v2-path-resolution.md) § B.
 
 ```bash
 if [ ! -f .apexyard-fork ]; then

--- a/bin/apexyard
+++ b/bin/apexyard
@@ -20,14 +20,21 @@
 set -u
 
 # ---------------------------------------------------------------------------
-# Resolve the ops-fork root from $PWD by walking up until we find a dir
-# with onboarding.yaml AND apexyard.projects.yaml. Same algorithm as the
-# briefing helper itself; we replicate it here so the shim stays a single
-# self-contained file.
+# Resolve the ops-fork root from $PWD by walking up. Honours both the
+# v2 `.apexyard-fork` marker (split-portfolio v2, framework ≥ #242) and
+# the legacy v1 anchor (onboarding.yaml + apexyard.projects.yaml). Same
+# algorithm as the briefing helper itself; we replicate it here so the
+# shim stays a single self-contained file.
 # ---------------------------------------------------------------------------
 find_ops_root() {
   local cur="$PWD"
   while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    # v2 anchor (cheap presence test).
+    if [ -e "$cur/.apexyard-fork" ]; then
+      printf '%s' "$cur"
+      return 0
+    fi
+    # Legacy v1 anchor.
     if [ -e "$cur/onboarding.yaml" ] && [ -e "$cur/apexyard.projects.yaml" ]; then
       printf '%s' "$cur"
       return 0
@@ -60,7 +67,7 @@ case "$cmd" in
     ;;
   status)
     if ! ops_root=$(find_ops_root); then
-      echo "apexyard: not inside an apexyard fork (no onboarding.yaml + apexyard.projects.yaml found above $PWD)" >&2
+      echo "apexyard: not inside an apexyard fork (no .apexyard-fork marker, and no onboarding.yaml + apexyard.projects.yaml found above $PWD)" >&2
       exit 1
     fi
 

--- a/docs/agdr/AgDR-0021-split-portfolio-v2-path-resolution.md
+++ b/docs/agdr/AgDR-0021-split-portfolio-v2-path-resolution.md
@@ -1,0 +1,106 @@
+# AgDR-0021 — Split-portfolio v2 path resolution: marker file, migration shape, and consumer routing
+
+> In the context of moving `onboarding.yaml` and `workspace/` into the private sibling repo (#242), facing the choice of how the public fork advertises itself to ops-root walkers once neither of the legacy anchor files is present, plus four sub-decisions about migration shape, I decided **a presence-only marker file (`.apexyard-fork`) with an explanatory comment writers MAY include, default-yes migration default with per-file-class y/n, `mv` over `cp+delete`, v2-marker precedence over legacy-pair anchor, and no symlink fallback for the v2 additions**, to achieve a clean ops-root resolution that works in both v1-legacy and v2-migrated forks without forcing adopters through a synchronous migration, accepting that adopters who manually delete the `.apexyard-fork` marker after a v2 migration will appear to the framework as un-configured forks.
+
+## Context
+
+Split-portfolio mode (introduced in AgDR-0010 / framework #145) moved the registry + per-project docs to a private sibling repo. v2 (#242) extends this to `onboarding.yaml` + `workspace/`, so the public fork holds only framework files + adopter customisations to skills/hooks/rules. That sounds like a small file-shuffle but it forces several load-bearing decisions because today's ops-root walk-up requires BOTH `onboarding.yaml` AND `apexyard.projects.yaml` at the candidate dir to identify the fork — after v2, neither file is in the public fork. We need a new anchor; we need to keep legacy adopters working; we need a migration; we need it to be safe.
+
+## Options Considered
+
+### A. Public-fork anchor: marker file vs sentinel config key vs `.git`-walk + heuristic
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Marker file `.apexyard-fork` (chosen)** | One-line presence check, language-agnostic, no parsing. Trivial to write at `/setup` or `/update` migration time. Idempotent (`touch`). | Adopters who manually `rm` it after a v2 migration silently break the walk. Mitigated by a clear filename + README mention. |
+| Sentinel config key in `.claude/project-config.json` (e.g. `apexyard.fork_anchor: true`) | Co-located with other config. Parseable. | Requires reading/parsing JSON on every walk-up step (~7 hooks call this). A presence-check is ~10× cheaper. Operators who hand-edit the config can accidentally remove the key with no visible feedback. |
+| `.git` + heuristic (e.g. `.git` + `.claude/` + `roles/` present) | No new file. | Heuristic. Brittle. Any repo with a similar structure passes the check (e.g. a fork-of-fork that's renaming things). False positives are confusing. |
+| New top-level dotfile like `.apexyard` (single file, JSON inside) | Carries metadata (framework version, fork ID). | Overkill for v2's needs. Migration burden — adopters now have to maintain JSON. Reach for it later if metadata grows. |
+
+### B. Marker content semantics: strictly empty vs explanatory comment allowed
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Presence-only with optional explanatory comment (chosen)** | Writers can include a single-line comment for human-grep ("# This file marks the directory as an ApexYard ops fork (split-portfolio v2)."). Readers ignore content; only presence matters. Hooks stay simple (`[ -f .apexyard-fork ]`). | Spec must explicitly say "readers MUST ignore content" so future maintainers don't add content-parsing logic. |
+| Strictly empty (`touch` only, no content) | Zero ambiguity for readers. | Operators grepping the dotfile find nothing useful; first-time encounter is "what does this mean?". |
+| Structured content (e.g. JSON with `version: 2`) | Carries version info for future migrations. | Couples the anchor to a schema. Writers must validate; readers must parse. Overkill for v2 (version is implied by file presence — pre-v2 forks don't have the marker). |
+
+### C. Migration default: opt-in vs default-yes vs auto-apply
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Default-yes with per-file-class y/n (chosen)** | Adopters who want the v2 layout get it without typing. Adopters who want to defer can say `n` to one or both file classes. Idempotent re-run. | Some adopters will accept the default without reading; the migration is destructive (mv). Mitigated by per-file-class confirmation + dry-run flag. |
+| Opt-in (default-no, operator types `y` to migrate) | Conservative; nothing changes by default. | Most split-portfolio adopters WANT v2 (it's the privacy upgrade they signed up for); making them opt in adds friction without value. |
+| Auto-apply with no prompt | Fastest. | Destructive ops with no consent is a framework anti-pattern. Even `/setup` confirms before writing files. |
+
+### D. Migration mechanics: `mv` vs `cp+delete`
+
+| Option | Pros | Cons |
+|---|---|---|
+| **`mv` (chosen)** | Atomic on the same filesystem; preserves inode, mtimes. No risk of stale copy left behind. | Cross-filesystem `mv` falls back to `cp+rm` under the hood (no guarantees mid-operation). For the v2 migration the public fork and the sibling repo are typically siblings on the same FS, so the atomic path is the common case. |
+| `cp` then `rm` (explicit two-step) | Operator-visible intermediate state. | Two failure points instead of one. Cross-FS this is what `mv` does anyway, but explicit `cp+rm` doesn't offer any advantage over letting `mv` do it. |
+| `rsync --remove-source-files` | Robust against interruption. | Heavy dependency for what `mv` does natively. Adds a tooling assumption. |
+
+### E. v2-marker vs legacy-anchor precedence in `_lib-ops-root.sh`
+
+| Option | Pros | Cons |
+|---|---|---|
+| **v2-marker precedence, legacy as fallback (chosen)** | Migrated adopters benefit from the cheap presence-check first. Un-migrated adopters still work via the legacy `onboarding.yaml + apexyard.projects.yaml` walk. Zero behaviour change for single-fork adopters (they have onboarding.yaml + apexyard.projects.yaml at their root regardless). | Two code paths to maintain forever (until we sunset the legacy pair). |
+| Legacy first, v2 fallback | Backwards-compatible by default. | Slower for v2-migrated adopters (parse two files instead of one stat). Loses the "v2 is the new default" signal. |
+| v2 only (drop legacy walk after a deprecation window) | Single code path. | Forces every legacy adopter through `/update` migration before the next framework release. Aggressive. |
+
+### F. Symlink fallback for v2 additions (onboarding, workspace_dir)
+
+| Option | Pros | Cons |
+|---|---|---|
+| **No symlink fallback for v2 additions (chosen)** | v2 requires the config block; symlink mode predates v2's plumbing. The config block has been recommended since #145. Adopters on the old symlink mode are framework-versions behind; they should upgrade the symlink-to-config-block first, then opt into v2. | Adopters on symlink-mode have a forced upgrade path. Documented in `docs/multi-project.md`. |
+| Allow symlinks for v2 additions (onboarding.yaml + workspace as symlinks into private repo) | Backwards-compatible with symlink-mode adopters. | Doubles the per-file resolution surface. Operating-system-fragile (Windows symlinks differ). Adopters who land on the symlink path will keep using it; the "config-block is the future" signal is muted. |
+
+### G. Workspace README handling: include in migration vs exclude as framework file
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Exclude `workspace/README.md` (chosen)** | The README is a committed framework artefact explaining the `workspace/*/` convention — it ships in the public fork and stays there. Migrating it would leave a gap in the public fork's convention docs. | Migration recipe gains a special case (`name == "README.md"` → skip). One-line check in both `/update` step 8a AND the manual recipe. |
+| Move it with everything else | Simpler recipe (no special case). | Leaves the public fork's `workspace/` empty of any guidance; first-time visitors to a v2 public fork find an empty dir with no explanation. |
+
+## Decision
+
+Chosen — for all seven:
+
+**A.** Marker file `.apexyard-fork` at the public-fork root.
+**B.** Presence-only semantics; writers MAY include a one-line explanatory comment; readers MUST ignore content.
+**C.** Default-yes migration with per-file-class y/n confirmation + dry-run.
+**D.** `mv` (atomic on common case; cross-FS falls through to `cp+rm` via `mv` itself).
+**E.** v2-marker checked first; legacy `onboarding.yaml + apexyard.projects.yaml` pair as fallback for un-migrated forks.
+**F.** No symlink fallback for v2 additions; config block required (consistent with the framework-#145+ direction).
+**G.** `workspace/README.md` stays in the public fork during migration; both the skill and manual recipe special-case it.
+
+Why this combination:
+
+1. **Marker file + presence-only** maximises simplicity. Adopters reading their public fork's root see `.apexyard-fork` and either recognise it from the docs or one `head` reveals the explanatory line. Walkers do a single `[ -f ]` check. No format ambiguity, no schema to evolve.
+2. **Default-yes migration** matches adopter intent. Split-portfolio adopters chose privacy; v2 extends the privacy promise. Defaulting to migrate is the right user-respecting choice; per-file-class y/n + dry-run leave the safety net intact.
+3. **v2-precedence with legacy fallback** lets every adopter cohort work simultaneously. Single-fork adopters never touch the v2 path. v1-split-portfolio adopters work until they migrate. v2-migrated adopters benefit from the faster anchor.
+4. **No symlink for v2** keeps the surface small. Symlink mode is legacy from before the config block existed; pushing v2 there too would mean two parallel resolution paths forever.
+5. **`workspace/README.md` stays public** preserves the framework's documentation of its own convention without leaking adopter content.
+
+## Consequences
+
+- Every framework hook that walks for ops-root now checks `.apexyard-fork` first, then falls back to the legacy pair. Walk-up cost on v2-migrated forks drops to a single `stat`.
+- Adopters who manually delete `.apexyard-fork` after migration will appear to walkers as un-configured forks. Mitigation: the filename includes "apexyard"; operators have to actively delete it. README in `docs/multi-project.md` § "Where session-state files live" notes the file's purpose.
+- The legacy `onboarding.yaml + apexyard.projects.yaml` walk-up condition stays load-bearing for un-migrated adopters. No deprecation window is set; we can sunset it in a later release once telemetry shows the legacy path isn't hit.
+- `/update` step 8a's migration is idempotent: re-running on a v2 layout is a no-op (files already in private repo → `mv` block skips; marker already present → `touch` is a no-op; config-block keys already set → `jq` merge preserves existing values). Idempotence is asserted in test case 2 of `test_split_portfolio_v2_migration.sh`.
+- Per-file-class y/n means adopters can defer one migration class (e.g. migrate `onboarding.yaml` now, defer `workspace/`). Walkers handle the half-migrated state via the legacy fallback.
+- The "no symlink for v2 additions" decision means adopters on symlink-mode (framework < #145) must upgrade to the config block before opting into v2. Documented in the v2 migration section of `docs/multi-project.md`.
+- `workspace/README.md` special-case lives in two places (skill + manual recipe). Keeping them in sync is a maintenance burden; both have a comment pointing at this AgDR.
+
+## Artifacts
+
+- Ticket: [me2resh/apexyard#242](https://github.com/me2resh/apexyard/issues/242)
+- Implementation PR: feature/GH-242-split-portfolio-v2 → PR #248
+- Lib changes: `.claude/hooks/_lib-ops-root.sh`, `.claude/hooks/_lib-portfolio-paths.sh`
+- Consumer updates: 7 hooks + `bin/apexyard` + `briefing.sh` + `/handover`
+- Migration: `.claude/skills/update/SKILL.md` step 8a
+- New-adopter path: `.claude/skills/setup/SKILL.md` step 2b
+- Tests: `.claude/hooks/tests/test_ops_root.sh` (new case 8: v2-marker precedence), `.claude/hooks/tests/test_split_portfolio_v2_migration.sh` (13 cases incl. idempotence)
+- Docs: `docs/multi-project.md` § "Migrating from split-portfolio v1 to v2"
+- Prior art: [AgDR-0010 — Portfolio config + self-healing](AgDR-0010-portfolio-config-and-self-healing.md) (split-portfolio v1), [AgDR-0011 — Bootstrap-skill exemption](AgDR-0011-bootstrap-skill-exemption.md) (related session-state pattern), [#229 + #230 fix](https://github.com/me2resh/apexyard/issues/229) (ops-root walk-up consolidation that introduced `_lib-ops-root.sh`)

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -10,13 +10,16 @@ ApexYard governs a **portfolio of repos as one organisation**. You fork apexyard
 
 ApexYard ships two supported patterns. **Read this section before you fork** — picking the wrong one and pushing private project names to a public fork is hard to recover from cleanly (the GitHub PR / Issue edit history survives a force-push).
 
-| | Single-fork mode (default) | Split-portfolio mode |
+| | Single-fork mode (default) | Split-portfolio mode (v2) |
 | --- | --- | --- |
 | **Repos** | One: your fork of `me2resh/apexyard` | Two: public fork **+** a separate private repo for the portfolio |
-| **Where the registry lives** | `apexyard.projects.yaml` in the fork | `apexyard.projects.yaml` in the private repo, symlinked into the fork |
-| **Where `projects/<name>/` lives** | Inside the fork | Inside the private repo, symlinked into the fork |
-| **Public exposure** | Every registered project name + handover finding is on a public GitHub repo | Public fork holds only framework files; private repo holds your portfolio data |
-| **Daily workflow** | Same | Same — skills resolve through the symlinks transparently |
+| **Where the registry lives** | `apexyard.projects.yaml` in the fork | `apexyard.projects.yaml` in the private repo, resolved via config block |
+| **Where `projects/<name>/` lives** | Inside the fork | Inside the private repo, resolved via config block |
+| **Where `onboarding.yaml` lives** | Inside the fork | Inside the private repo (v2, framework ≥ #242) |
+| **Where `workspace/<name>/` lives** | Inside the fork (gitignored) | Inside the private repo (v2, framework ≥ #242) |
+| **Ops-fork anchor on disk** | `onboarding.yaml + apexyard.projects.yaml` (legacy) — or `.apexyard-fork` marker file (v2) | `.apexyard-fork` marker file (v2) — neither legacy file is in the public fork |
+| **Public exposure** | Every registered project name + handover finding is on a public GitHub repo | Public fork holds only framework files + your customisations; private repo holds your portfolio data, company config, AND your managed-project clones |
+| **Daily workflow** | Same | Same — skills resolve through the config block transparently |
 | **Pick this if…** | All your projects are already public, OR you're on GitHub Pro / Team / Enterprise (which support private forks of public repos) | You're on GitHub Free with any project you don't want named publicly |
 
 **The trip-wire**: GitHub Free disallows changing a fork's visibility — you cannot make a fork of a public repo private after the fact. Combined with the framework's default of committing the registry to the fork, free-tier adopters with any private project risk accidentally publishing their portfolio names with a stray push (the framework itself never pushes without operator approval, but once the registry is committed locally the next push exposes it). The split-portfolio mode below is the supported way around this.
@@ -169,12 +172,16 @@ Use this mode if you're on GitHub Free with any project you don't want named pub
 
 The default sibling-dir name is **`<fork>-portfolio`**, so the relationship between the two repos is self-documenting on disk and on GitHub. If you kept the fork name as `apexyard`, the sibling defaults to `apexyard-portfolio`. If you renamed the fork (e.g. `cos` for Chief-of-Staff), the sibling defaults to `cos-portfolio`. Pick something else if you'd prefer — the framework only cares about the local path you point the config block at.
 
-Both repos live in your account; on disk they sit side-by-side. Inside the apexyard fork, the framework's portfolio-aware skills resolve `apexyard.projects.yaml` and `projects/` through one of two mechanisms:
+Both repos live in your account; on disk they sit side-by-side. Inside the apexyard fork, the framework's portfolio-aware skills resolve `apexyard.projects.yaml`, `projects/`, **`onboarding.yaml`** (v2), and **`workspace/`** (v2) through one of two mechanisms:
 
-- **Config block (recommended, framework ≥ #145).** A `portfolio:` block in `.claude/project-config.json` points the skills at `../apexyard-portfolio/apexyard.projects.yaml` and `../apexyard-portfolio/projects`. The `_lib-portfolio-paths.sh` helper resolves both. A `SessionStart` banner surfaces broken config (missing files, bad paths) at session start so you don't discover a misconfiguration mid-skill.
-- **Symlink (legacy, framework < #145).** `apexyard.projects.yaml` and `projects/` are symlinks into the portfolio repo (and gitignored from the fork itself). Existing skills resolve through the symlink transparently. Continues to work; if you're upgrading framework versions, prefer the config block.
+- **Config block (recommended, framework ≥ #145; v2 keys added in #242).** A `portfolio:` block in `.claude/project-config.json` points the skills at `../apexyard-portfolio/apexyard.projects.yaml`, `../apexyard-portfolio/projects`, `../apexyard-portfolio/onboarding.yaml`, and `../apexyard-portfolio/workspace`. The `_lib-portfolio-paths.sh` helper resolves all five (`registry`, `projects_dir`, `ideas_backlog`, `onboarding`, `workspace_dir`). A `SessionStart` banner surfaces broken config (missing files, bad paths) at session start so you don't discover a misconfiguration mid-skill.
+- **Symlink (legacy, framework < #145).** `apexyard.projects.yaml` and `projects/` are symlinks into the portfolio repo (and gitignored from the fork itself). Existing skills resolve through the symlink transparently. Continues to work; if you're upgrading framework versions, prefer the config block. The v2 additions (`onboarding`, `workspace_dir`) are config-block only — there is no legacy symlink path for them.
 
-The `/split-portfolio` skill (introduced #146) automates the full migration flow including the config-block write — see § "Migrating from single-fork to split-portfolio" below for adopters who already pushed private project names to a public fork.
+**The v2 additions: why both `onboarding.yaml` and `workspace/` move to the private repo.** Earlier split-portfolio releases (v1, framework < #242) kept `onboarding.yaml` (your company name, mission, team list, tech stack) AND `workspace/<name>/` (the local clones of your managed projects) in the public fork. Both leak. The v1 layout meant a CTO running ApexYard on a private SaaS effectively published their team roster + tech-stack + every project name on a public GitHub repo via routine session activity. v2 closes that gap: every adopter-specific artefact lives in the private sibling repo; the public fork holds only framework files plus the operator's customisations to skills/hooks/rules.
+
+**The ops-fork anchor under v2.** Pre-v2 every hook + skill that walked up to find the ops fork looked for BOTH `onboarding.yaml` AND `apexyard.projects.yaml` at the candidate dir. Under v2, neither file is in the public fork — the walk-up condition fails. v2 introduces a presence-only marker file `.apexyard-fork` at the public-fork root; `_lib-ops-root.sh` and every walk-up consumer recognises both anchors (v2 marker first, legacy v1 pair as fallback for un-migrated adopters during the transition window).
+
+The `/split-portfolio` skill (introduced #146) automates the single-fork → split-portfolio migration. The `/update` skill (extended in #242) automates the v1 → v2 split-portfolio migration for adopters who're already split but on the older layout — see § "Migrating from split-portfolio v1 to v2" below.
 
 ### Setup — 7 steps, ~6 minutes
 
@@ -214,7 +221,7 @@ cd ~/ops/apexyard
 git remote add upstream https://github.com/me2resh/apexyard.git
 ```
 
-#### 5. Initialise the private portfolio
+#### 5. Initialise the private portfolio (v2 layout)
 
 ```bash
 cd ~/ops/apexyard-portfolio
@@ -227,10 +234,32 @@ defaults:
   ticket_prefix: GH
 EOF
 
-mkdir projects
+# v2: onboarding.yaml lives here too. Seed from the framework template
+# OR run /setup later inside the public fork — /setup writes to the
+# resolved onboarding path.
+cp ~/ops/apexyard/onboarding.yaml.example onboarding.yaml 2>/dev/null \
+  || cp ~/ops/apexyard/onboarding.yaml onboarding.yaml 2>/dev/null \
+  || cat > onboarding.yaml <<'YAML'
+company:
+  name: "Your Company Name"
+  mission: ""
+YAML
 
-git add apexyard.projects.yaml projects
-git commit -m "chore: initialise private portfolio"
+# v2: workspace/ lives here too. Empty dir to start; /handover and
+# manual `git clone workspace/<name>` will populate it.
+mkdir -p projects workspace
+
+# Ignore the inner managed-project clones inside workspace/ so they
+# don't get double-tracked in the private repo either.
+cat > .gitignore <<'IGNORE'
+workspace/*/
+IGNORE
+
+# Keep the dirs alive across the initial commit.
+touch projects/.gitkeep workspace/.gitkeep
+
+git add apexyard.projects.yaml onboarding.yaml projects workspace .gitignore
+git commit -m "chore: initialise private portfolio (split-portfolio v2)"
 git push
 ```
 
@@ -238,44 +267,56 @@ git push
 
 The recommended path is the **config block** (framework version ≥ #145). The symlink approach below is the legacy fallback for older framework versions — both work.
 
-##### Recommended: config-block mode
+##### Recommended: config-block mode (v2)
 
 ```bash
 cd ~/ops/apexyard
 
-# Tell the fork to ignore the registry + projects/ — they live in the portfolio.
+# Tell the fork to ignore everything that lives in the private repo:
+# registry, per-project docs, onboarding config, and the workspace dir.
 cat >> .gitignore <<'EOF'
 
-# Portfolio data lives in a separate private repo (split-portfolio mode).
+# Portfolio data lives in a separate private repo (split-portfolio v2).
 # See docs/multi-project.md.
 apexyard.projects.yaml
 projects
+onboarding.yaml
+workspace
 EOF
 
-# If projects/README.md is currently tracked from the upstream framework,
-# untrack it so the config-block resolution can take its place:
-git rm -r --cached projects 2>/dev/null || true
+# If any of these are currently tracked from the upstream framework,
+# untrack them so the config-block resolution can take their place:
+git rm -r --cached projects onboarding.yaml workspace 2>/dev/null || true
 
-# Write the portfolio: config block pointing at the sibling repo.
+# Write the v2 portfolio: config block pointing at the sibling repo.
 # Paths resolve relative to the ops-fork root (this directory).
 # If you used a different sibling-dir name than apexyard-portfolio,
-# substitute it in all three paths below.
+# substitute it in all five paths below.
 cat > .claude/project-config.json <<'JSON'
 {
   "portfolio": {
     "registry": "../apexyard-portfolio/apexyard.projects.yaml",
     "projects_dir": "../apexyard-portfolio/projects",
-    "ideas_backlog": "../apexyard-portfolio/projects/ideas-backlog.md"
+    "ideas_backlog": "../apexyard-portfolio/projects/ideas-backlog.md",
+    "onboarding": "../apexyard-portfolio/onboarding.yaml",
+    "workspace_dir": "../apexyard-portfolio/workspace"
   }
 }
 JSON
 
-git add .gitignore .claude/project-config.json
-git commit -m "chore: configure split-portfolio mode (config-block path resolution)"
+# Write the v2 ops-fork anchor. Presence-only marker; content is ignored
+# but a short identifying line helps human grep. Every framework hook
+# that walks up to find the ops fork looks for this marker first
+# (legacy onboarding.yaml + apexyard.projects.yaml pair stays as a
+# fallback for un-migrated forks).
+echo "# This file marks the directory as an ApexYard ops fork (split-portfolio v2)." > .apexyard-fork
+
+git add .gitignore .claude/project-config.json .apexyard-fork
+git commit -m "chore: configure split-portfolio v2 (config-block path resolution + marker)"
 git push
 ```
 
-The `SessionStart` hook chain calls `portfolio_validate` from `_lib-portfolio-paths.sh` on every session start. If the resolved registry / projects_dir / ideas_backlog paths are broken (typo, missing file, etc.), you'll see a one-line banner naming the failure. Silent on success.
+The `SessionStart` hook chain calls `portfolio_validate` from `_lib-portfolio-paths.sh` on every session start. If the resolved registry / projects_dir / ideas_backlog / onboarding / workspace_dir paths are broken (typo, missing file, etc.), you'll see a one-line banner naming the failure. Silent on success.
 
 ##### Legacy: symlink-based mode (framework < #145)
 
@@ -346,6 +387,92 @@ You'll never need to manage session-state files by hand. If you ever see a "BLOC
 - **One conflict path on `/update`** (the `projects/README.md` case above). Resolved manually if it ever fires.
 
 In exchange, **zero of your private project names ever land on a public GitHub repo**, ever.
+
+### Migrating from split-portfolio v1 to v2
+
+If you adopted split-portfolio mode before framework #242, your fork is on the v1 layout: `apexyard.projects.yaml` and `projects/` resolve to the sibling private repo (good), but `onboarding.yaml` and `workspace/` are still in the public fork. The v2 migration moves both to the private repo too, and writes the new `.apexyard-fork` anchor.
+
+**You don't need to run this manually — `/update` detects the v1 layout and offers the migration as a default-yes step during the next upstream sync.** When you run `/update` after pulling framework ≥ #242, you'll see:
+
+```
+ApexYard /update detected your fork is in split-portfolio mode (v1 layout):
+
+  - apexyard.projects.yaml     → resolved to a sibling private repo (good)
+  - projects/                  → resolved to a sibling private repo (good)
+  - onboarding.yaml            → still in this public fork (v1 layout)
+  - workspace/                 → still in this public fork (v1 layout)
+
+Split-portfolio v2 (introduced in framework #242) moves onboarding.yaml
+AND workspace/ to the private sibling repo too, so the public fork holds
+ONLY framework files + your customisations to skills/hooks/rules.
+
+Migrate now? This will:
+  - Move onboarding.yaml to the sibling private repo
+  - Move workspace/<name>/ contents to the sibling private repo
+  - Add gitignore entries for both in the public fork
+  - Write a .apexyard-fork marker (the v2 ops-fork anchor)
+  - Add portfolio.{onboarding,workspace_dir} keys to .claude/project-config.json
+
+Files MOVED, not copied — destructive. Idempotent — if interrupted, re-run.
+
+[Y / n / dry-run — show commands, don't execute]
+```
+
+The migration is **per-file-class confirmable** (move `onboarding.yaml`? Y/N; move `workspace/`? Y/N), so you can defer one and migrate the other. It's also **idempotent** — if you re-run `/update` later, the migration is a no-op.
+
+`/update --dry-run` walks through the migration steps without executing them, useful for previewing what would change.
+
+The skill **does not commit** — staging is the contract; you own both the public-fork commit AND the sibling-repo commit. After accepting the migration:
+
+```bash
+# Public fork — review what's staged + the marker + config-block additions
+git diff --cached
+git commit -m "chore: migrate to split-portfolio v2"
+
+# Private sibling repo — onboarding + workspace landed here
+cd ../apexyard-portfolio
+git status        # see the moved files
+git add onboarding.yaml workspace
+git commit -m "chore: receive onboarding + workspace from public fork (split-portfolio v2)"
+```
+
+**What if you want to migrate by hand?** Run the same steps the `/update` skill runs:
+
+```bash
+cd ~/ops/apexyard
+
+SIBLING=../apexyard-portfolio   # adjust to your sibling-dir name
+
+# Move the two file classes
+mv onboarding.yaml "$SIBLING/onboarding.yaml"
+mkdir -p "$SIBLING/workspace"
+for entry in workspace/*; do
+  [ -e "$entry" ] || continue
+  name=$(basename "$entry")
+  [ "$name" = "README.md" ] && continue   # framework file, stays
+  mv "$entry" "$SIBLING/workspace/$name"
+done
+
+# Update .gitignore in the public fork
+cat >> .gitignore <<'IGNORE'
+
+# Split-portfolio v2 (framework ≥ #242)
+onboarding.yaml
+workspace
+IGNORE
+
+# Write the v2 anchor
+echo "# This file marks the directory as an ApexYard ops fork (split-portfolio v2)." > .apexyard-fork
+
+# Update the config block — add the v2 keys
+jq --arg onb "$SIBLING/onboarding.yaml" \
+   --arg ws  "$SIBLING/workspace" \
+   '.portfolio.onboarding = (.portfolio.onboarding // $onb)
+    | .portfolio.workspace_dir = (.portfolio.workspace_dir // $ws)' \
+   .claude/project-config.json > /tmp/pc.json && mv /tmp/pc.json .claude/project-config.json
+
+git add .gitignore .apexyard-fork .claude/project-config.json
+```
 
 ### Migrating from single-fork to split-portfolio
 


### PR DESCRIPTION
## Summary

Move every adopter-specific artefact (`onboarding.yaml` + `workspace/<name>/`) out of the public fork and into the private sibling repo, so the public fork holds only framework files plus operator customisations to skills/hooks/rules. Single-fork mode is unaffected.

- **Architecture**: `_lib-ops-root.sh` recognises a presence-only `.apexyard-fork` marker as the v2 anchor (legacy `onboarding.yaml + apexyard.projects.yaml` pair stays as fallback for un-migrated forks). `_lib-portfolio-paths.sh` exposes new resolvers `portfolio_onboarding_path`, `portfolio_workspace_dir`, and `portfolio_is_v2`. New defaults keys `portfolio.onboarding` + `portfolio.workspace_dir`.
- **Consumers updated**: `check-portfolio-config.sh`, `clear-bootstrap-marker.sh`, `onboarding-check.sh`, `require-active-ticket.sh`, `require-migration-ticket.sh`, both `require-agdr-for-arch-*.sh`, `bin/apexyard`, `.claude/skills/status/briefing.sh`, `.claude/skills/handover/SKILL.md` — all switched to the v2-aware ops-root walk and the resolved workspace dir, with inline-walk fallbacks so the hooks self-heal if the lib is missing.
- **Migration via `/update`**: new step 8a detects pre-v2 split-portfolio adopters (portfolio block present but no `.apexyard-fork` marker) and offers a default-yes migration with per-file-class confirmation, `--dry-run` support, explicit idempotence. Files moved (not copied), `.gitignore` updated, marker written, v2 config-block keys added. Skill never auto-commits.
- **`/setup` integration**: Step 2b creates the v2 layout from the start for new split-portfolio adopters (private repo seeds `onboarding.yaml` + `workspace/`, public fork gets `.apexyard-fork` marker + config-block + gitignore). Step 6 also writes `.apexyard-fork` for single-fork adopters (idempotent, cheaper presence test).
- **Docs**: `docs/multi-project.md` § "Split-portfolio mode" updated to describe v2 as the default with the v1→v2 migration recipe (both `/update`-driven and manual).

## Testing

Test results — all 26 hook tests pass, including 12 new cases:

\`\`\`
TOTAL: 26 | PASS: 26 | FAIL: 0
\`\`\`

New tests:

- \`test_ops_root.sh\` — 3 new cases (v2 marker walk-up, in-workspace v2 resolution, v2-marker-precedence-over-legacy).
- \`test_portfolio_paths.sh\` — 9 new cases (defaults for new resolvers, override-wins for v2 paths, validate catches missing overrides, validate tolerates missing in-fork workspace, \`portfolio_is_v2\` detection).
- \`test_split_portfolio_v2_migration.sh\` — 13 cases end-to-end (build pre-v2 fixture, run migration recipe from \`/update\` step 8a, assert v2 post-state, idempotence, post-migration \`resolve_ops_root\` walk).

Manual smoke checklist:

- [ ] Single-fork adopter sees zero behaviour change (no \`.apexyard-fork\` written automatically; legacy walk-up still works)
- [ ] Pre-v2 split-portfolio adopter: \`/update\` surfaces the migration offer with per-file-class confirmation
- [ ] \`/update --dry-run\` walks through migration steps without executing
- [ ] Re-running \`/update\` on a v2 layout is a silent no-op for the migration step
- [ ] \`portfolio_validate\` SessionStart banner stays silent on a healthy v2 layout
- [ ] \`bin/apexyard status\` from inside \`<sibling-repo>/workspace/<name>/\` resolves the workspace name correctly (v2 path)

## Glossary

| Term | Definition |
|------|------------|
| split-portfolio v1 layout | Earlier mode (framework #145–#241): \`apexyard.projects.yaml\` + \`projects/\` resolved through a config block to a sibling private repo, but \`onboarding.yaml\` + \`workspace/\` stayed in the public fork |
| split-portfolio v2 layout | This change (framework ≥ #242): \`onboarding.yaml\` + \`workspace/\` ALSO move to the sibling private repo; public fork holds only framework files + operator customisations |
| \`.apexyard-fork\` marker | Presence-only marker file written at the public-fork root in v2; the new ops-fork anchor that \`_lib-ops-root.sh\` and every walk-up consumer recognises (legacy \`onboarding.yaml + apexyard.projects.yaml\` pair stays as a fallback for un-migrated forks) |
| ops-fork root | The directory containing the apexyard fork's framework files + the new anchor — distinct from a managed-project clone's git toplevel, which lives one level deeper at \`<workspace_dir>/<name>/\` |
| MARKER_HOME | Hook-internal variable for the resolved ops-fork root — where \`.claude/session/*\` markers (active ticket, code-review approvals, CEO approvals, bootstrap-skill marker) get written and read |
| \`portfolio_onboarding_path\` | New resolver (#242) — returns the absolute path to \`onboarding.yaml\`, honouring the v2 sibling-repo override |
| \`portfolio_workspace_dir\` | New resolver (#242) — returns the absolute path to the workspace dir, honouring the v2 sibling-repo override |
| migration recipe | The bash steps in \`/update\` step 8a that move \`onboarding.yaml\` + \`workspace/<name>/\` into the sibling repo, write the marker, update \`.gitignore\`, and merge the v2 config-block keys |

Closes #242