### PR TITLE
feat(#245): /investigation skill + template

### DIFF
--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -11,7 +11,8 @@
       "Testing",
       "CI",
       "Docs",
-      "Spike"
+      "Spike",
+      "Investigation"
     ],
     "label_priority_scheme": "P0,P1,P2,P3",
     "required_sections": {
@@ -22,7 +23,8 @@
       "CI": ["Driver", "Scope", "Acceptance Criteria"],
       "Docs": ["Driver", "Acceptance Criteria"],
       "Bug": ["Given / When / Then", "Repro"],
-      "Spike": ["Hypothesis", "Budget", "Kill Criteria", "Disposition"]
+      "Spike": ["Hypothesis", "Budget", "Kill Criteria", "Disposition"],
+      "Investigation": ["Trigger", "Hypothesis being tested", "Method", "Findings", "Conclusion", "Follow-up actions"]
     },
     "skip_marker": "<!-- validate-issue-structure: skip -->",
     "_bootstrap_skills_comment": "Skills that run BEFORE any ticket can exist (fork bootstrap, project handover, framework upstream-sync). When one of these is active (marker at .claude/session/active-bootstrap), require-active-ticket.sh exempts the gate. The marker is written by the skill itself on entry, cleared on completion, AND reset at SessionStart so a stale marker can't carry over. See AgDR-0011-bootstrap-skill-exemption.md and me2resh/apexyard#150.",

