### PR TITLE
feat(#243): private repo houses company custom skills + cross-org handbooks

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -12,7 +12,7 @@ model: inherit
 You are an automated code reviewer. Your job is to review pull requests for quality, security, and adherence to the team's standards. Two layers of standards apply, both consulted on every review:
 
 - **Framework rules** at `.claude/rules/*.md` — the generic ApexYard standards (code quality, PR workflow, AgDR requirements, etc.). Always loaded.
-- **Adopter handbooks** at `handbooks/**/*.md` — company-specific coding standards layered on top. Loaded per the discovery rules in [`handbooks/README.md`](../../handbooks/README.md). See § "Adopter handbooks" below for how to apply them in a review.
+- **Adopter handbooks** at `handbooks/**/*.md` (public layer) AND `<private_repo>/custom-handbooks/**/*.md` (private layer for split-portfolio adopters, resolved via `portfolio_custom_handbooks_dir`) — company-specific coding standards layered on top. Loaded per the discovery rules in [`handbooks/README.md`](../../handbooks/README.md) and § 8 below.
 
 ---
 
@@ -140,32 +140,58 @@ This PR cannot be merged until technical decisions are documented.
 
 ### 8. Adopter Handbooks
 
-Beyond the framework's generic rules, the adopter ships company-specific standards as **handbooks** at `handbooks/**/*.md`. Discover and apply them on every review.
+Beyond the framework's generic rules, the adopter ships company-specific standards as **handbooks** at two layered locations. Discover and apply both on every review:
+
+| Source | Where | When to use |
+|---|---|---|
+| **Public handbooks** | `handbooks/**/*.md` in the public ops fork | Generic adopter customisations safe to publish on a public framework fork |
+| **Private custom handbooks** | `<private_repo>/custom-handbooks/**/*.md`, resolved via `portfolio_custom_handbooks_dir` from `.claude/hooks/_lib-portfolio-paths.sh` | Company-confidential standards that name internal systems, refer to proprietary policy, or otherwise should not appear on a public repo (split-portfolio adopters only — single-fork adopters typically don't have this dir) |
+
+Both layers use the **same path-convention** (architecture / general / language) and the same advisory/blocking semantics. Both load on every review.
 
 #### Discovery (path-convention)
 
-| Path glob | Load condition |
-|---|---|
-| `handbooks/architecture/*.md` | Always — every PR |
-| `handbooks/general/*.md` | Always — every PR |
-| `handbooks/language/<lang>/*.md` | When the PR diff includes files matching `<lang>`'s extensions: `typescript/` → `**/*.{ts,tsx}`, `python/` → `**/*.py`, `go/` → `**/*.go`, `rust/` → `**/*.rs`. Other directories under `language/` follow the same `<lang>/` → matching-extension convention. |
-| `handbooks/<other>/*.md` | Default to always-load if you don't recognise the directory; flag in your review that the directory convention is undocumented. |
+The path conventions below apply to **each** of the two source roots. Within a single review you may load handbooks from both sources for the same bucket — that's the expected case for a split-portfolio adopter who has, say, both a public `architecture/clean-architecture-layers.md` AND a private `architecture/internal-pii-handling.md`.
 
-Discovery shape:
+| Path glob (relative to source root) | Load condition |
+|---|---|
+| `architecture/*.md` | Always — every PR |
+| `general/*.md` | Always — every PR |
+| `language/<lang>/*.md` | When the PR diff includes files matching `<lang>`'s extensions: `typescript/` → `**/*.{ts,tsx}`, `python/` → `**/*.py`, `go/` → `**/*.go`, `rust/` → `**/*.rs`. Other directories under `language/` follow the same `<lang>/` → matching-extension convention. |
+| `<other>/*.md` | Default to always-load if you don't recognise the directory; flag in your review that the directory convention is undocumented. |
+
+Discovery shape (load BOTH source roots):
 
 ```bash
-# Always-load buckets
-find handbooks/architecture handbooks/general -name '*.md' 2>/dev/null
+# Resolve the private custom-handbooks dir (split-portfolio adopters).
+# Empty / missing dir → just skip the private layer; not an error.
+PRIV=""
+if [ -f "$OPS_ROOT/.claude/hooks/_lib-portfolio-paths.sh" ]; then
+  source "$OPS_ROOT/.claude/hooks/_lib-read-config.sh"
+  source "$OPS_ROOT/.claude/hooks/_lib-portfolio-paths.sh"
+  candidate=$(portfolio_custom_handbooks_dir 2>/dev/null)
+  [ -n "$candidate" ] && [ -d "$candidate" ] && PRIV="$candidate"
+fi
 
-# Diff-matched language buckets
+# Always-load buckets — public + private (private may be empty).
+find handbooks/architecture handbooks/general -name '*.md' 2>/dev/null
+[ -n "$PRIV" ] && find "$PRIV/architecture" "$PRIV/general" -name '*.md' 2>/dev/null
+
+# Diff-matched language buckets — public + private.
 gh pr diff <number> --name-only | (
-  grep -qE '\.(ts|tsx)$' && find handbooks/language/typescript -name '*.md' 2>/dev/null
-  grep -qE '\.py$'       && find handbooks/language/python     -name '*.md' 2>/dev/null
+  if grep -qE '\.(ts|tsx)$'; then
+    find handbooks/language/typescript -name '*.md' 2>/dev/null
+    [ -n "$PRIV" ] && find "$PRIV/language/typescript" -name '*.md' 2>/dev/null
+  fi
   # ... etc per language
 )
 ```
 
 Read each loaded handbook in full. They're flat markdown — no parser needed.
+
+#### Per-handbook precedence on overlapping topics
+
+When a custom handbook addresses the same topic as a public handbook (no automated detection — operator's call), **apply BOTH**. There's no automatic precedence rule because we can't reliably detect "same topic" — adopters who want their custom rule to override / amend a public one should write the conflict resolution in prose inside the custom handbook ("This rule REPLACES `handbooks/architecture/<X>.md`'s position on <Y>"). Cite both handbooks in the finding when both are relevant.
 
 #### Enforcement: advisory vs blocking
 
@@ -178,13 +204,13 @@ Each handbook is **advisory** by default. A handbook is **blocking** if and only
 
 #### What to surface
 
-For each loaded handbook:
+For each loaded handbook (public or private custom):
 
 1. Read the "What Rex flags" section — that's the trigger pattern list.
 2. Read the "What's NOT a violation" section — that's the false-positive guard.
 3. Scan the diff for the trigger patterns; suppress matches that fall under the false-positive guard.
 4. For each genuine violation, surface a finding citing:
-   - The handbook path (e.g. `handbooks/architecture/clean-architecture-layers.md`)
+   - The handbook path (e.g. `handbooks/architecture/clean-architecture-layers.md` for public, `<private>/custom-handbooks/architecture/internal-pii-handling.md` for private — the absolute resolved path)
    - The file:line in the diff
    - The specific rule violated (one-sentence summary)
    - The mitigation, if the handbook suggests one
@@ -370,7 +396,7 @@ Report the failure in plain text with the exact command the caller needs to run.
    - List what needs to be documented
    - The PR author must run `/decide` and link the AgDR before re-review
 8. **Approval marker format is BLOCKING** — on APPROVED verdicts, write the marker at `.claude/session/reviews/{pr}-rex.approved` containing exactly the 40-char HEAD SHA + newline. No labels, no JSON, no extra text. See the "Approval marker — EXACT FORMAT REQUIRED" section above. A malformed marker blocks the merge and forces a rule-violating hand-edit, so getting the format right is as important as the review content.
-9. **Handbooks layer on top of framework rules** — discover and apply handbooks at `handbooks/**/*.md` per the path-convention rules in § 8. Advisory handbooks generate `nit:` / `suggestion:` comments; blocking handbooks (containing `ENFORCEMENT: blocking` at the top of the file) become REQUEST CHANGES verdicts. Adopters extend the standards by adding handbook files; you don't need a code change to teach Rex a new rule.
+9. **Handbooks layer on top of framework rules** — discover and apply handbooks from BOTH the public `handbooks/**/*.md` tree AND (for split-portfolio adopters) the private custom-handbooks dir resolved via `portfolio_custom_handbooks_dir`. See § 8 for the path-convention rules and the discovery shape. Advisory handbooks generate `nit:` / `suggestion:` comments; blocking handbooks (containing `ENFORCEMENT: blocking` at the top of the file) become REQUEST CHANGES verdicts regardless of whether they live in the public or private layer. Adopters extend the standards by adding handbook files; you don't need a code change to teach Rex a new rule.
 
 ## Example Invocation
 

--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -36,6 +36,8 @@
 #   ideas_backlog → ./projects/ideas-backlog.md
 #   onboarding    → ./onboarding.yaml
 #   workspace_dir → ./workspace
+#   custom_skills_dir    → ./custom-skills      (split-portfolio v2 + #243)
+#   custom_handbooks_dir → ./custom-handbooks   (split-portfolio v2 + #243)
 #
 # Caching: results cached per-process in shell vars to avoid repeat jq
 # calls. Same pattern as _CONFIG_CACHE in _lib-read-config.sh.
@@ -212,6 +214,53 @@ portfolio_workspace_dir() {
 }
 
 # ------------------------------------------------------------------------------
+# Public: portfolio_custom_skills_dir
+#   Resolves the path to the company-private custom-skills directory. In
+#   single-fork mode this defaults to an in-fork path (rarely used — adopters
+#   can drop a custom skill straight into .claude/skills/<name>/ if they
+#   don't need split-portfolio privacy). In split-portfolio v2 mode this
+#   lives in the private sibling repo (e.g. ../<fork>-portfolio/custom-skills).
+#
+#   The link-custom-skills.sh SessionStart hook reads this path and creates
+#   gitignored symlinks at .claude/skills/<name>/ for each subdirectory it
+#   finds.
+#
+#   Default: ./custom-skills (relative to ops-fork root)
+# ------------------------------------------------------------------------------
+_PORTFOLIO_CUSTOM_SKILLS_DIR_CACHE=""
+portfolio_custom_skills_dir() {
+  if [ -n "$_PORTFOLIO_CUSTOM_SKILLS_DIR_CACHE" ]; then
+    echo "$_PORTFOLIO_CUSTOM_SKILLS_DIR_CACHE"
+    return 0
+  fi
+  local raw
+  raw=$(_portfolio_get '.portfolio.custom_skills_dir' './custom-skills')
+  _PORTFOLIO_CUSTOM_SKILLS_DIR_CACHE=$(_portfolio_resolve "$raw")
+  echo "$_PORTFOLIO_CUSTOM_SKILLS_DIR_CACHE"
+}
+
+# ------------------------------------------------------------------------------
+# Public: portfolio_custom_handbooks_dir
+#   Resolves the path to the company-private custom-handbooks directory.
+#   Same shape as portfolio_custom_skills_dir but for adopter coding
+#   standards (the Rex agent reads this path as a second discovery source
+#   beyond the public-fork's handbooks/ tree).
+#
+#   Default: ./custom-handbooks (relative to ops-fork root)
+# ------------------------------------------------------------------------------
+_PORTFOLIO_CUSTOM_HANDBOOKS_DIR_CACHE=""
+portfolio_custom_handbooks_dir() {
+  if [ -n "$_PORTFOLIO_CUSTOM_HANDBOOKS_DIR_CACHE" ]; then
+    echo "$_PORTFOLIO_CUSTOM_HANDBOOKS_DIR_CACHE"
+    return 0
+  fi
+  local raw
+  raw=$(_portfolio_get '.portfolio.custom_handbooks_dir' './custom-handbooks')
+  _PORTFOLIO_CUSTOM_HANDBOOKS_DIR_CACHE=$(_portfolio_resolve "$raw")
+  echo "$_PORTFOLIO_CUSTOM_HANDBOOKS_DIR_CACHE"
+}
+
+# ------------------------------------------------------------------------------
 # Public: portfolio_validate
 #   Sanity-check that resolved paths are actually usable.
 #   On success: prints nothing, returns 0.
@@ -335,6 +384,8 @@ portfolio_clear_cache() {
   _PORTFOLIO_IDEAS_BACKLOG_CACHE=""
   _PORTFOLIO_ONBOARDING_CACHE=""
   _PORTFOLIO_WORKSPACE_DIR_CACHE=""
+  _PORTFOLIO_CUSTOM_SKILLS_DIR_CACHE=""
+  _PORTFOLIO_CUSTOM_HANDBOOKS_DIR_CACHE=""
 }
 
 # ------------------------------------------------------------------------------

--- a/.claude/hooks/link-custom-skills.sh
+++ b/.claude/hooks/link-custom-skills.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# link-custom-skills.sh — SessionStart hook
+#
+# Surfaces company-private custom skills (stored in the split-portfolio
+# private sibling repo at <private>/custom-skills/<name>/) to Claude Code
+# via the public fork's .claude/skills/ discovery path.
+#
+# Implementation: gitignored symlinks at .claude/skills/<name>/ pointing to
+# <private>/custom-skills/<name>/. Claude Code's skill discovery walks
+# .claude/skills/*/SKILL.md, so the symlink makes the private skill
+# transparently visible without copying or moving anything.
+#
+# Behaviour summary (advisory hook — exit 0 always; this is plumbing, not
+# a gate):
+#
+#   - No private custom-skills dir resolved or directory missing → no-op,
+#     silent. Single-fork adopters and split-portfolio adopters who haven't
+#     created custom-skills/ yet see nothing.
+#   - For each subdirectory under <private>/custom-skills/<name>/ that
+#     contains SKILL.md, ensure a symlink exists at .claude/skills/<name>.
+#       * If a framework skill of the same name exists at .claude/skills/<name>
+#         AS A REAL DIRECTORY (not a symlink we created previously), the custom
+#         skill WINS — we replace it with the symlink and emit a one-line
+#         visible warning naming the override.
+#       * If the existing entry is already a symlink to the same target, no-op.
+#       * If the existing entry is a symlink to a different target, replace
+#         it (operator may have changed the private dir).
+#   - On Windows: decline gracefully — print a one-line manual-install
+#     pointer and skip. Mirrors the LSP-on-Windows behaviour from /setup.
+#
+# All output goes to stderr so it shows up in the SessionStart banner stream
+# without polluting stdout that other hooks/skills might consume.
+
+set -u
+
+# Detect Windows. Same shape as /setup Step 2c.5(a).
+case "${OSTYPE:-}" in
+  msys*|cygwin*|win32*)
+    IS_WINDOWS=1
+    ;;
+  *)
+    IS_WINDOWS=0
+    ;;
+esac
+if [ "$IS_WINDOWS" -eq 0 ]; then
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|CYGWIN*|Windows*) IS_WINDOWS=1 ;;
+  esac
+fi
+
+# Resolve the ops-fork root by walking up from $PWD. Cheaper than the full
+# helper for the no-op cases (no helper sourced, no jq fork). The helper
+# walks the same path; we replicate that minimal logic here so the hook
+# stays useful even if the lib hasn't been installed yet on a fresh fork.
+ops_root=""
+cur="$PWD"
+while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+  if [ -f "$cur/.apexyard-fork" ]; then
+    ops_root="$cur"; break
+  fi
+  if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+    ops_root="$cur"; break
+  fi
+  cur=$(dirname "$cur")
+done
+
+# Outside any apexyard fork → nothing to do.
+[ -z "$ops_root" ] && exit 0
+
+LIB_PORTFOLIO="$ops_root/.claude/hooks/_lib-portfolio-paths.sh"
+LIB_CONFIG="$ops_root/.claude/hooks/_lib-read-config.sh"
+
+# Helpers missing → no-op silently. The hook can't resolve paths without
+# them, and complaining loudly on every session start would be noise during
+# a botched install.
+[ ! -f "$LIB_PORTFOLIO" ] && exit 0
+[ ! -f "$LIB_CONFIG" ] && exit 0
+
+# shellcheck source=/dev/null
+. "$LIB_CONFIG"
+# shellcheck source=/dev/null
+. "$LIB_PORTFOLIO"
+
+custom_skills_dir=$(portfolio_custom_skills_dir 2>/dev/null)
+
+# Helper failure → no-op silently.
+[ -z "$custom_skills_dir" ] && exit 0
+
+# No custom-skills dir on disk → no-op silently. This is the most common
+# case (every fork that hasn't opted in to private custom skills).
+[ ! -d "$custom_skills_dir" ] && exit 0
+
+# Found a custom-skills dir. Now, if we're on Windows, decline gracefully.
+# We hit this AFTER detecting a configured custom-skills dir so adopters
+# who don't use custom skills don't see Windows-specific output.
+if [ "$IS_WINDOWS" -eq 1 ]; then
+  echo "ApexYard: detected $custom_skills_dir but symlink-based skill linking is not supported on Windows in this release." >&2
+  echo "  Manual workaround: copy each subdir of custom-skills/ into .claude/skills/ on this machine." >&2
+  echo "  See docs/multi-project.md § 'Private custom skills + handbooks' for the full pointer." >&2
+  exit 0
+fi
+
+skills_target_dir="$ops_root/.claude/skills"
+mkdir -p "$skills_target_dir"
+
+# Iterate every direct child of custom_skills_dir that is itself a directory
+# AND contains SKILL.md (skip README.md / accidental files).
+linked_count=0
+collision_warnings=""
+for src in "$custom_skills_dir"/*/; do
+  # Glob with no matches expands to the literal pattern — guard.
+  [ -d "$src" ] || continue
+  src="${src%/}"
+  name=$(basename "$src")
+
+  # Skip if the source dir doesn't contain a SKILL.md — nothing for Claude
+  # Code to discover.
+  [ -f "$src/SKILL.md" ] || continue
+
+  target="$skills_target_dir/$name"
+
+  # If target is already a symlink, check where it points. Idempotent path:
+  # already pointing at this src → nothing to do.
+  if [ -L "$target" ]; then
+    existing=$(readlink "$target" 2>/dev/null || echo "")
+    # Resolve relative existing → absolute for fair comparison.
+    case "$existing" in
+      /*) ;;
+      *)  existing="$skills_target_dir/$existing" ;;
+    esac
+    # Canonicalise both sides for comparison. We use cd+pwd because
+    # `realpath` isn't always present on macOS.
+    canon_existing=$(cd "$(dirname "$existing")" 2>/dev/null && pwd -P)/$(basename "$existing")
+    canon_src=$(cd "$(dirname "$src")" 2>/dev/null && pwd -P)/$(basename "$src")
+    if [ "$canon_existing" = "$canon_src" ]; then
+      # Already linked correctly. No-op.
+      continue
+    fi
+    # Symlink points elsewhere — operator may have re-pointed the private
+    # dir. Replace.
+    rm -f "$target"
+    ln -s "$src" "$target"
+    linked_count=$((linked_count + 1))
+    continue
+  fi
+
+  # If a real directory exists at the target → name collision with a
+  # framework skill (or a previously-installed adopter copy). Custom wins;
+  # warn visibly.
+  if [ -d "$target" ]; then
+    # Move the existing dir aside as a backup so we don't lose it. The
+    # backup name is deterministic (no timestamp) so re-runs converge.
+    backup="${target}.framework.bak"
+    if [ ! -e "$backup" ]; then
+      mv "$target" "$backup"
+    else
+      # Backup already exists from a previous run — just remove the dir.
+      rm -rf "$target"
+    fi
+    ln -s "$src" "$target"
+    linked_count=$((linked_count + 1))
+    collision_warnings="${collision_warnings}  - $name (custom override; framework version moved to $(basename "$backup"))\n"
+    continue
+  fi
+
+  # Nothing at the target — create the symlink.
+  ln -s "$src" "$target"
+  linked_count=$((linked_count + 1))
+done
+
+# Surface a one-line summary if we did anything, plus any collision
+# warnings. Stay silent when there's nothing to report.
+if [ "$linked_count" -gt 0 ]; then
+  echo "ApexYard: linked $linked_count custom skill(s) from $custom_skills_dir into .claude/skills/." >&2
+fi
+
+if [ -n "$collision_warnings" ]; then
+  echo "ApexYard: custom skill(s) override framework skill(s):" >&2
+  printf "%b" "$collision_warnings" >&2
+fi
+
+exit 0

--- a/.claude/hooks/tests/test_link_custom_skills.sh
+++ b/.claude/hooks/tests/test_link_custom_skills.sh
@@ -109,8 +109,11 @@ SB=$(make_fork)
 out=$(run_hook "$SB")
 rc=$?
 # Should be exit 0, empty output, no symlinks created.
-[ "$rc" -eq 0 ] && [ -z "$out" ] && [ -z "$(ls -A "$SB/.claude/skills" 2>/dev/null)" ]
-rc2=$?
+ok=1
+[ "$rc" -eq 0 ] || ok=0
+[ -z "$out" ] || ok=0
+[ -z "$(ls -A "$SB/.claude/skills" 2>/dev/null)" ] || ok=0
+[ "$ok" -eq 1 ] && rc2=0 || rc2=1
 assert "case 1: no private custom-skills dir → no-op silent (no symlinks, no output)" "$rc2"
 rm -rf "$SB"
 

--- a/.claude/hooks/tests/test_link_custom_skills.sh
+++ b/.claude/hooks/tests/test_link_custom_skills.sh
@@ -1,0 +1,304 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/link-custom-skills.sh — the SessionStart
+# hook that surfaces private custom skills (split-portfolio v2 + #243) to
+# Claude Code by symlinking them into the public fork's .claude/skills/.
+#
+# Cases:
+#   1. No private custom-skills dir → no-op (silent, exit 0, no symlinks)
+#   2. Private dir with two custom skills → both symlinked, summary printed
+#   3. Custom skill name collides with framework skill → custom wins;
+#      framework dir moved to <name>.framework.bak; warning printed
+#   4. Windows OS detection → graceful decline with manual-install pointer
+#   5. Idempotency — re-running with the same private dir is a no-op
+#      (same target, same name, no spurious warnings)
+#   6. Subdir without SKILL.md is skipped (no symlink created)
+#
+# Each case builds an isolated sandbox under $TMPDIR with the v2
+# `.apexyard-fork` marker + the project-config helpers + the hook itself.
+
+set -u
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/link-custom-skills.sh"
+LIB_PORTFOLIO_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-portfolio-paths.sh"
+LIB_CONFIG_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-read-config.sh"
+DEFAULTS_SRC="$(cd "$(dirname "$0")/../.." && pwd)/project-config.defaults.json"
+
+if [ ! -f "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found at $HOOK_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$LIB_PORTFOLIO_SRC" ] || [ ! -f "$LIB_CONFIG_SRC" ] || [ ! -f "$DEFAULTS_SRC" ]; then
+  echo "FAIL: prerequisite libs / defaults missing" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# --------------------------------------------------------------------------
+# make_fork: build an isolated apexyard fork sandbox with the v2 marker,
+# the hook script, the portfolio + config libs, and the defaults file.
+# Returns the sandbox path on stdout.
+# --------------------------------------------------------------------------
+make_fork() {
+  local sb
+  sb=$(mktemp -d)
+  sb=$(cd "$sb" && pwd -P)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name  "test"
+
+    # v2 anchor — the new layout. Using v2 means we don't also need the
+    # legacy onboarding.yaml + apexyard.projects.yaml pair, but adding
+    # them too keeps validate happy if the test happens to invoke it.
+    touch .apexyard-fork onboarding.yaml
+    cat > apexyard.projects.yaml <<'YAML'
+version: 1
+projects: []
+YAML
+    mkdir -p projects
+    cat > projects/ideas-backlog.md <<'MD'
+# ideas
+MD
+
+    mkdir -p .claude/hooks .claude/skills
+    cp "$HOOK_SRC"          .claude/hooks/link-custom-skills.sh
+    cp "$LIB_PORTFOLIO_SRC" .claude/hooks/_lib-portfolio-paths.sh
+    cp "$LIB_CONFIG_SRC"    .claude/hooks/_lib-read-config.sh
+    cp "$DEFAULTS_SRC"      .claude/project-config.defaults.json
+    chmod +x .claude/hooks/link-custom-skills.sh
+
+    git add -A
+    git commit -q -m "test fixture"
+  )
+  echo "$sb"
+}
+
+# --------------------------------------------------------------------------
+# run_hook <sandbox> [extra-env-prefix]
+# Runs the hook from inside the sandbox and prints stdout+stderr.
+# --------------------------------------------------------------------------
+run_hook() {
+  local sb="$1"
+  local prefix="${2:-}"
+  ( cd "$sb" || exit 99
+    eval "$prefix bash .claude/hooks/link-custom-skills.sh 2>&1" )
+}
+
+assert() {
+  local name="$1"
+  local cond_rc="$2"
+  if [ "$cond_rc" -eq 0 ]; then
+    PASS=$((PASS + 1))
+    echo "PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  - $name"
+    echo "FAIL: $name"
+  fi
+}
+
+# ==========================================================================
+# Case 1 — no private custom-skills dir → no-op silent
+# ==========================================================================
+SB=$(make_fork)
+# No custom-skills dir created anywhere; no project-config override.
+out=$(run_hook "$SB")
+rc=$?
+# Should be exit 0, empty output, no symlinks created.
+[ "$rc" -eq 0 ] && [ -z "$out" ] && [ -z "$(ls -A "$SB/.claude/skills" 2>/dev/null)" ]
+assert "case 1: no private custom-skills dir → no-op silent (no symlinks, no output)" $?
+rm -rf "$SB"
+
+# ==========================================================================
+# Case 2 — private custom-skills dir with two skills → both symlinked
+# ==========================================================================
+SB=$(make_fork)
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+mkdir -p "$SIB/custom-skills/file-internal-bug" "$SIB/custom-skills/check-policy"
+cat > "$SIB/custom-skills/file-internal-bug/SKILL.md" <<'MD'
+---
+name: file-internal-bug
+description: File a bug in the internal tracker
+---
+# /file-internal-bug
+MD
+cat > "$SIB/custom-skills/check-policy/SKILL.md" <<'MD'
+---
+name: check-policy
+description: Check against the internal compliance corpus
+---
+# /check-policy
+MD
+cat > "$SB/.claude/project-config.json" <<JSON
+{ "portfolio": { "custom_skills_dir": "$SIB/custom-skills" } }
+JSON
+
+out=$(run_hook "$SB")
+rc=$?
+# Should: exit 0, summary line printed mentioning 2, both symlinks present
+# pointing into the sibling, AND both symlinks resolve to a SKILL.md.
+ok=1
+[ "$rc" -eq 0 ] || ok=0
+echo "$out" | grep -q "linked 2 custom skill" || ok=0
+[ -L "$SB/.claude/skills/file-internal-bug" ] || ok=0
+[ -L "$SB/.claude/skills/check-policy" ] || ok=0
+[ -f "$SB/.claude/skills/file-internal-bug/SKILL.md" ] || ok=0
+[ -f "$SB/.claude/skills/check-policy/SKILL.md" ] || ok=0
+[ "$ok" -eq 1 ] && rc2=0 || rc2=1
+assert "case 2: private dir with 2 custom skills → both symlinked, summary printed" "$rc2"
+if [ "$ok" -ne 1 ]; then echo "  out: $out"; fi
+rm -rf "$SB" "$SIB"
+
+# ==========================================================================
+# Case 3 — custom skill name collides with framework skill → custom wins
+# ==========================================================================
+SB=$(make_fork)
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+# Pre-populate a "framework" skill at the target name.
+mkdir -p "$SB/.claude/skills/feature"
+cat > "$SB/.claude/skills/feature/SKILL.md" <<'MD'
+---
+name: feature
+---
+# Framework /feature
+MD
+# Now create a custom skill of the same name in the private repo.
+mkdir -p "$SIB/custom-skills/feature"
+cat > "$SIB/custom-skills/feature/SKILL.md" <<'MD'
+---
+name: feature
+description: Custom feature skill (overrides framework default)
+---
+# Custom /feature
+MD
+cat > "$SB/.claude/project-config.json" <<JSON
+{ "portfolio": { "custom_skills_dir": "$SIB/custom-skills" } }
+JSON
+
+out=$(run_hook "$SB")
+rc=$?
+ok=1
+[ "$rc" -eq 0 ] || ok=0
+# Framework dir moved to <name>.framework.bak.
+[ -d "$SB/.claude/skills/feature.framework.bak" ] || ok=0
+# Custom symlink in place.
+[ -L "$SB/.claude/skills/feature" ] || ok=0
+# Symlink resolves to the custom SKILL.md (the body says "Custom").
+grep -q 'Custom /feature' "$SB/.claude/skills/feature/SKILL.md" || ok=0
+# Warning surfaced naming the override.
+echo "$out" | grep -q "override framework skill" || ok=0
+echo "$out" | grep -q "feature" || ok=0
+[ "$ok" -eq 1 ] && rc2=0 || rc2=1
+assert "case 3: name collision → custom wins; framework moved to .bak; warning printed" "$rc2"
+if [ "$ok" -ne 1 ]; then echo "  out: $out"; fi
+rm -rf "$SB" "$SIB"
+
+# ==========================================================================
+# Case 4 — Windows OS detection → graceful decline
+# ==========================================================================
+SB=$(make_fork)
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+mkdir -p "$SIB/custom-skills/file-internal-bug"
+cat > "$SIB/custom-skills/file-internal-bug/SKILL.md" <<'MD'
+---
+name: file-internal-bug
+---
+MD
+cat > "$SB/.claude/project-config.json" <<JSON
+{ "portfolio": { "custom_skills_dir": "$SIB/custom-skills" } }
+JSON
+
+# Force Windows path: set OSTYPE to "msys" so the hook hits the Windows
+# branch. We pass the env via the run_hook prefix.
+out=$(run_hook "$SB" "OSTYPE=msys")
+rc=$?
+ok=1
+[ "$rc" -eq 0 ] || ok=0
+# Decline message printed.
+echo "$out" | grep -q "not supported on Windows" || ok=0
+echo "$out" | grep -q "Manual workaround" || ok=0
+# No symlinks created.
+[ ! -L "$SB/.claude/skills/file-internal-bug" ] || ok=0
+[ "$ok" -eq 1 ] && rc2=0 || rc2=1
+assert "case 4: Windows OS → graceful decline with manual-install pointer; no symlinks" "$rc2"
+if [ "$ok" -ne 1 ]; then echo "  out: $out"; fi
+rm -rf "$SB" "$SIB"
+
+# ==========================================================================
+# Case 5 — idempotency: re-run is a no-op (no spurious warnings, no rework)
+# ==========================================================================
+SB=$(make_fork)
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+mkdir -p "$SIB/custom-skills/check-policy"
+cat > "$SIB/custom-skills/check-policy/SKILL.md" <<'MD'
+---
+name: check-policy
+---
+MD
+cat > "$SB/.claude/project-config.json" <<JSON
+{ "portfolio": { "custom_skills_dir": "$SIB/custom-skills" } }
+JSON
+
+# First run — should link.
+out1=$(run_hook "$SB")
+# Second run — should be silent (no work to do).
+out2=$(run_hook "$SB")
+ok=1
+[ -L "$SB/.claude/skills/check-policy" ] || ok=0
+echo "$out1" | grep -q "linked 1 custom skill" || ok=0
+[ -z "$out2" ] || ok=0
+[ "$ok" -eq 1 ] && rc2=0 || rc2=1
+assert "case 5: idempotent — second run is silent, symlink remains correct" "$rc2"
+if [ "$ok" -ne 1 ]; then echo "  out1: $out1"; echo "  out2: $out2"; fi
+rm -rf "$SB" "$SIB"
+
+# ==========================================================================
+# Case 6 — subdir without SKILL.md is skipped
+# ==========================================================================
+SB=$(make_fork)
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+mkdir -p "$SIB/custom-skills/no-skill-md/scratch"
+echo "not a skill" > "$SIB/custom-skills/no-skill-md/notes.txt"
+mkdir -p "$SIB/custom-skills/real-skill"
+cat > "$SIB/custom-skills/real-skill/SKILL.md" <<'MD'
+---
+name: real-skill
+---
+MD
+cat > "$SB/.claude/project-config.json" <<JSON
+{ "portfolio": { "custom_skills_dir": "$SIB/custom-skills" } }
+JSON
+
+out=$(run_hook "$SB")
+ok=1
+# Only the real skill is linked.
+[ -L "$SB/.claude/skills/real-skill" ] || ok=0
+[ ! -e "$SB/.claude/skills/no-skill-md" ] || ok=0
+# Summary line says 1.
+echo "$out" | grep -q "linked 1 custom skill" || ok=0
+[ "$ok" -eq 1 ] && rc2=0 || rc2=1
+assert "case 6: subdir without SKILL.md is skipped; only valid skills linked" "$rc2"
+if [ "$ok" -ne 1 ]; then echo "  out: $out"; fi
+rm -rf "$SB" "$SIB"
+
+# ==========================================================================
+# Summary
+# ==========================================================================
+echo
+echo "===== test_link_custom_skills.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed cases:$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_link_custom_skills.sh
+++ b/.claude/hooks/tests/test_link_custom_skills.sh
@@ -110,7 +110,8 @@ out=$(run_hook "$SB")
 rc=$?
 # Should be exit 0, empty output, no symlinks created.
 [ "$rc" -eq 0 ] && [ -z "$out" ] && [ -z "$(ls -A "$SB/.claude/skills" 2>/dev/null)" ]
-assert "case 1: no private custom-skills dir → no-op silent (no symlinks, no output)" $?
+rc2=$?
+assert "case 1: no private custom-skills dir → no-op silent (no symlinks, no output)" "$rc2"
 rm -rf "$SB"
 
 # ==========================================================================

--- a/.claude/hooks/tests/test_portfolio_paths.sh
+++ b/.claude/hooks/tests/test_portfolio_paths.sh
@@ -566,6 +566,81 @@ if [ -z "$r" ] && [ "$rc" -ne 0 ]; then exit 0; else echo "got=$r rc=$rc"; exit 
 '
 rm -rf "$SB"
 
+
+# Case 21 (#243): portfolio_custom_skills_dir defaults to in-fork path
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+run_case "v2/#243: portfolio_custom_skills_dir defaults to in-fork ./custom-skills" "$SB" '
+r=$(portfolio_custom_skills_dir)
+expected="'"$SB"'/custom-skills"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 22 (#243): portfolio_custom_handbooks_dir defaults to in-fork path
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+run_case "v2/#243: portfolio_custom_handbooks_dir defaults to in-fork ./custom-handbooks" "$SB" '
+r=$(portfolio_custom_handbooks_dir)
+expected="'"$SB"'/custom-handbooks"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 23 (#243): explicit overrides for the new keys win (split-portfolio v2 mode)
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+mkdir -p "$SIB/custom-skills" "$SIB/custom-handbooks"
+cat > "$SB/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "custom_skills_dir": "$SIB/custom-skills",
+    "custom_handbooks_dir": "$SIB/custom-handbooks"
+  }
+}
+JSON
+run_case "v2/#243: portfolio_custom_skills_dir override → sibling repo path" "$SB" '
+r=$(portfolio_custom_skills_dir)
+expected="'"$SIB"'/custom-skills"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "v2/#243: portfolio_custom_handbooks_dir override → sibling repo path" "$SB" '
+r=$(portfolio_custom_handbooks_dir)
+expected="'"$SIB"'/custom-handbooks"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SB" "$SIB"
+
+# ---------------------------------------------------------------------------
+# Case 24 (#243): relative override resolves against fork root
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+mkdir -p "$SB/elsewhere-skills" "$SB/elsewhere-hb"
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{
+  "portfolio": {
+    "custom_skills_dir": "./elsewhere-skills",
+    "custom_handbooks_dir": "./elsewhere-hb"
+  }
+}
+JSON
+run_case "v2/#243: relative-override custom_skills_dir resolves against fork root" "$SB" '
+r=$(portfolio_custom_skills_dir)
+expected="'"$SB"'/elsewhere-skills"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "v2/#243: relative-override custom_handbooks_dir resolves against fork root" "$SB" '
+r=$(portfolio_custom_handbooks_dir)
+expected="'"$SB"'/elsewhere-hb"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SB"
+
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -137,11 +137,13 @@
   ],
 
   "portfolio": {
-    "_comment": "Path resolution for the portfolio registry + per-project docs + ideas backlog + onboarding config + workspace dir. Defaults match single-fork mode (paths inside the fork). Override in .claude/project-config.json for split-portfolio mode (e.g. \"../portfolio/apexyard.projects.yaml\"). Relative paths resolve against the ops-fork root (the dir containing the .apexyard-fork marker, or the legacy onboarding.yaml + apexyard.projects.yaml pair). See docs/multi-project.md and AgDR-0010-portfolio-config-and-self-healing.md. The `onboarding` and `workspace_dir` keys were added in framework #242 (split-portfolio v2) — see docs/multi-project.md § 'Split-portfolio mode'.",
+    "_comment": "Path resolution for the portfolio registry + per-project docs + ideas backlog + onboarding config + workspace dir + private custom skills/handbooks. Defaults match single-fork mode (paths inside the fork). Override in .claude/project-config.json for split-portfolio mode (e.g. \"../portfolio/apexyard.projects.yaml\"). Relative paths resolve against the ops-fork root (the dir containing the .apexyard-fork marker, or the legacy onboarding.yaml + apexyard.projects.yaml pair). See docs/multi-project.md and AgDR-0010-portfolio-config-and-self-healing.md. The `onboarding` and `workspace_dir` keys were added in framework #242 (split-portfolio v2). The `custom_skills_dir` and `custom_handbooks_dir` keys were added in framework #243 — see docs/multi-project.md § 'Private custom skills + handbooks'.",
     "registry": "./apexyard.projects.yaml",
     "projects_dir": "./projects",
     "ideas_backlog": "./projects/ideas-backlog.md",
     "onboarding": "./onboarding.yaml",
-    "workspace_dir": "./workspace"
+    "workspace_dir": "./workspace",
+    "custom_skills_dir": "./custom-skills",
+    "custom_handbooks_dir": "./custom-handbooks"
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,10 @@
           {
             "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/clear-bootstrap-marker.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ ! -f \"$r/.apexyard-fork\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/link-custom-skills.sh\"'"
           }
         ]
       }

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -112,6 +112,8 @@ The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — pub
    - empty `projects/` dir (with a `.gitkeep` so the dir survives the initial commit)
    - empty `workspace/` dir (with a `.gitkeep`) — managed-project clones land here
    - **`onboarding.yaml`** seeded from the framework template — split-portfolio v2 (#242) moves company/team/stack config to the private repo too, so the public fork stays slim
+   - empty **`custom-skills/`** dir + a one-paragraph `custom-skills/README.md` explaining the convention. Company-specific proprietary skills (`/file-internal-bug`, `/check-policy`, etc.) live as `custom-skills/<name>/SKILL.md` here; the public fork's `link-custom-skills.sh` SessionStart hook symlinks each into `.claude/skills/<name>/` so Claude Code discovers them. Custom skill names override framework skills of the same name (warning printed at SessionStart). See `docs/multi-project.md` § "Private custom skills + handbooks" for the full convention. (Added in #243.)
+   - empty **`custom-handbooks/`** dir + a one-paragraph `custom-handbooks/README.md` explaining the convention. Company-confidential coding standards live as `custom-handbooks/{architecture,general,language/<lang>}/*.md` here, mirroring the public `handbooks/` path-convention. Rex consumes both layers during code review (advisory by default, blocking with `ENFORCEMENT: blocking` at the top of the file). See `handbooks/README.md` for the format. (Added in #243.)
    - `.gitignore` with `workspace/*/` so the inner clones don't get double-tracked in the private repo either
    - initial commit + push
 6. **Configure path resolution in the fork** (recommended — v2 config-block mode):
@@ -126,10 +128,14 @@ The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — pub
          "projects_dir": "../apexyard-portfolio/projects",
          "ideas_backlog": "../apexyard-portfolio/projects/ideas-backlog.md",
          "onboarding": "../apexyard-portfolio/onboarding.yaml",
-         "workspace_dir": "../apexyard-portfolio/workspace"
+         "workspace_dir": "../apexyard-portfolio/workspace",
+         "custom_skills_dir": "../apexyard-portfolio/custom-skills",
+         "custom_handbooks_dir": "../apexyard-portfolio/custom-handbooks"
        }
      }
      ```
