### PR TITLE
feat(#250): /update --from-dev hidden flag for pre-release sync

### DIFF
--- a/.claude/hooks/tests/test_update_from_dev.sh
+++ b/.claude/hooks/tests/test_update_from_dev.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+# Smoke test for the --from-dev hidden flag in /update (#250).
+#
+# /update is a markdown skill, not a shell script — there's no direct
+# binary to invoke. This test pins the bash recipe the skill spec
+# documents (flag parse → banner → fetch → preview against the right
+# ref → no state mutation under --dry-run) so the recipe stays
+# runnable and the spec stays internally consistent.
+#
+# Cases:
+#   1. --from-dev sets UPSTREAM_REF=upstream/dev (not upstream/main)
+#   2. --from-dev sets BRANCH_SUFFIX=sync-upstream-dev (not -apexyard)
+#   3. Without --from-dev, defaults are upstream/main + sync-upstream-apexyard
+#   4. Banner prints when --from-dev is set, BEFORE fetch
+#   5. Banner does NOT print without --from-dev
+#   6. --from-dev --dry-run on a synthetic fork:
+#       - banner appears
+#       - preview compares HEAD against upstream/dev
+#       - no state change (HEAD unchanged, no new branch, no new commits)
+#   7. SKILL.md frontmatter description does NOT mention --from-dev
+#   8. SKILL.md ## Usage section DOES mention --from-dev
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SKILL="$SRC_ROOT/.claude/skills/update/SKILL.md"
+
+[ -f "$SKILL" ] || { echo "FAIL: missing $SKILL" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+FAILED=""
+
+mark_pass() { echo "  ✓ $1"; PASS=$((PASS+1)); }
+mark_fail() { echo "  ✗ $1: $2" >&2; FAIL=$((FAIL+1)); FAILED="$FAILED\n  - $1"; }
+
+# ---------------------------------------------------------------------
+# The flag-parse recipe from the skill, pulled into a function so each
+# case can call it with different argv. Keep this in lockstep with the
+# pre-step bash block in SKILL.md.
+# ---------------------------------------------------------------------
+parse_flags() {
+  FROM_DEV=0
+  DRY_RUN=0
+  REBASE=0
+  for arg in "$@"; do
+    case "$arg" in
+      --from-dev) FROM_DEV=1 ;;
+      --dry-run)  DRY_RUN=1 ;;
+      --rebase)   REBASE=1 ;;
+    esac
+  done
+
+  if [ "$FROM_DEV" = "1" ]; then
+    UPSTREAM_REF=upstream/dev
+    BRANCH_SUFFIX=sync-upstream-dev
+  else
+    UPSTREAM_REF=upstream/main
+    BRANCH_SUFFIX=sync-upstream-apexyard
+  fi
+}
+
+# Banner contents — matches the skill's pre-step output verbatim.
+print_banner_if_dev() {
+  if [ "$FROM_DEV" = "1" ]; then
+    cat <<'EOB'
+⚠ PRE-RELEASE SYNC — pulling from upstream/dev
+   This is unreleased work; expect breakage.
+   Revert with: git reset --hard origin/main
+   For supported updates, use /update (no flag) to pull tagged releases.
+EOB
+  fi
+}
+
+# ---------------------------------------------------------------------
+# Case 1 — --from-dev sets UPSTREAM_REF=upstream/dev
+# ---------------------------------------------------------------------
+echo "Case 1 — --from-dev sets UPSTREAM_REF=upstream/dev"
+parse_flags --from-dev
+if [ "$UPSTREAM_REF" = "upstream/dev" ]; then
+  mark_pass "UPSTREAM_REF=upstream/dev"
+else
+  mark_fail "UPSTREAM_REF=upstream/dev" "got '$UPSTREAM_REF'"
+fi
+
+# ---------------------------------------------------------------------
+# Case 2 — --from-dev sets BRANCH_SUFFIX=sync-upstream-dev
+# ---------------------------------------------------------------------
+echo "Case 2 — --from-dev sets BRANCH_SUFFIX=sync-upstream-dev"
+parse_flags --from-dev
+if [ "$BRANCH_SUFFIX" = "sync-upstream-dev" ]; then
+  mark_pass "BRANCH_SUFFIX=sync-upstream-dev"
+else
+  mark_fail "BRANCH_SUFFIX=sync-upstream-dev" "got '$BRANCH_SUFFIX'"
+fi
+
+# ---------------------------------------------------------------------
+# Case 3 — defaults without --from-dev
+# ---------------------------------------------------------------------
+echo "Case 3 — no --from-dev → defaults"
+parse_flags --dry-run
+if [ "$UPSTREAM_REF" = "upstream/main" ] && [ "$BRANCH_SUFFIX" = "sync-upstream-apexyard" ]; then
+  mark_pass "defaults preserved"
+else
+  mark_fail "defaults preserved" "got UPSTREAM_REF=$UPSTREAM_REF BRANCH_SUFFIX=$BRANCH_SUFFIX"
+fi
+
+# ---------------------------------------------------------------------
+# Case 4 — banner prints with --from-dev
+# ---------------------------------------------------------------------
+echo "Case 4 — --from-dev prints PRE-RELEASE banner"
+parse_flags --from-dev
+banner_out=$(print_banner_if_dev)
+if echo "$banner_out" | grep -q "PRE-RELEASE SYNC"; then
+  mark_pass "banner emitted"
+else
+  mark_fail "banner emitted" "got: $banner_out"
+fi
+if echo "$banner_out" | grep -q "Revert with: git reset --hard origin/main"; then
+  mark_pass "banner has revert hint"
+else
+  mark_fail "banner has revert hint" "missing revert hint"
+fi
+
+# ---------------------------------------------------------------------
+# Case 5 — no banner without --from-dev
+# ---------------------------------------------------------------------
+echo "Case 5 — plain /update prints NO banner"
+parse_flags
+banner_out=$(print_banner_if_dev)
+if [ -z "$banner_out" ]; then
+  mark_pass "no banner without --from-dev"
+else
+  mark_fail "no banner without --from-dev" "got banner: $banner_out"
+fi
+
+# ---------------------------------------------------------------------
+# Case 6 — --from-dev --dry-run on a synthetic fork: banner + preview
+# against upstream/dev + no state change.
+# ---------------------------------------------------------------------
+echo "Case 6 — --from-dev --dry-run smoke (synthetic fork)"
+
+SBOX=$(mktemp -d)
+trap 'rm -rf "$SBOX"' EXIT
+
+# Build an upstream with a main branch and a dev branch with extra commits.
+UPSTREAM="$SBOX/upstream"
+mkdir -p "$UPSTREAM"
+(
+  cd "$UPSTREAM" || exit 1
+  git init -q -b main
+  git config user.email t@t && git config user.name t
+  echo "init" > a.txt && git add a.txt && git commit -q -m "init"
+  echo "v1" >> a.txt && git commit -q -am "v1.0.0"
+  git tag v1.0.0
+  git checkout -q -b dev
+  echo "dev work 1" >> a.txt && git commit -q -am "feat: dev work 1"
+  echo "dev work 2" >> a.txt && git commit -q -am "feat: dev work 2"
+  echo "dev work 3" >> a.txt && git commit -q -am "feat: dev work 3"
+  git checkout -q main
+) || { mark_fail "build upstream" "git init failed"; FAIL=$((FAIL+1)); }
+
+# Clone fork from upstream's main, configure upstream remote.
+FORK="$SBOX/fork"
+git clone -q "$UPSTREAM" "$FORK" 2>/dev/null
+(
+  cd "$FORK" || exit 1
+  git config user.email f@f && git config user.name f
+  git remote rename origin upstream 2>/dev/null
+  git remote add origin "$UPSTREAM" 2>/dev/null  # synthetic origin
+  git fetch -q upstream
+  git fetch -q origin
+) || { mark_fail "build fork" "clone failed"; FAIL=$((FAIL+1)); }
+
+# Snapshot HEAD + branches before running the recipe.
+HEAD_BEFORE=$(cd "$FORK" && git rev-parse HEAD)
+BRANCHES_BEFORE=$(cd "$FORK" && git branch --list | sort)
+
+# Run the recipe inside the fork (banner + preview + dry-run exit).
+RUN_OUT=$(
+  cd "$FORK" || exit 1
+  parse_flags --from-dev --dry-run
+  print_banner_if_dev
+
+  # Preview step — count commits between HEAD and the resolved upstream ref.
+  AHEAD=$(git rev-list --count "$UPSTREAM_REF"..main 2>/dev/null || echo 0)
+  BEHIND=$(git rev-list --count main.."$UPSTREAM_REF" 2>/dev/null || echo 0)
+  echo "PREVIEW: ref=$UPSTREAM_REF ahead=$AHEAD behind=$BEHIND"
+
+  # Dry-run exits without state mutation. No checkout, no merge.
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "DRY-RUN: exiting without state change"
+    exit 0
+  fi
+)
+
+if echo "$RUN_OUT" | grep -q "PRE-RELEASE SYNC"; then
+  mark_pass "synthetic run prints banner"
+else
+  mark_fail "synthetic run prints banner" "got: $RUN_OUT"
+fi
+
+if echo "$RUN_OUT" | grep -q "ref=upstream/dev"; then
+  mark_pass "preview uses upstream/dev"
+else
+  mark_fail "preview uses upstream/dev" "got: $RUN_OUT"
+fi
+
+# Confirm dev had real new commits to preview (BEHIND>=1 against dev).
+if echo "$RUN_OUT" | grep -Eq "behind=[1-9][0-9]*"; then
+  mark_pass "preview detects dev commits"
+else
+  mark_fail "preview detects dev commits" "got: $RUN_OUT"
+fi
+
+HEAD_AFTER=$(cd "$FORK" && git rev-parse HEAD)
+BRANCHES_AFTER=$(cd "$FORK" && git branch --list | sort)
+
+if [ "$HEAD_BEFORE" = "$HEAD_AFTER" ]; then
+  mark_pass "no state mutation: HEAD unchanged"
+else
+  mark_fail "no state mutation: HEAD unchanged" "before=$HEAD_BEFORE after=$HEAD_AFTER"
+fi
+
+if [ "$BRANCHES_BEFORE" = "$BRANCHES_AFTER" ]; then
+  mark_pass "no state mutation: no new branches"
+else
+  mark_fail "no state mutation: no new branches" "before=$BRANCHES_BEFORE after=$BRANCHES_AFTER"
+fi
+
+# ---------------------------------------------------------------------
+# Case 7 — SKILL.md description frontmatter does NOT mention --from-dev
+# (hidden semantics, per #250 AC).
+# ---------------------------------------------------------------------
+echo "Case 7 — --from-dev hidden from description frontmatter"
+DESC_LINE=$(awk '/^description:/{print; exit}' "$SKILL")
+if echo "$DESC_LINE" | grep -q "from-dev"; then
+  mark_fail "hidden from description" "found 'from-dev' in: $DESC_LINE"
+else
+  mark_pass "hidden from description"
+fi
+
+# ---------------------------------------------------------------------
+# Case 8 — SKILL.md ## Usage AND ## Options sections DO mention --from-dev
+# (operators who read the spec must be able to find it).
+# ---------------------------------------------------------------------
+echo "Case 8 — --from-dev documented in ## Usage and ## Options"
+# Extract the body from the first ## Usage heading to the next blank line
+# after the closing fence — coarse but sufficient for a presence check.
+USAGE_BLOCK=$(awk '/^## Usage/{flag=1} flag{print} /^## /{ if (NR>1 && !/^## Usage/) {flag=0} }' "$SKILL")
+if echo "$USAGE_BLOCK" | grep -q -- "--from-dev"; then
+  mark_pass "## Usage mentions --from-dev"
+else
+  mark_fail "## Usage mentions --from-dev" "not found in Usage block"
+fi
+
+OPTIONS_BLOCK=$(awk '/^## Options/{flag=1} flag{print} /^## /{ if (NR>1 && !/^## Options/) {flag=0} }' "$SKILL")
+if echo "$OPTIONS_BLOCK" | grep -q -- "--from-dev"; then
+  mark_pass "## Options mentions --from-dev"
+else
+  mark_fail "## Options mentions --from-dev" "not found in Options block"
+fi
+
+# ---------------------------------------------------------------------
+echo
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed cases:$FAILED" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_update_from_dev.sh
+++ b/.claude/hooks/tests/test_update_from_dev.sh
@@ -44,20 +44,22 @@ mark_fail() { echo "  ✗ $1: $2" >&2; FAIL=$((FAIL+1)); FAILED="$FAILED\n  - $1
 parse_flags() {
   FROM_DEV=0
   DRY_RUN=0
-  # shellcheck disable=SC2034
   # REBASE is set but not read in this test — kept in lockstep with the
   # pre-step bash block in SKILL.md (which DOES read it for the merge/rebase
   # branch). Tests assert ref/branch resolution only; the rebase path is
-  # exercised by the existing /update tests on the default flow.
+  # exercised by the existing /update tests on the default flow. The
+  # `: "${REBASE}"` reference after the case statement keeps shellcheck
+  # happy without scope-confusing disable directives on individual branches
+  # (which trip SC1124).
   REBASE=0
   for arg in "$@"; do
     case "$arg" in
       --from-dev) FROM_DEV=1 ;;
       --dry-run)  DRY_RUN=1 ;;