--- a/.claude/skills/investigation/SKILL.md
+++ b/.claude/skills/investigation/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: investigation
+description: Create a structured investigation ticket + live-doc for sustained root-cause work — incident retrospectives, bug archaeology, regression hunts, performance mysteries, competitive analyses. Distinct from /spike (forward-looking hypothesis with a budget), /bug (immediate-fix), and /debug (live debugging session). Investigations close when every Follow-up action lands, not on PR merge.
+argument-hint: "[short-slug-or-incident-id]"
+allowed-tools: Bash, Read, Write
+---
+
+# /investigation — Create an Investigation Ticket + Live-Doc
+
+Creates a structured GitHub Issue + a sibling live-doc markdown file for an **investigation** — sustained root-cause work whose deliverable is a *written artefact* of what was observed, what we concluded, and what's next. Distinct from `/spike` (forward-looking hypothesis with a budget) and `/bug` (immediate-fix) — see the comparison block at the top of `templates/investigation.md`.
+
+> **When to use an investigation vs a bug vs a spike.** A `/bug` is filed when you already know what's broken and need to coordinate the fix. A `/spike` is filed when you want to test a forward-looking hypothesis ("will this approach work?") inside a time budget. An `/investigation` is filed when the *question itself* is the unknown — "why did this happen?", "what's actually going on with the metric drift?", "how does competitor X handle this?". The investigation produces a written record; the bug fix that may follow is a downstream artefact.
+
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+projects_dir=$(portfolio_projects_dir)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
+## Usage
+
+```
+/investigation                              # asks for the trigger interactively, derives slug
+/investigation order-api-spike-may-12       # pre-fills the slug; asks for the trigger detail
+/investigation PD-4471                      # incident ID as slug
+```
+
+## Process
+
+### 1. Resolve the target project
+
+Read `.claude/session/current-ticket` to determine the active project context. Then:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+projects_dir=$(portfolio_projects_dir)
+```
+
+- If the active ticket is on a managed project's repo → use that project's name + repo.
+- Else if exactly one project is registered → use it.
+- Else if multiple projects are registered → ask:
+
+  ```
+  Which project is this investigation for?
+  (Or 'framework' if it's about the apexyard framework itself.)
+  ```
+
+- If no projects are registered, ask for the repo in `owner/repo` format. The live-doc lands at `docs/investigations/<YYYY-MM-DD>-<slug>.md` in the ops fork root (the framework's own investigations live there).
+
+### 2. Verify the prefix is on the whitelist
+
+Read `.ticket.prefix_whitelist` from `.claude/project-config.*.json`. If `Investigation` (case-insensitive) is not in the list, warn and stop:
+
+```
+This fork's ticket schema doesn't include 'Investigation' as a valid prefix.
+Either add it to .claude/project-config.json → .ticket.prefix_whitelist, or
+file the ticket using whichever prefix the fork uses for root-cause work.
+```
+
+(The shipped default in `.claude/project-config.defaults.json` includes `Investigation`. This check exists for forks that have customised the whitelist — see apexyard#109.)
+
+### 3. Parse or ask for the slug
+
+Take the slug from `$ARGUMENTS` (kebab-cased). If empty, ask:
+
+```
+What's a short slug for this investigation? (3-5 words, kebab-case)
+Example: "order-api-spike-may-12" or "PD-4471".
+```
+
+The slug becomes part of the live-doc filename: `<YYYY-MM-DD>-<slug>.md`. Today's date prefixes automatically (so the same slug can be reused for a follow-up investigation next month without colliding).
+
+### 4. Gather details (one section at a time)
+
+Ask conversationally — do NOT batch all questions. Wait for each answer before asking the next. Mirror the section structure of `templates/investigation.md` so the user sees their answers slot into the artefact directly.
+
+**a) Trigger (required)**
+
+```
+What kicked this off? One paragraph.
+Examples:
+  - "Production incident PD-4471 at 14:03 UTC on 2026-05-12 — error rate
+    on /api/orders spiked from 0.2% to 11% for 22 minutes."
+  - "Customer report from #cs-tickets-3471 — exports >100k rows always fail."
+  - "Reviewing why we picked Auth0 in 2024 vs Cognito today."
+
+Include the link / incident ID / date if you have it.
+```
+
+**b) Hypothesis being tested (required)**
+
+```
+What did you think was happening BEFORE starting? List 2–4 hypotheses
+you wanted to confirm or rule out. I'll format them as a checkbox tree.
+
+Example:
+  - Upstream dependency degradation
+  - Internal queue backup
+  - Recent deploy regressed something
+```
+
+Push back if the user offers only one hypothesis — investigations exist precisely because the answer isn't obvious; entertaining multiple causes upfront is the methodology. If the user genuinely has one hypothesis only, that's usually a sign they should file a `/bug` instead. Surface that gently:
+
+```
+Only one hypothesis? An investigation usually entertains 2–4 — that's
+what distinguishes it from a /bug (where you already know what's broken).
+Are you sure /bug isn't the right call here? If yes to investigation,
+I'll proceed with the one hypothesis.
+```
+
+**c) Evidence sources you'll consult (required)**
+
+```
+Where will you gather evidence? List the sources.
+Examples:
+  - CloudWatch logs for /api/orders, 14:00–14:30 UTC
+  - Payments provider status page
+  - order_events table (SQL)
+  - Last 4 deploys to OrderService
+  - Staging replay of failed payloads
+
+These become the "Method" section — the path a reader follows.
+```
+
+**d) Initial method sketch (optional)**
+
+```
+Any specific queries / commands / steps you've already planned?
+(or press Enter to fill in as you go)
+```
+
+If the user provides specifics, they go into the Method section. If they skip, the Method section starts empty in the live-doc and the investigator fills it in as evidence comes in.
+
+### 5. Show the formatted ticket + live-doc plan for confirmation
+
+Resolve the investigation template via the portfolio helper so adopter overrides win when present:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+template=$(portfolio_resolve_template investigation.md)   # → custom-templates/investigation.md if present, else templates/investigation.md
+```
+
+Single-fork adopters (no `portfolio` block) and adopters with no override fall straight through to `templates/investigation.md`. Adopters who want a customised investigation shape (e.g. Five Whys instead of Hypothesis Tree) drop their version at `<private_repo>/custom-templates/investigation.md`. See `templates/README.md` for the path-mirroring convention.
+
+Read the resolved template and substitute the gathered inputs into the four sections that have inputs (Trigger, Hypothesis being tested, Method sketch, plus the placeholder Findings / Conclusion / Follow-up actions sections to fill in as the investigation progresses).
+
+Display the full ticket + the live-doc path:
+
+```
+Here's what I'll create:
+
+GitHub Issue:
+  Title:  [Investigation] {slug}
+  Labels: investigation
+  Repo:   {owner/repo}
+  Body:   (template-rendered — Trigger + Hypothesis + Method sketch
+           pre-filled; Findings / Conclusion / Follow-up actions empty
+           for now)
+
+Live-doc:
+  Path:   {projects_dir}/{project}/investigations/{YYYY-MM-DD}-{slug}.md
+          (or docs/investigations/{YYYY-MM-DD}-{slug}.md for framework
+           investigations)
+
+The live-doc IS the working surface — update it as evidence comes in.
+The GitHub issue tracks visibility + close state (closes when every
+Follow-up action lands or is explicitly dropped).
+
+Create both? (yes / edit / cancel)
+```
+
+### 6. Handle response
+
+- **yes** / **looks good** / **go** → create the issue + write the live-doc
+- **edit X** / **change Y** → ask what to change, update, re-show
+- **cancel** / **no** → abort
+
+### 7. Write the live-doc
+
+Compute the date prefix (UTC `YYYY-MM-DD`) and the target path:
+
+```bash
+date_prefix=$(date -u +%Y-%m-%d)
+if [ "$project" = "framework" ]; then
+  livedoc_dir="$(git rev-parse --show-toplevel)/docs/investigations"
+else
+  livedoc_dir="$projects_dir/$project/investigations"
+fi
+mkdir -p "$livedoc_dir"
+livedoc_path="$livedoc_dir/${date_prefix}-${slug}.md"
+```
+
+Substitute the gathered values into the resolved template and write the file via the `Write` tool. The Metadata block at the bottom of the file references the GitHub issue number — leave it as `#{NNN}` until step 8, then patch it.
+
+### 8. Create the GitHub Issue
+
+```bash
+gh issue create --repo {owner/repo} \
+  --title "[Investigation] {slug}" \
+  --label "investigation" \
+  --body "{rendered template body, with the Metadata block pointing at the live-doc path}"
+```
+
+Capture the issue number from the URL `gh` returns; patch the live-doc's Metadata block to replace `#{NNN}` with the real number.
+
+If the `investigation` label doesn't exist on the target repo, create it idempotently:
+
+```bash
+gh label create investigation \
+  --color "5319E7" \
+  --description "Sustained root-cause work — closes when Follow-up actions land, not on PR merge" \
+  --repo {owner/repo} 2>/dev/null || true
+```
+
+### 9. Return paths + next steps
+
+```
+Created: {owner/repo}#{number} — [Investigation] {slug}
+{url}
+
+Live-doc: {livedoc_path}
+
+Next steps:
+  1. Open the live-doc and update Findings as evidence comes in.
+  2. Each hypothesis in the tree gets evidence-for / evidence-against
+     bullets underneath — prune as you rule things out.
+  3. When you reach a conclusion, fill in the Conclusion section.
+  4. List Follow-up actions, each linked to a tracker ticket
+     (`/bug`, `/feature`, `/spike`, `/decide`) or marked `(no follow-up)`.
+  5. Close the GitHub issue when every Follow-up action is resolved
+     — NOT on PR merge.
+
+Suggested follow-up skills depending on what the investigation surfaces:
+  /bug    — file an immediate-fix bug
+  /spike  — file a hypothesis-driven exploration
+  /decide — record a technical decision that fell out
+  /feature — propose a new feature the investigation revealed a need for
+```
+
+## Rules
+
+1. **One section at a time.** Never batch questions. Wait for each answer before asking the next.
+2. **Always confirm before creating.** Show the full plan (issue + live-doc path) and get explicit "yes".
+3. **At least 2 hypotheses by default.** If only one, gently surface that `/bug` might be the right tool. Allow the user to override.
+4. **Trigger + Hypothesis + Evidence sources are mandatory.** Method sketch is optional (fills in as you go).
+5. **Live-doc is the working surface.** The GitHub issue tracks visibility + close state; the live-doc holds the evolving evidence + findings.
+6. **Close semantics are different from every other ticket type.** Investigations close when every Follow-up action is resolved or explicitly dropped — NOT on PR merge. The `investigation` label is the signal that downstream automation (if any) should treat the ticket as long-running.
+7. **Labels.** `investigation` always. Priority labels (P0 / P1 / etc.) are NOT applied by default — investigations are scoped by *the question*, not prioritised by P-class. If the investigation is incident-driven and the operator wants a P-label, they can add one manually.
+8. **No close gate (no `/investigation-close` skill).** The Follow-up actions section IS the close gate. Operators close the issue when actions land. Different from `/spike-close` because investigations have an open-ended action list, not a binary disposition. See AgDR-0027 for the rationale.
+9. **Template override.** Adopters who prefer Five Whys / Fishbone over the default Hypothesis Tree drop a replacement at `<private_repo>/custom-templates/investigation.md`. The skill resolves via `portfolio_resolve_template` — no skill changes needed.
+
+## How investigations relate to other skills
+
+| Skill | Purpose | When to chain into `/investigation` |
+|-------|---------|-------------------------------------|
+| `/bug` | Immediate-fix scenario, known broken behaviour | Rare — investigations usually file bugs as follow-up actions, not the other way around |
+| `/spike` | Forward-looking hypothesis with a budget | An investigation may conclude "we need a spike to test the fix approach" — file via `/spike` as a follow-up action |
+| `/debug` | Live debugging session (process helper) | A `/debug` session that surfaces a deeper "why did this happen" question naturally promotes to `/investigation` for the written artefact |
+| `/decide` | Record a technical decision (AgDR) | An investigation often concludes with a decision — record it via `/decide` as a follow-up action; cite the investigation from the AgDR |
+| `/feature` | Propose a new user-facing feature | An investigation that reveals a missing capability files a `/feature` as a follow-up action |
+| `/migration` | Migration ticket + AgDR | If the investigation's remediation is a migration, file via `/migration` (which itself produces a ticket + AgDR pair) |
+
+The bidirectional summary: investigations are usually **upstream** of other ticket types (they reveal what needs to happen); they're rarely downstream of them.

--- a/.claude/skills/investigation/tests/README.md
+++ b/.claude/skills/investigation/tests/README.md
@@ -1,0 +1,54 @@
+# /investigation smoke test
+
+Standalone bash script that verifies the **shape contracts** the
+`/investigation` skill depends on. The skill itself runs inside Claude
+Code (interactive interview, `gh issue create`, file writes); this script
+exists so a human or CI job can confirm the load-bearing contracts haven't
+drifted.
+
+## What it checks
+
+1. **Template required-section coverage** — `templates/investigation.md`
+   contains every section the SKILL.md interview promises to fill in
+   (`Trigger`, `Hypothesis being tested`, `Method`, `Findings`,
+   `Conclusion`, `Follow-up actions`).
+2. **AgDR-style opener** — the template starts with the
+   `> In the context of …` form, matching the framework's AgDR
+   convention so readers parse intent in one line.
+3. **Sibling-skill naming** — the when-to-use comparison block names
+   `/spike`, `/bug`, and `/decide` so operators landing on the template
+   from a search hit see the boundaries spelled out.
+4. **`portfolio_resolve_template` override semantics** — builds a synthetic
+   ops-fork + sibling private-repo fixture, drops a marker custom-template
+   at `<sibling>/custom-templates/investigation.md`, and asserts the
+   resolver picks the override over the framework default. Closes the
+   contract with the `_lib-portfolio-paths.sh` helper (#244).
+5. **project-config / template alignment** —
+   `.ticket.required_sections.Investigation` in
+   `.claude/project-config.defaults.json` matches the sections actually in
+   the template, AND `.ticket.prefix_whitelist` contains `Investigation`
+   (so `validate-issue-structure.sh` doesn't reject the new prefix).
+6. **SKILL.md frontmatter sanity** — `name`, `argument-hint`, and
+   `allowed-tools` keys are present.
+
+## Run
+
+From the apexyard fork root:
+
+```bash
+bash .claude/skills/investigation/tests/smoke.sh
+```
+
+Builds the override-test fixture in `$TMPDIR/investigation-fixture-*`,
+runs the checks, and removes the fixture on exit (success or failure).
+
+Exit code: `0` on success, `1` if any contract check fails.
+
+## What it does NOT check
+
+- The interactive interview flow (lives inside Claude Code; not bash-testable).
+- The `gh issue create` call (would need a live GitHub repo).
+- The live-doc file-write step (would need a mocked `Write` tool).
+
+Those run end-to-end every time an operator invokes `/investigation`; if
+they break, the failure surfaces in the next real invocation.

--- a/.claude/skills/investigation/tests/smoke.sh
+++ b/.claude/skills/investigation/tests/smoke.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# /investigation smoke test
+#
+# Verifies the contract that the consuming skill depends on:
+#
+#   1. templates/investigation.md exists and contains every required section
+#      (Trigger, Hypothesis being tested, Method, Findings, Conclusion,
+#       Follow-up actions) — these are what /investigation interviews on
+#       and what AgDR-0027 names as the load-bearing shape.
+#
+#   2. The AgDR-style "In the context of ..." opener is present at the top
+#      (matches the framework's AgDR shape; lets readers parse intent in
+#       one line).
+#
+#   3. The portfolio_resolve_template helper resolves a custom override
+#      when one is dropped at <private_repo>/custom-templates/investigation.md,
+#      and falls through to templates/investigation.md otherwise.
+#
+#   4. The skill's required-sections claim matches what's actually in the
+#      project-config defaults — no drift between the SKILL.md sections
+#      and the .ticket.required_sections.Investigation list.
+#
+# The skill itself runs inside Claude Code (interactive interview, gh issue
+# create, file writes). This smoke test verifies the *shape contracts* —
+# if any of them drifts, the skill's contract with the template / config /
+# adopter-override-helper breaks.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+assert_grep() {
+  local label="$1"
+  local pattern="$2"
+  local file="$3"
+  if grep -qE "$pattern" "$file"; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (pattern: $pattern; file: $file)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (expected: $expected; actual: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Resolve the ops-fork root. From inside the skill's tests/ dir, walk up
+# until we hit the dir containing templates/investigation.md.
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+ops_root="$script_dir"
+while [ "$ops_root" != "/" ] && [ ! -f "$ops_root/templates/investigation.md" ]; do
+  ops_root=$(dirname "$ops_root")
+done
+if [ ! -f "$ops_root/templates/investigation.md" ]; then
+  echo "FAIL: could not locate ops-fork root (templates/investigation.md missing)"
+  exit 1
+fi
+
+echo "Smoke test: /investigation contract checks (ops_root=$ops_root)"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. Template ships with every required section
+# ---------------------------------------------------------------------------
+echo "1. Template required-section coverage:"
+template="$ops_root/templates/investigation.md"
+assert_grep "Trigger heading"                "^## Trigger"                "$template"
+assert_grep "Hypothesis being tested heading" "^## Hypothesis being tested" "$template"
+assert_grep "Method heading"                 "^## Method"                 "$template"
+assert_grep "Findings heading"               "^## Findings"               "$template"
+assert_grep "Conclusion heading"             "^## Conclusion"             "$template"
+assert_grep "Follow-up actions heading"      "^## Follow-up actions"      "$template"
+
+# ---------------------------------------------------------------------------
+# 2. AgDR-style opener present
+# ---------------------------------------------------------------------------
+echo ""
+echo "2. AgDR-style 'In the context of' opener:"
+assert_grep "In the context of opener" "^> In the context of " "$template"
+
+# ---------------------------------------------------------------------------
+# 3. When-to-use comparison block names the sibling skills
+# ---------------------------------------------------------------------------
+echo ""
+echo "3. When-to-use block names the sibling skills:"
+assert_grep "Names /spike"  "/spike"  "$template"
+assert_grep "Names /bug"    "/bug"    "$template"
+assert_grep "Names /decide" "/decide" "$template"
+
+# ---------------------------------------------------------------------------
+# 4. portfolio_resolve_template override semantics
+# ---------------------------------------------------------------------------
+echo ""
+echo "4. portfolio_resolve_template override semantics:"
+
+# Source the helper. The helper sources _lib-read-config.sh internally on
+# first use, so just point at portfolio-paths directly.
+# shellcheck source=/dev/null
+. "$ops_root/.claude/hooks/_lib-portfolio-paths.sh"
+
+# Walk-up to find ops fork looks for .apexyard-fork OR onboarding+registry.
+# We're inside a worktree without those, so cd into the ops root first.
+pushd "$ops_root" >/dev/null
+
+# Test path A: no custom-templates/investigation.md → resolves to framework default
+portfolio_clear_cache
+resolved=$(portfolio_resolve_template investigation.md 2>/dev/null || echo "(not resolved)")
+case "$resolved" in
+  */templates/investigation.md)
+    echo "  PASS: no override → falls through to templates/investigation.md ($resolved)"
+    PASS=$((PASS + 1))
+    ;;
+  *)
+    # In a fresh worktree without ops-fork anchor, portfolio_resolve_template
+    # may not find the registry. Skip cleanly with a note rather than failing.
+    echo "  SKIP: portfolio resolver didn't locate the registry from this worktree (resolved='$resolved')"
+    echo "        This is expected when running from a worktree without an .apexyard-fork marker."
+    ;;
+esac
+
+# Test path B: synthesise a custom override using a fixture private-repo dir
+#   - create temp dir with apexyard.projects.yaml + custom-templates/investigation.md
+#   - point a temporary project-config at it
+#   - assert the resolver picks the override
+fixture_root=$(mktemp -d -t investigation-fixture-XXXXXX)
+trap 'rm -rf "$fixture_root"' EXIT
+
+# Build a synthetic ops-fork rooted at $fixture_root/fork with a config
+# pointing at a sibling $fixture_root/portfolio that holds the override.
+mkdir -p "$fixture_root/fork/.claude/hooks"
+mkdir -p "$fixture_root/fork/templates"
+mkdir -p "$fixture_root/portfolio/custom-templates"
+
+# Mark the synthetic fork as an ops fork (v2 anchor).
+touch "$fixture_root/fork/.apexyard-fork"
+
+# Seed an empty registry in the sibling.
+cat > "$fixture_root/portfolio/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects: []
+YAML
+
+# Seed the framework template at the synthetic fork (resolver fallback target).
+cat > "$fixture_root/fork/templates/investigation.md" <<'MD'
+# framework default
+## Trigger
+## Hypothesis being tested
+## Method
+## Findings
+## Conclusion
+## Follow-up actions
+MD
+
+# Seed the adopter override at the sibling private repo.
+cat > "$fixture_root/portfolio/custom-templates/investigation.md" <<'MD'
+# ADOPTER OVERRIDE
+## Trigger
+## Hypothesis being tested
+## Method
+## Findings
+## Conclusion
+## Follow-up actions
+MD
+
+# Write a minimal project-config pointing at the sibling.
+mkdir -p "$fixture_root/fork/.claude"
+cat > "$fixture_root/fork/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "registry": "../portfolio/apexyard.projects.yaml",
+    "projects_dir": "../portfolio/projects",
+    "ideas_backlog": "../portfolio/projects/ideas-backlog.md"
+  }
+}
+JSON
+
+# Also seed a defaults file — _config_load returns '{}' if defaults are missing,
+# which makes config_get_or fall through to its fallback value (the in-fork
+# './apexyard.projects.yaml') and bypass our portfolio block entirely.
+cp "$ops_root/.claude/project-config.defaults.json" "$fixture_root/fork/.claude/project-config.defaults.json"
+
+# Mirror the helper libraries into the fixture so the resolver works
+# without depending on the worktree's ops fork having been initialised.
+cp "$ops_root/.claude/hooks/_lib-read-config.sh"        "$fixture_root/fork/.claude/hooks/"
+cp "$ops_root/.claude/hooks/_lib-portfolio-paths.sh"    "$fixture_root/fork/.claude/hooks/"
+
+# Initialise the fixture as a git repo so the helpers' rev-parse walks resolve.
+( cd "$fixture_root/fork" && git init -q 2>/dev/null && git add -A 2>/dev/null && git -c user.email=t@t -c user.name=t commit -q -m init 2>/dev/null || true )
+
+# Run the resolver from inside the fixture fork.
+override_resolved=$(
+  cd "$fixture_root/fork" && \
+  bash -c '
+    . .claude/hooks/_lib-read-config.sh
+    . .claude/hooks/_lib-portfolio-paths.sh
+    portfolio_clear_cache
+    portfolio_resolve_template investigation.md
+  '
+)
+
+case "$override_resolved" in
+  */portfolio/custom-templates/investigation.md)
+    echo "  PASS: custom override wins → $override_resolved"
+    PASS=$((PASS + 1))
+    # Sanity-check it's actually the adopter version, not the framework one.
+    if grep -q "ADOPTER OVERRIDE" "$override_resolved"; then
+      echo "  PASS: resolved file contains the adopter marker"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: resolved file did not contain the adopter marker"
+      FAIL=$((FAIL + 1))
+    fi
+    ;;
+  *)
+    echo "  FAIL: override did not win (resolved='$override_resolved')"
+    FAIL=$((FAIL + 1))
+    ;;
+esac
+
+popd >/dev/null
+
+# ---------------------------------------------------------------------------
+# 5. project-config defaults align with template sections
+# ---------------------------------------------------------------------------
+echo ""
+echo "5. project-config defaults align with template sections:"
+defaults_json="$ops_root/.claude/project-config.defaults.json"
+if command -v jq >/dev/null 2>&1; then
+  required_sections=$(jq -r '.ticket.required_sections.Investigation[]' "$defaults_json" 2>/dev/null | sort)
+  expected="Conclusion
+Findings
+Follow-up actions
+Hypothesis being tested
+Method
+Trigger"
+  if [[ "$required_sections" == "$expected" ]]; then
+    echo "  PASS: .ticket.required_sections.Investigation matches the template sections"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: required_sections drift"
+    echo "    Got:"
+    echo "$required_sections" | sed 's/^/      /'
+    echo "    Expected:"
+    echo "$expected" | sed 's/^/      /'
+    FAIL=$((FAIL + 1))
+  fi
+
+  # Also: prefix_whitelist contains Investigation
+  prefix_match=$(jq -r '.ticket.prefix_whitelist[] | select(. == "Investigation")' "$defaults_json")
+  if [[ "$prefix_match" == "Investigation" ]]; then
+    echo "  PASS: .ticket.prefix_whitelist contains 'Investigation'"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: .ticket.prefix_whitelist missing 'Investigation'"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  SKIP: jq not installed; can't introspect project-config.defaults.json"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. SKILL.md frontmatter sanity
+# ---------------------------------------------------------------------------
+echo ""
+echo "6. SKILL.md frontmatter sanity:"
+skill_md="$ops_root/.claude/skills/investigation/SKILL.md"
+assert_grep "name: investigation"                          "^name: investigation$"             "$skill_md"
+assert_grep "argument-hint declared"                        "^argument-hint: "                  "$skill_md"
+assert_grep "allowed-tools includes Bash + Read + Write"    "^allowed-tools: Bash, Read, Write" "$skill_md"
+
+echo ""
+echo "----------------------------------------"
+echo "Total: $((PASS + FAIL))   Passed: $PASS   Failed: $FAIL"
+echo "----------------------------------------"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+echo ""
+echo "OK: /investigation contract checks passed."
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ Template: @templates/agdr.md
 | ADR | Recording architecture decisions | `templates/adr.md` |
 | AgDR | Recording AI agent decisions | `templates/agdr.md` |
 | Migration AgDR | Recording migration decisions (rollback, downtime, consumers, observability) | `templates/agdr-migration.md` |
