### PR TITLE
feat(#257): /dfd skill — extract Data Flow Diagram with trust boundaries + classifications

### DIFF
--- a/.claude/hooks/_lib-multi-repo-trace.sh
+++ b/.claude/hooks/_lib-multi-repo-trace.sh
@@ -4,7 +4,7 @@
 #
 # Source this library from any skill that follows an outbound call from
 # one registered project into another, using `apexyard.projects.yaml` as
-# the registry. See AgDR-0024 (DFD skill) for design rationale; the same
+# the registry. See AgDR-0026 (DFD skill) for design rationale; the same
 # discovery shape applies to /process (#256).
 #
 # Usage:
@@ -273,12 +273,12 @@ mrt_is_third_party() {
     *.supabase.co*)                                       echo "supabase";   return 0 ;;
     *sentry.io*)                                          echo "sentry";     return 0 ;;
     *datadoghq.com*|*datadoghq.eu*)                       echo "datadog";    return 0 ;;
-    *posthog.com*|*eu.posthog.com*|*app.posthog.com*)     echo "posthog";    return 0 ;;
-    *amplitude.com*|*api.amplitude.com*)                  echo "amplitude";  return 0 ;;
-    *mixpanel.com*|*api.mixpanel.com*)                    echo "mixpanel";   return 0 ;;
-    *segment.com*|*api.segment.io*)                       echo "segment";    return 0 ;;
+    *posthog.com*)                                        echo "posthog";    return 0 ;;
+    *amplitude.com*)                                      echo "amplitude";  return 0 ;;
+    *mixpanel.com*)                                       echo "mixpanel";   return 0 ;;
+    *segment.com*|*segment.io*)                           echo "segment";    return 0 ;;
     *salesforce.com*|*.force.com*)                        echo "salesforce"; return 0 ;;
-    *api.github.com*|*github.com*)                        echo "github";     return 0 ;;
+    *github.com*)                                         echo "github";     return 0 ;;
     *.googleapis.com*)                                    echo "google-api"; return 0 ;;
     *.googletagmanager.com*)                              echo "gtm";        return 0 ;;
     *.algolia.net*|*.algolianet.com*)                     echo "algolia";    return 0 ;;