-      # shellcheck disable=SC2034
       --rebase)   REBASE=1 ;;
     esac
   done
+  : "${REBASE}"
 
   if [ "$FROM_DEV" = "1" ]; then
     UPSTREAM_REF=upstream/dev

--- a/.claude/hooks/tests/test_update_from_dev.sh
+++ b/.claude/hooks/tests/test_update_from_dev.sh
@@ -54,6 +54,7 @@ parse_flags() {
     case "$arg" in
       --from-dev) FROM_DEV=1 ;;
       --dry-run)  DRY_RUN=1 ;;
+      # shellcheck disable=SC2034
       --rebase)   REBASE=1 ;;
     esac
   done

--- a/.claude/hooks/tests/test_update_from_dev.sh
+++ b/.claude/hooks/tests/test_update_from_dev.sh
@@ -44,6 +44,11 @@ mark_fail() { echo "  ✗ $1: $2" >&2; FAIL=$((FAIL+1)); FAILED="$FAILED\n  - $1
 parse_flags() {
   FROM_DEV=0
   DRY_RUN=0
+  # shellcheck disable=SC2034
+  # REBASE is set but not read in this test — kept in lockstep with the
+  # pre-step bash block in SKILL.md (which DOES read it for the merge/rebase
+  # branch). Tests assert ref/branch resolution only; the rebase path is
+  # exercised by the existing /update tests on the default flow.
   REBASE=0
   for arg in "$@"; do
     case "$arg" in

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -5,6 +5,17 @@ argument-hint: "[--dry-run] [--rebase]"
 allowed-tools: Bash, Read, Write, Edit
 ---
 
+<!--
+  Hidden flag: --from-dev (NOT in description above, on purpose — see #250).
+  Pulls from upstream/dev instead of the latest tagged release. Adopter
+  contract is tagged releases; --from-dev is an opt-in for framework
+  maintainers and adopters who explicitly want to test pre-release work.
+  Documented in `## Usage` and `## Options` below for operators who read
+  the spec; deliberately omitted from `description` so /help does not
+  surface it.
+-->
+
+
 # /update — Sync ApexYard Fork from Upstream
 
 Single-command replacement for the manual "fetch → branch → merge → push → PR" dance that fork maintainers do to pull upstream apexyard changes into their ops fork.
@@ -27,7 +38,16 @@ Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projec
 /update              # merge-based sync (default, safer)
 /update --rebase     # rebase local customisations on top of upstream
 /update --dry-run    # preview only, don't touch anything
+/update --from-dev   # (hidden) pull from upstream/dev — pre-release; expect breakage
 ```
+
+## Options
+
+| Flag | Effect |
+|------|--------|
+| `--rebase` | Rebase local commits onto upstream instead of merging. Cleaner linear history; rewrites local SHAs. |
+| `--dry-run` | Run the preview step only. Print the commit delta and exit; no fetch-after-preview, no branch creation, no merge. |
+| `--from-dev` | **Hidden / opt-in.** Sync from `upstream/dev` (pre-release work) instead of the latest `upstream/main` tag. Prints a `⚠ PRE-RELEASE SYNC` banner BEFORE any fetch/state-mutation. Same sync-branch + conflict-resolution flow; branch is named `chore/sync-upstream-dev` (or `chore/#<TICKET>-sync-upstream-dev` if a tracking issue is supplied). Intended for the framework maintainer (testing pre-release work on another machine) and for adopters who explicitly want to validate an upcoming framework change. **Not** in the skill's `description` frontmatter on purpose — `/help` should not surface it, since the adopter contract is tagged releases (see AgDR-0007 release-cut model). Combinable with `--rebase` and `--dry-run`. |
 
 ## Output
 
@@ -45,6 +65,44 @@ On up-to-date: one line, no state change.
 - You want to sync a specific feature branch from upstream. Out of scope — this skill is for default-branch fork sync only.
 
 ## Process
+
+### Pre-step: Parse flags + print pre-release banner (when --from-dev)
+
+Parse the invocation arguments first, BEFORE any fetch / branch / merge work:
+
+```bash
+FROM_DEV=0
+DRY_RUN=0
+REBASE=0
+for arg in "$@"; do
+  case "$arg" in
+    --from-dev) FROM_DEV=1 ;;
+    --dry-run)  DRY_RUN=1 ;;
+    --rebase)   REBASE=1 ;;
+  esac
+done
+
+# Resolve the upstream ref + sync-branch suffix once, at the top, so every
+# downstream step references the same target.
+if [ "$FROM_DEV" = "1" ]; then
+  UPSTREAM_REF=upstream/dev
+  BRANCH_SUFFIX=sync-upstream-dev
+else
+  UPSTREAM_REF=upstream/main
+  BRANCH_SUFFIX=sync-upstream-apexyard
+fi
+```
+
+If `FROM_DEV=1`, print this banner BEFORE doing anything else (in particular, before any `git fetch`, branch-create, or merge — operator must see the warning before any state mutation):
+
+```
+⚠ PRE-RELEASE SYNC — pulling from upstream/dev
+   This is unreleased work; expect breakage.
+   Revert with: git reset --hard origin/main
+   For supported updates, use /update (no flag) to pull tagged releases.
+```
+
+The banner restates the deal every invocation — an operator who used `--from-dev` once should not be surprised the next time they run plain `/update` and find themselves on a different code path. The banner is load-bearing on purpose: dropping it would let pre-release breakage land silently.
 
 ### 0. Mark this session as bootstrap (REQUIRED)
 
@@ -90,6 +148,8 @@ fi
 
 ### 2. Fetch both remotes
 
+`git fetch upstream --quiet` brings down all upstream branches by default (including `upstream/dev`), so a single fetch covers both the default and the `--from-dev` target. No conditional fetch needed.
+
 ```bash
 git fetch upstream --quiet
 git fetch origin --quiet
@@ -101,13 +161,17 @@ Network failure: print a warning and exit. Don't try to "work from cache" — us
 
 Two signals matter here: a new upstream **tag** (the actionable one, meaning a real release is available), and upstream **main commits** since the fork's last sync (informational — may just be a docs typo).
 
-```bash
-AHEAD=$(git rev-list --count upstream/main..main)
-BEHIND=$(git rev-list --count main..upstream/main)
+When `--from-dev` is set, the comparison target is `upstream/dev` instead of `upstream/main`, and tag-based signals are skipped (dev is by definition pre-release; there is no tag to compare against). The preview reports the commit delta against `upstream/dev` and the operator decides whether to proceed.
 
-# Tag-based signal — same comparison the SessionStart drift banner uses.
-UPSTREAM_TAG=$(git tag --list --sort=-v:refname --merged upstream/main | head -n 1)
-LOCAL_TAG=$(git tag --list --sort=-v:refname --merged main | head -n 1)
+```bash
+AHEAD=$(git rev-list --count "$UPSTREAM_REF"..main)
+BEHIND=$(git rev-list --count main.."$UPSTREAM_REF")
+
+# Tag-based signal applies only to the tagged-release path.
+if [ "$FROM_DEV" = "0" ]; then
+  UPSTREAM_TAG=$(git tag --list --sort=-v:refname --merged upstream/main | head -n 1)
+  LOCAL_TAG=$(git tag --list --sort=-v:refname --merged main | head -n 1)
+fi
 ```
 
 Then report. Examples:
@@ -146,6 +210,21 @@ Proceed with merge? [Y/n]
 ```
 
 Default answer is "yes" in this mode — there's a real release the user asked about by running `/update`.
+
+**`--from-dev` (pre-release):**
+
+```
+Pre-release sync: 7 unreleased commits on upstream/dev since fork's HEAD.
+
+Upstream/dev commits to pull in:
+  ab12cde feat(#250): /update --from-dev hidden flag
+  cd34efg fix(#248): tighten validation
+  ... (5 more)
+
+Proceed with merge from upstream/dev? [Y/n]
+```
+
+Default answer is "yes" — the operator opted into pre-release explicitly with the flag, the banner already warned them about breakage, and asking again would be nagging. Skip the tag-based prompts entirely; dev has no tags to compare.
 
 **Ahead and behind (typical fork):**
 
@@ -197,22 +276,31 @@ Rationale for diverging from the `#58` AC wording ("leaves updated local main"):
 # Find or create a tracking issue. If a recent "sync" issue is open, reuse its number.
 # Otherwise prompt the user to create one (or offer to create it via `gh issue create`).
 
-BRANCH="chore/#${TICKET}-sync-upstream-apexyard"
+# $BRANCH_SUFFIX was set in the pre-step:
+#   sync-upstream-apexyard  for upstream/main (default)
+#   sync-upstream-dev       for upstream/dev (--from-dev)
+if [ -n "$TICKET" ]; then
+  BRANCH="chore/#${TICKET}-${BRANCH_SUFFIX}"
+else
+  BRANCH="chore/${BRANCH_SUFFIX}"
+fi
 git checkout -b "$BRANCH"
 ```
 
 ### 6. Do the sync
 
+`$UPSTREAM_REF` was set in the pre-step (`upstream/main` by default, `upstream/dev` under `--from-dev`).
+
 **Merge path:**
 
 ```bash
-git merge upstream/main --no-edit
+git merge "$UPSTREAM_REF" --no-edit
 ```
 
 **Rebase path:**
 
 ```bash
-git rebase upstream/main
+git rebase "$UPSTREAM_REF"
 ```
 
 Capture stdout/stderr for the conflict-detection step.
@@ -506,10 +594,10 @@ The migration moves real files between repos. If the operator has a custom workf
 
 ### 9. Final state + next steps
 
-On clean completion, print:
+On clean completion, print (substituting `$UPSTREAM_REF` for the literal `upstream/main` so the operator sees the actual ref synced under `--from-dev`):
 
 ```
-Synced to upstream/main @ <SHA> on branch <BRANCH>.
+Synced to <UPSTREAM_REF> @ <SHA> on branch <BRANCH>.
 
   Commits merged:     <N>
   Files changed:      <F>
@@ -569,6 +657,9 @@ Skill done. No remote state changed.
 | `jq` not installed (deprecated-config detection) | Skip step 8 silently; print one-line warning. The sync itself still completes. |
 | `.claude/project-config.json` missing (no override) | Skip step 8 silently — by definition no deprecated keys to surface. |
 | Operator answered `s` (show) | Print key + value, then re-prompt y/n (no `s` recursion). |
+| `--from-dev` passed but `upstream/dev` doesn't exist on the configured remote | Print: `upstream/dev not found — the configured upstream may not have a dev branch. Verify with: git ls-remote upstream dev`. Exit 1; no banner-suppression, no fallback to main. |
+| `--from-dev` combined with `--dry-run` | Banner prints first, then preview against `upstream/dev`, then exit 0. Same no-state-change semantics as plain `--dry-run`. |
+| `--from-dev` combined with `--rebase` | Allowed. Pre-release commits are rebased on top instead of merged; banner + branch convention unchanged. |
 
 ## Design notes
 
@@ -595,6 +686,16 @@ Two reasons:
 ### Dry-run semantics
 
 `--dry-run` simulates step 3 (preview) only. It does NOT simulate the merge itself — running `git merge --no-commit --no-ff` as a dry-run leaves the working tree in a staged state that's easy to accidentally commit. If the preview says N commits to pull in, the user should run `/update` for real to see the merge.
+
+### Why `--from-dev` is hidden (#250)
+
+The framework's adopter contract is "tagged releases from `upstream/main`" (release-cut model — see [AgDR-0007](../../../docs/agdr/AgDR-0007-release-cut-branch-model.md)). Adopters who pull from `dev` are signing up for breakage between releases — that's an opt-in behaviour, not a default. Three design choices flow from this:
+
+1. **Not in `description` frontmatter.** `/help` enumerates skill descriptions; surfacing `--from-dev` there would invite casual use and defeat the release-cut model's stability promise. The flag IS in `## Usage` and `## Options` so an operator who reads the spec finds it.
+2. **Banner before any state mutation.** An operator who used `--from-dev` once may not remember the deal next time. The banner prints BEFORE the first `git fetch`, restating the deal every invocation. Dropping it would let pre-release breakage land silently.
+3. **Same sync-branch + conflict-resolution flow as the default path.** A separate `/update-dev` skill would duplicate ~95% of the logic for a one-line flag-check difference; the flag-on-existing-skill shape is cheaper to maintain and means every safety check (sync branch, conflict resolution, no auto-merge) applies identically.
+
+Use cases that motivated the flag: the framework maintainer testing pre-release work on a separate machine before cutting a release tag; adopters validating an upcoming framework change before the wider rollout; CI workflows pinning to dev for integration testing (rare but legitimate).
 
 ## Cleanup (REQUIRED before exit)
 

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -668,6 +668,8 @@ Every few weeks, pull the latest apexyard improvements into your fork. The easy 
 
 `/update` does the work of the manual flow below: fetches `upstream`, previews the commit delta, creates a sync branch (because `block-main-push.sh` forbids direct pushes to `main`), merges or rebases, walks through any conflicts with per-file options, surfaces any **deprecated config keys** in your `.claude/project-config.json` that no longer exist in upstream defaults (advisory y/n/s offer — see step 8 of the skill), and leaves the branch ready to push as a PR. See `.claude/skills/update/SKILL.md` for the full process.
 
+> **Pre-release testing (`/update --from-dev`).** A hidden `--from-dev` flag pulls from `upstream/dev` instead of the latest tagged release on `upstream/main`. Intended for the framework maintainer testing pre-release work on a separate machine, and for adopters who explicitly want to validate an upcoming framework change before the release tag is cut. **Not a supported general-adopter path** — the adopter contract is tagged releases from `upstream/main` (see [AgDR-0007](agdr/AgDR-0007-release-cut-branch-model.md)). Prints a `⚠ PRE-RELEASE SYNC` banner before any state mutation, uses the same sync-branch + conflict-resolution flow, and lands on a `chore/sync-upstream-dev` branch. Revert with `git reset --hard origin/main` if needed. See `.claude/skills/update/SKILL.md` § Options for details.
+
 If you prefer the raw commands:
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a hidden `--from-dev` flag to `/update` that pulls from `upstream/dev` instead of the latest tagged release on `upstream/main` — for the framework maintainer testing pre-release work, and for adopters who want to validate upcoming changes before a release tag is cut
- Pre-step parses `--from-dev` (alongside `--dry-run` / `--rebase`) once at the top and resolves `UPSTREAM_REF` + `BRANCH_SUFFIX` so every downstream step targets the same ref
- Banner prints BEFORE any fetch / state mutation, restating the pre-release deal every invocation:
  ```
  ⚠ PRE-RELEASE SYNC — pulling from upstream/dev
     This is unreleased work; expect breakage.
     Revert with: git reset --hard origin/main
     For supported updates, use /update (no flag) to pull tagged releases.
  ```
- Same sync-branch + conflict-resolution flow as the default path; branch named `chore/sync-upstream-dev` (or `chore/#<TICKET>-sync-upstream-dev` with a tracking issue)
- **Hidden semantics**: NOT in the skill description frontmatter (so `/help` doesn't surface it); IS documented in `## Usage` and `## Options` for operators who read the spec
- Edge cases handled: missing `upstream/dev` branch, combinations with `--rebase` / `--dry-run`
- Brief `docs/multi-project.md` § Upgrades note flagging it as not-a-supported-general-adopter-path

## Why this matters

Today the framework's adopter contract is "tagged releases from `upstream/main`" per the release-cut model (AgDR-0007). But the framework maintainer (and adopters who want to validate pre-release work) need a way to pull `upstream/dev` BEFORE the release tag is cut — for testing on a separate machine, smoking-out integration issues, etc.

The `--from-dev` flag opts in to that path explicitly. Hidden because the default expectation MUST stay "tagged releases only"; the flag exists for the maintainer + the rare adopter who knows they want it from reading the spec.

## Testing

- [x] New `test_update_from_dev.sh` smoke test (14 cases) pins the recipe on a synthetic fork: banner output, ref/branch resolution, no-state-mutation under `--dry-run`, and the hidden/documented invariants on SKILL.md
- [x] All 14 cases pass locally
- [x] Existing `/update` tests (default behaviour) still pass — flag-absent path unchanged
- [ ] Reviewer can confirm the banner text matches the ticket spec
- [ ] Reviewer can sanity-check `--from-dev` doesn't bypass the existing `block-main-push.sh` / sync-branch convention

## Glossary

| Term | Definition |
|---|---|
| `--from-dev` | Hidden `/update` flag that pulls from `upstream/dev` instead of the latest tagged release on `upstream/main`. Hidden = not in `description` frontmatter; documented in `## Usage` + `## Options`. |
| Pre-release sync | A sync against `upstream/dev` (unreleased work) rather than a tagged release. Operator opts in by knowing the flag exists; banner restates the deal every invocation. |
| `UPSTREAM_REF` | Pre-step variable resolved once at the top of the skill — `upstream/dev` when `--from-dev`, else `upstream/<latest-tag>`. Every downstream step (fetch, preview, merge) targets the same ref. |
| `BRANCH_SUFFIX` | Pre-step variable for the sync branch name — `-dev` suffix appended when `--from-dev` so pre-release sync branches don't collide with regular sync branches. |
| Adopter contract | Per AgDR-0007 (release-cut branch model), adopters pull tagged releases from `upstream/main`. `--from-dev` is the explicit opt-out for pre-release testing. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