+| Investigation | Sustained root-cause work — incident retros, bug archaeology, regression hunts, performance mysteries. Hypothesis-tree methodology; live-doc workflow. Used by `/investigation`. | `templates/investigation.md` |
 | C4 Context (L1) | System + external actors (one per project) | `templates/architecture/c4-context.md` |
 | C4 Container (L2) | Deployable units inside the system | `templates/architecture/c4-container.md` |
 | Architecture Vision | Target-state architecture + multi-quarter migration path + explicit anti-scope | `templates/architecture/vision.md` |
@@ -187,10 +188,10 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Rules | `.claude/rules/` | 11 modular rule files (AgDR triggers, code standards, git conventions, leak protection, parallel work, plan mode, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Handbooks | `handbooks/` | Adopter-authored coding standards consumed by Rex during code review. Discovery by path-convention (`architecture/` + `general/` always-load; `language/<lang>/` loads on diff-match). Advisory by default; opt in to blocking via `ENFORCEMENT: blocking` marker. See [`handbooks/README.md`](handbooks/README.md). |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer — Rex, Security Reviewer — Hatim, Dependency Auditor — Munir, PR Manager — Tariq, Ticket Manager — Idris) |
-| Skills | `.claude/skills/` | 44 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 47 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (44)
+### Available skills (47)
 
 | Skill | Purpose |
 |-------|---------|