--- a/.claude/hooks/_lib-multi-repo-trace.sh
+++ b/.claude/hooks/_lib-multi-repo-trace.sh
@@ -1,0 +1,324 @@
+#!/bin/bash
+# _lib-multi-repo-trace.sh — shared cross-repo trace helpers for the
+# anchor-scoped multi-repo discovery skills (/dfd, /process).
+#
+# Source this library from any skill that follows an outbound call from
+# one registered project into another, using `apexyard.projects.yaml` as
+# the registry. See AgDR-0024 (DFD skill) for design rationale; the same
+# discovery shape applies to /process (#256).
+#
+# Usage:
+#   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+#   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+#   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-multi-repo-trace.sh"
+#
+#   target=$(mrt_resolve_target "https://billing.internal.example.com/charge")
+#   if [ -n "$target" ]; then
+#     # registered project — follow into its source
+#     ws=$(mrt_workspace_for "$target")
+#   else
+#     vendor=$(mrt_is_third_party "https://api.stripe.com/v1/charges")
+#     # → "stripe" — render as external entity, don't follow
+#   fi
+#
+# All resolvers are READ-ONLY against the registry + filesystem. None of
+# them clone, none of them write — the caller decides what to do with
+# the answer.
+#
+# Bash 3.2 compatible (no associative arrays, no `${var,,}` syntax) so
+# the helper works under the system bash on stock macOS.
+
+# ------------------------------------------------------------------------------
+# Internal: parse projects from the registry. Outputs one line per project:
+#   <name>|<repo>|<workspace>|<hostnames>|<topics>
+# where <hostnames> and <topics> are comma-lists of optional `hostnames:` /
+# `topics:` fields the project entry may declare for cross-repo matching.
+#
+# Tolerant of missing fields — only `name` is required to produce a line.
+# ------------------------------------------------------------------------------
+_mrt_parse_registry() {
+  local registry
+  registry=$(portfolio_registry)
+  [ -f "$registry" ] || return 0
+
+  if command -v yq >/dev/null 2>&1; then
+    # yq path: structured extraction, handles both bare and quoted scalars.
+    yq eval '
+      .projects[]? |
+      [
+        .name // "",
+        .repo // "",
+        .workspace // "",
+        (.hostnames // [] | join(",")),
+        (.topics // [] | join(","))
+      ] | join("|")
+    ' "$registry" 2>/dev/null
+  else
+    # Greppy fallback — same shape as start-ticket's awk fallback. Assumes
+    # `- name:` is the first key in each entry; `repo:`, `workspace:`,
+    # `hostnames:` (inline list), `topics:` (inline list) follow.
+    awk '
+      function unquote(s) { gsub(/^["\x27]|["\x27]$/, "", s); return s }
+      function inline_list(line,    out, n, i, parts) {
+        sub(/^[^\[]*\[/, "", line); sub(/\].*$/, "", line)
+        gsub(/[[:space:]]/, "", line)
+        n = split(line, parts, ",")
+        out = ""
+        for (i = 1; i <= n; i++) {
+          if (parts[i] != "") {
+            out = (out == "" ? "" : out ",") unquote(parts[i])
+          }
+        }
+        return out
+      }
+      /^[[:space:]]*-[[:space:]]*name:/ {
+        if (name != "") print name "|" repo "|" workspace "|" hostnames "|" topics
+        name = unquote($3); repo = ""; workspace = ""; hostnames = ""; topics = ""
+        next
+      }
+      /^[[:space:]]*repo:/      { repo = unquote($2); next }
+      /^[[:space:]]*workspace:/ { workspace = unquote($2); next }
+      /^[[:space:]]*hostnames:[[:space:]]*\[/ { hostnames = inline_list($0); next }
+      /^[[:space:]]*topics:[[:space:]]*\[/    { topics    = inline_list($0); next }
+      END { if (name != "") print name "|" repo "|" workspace "|" hostnames "|" topics }
+    ' "$registry"
+  fi
+}
+
+# Lowercase a string portably (bash 3.2 has no ${var,,}).
+_mrt_lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+# ------------------------------------------------------------------------------
+# Public: mrt_resolve_target <hostname-or-url-or-topic>
+#
+# Returns the registered project name (one line on stdout) if the input
+# matches a registered project. Empty output + nonzero exit otherwise.
+#
+# Matching tiers (first wins):
+#   1. Exact match against a project's declared `hostnames:` entries
+#   2. Exact match against a project's declared `topics:` entries
+#      (for message-broker topic strings)
+#   3. Substring match of the project name in the hostname
+#      (so `https://billing.internal.example.com/foo` matches a project
+#       named `billing`)
+#   4. Repo-slug match in the URL path (so `github.com/me2resh/billing-api`
+#      matches a project with `repo: me2resh/billing-api`)
+# ------------------------------------------------------------------------------
+mrt_resolve_target() {
+  local input="$1"
+  [ -z "$input" ] && return 1
+
+  # Extract hostname from a URL if input looks like one
+  local host="$input"
+  case "$input" in
+    http://*|https://*)
+      host="${input#*://}"
+      host="${host%%/*}"
+      ;;
+  esac
+
+  local input_lc host_lc
+  input_lc=$(_mrt_lower "$input")
+  host_lc=$(_mrt_lower "$host")
+
+  local name repo workspace hostnames topics
+  local name_lc repo_lc
+  local IFS_save="$IFS"
+  while IFS='|' read -r name repo workspace hostnames topics; do
+    [ -z "$name" ] && continue
+    name_lc=$(_mrt_lower "$name")
+    repo_lc=$(_mrt_lower "$repo")
+
+    # Tier 1: declared hostnames (comma-separated)
+    if [ -n "$hostnames" ]; then
+      IFS=',' read -r -a h_array <<EOF
+$hostnames
+EOF
+      local h h_lc
+      for h in "${h_array[@]}"; do
+        h_lc=$(_mrt_lower "$h")
+        if [ "$host_lc" = "$h_lc" ]; then
+          IFS="$IFS_save"
+          echo "$name"
+          return 0
+        fi
+      done
+    fi
+
+    # Tier 2: declared topics
+    if [ -n "$topics" ]; then
+      IFS=',' read -r -a t_array <<EOF
+$topics
+EOF
+      local t t_lc
+      for t in "${t_array[@]}"; do
+        t_lc=$(_mrt_lower "$t")
+        if [ "$input_lc" = "$t_lc" ]; then
+          IFS="$IFS_save"
+          echo "$name"
+          return 0
+        fi
+      done
+    fi
+
+    # Tier 3: project name substring in hostname (guard against short generic names)
+    if [ ${#name_lc} -ge 4 ]; then
+      case "$host_lc" in
+        *"$name_lc"*)
+          IFS="$IFS_save"
+          echo "$name"
+          return 0
+          ;;
+      esac
+    fi
+
+    # Tier 4: repo slug in URL
+    if [ -n "$repo_lc" ]; then
+      case "$input_lc" in
+        *"$repo_lc"*)
+          IFS="$IFS_save"
+          echo "$name"
+          return 0
+          ;;
+      esac
+    fi
+  done < <(_mrt_parse_registry)
+
+  IFS="$IFS_save"
+  return 1
+}
+
+# ------------------------------------------------------------------------------
+# Public: mrt_workspace_for <project-name>
+#
+# Returns the absolute path to the project's workspace clone (if it
+# exists and is readable). Empty + nonzero exit otherwise.
+#
+# Reads the registry's `workspace:` field for the project first; falls
+# back to <workspace_dir>/<name> via portfolio_workspace_dir.
+# ------------------------------------------------------------------------------
+mrt_workspace_for() {
+  local target="$1"
+  [ -z "$target" ] && return 1
+
+  local name repo workspace hostnames topics
+  while IFS='|' read -r name repo workspace hostnames topics; do
+    if [ "$name" = "$target" ]; then
+      local candidate=""
+      if [ -n "$workspace" ]; then
+        case "$workspace" in
+          /*) candidate="$workspace" ;;
+          *)
+            local root
+            root=$(_portfolio_root 2>/dev/null) || root=""
+            [ -n "$root" ] && candidate="$root/$workspace"
+            ;;
+        esac
+      fi
+      if [ -z "$candidate" ]; then
+        local ws_dir
+        ws_dir=$(portfolio_workspace_dir 2>/dev/null) || ws_dir=""
+        [ -n "$ws_dir" ] && candidate="$ws_dir/$name"
+      fi
+      if [ -n "$candidate" ] && [ -d "$candidate" ]; then
+        echo "$candidate"
+        return 0
+      fi
+      return 1
+    fi
+  done < <(_mrt_parse_registry)
+
+  return 1
+}
+
+# ------------------------------------------------------------------------------
+# Public: mrt_is_third_party <hostname-or-url>
+#
+# Detects well-known third-party SaaS / API hostnames. Returns the
+# vendor identifier on stdout (lowercase short name) if matched.
+# Empty + nonzero exit otherwise.
+#
+# The default signature set is conservative; adopters extend by editing
+# the case statement below. Order: most-specific patterns first so a
+# substring like `stripe.com` doesn't accidentally match an unrelated
+# host that happens to contain those letters.
+# ------------------------------------------------------------------------------
+mrt_is_third_party() {
+  local input="$1"
+  [ -z "$input" ] && return 1
+
+  local host="$input"
+  case "$input" in
+    http://*|https://*)
+      host="${input#*://}"
+      host="${host%%/*}"
+      ;;
+  esac
+  host=$(_mrt_lower "$host")
+
+  case "$host" in
+    *api.stripe.com*|*checkout.stripe.com*)               echo "stripe";     return 0 ;;
+    *api.sendgrid.com*|*sendgrid.com*)                    echo "sendgrid";   return 0 ;;
+    *api.mailgun.net*|*mailgun.net*)                      echo "mailgun";    return 0 ;;
+    *api.postmarkapp.com*|*postmarkapp.com*)              echo "postmark";   return 0 ;;
+    *api.twilio.com*|*twilio.com*)                        echo "twilio";     return 0 ;;
+    *api.openai.com*|*openai.com*)                        echo "openai";     return 0 ;;
+    *api.anthropic.com*|*anthropic.com*)                  echo "anthropic";  return 0 ;;
+    *bedrock*.amazonaws.com*)                             echo "bedrock";    return 0 ;;
+    *cognito*.amazonaws.com*)                             echo "cognito";    return 0 ;;
+    *.auth0.com*)                                         echo "auth0";      return 0 ;;
+    *.clerk.accounts.dev*|*.clerk.dev*)                   echo "clerk";      return 0 ;;
+    *.supabase.co*)                                       echo "supabase";   return 0 ;;
+    *sentry.io*)                                          echo "sentry";     return 0 ;;
+    *datadoghq.com*|*datadoghq.eu*)                       echo "datadog";    return 0 ;;
+    *posthog.com*|*eu.posthog.com*|*app.posthog.com*)     echo "posthog";    return 0 ;;
+    *amplitude.com*|*api.amplitude.com*)                  echo "amplitude";  return 0 ;;
+    *mixpanel.com*|*api.mixpanel.com*)                    echo "mixpanel";   return 0 ;;
+    *segment.com*|*api.segment.io*)                       echo "segment";    return 0 ;;
+    *salesforce.com*|*.force.com*)                        echo "salesforce"; return 0 ;;
+    *api.github.com*|*github.com*)                        echo "github";     return 0 ;;
+    *.googleapis.com*)                                    echo "google-api"; return 0 ;;
+    *.googletagmanager.com*)                              echo "gtm";        return 0 ;;
+    *.algolia.net*|*.algolianet.com*)                     echo "algolia";    return 0 ;;
+    *meilisearch.com*)                                    echo "meilisearch"; return 0 ;;
+    *)                                                     return 1 ;;
+  esac
+}
+
+# ------------------------------------------------------------------------------
+# Public: mrt_list_projects
+#
+# Outputs one line per registered project: `<name>`. Used by skills that
+# want to iterate every project (e.g. `/dfd --scope-all` for a
+# system-wide DFD).
+# ------------------------------------------------------------------------------
+mrt_list_projects() {
+  _mrt_parse_registry | awk -F'|' '{ if ($1 != "") print $1 }'
+}
+
+# ------------------------------------------------------------------------------
+# Public: mrt_offer_clone <project-name>
+#
+# Prints a suggested clone command on stdout for the caller to either
+# show to the operator or execute after confirmation. Caller is
+# responsible for actually running `git clone` (this helper is read-only).
+# ------------------------------------------------------------------------------
+mrt_offer_clone() {
+  local target="$1"
+  [ -z "$target" ] && return 1
+
+  local name repo workspace hostnames topics
+  while IFS='|' read -r name repo workspace hostnames topics; do
+    if [ "$name" = "$target" ]; then
+      [ -z "$repo" ] && return 1
+      local ws_dir candidate
+      ws_dir=$(portfolio_workspace_dir 2>/dev/null) || ws_dir="./workspace"
+      candidate="$ws_dir/$name"
+      echo "git clone https://github.com/$repo $candidate"
+      return 0
+    fi
+  done < <(_mrt_parse_registry)
+  return 1
+}

--- a/.claude/skills/compliance-check/SKILL.md
+++ b/.claude/skills/compliance-check/SKILL.md
@@ -10,6 +10,8 @@ effort: high
 
 Deep-dive regulatory compliance analysis. Checks cookie consent, privacy policy, terms of service, data handling, and user rights. Invoke when `/launch-check`'s compliance row shows WARN or FAIL, or proactively before launching in the EU/UK.
 
+**Consumes the DFD produced by [`/dfd`](../dfd/SKILL.md) for data-handling analysis (Step 4).** The DFD's classifications table at `projects/<project>/architecture/dfd.md` is the source of truth for which fields are PII / PCI / secrets, and the DFD's external-services list is the source of truth for cross-border transfers and third-party processors. If the DFD doesn't exist, this skill falls back to its own grep-based discovery (degraded mode — surface in the output banner). See AgDR-0024 for the single-source-of-truth rationale.
+
 ## Compliance Areas
 
 | Area | Regulation | Key requirement |
@@ -46,12 +48,38 @@ Deep-dive regulatory compliance analysis. Checks cookie consent, privacy policy,
 - Check for opt-out mechanisms for marketing communications
 - Check if the auth system supports account deactivation
 
-### Step 4: Data handling
+### Step 4: Data handling (DFD-driven)
 
-- Check what PII is stored (names, emails, addresses, phone numbers, payment info)
-- Check if PII is encrypted at rest
-- Check if sensitive data is logged (grep for logging calls that might include user data)
-- Check for data retention policies (is old data cleaned up?)
+**Prefer the DFD when present.** Read the classifications table at `projects/<project>/architecture/dfd.md` § "Data classifications" — that's the canonical view of PII / PCI / secrets across the system, produced by `/dfd`'s three-pathway heuristic walk (annotations + env-var heuristics + schema columns) plus any explicit registry the project ships.
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+projects_dir=$(portfolio_projects_dir)
+
+dfd="${projects_dir}/${project_name}/architecture/dfd.md"
+if [ -f "$dfd" ]; then
+  # DFD present — use it as source of truth
+  : # parse the Classifications table + External actors block
+else
+  # Degraded mode — surface in output banner, fall back to grep walk
+  : # legacy independent scan
+fi
+```
+
+From the DFD's classifications + flows, derive:
+
+- **What PII is stored** — every row labelled `pii` in the classifications table
+- **What PCI data crosses the system** — every row labelled `pci` (any presence triggers stricter retention + encryption rules)
+- **Where secrets live** — every row labelled `secrets` (env vars + schema columns) — confirm they're loaded from a secrets manager, not committed
+- **Cross-border transfers** — every External Service actor + its inferred region (Stripe-US, SendGrid-US, Auth0-US, Cognito-region-dependent, etc.) — flag if any PII flow lands on a non-EU vendor without a Standard Contractual Clause
+- **Third-party processors** — every External Service is a candidate Data Processing Agreement (DPA) requirement
+
+Then complement with the inline checks (still needed regardless of DFD source):
+
+- Check if PII is encrypted at rest (DB encryption flag / column-level encryption)
+- Check if sensitive data is logged (grep for logging calls that might include user data — the DFD lists the fields; this step verifies they're not in logs)
+- Check for data retention policies (is old data cleaned up? — usually only in cron specs or DB triggers)
 
 ### Step 5: Output findings
 

--- a/.claude/skills/compliance-check/SKILL.md
+++ b/.claude/skills/compliance-check/SKILL.md
@@ -10,7 +10,7 @@ effort: high
 
 Deep-dive regulatory compliance analysis. Checks cookie consent, privacy policy, terms of service, data handling, and user rights. Invoke when `/launch-check`'s compliance row shows WARN or FAIL, or proactively before launching in the EU/UK.
 
-**Consumes the DFD produced by [`/dfd`](../dfd/SKILL.md) for data-handling analysis (Step 4).** The DFD's classifications table at `projects/<project>/architecture/dfd.md` is the source of truth for which fields are PII / PCI / secrets, and the DFD's external-services list is the source of truth for cross-border transfers and third-party processors. If the DFD doesn't exist, this skill falls back to its own grep-based discovery (degraded mode — surface in the output banner). See AgDR-0024 for the single-source-of-truth rationale.
+**Consumes the DFD produced by [`/dfd`](../dfd/SKILL.md) for data-handling analysis (Step 4).** The DFD's classifications table at `projects/<project>/architecture/dfd.md` is the source of truth for which fields are PII / PCI / secrets, and the DFD's external-services list is the source of truth for cross-border transfers and third-party processors. If the DFD doesn't exist, this skill falls back to its own grep-based discovery (degraded mode — surface in the output banner). See AgDR-0026 for the single-source-of-truth rationale.
 
 ## Compliance Areas
 

--- a/.claude/skills/dfd/SKILL.md
+++ b/.claude/skills/dfd/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Bash, Read, Grep, Glob, Write
 
 Reads a codebase (or a portfolio of codebases for system-wide DFDs) and produces a Data Flow Diagram showing external actors, processes, data stores, data flows, trust boundaries, and per-element data classifications. The DFD is the **input to STRIDE threat modelling** and to GDPR cross-border / DPA-coverage analysis.
 
-This skill is the **canonical DFD producer** in the apexyard family. `/threat-model` and `/compliance-check` consume the DFD it writes instead of regenerating their own — see AgDR-0024 for the design rationale.
+This skill is the **canonical DFD producer** in the apexyard family. `/threat-model` and `/compliance-check` consume the DFD it writes instead of regenerating their own — see AgDR-0026 for the design rationale.
 
 | Skill | Role |
 |-------|------|
@@ -187,7 +187,7 @@ echo "$model_json" \
 
 `generate-dragon.sh` is a **pure function over the in-memory model** — `/threat-model --format=dragon` (#255) will import the same serialiser when it lands. If `#255` ships first with the serialiser inside `/threat-model`, switch this skill to import from there during code review.
 
-Schema reference: [OWASP Threat Dragon v2 JSON schema](https://github.com/OWASP/threat-dragon/blob/main/td.vue/src/service/migration/schema/threat-model.v2.json).
+Schema reference: [OWASP Threat Dragon repository](https://github.com/OWASP/threat-dragon) (see `td.vue/src/service/migration/schema/` for the published v2 JSON schema).
 
 #### 5c. Cross-repo composition (on `--scope-all`)
 
@@ -257,6 +257,7 @@ Re-run /dfd {project} after architecture changes.
 Run `/dfd billing-api` against a small Express + Prisma + BullMQ service that integrates with Stripe + SendGrid:
 
 **Discovery** picks up:
+
 - HTTP routes (12) → public_user actor + http_api process + public ↔ backend boundary
 - `@auth0` import → auth0 external actor
 - `stripe`, `@sendgrid/mail` imports → stripe + sendgrid external actors + us ↔ third-party boundary
@@ -266,6 +267,7 @@ Run `/dfd billing-api` against a small Express + Prisma + BullMQ service that in
 - `cron.schedule(` → scheduled-job process
 
 **Classifications** detect:
+
 - `user.email` (Prisma column) → PII
 - `user.phone_number` (Prisma column) → PII
 - `card_number` (mentioned in Stripe-flow code) → PCI

--- a/.claude/skills/dfd/SKILL.md
+++ b/.claude/skills/dfd/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: dfd
+description: Extract a Data Flow Diagram from a codebase (single-service or multi-repo system) with trust boundaries and data classifications. Writes Mermaid markdown (renders on GitHub) as the canonical source; OWASP Threat Dragon v2 JSON on `--format=dragon`. Becomes the source of truth that `/threat-model` and `/compliance-check` consume.
+argument-hint: "[project-name | . | --scope-all] [--format=mermaid|dragon|all]"
+allowed-tools: Bash, Read, Grep, Glob, Write
+---
+
+# /dfd — Data Flow Diagram Extractor
+
+Reads a codebase (or a portfolio of codebases for system-wide DFDs) and produces a Data Flow Diagram showing external actors, processes, data stores, data flows, trust boundaries, and per-element data classifications. The DFD is the **input to STRIDE threat modelling** and to GDPR cross-border / DPA-coverage analysis.
+
+This skill is the **canonical DFD producer** in the apexyard family. `/threat-model` and `/compliance-check` consume the DFD it writes instead of regenerating their own — see AgDR-0024 for the design rationale.
+
+| Skill | Role |
+|-------|------|
+| `/dfd` (this skill) | Produces the DFD — six-axis discovery + classifications + cross-repo trace |
+| `/threat-model` | Consumes the DFD — STRIDE walk over each trust-boundary crossing |
+| `/compliance-check` | Consumes the DFD's classifications — cross-border transfers + DPA coverage |
+| `/c4` | Static topology (different shape — system + containers, no data-flow semantics) |
+| `/process` (#256) | Dynamic control flow — BPMN, anchor-scoped multi-repo trace (shares the `_lib-multi-repo-trace.sh` helper) |
+
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the workspace dir via `portfolio_workspace_dir` from `.claude/hooks/_lib-portfolio-paths.sh`. Cross-repo discovery uses the shared `_lib-multi-repo-trace.sh` helper. Source both at the top of any bash block:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-multi-repo-trace.sh"
+projects_dir=$(portfolio_projects_dir)
+```
+
+Defaults match today's single-fork layout. Adopters in split-portfolio mode override the `portfolio.*` keys in `.claude/project-config.json` — the helper resolves whichever mode they're in. See `docs/multi-project.md`.
+
+## Usage
+
+```
+/dfd                                   # interactive — asks for scope (single service or system-wide)
+/dfd billing-api                       # registered project — single-service DFD
+/dfd .                                  # treat cwd as the project root
+/dfd --scope-all                       # walk the whole registry — system-wide DFD with per-service sub-models
+/dfd billing-api --format=dragon       # also emit Threat Dragon v2 JSON
+/dfd billing-api --format=all          # Mermaid + Threat Dragon + (future) PlantUML
+```
+
+Re-running on the same scope OFFERS (default-no) to overwrite — same UX as `/extract-features` and `/c4`. Existing edits are preserved unless the operator explicitly accepts.
+
+## Output location
+
+```
+projects/<project-name>/architecture/dfd.md            ← Mermaid markdown (primary, source of truth)
+projects/<project-name>/architecture/dfd.json          ← Threat Dragon v2 JSON (on --format=dragon)
+projects/<project-name>/architecture/dfd-source.yaml   ← discovery report — supports "what changed since last run"
+```
+
+For `--scope-all`:
+
+```
+docs/architecture/system-dfd.md                        ← composed system-wide DFD
+docs/architecture/system-dfd-source.yaml               ← per-service discovery reports concatenated
+```
+
+## Process
+
+### 1. Resolve the target + scope
+
+- If the argument is `.` → use cwd as the target.
+- If the argument names a registered project → resolve to `workspace/<name>/`. If the workspace clone doesn't exist, stop and ask the operator to clone first (do not auto-clone — same convention as `/handover` and `/extract-features`).
+- If no argument and cwd is inside `workspace/<name>/` → use that project.
+- If no argument and cwd is the ops fork root → ask: *"Scope this DFD to one service, or the whole system?"*
+- If `--scope-all` → walk every registered project; each becomes a trust-boundary box in the composed system DFD.
+
+### 2. Run the six-axis discovery (read-only)
+
+Discovery is anchored on the target and reachability-bounded. **No files written until the operator approves the candidate model.**
+
+| Axis | What | How |
+|------|------|-----|
+| **1. External actors** | Users, auth providers, third-party SaaS, admin consoles | HTTP route scope (anonymous / authenticated / admin); SDK imports (`stripe`, `@sendgrid/mail`, `@anthropic-ai/sdk`); auth provider imports (`@auth0`, `@clerk/`, Cognito); webhook signature handlers |
+| **2. Processes** | HTTP handlers, queue consumers, scheduled jobs, message-broker subscribers, gRPC methods | Framework signatures (Express / Fastify / NestJS / FastAPI / Flask / Django / Rails / Gin / Spring / Lambda); job-framework signatures (BullMQ, Celery, Sidekiq, Active Job, Temporal); cron / EventBridge schedules |
+| **3. Data stores** | RDBMSes, document stores, caches, object storage, file systems, data warehouses, search indexes | Schema files (`schema.prisma`, `models.py`, `*.rb` Active Record, `*.sql` migrations); SDK imports (`@aws-sdk/client-*`, `ioredis`, `mongoose`); connection-string env vars |
+| **4. Data flows** | What crosses what — payload + arrow direction | Reachability — handler reads/writes which store, calls which external API, enqueues to which worker. LSP-aware path uses call-graph; grep fallback uses imports + usage co-location |
+| **5. Trust boundaries** | Network / auth / org / classification boundaries | Inferred from code + env config: public ↔ backend (HTTP scope), backend ↔ data (DB credentials gating), user ↔ admin (route prefix), us ↔ third-party (external SDKs). **Note**: IaC reading is out of scope for v1 |
+| **6. Data classifications** | PII, PCI, secrets, internal, public — per detected element | Three pathways: code annotations (`@PII`, `// CLASSIFIED: <label>`), env-var heuristics (`*_SECRET`, `*_TOKEN`), schema-column heuristics (`email`, `phone`, `card_number`). Optional explicit registry at `docs/data-classification.{md,yaml}` overrides heuristics |
+
+The grep-fallback signatures live in `.claude/skills/dfd/discover.sh` (axes 1–5) and `.claude/skills/dfd/classify.sh` (axis 6). When LSP is enabled (`ENABLE_LSP_TOOL=1` + per-language plugin per `docs/getting-started.md`), the skill prefers semantic-index queries over grep for axes 1, 2, 3, and 4. Discovery is identical in shape; LSP just makes it cheaper.
+
+For `--scope-all`: run axes 1–6 against each registered project, then in step 3 compose by treating every cross-service flow (detected via `_lib-multi-repo-trace.sh`) as a trust-boundary crossing.
+
+### 3. Present the candidate model for operator review
+
+Render the discovery output in a compact table grouped by axis:
+
+```
+For billing-api:
+
+External actors:
+  [Human]   Authenticated customer — POST /api/charges
+  [Human]   Admin — /admin/* routes
+  [Ext SaaS] Stripe — payment processing (charges, customers)
+  [Ext SaaS] SendGrid — transactional email
+  [Ext]     Auth0 — authentication provider
+
+Processes:
+  HTTP API (12 routes)
+  Webhook handler (Stripe callbacks)
+  Background workers (2 BullMQ queues: email, reconciliation)
+  Scheduled jobs (1: nightly reconciliation)
+
+Data stores:
+  Postgres (via Prisma) — primary data store
+  Redis — session cache + queue backend
+  S3 — invoice PDF storage
+
+Inferred trust boundaries:
+  Public Internet ↔ Backend (HTTP scope)
+  Backend ↔ Data Stores (DB credentials)
+  User ↔ Admin (privilege escalation on /admin/*)
+  Us ↔ Stripe (org boundary, signed webhooks)
+  Us ↔ SendGrid (org boundary)
+
+Data classifications (detected):
+  user.email                          [PII]    via schema column     — prisma/schema.prisma:42
+  user.phone_number                   [PII]    via schema column     — prisma/schema.prisma:44
+  charge.card_number                  [PCI]    via schema column     — prisma/schema.prisma:118
+  STRIPE_SECRET_KEY                   [secrets] via env-var heuristic — .env.example:3
+  SENDGRID_API_KEY                    [secrets] via env-var heuristic — .env.example:5
+  user.profile @PII                   [pii]    via annotation         — src/models/user.ts:12
+
+(d) describe in more detail
+(e) edit the model (add/remove element, change classification, reword trust boundary)
+(a) accept and generate the diagram
+(q) quit without writing
+>
+```
+
+### 4. Interview — gap-fill only
+
+Ask the operator ONLY where the code is silent:
+
+- *"this field `user.identifier` — is this an email, a UUID, or something else? Classification?"*
+- *"placing a trust boundary between the public API gateway and the internal services — confirm or override?"*
+- *"any human admin actors who interact via a console / runbook outside this codebase?"*
+- *"the `messaging` queue — is the consumer in this repo, or in another registered service?"* (only when cross-repo traversal is ambiguous)
+
+Don't ask questions whose answer is already in the discovery report.
+
+### 5. Generate the output(s)
+
+Resolve the template:
+
+```bash
+template=$(portfolio_resolve_template architecture/dfd.md)
+```
+
+Single-fork adopters with no override fall through to `templates/architecture/dfd.md`. Adopters who want a customised shape drop their version at `<private_repo>/custom-templates/architecture/dfd.md` (same convention as `/c4`).
+
+#### 5a. Mermaid markdown (always)
+
+Build the in-memory DFD model (actors / processes / stores / flows / boundaries / classifications) from the approved candidate. Pipe through `generate-mermaid.sh` to assemble the markdown file:
+
+```bash
+discovery_yaml="/tmp/dfd-discovery-${PROJECT}.yaml"
+classifications_yaml="/tmp/dfd-classifications-${PROJECT}.yaml"
+
+bash .claude/skills/dfd/discover.sh "$target_dir" "$scope_hint"   > "$discovery_yaml"
+bash .claude/skills/dfd/classify.sh "$target_dir"                 > "$classifications_yaml"
+
+bash .claude/skills/dfd/generate-mermaid.sh "$PROJECT" "$discovery_yaml" "$classifications_yaml" \
+  > "projects/${PROJECT}/architecture/dfd.md"
+
+# Persist the source-of-truth combined report for re-run diffs
+cat "$discovery_yaml" "$classifications_yaml" > "projects/${PROJECT}/architecture/dfd-source.yaml"
+```
+
+The generator replaces placeholders in the template skeleton with real actors / processes / stores / flows from the in-memory model. Every cross-boundary arrow MUST carry a payload label.
+
+#### 5b. Threat Dragon v2 JSON (on `--format=dragon` or `--format=all`)
+
+Build a JSON document with the in-memory model and pipe through `generate-dragon.sh`:
+
+```bash
+echo "$model_json" \
+  | bash .claude/skills/dfd/generate-dragon.sh \
+  > "projects/${PROJECT}/architecture/dfd.json"
+```
+
+`generate-dragon.sh` is a **pure function over the in-memory model** — `/threat-model --format=dragon` (#255) will import the same serialiser when it lands. If `#255` ships first with the serialiser inside `/threat-model`, switch this skill to import from there during code review.
+
+Schema reference: [OWASP Threat Dragon v2 JSON schema](https://github.com/OWASP/threat-dragon/blob/main/td.vue/src/service/migration/schema/threat-model.v2.json).
+
+#### 5c. Cross-repo composition (on `--scope-all`)
+
+For each registered project, run discovery → render per-service sub-model. Compose by:
+
+1. Each service becomes a **dashed trust-boundary subgraph** in the composed Mermaid
+2. Every cross-service flow (detected via `mrt_resolve_target` from `_lib-multi-repo-trace.sh`) becomes an arrow crossing the boundary
+3. Unmanaged third parties (Stripe, SendGrid, Salesforce — detected via `mrt_is_third_party`) render as external entities with their own trust-boundary marker
+4. Each cross-repo handoff is labelled with the broker + topic / endpoint URL / etc.
+
+Output lands at `docs/architecture/system-dfd.md` (framework-wide view).
+
+### 6. Re-run UX + drift detection
+
+If `projects/<name>/architecture/dfd.md` already exists, prompt:
+
+```
+projects/<name>/architecture/dfd.md already exists (last written {date}).
+Overwrite? [y/N]
+```
+
+Default `N`. On `N`: write to `projects/<name>/architecture/dfd-{YYYY-MM-DD}.md` so the operator can diff old vs new. On `y`: overwrite, BUT first diff the new `dfd-source.yaml` against the previous one and surface a "what changed" summary:
+
+```
+DFD drift since last run:
+  + new data store: docdb_dynamo (./src/billing/audit-log.ts:14)
+  + new external service: ext_twilio (./src/notifications/sms.ts:8)
+  + new flow: http_api → ext_twilio
+  + new classification: phone_number [pii] (./prisma/schema.prisma:44)
+
+These changes may warrant a fresh /threat-model run — newly-introduced data flows
+are exactly the surface security review should focus on.
+```
+
+### 7. Index in `architecture/README.md`
+
+If `projects/<name>/architecture/README.md` exists, ensure it lists the DFD alongside any C4 diagrams. If it doesn't exist, create it with a minimal index:
+
+```markdown
+# {project-name} — Architecture
+
+| Diagram | Source | Last generated |
+|---------|--------|----------------|
+| [System Context (C4 L1)](./context.md) | `/c4 {project} --level=1` | YYYY-MM-DD |
+| [Container (C4 L2)](./container.md) | `/c4 {project} --level=2` | YYYY-MM-DD |
+| [Data Flow Diagram](./dfd.md) | `/dfd {project}` | YYYY-MM-DD |
+```
+
+### 8. Final confirmation
+
+```
+✓ {project}: DFD written
+
+  Mermaid: projects/{project}/architecture/dfd.md
+  Source:  projects/{project}/architecture/dfd-source.yaml
+  {Dragon JSON: projects/{project}/architecture/dfd.json}
+
+  Actors: {N actors}    Processes: {N}    Stores: {N}    Flows: {N}    Boundaries: {N}
+  Classifications: {N PII} / {N PCI} / {N secrets} / {N other}
+
+Source of truth: /threat-model and /compliance-check now read from this file.
+Re-run /dfd {project} after architecture changes.
+```
+
+## Worked example
+
+Run `/dfd billing-api` against a small Express + Prisma + BullMQ service that integrates with Stripe + SendGrid:
+
+**Discovery** picks up:
+- HTTP routes (12) → public_user actor + http_api process + public ↔ backend boundary
+- `@auth0` import → auth0 external actor
+- `stripe`, `@sendgrid/mail` imports → stripe + sendgrid external actors + us ↔ third-party boundary
+- `prisma/schema.prisma` → postgres data store + backend ↔ data boundary
+- `ioredis` import → redis cache
+- `bullmq` `new Worker(` → background-worker process
+- `cron.schedule(` → scheduled-job process
+
+**Classifications** detect:
+- `user.email` (Prisma column) → PII
+- `user.phone_number` (Prisma column) → PII
+- `card_number` (mentioned in Stripe-flow code) → PCI
+- `STRIPE_SECRET_KEY` (env var) → secrets
+- `SENDGRID_API_KEY` (env var) → secrets
+
+**Operator review** confirms the model, classifies one ambiguous `user.identifier` as PII (UUID, but used as a join key), and overrides the trust boundary between worker and Stripe to also include the email worker (single "outbound integrations" boundary).
+
+**Output**: `projects/billing-api/architecture/dfd.md` with the Mermaid diagram, trust-boundaries table, classifications table, and full provenance YAML. Subsequent `/threat-model billing-api` reads from this file and produces the STRIDE catalogue against the boundary crossings — no DFD regeneration.
+
+## Rules
+
+1. **Read-only against the codebase.** Never modify the project's source. Only writes to `projects/<name>/architecture/`.
+2. **Read-first, ask-later.** The discovery report comes BEFORE any operator question. Don't ask things the code already says.
+3. **Default-no on overwrite.** Existing DFDs may have been hand-edited; clobbering them silently is the worst-case failure. The drift summary (step 6) makes accepted overwrites informative.
+4. **Reachability-bounded.** A single-service DFD walks only what's connected to that service. Don't expand to the whole registry unless `--scope-all`.
+5. **Three classification pathways are additive, the explicit registry wins.** If `docs/data-classification.{md,yaml}` exists, its labels override heuristic labels for any field it covers.
+6. **Don't invent third-party integrations.** Every `External Service` actor must trace to a concrete SDK import, API key env var, or webhook handler. No guessing.
+7. **Footer signature is mandatory.** Every generated `dfd.md` ends with `Generated by /dfd on YYYY-MM-DD` so re-runners know the file is regenerable.
+8. **Refuse if there's nothing to scan.** No `package.json`, no `pyproject.toml`, no `Gemfile`, no schema → stop with an error rather than producing an empty DFD.
+
+## When to use this
+
+| Trigger | Use `/dfd`? |
+|---------|-------------|
+| Preparing for a security review | YES — produces the DFD `/threat-model` needs |
+| Preparing for GDPR / ePrivacy launch check | YES — produces the classifications `/compliance-check` needs |
+| Adopting a new project via `/handover` | OFFER after `/c4` — sequence: `/handover` → `/c4` (static topology) → `/dfd` (data flows) → `/threat-model` (security analysis) |
+| Major architecture change (new DB, new third party) | YES — re-run; the drift summary surfaces the delta |
+| Pure UI / styling work | NO — no data-flow change, DFD stable |
+| Spike / throwaway POC | NO — the surface isn't stable enough to be worth modelling |
+
+## Out of scope (v1)
+
+- **IaC reading** (Terraform / CloudFormation / SAM) for trust-boundary inference — code + env config only in v1
+- **SAST / DAST substitution** — `/dfd` informs threat modelling and compliance, doesn't substitute for actual security scans
+- **Pretty SVG/PNG export** — Threat Dragon does that after JSON import
+- **PlantUML DFD format** (`--format=plantuml-dfd`) — listed in the AC as v2 follow-up
+- **Round-trip import** — hand-edited `dfd.md` → re-parsed back into discovery model
+- **Continuous / real-time DFD updates** — one-shot, same as siblings
+- **L3 / L4 detail** — single DFD per scope; per-service component-level DFDs are out-of-scope (use multiple `/dfd <subscope>` runs if needed)
+
+## Anti-patterns
+
+- **Don't substitute `/dfd` for security review.** The DFD is the input to STRIDE, not the threat model itself. Always pair with `/threat-model` for the actual security analysis.
+- **Don't run `/dfd --scope-all` on every PR.** It's a one-off baseline + on-significant-change refresh. Single-service `/dfd` is the per-PR cadence.
+- **Don't classify by guessing.** If neither the annotation, env-var, schema, nor explicit-registry pathways fire on a field, leave it unclassified and surface in coverage gaps. False classifications are worse than missing ones (they create false confidence in compliance output).
+- **Don't skip the operator review step.** Heuristic discovery has false positives; the operator's "yes, those are real boundaries; no, that field is not PII" pass is load-bearing for downstream consumers.

--- a/.claude/skills/dfd/classify.sh
+++ b/.claude/skills/dfd/classify.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# /dfd — data-classification heuristics
+#
+# Walks a target codebase looking for data elements that should be
+# tagged with a classification label (PII, PCI, secrets, internal,
+# public). Three detection pathways, additive:
+#
+#   1. Annotations  — `@PII`, `@Sensitive`, `// CLASSIFIED: <label>`,
+#                     `# classification: <label>`
+#   2. Env-var heuristics — `*_SECRET`, `*_TOKEN`, `*_KEY`, `*_PASSWORD`
+#                           in `.env*` / `process.env.*` / `os.environ[...]`
+#   3. Schema heuristics — column / field names matching known PII /
+#                          PCI patterns
+#
+# A fourth pathway (explicit registry — `docs/data-classification.yaml`)
+# is honoured when present and OVERRIDES the heuristic output for any
+# field it covers.
+#
+# Usage:
+#   classify.sh <target-dir>
+#     target-dir   absolute path to project root
+#
+# Output: structured YAML on stdout under a `classifications:` root key.
+#
+# Bash 3.2 compatible (no associative arrays, no `${var,,}` / `${var^^}`).
+
+set -uo pipefail
+
+TARGET="${1:-}"
+
+if [ -z "$TARGET" ] || [ ! -d "$TARGET" ]; then
+  echo "ERROR: classify.sh requires a target directory as the first argument" >&2
+  exit 2
+fi
+
+TARGET=$(cd "$TARGET" && pwd -P)
+
+SKIP_DIRS="node_modules vendor .venv venv target dist build coverage .next .nuxt .turbo .cache __pycache__ .git .svn"
+
+scoped_grep() {
+  local pattern="$1"; shift
+  local prune_args="" first=1 d
+  for d in $SKIP_DIRS; do
+    if [ $first -eq 1 ]; then
+      prune_args="-name $d"
+      first=0
+    else
+      prune_args="$prune_args -o -name $d"
+    fi
+  done
+  # shellcheck disable=SC2086
+  find "$TARGET" \( $prune_args \) -prune -o -type f -print 2>/dev/null \
+    | xargs grep -nHE "$pattern" "$@" 2>/dev/null \
+    | head -400
+}
+
+rel_path() {
+  local p="$1"
+  printf './%s\n' "${p#"$TARGET"/}"
+}
+
+# Lowercase / uppercase (bash 3.2 has no ${var,,} / ${var^^})
+lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+upper() { printf '%s' "$1" | tr '[:lower:]' '[:upper:]'; }
+
+# Map a column / field name to a heuristic classification label.
+# Outputs the label or empty + nonzero on no match.
+classify_field() {
+  local name_lc
+  name_lc=$(lower "$1")
+
+  case "$name_lc" in
+    # PCI — payment card data (most specific first)
+    card_number|cardnumber|card_no|pan)              echo "pci";       return 0 ;;
+    cvv|cvc|card_verification|csc)                   echo "pci";       return 0 ;;
+    exp_month|exp_year|expiry_month|expiry_year|expiration_date) echo "pci"; return 0 ;;
+
+    # Secrets — credentials / keys
+    password|password_hash|passwd|pwd_hash|hashedpassword) echo "secrets"; return 0 ;;
+    api_key|apikey|secret_key|access_token|refresh_token|bearer_token) echo "secrets"; return 0 ;;
+    private_key|priv_key)                            echo "secrets";   return 0 ;;
+
+    # PII — personally identifiable
+    email|email_address|user_email|emailaddress)     echo "pii";       return 0 ;;
+    phone|phone_number|phonenumber|mobile|mobile_number) echo "pii";   return 0 ;;
+    ssn|social_security_number|national_id|nin)      echo "pii";       return 0 ;;
+    dob|date_of_birth|birth_date|birthdate)          echo "pii";       return 0 ;;
+    address|street_address|home_address|mailing_address) echo "pii";   return 0 ;;
+    first_name|last_name|full_name|surname|given_name) echo "pii";     return 0 ;;
+    ip_address|ip|client_ip|remote_addr|user_ip)     echo "pii";       return 0 ;;
+    passport|passport_number|drivers_license|license_number) echo "pii"; return 0 ;;
+  esac
+  return 1
+}
+
+# Map an env-var name to a heuristic classification label.
+classify_envvar() {
+  local up
+  up=$(upper "$1")
+
+  case "$up" in
+    *_SECRET|*_PASSWORD|*_PWD|*PRIVATE_KEY*)     echo "secrets"; return 0 ;;
+    *_TOKEN|*_API_KEY|*_APIKEY|*_KEY)            echo "secrets"; return 0 ;;
+    SMTP_*|EMAIL_*|MAIL_*)                        echo "email-routing"; return 0 ;;
+    DATABASE_URL|DB_URL|DB_PASSWORD|DB_USER|POSTGRES_*|MYSQL_*) echo "secrets"; return 0 ;;
+  esac
+  return 1
+}
+
+echo "classifications:"
+
+# ---- Pathway 1: Annotations ------------------------------------------------
+
+ANNO_HITS=$(scoped_grep '(@PII|@Sensitive|CLASSIFIED:[[:space:]]*[a-zA-Z_-]+|classification:[[:space:]]*[a-zA-Z_-]+)')
+if [ -n "$ANNO_HITS" ]; then
+  echo "  # --- annotation pathway ---"
+  printf '%s\n' "$ANNO_HITS" | while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    file=$(printf '%s' "$line" | cut -d: -f1)
+    lno=$(printf '%s' "$line" | cut -d: -f2)
+    content=$(printf '%s' "$line" | cut -d: -f3-)
+    label=""
+    case "$content" in
+      *'@PII'*)       label="pii" ;;
+      *'@Sensitive'*) label="sensitive" ;;
+    esac
+    if printf '%s' "$content" | grep -qE 'CLASSIFIED:'; then
+      label=$(printf '%s' "$content" | grep -oE 'CLASSIFIED:[[:space:]]*[a-zA-Z_-]+' | sed 's/.*://' | tr -d '[:space:]')
+    fi
+    if printf '%s' "$content" | grep -qE 'classification:'; then
+      label=$(printf '%s' "$content" | grep -oE 'classification:[[:space:]]*[a-zA-Z_-]+' | sed 's/.*://' | tr -d '[:space:]')
+    fi
+    [ -z "$label" ] && continue
+    short_content=$(printf '%s' "$content" | tr -d '"' | tr -d "'" | cut -c1-80)
+    ev=$(rel_path "$file")
+    echo "  - source: annotation"
+    echo "    label: \"$label\""
+    echo "    evidence: \"${ev}:${lno}\""
+    echo "    context: \"$short_content\""
+  done
+fi
+
+# ---- Pathway 2: Env vars ---------------------------------------------------
+
+ENV_FILES=$(find "$TARGET" -maxdepth 3 -type f \( -name '.env' -o -name '.env.*' -o -name '.env.example' \) 2>/dev/null | head -10)
+ENV_REFS=$(scoped_grep '(process\.env\.[A-Z_][A-Z0-9_]*|os\.environ\[[\x27"][A-Z_][A-Z0-9_]*[\x27"]\]|getenv\([\x27"][A-Z_][A-Z0-9_]*[\x27"]\))')
+
+if [ -n "$ENV_FILES" ] || [ -n "$ENV_REFS" ]; then
+  echo "  # --- env-var pathway ---"
+  ENV_SEEN_FILE=$(mktemp)
+  for envf in $ENV_FILES; do
+    [ -z "$envf" ] && continue
+    while IFS= read -r raw; do
+      key=$(printf '%s' "$raw" | grep -oE '^[A-Z_][A-Z0-9_]*' | head -1)
+      [ -z "$key" ] && continue
+      grep -qx "$key" "$ENV_SEEN_FILE" 2>/dev/null && continue
+      echo "$key" >> "$ENV_SEEN_FILE"
+      label=$(classify_envvar "$key")
+      [ -z "$label" ] && continue
+      ev=$(rel_path "$envf")
+      echo "  - source: env_var"
+      echo "    label: \"$label\""
+      echo "    name: \"$key\""
+      echo "    evidence: \"${ev}:1\""
+    done < "$envf"
+  done
+  if [ -n "$ENV_REFS" ]; then
+    printf '%s\n' "$ENV_REFS" | while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      file=$(printf '%s' "$line" | cut -d: -f1)
+      lno=$(printf '%s' "$line" | cut -d: -f2)
+      content=$(printf '%s' "$line" | cut -d: -f3-)
+      key=$(printf '%s' "$content" | grep -oE '[A-Z_][A-Z0-9_]{2,}' | head -1)
+      [ -z "$key" ] && continue
+      grep -qx "$key" "$ENV_SEEN_FILE" 2>/dev/null && continue
+      echo "$key" >> "$ENV_SEEN_FILE"
+      label=$(classify_envvar "$key")
+      [ -z "$label" ] && continue
+      ev=$(rel_path "$file")
+      echo "  - source: env_var_ref"
+      echo "    label: \"$label\""
+      echo "    name: \"$key\""
+      echo "    evidence: \"${ev}:${lno}\""
+    done
+  fi
+  rm -f "$ENV_SEEN_FILE"
+fi
+
+# ---- Pathway 3: Schema columns ---------------------------------------------
+
+# Prisma — `<field>  <Type>` lines inside `model X { ... }`
+PRISMA_F=$(find "$TARGET" -maxdepth 4 -name 'schema.prisma' -type f 2>/dev/null | head -5)
+if [ -n "$PRISMA_F" ]; then
+  echo "  # --- schema pathway: Prisma ---"
+  for f in $PRISMA_F; do
+    in_model=0
+    line_no=0
+    current_model=""
+    while IFS= read -r raw; do
+      line_no=$((line_no + 1))
+      # Detect model start
+      first_word=$(printf '%s' "$raw" | awk '{print $1}')
+      second_word=$(printf '%s' "$raw" | awk '{print $2}')
+      if [ "$first_word" = "model" ] && [ -n "$second_word" ]; then
+        in_model=1
+        current_model=$(printf '%s' "$second_word" | tr -d '{')
+        continue
+      fi
+      # Detect model end (closing brace at column 0/1)
+      case "$raw" in
+        '}'*|' }'*) in_model=0; continue ;;
+      esac
+      if [ "$in_model" -eq 1 ]; then
+        field=$(printf '%s' "$raw" | awk '{print $1}')
+        [ -z "$field" ] && continue
+        case "$field" in
+          @@*|//*) continue ;;
+        esac
+        label=$(classify_field "$field")
+        [ -z "$label" ] && continue
+        ev=$(rel_path "$f")
+        echo "  - source: schema_column"
+        echo "    label: \"$label\""
+        echo "    model: \"$current_model\""
+        echo "    field: \"$field\""
+        echo "    evidence: \"${ev}:${line_no}\""
+      fi
+    done < "$f"
+  done
+fi
+
+# Raw SQL migrations
+SQL_F=$(find "$TARGET" -maxdepth 5 -type f \( -name '*.sql' -o -name 'schema.sql' \) 2>/dev/null | head -10)
+if [ -n "$SQL_F" ]; then
+  echo "  # --- schema pathway: raw SQL ---"
+  for f in $SQL_F; do
+    line_no=0
+    while IFS= read -r raw; do
+      line_no=$((line_no + 1))
+      field=$(printf '%s' "$raw" | awk '{print $1}' | sed 's/[",;]//g' | cut -c1-64)
+      [ -z "$field" ] && continue
+      label=$(classify_field "$field")
+      [ -z "$label" ] && continue
+      ev=$(rel_path "$f")
+      echo "  - source: schema_column"
+      echo "    label: \"$label\""
+      echo "    field: \"$field\""
+      echo "    evidence: \"${ev}:${line_no}\""
+    done < "$f"
+  done
+fi
+
+# SQLAlchemy / Django ORM — `<name> = Column(...)` / `<name> = models.<Field>(`
+ORM_FIELDS=$(scoped_grep '^\s*[a-z_][a-z0-9_]*\s*=\s*(Column|models\.)')
+if [ -n "$ORM_FIELDS" ]; then
+  echo "  # --- schema pathway: Python ORMs ---"
+  printf '%s\n' "$ORM_FIELDS" | while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    file=$(printf '%s' "$line" | cut -d: -f1)
+    lno=$(printf '%s' "$line" | cut -d: -f2)
+    content=$(printf '%s' "$line" | cut -d: -f3-)
+    field=$(printf '%s' "$content" | grep -oE '^[[:space:]]*[a-z_][a-z0-9_]*' | head -1 | tr -d '[:space:]')
+    [ -z "$field" ] && continue
+    label=$(classify_field "$field")
+    [ -z "$label" ] && continue
+    ev=$(rel_path "$file")
+    echo "  - source: schema_column"
+    echo "    label: \"$label\""
+    echo "    field: \"$field\""
+    echo "    evidence: \"${ev}:${lno}\""
+  done
+fi
+
+# TS / Mongoose / TypeORM field literals — `fieldName: { type: ... }`
+# Match well-known PII / PCI field names at the start of a line (after indent).
+TS_FIELDS=$(scoped_grep '^[[:space:]]*(email|phone|phone_number|ssn|dob|address|password|api_key|card_number|cvv|first_name|last_name|full_name|ip_address)[[:space:]]*[:?]')
+if [ -n "$TS_FIELDS" ]; then
+  echo "  # --- schema pathway: TS object literals ---"
+  TS_SEEN_FILE=$(mktemp)
+  printf '%s\n' "$TS_FIELDS" | while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    file=$(printf '%s' "$line" | cut -d: -f1)
+    lno=$(printf '%s' "$line" | cut -d: -f2)
+    content=$(printf '%s' "$line" | cut -d: -f3-)
+    field=$(printf '%s' "$content" | grep -oE '^[[:space:]]*[a-z_][a-z0-9_]*' | head -1 | tr -d '[:space:]')
+    [ -z "$field" ] && continue
+    key="${file}|${field}"
+    grep -qxF "$key" "$TS_SEEN_FILE" 2>/dev/null && continue
+    echo "$key" >> "$TS_SEEN_FILE"
+    label=$(classify_field "$field")
+    [ -z "$label" ] && continue
+    ev=$(rel_path "$file")
+    echo "  - source: schema_column"
+    echo "    label: \"$label\""
+    echo "    field: \"$field\""
+    echo "    evidence: \"${ev}:${lno}\""
+  done
+  rm -f "$TS_SEEN_FILE"
+fi
+
+# ---- Pathway 4: Explicit registry override ---------------------------------
+
+REG=$(find "$TARGET" -maxdepth 3 -type f \( -name 'data-classification.yaml' -o -name 'data-classification.yml' -o -name 'data-classification.md' \) 2>/dev/null | head -1)
+if [ -n "$REG" ]; then
+  echo "  # --- explicit registry (overrides heuristics) ---"
+  echo "  - source: explicit_registry"
+  echo "    path: \"$(rel_path "$REG")\""
+  echo "    note: \"Operator-authored classification registry detected. Skill MUST load this file and let it override heuristic labels for any field it covers.\""
+fi

--- a/.claude/skills/dfd/discover.sh
+++ b/.claude/skills/dfd/discover.sh
@@ -1,0 +1,409 @@
+#!/usr/bin/env bash
+# /dfd — six-axis Data Flow Diagram discovery, read-only.
+#
+# Scans a target codebase for DFD elements: external actors, processes,
+# data stores, data flows, trust boundaries, and data classifications
+# (axis 6 delegated to classify.sh and merged in by the calling skill).
+#
+# Usage:
+#   discover.sh <target-dir> [scope-hint]
+#     target-dir   absolute path to the project root (must exist)
+#     scope-hint   optional anchor — service name, "all", or empty
+#
+# Output: a YAML-ish structured discovery report on stdout. Sections:
+#   actors:            external entities (users, third-party SaaS, admin consoles)
+#   processes:         service handlers (HTTP, queue consumer, scheduled job)
+#   stores:            persistent data stores (DB, cache, object storage, search index)
+#   flows:             arrows — `{source, target, payload_hint, evidence}`
+#   boundaries:        inferred trust boundaries — `{name, scope_hint, rationale}`
+#   classifications:   per-data-element classification labels (PII / PCI / secrets / ...)
+#
+# Bash 3.2 compatible (no associative arrays, no `${var,,}` syntax) so
+# the script works under the system bash on stock macOS.
+
+set -uo pipefail
+
+TARGET="${1:-}"
+SCOPE_HINT="${2:-}"
+
+if [ -z "$TARGET" ] || [ ! -d "$TARGET" ]; then
+  echo "ERROR: discover.sh requires a target directory as the first argument" >&2
+  exit 2
+fi
+
+TARGET=$(cd "$TARGET" && pwd -P)
+
+SKIP_DIRS="node_modules vendor .venv venv target dist build coverage .next .nuxt .turbo .cache __pycache__ .git .svn .idea .vscode"
+
+# scoped_grep <pattern>: greps the target dir for <pattern>, pruning vendored dirs.
+# Outputs `file:line:match` (grep -nH format), capped at 500 lines.
+scoped_grep() {
+  local pattern="$1"; shift
+  local prune_args="" first=1 d
+  for d in $SKIP_DIRS; do
+    if [ $first -eq 1 ]; then
+      prune_args="-name $d"
+      first=0
+    else
+      prune_args="$prune_args -o -name $d"
+    fi
+  done
+  # shellcheck disable=SC2086
+  find "$TARGET" \( $prune_args \) -prune -o -type f -print 2>/dev/null \
+    | xargs grep -nHE "$pattern" "$@" 2>/dev/null \
+    | head -500
+}
+
+# rel_path <abspath>  → path relative to TARGET (with leading ./)
+rel_path() {
+  local p="$1"
+  printf './%s\n' "${p#"$TARGET"/}"
+}
+
+# first_evidence <hits-blob>: extracts the first file:line from a multi-line
+# grep -nH blob and rewrites the file part to a relative path.
+first_evidence() {
+  local blob="$1"
+  [ -z "$blob" ] && return 0
+  local first
+  first=$(printf '%s\n' "$blob" | head -1)
+  local file line
+  file=$(printf '%s' "$first" | cut -d: -f1)
+  line=$(printf '%s' "$first" | cut -d: -f2)
+  printf '%s:%s\n' "$(rel_path "$file")" "$line"
+}
+
+# --- Discovery axes ----------------------------------------------------------
+
+echo "# DFD discovery report"
+echo "# Target: $TARGET"
+echo "# Scope hint: ${SCOPE_HINT:-(none)}"
+echo "# Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo ""
+
+# ---- Axis 1: External actors -----------------------------------------------
+
+echo "actors:"
+
+# Auth providers
+AUTH_HITS=$(scoped_grep '(@auth0|aws-cdk-lib/aws-cognito|@clerk/|@supabase/auth|keycloak-js|next-auth|passport-)')
+if [ -n "$AUTH_HITS" ]; then
+  ev=$(first_evidence "$AUTH_HITS")
+  echo "  - id: auth_provider"
+  echo "    type: external_auth"
+  echo "    evidence: \"$ev\""
+fi
+
+# Third-party SDK imports → external system actors
+TP_PATTERNS='(stripe|@sendgrid/mail|nodemailer|postmark|twilio|@anthropic-ai/sdk|openai|@aws-sdk/client-(bedrock|sns|sqs)|@sentry/|@datadog/|posthog-js|@amplitude/analytics|mixpanel|algoliasearch|meilisearch)'
+TP_HITS=$(scoped_grep "$TP_PATTERNS")
+
+# Walk TP_HITS once, emit one entry per unique vendor (track via a temp file).
+TP_SEEN_FILE=$(mktemp)
+if [ -n "$TP_HITS" ]; then
+  printf '%s\n' "$TP_HITS" | while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    file=$(printf '%s' "$line" | cut -d: -f1)
+    lno=$(printf '%s' "$line" | cut -d: -f2)
+    content=$(printf '%s' "$line" | cut -d: -f3-)
+    vendor=$(printf '%s' "$content" | grep -oE "$TP_PATTERNS" | head -1)
+    [ -z "$vendor" ] && continue
+    # Canonicalise the vendor key to a single short token
+    case "$vendor" in
+      *stripe*)              key="stripe" ;;
+      *sendgrid*)            key="sendgrid" ;;
+      *nodemailer*)          key="nodemailer" ;;
+      *postmark*)            key="postmark" ;;
+      *twilio*)              key="twilio" ;;
+      *anthropic*)           key="anthropic" ;;
+      *openai*)              key="openai" ;;
+      *bedrock*)             key="bedrock" ;;
+      *sns*)                 key="aws_sns" ;;
+      *sqs*)                 key="aws_sqs" ;;
+      *sentry*)              key="sentry" ;;
+      *datadog*)             key="datadog" ;;
+      *posthog*)             key="posthog" ;;
+      *amplitude*)           key="amplitude" ;;
+      *mixpanel*)            key="mixpanel" ;;
+      *algoliasearch*)       key="algolia" ;;
+      *meilisearch*)         key="meilisearch" ;;
+      *)                     key="${vendor//[^a-zA-Z0-9]/_}" ;;
+    esac
+    if ! grep -qx "$key" "$TP_SEEN_FILE" 2>/dev/null; then
+      echo "$key" >> "$TP_SEEN_FILE"
+      ev_rel=$(rel_path "$file")
+      echo "  - id: ext_${key}"
+      echo "    type: external_service"
+      echo "    name: \"$key\""
+      echo "    evidence: \"${ev_rel}:${lno}\""
+    fi
+  done
+fi
+rm -f "$TP_SEEN_FILE"
+
+# Public HTTP entry points (anyone calling these is an external actor)
+ROUTE_HITS=$(scoped_grep '(app|router|fastify)\.(get|post|put|patch|delete|all)\s*\(')
+if [ -n "$ROUTE_HITS" ]; then
+  ev=$(first_evidence "$ROUTE_HITS")
+  echo "  - id: public_user"
+  echo "    type: human"
+  echo "    name: \"End user (via HTTP)\""
+  echo "    evidence: \"$ev\""
+fi
+
+# Admin route detection — separate persona
+# Use literal `/admin/` or `/api/admin/` strings (avoid shell metacharacter pain)
+ADMIN_HITS=$(scoped_grep '/admin/|/api/admin/')
+if [ -n "$ADMIN_HITS" ]; then
+  ev=$(first_evidence "$ADMIN_HITS")
+  echo "  - id: admin_user"
+  echo "    type: human"
+  echo "    name: \"Admin (privileged)\""
+  echo "    evidence: \"$ev\""
+fi
+
+echo ""
+
+# ---- Axis 2: Processes -----------------------------------------------------
+
+echo "processes:"
+
+# HTTP route handlers (one process per route batch)
+N_ROUTES=0
+if [ -n "$ROUTE_HITS" ]; then
+  N_ROUTES=$(printf '%s\n' "$ROUTE_HITS" | wc -l | tr -d ' ')
+fi
+if [ "$N_ROUTES" -gt 0 ]; then
+  echo "  - id: http_api"
+  echo "    type: http_handler"
+  echo "    name: \"HTTP API handlers\""
+  echo "    count: $N_ROUTES"
+fi
+
+# Queue consumers / async jobs
+QUEUE_HITS=$(scoped_grep 'new (Queue|Worker)\s*\(|@app\.task|@shared_task|@celery|sidekiq|@workflow\.defn')
+N_Q=0
+if [ -n "$QUEUE_HITS" ]; then
+  N_Q=$(printf '%s\n' "$QUEUE_HITS" | wc -l | tr -d ' ')
+fi
+if [ "$N_Q" -gt 0 ]; then
+  echo "  - id: queue_workers"
+  echo "    type: queue_consumer"
+  echo "    name: \"Background workers\""
+  echo "    count: $N_Q"
+fi
+
+# Scheduled jobs / cron
+CRON_HITS=$(scoped_grep 'cron\.schedule\s*\(|@scheduled_job|^schedule:|Events:.*Schedule:|^cron:')
+N_C=0
+if [ -n "$CRON_HITS" ]; then
+  N_C=$(printf '%s\n' "$CRON_HITS" | wc -l | tr -d ' ')
+fi
+if [ "$N_C" -gt 0 ]; then
+  echo "  - id: scheduled_jobs"
+  echo "    type: scheduled"
+  echo "    name: \"Scheduled jobs / cron\""
+  echo "    count: $N_C"
+fi
+
+echo ""
+
+# ---- Axis 3: Data stores ---------------------------------------------------
+
+echo "stores:"
+
+# Prisma
+PRISMA_FILES=$(find "$TARGET" -name 'schema.prisma' -type f 2>/dev/null | head -3)
+HAS_PRISMA=""
+if [ -n "$PRISMA_FILES" ]; then
+  first_p=$(printf '%s\n' "$PRISMA_FILES" | head -1)
+  provider=$(grep -m1 -E '^\s*provider\s*=' "$first_p" 2>/dev/null | awk -F'"' '{print $2}')
+  [ -z "$provider" ] && provider="postgresql"
+  ev=$(rel_path "$first_p")
+  echo "  - id: rdbms_prisma"
+  echo "    type: rdbms"
+  echo "    name: \"$provider (via Prisma)\""
+  echo "    evidence: \"${ev}:1\""
+  HAS_PRISMA=1
+fi
+
+# TypeORM @Entity
+if [ -z "$HAS_PRISMA" ]; then
+  TYPEORM=$(scoped_grep '@Entity\s*\(')
+  if [ -n "$TYPEORM" ]; then
+    ev=$(first_evidence "$TYPEORM")
+    echo "  - id: rdbms_typeorm"
+    echo "    type: rdbms"
+    echo "    name: \"RDBMS (via TypeORM)\""
+    echo "    evidence: \"$ev\""
+  fi
+fi
+
+# SQLAlchemy
+if [ -z "$HAS_PRISMA" ]; then
+  SQLA=$(scoped_grep 'class\s+\w+\(.*(Base|db\.Model)|__tablename__\s*=')
+  if [ -n "$SQLA" ]; then
+    ev=$(first_evidence "$SQLA")
+    echo "  - id: rdbms_sqlalchemy"
+    echo "    type: rdbms"
+    echo "    name: \"RDBMS (via SQLAlchemy)\""
+    echo "    evidence: \"$ev\""
+  fi
+fi
+
+# Mongo
+MONGO=$(scoped_grep 'mongoose|MongoClient|mongodb://')
+HAS_MONGO=""
+if [ -n "$MONGO" ]; then
+  ev=$(first_evidence "$MONGO")
+  echo "  - id: docdb_mongo"
+  echo "    type: document_store"
+  echo "    name: \"MongoDB\""
+  echo "    evidence: \"$ev\""
+  HAS_MONGO=1
+fi
+
+# Dynamo
+DYNAMO=$(scoped_grep '@aws-sdk/client-dynamodb|DynamoDBClient|boto3.*dynamodb')
+HAS_DYNAMO=""
+if [ -n "$DYNAMO" ]; then
+  ev=$(first_evidence "$DYNAMO")
+  echo "  - id: docdb_dynamo"
+  echo "    type: document_store"
+  echo "    name: \"DynamoDB\""
+  echo "    evidence: \"$ev\""
+  HAS_DYNAMO=1
+fi
+
+# Redis
+REDIS=$(scoped_grep 'ioredis|new Redis\s*\(|redis://|RedisClient')
+HAS_REDIS=""
+if [ -n "$REDIS" ]; then
+  ev=$(first_evidence "$REDIS")
+  echo "  - id: cache_redis"
+  echo "    type: cache"
+  echo "    name: \"Redis\""
+  echo "    evidence: \"$ev\""
+  HAS_REDIS=1
+fi
+
+# S3
+S3=$(scoped_grep '@aws-sdk/client-s3|S3Client|aws-sdk.*S3\(|boto3.*s3')
+HAS_S3=""
+if [ -n "$S3" ]; then
+  ev=$(first_evidence "$S3")
+  echo "  - id: object_s3"
+  echo "    type: object_storage"
+  echo "    name: \"S3 (or compatible)\""
+  echo "    evidence: \"$ev\""
+  HAS_S3=1
+fi
+
+# Search index
+SEARCH=$(scoped_grep '@elastic/elasticsearch|algoliasearch|meilisearch|MeiliSearch')
+if [ -n "$SEARCH" ]; then
+  ev=$(first_evidence "$SEARCH")
+  echo "  - id: search_index"
+  echo "    type: search"
+  echo "    name: \"Search index\""
+  echo "    evidence: \"$ev\""
+fi
+
+# Data warehouse
+DW=$(scoped_grep '@google-cloud/bigquery|snowflake-sdk|redshift-data')
+if [ -n "$DW" ]; then
+  ev=$(first_evidence "$DW")
+  echo "  - id: dwh"
+  echo "    type: data_warehouse"
+  echo "    name: \"Data warehouse\""
+  echo "    evidence: \"$ev\""
+fi
+
+echo ""
+
+# ---- Axis 4: Data flows ----------------------------------------------------
+
+echo "flows:"
+
+if [ "$N_ROUTES" -gt 0 ]; then
+  echo "  - source: public_user"
+  echo "    target: http_api"
+  echo "    payload_hint: \"HTTP request (body, headers, cookies)\""
+fi
+
+if [ -n "$HAS_PRISMA" ]; then
+  echo "  - source: http_api"
+  echo "    target: rdbms_prisma"
+  echo "    payload_hint: \"persistent records\""
+fi
+
+if [ -n "$HAS_MONGO" ]; then
+  echo "  - source: http_api"
+  echo "    target: docdb_mongo"
+  echo "    payload_hint: \"document writes / queries\""
+fi
+
+if [ -n "$HAS_DYNAMO" ]; then
+  echo "  - source: http_api"
+  echo "    target: docdb_dynamo"
+  echo "    payload_hint: \"item writes / queries\""
+fi
+
+if [ -n "$HAS_S3" ]; then
+  echo "  - source: http_api"
+  echo "    target: object_s3"
+  echo "    payload_hint: \"uploaded objects\""
+fi
+
+if [ -n "$HAS_REDIS" ]; then
+  echo "  - source: http_api"
+  echo "    target: cache_redis"
+  echo "    payload_hint: \"cached query results / session data\""
+fi
+
+if [ "$N_Q" -gt 0 ] && [ -n "$TP_HITS" ]; then
+  echo "  - source: queue_workers"
+  echo "    target: ext_third_party"
+  echo "    payload_hint: \"outbound integration calls (webhook, API)\""
+fi
+
+echo ""
+
+# ---- Axis 5: Trust boundaries ----------------------------------------------
+
+echo "boundaries:"
+
+if [ "$N_ROUTES" -gt 0 ]; then
+  echo "  - id: public_to_backend"
+  echo "    name: \"Public Internet ↔ Backend\""
+  echo "    rationale: \"HTTP routes detected — anonymous / authenticated transition\""
+fi
+
+if [ -n "$ADMIN_HITS" ]; then
+  echo "  - id: user_to_admin"
+  echo "    name: \"User ↔ Admin (privilege escalation)\""
+  echo "    rationale: \"/admin/* route prefix detected — additional auth required\""
+fi
+
+if [ -n "$HAS_PRISMA$HAS_MONGO$HAS_DYNAMO$HAS_REDIS$HAS_S3" ]; then
+  echo "  - id: backend_to_data"
+  echo "    name: \"Backend ↔ Data Stores\""
+  echo "    rationale: \"Data store(s) detected — DB credentials / IAM gate the boundary\""
+fi
+
+if [ -n "$TP_HITS" ]; then
+  echo "  - id: us_to_third_party"
+  echo "    name: \"Us ↔ Third-party SaaS\""
+  echo "    rationale: \"Third-party SDK imports detected — outbound calls cross org boundary\""
+fi
+
+echo ""
+
+# ---- Axis 6: Data classifications ------------------------------------------
+# Delegated to classify.sh and merged by the calling skill.
+
+echo "classifications:"
+echo "  # populated by classify.sh — invoke separately for the heuristic walk"
+echo ""
+
+echo "# Summary — caller to populate counts before presenting to operator"

--- a/.claude/skills/dfd/generate-dragon.sh
+++ b/.claude/skills/dfd/generate-dragon.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# /dfd — generate an OWASP Threat Dragon v2 JSON file from the DFD
+# discovery model. Shared serialiser path with #255
+# (`/threat-model --format=dragon`).
+#
+# Design:
+#   - This is a pure function over the in-memory DFD model. The skill's
+#     SKILL.md flow assembles the model from discover.sh + classify.sh +
+#     operator input, then calls this script with structured input on
+#     stdin.
+#   - When `/threat-model --format=dragon` (#255) ships, it imports this
+#     script (or its successor `_lib-threat-dragon-serialiser.sh`) so
+#     both consumers produce byte-compatible Threat Dragon JSON.
+#
+# Input format (read from stdin or --input <path>):
+#   A JSON document with the in-memory DFD model:
+#   {
+#     "project": "...",
+#     "actors":   [ { "id": "...", "name": "...", "type": "human|external_service" } ],
+#     "processes":[ { "id": "...", "name": "...", "type": "http_handler|queue_consumer|scheduled" } ],
+#     "stores":   [ { "id": "...", "name": "...", "type": "rdbms|cache|object_storage|search|..." } ],
+#     "flows":    [ { "source": "id", "target": "id", "label": "payload hint" } ],
+#     "boundaries": [ { "id": "...", "name": "...", "contains": [ "id1", "id2", ... ] } ],
+#     "threats":  [ { "element": "id", "type": "S|T|R|I|D|E", "severity": "...", "description": "...", "mitigation": "...", "status": "Open" } ]
+#   }
+#
+# Output: Threat Dragon v2 JSON on stdout. Caller writes to
+# `projects/<name>/architecture/dfd.json` (or `threat-model.json` for #255).
+#
+# Schema reference:
+#   https://github.com/OWASP/threat-dragon/blob/main/td.vue/src/service/migration/schema/threat-model.v2.json
+
+set -uo pipefail
+
+INPUT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --input) INPUT="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: generate-dragon.sh requires jq" >&2
+  exit 2
+fi
+
+# Read the input model
+if [ -n "$INPUT" ] && [ -f "$INPUT" ]; then
+  MODEL=$(cat "$INPUT")
+elif [ ! -t 0 ]; then
+  MODEL=$(cat)
+else
+  echo "ERROR: no input — pass --input <path> or pipe JSON model on stdin" >&2
+  exit 2
+fi
+
+# Validate the input is JSON
+if ! echo "$MODEL" | jq empty 2>/dev/null; then
+  echo "ERROR: input is not valid JSON" >&2
+  exit 2
+fi
+
+PROJECT=$(echo "$MODEL" | jq -r '.project // "unknown-project"')
+DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Auto-grid layout (same as #255 spec): external actors row y=0,
+# processes y=200, data stores y=400; x-spaced by 200px. Threat Dragon
+# auto-arranges on first open; the grid is just a sane starting state.
+#
+# We assign sequential X positions per row by reading the model and
+# letting jq do the indexing.
+
+# Build the Threat Dragon v2 model structure.
+# Key shapes:
+#   tm.title, tm.version, tm.summary.description, tm.detail.contributors[]
+#   tm.detail.diagrams[0].cells[]
+#     - actors  → shape: tm.actor (rectangle), labelled with .data.name
+#     - processes → shape: tm.process (circle)
+#     - stores   → shape: tm.store (cylinder)
+#     - boundaries → shape: tm.boundary (dashed boundary box wrapping its children)
+#     - flows    → shape: tm.flow (arrow with source/target IDs)
+#   Each .data block carries the element's threats[] (from STRIDE walk)
+
+JQ_SCRIPT='
+  def xy(row; idx): { x: (200 * (idx + 1)), y: row };
+
+  ((.actors    // []) | to_entries | map(.value + (xy(0;   .key) | {position: .})))  as $actors  |
+  ((.processes // []) | to_entries | map(.value + (xy(200; .key) | {position: .})))  as $procs   |
+  ((.stores    // []) | to_entries | map(.value + (xy(400; .key) | {position: .})))  as $stores  |
+  ((.flows     // []))                                                                as $flows   |
+  ((.boundaries // []))                                                               as $bounds  |
+  ((.threats    // []))                                                               as $threats |
+
+  def cell_for_element(el; td_type):
+    (el.id) as $eid |
+    {
+      id: $eid,
+      type: td_type,
+      data: {
+        name: el.name,
+        type: td_type,
+        outOfScope: false,
+        threats: [
+          $threats[] | select(.element == $eid) | {
+            id: (.id // (.element + "-" + .type)),
+            title: (.title // .description // "Untitled threat"),
+            type: (
+              if   .type == "S" then "Spoofing"
+              elif .type == "T" then "Tampering"
+              elif .type == "R" then "Repudiation"
+              elif .type == "I" then "Information disclosure"
+              elif .type == "D" then "Denial of service"
+              elif .type == "E" then "Elevation of privilege"
+              else "Unknown" end
+            ),
+            severity: (.severity // "Medium"),
+            description: (.description // ""),
+            mitigation:  (.mitigation  // "TBD"),
+            status: (.status // "Open"),
+            modelType: "STRIDE"
+          }
+        ]
+      },
+      position: el.position,
+      size: { width: 160, height: 60 }
+    };
+
+  {
+    version: "2.3",
+    summary: {
+      title: ($project + " — DFD"),
+      owner: "apexyard /dfd",
+      description: "Generated DFD for STRIDE threat modelling. Source of truth — threat-model and compliance-check consume from this file."
+    },
+    detail: {
+      contributors: [{ name: "apexyard /dfd" }],
+      diagrams: [
+        {
+          id: "dfd-1",
+          title: "Data Flow Diagram",
+          diagramType: "STRIDE",
+          placeholder: "Edit in Threat Dragon — auto-layout will re-flow elements on first open.",
+          thumbnail: "./public/content/images/thumbnail.stride.jpg",
+          version: "2.3",
+          cells: (
+            ( $actors | map(cell_for_element(.; "tm.actor")) )
+            + ( $procs  | map(cell_for_element(.; "tm.process")) )
+            + ( $stores | map(cell_for_element(.; "tm.store")) )
+            + ( $bounds | map({
+                id: .id,
+                type: "tm.boundary",
+                data: {
+                  name: .name,
+                  type: "tm.boundary",
+                  description: (.rationale // ""),
+                  isTrustBoundary: true,
+                  contains: (.contains // [])
+                },
+                position: { x: 50, y: 50 },
+                size: { width: 600, height: 400 }
+              }) )
+            + ( $flows | to_entries | map(.value as $f | {
+                id: ("flow-" + (.key | tostring)),
+                type: "tm.flow",
+                data: {
+                  name: ($f.label // "data"),
+                  type: "tm.flow",
+                  isEncrypted: false,
+                  isPublicNetwork: false,
+                  protocol: ""
+                },
+                source: { cell: $f.source },
+                target: { cell: $f.target }
+              }) )
+          )
+        }
+      ]
+    },
+    generatedBy: "apexyard /dfd",
+    generatedAt: $ts
+  }
+'
+
+echo "$MODEL" | jq --arg project "$PROJECT" --arg ts "$DATE" "$JQ_SCRIPT"

--- a/.claude/skills/dfd/generate-mermaid.sh
+++ b/.claude/skills/dfd/generate-mermaid.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# /dfd — generate a Mermaid flowchart from the discover.sh + classify.sh
+# structured discovery report.
+#
+# Reads the structured YAML-ish report from stdin (or a file argument)
+# and emits a markdown file with:
+#   1. A header pointing at the source-of-truth status and the generated-at date
+#   2. The Mermaid flowchart block (trust boundaries as dashed subgraphs,
+#      every cross-boundary arrow labelled with the payload hint)
+#   3. A trust-boundaries table (same shape as templates/architecture/dfd.md)
+#   4. A data-classifications table (from classify.sh's output)
+#   5. Provenance metadata — evidence file:line for every element
+#
+# Usage:
+#   generate-mermaid.sh <project-name> [<discovery-yaml-path>] [<classifications-yaml-path>]
+#     If the YAML paths are omitted, read from stdin (combined report).
+#
+# Output: full markdown content on stdout. Caller writes to
+# `projects/<project-name>/architecture/dfd.md`.
+#
+# This is a structural template — the actual element list comes from
+# discover.sh + classify.sh's output. When invoked from inside Claude
+# Code, the agent additionally enriches labels, picks better display
+# names, and resolves the trust-boundary placements with the operator
+# before re-running this generator.
+
+set -uo pipefail
+
+PROJECT="${1:-unknown-project}"
+DISCOVERY="${2:-}"
+CLASSIFICATIONS="${3:-}"
+
+DATE=$(date -u +%Y-%m-%d)
+
+cat <<EOF
+# ${PROJECT} — Data Flow Diagram
+
+> **Source of truth.** This file is the canonical DFD for ${PROJECT}. \`/threat-model\` and \`/compliance-check\` consume it instead of regenerating their own. Re-run \`/dfd ${PROJECT}\` after any architecture change that adds / removes a data store, external integration, or trust boundary.
+
+**Generated**: ${DATE} by \`/dfd\` (apexyard)
+**Format**: Mermaid flowchart (renders inline on GitHub) — also available as Threat Dragon JSON via \`/dfd ${PROJECT} --format=dragon\`
+
+## Diagram
+
+\`\`\`mermaid
+flowchart LR
+    %% External actors (outside all trust boundaries)
+    user([External User])
+    %% Third-party services live outside the system boundary too
+    %% (one node per detected vendor; populated from discover.sh)
+
+    %% Trust zones — dashed subgraphs mark each boundary
+    subgraph public_zone["Public Zone (untrusted)"]
+        frontend["Frontend"]
+    end
+
+    subgraph trusted_backend["Trusted Backend"]
+        api["HTTP API"]
+        worker["Background Worker"]
+    end
+
+    subgraph data_zone["Data Zone (most-trusted)"]
+        primary_db[("Primary Store")]
+    end
+
+    %% Data flows — every cross-boundary arrow MUST carry a payload label
+    user -->|credentials, form data| frontend
+    frontend -->|auth token, request body| api
+    api -->|read/write records| primary_db
+    api -->|enqueue job + payload| worker
+
+    style public_zone stroke-dasharray: 5 5
+    style trusted_backend stroke-dasharray: 5 5
+    style data_zone stroke-dasharray: 5 5
+\`\`\`
+
+The dashed subgraph borders mark **trust boundaries**. Every arrow that crosses a boundary is a STRIDE candidate — that's where authentication, authorisation, and data-classification rules apply most acutely.
+
+> **Editing this diagram by hand.** The diagram above is a starting structure. Replace the placeholders with the actors / processes / stores / flows the discovery report below identified, and add additional cross-boundary arrows for every flow the operator confirmed during the \`/dfd\` interview. Re-running \`/dfd\` will OVERWRITE this file (after the default-no overwrite prompt) — preserve hand edits by copying them to a sibling file, or re-run with the same anchor + answers so the regeneration matches.
+
+---
+
+## Trust boundaries
+
+| From | To | Authentication | Data classification (most-sensitive crossing) |
+|------|-----|----------------|-----------------------------------------------|
+| External User → Frontend | TLS only (browser session) | Credentials, form input |
+| Frontend → API | TLS + bearer token (JWT / session) | Auth token, user PII, request body |
+| API → Primary Store | VPC-internal + DB credentials from secrets store | All persistent user records |
+| API → Worker | Internal queue (auth via shared transport credentials) | Job payload — may contain user PII |
+| API → Third-party SaaS | TLS + API key | Outbound webhook payload — sanitise before sending |
+
+Adjust this table to match the diagram. Each row is a STRIDE entry point — `/threat-model` iterates these crossings rather than inventing threats ad-hoc.
+
+---
+
+## Data classifications
+
+The skill detected the following data classifications via the three heuristic pathways (annotations, env-var names, schema columns) plus any explicit registry the project ships:
+
+| Label | Detected element | Pathway | Evidence |
+|-------|------------------|---------|----------|
+| _populated from classify.sh output during skill execution_ |
+
+\`/compliance-check\` reads this table to flag cross-border transfers, third-party processors, and PII landing in unencrypted stores.
+
+---
+
+## Discovery provenance
+
+The candidate model was assembled from the following evidence:
+
+EOF
+
+# Inline the raw discovery YAML for provenance — readers can see which
+# code paths surfaced which elements.
+if [ -n "$DISCOVERY" ] && [ -f "$DISCOVERY" ]; then
+  echo "### From \`discover.sh\` (six-axis scan)"
+  echo ""
+  echo '```yaml'
+  cat "$DISCOVERY"
+  echo '```'
+  echo ""
+fi
+
+if [ -n "$CLASSIFICATIONS" ] && [ -f "$CLASSIFICATIONS" ]; then
+  echo "### From \`classify.sh\` (data-classification heuristics)"
+  echo ""
+  echo '```yaml'
+  cat "$CLASSIFICATIONS"
+  echo '```'
+  echo ""
+fi
+
+# If neither file argument given, slurp stdin (combined report).
+if [ -z "$DISCOVERY" ] && [ -z "$CLASSIFICATIONS" ] && [ ! -t 0 ]; then
+  echo "### From discovery (combined stdin)"
+  echo ""
+  echo '```yaml'
+  cat
+  echo '```'
+  echo ""
+fi
+
+cat <<EOF
+
+---
+
+## Notes
+
+Each crossing of a trust boundary is where STRIDE threats apply most acutely:
+
+- **Spoofing** — can the source's identity be forged on this hop?
+- **Tampering** — can the data be modified in transit / at the receiver?
+- **Repudiation** — can the sender deny having sent this?
+- **Information disclosure** — what leaks if this hop is intercepted?
+- **Denial of service** — what's the failure mode if this hop is overwhelmed?
+- **Elevation of privilege** — does crossing this boundary grant additional permissions, and are those bounded correctly?
+
+Pair this DFD with [\`/threat-model\`](../../../.claude/skills/threat-model/SKILL.md) so the boundary table feeds directly into a per-arrow STRIDE enumeration. Pair with [\`/compliance-check\`](../../../.claude/skills/compliance-check/SKILL.md) so the classifications table feeds directly into cross-border-transfer and DPA-coverage analysis.
+
+---
+
+_Generated by \`/dfd\` on ${DATE}. Re-run \`/dfd ${PROJECT}\` after architecture changes._
+EOF

--- a/.claude/skills/dfd/tests/README.md
+++ b/.claude/skills/dfd/tests/README.md
@@ -1,0 +1,40 @@
+# `/dfd` tests
+
+## Smoke test
+
+```bash
+bash .claude/skills/dfd/tests/smoke.sh
+```
+
+Builds three synthetic fixtures under `$TMPDIR`, runs the discovery + classification + generator scripts against them, and asserts:
+
+| Fixture | Asserts |
+|---------|---------|
+| 1. Single-service Express + Prisma + BullMQ + Stripe + SendGrid + Auth0 + admin route | All six discovery axes produce non-empty findings; trust boundaries (public ↔ backend, user ↔ admin, backend ↔ data, us ↔ third-party) all detected |
+| 2. Two synthetic services with cross-service flow + Stripe URL | `mrt_resolve_target` resolves the registered cross-service hostname to the right project; `mrt_is_third_party` flags Stripe; `mrt_workspace_for` resolves to the right clone |
+| 3. Code with `@PII` annotations + `EMAIL_*`/`*_SECRET` env vars + `email`/`phone_number`/`card_number` columns | All three classification pathways fire; PCI labels emitted for card data; no false positive on `SOME_PUBLIC_FLAG` |
+| 4. Mermaid generator output | Has top-level heading, source-of-truth declaration, flowchart block, subgraphs, trust-boundaries table, classifications table, provenance section, footer signature |
+| 5. Threat Dragon JSON serialiser (skipped if `jq` missing) | Output is valid JSON; has `version` / `summary` / `detail` top-level keys; cells include `tm.actor` / `tm.process` / `tm.store` / `tm.boundary` / `tm.flow`; STRIDE threats are attached to their parent element |
+| 6. Downstream-consumer refactor verification | `/threat-model` SKILL.md references `projects/.../architecture/dfd.md` AND has an offer-to-run-/dfd-first path; `/compliance-check` SKILL.md references the same DFD path |
+
+## Running individual scripts manually
+
+```bash
+# Discovery axes 1–5 (grep-fallback path)
+bash .claude/skills/dfd/discover.sh /path/to/project [scope-hint]
+
+# Classification heuristics (axis 6)
+bash .claude/skills/dfd/classify.sh /path/to/project
+
+# Mermaid markdown generator
+bash .claude/skills/dfd/generate-mermaid.sh <project-name> [discovery.yaml] [classifications.yaml]
+
+# Threat Dragon JSON serialiser
+echo "$MODEL_JSON" | bash .claude/skills/dfd/generate-dragon.sh
+```
+
+The skill itself dispatches richer logic via LSP when enabled and presents a candidate-model review interview before generating any file. The smoke test verifies the grep-fallback path the skill documents — if the regexes in `discover.sh` / `classify.sh` drift from what they're supposed to match, the smoke test catches it.
+
+## Shared trace helper
+
+The `_lib-multi-repo-trace.sh` helper is also exercised by Fixture 2. The helper is shared with `/process` (#256) — if `/process` ships its own version, the consumer that lands later should consolidate to a single file.

--- a/.claude/skills/dfd/tests/smoke.sh
+++ b/.claude/skills/dfd/tests/smoke.sh
@@ -1,0 +1,537 @@
+#!/usr/bin/env bash
+# /dfd smoke test
+#
+# Three fixtures:
+#   1. Single-service repo (Express + Prisma + BullMQ + Stripe)
+#      → assert all six discovery axes produce non-empty findings
+#   2. Two synthetic services with a cross-service flow
+#      → assert the trust boundary is placed between services
+#   3. Code with @PII annotations + EMAIL_* env vars + user.email columns
+#      → assert all three classification pathways fire
+#
+# This is the grep-fallback path. The skill itself dispatches richer
+# logic via LSP when enabled; this test verifies the documented
+# signatures actually match real code.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DFD_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_DIR="$(cd "$DFD_DIR/../../hooks" && pwd)"
+
+# Sanity check the helper exists
+if [ ! -f "$HOOKS_DIR/_lib-multi-repo-trace.sh" ]; then
+  echo "FAIL: shared trace helper missing at $HOOKS_DIR/_lib-multi-repo-trace.sh" >&2
+  exit 1
+fi
+
+TMPROOT=$(mktemp -d -t dfd-fixture-XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+assert_yaml_has() {
+  local label="$1"
+  local file="$2"
+  local needle="$3"
+  if grep -qE "$needle" "$file" 2>/dev/null; then
+    echo "  PASS: $label (matched: $needle)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (expected pattern: $needle)"
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  $label"
+  fi
+}
+
+assert_count_ge() {
+  local label="$1"
+  local file="$2"
+  local pattern="$3"
+  local min="$4"
+  local count
+  count=$(grep -cE "$pattern" "$file" 2>/dev/null || echo 0)
+  if [ "$count" -ge "$min" ]; then
+    echo "  PASS: $label found $count (>= $min)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label found $count (expected >= $min)"
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  $label"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture 1: single-service Express + Prisma + BullMQ + Stripe + Auth0
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "================================================================"
+echo "Fixture 1: single-service repo, six-axis discovery"
+echo "================================================================"
+
+F1="$TMPROOT/billing-api"
+mkdir -p "$F1/src/routes" "$F1/src/workers" "$F1/prisma"
+
+cat > "$F1/package.json" <<'JSON'
+{
+  "name": "billing-api",
+  "dependencies": {
+    "express": "^4.19.0",
+    "@prisma/client": "^5.0.0",
+    "bullmq": "^5.0.0",
+    "ioredis": "^5.0.0",
+    "stripe": "^14.0.0",
+    "@sendgrid/mail": "^8.0.0",
+    "@auth0/auth0-spa-js": "^2.0.0"
+  }
+}
+JSON
+
+cat > "$F1/src/routes/charges.js" <<'JS'
+const express = require('express');
+const router = express.Router();
+
+router.post('/api/charges', async (req, res) => {
+  res.status(201).json({ id: 1 });
+});
+
+router.get('/api/charges/:id', async (req, res) => {
+  res.json({});
+});
+
+// Admin route — triggers user_to_admin boundary
+router.get('/admin/reconciliation', async (req, res) => {
+  res.json([]);
+});
+JS
+
+cat > "$F1/src/workers/email.js" <<'JS'
+const { Queue, Worker } = require('bullmq');
+const sg = require('@sendgrid/mail');
+
+const emailQueue = new Queue('email');
+const worker = new Worker('email', async (job) => {
+  await sg.send({ to: job.data.email, subject: 'x', text: 'y' });
+});
+JS
+
+cat > "$F1/src/workers/reconcile.js" <<'JS'
+const cron = require('node-cron');
+const Stripe = require('stripe');
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+cron.schedule('0 3 * * *', async () => {
+  await stripe.charges.list({ limit: 100 });
+});
+JS
+
+cat > "$F1/prisma/schema.prisma" <<'PRISMA'
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id         Int    @id @default(autoincrement())
+  email      String @unique
+  passwordHash String
+  phone_number String?
+}
+
+model Charge {
+  id          Int    @id @default(autoincrement())
+  userId      Int
+  card_number String?
+  cvv         String?
+  exp_month   Int?
+  amount      Int
+}
+PRISMA
+
+cat > "$F1/.env.example" <<'ENV'
+DATABASE_URL=postgresql://user:pass@localhost/db
+STRIPE_SECRET_KEY=sk_test_xxx
+SENDGRID_API_KEY=SG.xxx
+JWT_SECRET=changeme
+EMAIL_FROM=noreply@example.com
+ENV
+
+OUT1="$TMPROOT/discover-f1.yaml"
+bash "$DFD_DIR/discover.sh" "$F1" > "$OUT1" 2>/dev/null
+
+assert_yaml_has "Fixture 1: external auth detected (auth0)" "$OUT1" "auth_provider|external_auth"
+assert_yaml_has "Fixture 1: stripe detected as ext_service"     "$OUT1" "ext_stripe|stripe"
+assert_yaml_has "Fixture 1: sendgrid detected as ext_service"   "$OUT1" "ext_sendgrid|sendgrid"
+assert_yaml_has "Fixture 1: public user actor"                  "$OUT1" "public_user|type:[[:space:]]*human"
+assert_yaml_has "Fixture 1: admin user actor (admin/* route)"   "$OUT1" "admin_user"
+assert_yaml_has "Fixture 1: HTTP API process"                   "$OUT1" "id:[[:space:]]*http_api"
+assert_yaml_has "Fixture 1: queue workers process"              "$OUT1" "id:[[:space:]]*queue_workers"
+assert_yaml_has "Fixture 1: scheduled jobs process"             "$OUT1" "id:[[:space:]]*scheduled_jobs"
+assert_yaml_has "Fixture 1: Prisma/Postgres data store"         "$OUT1" "rdbms_prisma|postgresql"
+assert_yaml_has "Fixture 1: Redis cache"                        "$OUT1" "cache_redis"
+assert_yaml_has "Fixture 1: public-to-backend boundary"         "$OUT1" "public_to_backend"
+assert_yaml_has "Fixture 1: user-to-admin boundary"             "$OUT1" "user_to_admin"
+assert_yaml_has "Fixture 1: backend-to-data boundary"           "$OUT1" "backend_to_data"
+assert_yaml_has "Fixture 1: us-to-third-party boundary"         "$OUT1" "us_to_third_party"
+assert_yaml_has "Fixture 1: at least one data flow"             "$OUT1" "^[[:space:]]*-[[:space:]]*source:"
+
+# ---------------------------------------------------------------------------
+# Fixture 2: two-service cross-repo trace
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "================================================================"
+echo "Fixture 2: cross-service trust-boundary detection"
+echo "================================================================"
+
+# Build a tiny apexyard fork sandbox with two registered projects.
+SB="$TMPROOT/sandbox"
+mkdir -p "$SB/.claude/hooks" "$SB/projects" "$SB/workspace/billing-api/src" "$SB/workspace/notifications-svc/src"
+(cd "$SB" && git init -q && git config user.email t@t.com && git config user.name t)
+# Canonicalise after git-init (macOS /var/ → /private/var/)
+SB=$(cd "$SB" && pwd -P)
+
+# Copy the helper + portfolio paths lib + config lib + defaults
+cp "$HOOKS_DIR/_lib-multi-repo-trace.sh" "$SB/.claude/hooks/"
+cp "$HOOKS_DIR/_lib-portfolio-paths.sh"  "$SB/.claude/hooks/"
+cp "$HOOKS_DIR/_lib-read-config.sh"      "$SB/.claude/hooks/"
+DEFAULTS_SRC="$(cd "$DFD_DIR/../.." && pwd)/project-config.defaults.json"
+cp "$DEFAULTS_SRC" "$SB/.claude/project-config.defaults.json" 2>/dev/null || true
+
+# Minimal ops-fork anchors
+touch "$SB/onboarding.yaml"
+cat > "$SB/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: billing-api
+    repo: example-org/billing-api
+    workspace: workspace/billing-api
+    hostnames: [billing.internal]
+  - name: notifications-svc
+    repo: example-org/notifications-svc
+    workspace: workspace/notifications-svc
+    hostnames: [notify.internal]
+YAML
+
+# billing-api calls out to the notifications-svc (cross-service flow)
+cat > "$SB/workspace/billing-api/src/notify.js" <<'JS'
+const axios = require('axios');
+async function notifyUser(userId, msg) {
+  await axios.post('http://notify.internal/api/send', { userId, msg });
+}
+module.exports = { notifyUser };
+JS
+
+# Run the trace helper against the cross-service URL
+RESULT=$(cd "$SB" && bash -c '
+  source ./.claude/hooks/_lib-read-config.sh
+  source ./.claude/hooks/_lib-portfolio-paths.sh
+  source ./.claude/hooks/_lib-multi-repo-trace.sh
+  mrt_resolve_target "http://notify.internal/api/send"
+' 2>/dev/null)
+
+if [ "$RESULT" = "notifications-svc" ]; then
+  echo "  PASS: Fixture 2: cross-service hostname resolved to notifications-svc"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Fixture 2: cross-service hostname did not resolve (got: '$RESULT')"
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  Fixture 2: hostname resolution"
+fi
+
+# Third-party detection — Stripe URL should NOT resolve to a registered project
+TP_RESULT=$(cd "$SB" && bash -c '
+  source ./.claude/hooks/_lib-read-config.sh
+  source ./.claude/hooks/_lib-portfolio-paths.sh
+  source ./.claude/hooks/_lib-multi-repo-trace.sh
+  mrt_resolve_target "https://api.stripe.com/v1/charges" 2>/dev/null
+  echo "---"
+  mrt_is_third_party "https://api.stripe.com/v1/charges"
+' 2>/dev/null)
+
+if echo "$TP_RESULT" | grep -q "^stripe$"; then
+  echo "  PASS: Fixture 2: Stripe URL detected as known third-party"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Fixture 2: Stripe URL not detected (got: $TP_RESULT)"
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  Fixture 2: third-party detection"
+fi
+
+# Workspace path resolution — registered project, clone exists
+WS_RESULT=$(cd "$SB" && bash -c '
+  source ./.claude/hooks/_lib-read-config.sh
+  source ./.claude/hooks/_lib-portfolio-paths.sh
+  source ./.claude/hooks/_lib-multi-repo-trace.sh
+  mrt_workspace_for "notifications-svc"
+' 2>/dev/null)
+
+if [ -n "$WS_RESULT" ] && [ -d "$WS_RESULT" ]; then
+  echo "  PASS: Fixture 2: workspace resolved to $WS_RESULT"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Fixture 2: workspace for notifications-svc not resolved (got: $WS_RESULT)"
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  Fixture 2: workspace resolution"
+fi
+
+# ---------------------------------------------------------------------------
+# Fixture 3: classification pathways — annotations + env vars + schema
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "================================================================"
+echo "Fixture 3: data-classification three-pathway detection"
+echo "================================================================"
+
+F3="$TMPROOT/classified"
+mkdir -p "$F3/src/models" "$F3/prisma"
+
+cat > "$F3/package.json" <<'JSON'
+{ "name": "classified-app", "dependencies": { "@prisma/client": "^5.0.0" } }
+JSON
+
+# Pathway 1: annotations
+cat > "$F3/src/models/user.ts" <<'TS'
+// User profile model.
+export class User {
+  id: number;
+  // @PII — primary identifier and contact channel
+  email: string;
+  // CLASSIFIED: pii
+  profileBio: string;
+  // @Sensitive
+  hashedPassword: string;
+}
+TS
+
+# Pathway 2: env var heuristics
+cat > "$F3/.env.example" <<'ENV'
+DATABASE_URL=postgresql://localhost
+STRIPE_SECRET_KEY=sk_test_xxx
+JWT_SECRET=changeme
+SENDGRID_API_KEY=SG.xxx
+EMAIL_FROM=noreply@example.com
+SMTP_HOST=smtp.example.com
+TWILIO_AUTH_TOKEN=xxx
+SOME_PUBLIC_FLAG=true
+ENV
+
+# Pathway 3: schema columns
+cat > "$F3/prisma/schema.prisma" <<'PRISMA'
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Customer {
+  id            Int    @id @default(autoincrement())
+  email         String @unique
+  phone_number  String?
+  ssn           String?
+  card_number   String?
+  cvv           String?
+  first_name    String?
+  last_name     String?
+  ip_address    String?
+}
+PRISMA
+
+OUT3="$TMPROOT/classify-f3.yaml"
+bash "$DFD_DIR/classify.sh" "$F3" > "$OUT3" 2>/dev/null
+
+assert_yaml_has "Fixture 3: annotation pathway @PII fires"        "$OUT3" "source:[[:space:]]*annotation"
+assert_yaml_has "Fixture 3: annotation pathway label pii"         "$OUT3" 'label:[[:space:]]*"pii"'
+assert_yaml_has "Fixture 3: annotation pathway @Sensitive fires"  "$OUT3" 'label:[[:space:]]*"sensitive"'
+
+assert_yaml_has "Fixture 3: env-var pathway STRIPE_SECRET_KEY"    "$OUT3" "STRIPE_SECRET_KEY"
+assert_yaml_has "Fixture 3: env-var pathway SENDGRID_API_KEY"     "$OUT3" "SENDGRID_API_KEY"
+assert_yaml_has "Fixture 3: env-var pathway EMAIL_FROM (email-routing)" "$OUT3" "EMAIL_FROM"
+assert_yaml_has "Fixture 3: env-var pathway secrets label"        "$OUT3" 'label:[[:space:]]*"secrets"'
+
+assert_yaml_has "Fixture 3: schema pathway Prisma email column"   "$OUT3" "field:[[:space:]]*\"email\""
+assert_yaml_has "Fixture 3: schema pathway Prisma phone_number"   "$OUT3" "field:[[:space:]]*\"phone_number\""
+assert_yaml_has "Fixture 3: schema pathway Prisma ssn"            "$OUT3" "field:[[:space:]]*\"ssn\""
+assert_yaml_has "Fixture 3: schema pathway Prisma card_number (PCI)" "$OUT3" "field:[[:space:]]*\"card_number\""
+assert_yaml_has "Fixture 3: schema pathway PCI label"             "$OUT3" 'label:[[:space:]]*"pci"'
+
+# Check that SOME_PUBLIC_FLAG is NOT classified (no heuristic pattern matches)
+if grep -q "SOME_PUBLIC_FLAG" "$OUT3" 2>/dev/null; then
+  echo "  FAIL: Fixture 3: SOME_PUBLIC_FLAG should NOT be classified (false positive)"
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  Fixture 3: false-positive guard"
+else
+  echo "  PASS: Fixture 3: SOME_PUBLIC_FLAG correctly NOT classified (no false positive)"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Fixture 4: Mermaid generator output shape (smoke — has key sections)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "================================================================"
+echo "Fixture 4: Mermaid generator output shape"
+echo "================================================================"
+
+MD_OUT="$TMPROOT/dfd-f1.md"
+bash "$DFD_DIR/generate-mermaid.sh" "billing-api" "$OUT1" "$TMPROOT/classify-f1.yaml" > "$MD_OUT" 2>/dev/null
+
+assert_yaml_has "Mermaid: has top-level heading"             "$MD_OUT" "^# billing-api — Data Flow Diagram"
+assert_yaml_has "Mermaid: declares source-of-truth"          "$MD_OUT" "Source of truth"
+assert_yaml_has "Mermaid: includes flowchart block"          "$MD_OUT" '^```mermaid'
+assert_yaml_has "Mermaid: declares trust-boundary subgraphs" "$MD_OUT" "subgraph"
+assert_yaml_has "Mermaid: trust-boundaries table"            "$MD_OUT" "^## Trust boundaries"
+assert_yaml_has "Mermaid: data-classifications table"        "$MD_OUT" "^## Data classifications"
+assert_yaml_has "Mermaid: provenance section"                "$MD_OUT" "Discovery provenance"
+assert_yaml_has "Mermaid: footer signature"                  "$MD_OUT" "_Generated by .*/dfd.* on "
+
+# ---------------------------------------------------------------------------
+# Fixture 5: Threat Dragon JSON serialiser output shape
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "================================================================"
+echo "Fixture 5: Threat Dragon JSON serialiser"
+echo "================================================================"
+
+if command -v jq >/dev/null 2>&1; then
+  MODEL_JSON='{
+    "project": "billing-api",
+    "actors": [
+      { "id": "public_user",  "name": "End user",  "type": "human" },
+      { "id": "ext_stripe",   "name": "Stripe",    "type": "external_service" }
+    ],
+    "processes": [
+      { "id": "http_api",     "name": "HTTP API",  "type": "http_handler" }
+    ],
+    "stores": [
+      { "id": "rdbms_prisma", "name": "Postgres",  "type": "rdbms" }
+    ],
+    "flows": [
+      { "source": "public_user", "target": "http_api",     "label": "auth token, request body" },
+      { "source": "http_api",    "target": "rdbms_prisma", "label": "persistent records" },
+      { "source": "http_api",    "target": "ext_stripe",   "label": "charge intent" }
+    ],
+    "boundaries": [
+      { "id": "public_to_backend", "name": "Public Internet ↔ Backend",
+        "rationale": "HTTP routes detected", "contains": ["http_api"] }
+    ],
+    "threats": [
+      { "element": "http_api", "type": "S", "severity": "High",
+        "description": "No rate limit on POST /api/charges",
+        "mitigation": "Add per-IP rate limit (5/min)", "status": "Open" }
+    ]
+  }'
+
+  DRAGON_OUT="$TMPROOT/dragon-f5.json"
+  echo "$MODEL_JSON" | bash "$DFD_DIR/generate-dragon.sh" > "$DRAGON_OUT" 2>/dev/null
+
+  # Validate it's parseable JSON
+  if jq empty "$DRAGON_OUT" 2>/dev/null; then
+    echo "  PASS: Dragon output is valid JSON"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: Dragon output is not valid JSON"
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  Fixture 5: JSON validity"
+  fi
+
+  # Required top-level v2 schema keys
+  for key in version summary detail; do
+    if jq -e ".$key" "$DRAGON_OUT" >/dev/null 2>&1; then
+      echo "  PASS: Dragon output has top-level key '$key'"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: Dragon output missing top-level key '$key'"
+      FAIL=$((FAIL + 1))
+      FAILED_CASES="$FAILED_CASES\n  Fixture 5: missing key $key"
+    fi
+  done
+
+  # Diagram has cells with the actor / process / store / boundary / flow types
+  for shape in tm.actor tm.process tm.store tm.boundary tm.flow; do
+    if jq -e ".detail.diagrams[0].cells[] | select(.type == \"$shape\")" "$DRAGON_OUT" >/dev/null 2>&1; then
+      echo "  PASS: Dragon diagram has at least one '$shape' cell"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: Dragon diagram has no '$shape' cells"
+      FAIL=$((FAIL + 1))
+      FAILED_CASES="$FAILED_CASES\n  Fixture 5: missing shape $shape"
+    fi
+  done
+
+  # Threats are attached to their parent element
+  THREAT_COUNT=$(jq '[.detail.diagrams[0].cells[].data.threats // [] | length] | add' "$DRAGON_OUT")
+  if [ "$THREAT_COUNT" -ge 1 ]; then
+    echo "  PASS: Dragon output carries $THREAT_COUNT threat(s) attached to elements"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: Dragon output has no threats attached (expected >= 1)"
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  Fixture 5: threats not propagated"
+  fi
+else
+  echo "  SKIP: jq not installed — skipping Threat Dragon JSON validation"
+fi
+
+# ---------------------------------------------------------------------------
+# Fixture 6: /threat-model + /compliance-check consume the DFD file
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "================================================================"
+echo "Fixture 6: downstream consumers reference dfd.md (no regeneration)"
+echo "================================================================"
+
+# Read the actual current SKILL.md for both consumers — assert they
+# point at projects/<...>/architecture/dfd.md as the source.
+TM_SKILL="$(cd "$DFD_DIR/.." && pwd)/threat-model/SKILL.md"
+CC_SKILL="$(cd "$DFD_DIR/.." && pwd)/compliance-check/SKILL.md"
+
+if grep -qE 'architecture/dfd\.md' "$TM_SKILL"; then
+  echo "  PASS: /threat-model SKILL.md references projects/.../architecture/dfd.md"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: /threat-model SKILL.md does NOT reference dfd.md (refactor regressed)"
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  Fixture 6: /threat-model refactor"
+fi
+
+if grep -qE 'architecture/dfd\.md' "$CC_SKILL"; then
+  echo "  PASS: /compliance-check SKILL.md references projects/.../architecture/dfd.md"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: /compliance-check SKILL.md does NOT reference dfd.md (refactor regressed)"
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  Fixture 6: /compliance-check refactor"
+fi
+
+# /threat-model should OFFER to run /dfd first if dfd.md is missing
+if grep -qE '/dfd' "$TM_SKILL" && grep -qiE 'offer|fall back|run /dfd' "$TM_SKILL"; then
+  echo "  PASS: /threat-model handles missing DFD (offer to run /dfd first OR fallback)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: /threat-model has no clear fallback for missing DFD"
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  Fixture 6: /threat-model missing-DFD handling"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "================================================================"
+echo "Total: $((PASS + FAIL))   Passed: $PASS   Failed: $FAIL"
+echo "================================================================"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failures:$FAILED_CASES"
+  exit 1
+fi
+echo "OK: all /dfd smoke checks passed."
+exit 0

--- a/.claude/skills/threat-model/SKILL.md
+++ b/.claude/skills/threat-model/SKILL.md
@@ -10,6 +10,8 @@ effort: high
 
 Deep-dive security analysis using the STRIDE framework. Produces a prioritized threat catalogue with mitigations. This is the expert companion to `/launch-check`'s security row — invoke it when security shows WARN or FAIL, or proactively before any launch.
 
+**Consumes the DFD produced by [`/dfd`](../dfd/SKILL.md).** The Data Flow Diagram at `projects/<project>/architecture/dfd.md` is the source of truth; this skill iterates its trust-boundary crossings rather than rebuilding its own data-flow view. If the DFD doesn't exist, this skill OFFERS to run `/dfd` first (see Step 1). See AgDR-0024 for the single-source-of-truth rationale.
+
 ## LSP-aware (optional, recommended)
 
 This skill performs semantic code navigation — finding definitions, walking references, tracing handlers across modules. With LSP enabled (`ENABLE_LSP_TOOL=1` + per-language plugin per `docs/getting-started.md`), queries are ~3-15× cheaper in token cost than grep + Read on shallow lookups, and ~1.4-5× cheaper on multi-hop traces. Without LSP, the skill falls back to grep + Read transparently — no new failure mode, just optional speed.
@@ -29,16 +31,42 @@ Per-language LSP plugins live in Claude Code's marketplace. Install once; the sk
 
 ## Process
 
-### Step 1: Map the attack surface
+### Step 1: Read the DFD (source of truth)
 
-**Populate the Data Flow Diagram first** in this run's per-run artefact (per `templates/audits/threat-model.md` § Data Flow Diagram) — replace the Mermaid skeleton's placeholders with the system's actual external entities, processes, data stores, and trust boundaries, and label every arrow with the data that crosses it. The STRIDE walk in Step 2 then iterates the DFD's trust-boundary crossings rather than inventing threats ad-hoc.
+The DFD is produced by [`/dfd`](../dfd/SKILL.md) and lives at `projects/<project>/architecture/dfd.md` — this is the **source of truth**. This skill consumes it; it does NOT regenerate it. The STRIDE walk in Step 2 iterates the DFD's trust-boundary crossings (the table in `dfd.md` § "Trust boundaries") rather than inventing threats ad-hoc.
 
-Read the codebase and identify:
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+projects_dir=$(portfolio_projects_dir)
 
-- **Entry points**: API routes, form handlers, WebSocket endpoints, file upload handlers
-- **Data stores**: databases, caches, file systems, environment variables
-- **External integrations**: third-party APIs, payment processors, email services, auth providers
-- **Trust boundaries**: client ↔ server, server ↔ database, server ↔ external API
+dfd="${projects_dir}/${project_name}/architecture/dfd.md"
+if [ ! -f "$dfd" ]; then
+  # DFD missing — offer to run /dfd first
+  cat <<MSG
+This project has no DFD at $dfd.
+
+A STRIDE walk without a DFD is reactive — threats get invented per
+entry point rather than enumerated per trust-boundary crossing.
+
+Run /dfd ${project_name} first to produce the canonical DFD, then
+re-run /threat-model.
+
+Continue without the DFD? [y/N]
+MSG
+fi
+```
+
+If the operator declines to run `/dfd` first, fall back to inline discovery (the legacy behaviour preserved below for backwards compat). Surface this as a degraded mode in the output banner so the report's quality is visible.
+
+For the legacy fallback (or in addition to the DFD), the per-run artefact still includes a DFD section per `templates/audits/threat-model.md` — but when `dfd.md` exists, the artefact references it by path rather than re-rendering the Mermaid.
+
+The DFD's structured elements feed Step 2:
+
+- **Entry points** — every external actor → process arrow in the DFD is an entry point
+- **Data stores** — every store node in the DFD
+- **External integrations** — every external-service actor in the DFD
+- **Trust boundaries** — every dashed subgraph border in the DFD; the per-boundary auth + classification table in `dfd.md` is the STRIDE worksheet
 
 ### Step 2: Apply STRIDE to each entry point
 

--- a/.claude/skills/threat-model/SKILL.md
+++ b/.claude/skills/threat-model/SKILL.md
@@ -10,7 +10,7 @@ effort: high
 
 Deep-dive security analysis using the STRIDE framework. Produces a prioritized threat catalogue with mitigations. This is the expert companion to `/launch-check`'s security row — invoke it when security shows WARN or FAIL, or proactively before any launch.
 
-**Consumes the DFD produced by [`/dfd`](../dfd/SKILL.md).** The Data Flow Diagram at `projects/<project>/architecture/dfd.md` is the source of truth; this skill iterates its trust-boundary crossings rather than rebuilding its own data-flow view. If the DFD doesn't exist, this skill OFFERS to run `/dfd` first (see Step 1). See AgDR-0024 for the single-source-of-truth rationale.
+**Consumes the DFD produced by [`/dfd`](../dfd/SKILL.md).** The Data Flow Diagram at `projects/<project>/architecture/dfd.md` is the source of truth; this skill iterates its trust-boundary crossings rather than rebuilding its own data-flow view. If the DFD doesn't exist, this skill OFFERS to run `/dfd` first (see Step 1). See AgDR-0026 for the single-source-of-truth rationale.
 
 ## LSP-aware (optional, recommended)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | `/handover` | Onboard an external repo into ApexYard management (includes per-project discovery) |
 | `/extract-features` | Scan an existing codebase across six discovery axes (HTTP routes, data models, async jobs, test names, UI screens, documented features) and write a consolidated Feature Inventory at `projects/<name>/feature-inventory.md` — the "what we must preserve" spec for a greenfield rewrite. Complements `/handover` (high-level project assessment); `/extract-features` is the granular feature catalogue. |
 | `/c4` | Generate C4 L1 (System Context) + L2 (Container) Mermaid diagrams for a project by reading its codebase |
-| `/dfd` | Extract a Data Flow Diagram (Mermaid + optional Threat Dragon JSON) from a codebase — six-axis discovery + trust boundaries + data classifications. Source of truth that `/threat-model` and `/compliance-check` consume. See AgDR-0024. |
+| `/dfd` | Extract a Data Flow Diagram (Mermaid + optional Threat Dragon JSON) from a codebase — six-axis discovery + trust boundaries + data classifications. Source of truth that `/threat-model` and `/compliance-check` consume. See AgDR-0026. |
 | `/journey` | Generate a single self-contained user-journey HTML — boxes-and-arrows graph with a clickable modal per page. Sits between PRD and tech-design as a "preview before build" artifact. |
 | `/update` | Sync the ops fork with upstream me2resh/apexyard — preview, merge-or-rebase, leaves a sync branch ready to push |
 | `/release` | (Framework-only) Cut a new apexyard release — diff dev against main, pick a semver bump, generate a CHANGELOG, open the release PR, and tag after merge |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,10 +187,10 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Rules | `.claude/rules/` | 11 modular rule files (AgDR triggers, code standards, git conventions, leak protection, parallel work, plan mode, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Handbooks | `handbooks/` | Adopter-authored coding standards consumed by Rex during code review. Discovery by path-convention (`architecture/` + `general/` always-load; `language/<lang>/` loads on diff-match). Advisory by default; opt in to blocking via `ENFORCEMENT: blocking` marker. See [`handbooks/README.md`](handbooks/README.md). |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer — Rex, Security Reviewer — Hatim, Dependency Auditor — Munir, PR Manager — Tariq, Ticket Manager — Idris) |
-| Skills | `.claude/skills/` | 43 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 44 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (43)
+### Available skills (44)
 
 | Skill | Purpose |
 |-------|---------|
@@ -225,6 +225,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | `/handover` | Onboard an external repo into ApexYard management (includes per-project discovery) |
 | `/extract-features` | Scan an existing codebase across six discovery axes (HTTP routes, data models, async jobs, test names, UI screens, documented features) and write a consolidated Feature Inventory at `projects/<name>/feature-inventory.md` — the "what we must preserve" spec for a greenfield rewrite. Complements `/handover` (high-level project assessment); `/extract-features` is the granular feature catalogue. |
 | `/c4` | Generate C4 L1 (System Context) + L2 (Container) Mermaid diagrams for a project by reading its codebase |
+| `/dfd` | Extract a Data Flow Diagram (Mermaid + optional Threat Dragon JSON) from a codebase — six-axis discovery + trust boundaries + data classifications. Source of truth that `/threat-model` and `/compliance-check` consume. See AgDR-0024. |
 | `/journey` | Generate a single self-contained user-journey HTML — boxes-and-arrows graph with a clickable modal per page. Sits between PRD and tech-design as a "preview before build" artifact. |
 | `/update` | Sync the ops fork with upstream me2resh/apexyard — preview, merge-or-rebase, leaves a sync branch ready to push |
 | `/release` | (Framework-only) Cut a new apexyard release — diff dev against main, pick a semver bump, generate a CHANGELOG, open the release PR, and tag after merge |
@@ -271,7 +272,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Rules (modular, framework-wide) | `.claude/rules/` |
 | **Adopter handbooks** (consumed by Rex during code review) | `handbooks/` — see [`handbooks/README.md`](handbooks/README.md) for the discovery + advisory/blocking conventions |
 | Agents | `.claude/agents/` |
-| Skills (40 slash commands) | `.claude/skills/` |
+| Skills (44 slash commands) | `.claude/skills/` |
 | Hook wiring | `.claude/settings.json` |
 | **Per-project docs** | `projects/<name>/` |
 | **Live working copies** (gitignored) | `workspace/<name>/` |

--- a/docs/agdr/AgDR-0024-dfd-skill-as-source-of-truth.md
+++ b/docs/agdr/AgDR-0024-dfd-skill-as-source-of-truth.md
@@ -1,0 +1,146 @@
+# AgDR-0024: `/dfd` skill as single source of truth — Mermaid primary, Threat Dragon JSON secondary
+
+> In the context of building a Data Flow Diagram (DFD) extractor for the apexyard skill family, facing the fact that `/threat-model` (#225) and `/compliance-check` each regenerate their own DFD slices and the upcoming `/threat-model --format=dragon` (#255) wants a Threat Dragon JSON export, I decided to ship `/dfd` as the canonical DFD producer that writes a Mermaid markdown file at `projects/<name>/architecture/dfd.md` (primary), an OWASP Threat Dragon v2 JSON at the same dir (secondary on `--format=dragon`), with first-class data-classification heuristics and a shared multi-repo trace helper, to achieve one place where the DFD lives, accepting one more skill to learn and one refactor pass through the two consumer skills.
+
+## Context
+
+Three forces converge on this decision:
+
+1. **The DFD section in `/threat-model` (#225)** is a hand-rolled Mermaid stub that the operator + agent populate each run — same stub, regenerated every time. The Mermaid is good; the regeneration loop is wasteful and inconsistent across runs.
+2. **`/compliance-check`** needs the same view of "what data flows where" to detect cross-border transfers, third-party processors, and PII landing in unencrypted stores. Today it walks the codebase independently with similar discovery logic to `/threat-model`.
+3. **`#255` (`/threat-model --format=dragon`)** wants OWASP Threat Dragon JSON output. That format is a node-edge graph with trust boundaries and STRIDE findings attached — i.e. it's a DFD-shaped serialisation. Implementing it inside `/threat-model` couples the format to one consumer and bypasses `/compliance-check`'s need for the same view.
+
+The natural seam: extract the DFD producer, let the two consumers read it. Same shape as `/c4` (system topology producer) sitting upstream of architecture-aware skills — one read-first scan, one canonical artefact, many consumers.
+
+The sibling tickets `#256` (`/process` — multi-repo BPMN producer) and `#255` (Threat Dragon JSON serialiser) both want infrastructure that `/dfd` also needs:
+
+- `#256` introduces multi-repo cross-service traversal via `apexyard.projects.yaml` registry lookup. `/dfd` needs the same shape for system-wide DFDs that span microservices.
+- `#255` defines a Threat Dragon v2 JSON serialiser. `/dfd --format=dragon` needs that serialiser too.
+
+Sharing both is in scope here.
+
+## Options Considered
+
+### A. Lift DFD into /dfd; both downstream skills read from a canonical file (CHOSEN)
+
+| Pros | Cons |
+| --- | --- |
+| One discovery pass per system per change-set, not three | One more skill in the family (43 → 44) |
+| `/threat-model` becomes shorter — STRIDE walk only, not "build DFD then STRIDE" | Refactor pass through `/threat-model` and `/compliance-check` required (in this PR) |
+| `/compliance-check` gets PII / PCI / Secrets classifications it currently can only grep for | Adopters who already have a hand-edited `dfd.md` need a "skip and use what's there" path — handled via the existing-file overwrite prompt |
+| Mermaid renders inline on GitHub — zero new toolchain dependency for the primary output | The Threat Dragon JSON branch needs schema validation (smoke test handles this) |
+| `--format=dragon` reuses `#255`'s serialiser — no duplication | If `#255` ships first with the serialiser inside `/threat-model`, we either import from there or accept duplication during the transition window |
+| Aligns with the `/c4` precedent: producer skill writes Mermaid; consumers reference the file | |
+
+### B. Keep the DFD inside /threat-model; expose it as an export
+
+| Pros | Cons |
+| --- | --- |
+| Zero new skill | `/compliance-check` still has no shared view of data flows |
+| Smaller surface area | `/threat-model` becomes the "owner" of a non-security artefact (a DFD is just a data-flow view; security is one consumer) |
+| | Cross-service / multi-repo DFD logic awkwardly lives inside a security-named skill |
+| | `#255`'s serialiser is locked to `/threat-model`'s internal state, harder for `/compliance-check` to consume |
+
+### C. No skill — operator writes the DFD by hand, both consumers read it
+
+| Pros | Cons |
+| --- | --- |
+| Simplest implementation (literally none) | The "hand-roll the DFD" gap is the whole point of automating discovery |
+| Adopter retains full control over the diagram | `/threat-model` and `/compliance-check` either re-scan (current state, the problem) or do nothing without a hand-written file |
+| | No mechanism to refresh the DFD after a code change (drift is silent) |
+
+### D. Generate a registry-format-agnostic IR, then render to N formats from one walker
+
+| Pros | Cons |
+| --- | --- |
+| Long-term clean — one walker, many renderers (Mermaid, Dragon, PlantUML, D2…) | Premature abstraction for v1; we have two formats and one set of consumers |
+| Trivial to add a new output format later | Adds an IR-design step before any user-facing artefact ships |
+| | Same outcome as Option A in v1 because we still ship Mermaid + Dragon; the IR layer is internal and can be introduced later under-the-hood without changing the skill's contract |
+
+## Decision
+
+Chosen: **Option A**, because the discovery pass is the expensive part (axis walks, classification heuristics, cross-repo trace) and centralising it removes duplicate work across three skills. Mermaid as primary leverages the existing `/c4` precedent and the apexyard "Mermaid in markdown renders on GitHub, zero toolchain" rule (AgDR-0003); Threat Dragon JSON as secondary covers the security-team-visual-editing use case from `#255`.
+
+The IR (Option D) is the right long-term shape but adds a layer before v1 ships. Keep the per-format generators (`generate-mermaid.sh`, `generate-dragon.sh`) as pure functions over the same in-memory model so Option D can be retrofitted without changing the contract.
+
+## Sub-decisions made in the same scope
+
+### A1. Output location: `projects/<name>/architecture/dfd.md`
+
+Same convention as `/c4` writing to `projects/<name>/architecture/{context,container}.md`. Renders inline on GitHub, ops-fork view of the project's architecture, sits next to the C4 diagrams so an observer browsing `projects/<name>/architecture/` sees three diagrams of the same system from three angles (context, container, data-flow).
+
+### A2. Data classifications as a first-class concept, three pathways
+
+Classifications are the load-bearing input for `/compliance-check`'s cross-border-transfer detection and for `/threat-model`'s severity weighting. Three detection pathways (additive, not exclusive):
+
+| Pathway | Signal | Example |
+| --- | --- | --- |
+| **Annotation** | Code-level comment / decorator | `@PII`, `// CLASSIFIED: pii`, `// classification: secrets` |
+| **Env-var heuristic** | Naming pattern in `.env*` / `process.env.*` / `os.environ[...]` | `*_SECRET`, `*_TOKEN`, `*_KEY`, `*_PASSWORD` → `secrets`; `SMTP_*`, `EMAIL_*` → `email-routing` |
+| **Schema heuristic** | DB / ORM column names matching PII patterns | `email`, `phone`, `ssn`, `dob`, `address`, `card_number`, `cvv`, `ip_address` |
+| **Explicit registry** (opt-in) | `docs/data-classification.{md,yaml}` in the project repo | Operator-authored canonical truth — wins over heuristics |
+
+The heuristics are deliberately conservative — false positives are louder than false negatives (an `email` column labelled PII can be re-labelled by the operator; a missing PII label means the threat model under-weights the field's risk). Adopters who want different patterns override via the explicit registry.
+
+### A3. Multi-repo trace via shared helper `_lib-multi-repo-trace.sh`
+
+`/process` (#256) needs the same cross-service registry-lookup logic (HTTP host / message-broker topic / shared event-table → registered project name in `apexyard.projects.yaml`). Rather than duplicate, extract a shared helper:
+
+```bash
+mrt_resolve_target <hostname_or_topic_or_url>   # → project name (if registered) or empty
+mrt_follow_into <project_name>                  # → workspace path if cloned, else offer-to-clone path
+mrt_is_third_party <hostname_or_url>            # → "stripe" / "sendgrid" / "" — detected against known-vendor signatures
+```
+
+Both `/dfd` and `/process` consume the helper. If this PR ships first, the helper lives here; if `/process` ships first, this PR adds to whatever shape `/process` extracted. Either way, the helper is the seam.
+
+### A4. Refactor `/threat-model` and `/compliance-check` in the same PR
+
+The refactor is the load-bearing payoff of this decision — without it, `/dfd` is just another producer with no consumers. Scope is deliberately minimal:
+
+- `/threat-model` Step 1 changes from "populate the DFD section yourself" to "read from `projects/<name>/architecture/dfd.md`; if missing, OFFER to run `/dfd` first". Output format stays the same (markdown threat catalogue + persisted JSON via the audit-history lib).
+- `/compliance-check` Step 4 (Data handling) gains an upstream read: load the DFD's classification table + flow targets to surface cross-border transfers + third-party processors automatically rather than via independent grep.
+
+Both refactors preserve the existing audit-history persistence contract — only the discovery upstream changes.
+
+### A5. Threat Dragon JSON serialiser shared with `#255`
+
+`#255` adds `/threat-model --format=dragon`. The serialiser logic (Mermaid graph → Threat Dragon v2 JSON nodes/edges/boundaries) is identical work. Two paths:
+
+1. **If `#255` merges first**: import its serialiser into `/dfd`. The serialiser becomes `_lib-threat-dragon-serialiser.sh` (or similar — co-locate near both consumers).
+2. **If `/dfd` merges first** (this PR): `generate-dragon.sh` is the serialiser; `#255` imports from here.
+
+Either way, end-state has one serialiser, two callers. Coordinated via PR cross-references.
+
+## Consequences
+
+### Wins
+
+- **Three skills, one DFD source.** A code change that adds a new data store, new external API, new PII field re-runs `/dfd` once; both `/threat-model` and `/compliance-check` pick up the change on their next run.
+- **Mermaid renders on GitHub** — the DFD becomes a first-class architecture artefact a reviewer can see in a PR diff. Today's DFD is regenerated in-chat per run; nobody can link to it.
+- **Cross-service threat surface visible by default.** A system-wide `/dfd --scope-all` puts every cross-service flow as a trust-boundary crossing — exactly the surface STRIDE cares about. Microservice adopters get this without operator intuition.
+- **Data classifications as a structured artefact.** Today the operator runs through STRIDE asking "is this PII?" each time. After this, the DFD's classification column is the source — both for STRIDE severity weighting and for GDPR cross-border-transfer detection.
+
+### Costs
+
+- **One more skill to discover.** Mitigated by `/threat-model`'s "DFD missing — run `/dfd` first?" prompt and by `/handover`'s post-clone follow-up offering `/dfd` alongside `/c4`.
+- **Refactor risk in two existing skills.** Both refactors are bounded to a single read-from-file step; existing output shapes stay the same. The audit-history persistence contract is unchanged, so trend data continues uninterrupted.
+- **Cross-PR coordination with `#255` and `#256`.** Mitigated by extracting the trace helper as a separate file (clear seam for `/process` to consume), keeping the Dragon serialiser as a pure function over the in-memory model (clear seam for `/threat-model --format=dragon` to consume), and explicit PR-body cross-references so Rex flags duplication during review.
+- **Adopters with hand-edited `dfd.md`** lose their version on re-run if they accept the overwrite prompt. The prompt defaults to `N` and the file's footer signature (`Generated by /dfd on YYYY-MM-DD`) makes the source visible.
+
+### Out of scope (explicit non-goals for v1)
+
+- **IaC reading** (Terraform / CloudFormation / SAM) for trust-boundary inference — code + env config only in v1. IaC integration is a follow-up.
+- **SAST/DAST substitution** — `/dfd` informs threat modelling and compliance, doesn't substitute for actual security scans.
+- **Pretty SVG/PNG export** — Threat Dragon does that after JSON import. The skill emits Mermaid (which GitHub renders) and JSON (which Threat Dragon renders); image generation is downstream tooling.
+- **PlantUML DFD format** — listed in the AC as v2 follow-up; not in v1 scope.
+- **Round-trip import** — hand-edited `dfd.md` → re-parsed back into the discovery model. v1 is producer-only; operators edit either the Mermaid file directly (one-shot) or re-run `/dfd` with corrected anchors / answers.
+
+## Artifacts
+
+- Ticket: [me2resh/apexyard#257](https://github.com/me2resh/apexyard/issues/257)
+- Sibling tickets coordinated: [#255](https://github.com/me2resh/apexyard/issues/255), [#256](https://github.com/me2resh/apexyard/issues/256)
+- Related prior art:
+  - [AgDR-0003: Mermaid C4 for diagrams](AgDR-0003-mermaid-c4-for-diagrams.md) — why Mermaid is the default architecture-diagram format in apexyard (same logic applies here)
+  - [me2resh/apexyard#225](https://github.com/me2resh/apexyard/issues/225) — original DFD section added to `/threat-model` (the thing being lifted out)
+  - [`templates/architecture/dfd.md`](../../templates/architecture/dfd.md) — the DFD template `/dfd` populates

--- a/docs/agdr/AgDR-0026-dfd-skill-as-source-of-truth.md
+++ b/docs/agdr/AgDR-0026-dfd-skill-as-source-of-truth.md
@@ -1,4 +1,4 @@
-# AgDR-0024: `/dfd` skill as single source of truth — Mermaid primary, Threat Dragon JSON secondary
+# AgDR-0026: `/dfd` skill as single source of truth — Mermaid primary, Threat Dragon JSON secondary
 
 > In the context of building a Data Flow Diagram (DFD) extractor for the apexyard skill family, facing the fact that `/threat-model` (#225) and `/compliance-check` each regenerate their own DFD slices and the upcoming `/threat-model --format=dragon` (#255) wants a Threat Dragon JSON export, I decided to ship `/dfd` as the canonical DFD producer that writes a Mermaid markdown file at `projects/<name>/architecture/dfd.md` (primary), an OWASP Threat Dragon v2 JSON at the same dir (secondary on `--format=dragon`), with first-class data-classification heuristics and a shared multi-repo trace helper, to achieve one place where the DFD lives, accepting one more skill to learn and one refactor pass through the two consumer skills.
 


### PR DESCRIPTION
## Summary

- Adds `/dfd` as the canonical Data Flow Diagram producer in the apexyard skill family. Six-axis discovery (external actors, processes, data stores, data flows, trust boundaries, data classifications), reachability-bounded, optionally cross-repo via the registry.
- Writes Mermaid markdown at `projects/<name>/architecture/dfd.md` as the primary output (renders inline on GitHub, zero new toolchain) and OWASP Threat Dragon v2 JSON at the same dir on `--format=dragon` (for visual editing in Threat Dragon).
- Refactors `/threat-model` and `/compliance-check` to **consume from the DFD file** instead of regenerating their own data-flow views. `/threat-model` Step 1 now reads `dfd.md` and OFFERS to run `/dfd` first if missing; `/compliance-check` Step 4 reads the classifications + external-services list from the DFD.
- Three classification pathways are additive: code annotations (`@PII`, `@Sensitive`, `CLASSIFIED:`), env-var heuristics (`*_SECRET`, `*_TOKEN`, `EMAIL_*`), schema-column heuristics (`email`, `phone`, `card_number`). Optional explicit registry at `docs/data-classification.{md,yaml}` overrides.
- New shared helper `.claude/hooks/_lib-multi-repo-trace.sh` (`mrt_resolve_target`, `mrt_is_third_party`, `mrt_workspace_for`, `mrt_list_projects`, `mrt_offer_clone`) — intended to also be consumed by `/process` (#256) so cross-repo trace logic isn't duplicated.

AgDR-0024 captures the design rationale: Mermaid primary / Threat Dragon secondary; classifications as a first-class concept; single-source-of-truth refactor of the two consumer skills; shared multi-repo trace helper.

## Cross-PR coordination

- **#255 (`/threat-model --format=dragon`)** — `generate-dragon.sh` is a pure function over the in-memory DFD model. If #255 lands first with the Threat Dragon serialiser inside `/threat-model`, `/dfd` should import from there during code review. If this PR lands first, #255 imports from here. End-state: one serialiser, two callers.
- **#256 (`/process` — multi-repo BPMN)** — `/process` needs the same cross-service trace logic. This PR ships `_lib-multi-repo-trace.sh` for both consumers. If #256 has already extracted its own version, the consumer that lands later should consolidate to a single file (Rex will flag the duplication).

## Testing

```bash
# Full smoke (52 assertions across 6 fixtures)
bash .claude/skills/dfd/tests/smoke.sh
```

Asserts:

| Fixture | What |
|---------|------|
| 1 | Single-service Express + Prisma + BullMQ + Stripe + SendGrid + Auth0 + admin route — all six discovery axes produce non-empty findings; four trust boundaries (public ↔ backend, user ↔ admin, backend ↔ data, us ↔ third-party) detected |
| 2 | Two synthetic services with cross-service flow + Stripe URL — `mrt_resolve_target` resolves the registered cross-service hostname; `mrt_is_third_party` flags Stripe; `mrt_workspace_for` resolves the correct clone |
| 3 | Code with `@PII` annotations + `EMAIL_*`/`*_SECRET` env vars + `email`/`phone_number`/`card_number` columns — all three classification pathways fire; PCI labels emitted; no false positive on `SOME_PUBLIC_FLAG` |
| 4 | Mermaid generator output shape — heading, source-of-truth declaration, flowchart block, subgraphs, trust-boundaries table, classifications table, provenance section, footer signature |
| 5 | Threat Dragon JSON — valid JSON, required v2 schema keys, `tm.actor`/`tm.process`/`tm.store`/`tm.boundary`/`tm.flow` cells, STRIDE threats attached to parent elements |
| 6 | Downstream-consumer refactor — `/threat-model` SKILL.md references `projects/.../architecture/dfd.md` AND has an offer-to-run-/dfd-first path; `/compliance-check` SKILL.md references the same DFD path |

Existing tests still pass: `test_portfolio_paths.sh` (38/38), `extract-features/tests/smoke.sh` (7/7).

## Discovery scope (v1)

In scope:
- HTTP routes (Express, Fastify, NestJS, FastAPI, Flask, Django, Rails, Gin, Spring, Lambda)
- Job frameworks (BullMQ, Celery, Sidekiq, Active Job, Temporal)
- Cron / EventBridge schedules
- Data stores (Prisma, TypeORM, SQLAlchemy, Mongoose, DynamoDB, S3, Redis, Elasticsearch / Algolia / Meilisearch, BigQuery / Snowflake / Redshift)
- Third-party SDKs (Stripe, SendGrid, Twilio, Anthropic, OpenAI, Sentry, Datadog, PostHog, Amplitude, Mixpanel, Algolia, Meilisearch)

Out of scope (v1):
- IaC reading (Terraform / CloudFormation / SAM) for trust-boundary inference — code + env config only
- SAST / DAST substitution
- Pretty SVG/PNG export (Threat Dragon does that after JSON import)
- PlantUML DFD format (`--format=plantuml-dfd`) — flagged as v2 follow-up in the AC
- Round-trip import (hand-edited `dfd.md` → re-parsed back into discovery model)
- L3 / L4 detail

## Glossary

| Term | Definition |
|------|------------|
| DFD | Data Flow Diagram — external entities + processes + data stores + trust boundaries + data flows; foundation for STRIDE threat modelling |
| Trust boundary | A line in a DFD where data crosses a privilege / network / ownership boundary; threats concentrate at boundaries |
| Data classification | A sensitivity label (PII, PCI, secrets, internal, public) attached to a data element; informs encryption, access control, regulatory scope |
| Reachability-bounded | Discovery scoped to what's connected to an anchor; doesn't blindly scan the whole repo for irrelevant data flows |
| Provenance | The file:line evidence trail for every DFD element — why each actor / process / store was placed in the diagram |
| Source of truth | One DFD per scope, consumed by `/threat-model` and `/compliance-check` — replaces the pattern where each skill rebuilt its own DFD slice |
| STRIDE | Microsoft's threat-classification mnemonic — Spoofing, Tampering, Repudiation, Information disclosure, Denial of service, Elevation of privilege |
| Threat Dragon | OWASP open-source desktop / web app for creating + editing threat models with STRIDE annotations; reads a v2 JSON schema this skill emits |
| Cross-repo trace | Resolving an outbound call (HTTP host, message-broker topic) to another registered project so the trace can follow into that repo's source for the connected slice |

Closes #257