### PR TITLE
feat(#244): custom templates layer in private repo with override semantics

### DIFF
--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -349,3 +349,74 @@ portfolio_is_v2() {
   root=$(_portfolio_root)
   [ -n "$root" ] && [ -f "$root/.apexyard-fork" ]
 }
+
+# ------------------------------------------------------------------------------
+# Public: portfolio_resolve_template <relative_path>
+#   Resolves a template path with adopter-override semantics:
+#     1. If <private_repo>/custom-templates/<relative_path> exists,
+#        return its absolute path.
+#     2. Else if <ops_root>/templates/<relative_path> exists,
+#        return that absolute path.
+#     3. Else return empty + nonzero exit (caller decides what to do).
+#
+#   <private_repo> is the directory holding the registry (resolved via
+#   portfolio_registry's parent), so split-portfolio adopters drop
+#   overrides next to their other portfolio data while single-fork
+#   adopters fall straight through to the framework default.
+#
+#   The <relative_path> mirrors the framework's templates/ shape:
+#     portfolio_resolve_template prd.md
+#     portfolio_resolve_template architecture/c4-context.md
+#     portfolio_resolve_template agdr-migration.md
+#
+#   Examples:
+#     # Split-portfolio v2 with custom PRD shape:
+#     portfolio_resolve_template prd.md
+#     # → /home/me/ops/apexyard-portfolio/custom-templates/prd.md
+#
+#     # Single-fork adopter, no override:
+#     portfolio_resolve_template prd.md
+#     # → /home/me/ops/apexyard/templates/prd.md
+#
+#     # Neither exists:
+#     portfolio_resolve_template does-not-exist.md   # exits 1
+# ------------------------------------------------------------------------------
+portfolio_resolve_template() {
+  local rel="$1"
+  if [ -z "$rel" ]; then
+    return 1
+  fi
+
+  # Strip a leading ./ for tidier matches.
+  rel="${rel#./}"
+
+  # 1. Custom override under <private_repo>/custom-templates/.
+  #    The "private repo" is the directory holding the registry — for
+  #    single-fork adopters this is the ops-fork root (so
+  #    custom-templates/ would also live in the fork, which is fine);
+  #    for split-portfolio adopters it's the sibling private repo.
+  local registry custom_dir custom_path
+  registry=$(portfolio_registry)
+  if [ -n "$registry" ]; then
+    custom_dir=$(dirname "$registry")
+    custom_path="$custom_dir/custom-templates/$rel"
+    if [ -f "$custom_path" ]; then
+      echo "$custom_path"
+      return 0
+    fi
+  fi
+
+  # 2. Framework default under <ops_root>/templates/.
+  local root framework_path
+  root=$(_portfolio_root)
+  if [ -n "$root" ]; then
+    framework_path="$root/templates/$rel"
+    if [ -f "$framework_path" ]; then
+      echo "$framework_path"
+      return 0
+    fi
+  fi
+
+  # 3. Neither exists.
+  return 1
+}

--- a/.claude/hooks/tests/test_portfolio_paths.sh
+++ b/.claude/hooks/tests/test_portfolio_paths.sh
@@ -442,6 +442,131 @@ if portfolio_is_v2; then exit 0; else echo "expected zero exit"; exit 1; fi
 rm -rf "$SB"
 
 # ---------------------------------------------------------------------------
+# Case 17 (custom-templates): seed templates/ in the sandbox so the
+# framework-default branch has something to find. Then test override
+# semantics.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+mkdir -p "$SB/templates/architecture"
+cat > "$SB/templates/prd.md" <<'MD'
+# Framework PRD
+MD
+cat > "$SB/templates/agdr.md" <<'MD'
+# Framework AgDR
+MD
+cat > "$SB/templates/architecture/c4-context.md" <<'MD'
+# Framework C4 Context
+MD
+run_case "custom-templates: framework default returned when no override" "$SB" '
+r=$(portfolio_resolve_template prd.md)
+expected="'"$SB"'/templates/prd.md"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "custom-templates: framework default returned for nested path" "$SB" '
+r=$(portfolio_resolve_template architecture/c4-context.md)
+expected="'"$SB"'/templates/architecture/c4-context.md"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "custom-templates: missing both → empty + nonzero exit" "$SB" '
+r=$(portfolio_resolve_template does-not-exist.md)
+rc=$?
+if [ -z "$r" ] && [ "$rc" -ne 0 ]; then exit 0; else echo "got=$r rc=$rc"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 18 (custom-templates): single-fork adopter with custom-templates
+# next to the registry — override wins over framework default.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+mkdir -p "$SB/templates/architecture"
+cat > "$SB/templates/prd.md" <<'MD'
+# Framework PRD
+MD
+cat > "$SB/templates/architecture/c4-context.md" <<'MD'
+# Framework C4 Context
+MD
+mkdir -p "$SB/custom-templates/architecture"
+cat > "$SB/custom-templates/prd.md" <<'MD'
+# Custom PRD
+MD
+cat > "$SB/custom-templates/architecture/c4-context.md" <<'MD'
+# Custom C4 Context
+MD
+run_case "custom-templates: custom prd.md wins over framework default" "$SB" '
+r=$(portfolio_resolve_template prd.md)
+expected="'"$SB"'/custom-templates/prd.md"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "custom-templates: nested custom override wins over framework default" "$SB" '
+r=$(portfolio_resolve_template architecture/c4-context.md)
+expected="'"$SB"'/custom-templates/architecture/c4-context.md"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 19 (custom-templates): split-portfolio v2 — custom-templates
+# lives in the sibling private repo (next to the registry override).
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+mkdir -p "$SB/templates"
+cat > "$SB/templates/prd.md" <<'MD'
+# Framework PRD
+MD
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+cat > "$SIB/apex.yaml" <<'YAML'
+version: 1
+projects: []
+YAML
+mkdir -p "$SIB/proj"
+mkdir -p "$SIB/custom-templates/architecture"
+cat > "$SIB/custom-templates/prd.md" <<'MD'
+# Sibling Custom PRD
+MD
+cat > "$SIB/custom-templates/architecture/c4-context.md" <<'MD'
+# Sibling Custom C4 Context
+MD
+cat > "$SB/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "registry": "$SIB/apex.yaml",
+    "projects_dir": "$SIB/proj"
+  }
+}
+JSON
+run_case "custom-templates: split-portfolio sibling override wins" "$SB" '
+r=$(portfolio_resolve_template prd.md)
+expected="'"$SIB"'/custom-templates/prd.md"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "custom-templates: split-portfolio sibling nested override wins" "$SB" '
+r=$(portfolio_resolve_template architecture/c4-context.md)
+expected="'"$SIB"'/custom-templates/architecture/c4-context.md"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "custom-templates: split-portfolio falls through to framework when no override" "$SB" '
+# Remove the sibling override for prd.md, leave c4-context.md custom.
+rm -f "'"$SIB"'/custom-templates/prd.md"
+r=$(portfolio_resolve_template prd.md)
+expected="'"$SB"'/templates/prd.md"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SB" "$SIB"
+
+# ---------------------------------------------------------------------------
+# Case 20 (custom-templates): empty input → nonzero exit
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+run_case "custom-templates: empty input → nonzero exit" "$SB" '
+r=$(portfolio_resolve_template "")
+rc=$?
+if [ -z "$r" ] && [ "$rc" -ne 0 ]; then exit 0; else echo "got=$r rc=$rc"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo

