### PR TITLE
feat(#249): /extract-features skill for greenfield rewrite inventories

### DIFF
--- a/.claude/skills/extract-features/SKILL.md
+++ b/.claude/skills/extract-features/SKILL.md
@@ -1,0 +1,391 @@
+---
+name: extract-features
+description: Scan an existing codebase and produce a structured Feature Inventory — six discovery axes (HTTP routes, data models, async jobs, test names, UI screens, documented features) consolidated into a "what we must preserve" specification suitable for a greenfield rewrite.
+argument-hint: "[project-name]"
+allowed-tools: Bash, Read, Grep, Glob, Write
+---
+
+# /extract-features — Feature Inventory for Greenfield Rewrites
+
+Walks the target project's codebase across **six discovery axes** and writes a consolidated Feature Inventory. The artefact is the "what we must preserve" specification for a greenfield rewrite (different language, framework, or architecture) — instead of reverse-engineering features one route at a time, hand the inventory to the rewrite team.
+
+This skill complements `/handover`:
+
+- `/handover` produces a **high-level project assessment** — origin, current health, integration plan, applicable roles. The output is the bridge between "we just inherited this codebase" and "this codebase is now governed by our normal SDLC".
+- `/extract-features` produces a **granular feature catalogue** — every route, model, job, test name, UI screen, and documented capability the existing system exposes. The output is the input to a greenfield-rewrite spec.
+
+Run `/handover` first when adopting an unfamiliar repo; run `/extract-features` second when you've decided to rewrite it.
+
+## LSP-aware (optional, recommended)
+
+Discovery walks across all six axes — `documentSymbol`, `references`, `definition` queries — are the obvious win for LSP. With `ENABLE_LSP_TOOL=1` + per-language plugin (per `docs/getting-started.md` § "Optional: LSP-aware code navigation"), route-handler enumeration, model walks, and test-name extraction are ~3-15× cheaper in token cost than grep + Read. Without LSP, the skill falls back to grep transparently using the framework signatures listed below. No new failure mode, just optional speed.
+
+The skill detects the active language from `package.json` / `pyproject.toml` / `Gemfile` / `go.mod` / `Cargo.toml` and dispatches to the matching axis-walker logic regardless of LSP state.
+
+## Path resolution
+
+Read the registry path via `portfolio_registry` and the per-project docs dir via `portfolio_projects_dir` from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+projects_dir=$(portfolio_projects_dir)
+```
+
+Defaults match today's single-fork layout (`./projects`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir}` keys in `.claude/project-config.json` — the helper resolves whichever mode they're in. See `docs/multi-project.md`.
+
+## Usage
+
+```
+/extract-features                       # current project (cwd inside workspace/<name>/)
+/extract-features billing-api           # registered project; resolve to workspace/billing-api/
+/extract-features .                     # treat cwd as the project root
+```
+
+If `<project-name>` is given but `workspace/<name>/` doesn't exist, the skill stops and asks the user to clone the project (it does not auto-clone — that's a side-effect with cost; same convention as `/handover`).
+
+## Output location
+
+```
+projects/<name>/feature-inventory.md          ← the artefact
+```
+
+The file is a **one-off scan**, not a recurring audit. There is no audit-history rotation. If the file already exists, the skill OFFERS (default-no) to overwrite — accept only if the codebase has changed substantially since the last run.
+
+## Custom template override (forward-looking)
+
+If `custom-templates/extract-features.md` exists in the configured custom-templates root (per the framework's template-override layer, when available), use it as the artefact template. Otherwise use the framework default in step 4 below. Resolve via:
+
+```bash
+custom_template=""
+if [[ -n "${APEXYARD_CUSTOM_TEMPLATES_ROOT:-}" ]] \
+   && [[ -f "${APEXYARD_CUSTOM_TEMPLATES_ROOT}/extract-features.md" ]]; then
+  custom_template="${APEXYARD_CUSTOM_TEMPLATES_ROOT}/extract-features.md"
+fi
+```
+
+If the template-override layer is not yet present in this fork, the variable is unset and the skill silently uses the default. Single-fork mode adopters are unaffected.
+
+## Process
+
+### 0. Resolve the target
+
+- If the argument is `.` → use cwd.
+- If the argument names a registered project → resolve to `workspace/<name>/` (the live working copy). If the workspace clone doesn't exist, prompt the user to clone first; do not auto-clone.
+- If no argument and cwd is inside `workspace/<name>/` → use that project.
+- If no argument and cwd is the ops-fork root → ask which registered project.
+
+If the resolved target has none of the discovery signals (no `package.json`, `pyproject.toml`, `Gemfile`, `go.mod`, `Cargo.toml`, no source dirs) → stop and tell the user there's nothing to scan.
+
+Capture and report the **scope**: which subdirectories will be walked, which will be skipped (vendored: `node_modules`, `vendor`, `.venv`, `target`, `dist`, `build`, `coverage`, `.next`, `.nuxt`).
+
+### 1. Detect the tech stack
+
+Same detection table as `/handover` step 3 — minimum information to dispatch the per-axis walkers:
+
+| Signal | Stack |
+|--------|-------|
+| `package.json` | Node — read `dependencies` / `devDependencies` to identify framework |
+| `pyproject.toml` / `requirements.txt` / `setup.py` | Python |
+| `Gemfile` / `Gemfile.lock` | Ruby |
+| `go.mod` | Go |
+| `Cargo.toml` | Rust |
+| `composer.json` | PHP |
+| `pom.xml` / `build.gradle` | JVM |
+
+Multiple stacks in one repo (monorepo, polyglot) → walk each subroot independently and merge findings under one inventory.
+
+### 2. Walk the six discovery axes (in parallel where possible)
+
+Run the six axis-walkers below. Each produces a list; the consolidated matrix in step 3 dedupes across axes (a route handler covered by a test name shouldn't appear twice under different "features").
+
+When LSP is enabled and the per-language plugin is installed, prefer `documentSymbol` over grep for handler / class / function enumeration. When LSP is absent, use the grep signatures listed.
+
+#### Axis 2a — HTTP routes / entry points
+
+Routes describe the **HTTP shape** of the system — every URL the system exposes is a candidate user-facing feature.
+
+| Framework | Signature (grep fallback) |
+|-----------|---------------------------|
+| Express / Connect | `app\.(get\|post\|put\|patch\|delete\|all)\s*\(` ; `router\.(get\|post\|...)` |
+| Fastify | `(fastify\|app)\.(get\|post\|put\|patch\|delete\|route)\s*\(` |
+| NestJS | `@(Get\|Post\|Put\|Patch\|Delete\|All\|Options\|Head)\s*\(` |
+| Hapi | `server\.route\s*\(` |
+| Hono / Koa | `app\.(get\|post\|...)`; `router\.(get\|post\|...)` |
+| Next.js (Pages Router) | files under `pages/api/**/*.{ts,tsx,js,jsx}` |
+| Next.js (App Router) | files named `route.{ts,js}` under `app/**` |
+| Remix | files named `loader\|action` exports under `app/routes/**` |
+| FastAPI | `@(app\|router)\.(get\|post\|put\|patch\|delete\|api_route)\s*\(` |
+| Flask | `@(app\|bp)\.route\s*\(` ; `@(app\|bp)\.(get\|post\|put\|patch\|delete)` |
+| Django | `urls.py` → `path(`, `re_path(`, `url(` ; class-based views; DRF `@api_view`, `routers.register` |
+| Rails | `config/routes.rb` → `get`, `post`, `resources`, `resource`, `namespace`, `scope` |
+| Sinatra | `^\s*(get\|post\|put\|patch\|delete)\s+['"]` |
+| Gin | `router\.(GET\|POST\|PUT\|PATCH\|DELETE\|Handle)\s*\(` |
+| Echo | `e\.(GET\|POST\|...)` ; `g\.(GET\|POST\|...)` |
+| Chi / Fiber | `r\.(Get\|Post\|...)` ; `app\.(Get\|Post\|...)` |
+| Axum | `Router::new()\.route\s*\(` |
+| Actix-web | `\.service\s*\(` ; `web::(get\|post\|put\|patch\|delete)` |
+| Rocket | `#\[(get\|post\|put\|patch\|delete)` |
+| Laravel | `routes/web.php`, `routes/api.php` → `Route::(get\|post\|...)` |
+| Spring | `@(GetMapping\|PostMapping\|PutMapping\|PatchMapping\|DeleteMapping\|RequestMapping)` |
+| AWS SAM / Serverless | `template.yaml` / `serverless.yml` → `Events:` with `Api:` / `HttpApi:` |
+| GraphQL | `Query\|Mutation\|Subscription` resolver definitions; SDL `.graphql` files |
+
+For each route capture: HTTP method, path, handler symbol (file + line), and any docstring / comment immediately above. The handler name + comment is usually a strong feature signal.
+
+#### Axis 2b — Data models / DB schema
+
+Models describe the **data shape** of the system — every persistent entity and its relations.
+
+| Framework | Signature |
+|-----------|-----------|
+| Prisma | `prisma/schema.prisma` → `model X { ... }` blocks; `prisma/migrations/**` |
+| TypeORM | `@Entity\(\)` decorators; classes extending `BaseEntity` |
+| Sequelize | `sequelize.define\s*\(` ; classes extending `Model` |
+| Drizzle | `pgTable\|mysqlTable\|sqliteTable\s*\(` ; `drizzle.config.{ts,js}` |
+| Mongoose | `mongoose\.(model\|Schema)` ; `new Schema\s*\(` |
+| Knex | `knexfile.{js,ts}`; `knex.schema.createTable` in migrations |
+| SQLAlchemy | classes extending `Base` / `db.Model` ; `__tablename__` ; `Column(` |
+| Django ORM | `models.py` → classes extending `models.Model` |
+| Active Record (Rails) | `app/models/**/*.rb` → `class X < ApplicationRecord`; `db/schema.rb` ; `db/migrate/**` |
+| GORM (Go) | structs with `gorm:` tags; `db.AutoMigrate(` |
+| Diesel (Rust) | `table!` macro; `schema.rs` |
+| ActiveRecord-Java (JPA / Hibernate) | `@Entity` annotations |
+| Raw SQL | `migrations/**/*.sql` ; `db/schema.sql` |
+
+For each model capture: name, table name (if different), field list (name + type), relations (`@OneToMany`, `belongs_to`, `references`), and any unique / index constraints. Field names hint at features (an `email_verified_at` column implies email-verification flow).
+
+#### Axis 2c — Async jobs / queue handlers
+
+Background jobs describe **deferred work** — usually one job = one async feature (send email, generate report, sync external system).
+
+| Framework | Signature |
+|-----------|-----------|
+| BullMQ / Bull | `new Queue\s*\(` ; `new Worker\s*\(` ; `\.process\s*\(` |
+| Bee-queue | `new Queue\s*\(` (with `bee-queue` import) |
+| Agenda | `agenda\.define\s*\(` |
+| Inngest | `inngest\.createFunction\s*\(` ; `serve\(\{ functions:` |
+| node-cron | `cron\.schedule\s*\(` |
+| Celery | `@app\.task` ; `@shared_task` ; `@task` |
+| RQ | `Queue\(.*\)\.enqueue` |
+| APScheduler | `scheduler\.add_job` ; `@scheduler\.scheduled_job` |
+| Sidekiq | classes including `Sidekiq::Worker` / `Sidekiq::Job` ; `perform\(` method |
+| Resque | classes with `@queue =` |
+| Active Job (Rails) | `app/jobs/**/*.rb` → `class X < ApplicationJob` |
+| AWS SQS handlers | Lambda handlers with `Records[].eventSource == "aws:sqs"` ; SAM `Events: SQS:` |
+| AWS EventBridge / cron | SAM `Events: Schedule:` ; CloudWatch Events rules |
+| Cron defs | `crontab` files; `*/N * * * *` patterns in YAML / config |
+| Temporal / Cadence | `@workflow.defn` ; `@activity.defn` |
+| Faktory | classes including `Faktory::Job` |
+
+For each job capture: name, trigger (queue name, cron expression, event source), and the handler function. Job names are typically verb-phrases that name a feature directly.
+
+#### Axis 2d — Test names (the gold axis)
+
+**Test names are the cheapest, most accurate signal of what a system DOES** — they're written by humans deliberately describing behaviour. Routes describe HTTP shape; models describe data shape; **tests describe behaviour**. Walking test names surfaces features that routes + models can't (e.g. "user can recover password via email", "admin can bulk-delete users with confirmation").
+
+| Framework | Signature |
+|-----------|-----------|
+| Jest / Vitest / Mocha | `describe\s*\(\s*['"`]` ; `it\s*\(\s*['"`]` ; `test\s*\(\s*['"`]` |
+| Playwright / Cypress | `test\s*\(\s*['"`]` ; `describe\s*\(\s*['"`]` ; `it\s*\(\s*['"`]` |
+| pytest | `def test_[a-z_]+\s*\(` ; class `Test\w+:` |
+| unittest | `def test_[a-z_]+\s*\(self` ; class `(\w+)\s*\(\s*unittest\.TestCase` |
+| RSpec | `describe\s+['"]` ; `context\s+['"]` ; `it\s+['"]` |
+| Minitest | `class \w+ < (Minitest::Test\|ActiveSupport::TestCase)` ; `def test_\w+` ; `it ['"]` |
+| Go testing | `func Test\w+\(t \*testing\.T\)` ; `t\.Run\s*\(\s*"` |
+| Cargo test | `#\[test\]` ; `mod tests` ; `fn \w+\(\)` inside `tests` module |
+| JUnit | `@Test` annotations; method names `void should_\w+` ; `void test\w+` |
+| PHPUnit | `function test\w+\(` ; `@test` docblocks |
+
+For each test capture: the full describe/context/it sentence (concatenated for nested specs). Cluster the sentences — patterns like "user can …", "admin can …", "guest cannot …" reveal features and roles.
+
+#### Axis 2e — UI screens / forms / interactions
+
+UI components describe the **interaction surface** of the system — every screen, form, and named interaction is a candidate feature.
+
+| Framework | Signature |
+|-----------|-----------|
+| React (router) | `react-router-dom` `<Route path=`; Next.js `pages/**`; Next.js `app/**/page.{tsx,js}`; Remix `app/routes/**` |
+| React (components) | top-level `function|const \w+ = ...` returning JSX in `src/components/`, `src/screens/`, `src/pages/`, `src/views/` |
+| Vue | `.vue` files; `defineComponent\s*\(` ; route files (`router/index.ts`) |
+| Svelte / SvelteKit | `routes/**/+page.svelte` ; `routes/**/+layout.svelte` ; `.svelte` components |
+| Angular | `@Component\s*\(` ; `RouterModule\.forRoot\s*\(\s*\[` ; `path:` entries |
+| Form libraries | `<form>` tags; `useForm\(`; `react-hook-form` `register\(`; `formik`; `<Field name="`; Vue `v-model` |
+| Storybook | `*.stories.{ts,tsx,js,jsx,mdx}` files — story names are user-flow names |
+| Tailwind / CSS modules | not features themselves, but presence indicates UI surface area |
+| Mobile (RN) | `react-navigation` `Stack.Screen name=` ; `<Tab.Screen name=` |
+| Mobile (Flutter) | `MaterialPageRoute` ; `GoRoute` ; `Navigator.push` |
+
+For each screen capture: route path (if router-mapped), component name, and the form fields it contains (if any). Form-field names + labels are explicit feature signals (a `confirmEmail` field implies email-verification UX).
+
+#### Axis 2f — Documented features
+
+Documented features are the **author's own enumeration** — usually the most accurate but least complete (often stale).
+
+Sources:
+
+- `README*` — look for "Features" / "What it does" sections (`^##\s+Features?` headers and the bullet list that follows)
+- `docs/features/**` — entire directory if present
+- `docs/index.md` / `docs/README.md` — top-level docs
+- `CHANGELOG*` — extract `## [Unreleased] Added` and historical `### Added` blocks
+- `CONTRIBUTING.md` — sometimes includes a feature taxonomy
+- API docs (`openapi.yaml`, `swagger.json`) — every operation summary is a feature
+- GitHub Issues with `enhancement` / `feature` labels (closed) — can hint at what shipped, but treat as supplementary
+
+For each documented feature capture: title, source (file + line), and the description verbatim. This is the only axis where the author's intent is recorded; the other five infer it from the code.
+
+### 3. Consolidate
+
+Build a **single feature matrix** that dedupes findings across the six axes. The matrix columns:
+
+| Column | Source |
+|--------|--------|
+| Feature | Inferred name (verb-phrase preferred: "Create order", "Reset password via email", "Bulk-delete users") |
+| Surface | UI / API / Job / Internal — the entry point the user / operator interacts with |
+| Status | Active (referenced from a current code path) / Deprecated (only in CHANGELOG / removed code) / Untested (route exists, no test names match) |
+| Source | Which axes corroborated the feature — e.g. `route + test`, `model + UI`, `doc only` |
+| Notes | Constraints, side effects, integrations the scanner spotted (e.g. "sends email via SendGrid", "Stripe webhook required", "rate-limited to 10/min") |
+
+Deduplication rules:
+
+- A route + a test that exercises it + a UI form that posts to it → **one** matrix row, sources: `route + test + UI`
+- A model with no route and no test → still a row (data feature), sources: `model only`
+- A documented feature not corroborated by code → row with `Status: Documented but not found in code` and a note flagging stale docs
+
+Aim for **30-150 rows** for a typical mid-sized app. If you produce fewer than 10 rows on a non-trivial codebase, the walker missed signatures — flag in "Coverage gaps".
+
+### 4. Write the inventory
+
+Default template (used when no custom override is configured):
+
+````markdown
+# {project-name} — Feature Inventory
+
+**Date**: {YYYY-MM-DD}
+**Scanner**: `/extract-features` (apexyard)
+**Scope**: {repo path}
+**Stack detected**: {language(s) + framework(s) from step 1}
+
+## Coverage scope
+
+**Walked**:
+- {list of subdirectories actually scanned, e.g. `src/`, `app/`, `tests/`, `docs/`}
+
+**Skipped** (vendored / generated / fixtures):
+- {list of directories pruned, e.g. `node_modules/`, `dist/`, `.next/`, `coverage/`, `tests/fixtures/`}
+
+**Axes that produced findings**:
+- {checked list of the six axes, with `(N items)` per axis}
+
+## Consolidated feature matrix
+
+| # | Feature | Surface | Status | Source | Notes |
+|---|---------|---------|--------|--------|-------|
+| 1 | Create order | API + UI | Active | route + test + UI | POST `/api/orders`; charges Stripe; sends confirmation email |
+| 2 | Reset password via email | UI + Job | Active | route + test + UI + job | one-time token expires in 1h |
+| ... | ... | ... | ... | ... | ... |
+
+## Per-axis findings
+
+### HTTP routes / entry points ({N})
+
+| Method | Path | Handler | File | Notes |
+|--------|------|---------|------|-------|
+| ... | ... | ... | ... | ... |
+
+### Data models / DB schema ({N})
+
+| Model | Table | Fields | Relations | File |
+|-------|-------|--------|-----------|------|
+| ... | ... | ... | ... | ... |
+
+### Async jobs / queue handlers ({N})
+
+| Job | Trigger | Handler | File |
+|-----|---------|---------|------|
+| ... | ... | ... | ... |
+
+### Test names ({N})
+
+Grouped by file or feature cluster:
+
+#### `tests/orders.test.ts`
+- Order creation › creates order with valid payload › returns 201
+- Order creation › rejects invalid currency › returns 400
+- Order creation › sends confirmation email on success
+- ...
+
+### UI screens / forms / interactions ({N})
+
+| Route | Component | Fields | File |
+|-------|-----------|--------|------|
+| ... | ... | ... | ... |
+
+### Documented features ({N})
+
+| Title | Source | Description |
+|-------|--------|-------------|
+| ... | ... | ... |
+
+## Coverage gaps
+
+The scanner could **not** determine these — they need human review of the existing code or stakeholder interviews:
+
+- **Business rules embedded in code logic** — discount stacking, eligibility checks, fraud heuristics. The scanner sees the function, not the policy.
+- **Integration patterns** — webhook signature schemes, retry policies, dead-letter queues unless they're explicit in IaC.
+- **Permission / authorisation matrix** — which roles can do what. Routes show endpoints; only manual review of guards / middleware reveals the full matrix.
+- **Configuration-driven behaviour** — feature flags, environment-specific toggles.
+- **Implicit features in cron / SQS handlers** with generic names — a job called `process_queue` doesn't name a feature.
+- **Data-cleanup / TTL policies** — usually only in DB triggers or cron specs.
+- **Stale documented features** — entries in CHANGELOG / README that reference removed code.
+
+## Recommended next steps
+
+1. **Review with the previous owner** — reconcile the matrix with their mental model. Expect ~10-20% drift (features they think exist that don't, features that exist they forgot about).
+2. **Write user stories per matrix row** — translate "GET /api/orders" into "As a customer, I want to view my orders". The inventory is the input; user-story authoring is a human task (consider `/feature` for each story you intend to ship in v1).
+3. **Identify the smallest-coherent-subset for v1 of the rewrite** — not every feature needs to ship in the first release. Bucket features into `must-have v1` / `nice-to-have v1.x` / `defer / drop`.
+4. **Validate the deferred / dropped buckets with stakeholders** — the prior-art bias makes the inventory feel exhaustive, but rewriting is also an opportunity to drop dead weight.
+5. **Run `/handover {project-name}`** if not already — for the high-level project assessment and integration plan that complements this granular inventory.
+6. **Use `/c4 {project-name} --level=2`** to capture the existing system's container topology — pairs well with the inventory as input to a rewrite design.
+
+## Open questions
+
+- {anything axis-specific the scanner couldn't resolve, e.g. "saw `app.use(authMiddleware)` but couldn't trace the auth scheme — JWT? session? OAuth?"}
+
+````
+
+### 5. Save and report
+
+Write `projects/<name>/feature-inventory.md`. If the file exists, prompt:
+
+```
+projects/<name>/feature-inventory.md already exists (last written {date}).
+Overwrite? [y/N]
+```
+
+Default `N`. On `N`, write to `projects/<name>/feature-inventory-{YYYY-MM-DD}.md` and tell the user where the new file landed. The original is preserved.
+
+Print a one-line summary on completion:
+
+```
+Feature inventory written: projects/<name>/feature-inventory.md
+{N} features cataloged across {axes-with-findings}/6 axes.
+{N} coverage gaps flagged. {N} recommended next steps.
+```
+
+## Why this skill exists
+
+A greenfield rewrite that proceeds without a feature inventory has two common failure modes:
+
+1. **Forgotten features** — the rewrite ships and a long-tail user files a bug because feature X wasn't ported. The team thought X was deprecated; it wasn't.
+2. **Reverse-engineering during build** — every developer on the rewrite team spelunks the old codebase one route / one model at a time, duplicating work and producing inconsistent mental models.
+
+The inventory is the single artefact that cuts both. It's not a spec, it's not a migration plan — it's a catalogue. The team negotiates trade-offs (drop / redesign / keep-as-is) against a known list, not against vibes.
+
+## Anti-patterns
+
+- **Don't auto-generate user stories from the matrix.** The inventory says "POST `/api/orders` exists"; only a human can decide it should become "As a customer, I want to place an order with one-click checkout". Translation is design work, not scanner work.
+- **Don't size features.** The matrix lists features but does not estimate effort to rewrite each one. Sizing depends on target stack, team familiarity, and downstream dependencies — all out of scope here.
+- **Don't run this every sprint.** It's a pre-rewrite scan, not a recurring audit. Run once, treat the artefact as a baseline, update only when the source codebase has changed substantially.
+- **Don't substitute this for `/code-review` or `/launch-check`.** The inventory says what features exist; it doesn't say whether they're well-implemented, secure, or production-ready. Use the audit skills for quality signals.
+- **Don't skip the human review step.** Prior-art bias is real — the matrix can feel authoritative even when it's missing 20% of the picture. Always reconcile with the previous owner / stakeholders before treating the inventory as canonical.

--- a/.claude/skills/extract-features/SKILL.md
+++ b/.claude/skills/extract-features/SKILL.md
@@ -206,7 +206,7 @@ UI components describe the **interaction surface** of the system — every scree
 | Framework | Signature |
 |-----------|-----------|
 | React (router) | `react-router-dom` `<Route path=`; Next.js `pages/**`; Next.js `app/**/page.{tsx,js}`; Remix `app/routes/**` |
-| React (components) | top-level `function|const \w+ = ...` returning JSX in `src/components/`, `src/screens/`, `src/pages/`, `src/views/` |
+| React (components) | top-level `function\|const \w+ = ...` returning JSX in `src/components/`, `src/screens/`, `src/pages/`, `src/views/` |
 | Vue | `.vue` files; `defineComponent\s*\(` ; route files (`router/index.ts`) |
 | Svelte / SvelteKit | `routes/**/+page.svelte` ; `routes/**/+layout.svelte` ; `.svelte` components |
 | Angular | `@Component\s*\(` ; `RouterModule\.forRoot\s*\(\s*\[` ; `path:` entries |

--- a/.claude/skills/extract-features/tests/README.md
+++ b/.claude/skills/extract-features/tests/README.md
@@ -1,0 +1,58 @@
+# /extract-features smoke test
+
+Standalone bash script that builds a synthetic codebase fixture covering
+Express routes + Prisma models (plus BullMQ + cron jobs, Jest test names,
+React Router screens, and a README features section + CHANGELOG), then runs
+the grep-fallback signatures from `../SKILL.md` against it and asserts each
+of the six discovery axes produces non-empty findings.
+
+Verifies on every change that:
+
+- The grep regexes in SKILL.md still match what they're supposed to match
+  (the `app.get(` / `model X {` / `describe(` / `<Route path=` patterns)
+- Vendored-dir pruning (`node_modules/`) doesn't leak into the route count
+- Each axis exceeds a minimum-findings threshold so a regression that drops
+  a signature is caught
+
+The skill itself runs inside Claude Code with richer dispatch — LSP-aware
+walks where available, framework-specific signatures, dedup across axes,
+matrix consolidation. This script exists so a human or CI job can confirm
+the documented signatures haven't drifted.
+
+## Run
+
+From the apexyard fork root:
+
+```bash
+bash .claude/skills/extract-features/tests/smoke.sh
+```
+
+Builds the fixture in `$TMPDIR/extract-features-fixture-*`, runs the seven
+checks, and removes the fixture on exit (success or failure).
+
+Exit code: `0` on success, `1` if any axis produces fewer findings than its
+minimum threshold.
+
+## Fixture coverage
+
+| File | Axis exercised |
+|------|----------------|
+| `src/routes/orders.js` + `src/routes/auth.js` | HTTP routes (Express) |
+| `prisma/schema.prisma` | Data models (Prisma) |
+| `src/workers/email.js` + `src/workers/cleanup.js` | Async jobs (BullMQ + node-cron) |
+| `tests/orders.test.js` + `tests/auth.test.js` | Test names (Jest) |
+| `src/pages/router.jsx` + `src/pages/LoginPage.jsx` | UI screens (React Router) |
+| `README.md` + `CHANGELOG.md` + `docs/features/orders.md` | Documented features |
+
+This satisfies the ticket AC ("at least 2 framework signatures, e.g. Express
+routes + Prisma schema") with margin — all six axes have at least one signature.
+
+## Adding a framework signature
+
+Edit `../SKILL.md` to document the new signature, then either:
+
+1. Extend `smoke.sh` with a new fixture file + assertion if it's high-priority
+   (a major framework family like Django or Rails)
+2. Leave it to the skill's runtime dispatch otherwise (the smoke test is
+   sampling, not exhaustive — it covers two or three signatures per axis to
+   catch regressions, not every signature in the matrix)

--- a/.claude/skills/extract-features/tests/smoke.sh
+++ b/.claude/skills/extract-features/tests/smoke.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# /extract-features smoke test
+#
+# Builds a synthetic codebase fixture covering Express routes + Prisma models
+# (plus test names, jobs, and docs for good measure), runs the discovery
+# signatures from SKILL.md against it as plain grep, and asserts each axis
+# produces non-empty findings.
+#
+# The skill itself runs inside Claude Code with richer dispatch (LSP-aware
+# walks, framework-specific signature matching, dedup, matrix consolidation).
+# This smoke test verifies the *grep-fallback* path the skill documents — if
+# the regexes in SKILL.md drift from what they're supposed to match, this
+# script catches it.
+
+set -euo pipefail
+
+FIXTURE=$(mktemp -d -t extract-features-fixture-XXXXXX)
+trap 'rm -rf "$FIXTURE"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_nonempty() {
+  local label="$1"
+  local count="$2"
+  local min="${3:-1}"
+  if [[ "$count" -ge "$min" ]]; then
+    echo "  PASS: $label found $count item(s) (>= $min)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label found $count item(s) (expected >= $min)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Build the fixture: a tiny Express + Prisma + Jest app with a BullMQ worker,
+# a React page, a README features section, and a CHANGELOG.
+# ---------------------------------------------------------------------------
+
+mkdir -p "$FIXTURE/src/routes" "$FIXTURE/src/workers" "$FIXTURE/src/pages" \
+         "$FIXTURE/prisma" "$FIXTURE/tests" "$FIXTURE/docs/features"
+
+cat > "$FIXTURE/package.json" <<'JSON'
+{
+  "name": "fixture-app",
+  "version": "0.1.0",
+  "dependencies": {
+    "express": "^4.19.0",
+    "@prisma/client": "^5.0.0",
+    "bullmq": "^5.0.0",
+    "react": "^18.2.0",
+    "react-router-dom": "^6.20.0"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "prisma": "^5.0.0"
+  }
+}
+JSON
+
+# --- Axis 2a: HTTP routes (Express)
+cat > "$FIXTURE/src/routes/orders.js" <<'JS'
+const express = require('express');
+const router = express.Router();
+
+// List orders for the authenticated customer
+router.get('/api/orders', async (req, res) => {
+  res.json([]);
+});
+
+// Create a new order with line items + payment intent
+router.post('/api/orders', async (req, res) => {
+  res.status(201).json({ id: 1 });
+});
+
+// Cancel a pending order
+router.delete('/api/orders/:id', async (req, res) => {
+  res.status(204).send();
+});
+
+module.exports = router;
+JS
+
+cat > "$FIXTURE/src/routes/auth.js" <<'JS'
+const express = require('express');
+const app = express();
+
+app.post('/api/auth/login', (req, res) => res.json({ token: 'x' }));
+app.post('/api/auth/logout', (req, res) => res.status(204).send());
+app.post('/api/auth/password-reset', (req, res) => res.status(202).send());
+
+module.exports = app;
+JS
+
+# --- Axis 2b: Data models (Prisma)
+cat > "$FIXTURE/prisma/schema.prisma" <<'PRISMA'
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id                Int       @id @default(autoincrement())
+  email             String    @unique
+  emailVerifiedAt   DateTime?
+  passwordHash      String
+  createdAt         DateTime  @default(now())
+  orders            Order[]
+}
+
+model Order {
+  id          Int      @id @default(autoincrement())
+  userId      Int
+  user        User     @relation(fields: [userId], references: [id])
+  totalCents  Int
+  currency    String
+  status      String   @default("pending")
+  createdAt   DateTime @default(now())
+  items       OrderItem[]
+}
+
+model OrderItem {
+  id        Int    @id @default(autoincrement())
+  orderId   Int
+  order     Order  @relation(fields: [orderId], references: [id])
+  sku       String
+  quantity  Int
+}
+PRISMA
+
+# --- Axis 2c: Async jobs (BullMQ + cron)
+cat > "$FIXTURE/src/workers/email.js" <<'JS'
+const { Queue, Worker } = require('bullmq');
+
+const emailQueue = new Queue('email');
+
+const worker = new Worker('email', async (job) => {
+  // Send transactional email
+  console.log('sending', job.data);
+});
+
+module.exports = { emailQueue, worker };
+JS
+
+cat > "$FIXTURE/src/workers/cleanup.js" <<'JS'
+const cron = require('node-cron');
+
+// Nightly cleanup of expired password-reset tokens
+cron.schedule('0 3 * * *', async () => {
+  // delete expired tokens
+});
+JS
+
+# --- Axis 2d: Test names (Jest)
+cat > "$FIXTURE/tests/orders.test.js" <<'JS'
+describe('Order creation', () => {
+  it('creates order with valid payload', async () => {});
+  it('rejects invalid currency', async () => {});
+  it('sends confirmation email on success', async () => {});
+});
+
+describe('Order cancellation', () => {
+  it('allows the owner to cancel a pending order', async () => {});
+  it('rejects cancel by non-owner', async () => {});
+});
+JS
+
+cat > "$FIXTURE/tests/auth.test.js" <<'JS'
+describe('Authentication', () => {
+  it('logs in with valid credentials', async () => {});
+  it('rejects login with wrong password', async () => {});
+  it('sends password-reset email on request', async () => {});
+});
+JS
+
+# --- Axis 2e: UI screens (React Router)
+cat > "$FIXTURE/src/pages/router.jsx" <<'JSX'
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+
+export function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/orders" element={<OrdersPage />} />
+        <Route path="/orders/:id" element={<OrderDetail />} />
+        <Route path="/login" element={<LoginPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+JSX
+
+cat > "$FIXTURE/src/pages/LoginPage.jsx" <<'JSX'
+export function LoginPage() {
+  return (
+    <form>
+      <input name="email" type="email" />
+      <input name="password" type="password" />
+      <button type="submit">Log in</button>
+    </form>
+  );
+}
+JSX
+
+# --- Axis 2f: Documented features
+cat > "$FIXTURE/README.md" <<'MD'
+# fixture-app
+
+A tiny e-commerce backend.
+
+## Features
+
+- Customer accounts with email/password authentication
+- Password reset via email with one-time token
+- Place orders with line items and currency
+- Cancel pending orders (owner only)
+- Nightly cleanup of expired tokens
+MD
+
+cat > "$FIXTURE/CHANGELOG.md" <<'MD'
+# Changelog
+
+## [Unreleased]
+
+### Added
+- Bulk-cancel endpoint for admins
+- Order export to CSV
+
+## [0.1.0] - 2026-01-15
+
+### Added
+- Initial customer auth
+- Order create / list / cancel endpoints
+MD
+
+cat > "$FIXTURE/docs/features/orders.md" <<'MD'
+# Orders feature
+
+Customers can place orders containing one or more line items. Each order
+records the customer, total in cents, currency, and status.
+MD
+
+# ---------------------------------------------------------------------------
+# Run discovery axes against the fixture using the SKILL.md grep signatures
+# ---------------------------------------------------------------------------
+
+echo "Smoke test: /extract-features against synthetic fixture at $FIXTURE"
+echo ""
+echo "Axis 2a — HTTP routes (Express):"
+ROUTES=$(grep -RhEo '(app|router)\.(get|post|put|patch|delete|all)\s*\(' "$FIXTURE/src" 2>/dev/null | wc -l | tr -d ' ')
+assert_nonempty "Express route handlers" "$ROUTES" 5
+
+echo ""
+echo "Axis 2b — Data models (Prisma):"
+MODELS=$(grep -cE '^\s*model\s+\w+\s*\{' "$FIXTURE/prisma/schema.prisma" 2>/dev/null || echo 0)
+assert_nonempty "Prisma models" "$MODELS" 3
+
+echo ""
+echo "Axis 2c — Async jobs (BullMQ + cron):"
+QUEUES=$(grep -rEo 'new (Queue|Worker)\s*\(' "$FIXTURE/src/workers" 2>/dev/null | wc -l | tr -d ' ')
+CRONS=$(grep -rEo 'cron\.schedule\s*\(' "$FIXTURE/src/workers" 2>/dev/null | wc -l | tr -d ' ')
+JOBS=$((QUEUES + CRONS))
+assert_nonempty "BullMQ + cron handlers" "$JOBS" 2
+
+echo ""
+echo "Axis 2d — Test names (Jest):"
+DESCRIBES=$(grep -REo 'describe\s*\(\s*['"'"'"`][^'"'"'"`]+['"'"'"`]' "$FIXTURE/tests" 2>/dev/null | wc -l | tr -d ' ')
+ITS=$(grep -REo '\bit\s*\(\s*['"'"'"`][^'"'"'"`]+['"'"'"`]' "$FIXTURE/tests" 2>/dev/null | wc -l | tr -d ' ')
+TESTS=$((DESCRIBES + ITS))
+assert_nonempty "Jest describe + it strings" "$TESTS" 8
+
+echo ""
+echo "Axis 2e — UI screens (React Router):"
+SCREENS=$(grep -REo '<Route\s+path=' "$FIXTURE/src/pages" 2>/dev/null | wc -l | tr -d ' ')
+assert_nonempty "React Router routes" "$SCREENS" 3
+
+echo ""
+echo "Axis 2f — Documented features:"
+DOC_LINES=0
+if grep -qE '^##[[:space:]]+Features?' "$FIXTURE/README.md"; then
+  DOC_LINES=$(awk '/^##[[:space:]]+Features?/{flag=1; next} /^##/{flag=0} flag && /^- /' "$FIXTURE/README.md" | wc -l | tr -d ' ')
+fi
+ADDED_LINES=$(grep -cE '^### Added' "$FIXTURE/CHANGELOG.md" 2>/dev/null || echo 0)
+DOCS=$((DOC_LINES + ADDED_LINES))
+assert_nonempty "README features + CHANGELOG Added blocks" "$DOCS" 3
+
+echo ""
+echo "Vendored-dir pruning sanity check:"
+mkdir -p "$FIXTURE/node_modules/express"
+echo 'app.get("/leak", () => {})' > "$FIXTURE/node_modules/express/index.js"
+ROUTES_AFTER_PRUNE=$(grep -RhEo '(app|router)\.(get|post|put|patch|delete|all)\s*\(' "$FIXTURE/src" 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$ROUTES_AFTER_PRUNE" -eq "$ROUTES" ]]; then
+  echo "  PASS: scoping to src/ (not the whole tree) excludes node_modules/"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: route count changed when node_modules added; scoping is wrong"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "----------------------------------------"
+echo "Total: $((PASS + FAIL))   Passed: $PASS   Failed: $FAIL"
+echo "----------------------------------------"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+echo ""
+echo "OK: all 7 discovery checks passed against the synthetic fixture."
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | `/spike-close` | Disposition gate for spikes — `--promote` files a follow-up `[Feature]`, `--discard` writes a memo to `docs/spike-memos/<slug>.md`. |
 | `/idea` | Capture a new product idea to the backlog |
 | `/handover` | Onboard an external repo into ApexYard management (includes per-project discovery) |
+| `/extract-features` | Scan an existing codebase across six discovery axes (HTTP routes, data models, async jobs, test names, UI screens, documented features) and write a consolidated Feature Inventory at `projects/<name>/feature-inventory.md` — the "what we must preserve" spec for a greenfield rewrite. Complements `/handover` (high-level project assessment); `/extract-features` is the granular feature catalogue. |
 | `/c4` | Generate C4 L1 (System Context) + L2 (Container) Mermaid diagrams for a project by reading its codebase |
 | `/journey` | Generate a single self-contained user-journey HTML — boxes-and-arrows graph with a clickable modal per page. Sits between PRD and tech-design as a "preview before build" artifact. |
 | `/update` | Sync the ops fork with upstream me2resh/apexyard — preview, merge-or-rebase, leaves a sync branch ready to push |

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -569,6 +569,7 @@ Every portfolio skill reads `apexyard.projects.yaml` and iterates the registry.
 | `/roadmap` | Reads `projects/<name>/roadmap.md`; asks which project if ambiguous |
 | `/stakeholder-update` | Portfolio rollup with a section per project |
 | `/handover` | Writes to `projects/<name>/handover-assessment.md`, appends the project to the registry, and offers (default-no) to clone the project into `workspace/<name>/` for an LSP-aware deep-dive follow-up (`/code-review`, `/threat-model`, `/security-review`). The clone offer surfaces the cost (disk, gitignored status, `ENABLE_LSP_TOOL=1` + per-language plugin install) explicitly. |
+| `/extract-features` | Scans a project's codebase across six discovery axes (HTTP routes, data models, async jobs, test names, UI screens, documented features) and writes a consolidated Feature Inventory at `projects/<name>/feature-inventory.md`. Pairs with `/handover` as the **greenfield-rewrite path** — `/handover` produces the high-level project assessment, `/extract-features` produces the granular "what we must preserve" catalogue. One-off scan, not a recurring audit; re-runs OFFER (default-no) to overwrite. |
 | `/c4` | Reads a project's codebase and writes filled-in C4 L1 + L2 Mermaid diagrams (location depends on invocation context — see `.claude/skills/c4/SKILL.md`) |
 
 Skills that aren't portfolio-aware (`/decide`, `/write-spec`, `/code-review`, `/security-review`, `/audit-deps`) operate on the current working directory — `cd workspace/<name>/` first if you want them to run against a specific project's code.


### PR DESCRIPTION
## Summary

- Adds `/extract-features` slash command at `.claude/skills/extract-features/SKILL.md` — scans an existing codebase across **six discovery axes** (HTTP routes, data models, async jobs, test names, UI screens, documented features) and writes a consolidated Feature Inventory at `projects/<name>/feature-inventory.md`. The artefact is the "what we must preserve" specification suitable for handing to a greenfield-rewrite team — instead of reverse-engineering features one route at a time.
- Per-axis framework signatures cover the major ecosystems (Express / Fastify / NestJS / FastAPI / Django / Rails / Gin / Axum / Spring; Prisma / TypeORM / Drizzle / SQLAlchemy / Active Record / GORM; BullMQ / Celery / Sidekiq / Inngest / SQS / cron; Jest / pytest / RSpec / Go testing / Cargo test; React Router / Next.js / Vue / Svelte / Angular / RN; README + CHANGELOG + docs/features/).
- LSP-aware when `ENABLE_LSP_TOOL=1`; grep fallback transparently per the same pattern as `/handover`, `/threat-model`, `/security-review`.
- Output structure: date + scope (what was walked + skipped), consolidated feature matrix (Feature / Surface / Status / Source / Notes), per-axis findings, coverage gaps, recommended next steps. One-off scan — not a recurring audit; re-runs OFFER (default-no) to overwrite.
- Forward-looking custom-template override hook reads `custom-templates/extract-features.md` from the configured custom-templates root (per the in-flight #244 template-override layer); silently uses the framework default when unset, so single-fork mode is unaffected.
- Positions `/extract-features` as the **complement** to `/handover`: handover produces the high-level project assessment, extract-features produces the granular feature catalogue. Both are the greenfield-rewrite path. CLAUDE.md skills table + docs/multi-project.md skills behaviour table both gain a row.

## Testing

1. Run the smoke test from the fork root:
   ```
   bash .claude/skills/extract-features/tests/smoke.sh
   ```
   Expected output: `OK: all 7 discovery checks passed against the synthetic fixture.` Builds a synthetic Express + Prisma + BullMQ + node-cron + Jest + React Router + README/CHANGELOG fixture in `$TMPDIR`, runs the SKILL.md grep signatures against it, asserts each axis produces non-empty findings, and verifies vendored-dir pruning (`node_modules/`) doesn't leak into the route count. Verified passing locally — 7/7 checks green.
2. Open the SKILL.md and verify the YAML frontmatter (`name`, `description`, `argument-hint`, `allowed-tools`) follows the same shape as sibling skills (`handover`, `c4`, `journey`).
3. Confirm the CLAUDE.md skills-reference-table row reads cleanly in the table flow and the docs/multi-project.md skills-behaviour-table row positions the skill alongside `/handover`.

## Glossary

| Term | Definition |
|------|------------|
| Discovery axis | One of the six independent walks (HTTP routes, data models, async jobs, test names, UI screens, documented features) the skill performs across the target codebase. Each axis uses framework-specific signatures to enumerate findings. |
| Feature Inventory | The output artefact — a structured Markdown file at `projects/<name>/feature-inventory.md` consolidating per-axis findings into a "what the existing system does" catalogue. Suitable as the input to a greenfield-rewrite spec. |
| Framework signature | A regex / AST pattern that identifies a framework primitive in source code (e.g. `app.get(...)` for Express routes, `model X { ... }` for Prisma models). The skill ships ~50 signatures across the six axes. |
| LSP-aware | The skill prefers `documentSymbol` / `references` / `definition` queries via the optional Language Server Protocol tool when `ENABLE_LSP_TOOL=1` is set + per-language plugin installed. Falls back to grep transparently when LSP is absent. |
| Greenfield rewrite | Rebuilding an existing application in a different language, framework, or architecture. The inventory is the "what we must preserve" specification handed to the rewrite team — the alternative is reverse-engineering features one at a time during the build. |
| Custom-template override | An optional adopter-controlled artefact at `custom-templates/extract-features.md` (per the in-flight #244 template-override layer) that replaces the framework's default Feature Inventory template. Unset → silent default. |
| One-off scan | The skill is invoked when a rewrite is being planned, not on a schedule. Re-runs (e.g. quarterly during a long rewrite) prompt before overwrite — no audit-history rotation like /launch-check. |
| Source corroboration | A feature row in the consolidated matrix names which axes saw it (e.g. `route + test + UI`). Cross-axis corroboration is the dedup mechanism — a route + a test that exercises it + a UI form that posts to it = one row, not three. |

Closes #249