@@ -221,6 +222,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | `/migration` | Create a labelled migration ticket + migration AgDR in one guided flow (required by the migration gate) |
 | `/spike` | Create a hypothesis-driven, time-boxed, throw-away spike ticket (Hypothesis / Budget / Kill Criteria / Disposition). Spike PRs are exempt from the AgDR + 80% coverage gates; Rex + security auditor still apply. |
 | `/spike-close` | Disposition gate for spikes — `--promote` files a follow-up `[Feature]`, `--discard` writes a memo to `docs/spike-memos/<slug>.md`. |
+| `/investigation` | Create a structured investigation ticket + live-doc for sustained root-cause work (incident retro, bug archaeology, regression hunt, performance mystery). Distinct from `/spike` (forward-looking hypothesis with a budget) and `/bug` (immediate-fix). Closes when every Follow-up action lands, not on PR merge. Template override via `custom-templates/investigation.md`. See AgDR-0027. |
 | `/idea` | Capture a new product idea to the backlog |
 | `/handover` | Onboard an external repo into ApexYard management (includes per-project discovery) |
 | `/extract-features` | Scan an existing codebase across six discovery axes (HTTP routes, data models, async jobs, test names, UI screens, documented features) and write a consolidated Feature Inventory at `projects/<name>/feature-inventory.md` — the "what we must preserve" spec for a greenfield rewrite. Complements `/handover` (high-level project assessment); `/extract-features` is the granular feature catalogue. |