--- a/.claude/skills/c4/SKILL.md
+++ b/.claude/skills/c4/SKILL.md
@@ -150,7 +150,18 @@ On `a`: proceed to step 4.
 
 ### 4. Generate the Mermaid
 
-Use `templates/architecture/c4-context.md` as the structural skeleton for L1 and `templates/architecture/c4-container.md` for L2. Keep the surrounding markdown sections from the templates ("How to use this template" can be trimmed in the generated file since these are real diagrams, not templates).
+Resolve the C4 templates via the portfolio helper so adopter overrides win when present:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+context_template=$(portfolio_resolve_template architecture/c4-context.md)     # L1 skeleton
+container_template=$(portfolio_resolve_template architecture/c4-container.md) # L2 skeleton
+```
+
+Single-fork adopters (no `portfolio` block) and adopters with no override fall straight through to `templates/architecture/c4-{context,container}.md`. Adopters who want a customised C4 shape drop their versions at `<private_repo>/custom-templates/architecture/c4-{context,container}.md`. See `templates/README.md` for the path-mirroring convention.
+
+Keep the surrounding markdown sections from the resolved templates ("How to use this template" can be trimmed in the generated file since these are real diagrams, not templates).
 
 For **L1**:
 

--- a/.claude/skills/decide/SKILL.md
+++ b/.claude/skills/decide/SKILL.md
@@ -56,7 +56,17 @@ Create file at `{project-root}/docs/agdr/AgDR-{NNNN}-{slug}.md`.
 
 **Important**: AgDRs live in the **current project's repository**, not centralised. Each project has its own `docs/agdr/` folder and its own ID sequence.
 
-Use the AgDR template at `templates/agdr.md`:
+Resolve the AgDR template via the portfolio helper so adopter overrides win when present:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+template=$(portfolio_resolve_template agdr.md)   # → custom-templates/agdr.md if present, else templates/agdr.md
+```
+
+Single-fork adopters (no `portfolio` block) and adopters with no override fall straight through to `templates/agdr.md`. Adopters who want a customised AgDR shape drop their version at `<private_repo>/custom-templates/agdr.md`. See `templates/README.md` for the path-mirroring convention.
+
+The skeleton:
 
 ```markdown
 ---

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -395,7 +395,17 @@ If there's a `Dockerfile` at repo root but no `docker-compose.yml`: one containe
 
 #### Assembling the file
 
-Start from `templates/architecture/c4-container.md` (the template shipped in #50). Replace:
+Resolve the C4 container template via the portfolio helper so adopter overrides win when present:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+container_template=$(portfolio_resolve_template architecture/c4-container.md)
+```
+
+Single-fork adopters (no `portfolio` block) and adopters with no override fall straight through to `templates/architecture/c4-container.md` (the template shipped in #50). Adopters who want a customised C4 shape drop their version at `<private_repo>/custom-templates/architecture/c4-container.md`. See `templates/README.md` for the path-mirroring convention.
+
+Start from the resolved template. Replace:
 
 - `{Project Name}` → the project's real name (from the handover)
 - The sample `System_Boundary` contents → the containers you detected
@@ -428,7 +438,7 @@ Create `projects/<name>/architecture/` if missing.
 
 #### If there's nothing meaningful to draw
 
-If after scanning you find zero signals (no `package.json`, no `pyproject.toml`, no Dockerfile, no known framework, no DB), skip the file and note in the summary: `architecture/container.md: skipped (no container signals detected — add manually from templates/architecture/c4-container.md when ready)`. Better to write nothing than fabricate a wrong diagram.
+If after scanning you find zero signals (no `package.json`, no `pyproject.toml`, no Dockerfile, no known framework, no DB), skip the file and note in the summary: `architecture/container.md: skipped (no container signals detected — add manually from the C4 container template — resolve via portfolio_resolve_template architecture/c4-container.md — when ready)`. Better to write nothing than fabricate a wrong diagram.
 
 ### 7. Append to the portfolio registry
 

--- a/.claude/skills/migration/SKILL.md
+++ b/.claude/skills/migration/SKILL.md
@@ -94,7 +94,18 @@ Ask "Create ticket + AgDR? [y/N]". Only proceed on explicit `y`.
 
 ### 4. Create the AgDR first (local write, reversible)
 
-Copy `templates/agdr-migration.md` to the resolved path, filling in:
+Resolve the migration AgDR template via the portfolio helper so adopter overrides win when present:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+template=$(portfolio_resolve_template agdr-migration.md)   # → custom-templates/agdr-migration.md if present
+cp "$template" "$resolved_agdr_path"
+```
+
+Single-fork adopters (no `portfolio` block) and adopters with no override fall straight through to `templates/agdr-migration.md`. Adopters who want a customised migration-AgDR shape drop their version at `<private_repo>/custom-templates/agdr-migration.md`. See `templates/README.md` for the path-mirroring convention.
+
+Fill in:
 
 - Frontmatter (`id`, `timestamp`, `agent`, `model`, `trigger: user-prompt`, `status: draft`, `ticket` — left as `TBD` until step 5 creates the issue and we know the number)
 - The title, one-sentence summary, and every Section (Context, Options, Decision, Rollback Plan, Cross-Service Consumers, Testing Plan, Observability, Consequences) with the user's answers

--- a/.claude/skills/spike/SKILL.md
+++ b/.claude/skills/spike/SKILL.md
@@ -128,7 +128,17 @@ boundary you'd cross to fail-fast.
 
 ### 5. Show the formatted ticket for confirmation
 
-Display the full ticket:
+Resolve the spike body template via the portfolio helper so adopter overrides win when present:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+template=$(portfolio_resolve_template spike.md)   # → custom-templates/spike.md if present, else templates/spike.md
+```
+
+Single-fork adopters (no `portfolio` block) and adopters with no override fall straight through to `templates/spike.md`. Adopters who want a customised spike-body shape drop their version at `<private_repo>/custom-templates/spike.md`. See `templates/README.md` for the path-mirroring convention.
+
+Display the full ticket using the resolved template's section headings (the default `templates/spike.md` shape is reproduced below):
 
 ```
 Here's the ticket I'll create:

--- a/.claude/skills/write-spec/SKILL.md
+++ b/.claude/skills/write-spec/SKILL.md
@@ -50,7 +50,17 @@ If the project has integrations available:
 
 ### 4. Generate the PRD
 
-Use `templates/prd.md` as the base. The PRD should include:
+Resolve the PRD template via the portfolio helper so adopter overrides win when present:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+template=$(portfolio_resolve_template prd.md)   # → custom-templates/prd.md if present, else templates/prd.md
+```
+
+Single-fork adopters (no `portfolio` block) and adopters with no override fall straight through to `templates/prd.md`. Adopters who want a customised PRD shape drop their version at `<private_repo>/custom-templates/prd.md`. See `templates/README.md` for the path-mirroring convention.
+
+The PRD should include:
 
 ```markdown
 # {Feature Name} — PRD

--- a/docs/agdr/AgDR-0023-custom-templates-override-semantics.md
+++ b/docs/agdr/AgDR-0023-custom-templates-override-semantics.md
@@ -1,0 +1,79 @@
+---
+id: AgDR-0023
+timestamp: 2026-05-16T00:00:00Z
+agent: claude
+model: claude-opus-4-7
+trigger: user-prompt
+status: executed
+ticket: me2resh/apexyard#244
+---
+
+# Custom-templates layer: override semantics + path-mirroring discovery
+
+> In the context of split-portfolio adopters wanting to customise framework templates (PRD, AgDR, C4, migration AgDR, spike) without forking the consuming skill, facing the choice between additive merging vs full-replacement and between frontmatter/config-table discovery vs path-mirroring, I decided to ship a `custom-templates/` layer in the private repo with full-replacement override semantics and path-mirroring discovery (resolved by `portfolio_resolve_template`), to achieve "drop a file at the mirrored path and it wins" with zero configuration ceremony, accepting that overriding adopters lose framework template upgrades silently and must diff their override against new framework versions manually when running `/update`.
+
+## Context
+
+- Split-portfolio v2 (#242) put the registry, projects/, onboarding.yaml, and workspace/ into a private sibling repo. That left **templates** as the last adopter-touchable surface still living in the public fork.
+- Adopters with company-specific PRD shapes, AgDR styles, or C4 conventions had only one option: fork the consuming skill (`/write-spec`, `/decide`, etc.) — which forks all the surrounding logic, breaking framework upgrades for that skill forever.
+- The `_lib-portfolio-paths.sh` helper from #145 + #242 already provides the abstraction layer for path resolution; this PR extends it.
+- Two new skills (`/investigation` and `/vision`, planned in #B and #C) depend on the resolver. They ship after this lands.
+
+## Options Considered
+
+### Option dimension 1 — discovery mechanism
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Path-mirroring (chosen)** — drop file at `custom-templates/<path>` matching `templates/<path>` | Zero config; convention-over-configuration; same shape as `handbooks/<dim>/` discovery (#232); no registry to maintain | Adopters who place files at wrong path get silent framework-default fallback (no error) |
+| **Frontmatter pointer** — frontmatter in framework templates names override candidates | Explicit; framework can document its own override surface | Requires template-author cooperation; adopters can't add new override paths without framework changes |
+| **Config-block table** — `.claude/project-config.json` lists override pairs | Explicit override list; auditable; no "where does this go?" question | Operator maintenance burden; adding a new override = config edit + file write (two steps instead of one) |
+
+Path-mirroring won on operator UX (zero config) and consistency with the existing `handbooks/` discovery convention.
+
+### Option dimension 2 — resolution semantics (override vs additive)
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Full replacement (chosen)** — custom file wins; framework default ignored | Predictable; matches "templates are forms" model; adopter owns the whole shape they authored | Adopters lose framework template upgrades silently; must diff manually on `/update` |
+| **Additive merge** — framework default's sections + adopter's overrides composed | Framework template improvements flow automatically | Cross-markdown-file section merging is unreliable; section-name conflicts are silent; mental model is "what shape will I actually get?" — worse than override |
+
+Templates are forms (PRD shape, AgDR shape), not content. An adopter authoring `custom-templates/prd.md` deliberately wants their PRD shape used in place of the framework's. Additive composition would be a reliability hazard. The trade-off (lose framework upgrades silently) is documented in `templates/README.md` and `docs/multi-project.md` § "Custom templates".
+
+### Option dimension 3 — where overrides live
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Sibling to registry, in private repo for split-portfolio (chosen)** — `<private_repo>/custom-templates/` | Single-fork falls through naturally (registry is in fork → overrides also in fork); split-portfolio keeps overrides private | Helper has to resolve `<private_repo>` from `portfolio_registry`'s parent dir |
+| **Always in fork** — `<fork>/custom-templates/` regardless of mode | Simpler resolution (always `<ops_root>/custom-templates/`) | Split-portfolio adopters' overrides leak to public fork — defeats the purpose of split-portfolio mode |
+| **In `.claude/custom-templates/`** | Co-locates with other framework-config | `.claude/` is gitignored in some adopter setups; mixes adopter content with framework primitives |
+
+Sibling-to-registry won because it correctly handles both modes — the resolver derives `<private_repo>` from the resolved registry's parent dir, so the same code path works in single-fork (overrides in fork) and split-portfolio (overrides in private sibling).
+
+## Decision
+
+Chosen: **path-mirroring discovery + full-replacement override semantics + sibling-to-registry storage**, exposed via `portfolio_resolve_template <relative_path>` in `_lib-portfolio-paths.sh`.
+
+Resolution order:
+
+1. `<private_repo>/custom-templates/<relative_path>` — adopter override
+2. `<ops_root>/templates/<relative_path>` — framework default
+3. Empty + nonzero exit — caller decides what to do
+
+Updated consuming skills: `/decide`, `/write-spec`, `/c4`, `/migration`, `/spike`, `/handover`. New skills `/investigation` and `/vision` (planned in #B + #C) consume the resolver from inception.
+
+## Consequences
+
+- Adopters can author company-specific PRD / AgDR / C4 shapes without forking the consuming skill — drop the file at the mirrored path, ship.
+- Single-fork adopters with no `custom-templates/` dir see zero behaviour change. Helper falls straight through to framework default.
+- Split-portfolio adopters keep customisations in their private repo — never leaks to the public fork.
+- Adopters who override a template lose automatic framework template upgrades for that file. Mitigation: `templates/README.md` and `docs/multi-project.md` § "Custom templates" document the diff-on-`/update` discipline; `/update`'s deprecated-config-key advisory pattern (step 8 in the skill) is the model for a future "deprecated template shape" advisory if the failure mode bites adopters.
+- Adopters who misplace an override (typo in path, wrong nesting) get silent framework-default fallback. False-positive cost is low (you get the framework version, the skill still works); false-negative cost is also low (the operator notices when the customisation doesn't show up).
+- Two new skills (`/investigation`, `/vision`) can ship cleanly on top of this resolver in subsequent PRs.
+
+## Artifacts
+
+- PR for me2resh/apexyard#244
+- Helper addition: `.claude/hooks/_lib-portfolio-paths.sh` → `portfolio_resolve_template`
+- Tests: `.claude/hooks/tests/test_portfolio_paths.sh` (cases 17-20)
+- Docs: `templates/README.md`, `templates/custom-templates.README.example.md`, `docs/multi-project.md` § "Custom templates"

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -358,6 +358,43 @@ cd ~/ops/apexyard
 
 Adopt your first project with `/handover` — it writes to `../apexyard-portfolio/projects/<name>/` and appends to `../apexyard-portfolio/apexyard.projects.yaml`, both committed only to the private portfolio repo. The public fork stays slim.
 
+### Custom templates
+
+Every framework template (PRD, AgDR, migration AgDR, C4 context/container, vision, spike, etc.) can be overridden by an adopter-authored version. The mechanism is **path-mirroring** — drop your version at `<private_repo>/custom-templates/<path>` and it wins over the framework default at `templates/<path>`. No frontmatter, no config table, no registry.
+
+```
+~/ops/apexyard-portfolio/
+├── apexyard.projects.yaml
+├── projects/
+├── custom-templates/                    ← drop overrides here
+│   ├── prd.md                           ← overrides templates/prd.md
+│   ├── agdr.md                          ← overrides templates/agdr.md
+│   ├── agdr-migration.md                ← overrides templates/agdr-migration.md
+│   ├── spike.md                         ← overrides templates/spike.md
+│   └── architecture/
+│       ├── c4-context.md                ← overrides templates/architecture/c4-context.md
+│       └── c4-container.md              ← overrides templates/architecture/c4-container.md
+└── README.md
+```
+
+Why path-mirroring instead of frontmatter or a config table? Discovery is the convention itself — if you want to override `templates/<path>`, you put your version at `custom-templates/<path>`. Same shape as how `handbooks/<dim>/...` discovery works (#232). And resolution is **override, not additive**: an authored `custom-templates/prd.md` wins in full; the framework's `templates/prd.md` is ignored for that invocation. Templates are *forms*, not *content*, so partial-merge across two markdown files would be unreliable. Copy the framework default in full, then edit it.
+
+Single-fork adopters drop overrides at `<fork>/custom-templates/<path>` (sibling to `templates/`). Same resolution rule — adopters with no `custom-templates/` dir get the framework default automatically, zero behaviour change.
+
+The `_lib-portfolio-paths.sh` helper exposes `portfolio_resolve_template <relative_path>` (e.g. `portfolio_resolve_template architecture/c4-context.md`); every template-consuming skill (`/decide`, `/write-spec`, `/c4`, `/migration`, `/spike`, `/handover`) routes through it. Full reference: [`templates/README.md`](../templates/README.md). Design rationale: [`AgDR-0023`](agdr/AgDR-0023-custom-templates-override-semantics.md).
+
+To seed the directory in your private repo, copy the example README that ships with the framework:
+
+```bash
+cd ~/ops/apexyard-portfolio
+mkdir -p custom-templates
+cp ../apexyard/templates/custom-templates.README.example.md custom-templates/README.md
+git add custom-templates
+git commit -m "chore: scaffold custom-templates/ for adopter overrides"
+```
+
+The README is a starting point — the resolver doesn't read it; it's there for future-you and any human collaborator.
+
 ### Daily workflow under split mode
 
 ```bash

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,83 @@
+# Templates
+
+ApexYard ships markdown templates under `templates/` that consuming skills read at invocation time — `/decide` reads `agdr.md`, `/write-spec` reads `prd.md`, `/c4` reads `architecture/c4-context.md` and `architecture/c4-container.md`, `/migration` reads `agdr-migration.md`, `/spike` reads `spike.md`, `/handover` reads `architecture/c4-container.md`. The full inventory is in [`CLAUDE.md` § "Templates"](../CLAUDE.md).
+
+## Adopter overrides — the `custom-templates/` layer
+
+Every framework template can be overridden by an adopter-authored version. The override mechanism is **path-mirroring** — no frontmatter, no config table, no registry. If you want to override `templates/<path>`, drop your version at `<private_repo>/custom-templates/<path>`.
+
+| Framework default | Adopter override location |
+|--------------------|---------------------------|
+| `templates/prd.md` | `<private_repo>/custom-templates/prd.md` |
+| `templates/agdr.md` | `<private_repo>/custom-templates/agdr.md` |
+| `templates/agdr-migration.md` | `<private_repo>/custom-templates/agdr-migration.md` |
+| `templates/spike.md` | `<private_repo>/custom-templates/spike.md` |
+| `templates/architecture/c4-context.md` | `<private_repo>/custom-templates/architecture/c4-context.md` |
+| `templates/architecture/c4-container.md` | `<private_repo>/custom-templates/architecture/c4-container.md` |
+| `templates/architecture/vision.md` | `<private_repo>/custom-templates/architecture/vision.md` |
+| any nested file `templates/<a>/<b>/<c>.md` | `<private_repo>/custom-templates/<a>/<b>/<c>.md` |
+
+`<private_repo>` is the directory that holds your portfolio registry (`apexyard.projects.yaml`):
+
+- **Single-fork mode** — `<private_repo>` is the ops-fork root itself, so overrides live at `<fork>/custom-templates/<path>`. Same fork, sibling to `templates/`.
+- **Split-portfolio mode** — `<private_repo>` is the sibling private repo, so overrides live at `<fork>-portfolio/custom-templates/<path>`. The public fork holds only framework files; your customisations stay private.
+
+## Resolution semantics — override, not additive
+
+Templates are **forms**, not **content**. Overriding them means *replace*, not *append*. If `<private_repo>/custom-templates/prd.md` exists, `/write-spec` uses that file in place of the framework default. The framework's `templates/prd.md` is ignored for that invocation. Two consequences:
+
+1. **You own the whole shape.** Authoring a partial override (e.g. just a different header block, with the rest of the framework's body assumed) doesn't work — the framework can't merge sections from two markdown files reliably. Copy the framework default in full, then edit it.
+2. **Future framework updates to that template don't reach you.** When a framework release ships a richer PRD shape, your override won't pick up the change. This is the explicit trade-off — diff your override against the new framework version manually when you `/update`.
+
+## Mechanism — `portfolio_resolve_template`
+
+Skills route through the helper at `.claude/hooks/_lib-portfolio-paths.sh`:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+template=$(portfolio_resolve_template prd.md)
+# → <private_repo>/custom-templates/prd.md if it exists
+# → <ops_root>/templates/prd.md otherwise
+# → empty + nonzero exit if neither exists (caller decides what to do)
+```
+
+Single-fork adopters with no `custom-templates/` dir get the framework default automatically — zero configuration, zero behaviour change.
+
+## Authoring a custom template
+
+1. Pick the framework template you want to customise — e.g. `templates/prd.md`.
+2. Copy it to the matching path under your private repo's `custom-templates/`:
+
+   ```bash
+   # Single-fork mode:
+   mkdir -p custom-templates
+   cp templates/prd.md custom-templates/prd.md
+
+   # Split-portfolio mode (run from the public fork):
+   mkdir -p ../<fork>-portfolio/custom-templates
+   cp templates/prd.md ../<fork>-portfolio/custom-templates/prd.md
+   ```
+
+3. Edit the copy to match your company's preferred shape — section headings, default placeholders, internal links to your wiki, whatever.
+4. Commit it to the private repo (or to your fork in single-fork mode). The next invocation of the consuming skill picks it up with no extra configuration.
+
+For nested paths like `architecture/c4-context.md`, mirror the directory structure:
+
+```bash
+mkdir -p custom-templates/architecture
+cp templates/architecture/c4-context.md custom-templates/architecture/c4-context.md
+```
+
+## What's NOT in scope
+
+- **Per-project template overrides.** Overrides are framework-wide / org-wide only. If you need a project-specific template, fork the consuming skill instead.
+- **Template versioning / migration.** When the framework's template shape changes, you own the diff. Run `/update` periodically and check whether your override still aligns.
+- **Variable substitution / templating engines.** Templates are plain markdown with `{placeholder}` text the consuming skill (or you, post-fill) hand-edits. No Jinja, no Handlebars, no compile step.
+- **Encrypted custom templates.** Drop them in a private repo if confidentiality matters.
+
+## Related
+
+- [`docs/multi-project.md`](../docs/multi-project.md) § "Custom templates" — adopter-facing setup notes for split-portfolio mode.
+- [`AgDR-0023`](../docs/agdr/AgDR-0023-custom-templates-override-semantics.md) — design rationale (override-not-additive, path-mirroring, where overrides live).
+- [`templates/architecture/README.md`](architecture/README.md) — guide to the architecture-document templates specifically.

--- a/templates/custom-templates.README.example.md
+++ b/templates/custom-templates.README.example.md
@@ -1,0 +1,40 @@
+# Custom Templates
+
+This directory holds **adopter-authored overrides** for the framework's markdown templates. Overrides are **framework-wide** (not per-project) and **replace** the framework default in full (not additive).
+
+## Path convention
+
+Mirror the framework's `templates/<path>` shape. If you want to override `templates/prd.md`, put your version at `custom-templates/prd.md`. For nested paths like `templates/architecture/c4-context.md`, mirror the directory structure: `custom-templates/architecture/c4-context.md`.
+
+| Framework default | Your override here |
+|--------------------|---------------------|
+| `templates/prd.md` | `custom-templates/prd.md` |
+| `templates/agdr.md` | `custom-templates/agdr.md` |
+| `templates/agdr-migration.md` | `custom-templates/agdr-migration.md` |
+| `templates/spike.md` | `custom-templates/spike.md` |
+| `templates/architecture/c4-context.md` | `custom-templates/architecture/c4-context.md` |
+| `templates/architecture/c4-container.md` | `custom-templates/architecture/c4-container.md` |
+
+## Override semantics
+
+An authored override **replaces** the framework default — partial overrides aren't supported. Copy the framework version in full, then edit your copy. When the framework ships an updated template, your override doesn't pick up the change automatically; diff your version against the new framework default when you `/update`.
+
+## How resolution works
+
+Every template-consuming skill (`/decide`, `/write-spec`, `/c4`, `/migration`, `/spike`, `/handover`) routes through `portfolio_resolve_template` from `.claude/hooks/_lib-portfolio-paths.sh`:
+
+1. If `<this_dir>/<path>` exists → use it.
+2. Else if `<ops_root>/templates/<path>` exists → use the framework default.
+3. Else the skill returns an error (caller decides what to do).
+
+## What's NOT in scope
+
+- Per-project template overrides (still framework-wide / org-wide only)
+- Automatic merging or templating engines (templates stay as plain markdown)
+- Encryption (this is a private repo if you put it in one)
+
+## Related
+
+- [`templates/README.md`](../templates/README.md) — full framework-side documentation of the override mechanism
+- [`docs/multi-project.md`](../docs/multi-project.md) § "Custom templates" — adopter setup notes
+- [`AgDR-0023`](../docs/agdr/AgDR-0023-custom-templates-override-semantics.md) — design rationale


### PR DESCRIPTION
## Summary

Ships a `custom-templates/` layer that lets split-portfolio (and single-fork) adopters override framework markdown templates (PRD, AgDR, C4, migration AgDR, spike, container) without forking the consuming skill. Override discovery is **path-mirroring** — drop your version at `<private_repo>/custom-templates/<path>` matching `templates/<path>` and it wins. Resolution is **override-not-additive** — your custom file replaces the framework default in full. Foundational dependency for the upcoming `/investigation` and `/vision` skills.

- Adds `portfolio_resolve_template <relative_path>` to `_lib-portfolio-paths.sh` resolving `<private_repo>/custom-templates/<path>` first, falling through to `<ops_root>/templates/<path>`, returning empty + nonzero exit when neither exists.
- Routes `/decide`, `/write-spec`, `/c4`, `/migration`, `/spike`, `/handover` through the helper. Single-fork adopters with no `custom-templates/` dir see zero behaviour change.
- 8 new test cases (32 total, all passing) covering single-fork override, split-portfolio sibling override, nested-path override, framework-default fall-through, missing-both → nonzero exit, and empty input → nonzero exit.
- Documents the layer in `templates/README.md`, `docs/multi-project.md` § "Custom templates", and a copy-this-into-your-private-repo seed at `templates/custom-templates.README.example.md`.
- Records the design decision in `AgDR-0023` covering discovery mechanism (path-mirroring vs frontmatter vs config table), resolution semantics (override vs additive), and storage location (sibling-to-registry).

## Testing

1. Run the helper test suite: `bash .claude/hooks/tests/test_portfolio_paths.sh` — expect `Passed: 32 / Failed: 0`.
2. Smoke-test the resolver against a sandbox single-fork layout — confirm an authored `custom-templates/prd.md` wins over `templates/prd.md`, removing it falls back to the framework default.
3. Confirm full hook test suite stays green: every `bash .claude/hooks/tests/test_*.sh` reports zero failures (verified: 26 test files, all passing).
4. Inspect `AgDR-0023` to verify the override-semantics + path-mirroring rationale matches the AC's design notes.

## Glossary

| Term | Definition |
|------|------------|
| `custom-templates/` | Top-level directory in the adopter's private repo (or the ops fork in single-fork mode) holding override versions of framework templates. Mirrors the framework's `templates/` directory shape exactly. |
| Override (vs additive) | An adopter override **replaces** the framework default in full when a skill consumes the template. Templates are forms, not content; partial-merge across markdown files would be unreliable. |
| Path-mirroring | Discovery mechanism — to override `templates/<path>`, place your version at `custom-templates/<path>`. No frontmatter, no config table, no registry. Same convention as `handbooks/<dim>/` discovery. |
| `portfolio_resolve_template` | New helper in `_lib-portfolio-paths.sh`. Takes a relative path (e.g. `architecture/c4-context.md`), returns the absolute path of the override if present, else the framework default, else empty + nonzero exit. |
| Single-fork mode | Default ApexYard layout — one fork holds everything. The private-repo dir resolves to the fork root itself, so `custom-templates/` lives sibling-to `templates/`. |
| Split-portfolio mode | Public framework fork + private sibling repo holding the registry, projects, onboarding, workspace. With this PR, also `custom-templates/`. |
| AgDR (Agent Decision Record) | A single-page markdown record at `docs/agdr/AgDR-NNNN-<slug>.md` capturing options-considered + decision + consequences for any non-trivial technical choice an agent makes. |
| Foundational PR | A PR whose primary value is enabling other PRs. This one ships the resolver `/investigation` and `/vision` both depend on. |

Closes #244