+
+     The two `custom_*_dir` keys are optional — defaults match `./custom-skills` and `./custom-handbooks` resolved against the ops-fork root. Setting them explicitly here is the v2 split-portfolio shape and matches what step 5 just created in the private repo.
 
    - **Write the `.apexyard-fork` marker** at the public-fork root. This is the v2 ops-fork anchor — `_lib-ops-root.sh` and every hook that walks up to find the ops fork looks for this marker first (with the legacy `onboarding.yaml + apexyard.projects.yaml` pair as fallback). **Spec: presence-only — readers MUST ignore content; only file presence matters.** Writers MAY include a single explanatory line so `head .apexyard-fork` is informative for operators encountering it the first time. See [AgDR-0021](../../../docs/agdr/AgDR-0021-split-portfolio-v2-path-resolution.md) § B for the rationale.
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,17 @@
 # must not be double-tracked from the ops repo.
 workspace/*/
 !workspace/README.md
+
+# Backups of framework skills that were overridden by an adopter's
+# private custom skill (link-custom-skills.sh moves the framework version
+# aside as <skill-name>.framework.bak so the symlink can take its place).
+# These are per-machine artefacts; never committed.
+.claude/skills/*.framework.bak/
+
+# Symlinks at .claude/skills/<name>/ created by link-custom-skills.sh
+# pointing into the private sibling repo's custom-skills/ are NOT covered
+# by a globbed gitignore (we can't predict adopter skill names without
+# clobbering framework skill names). The hook never stages them, and
+# `git status` shows them as untracked symlinks — leave them alone.
+# If you absolutely want to suppress the untracked-symlink line, add the
+# specific name to .git/info/exclude on each clone.

--- a/docs/agdr/AgDR-0022-private-customs-name-collision-semantics.md
+++ b/docs/agdr/AgDR-0022-private-customs-name-collision-semantics.md
@@ -1,0 +1,121 @@
+# Private Customs — Delivery Mechanism, Name-Collision Semantics, and Two-Layer Handbook Discovery
+
+> In the context of split-portfolio v2 adopters wanting a private home for **company-specific** custom skills + cross-org handbooks, facing the question of *how* those private artefacts surface inside the public fork's runtime (`.claude/skills/`, Rex's handbook context), I decided to ship a SessionStart symlink hook plus a "custom wins, framework backed up to `.framework.bak`" name-collision rule plus a two-layer handbook discovery in Rex, to keep the public-fork tree authoritative-on-disk while letting the private repo override skills and append handbooks, accepting the trade-offs of relying on POSIX symlinks (Windows requires manual install) and a `.bak` artefact in `.claude/skills/`.
+
+## Context
+
+Adopters running split-portfolio v2 have a private sibling repo (`<fork>-portfolio`) that already houses the registry, per-project docs, `onboarding.yaml`, and `workspace/`. v2 closed the public-fork leak surface for those four file classes. The next gap is **adopter-authored skills + handbooks**:
+
+- A CTO running ApexYard internally writes a `/file-internal-bug` skill that knows the company's bug-tracker conventions. That skill body names the tracker URL, internal project codes, perhaps even API tokens. It cannot ship in the public fork.
+- The same CTO wants Rex to read a `company-coding-standards.md` handbook on every PR review. That handbook describes their internal naming conventions, sometimes referencing private repos. Also cannot ship in the public fork.
+
+Today the only way to wire these in is to commit them directly to the public fork (leaks) OR maintain them out-of-band and remember to re-apply on every machine (lossy). The framework needs a first-class home for both, and it has to:
+
+1. **Surface custom skills as if they were native** — `/file-internal-bug` must work at the user's prompt without ceremony
+2. **Surface custom handbooks to Rex** — Rex's code review must read them on diffs that match their language/architecture path conventions, same as framework handbooks
+3. **Never store either in the public fork's tree**
+
+Three sub-decisions had to be made together because they interact.
+
+## Decision A — Skill delivery mechanism: symlink vs plugin install vs config-block-only resolution
+
+### Options considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A1. Plugin install** — package each adopter custom skill as a Claude Code plugin and install via `/plugin install <local-path>` | First-class surface; matches the official plugin mechanism we use for LSP | Plugin-install plumbing is heavyweight per-skill; adopter has to repackage on every skill edit; no native symlink-like "edit in private repo, see in fork" iteration loop |
+| **A2. Direct copy on SessionStart** — copy `<sibling>/custom-skills/<name>/` → `<fork>/.claude/skills/<name>/` on every session start | Simple; no symlinks (works on Windows out of the box) | Writes into the public fork's tree, which means dirty working copy on every session, gitignored or not. Friction with `git status` review. Also: per-edit re-copy required, which silently overwrites in-progress edits |
+| **A3. Symlink on SessionStart** — `ln -sf <sibling>/custom-skills/<name> <fork>/.claude/skills/<name>` | Adopter edits in private repo, fork picks up immediately, no working-copy churn (the symlink itself is gitignored). Idempotent re-runs are cheap. | POSIX-only (Windows ln equivalent is fragile); leaves `.claude/skills/` with mixed real-dir + symlink-dir entries (operator has to remember which is which); requires gitignore discipline (already covered for v2) |
+| **A4. Runtime config-block resolution only** — extend Claude Code skill loader to consult `portfolio.custom_skills_dir`, no on-disk linking | Cleanest semantics; nothing lands in `.claude/skills/`; matches how onboarding.yaml resolution already works | Requires changes inside Claude Code itself (the loader, the slash-command resolver, the autocomplete index) — outside the framework's reach. Not viable in framework-only territory. |
+
+### Choice — **A3 (symlink on SessionStart)**
+
+The framework lives at the "everything outside Claude Code internals" boundary. A4 is the cleanest design but requires loader cooperation we don't have. A3 gets us 90% of A4's behaviour using existing primitives (symlinks + the SessionStart hook chain). A1 has the right semantics but the per-edit packaging tax is too high for the "I just want a skill" use case. A2 turns every session into a dirty tree.
+
+A3's failure mode (Windows) is contained: the `link-custom-skills.sh` hook detects `uname` reporting MSYS/MINGW/Cygwin and prints a one-line "manual-install pointer" instead of attempting `ln`. Adopters on Windows can copy by hand or run the hook under WSL where symlinks work. This is the same shape as the existing LSP optional-plugin behaviour — feature available on POSIX, graceful decline on Windows.
+
+## Decision B — Name-collision semantics: framework vs custom
+
+### Options considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **B1. Framework wins** — refuse to link custom `/handover` over framework `/handover`, print warning | Conservative; framework behaviour stays predictable; CEO never gets a custom skill they forgot they wrote shadowing the canonical one | Defeats the use case: adopters who want a customised `/handover` (their org has a different onboarding checklist) cannot override. They'd have to fork the skill upstream, which means going public again. |
+| **B2. Custom wins, no backup** — symlink overwrites the framework skill dir; on uninstall there's nothing to restore | Adopter intent is honoured | Destructive — if the operator removes their custom skill, the framework version is gone too; recovery requires `git checkout .claude/skills/handover` which is a chore + footgun |
+| **B3. Custom wins, framework moved to `.framework.bak`** — `mv .claude/skills/handover .claude/skills/handover.framework.bak; ln -sf <sibling>/custom-skills/handover .claude/skills/handover` | Adopter intent honoured AND the framework version is recoverable in one `mv` back. Visible in `ls`, so the operator sees what's happening. | Leaves a `.bak` artefact in `.claude/skills/`. Gitignored via `*.framework.bak` to avoid noise. Marginal cognitive overhead. |
+| **B4. Prompt operator on collision** — interactive ask: "framework `/handover` exists, override?" | Most explicit | Hook runs at SessionStart — there's no operator to prompt yet. Defers the decision to a place no operator can answer it. |
+
+### Choice — **B3 (custom wins, framework moved to `.framework.bak`)**
+
+The CTO writing a custom `/handover` is making a deliberate override decision. The framework should honour it (B1 fails the use case) but not destructively (B2 is a footgun). B4 doesn't work at SessionStart. B3 is the only option that both honours intent and leaves a recovery path. The `.framework.bak` artefact is the cost; gitignoring `*.framework.bak` keeps it out of `git status`.
+
+The hook prints a one-line warning on every collision so the operator sees `which command they overrode`:
+
+```
+link-custom-skills: /handover overridden by custom; framework moved to .claude/skills/handover.framework.bak
+```
+
+## Decision C — SessionStart timing for the link operation
+
+### Options considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **C1. SessionStart hook (chosen)** | Runs once per session before any skill is invoked; idempotent re-link refreshes if adopter added/renamed/deleted a custom skill between sessions; aligns with `clear-bootstrap-marker.sh`, `check-upstream-drift.sh`, `portfolio_validate` | Adds one more hook to the SessionStart chain. Latency contribution: < 50ms (single `find` + symlink calls). |
+| **C2. Trigger-on-skill-invoke** — link the specific skill the first time the operator types `/file-internal-bug` | Lazy; no startup cost | Plumbing intrusive; would require Claude Code to call the framework on skill-not-found, which it doesn't do. Same A4-shaped problem. |
+| **C3. One-shot install at `/setup` time** | Zero per-session cost | Adopters who add a new custom skill after running `/setup` have to remember to re-run a separate install command. High forgetfulness tax. |
+
+### Choice — **C1 (SessionStart hook)**
+
+SessionStart is already the framework's main "ensure invariants on every session" surface. Adding `link-custom-skills.sh` there matches the existing pattern, and the per-session latency cost (<50ms) is invisible against the rest of the SessionStart chain. C3 fails on the iteration loop — adopters edit custom skills frequently in early days, and "remember to re-install" is the exact ceremony the framework should absorb.
+
+The hook is silent on success (zero new custom skills, or N skills linked with no collisions) and prints **only one line per collision OR a summary like `linked 2 custom skills`** otherwise. Banner shape mirrors `check-upstream-drift.sh`.
+
+## Decision D — Rex handbook discovery: two-layer (framework + custom) vs single-layer
+
+### Options considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **D1. Single-layer, symlink custom handbooks into `handbooks/`** (same shape as the skills choice) | Symmetric with custom skills; one mechanism | Adopters editing handbooks would see them mixed with framework handbooks in `ls handbooks/`; collisions get the same `.framework.bak` treatment, which is overkill for the "additive notes" use case where adopters usually want to *add* a handbook rather than override one |
+| **D2. Two-layer: Rex reads both `handbooks/` (framework, in the fork) AND `<sibling>/custom-handbooks/` (resolved via the portfolio config block)** | Adopter handbooks are additive by default — they sit alongside framework ones in Rex's context without shadowing; symbolic override is still possible (same `architecture/` / `general/` / `language/<lang>/` path convention applies to both layers, so a custom file at `custom-handbooks/general/security.md` adds to whatever framework ships under `handbooks/general/`) | Two discovery roots; Rex's agent prompt has to enumerate both; slightly more complex to reason about |
+| **D3. Single-layer, all handbooks live in private repo** (move framework handbooks out of the public fork entirely) | Maximally clean separation | Loses the framework's shipped handbooks (the architecture/general/language/ examples Rex ships with). Adopters who don't write any handbooks get zero. |
+
+### Choice — **D2 (two-layer discovery in Rex)**
+
+Custom handbooks are typically **additive** — *"add our company's TypeScript naming convention on top of what apexyard already ships"*. The skills-style "custom wins, framework backed up" semantics are wrong for the additive case; they force every custom handbook to override a framework one. D1 reuses the skills mechanism but fights the actual use case.
+
+D3 is the cleanest design but loses the shipped handbooks, which are the demo content for the feature. D2 gets the best of both — Rex reads framework `handbooks/` plus `<sibling>/custom-handbooks/` (resolved via `portfolio.custom_handbooks_dir` from the config block), applies the same `architecture/` + `general/` + `language/<lang>/` path conventions to both, and the operator can layer or shadow as they choose just by where they put the file.
+
+The agent prompt for Rex (`.claude/agents/code-reviewer.md`) enumerates both roots in its discovery step. The framework's existing `handbooks/README.md` documents the layering.
+
+## Consequences
+
+### Positive
+
+- Adopters get a private home for company-specific skills and handbooks without ever staging private content in the public fork's tree
+- The `link-custom-skills.sh` hook is idempotent and SessionStart-driven, matching the existing framework hook patterns
+- Name collisions are visible (`.framework.bak` artefact + one-line warning) rather than silent
+- Rex picks up custom handbooks on the same diff-match conventions as framework handbooks — no per-handbook configuration
+- Windows operators get a graceful decline with a manual-install pointer rather than a confusing failure
+
+### Negative
+
+- `.claude/skills/` becomes a mixed dir of real dirs (framework) + symlinks (custom) + `*.framework.bak` (overridden). Operators reviewing `ls` must remember to interpret each. Mitigated by the hook printing a summary line on link/override.
+- Windows is degraded (manual install). Documented; same shape as LSP plugins.
+- Two-layer handbook discovery has a slightly larger surface in Rex's agent prompt than a single-layer model would. Acceptable; the agent prompt already enumerates multiple sources.
+
+### Open questions deferred to a future AgDR
+
+- Whether to support per-project custom handbooks (currently org-wide only; a managed-project would need to handbook-customise via its own repo's `handbooks/`).
+- Whether to expose custom-skill discovery to plain `claude` CLI (currently the symlink approach works for both interactive sessions and CLI use; verified during #243 implementation).
+
+## Artifacts
+
+- Implementation: `.claude/hooks/link-custom-skills.sh` (POSIX symlink, idempotent, Windows decline)
+- Tests: `.claude/hooks/tests/test_link_custom_skills.sh` (6 cases — no-op, two-skill link, collision, Windows, idempotent re-run, subdir-without-SKILL.md skip)
+- Path resolution: `_lib-portfolio-paths.sh` → `portfolio_custom_skills_dir`, `portfolio_custom_handbooks_dir`
+- Setup docs: `.claude/skills/setup/SKILL.md` (config-block keys); `docs/multi-project.md` (split-portfolio v2 section); `handbooks/README.md` (two-layer discovery note)
+- Wiring: `.claude/settings.json` (SessionStart entry); `.gitignore` (`.claude/skills/*.framework.bak`, custom-skills symlinks)
+- Agent prompt: `.claude/agents/code-reviewer.md` (Rex's discovery step now enumerates both handbook roots)
+- Issue: #243 / PR #253

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -425,6 +425,81 @@ You'll never need to manage session-state files by hand. If you ever see a "BLOC
 
 In exchange, **zero of your private project names ever land on a public GitHub repo**, ever.
 
+### Private custom skills + handbooks
+
+Split-portfolio mode also houses two layers of company-specific customisation that wouldn't be safe to publish on the public fork (introduced in framework #243):
+
+| Layer | Where in the private repo | What lives here |
+| --- | --- | --- |
+| **Custom skills** | `<private_repo>/custom-skills/<name>/SKILL.md` | Company-specific proprietary slash commands — `/file-internal-bug` against your internal tracker, `/check-policy` against a private compliance corpus, `/escalate-to-pagerduty`, etc. |
+| **Custom handbooks** | `<private_repo>/custom-handbooks/{architecture,general,language/<lang>}/*.md` | Company-confidential coding standards that name internal systems, refer to proprietary policy, or otherwise don't belong on a public repo. Same path-convention as the public `handbooks/` tree. |
+
+#### How discovery works
+
+- **Custom skills** — Claude Code discovers skills by walking `.claude/skills/<name>/SKILL.md` in the active fork. We don't control that glob path. The `link-custom-skills.sh` SessionStart hook fixes that gap: on every session start it iterates `<private_repo>/custom-skills/<name>/`, and for each subdirectory containing a `SKILL.md` it creates a gitignored symlink at `.claude/skills/<name>/` pointing into the private dir. Claude Code then sees the skill transparently. **Custom skills with the same name as a framework skill win** — the hook moves the framework version to `.claude/skills/<name>.framework.bak/` (gitignored) and prints a one-line warning at SessionStart so the override is visible. **Windows is not supported in v1**; the hook prints a one-line manual-install pointer and skips. Same shape as the LSP install on Windows.
+- **Custom handbooks** — Rex's agent prompt (`.claude/agents/code-reviewer.md` § 8) gains a second discovery path. The `portfolio_custom_handbooks_dir` resolver in `_lib-portfolio-paths.sh` returns the private dir; Rex globs both the public `handbooks/` tree AND the private one using the same architecture/general/language convention. No symlinks involved — handbooks aren't discovered by Claude Code, only by Rex's prompt, so a second glob is enough. Per-handbook precedence on overlapping topics: **Rex applies BOTH layers** and cites both when relevant; conflict resolution is the operator's responsibility (write it as prose in the custom handbook).
+
+#### Setup
+
+`/setup --split-portfolio` (or step 5 of the manual setup above) creates the two empty dirs in the private repo with a one-paragraph README explaining the convention. The two new keys go in your config block alongside the existing v2 keys:
+
+```json
+{
+  "portfolio": {
+    "registry":             "../apexyard-portfolio/apexyard.projects.yaml",
+    "projects_dir":         "../apexyard-portfolio/projects",
+    "ideas_backlog":        "../apexyard-portfolio/projects/ideas-backlog.md",
+    "onboarding":           "../apexyard-portfolio/onboarding.yaml",
+    "workspace_dir":        "../apexyard-portfolio/workspace",
+    "custom_skills_dir":    "../apexyard-portfolio/custom-skills",
+    "custom_handbooks_dir": "../apexyard-portfolio/custom-handbooks"
+  }
+}
+```
+
+The two `custom_*_dir` keys are optional — defaults resolve to `./custom-skills` and `./custom-handbooks` against the ops-fork root. For split-portfolio adopters, set them explicitly to the sibling repo so the dirs come out of the private layer.
+
+#### Authoring a custom skill
+
+Manual `cp + edit` is fine for v1 — there's no `/custom-skill` authoring helper:
+
+```bash
+cd ~/ops/apexyard-portfolio
+
+# Copy a framework skill as a starting shape (or write from scratch)
+cp -R ~/ops/apexyard/.claude/skills/feature custom-skills/file-internal-bug
+$EDITOR custom-skills/file-internal-bug/SKILL.md   # adjust frontmatter (name, description, argument-hint)
+
+git add custom-skills/file-internal-bug
+git commit -m "feat: add /file-internal-bug for the internal tracker"
+git push
+```
+
+Next session start in the public fork, the `link-custom-skills.sh` SessionStart hook surfaces the new skill as `.claude/skills/file-internal-bug/` and Claude Code starts discovering it.
+
+#### Authoring a custom handbook
+
+Same as the public-handbook convention — copy a sample, edit, commit:
+
+```bash
+cd ~/ops/apexyard-portfolio
+mkdir -p custom-handbooks/architecture
+cp ~/ops/apexyard/handbooks/architecture/clean-architecture-layers.md custom-handbooks/architecture/internal-pii-handling.md
+$EDITOR custom-handbooks/architecture/internal-pii-handling.md   # write the rule
+git add custom-handbooks/architecture/internal-pii-handling.md
+git commit -m "docs: handbook on internal PII handling"
+```
+
+Next code review, Rex globs both `handbooks/architecture/*.md` AND `<private>/custom-handbooks/architecture/*.md` and applies findings from both. Add `ENFORCEMENT: blocking` at the top of the file to opt the rule into REQUEST CHANGES verdicts; default is advisory.
+
+#### Out of scope (v1)
+
+- **Per-team / per-project handbook overrides.** Still framework-level only — handbooks travel with the ops fork (and the private layer for split-portfolio adopters). File a separate ticket if multi-team adopters need this.
+- **Encryption on top of gitignore for the private custom dirs.** They're inside a private GitHub repo; the gitignore on the public fork is the boundary.
+- **Distribution to other organisations.** Custom skills + handbooks are private to one org by design — sharing across orgs is what the public framework + handbooks layer is for.
+- **A `/custom-skill` authoring helper.** Manual `cp framework-skill custom-skills/...` + edit is fine for v1.
+- **Multi-version handbook conflict resolution.** Operator's prose responsibility.
+
 ### Migrating from split-portfolio v1 to v2
 
 If you adopted split-portfolio mode before framework #242, your fork is on the v1 layout: `apexyard.projects.yaml` and `projects/` resolve to the sibling private repo (good), but `onboarding.yaml` and `workspace/` are still in the public fork. The v2 migration moves both to the private repo too, and writes the new `.apexyard-fork` anchor.

--- a/handbooks/README.md
+++ b/handbooks/README.md
@@ -6,6 +6,8 @@ This is the place to encode the rules your team would otherwise enforce by Slack
 
 Decision rationale: [`docs/agdr/AgDR-0020-adopter-handbooks-for-rex.md`](../docs/agdr/AgDR-0020-adopter-handbooks-for-rex.md).
 
+> **Two layers, same convention.** This `handbooks/` tree lives in the public ops fork — handbooks here are safe to publish on a public framework fork. Split-portfolio adopters who want company-confidential handbooks (naming internal systems, referring to proprietary policy, etc.) can additionally drop them at `<private_repo>/custom-handbooks/{architecture,general,language/<lang>}/*.md`. Rex discovers both layers using the **same path-convention** described below and applies findings from both. Resolution helper: `portfolio_custom_handbooks_dir` in `.claude/hooks/_lib-portfolio-paths.sh`. Setup pointer: `docs/multi-project.md` § "Private custom skills + handbooks". Single-fork adopters typically only use this `handbooks/` tree.
+
 ## Discovery
 
 Rex finds handbooks by **path convention** — there is no YAML frontmatter, no `applies_to:` glob to maintain. The directory IS the targeting metadata.


### PR DESCRIPTION
## Summary

Split-portfolio v2 adopters can now drop **company-specific proprietary skills** (e.g. `/file-internal-bug` against an internal tracker, `/check-policy` against a private compliance corpus) and **company-confidential coding standards** (handbooks naming internal systems / proprietary policy) into the private sibling repo. The public framework fork stays slim — operator-authored generic customisations only.

- Two new layers in the private sibling repo (split-portfolio adopters): `<private_repo>/custom-skills/<name>/SKILL.md` for proprietary skills and `<private_repo>/custom-handbooks/{architecture,general,language/<lang>}/*.md` for confidential coding standards (same path-convention as public `handbooks/`).
- New SessionStart hook `link-custom-skills.sh` symlinks each custom-skill subdir into `.claude/skills/<name>/` so Claude Code's existing discovery walks it transparently. Custom skills with the same name as a framework skill **win** — framework version moves aside to `<name>.framework.bak` (gitignored) and a one-line warning is printed so the override is visible. Windows declines gracefully (mirrors LSP-on-Windows shape from `/setup`).
- Rex (`code-reviewer.md` § 8) gains a second discovery path for private custom handbooks via the new `portfolio_custom_handbooks_dir` resolver in `_lib-portfolio-paths.sh`. Both layers load on every review; per-handbook precedence on overlapping topics is operator-managed prose.
- `/setup --split-portfolio` creates the two empty dirs in the private repo with READMEs and threads them into the v2 config block (`portfolio.custom_skills_dir` / `portfolio.custom_handbooks_dir`). Single-fork adopters see zero behaviour change — the dirs default to in-fork paths and the SessionStart hook is a no-op when the dir is missing.

## Testing

- Run `bash .claude/hooks/tests/test_link_custom_skills.sh` — 6 cases (no-op / two-skills linked / name collision / Windows decline / idempotency / no-SKILL.md skip).
- Run `bash .claude/hooks/tests/test_portfolio_paths.sh` — 6 new cases for `portfolio_custom_skills_dir` + `portfolio_custom_handbooks_dir` (defaults / overrides / relative-resolution).
- Full hook test suite (24 test files) runs cleanly with 0 regressions.
- Manual repro for the symlink path: create `<private>/custom-skills/<name>/SKILL.md`, set the config-block override, start a new session — `.claude/skills/<name>/` exists as a symlink, `ls -la .claude/skills/<name>/SKILL.md` resolves into the private dir, summary line on stderr reports "linked 1 custom skill".

## Glossary

| Term | Definition |
|------|------------|
| Custom skill | A company-specific slash command authored as `SKILL.md` inside `<private>/custom-skills/<name>/`. Discovered by Claude Code via a SessionStart symlink at `.claude/skills/<name>/`. |
| Custom handbook | A company-specific coding-standards markdown file inside `<private>/custom-handbooks/{architecture,general,language/<lang>}/`. Discovered by Rex via a second glob source — no symlinks. |
| Split-portfolio v2 | The framework layout (introduced in #242) where `onboarding.yaml`, `apexyard.projects.yaml`, `projects/`, `workspace/` all live in the private sibling repo with the public fork holding only framework files. The `.apexyard-fork` marker anchors the fork-root walk-up. |
| `portfolio_custom_skills_dir` | New resolver in `_lib-portfolio-paths.sh` returning the absolute path to the custom-skills root. Default `./custom-skills`; overridable via the config block. |
| `portfolio_custom_handbooks_dir` | Sibling resolver for the custom-handbooks root. Default `./custom-handbooks`. |
| Name collision | Custom skill with the same name as a framework skill. Custom wins; framework version is moved to `<name>.framework.bak` (gitignored) and a SessionStart warning is printed. |
| Advisory vs blocking handbook | A handbook is advisory by default (Rex surfaces nits). Adding `ENFORCEMENT: blocking` at the top of the file flips it to a REQUEST CHANGES verdict. Identical behaviour across public and private layers. |

Closes #243