--- a/docs/agdr/AgDR-0027-investigation-skill-and-template.md
+++ b/docs/agdr/AgDR-0027-investigation-skill-and-template.md
@@ -1,0 +1,134 @@
+# Investigation skill — methodology choice, ticket-type vs label, live-doc vs after-the-fact
+
+> In the context of ApexYard's existing ticket family (`/feature`, `/bug`, `/spike`, `/task`, `/migration`) covering greenfield work, immediate-fix work, hypothesis-driven exploration, technical work, and migration work — facing a missing scaffold for **sustained root-cause investigation** that produces a *written artefact* of how an unknown was resolved (incident retrospective, bug archaeology, regression hunt, performance mystery, competitive analysis) — I decided to ship a new **Investigation** ticket type with a **hypothesis-tree** methodology, a **live-doc evidence-gathering** workflow (the markdown file IS the working surface, not an after-the-fact retrospective), and a **Trigger / Hypothesis / Method / Findings / Conclusion / Follow-up actions** template shape, with template-resolution routed through `portfolio_resolve_template` so adopters can override the structure without forking the skill — to achieve a consistent reusable artefact for "why did this happen" work that future-us (or a teammate) can pick up mid-thread, accepting that the investigation ticket does NOT close itself on PR merge (it closes only when every Follow-up action either lands or is explicitly dropped), that the hypothesis-tree methodology is opinionated (Five Whys and Fishbone fans will see their methodology absent from the template by default), and that the skill ships without a `/investigation-close` companion (the Follow-up actions section IS the close gate, prose-only).
+
+## Context
+
+Three problems pointed at the same gap:
+
+1. **No home for written investigation artefacts.** `/spike` handles hypothesis-driven *forward-looking* exploration ("does this approach work?"). `/bug` handles immediate-fix scenarios. `/debug` is a *process* helper for live debugging sessions. None of them produces a structured *written record* of "this is what we observed, here's the data, here's what we conclude" — the documentation shape that incident retros, bug archaeologies, and regression hunts need. Operators end up writing freeform docs that look different every time and rot in a `docs/notes/` folder nobody searches.
+
+2. **Methodology shopping.** Root-cause work has three well-known methodologies — Five Whys (Toyota / Lean), Fishbone / Ishikawa, Hypothesis Tree. Each is opinionated about *how* you decompose the problem. Without picking one, the skill is a freeform note-taker and adds little over a blank file. With the wrong one, half the user base finds the skill at odds with how they think.
+
+3. **Where does the artefact live, and when does it get written?** Two extremes: (a) the file is opened at the start of the investigation and updated as evidence accumulates ("live doc" — the doc IS the working surface); (b) the file is written after the work is done as a retrospective. Both have failure modes — (a) tends to be messy and unfinished if the investigator gets distracted; (b) tends to be thin because human memory degrades within hours of the work.
+
+## Options Considered
+
+### Option A — Add `investigation` as a LABEL on existing bug tickets, no new type or skill
+
+| Pros | Cons |
+|------|------|
+| Zero new surface — label-based, reuses `[Bug]` template | A bug is the *thing to fix*; an investigation is the *process of understanding what to fix*. They produce different artefacts (a fix vs a written record). Conflating them buries the investigation under the bug's lifecycle (the bug closes on merge; the investigation often outlives it) |
+| Adopters can opt in without framework changes | No interview / no template structure — operators still write freeform |
+| | A bug deserves Given/When/Then + Severity; an investigation deserves Trigger/Hypothesis/Method/Findings — overloading one schema confuses both |
+
+### Option B — New `Investigation` ticket type + `/investigation` skill + dedicated template (chosen)
+
+`Investigation` gets its own ticket prefix (`[Investigation]`), label (`investigation`), template (`templates/investigation.md`), and skill (`/investigation`). The skill interviews on the six template sections, optionally writes a sibling live-doc file at `<projects_dir>/<name>/investigations/<YYYY-MM-DD>-<slug>.md`, and creates the GitHub Issue referencing the live-doc.
+
+| Pros | Cons |
+|------|------|
+| Distinct shape mirrors distinct work — investigations are sustained, multi-day, often span multiple PRs | More surface: new template, new skill, new label, new prefix-whitelist entry |
+| Template forces structure that ad-hoc docs lack — reproducible artefact across the portfolio | Adopters used to filing investigation work as bugs have to relearn the boundary |
+| Optionally writes a live-doc the investigator updates as evidence comes in — separates the *ticket* (cross-cutting visibility) from the *working surface* (the file) | Two artefacts per investigation (issue + file) instead of one — operator has to keep them in sync |
+| Sits cleanly alongside `/spike` (forward-looking POC) and `/bug` (immediate-fix) without competing | The investigation ticket's close semantics are different from every other type (closes when follow-ups land, not on merge); operators have to remember |
+
+### Option C — Add a `[Investigation]` prefix that piggybacks on `/spike` (one skill, two prefixes)
+
+Reuse `/spike`'s interview machinery; just swap the prefix and the four required sections (Hypothesis / Budget / Kill Criteria / Disposition → Trigger / Method / Findings / Conclusion).
+
+| Pros | Cons |
+|------|------|
+| Less skill surface — one interview engine, two prefix dispatches | The two shapes diverge sharply: a spike is *time-boxed* with a *budget* and a *kill criterion*; an investigation has none of those (it ends when the question is answered, however long that takes) |
+| | A spike's Disposition (PROMOTE / DISCARD) is a binary forward-decision; an investigation's Follow-up actions are an open-ended list that can include "no follow-up" |
+| | Coupling forces both skills to evolve in lockstep — a change to the spike interview cascades into investigation, surprising adopters |
+
+### Methodology sub-choice — Five Whys vs Fishbone vs Hypothesis Tree (within Option B)
+
+| Methodology | Shape | Fits investigations because… | Fails because… |
+|-------------|-------|-------------------------------|----------------|
+| **Five Whys** | Linear chain of "why? why? why?" | Cheap, fast, no diagram needed, well-known | Forces a single causal chain; multi-cause incidents (the most interesting ones) get awkwardly flattened |
+| **Fishbone (Ishikawa)** | Diagram with category-spines (People / Process / Tech / Environment) | Good for brainstorming-style root-cause sessions in a group | Diagrams don't render cleanly in markdown / GitHub issue bodies; works in Miro, not in `gh issue view` |
+| **Hypothesis Tree (chosen)** | Nested bulleted list of hypotheses with evidence-for / evidence-against under each | Renders as plain markdown; supports multi-cause; iterates naturally as evidence comes in; matches how engineers actually think during debugging | Less prescriptive than Five Whys — investigators have to write the hypotheses; the template gives a starting shape |
+
+### Live-doc sub-choice — file written WHILE investigating vs AFTER
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **Live-doc (chosen)** | Captures evidence at the moment it's gathered (logs / SQL output / repro steps) — memory loss doesn't degrade the record. The doc IS the working surface. | Risks unfinished docs if the investigator drops the thread. Mitigation: the ticket's Follow-up actions section is the close gate, so a half-written doc has a ticket reminding it exists |
+| After-the-fact retrospective | Cleaner final artefact; ruthless editing | Memory degrades within hours; nuance lost. Common failure mode: operator never gets back to writing the retro at all |
+
+Live-doc wins because the worst failure mode (unfinished doc + open ticket) is recoverable; the after-the-fact failure mode (no doc at all) is permanent.
+
+## Decision
+
+Chosen: **Option B — new `Investigation` ticket type with its own skill, template, label, and prefix; hypothesis-tree methodology as the core; live-doc evidence-gathering workflow.**
+
+Three reasons it wins:
+
+1. **The work IS distinct from a bug or a spike.** A bug is "fix this broken behaviour." A spike is "explore this unknown to commit or reject an approach." An investigation is "understand why this happened so we can decide what to do." Conflating any pair confuses both. The new type makes the distinction visible at the prefix level.
+
+2. **Hypothesis-tree is the methodology that survives rendering in a GitHub issue body.** Fishbone needs a diagram; Five Whys flattens multi-cause incidents. Hypothesis-tree is just nested bullets, renders cleanly everywhere markdown does, and matches how engineers think during debugging (entertain several hypotheses, gather evidence on each, prune). The template ships a starter tree; adopters override via `custom-templates/investigation.md` if they want Five Whys / Fishbone instead.
+
+3. **Live-doc + Follow-up actions as the close gate is the right shape.** Investigations are sustained — they outlive a single PR merge. Auto-closing on merge is the wrong default (an "investigation closed because we shipped a fix" can mask follow-ups like "audit the rest of the codebase for the same pattern"). Leaving the ticket open until the Follow-up actions land puts the right close moment on the operator's calendar.
+
+### Why no `/investigation-close` companion (cf. `/spike-close`)
+
+`/spike-close` exists because spikes have a **binary disposition** (PROMOTE or DISCARD) that's hard to capture by just closing the issue — there's no place for the memo otherwise. Investigations have an **open-ended list** of follow-up actions, each of which is either a separate tracker ticket (already gets its own close), a documentation artefact (lands when committed), or explicitly `(no follow-up)`. The Follow-up actions section IS the close gate — when every action is resolved, the operator closes the issue. No third file needed.
+
+### Why hypothesis-tree over the alternatives (one more pass)
+
+Five Whys keeps showing up in incident-response literature because it's easy to teach. But the production-incident reality is that a single chain rarely holds — you usually find *three plausible causes* and have to weigh which contributed how much. Forcing a single chain into the template biases the investigation toward a single answer too early. Hypothesis-tree explicitly invites enumeration of competing hypotheses, with evidence under each — the right shape for the work.
+
+Fishbone is good for the *workshop* version of root-cause (six people, a whiteboard, an hour). It's bad for the *artefact* version (one engineer writing in a markdown file). Wrong tool for the medium.
+
+### Where the live-doc lives
+
+In **single-fork mode**: `projects/<project>/investigations/<YYYY-MM-DD>-<slug>.md`. The `projects/` dir is the per-project docs area, parallel to `projects/<project>/processes/<slug>.bpmn` (from `/process`), `projects/<project>/feature-inventory.md` (from `/extract-features`), `projects/<project>/architecture/c4-context.md` (from `/c4`).
+
+In **split-portfolio mode** the `projects_dir` resolver routes to the sibling private repo automatically.
+
+When invoked from the ops fork root (no project context), the live-doc lands at `docs/investigations/<YYYY-MM-DD>-<slug>.md` — the framework's own investigations live there.
+
+### Date-prefixed filenames
+
+`YYYY-MM-DD-<slug>.md` is the same convention `/spike-close --discard` uses for memo filenames (`docs/spike-memos/<slug>.md` — though `/spike-close` doesn't date-prefix; we add the date here because investigations cluster more around incidents than spikes do, and chronological sort is a useful directory listing).
+
+### Template override path
+
+`portfolio_resolve_template investigation.md` — drop a custom shape at `<private_repo>/custom-templates/investigation.md` to replace the framework default. Same path-mirroring convention as `prd.md`, `spike.md`, etc. See [`templates/README.md`](../../templates/README.md) and [AgDR-0023](AgDR-0023-custom-templates-override-semantics.md).
+
+## Consequences
+
+### Now safer
+
+- **One canonical shape for investigation artefacts.** Future-us can search `projects/*/investigations/` across the portfolio and skim the structure without re-parsing every author's idiosyncratic layout.
+- **Live-doc captures evidence at gather-time.** Less memory loss; more reproducible incidents.
+- **Follow-up actions section is the close gate.** No more orphan investigations that drift open forever — every follow-up either lands or is explicitly marked `(no follow-up)`, then the issue closes.
+
+### Now riskier
+
+- **Two artefacts per investigation (issue + file).** Operator has to keep them in sync. Mitigation: the skill writes the file path into the issue body so the issue links to the file; the file's metadata block links back to the issue.
+- **Methodology is opinionated.** Five Whys / Fishbone fans see their methodology absent from the template. Mitigation: `custom-templates/investigation.md` can replace the shape entirely; the rest of the skill (interview, file placement, issue creation) stays the same.
+- **No close gate beyond the operator's discipline.** Investigations rely on the operator closing the issue when follow-ups resolve. If they don't, the open count drifts up. Acceptable for v1 — if measurable in practice, add a `/investigation-close` skill or a hard gate later.
+
+### Now slower
+
+- **Investigation work explicitly takes longer than filing a bug.** That's deliberate — the bar is "produce a written artefact future-us can pick up", not "fix the symptom." Fast-fix bugs should stay on `/bug`.
+
+### Future work
+
+- **Auto-link to related tickets.** When `/investigation` runs and the live-doc lists follow-up actions, the skill could offer to file them as `/bug` / `/feature` / `/spike` tickets in the same flow. v2 — keeps v1 simple.
+- **Investigation rollups for `/stakeholder-update`.** Recent investigations are a useful weekly-update item ("we resolved 3 investigations this week"). v2 once enough investigations exist to roll up.
+- **`/investigation-close` if discipline-only proves insufficient.** Measurable trigger: count of `investigation`-labelled issues open > 30 days with no recent body update over the trailing 90 days.
+- **Cross-investigation patterns.** A `/agdr search` style helper for "have we investigated this before?" — useful once the corpus grows. v2.
+
+## Artifacts
+
+- `me2resh/apexyard#245` — feature ticket
+- `templates/investigation.md` — new template
+- `.claude/skills/investigation/SKILL.md` — new skill
+- `.claude/skills/investigation/tests/smoke.sh` — smoke test asserting template structure
+- `.claude/project-config.defaults.json` — `Investigation` added to `.ticket.prefix_whitelist` + `.ticket.required_sections`
+- `CLAUDE.md` — skill registry row + count bump
+- `templates/README.md` — investigation entry in the override table

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,6 +1,6 @@
 # Templates
 
-ApexYard ships markdown templates under `templates/` that consuming skills read at invocation time — `/decide` reads `agdr.md`, `/write-spec` reads `prd.md`, `/c4` reads `architecture/c4-context.md` and `architecture/c4-container.md`, `/migration` reads `agdr-migration.md`, `/spike` reads `spike.md`, `/handover` reads `architecture/c4-container.md`. The full inventory is in [`CLAUDE.md` § "Templates"](../CLAUDE.md).
+ApexYard ships markdown templates under `templates/` that consuming skills read at invocation time — `/decide` reads `agdr.md`, `/write-spec` reads `prd.md`, `/c4` reads `architecture/c4-context.md` and `architecture/c4-container.md`, `/migration` reads `agdr-migration.md`, `/spike` reads `spike.md`, `/investigation` reads `investigation.md`, `/handover` reads `architecture/c4-container.md`. The full inventory is in [`CLAUDE.md` § "Templates"](../CLAUDE.md).
 
 ## Adopter overrides — the `custom-templates/` layer
 
@@ -12,6 +12,7 @@ Every framework template can be overridden by an adopter-authored version. The o
 | `templates/agdr.md` | `<private_repo>/custom-templates/agdr.md` |
 | `templates/agdr-migration.md` | `<private_repo>/custom-templates/agdr-migration.md` |
 | `templates/spike.md` | `<private_repo>/custom-templates/spike.md` |
+| `templates/investigation.md` | `<private_repo>/custom-templates/investigation.md` |
 | `templates/architecture/c4-context.md` | `<private_repo>/custom-templates/architecture/c4-context.md` |
 | `templates/architecture/c4-container.md` | `<private_repo>/custom-templates/architecture/c4-container.md` |
 | `templates/architecture/vision.md` | `<private_repo>/custom-templates/architecture/vision.md` |

--- a/templates/investigation.md
+++ b/templates/investigation.md
@@ -1,0 +1,96 @@
+# [Investigation] {short title}
+
+> In the context of {what kicked this off}, facing {the unknown we needed to resolve}, I investigated {hypothesis or scope} to achieve {what we needed to learn}, accepting {time / scope tradeoffs}.
+
+## When to use this template
+
+- **Use `/investigation`** when you need a written record of "why did this happen" or "what's actually going on" — incident retrospectives, bug archaeology, regression hunts, performance mysteries, competitive analyses.
+- **Use `/spike`** if you're testing a *forward-looking* hypothesis ("does this approach work?") with a time budget.
+- **Use `/bug`** if you already know what's broken and need to file an immediate fix.
+- **Use `/decide`** if you're choosing between options and need an AgDR.
+
+An investigation IS the artefact. A bug fix is the artefact's *consequence*.
+
+## Trigger
+
+{What kicked this off — incident link, customer report, "the bug from #N", a metric anomaly, a teammate's question. One paragraph. Include the date/time and the link.}
+
+Example: *On 2026-05-12 at 14:03 UTC, error rate on `/api/orders` spiked from baseline 0.2 % to 11 % for 22 minutes. PagerDuty incident PD-4471. Self-resolved at 14:25 with no operator action.*
+
+## Hypothesis being tested
+
+{What you thought was happening BEFORE you started. What you needed to confirm or rule out. A hypothesis tree — bulleted, with sub-bullets for sub-hypotheses. Empty `[ ]` checkboxes for each so you can mark them as you go.}
+
+Example:
+
+- [ ] **H1 — Upstream dependency degradation.** Payments provider returned 5xx on a fraction of requests; our retry budget got eaten.
+  - [ ] H1a — Provider's own incident page shows degradation in the matching window.
+  - [ ] H1b — Our outbound error logs to the payments provider correlate with the spike.
+- [ ] **H2 — Internal queue backup.** A slow consumer caused order creation to time out.
+  - [ ] H2a — Queue depth metrics show a backlog in the matching window.
+  - [ ] H2b — Consumer error logs reference the queue we suspect.
+- [ ] **H3 — Recent deploy.** Code change in the last 24 h regressed order creation.
+  - [ ] H3a — Deploy log shows a change to `OrderService` within the window.
+  - [ ] H3b — Rolling back the change in staging reproduces the error rate.
+
+## Method
+
+{What you actually DID. Itemised so a reader can follow your path. Each item names the tool, the source, the time window. Distinguish *what you queried* from *what you found* (findings go below).}
+
+Example:
+
+1. Pulled production error logs from CloudWatch for `/api/orders`, 14:00–14:30 UTC. Filter: `5xx` responses. Result count → Findings.
+2. Pulled payments provider's status page snapshot for 14:00–14:30 UTC.
+3. Queried internal `order_events` table for `status='failed'` rows in the window. SQL recorded in artefacts/queries.md.
+4. Diffed the last 4 deploys to `OrderService` against the spike window.
+5. Reproduced the failure path in staging by replaying the top 5 failed payloads (sanitised).
+
+## Findings
+
+{What you confirmed, ruled out, what surprised you. Distinguish OBSERVATIONS (raw facts) from CONCLUSIONS (what they mean). Map each finding back to the hypothesis it supports or refutes.}
+
+### Observations
+
+- 217 failed `/api/orders` calls in the 22-minute window, all returning 502.
+- Payments provider's status page shows no incident in the window — **rules out H1**.
+- Queue depth metric (`order_queue.depth`) reached 4,200 at 14:08, vs baseline 100 — **supports H2**.
+- Consumer log shows `OrderConsumer` swallowed `DBConnectionError` between 14:03 and 14:25.
+- Last deploy to `OrderService` was 2 days prior — **rules out H3**.
+- Surprise: the DB connection pool was at max capacity (50/50) during the window, despite traffic being only 2× baseline.
+
+### Conclusions
+
+- **H1 ruled out.** Payments provider was healthy.
+- **H2 confirmed.** A DB connection pool exhaustion (50/50) caused `OrderConsumer` to error, which backed up the queue, which made order-creation requests time out at 502.
+- **H3 ruled out.** No recent deploy in the suspect window.
+- **Root cause: connection pool size of 50 is insufficient for 2× baseline traffic on the order path** — the autoscaling rule scales replicas but not the per-replica pool size.
+
+## Conclusion
+
+{One paragraph: the answer to the original question. Include the confidence level (high / medium / low) and what remaining uncertainty there is. If you couldn't reach a confident answer, say so explicitly.}
+
+Example: *The 14:03 spike was caused by DB connection pool exhaustion on the order path, triggered by a 2× traffic burst that overran the per-replica pool size of 50. Confidence: HIGH (reproduced in staging by capping pool size and replaying traffic). Remaining uncertainty: whether other services share the same pool-sizing assumption — see follow-up actions.*
+
+## Follow-up actions
+
+{What's NEXT. Each action linked to a tracker ticket if filed, or marked `(no follow-up)`. The investigation ticket CLOSES when every action is resolved or explicitly dropped — NOT on PR merge.}
+
+- [ ] **Raise pool size to 200 on the order path** — filed as #{NNN}, ships in next deploy.
+- [ ] **Audit other services for the same pool-sizing assumption** — filed as #{NNN}.
+- [ ] **Add an autoscaling rule that scales pool size with replica count** — filed as #{NNN}.
+- [ ] **Write a runbook entry for "connection pool exhaustion under burst traffic"** — filed as #{NNN}.
+- [ ] **Share findings with the platform team** — (no follow-up: shared in #platform on 2026-05-13).
+- [ ] **Backport the pool-size change to the staging environment** — (no follow-up: staging already runs the new value as of the repro).
+
+---
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Live-doc | `projects/{project}/investigations/{YYYY-MM-DD}-{slug}.md` |
+| GitHub issue | #{NNN} |
+| Started | YYYY-MM-DD |
+| Resolved | YYYY-MM-DD (or "open — see Follow-up actions") |
+| Investigator(s) | @handle |
+| Related AgDR | — (link if a decision falls out of the investigation) |


### PR DESCRIPTION
## Summary

- New `/investigation` skill + `templates/investigation.md` for sustained root-cause work — incident retrospectives, bug archaeology, regression hunts, performance mysteries. Sits between `/spike` (forward-looking hypothesis with a budget) and `/bug` (immediate-fix) without overlapping either.
- Template uses **hypothesis-tree methodology** (nested checkbox bullets, renders cleanly in GitHub) over Five Whys (flattens multi-cause incidents) or Fishbone (needs a diagram). Adopters override via `custom-templates/investigation.md` per the #244 layer.
- New `[Investigation]` ticket type — distinct from `/bug` because investigations are sustained, multi-day, often outlive a single PR. Closes when every Follow-up action lands or is explicitly dropped, **not** on PR merge.
- Live-doc workflow at `projects/<name>/investigations/<YYYY-MM-DD>-<slug>.md` (or `docs/investigations/...` for framework investigations) — the file IS the working surface; the GitHub issue tracks visibility + close state.
- AgDR-0027 captures the three methodology decisions: hypothesis-tree vs Five Whys vs Fishbone, investigation as new ticket TYPE vs label on `/bug`, live-doc vs after-the-fact retrospective.

## Testing

1. `bash .claude/skills/investigation/tests/smoke.sh` — 17 checks pass (template section coverage, AgDR-style opener, sibling-skill naming, portfolio_resolve_template override semantics with a live fixture, project-config / template alignment, SKILL.md frontmatter).
2. `bash .claude/hooks/tests/test_validate_issue_structure.sh` — still 19/19 passing with the new `Investigation` prefix added to the whitelist.
3. `bash .claude/hooks/tests/test_portfolio_paths.sh` — still 38/38 passing; the override fixture in the smoke test exercises `portfolio_resolve_template investigation.md` end-to-end.

Closes #245

---

## Glossary

| Term | Definition |
|------|------------|
| **Investigation** | Sustained root-cause work whose deliverable is a *written artefact* of what was observed, what we concluded, and what's next. New ticket type alongside Feature / Bug / Spike / Chore / Refactor / Testing / CI / Docs. |
| **Hypothesis tree** | Methodology where multiple competing hypotheses are listed as nested bullets with evidence-for / evidence-against under each. Renders as plain markdown (unlike Fishbone, which needs a diagram). Supports multi-cause incidents (unlike Five Whys, which forces a single causal chain). |
| **Live-doc** | A markdown file that IS the working surface during the investigation — evidence is captured at gather-time, not reconstructed from memory after the fact. The framework writes one at `projects/<name>/investigations/<YYYY-MM-DD>-<slug>.md` per investigation. |
| **Follow-up actions** | The closing section of an investigation, listing what's next (file a bug, ship a fix, write a runbook, share findings, or `(no follow-up)`). Each action either links to a tracker ticket or is explicitly dropped — when all are resolved, the investigation closes. There is no separate `/investigation-close` skill (unlike `/spike-close`) because the Follow-up actions section IS the close gate. |
| **`portfolio_resolve_template`** | Helper in `.claude/hooks/_lib-portfolio-paths.sh` (introduced #244) that resolves a template path with adopter-override semantics — checks `<private_repo>/custom-templates/<path>` first, falls through to `<ops_root>/templates/<path>`. The `/investigation` skill routes through it so adopters who prefer Five Whys or Fishbone can drop a replacement at `custom-templates/investigation.md` without forking the skill. |
| **AgDR-0027** | Records the three template-structure decisions for the investigation type: methodology choice (hypothesis-tree wins), new-type vs label-on-bug (new type because the work and close semantics are distinct), and live-doc vs after-the-fact (live-doc because memory degrades). |