### PR TITLE
fix(#227): greedy body extractor — no more truncation at embedded quotes

### DIFF
--- a/.claude/hooks/block-private-refs-in-public-repos.sh
+++ b/.claude/hooks/block-private-refs-in-public-repos.sh
@@ -148,19 +148,54 @@ fi
 # ---------------------------------------------------------------------------
 
 extract_flag_value() {
-  # $1 = python-flag regex (e.g. --title | -t). Matches:
+  # $1 = python-flag regex (e.g. --title | -t). Matches (possibly multi-line):
   #   --title "value with spaces"
   #   --title 'value'
   #   --title value
+  #
+  # Quoted-value regex is GREEDY and anchored on the next flag boundary
+  # (whitespace + `--<letter>`) or end-of-string. The earlier sed form
+  # `[^"]*` truncated at the first embedded double quote
+  # (me2resh/apexyard#227); for the leak-protection hook that's a real
+  # security tail — a body with an embedded `"` could let private refs in
+  # the back half slip past the gate. awk + greedy + boundary anchor
+  # gives us multi-line consumption and correct termination in one shot.
   local flag_re="$1"
   local cmd="$2"
-  local v
-  v=$(echo "$cmd" | sed -nE "s/.*(${flag_re})[[:space:]]+\"([^\"]*)\".*/\2/p" | head -1)
-  if [ -n "$v" ]; then echo "$v"; return; fi
-  v=$(echo "$cmd" | sed -nE "s/.*(${flag_re})[[:space:]]+'([^']*)'.*/\2/p" | head -1)
-  if [ -n "$v" ]; then echo "$v"; return; fi
-  v=$(echo "$cmd" | sed -nE "s/.*(${flag_re})[[:space:]]+([^[:space:]]+).*/\2/p" | head -1)
-  echo "$v"
+  printf '%s' "$cmd" | awk -v FLAG_RE="$flag_re" -v SQ="'" '
+    { buf = (NR == 1 ? $0 : buf "\n" $0) }
+    END {
+      s = buf
+      # Double-quoted value: greedy `(.*)` anchored on next flag or EOS.
+      re = "(" FLAG_RE ")[[:space:]]+\"(.*)\"([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^(" FLAG_RE ")[[:space:]]+\"", "", chunk)
+        sub("\"([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
+        sub("\"[[:space:]]*$", "", chunk)
+        print chunk
+        exit
+      }
+      # Single-quoted value: same greedy + anchor treatment.
+      re = "(" FLAG_RE ")[[:space:]]+" SQ "(.*)" SQ "([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^(" FLAG_RE ")[[:space:]]+" SQ, "", chunk)
+        sub(SQ "([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
+        sub(SQ "[[:space:]]*$", "", chunk)
+        print chunk
+        exit
+      }
+      # Unquoted value: single token, embedded quotes irrelevant.
+      re = "(" FLAG_RE ")[[:space:]]+[^[:space:]]+"
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^(" FLAG_RE ")[[:space:]]+", "", chunk)
+        print chunk
+        exit
+      }
+    }
+  '
 }
 
 TITLE=$(extract_flag_value '--title|-t' "$COMMAND")

--- a/.claude/hooks/tests/test_block_private_refs.sh
+++ b/.claude/hooks/tests/test_block_private_refs.sh
@@ -164,6 +164,51 @@ run_case "gh api issues leak" \
   2 "project name: curios-dog" \
   "gh api repos/me2resh/apexyard/issues -f title=bug -f body='discovered during curios-dog rebuild'"
 
+# 11. Embedded double quotes in body — me2resh/apexyard#227.
+#     Pre-227 the sed-based extractor's `[^"]*` truncated the body at the
+#     first internal `"`, which had a security tail: private refs that
+#     appeared in the BACK half of the body (past the truncation) slipped
+#     past the leak gate. Post-fix the awk extractor is greedy + anchored
+#     on next-flag-or-EOS, so a private project name in the back half is
+#     correctly detected.
+LEAK_AFTER_QUOTE_BODY='## Driver
+The "admin notice" string is shown to users.
+
+## Scope
+- Mention the "current state" label
+
+## Acceptance Criteria
+- [ ] discovered during curios-dog rebuild'
+
+run_case "leak in back half of body with embedded quote in front → block" \
+  2 "project name: curios-dog" \
+  "gh issue create --repo me2resh/apexyard --title 'fix' --body \"$LEAK_AFTER_QUOTE_BODY\""
+
+# 12. Same but for repo-slug ref past the embedded quote.
+LEAK_REPO_AFTER_QUOTE='Description of the issue.
+
+The "needs attention" flag is wrong.
+
+See me2resh/SharpPick#42 for similar.'
+
+run_case "repo-slug leak past embedded quote → block" \
+  2 "project repo: me2resh/SharpPick" \
+  "gh pr create --repo me2resh/apexyard --title 'fix' --body \"$LEAK_REPO_AFTER_QUOTE\""
+
+# 13. Clean body (no leak) with embedded quotes — should pass.
+CLEAN_WITH_QUOTES='## Driver
+The "admin notice" feature.
+
+## Scope
+- Updated to show "current state".
+
+## Acceptance Criteria
+- [ ] Updated.'
+
+run_case "clean body with embedded quotes → pass (no false positive)" \
+  0 "" \
+  "gh issue create --repo me2resh/apexyard --title 'fix' --body \"$CLEAN_WITH_QUOTES\""
+
 # ---------------------------------------------------------------------------
 # Result
 # ---------------------------------------------------------------------------

--- a/.claude/hooks/tests/test_validate_issue_structure.sh
+++ b/.claude/hooks/tests/test_validate_issue_structure.sh
@@ -291,6 +291,71 @@ run_case "--body-file path with valid Feature body → pass" \
   0 "" \
   "gh issue create --title '[Feature] X' --body-file $BODY_FILE_PATH"
 
+# --- Embedded double quotes in body — me2resh/apexyard#227 -----------------
+# Pre-227 the awk extractor's non-greedy `"([^"]*)"` regex truncated the
+# body at the FIRST embedded `"`, so any `##` heading past that point was
+# invisible to the hook and falsely reported as missing. Post-fix the
+# extractor is greedy + anchored on next-flag-or-EOS, so embedded `"` in
+# prose (admin-notice strings, status labels in quotes) no longer truncate.
+
+CHORE_EMBEDDED_QUOTE_BODY='## Driver
+Test of the body extractor.
+
+## Scope
+- Mention an admin notice that says "do the thing"
+- Another bullet mentioning "current state" labels
+
+## Acceptance Criteria
+- [ ] Whatever
+- [ ] Another one'
+
+run_case "Chore body with embedded double quotes → pass (no truncation)" \
+  0 "" \
+  "gh issue create --title '[Chore] Embedded-quote repro' --body \"$CHORE_EMBEDDED_QUOTE_BODY\""
+
+# Same body but with --label tail to confirm greedy match stops at next flag
+run_case "Chore body with embedded quotes + trailing --label → pass" \
+  0 "" \
+  "gh issue create --title '[Chore] x' --body \"$CHORE_EMBEDDED_QUOTE_BODY\" --label chore"
+
+# Feature body with embedded quote between User Story and Acceptance Criteria
+FEATURE_EMBEDDED_QUOTE_BODY='## User Story
+As a user I want to see an "admin notice" so I know what to do.
+
+## Acceptance Criteria
+- [ ] notice renders
+- [ ] dismiss button works'
+
+run_case "Feature body with embedded quotes in User Story → pass" \
+  0 "" \
+  "gh issue create --title '[Feature] embedded notice' --body \"$FEATURE_EMBEDDED_QUOTE_BODY\""
+
+# Bug body with embedded quotes — Given / When / Then often quotes prose
+BUG_EMBEDDED_QUOTE_BODY='## Given / When / Then
+Given the user sees an "admin notice"
+When they click "dismiss"
+Then the notice goes away
+
+## Repro
+1. open the app
+2. observe the "admin notice"
+3. click "dismiss"'
+
+run_case "Bug body with multiple embedded quotes → pass" \
+  0 "" \
+  "gh issue create --title '[Bug] dismiss notice' --body \"$BUG_EMBEDDED_QUOTE_BODY\""
+
+# Negative case: embedded quotes are no protection from missing sections.
+# Body has embedded quotes AND is genuinely missing a required section.
+BUG_EMBEDDED_BUT_INCOMPLETE='## Given / When / Then
+Given the user sees an "admin notice"
+When they click "dismiss"
+Then the notice goes away'
+
+run_case "Bug body with embedded quotes but missing Repro → still blocks" \
+  2 "missing section: ## Repro" \
+  "gh issue create --title '[Bug] no repro' --body \"$BUG_EMBEDDED_BUT_INCOMPLETE\""
+
 # ---------------------------------------------------------------------------
 # Result
 # ---------------------------------------------------------------------------

--- a/.claude/hooks/tests/test_validate_pr_create_upstream.sh
+++ b/.claude/hooks/tests/test_validate_pr_create_upstream.sh
@@ -149,22 +149,6 @@ run_pr_case "origin yes, upstream no → pass (short-circuit)" \
   'mock_gh_set_repo_existence "$sb" 7 fork-org/apexyard yes
    mock_gh_set_repo_existence "$sb" 7 me2resh/apexyard no'
 
-# ---- Embedded double quotes in title — me2resh/apexyard#227 -------------
-# Pre-227 the sed-based --title extractor's `[^"]*` regex truncated the
-# title at the first embedded quote, so a title like
-# `fix(#42): handle "X" string` extracted as `fix(#42): handle ` and
-# failed the type(TICKET): regex (or extracted the wrong ticket ref).
-# Post-fix the awk extractor is greedy + boundary-anchored, so the full
-# title survives extraction.
-
-# Embedded double-quote in title — must extract whole title, find ticket.
-run_pr_case "title with embedded double quotes → pass (ticket extracted)" \
-  "no" 'fix(#42): handle "admin notice" rendering' "no" 0 ""
-
-# Two embedded quotes — same behavior.
-run_pr_case "title with two embedded quotes → pass" \
-  "no" 'feat(#5): add "X" and "Y" labels' "no" 0 ""
-
 # ---- Summary ------------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_validate_pr_create_upstream.sh
+++ b/.claude/hooks/tests/test_validate_pr_create_upstream.sh
@@ -149,6 +149,22 @@ run_pr_case "origin yes, upstream no → pass (short-circuit)" \
   'mock_gh_set_repo_existence "$sb" 7 fork-org/apexyard yes
    mock_gh_set_repo_existence "$sb" 7 me2resh/apexyard no'
 
+# ---- Embedded double quotes in title — me2resh/apexyard#227 -------------
+# Pre-227 the sed-based --title extractor's `[^"]*` regex truncated the
+# title at the first embedded quote, so a title like
+# `fix(#42): handle "X" string` extracted as `fix(#42): handle ` and
+# failed the type(TICKET): regex (or extracted the wrong ticket ref).
+# Post-fix the awk extractor is greedy + boundary-anchored, so the full
+# title survives extraction.
+
+# Embedded double-quote in title — must extract whole title, find ticket.
+run_pr_case "title with embedded double quotes → pass (ticket extracted)" \
+  "no" 'fix(#42): handle "admin notice" rendering' "no" 0 ""
+
+# Two embedded quotes — same behavior.
+run_pr_case "title with two embedded quotes → pass" \
+  "no" 'feat(#5): add "X" and "Y" labels' "no" 0 ""
+
 # ---- Summary ------------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_verify_commit_refs_upstream.sh
+++ b/.claude/hooks/tests/test_verify_commit_refs_upstream.sh
@@ -179,6 +179,40 @@ run_case "origin yes, upstream no → pass (short-circuit on origin)" \
   'mock_gh_set_repo_existence "$sb" 7 fork-org/apexyard yes
    mock_gh_set_repo_existence "$sb" 7 me2resh/apexyard no'
 
+# ---- Embedded double quotes in commit message — me2resh/apexyard#227 ----
+# Pre-227 the sed-based -m extractor's `"([^"]*)"` regex truncated the
+# commit message at the FIRST embedded `"`, so any `Closes #N` reference
+# that lived past the first internal `"` was invisible to the hook.
+# Result: a fabricated #N in the back half slipped through, and a real
+# #N pre-quote got verified but the rest weren't. Post-fix the extractor
+# is greedy + anchored on next-flag-or-EOS.
+
+# Embedded quote followed by a real #N in origin → must extract #N → pass.
+run_case "commit msg with embedded quote + valid Closes #N after → pass" \
+  "no" \
+  'fix: handle "admin notice" string\n\nThe notice said "do the thing".\n\nCloses #42' \
+  0 "" \
+  ''
+
+# Embedded quote followed by a phantom #N → must extract #N → block.
+# Pre-fix: the regex would truncate at the first `"` and #99999 (post-quote)
+# would never be extracted → false PASS. Post-fix: full message scans, #99999
+# is found, the gh lookup fails on both repos, hook blocks.
+run_case "commit msg with embedded quote + phantom Closes #N after → block" \
+  "yes" \
+  'fix: handle "admin notice" string\n\nDescribed "current state" flow.\n\nCloses #99999' \
+  2 "do not exist" \
+  'mock_gh_set_repo_existence "$sb" 99999 fork-org/apexyard no
+   mock_gh_set_repo_existence "$sb" 99999 me2resh/apexyard no'
+
+# Multiple embedded quotes — pre-fix the second `"` would end the truncated
+# value early. Post-fix all #N references are extracted and verified.
+run_case "commit msg with multiple embedded quotes + Closes #N → pass" \
+  "no" \
+  'feat: add "X" and "Y" and "Z" tags\n\nAll three are "important".\n\nCloses #5' \
+  0 "" \
+  ''
+
 # ---- Summary ------------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/validate-issue-structure.sh
+++ b/.claude/hooks/validate-issue-structure.sh
@@ -61,29 +61,45 @@ extract_flag_value() {
   # to consume stdin as a single record (`RS="\0"` triggers paragraph mode
   # on BSD awk), so we build up one big string line-by-line in awk and run
   # match() against it in END.
+  #
+  # Quoted-value regex is GREEDY and anchored on the next flag boundary
+  # (whitespace + `--<letter>`) or end-of-string. The earlier non-greedy
+  # form `"([^"]*)"` truncated values at the first embedded double quote
+  # (me2resh/apexyard#227), so bodies that quoted prose like "admin notice"
+  # in a `## Scope` bullet lost every `##` heading that lived past the
+  # first internal `"`. Greedy + boundary anchor matches the closing `"`
+  # of the FLAG argument, not the first internal `"` inside the body.
+  # Backslash-escaped quotes (`\"...\"`) are not detected — they pass
+  # through as content, which is fine because shell-quoted heredoc bodies
+  # (the `$(cat <<'EOF' ... EOF)` shape Claude generates) don't produce
+  # backslash escapes.
   local flag_re="$1"
   local cmd="$2"
   printf '%s' "$cmd" | awk -v FLAG_RE="$flag_re" -v SQ="'" '
     { buf = (NR == 1 ? $0 : buf "\n" $0) }
     END {
       s = buf
-      # Try double-quoted value first.
-      re = "(" FLAG_RE ")[[:space:]]+\"([^\"]*)\""
+      # Double-quoted value: greedy `(.*)` anchored on next flag or EOS.
+      re = "(" FLAG_RE ")[[:space:]]+\"(.*)\"([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
       if (match(s, re)) {
         chunk = substr(s, RSTART, RLENGTH)
         sub("^(" FLAG_RE ")[[:space:]]+\"", "", chunk)
-        sub("\"$", "", chunk)
+        sub("\"([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
+        sub("\"[[:space:]]*$", "", chunk)
         print chunk
         exit
       }
-      re = "(" FLAG_RE ")[[:space:]]+" SQ "([^" SQ "]*)" SQ
+      # Single-quoted value: same greedy + anchor treatment.
+      re = "(" FLAG_RE ")[[:space:]]+" SQ "(.*)" SQ "([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
       if (match(s, re)) {
         chunk = substr(s, RSTART, RLENGTH)
         sub("^(" FLAG_RE ")[[:space:]]+" SQ, "", chunk)
-        sub(SQ "$", "", chunk)
+        sub(SQ "([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
+        sub(SQ "[[:space:]]*$", "", chunk)
         print chunk
         exit
       }
+      # Unquoted value: single token, embedded quotes irrelevant.
       re = "(" FLAG_RE ")[[:space:]]+[^[:space:]]+"
       if (match(s, re)) {
         chunk = substr(s, RSTART, RLENGTH)

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -26,11 +26,44 @@ fi
 
 ERRORS=""
 
-# Extract --title value (macOS-compatible, no grep -P)
-TITLE=$(echo "$COMMAND" | sed -n 's/.*--title[[:space:]]*["'"'"']\([^"'"'"']*\)["'"'"'].*/\1/p' | head -1)
-if [ -z "$TITLE" ]; then
-  TITLE=$(echo "$COMMAND" | sed -n 's/.*--title[[:space:]]*\([^[:space:]]*\).*/\1/p' | head -1)
-fi
+# Extract --title value. Greedy + boundary-anchored awk extraction so an
+# embedded `"` or `'` in the title (rare but possible — `[Bug] handle "X"`
+# / `[Chore] fix "foo" tests`) doesn't truncate at the first internal quote
+# (me2resh/apexyard#227). Same shape as validate-issue-structure.sh.
+TITLE=$(printf '%s' "$COMMAND" | awk -v SQ="'" '
+  { buf = (NR == 1 ? $0 : buf "\n" $0) }
+  END {
+    s = buf
+    # Double-quoted title, greedy.
+    re = "--title[[:space:]]+\"(.*)\"([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
+    if (match(s, re)) {
+      chunk = substr(s, RSTART, RLENGTH)
+      sub("^--title[[:space:]]+\"", "", chunk)
+      sub("\"([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
+      sub("\"[[:space:]]*$", "", chunk)
+      print chunk
+      exit
+    }
+    # Single-quoted title, greedy.
+    re = "--title[[:space:]]+" SQ "(.*)" SQ "([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
+    if (match(s, re)) {
+      chunk = substr(s, RSTART, RLENGTH)
+      sub("^--title[[:space:]]+" SQ, "", chunk)
+      sub(SQ "([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
+      sub(SQ "[[:space:]]*$", "", chunk)
+      print chunk
+      exit
+    }
+    # Unquoted single-token title.
+    re = "--title[[:space:]]+[^[:space:]]+"
+    if (match(s, re)) {
+      chunk = substr(s, RSTART, RLENGTH)
+      sub("^--title[[:space:]]+", "", chunk)
+      print chunk
+      exit
+    }
+  }
+')
 
 # Validate PR title format if we can extract it
 # Accepts: type(<TICKET>): … or type(<TICKET>)!: … (breaking change)

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -26,44 +26,20 @@ fi
 
 ERRORS=""
 
-# Extract --title value. Greedy + boundary-anchored awk extraction so an
-# embedded `"` or `'` in the title (rare but possible — `[Bug] handle "X"`
-# / `[Chore] fix "foo" tests`) doesn't truncate at the first internal quote
-# (me2resh/apexyard#227). Same shape as validate-issue-structure.sh.
-TITLE=$(printf '%s' "$COMMAND" | awk -v SQ="'" '
-  { buf = (NR == 1 ? $0 : buf "\n" $0) }
-  END {
-    s = buf
-    # Double-quoted title, greedy.
-    re = "--title[[:space:]]+\"(.*)\"([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
-    if (match(s, re)) {
-      chunk = substr(s, RSTART, RLENGTH)
-      sub("^--title[[:space:]]+\"", "", chunk)
-      sub("\"([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
-      sub("\"[[:space:]]*$", "", chunk)
-      print chunk
-      exit
-    }
-    # Single-quoted title, greedy.
-    re = "--title[[:space:]]+" SQ "(.*)" SQ "([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
-    if (match(s, re)) {
-      chunk = substr(s, RSTART, RLENGTH)
-      sub("^--title[[:space:]]+" SQ, "", chunk)
-      sub(SQ "([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
-      sub(SQ "[[:space:]]*$", "", chunk)
-      print chunk
-      exit
-    }
-    # Unquoted single-token title.
-    re = "--title[[:space:]]+[^[:space:]]+"
-    if (match(s, re)) {
-      chunk = substr(s, RSTART, RLENGTH)
-      sub("^--title[[:space:]]+", "", chunk)
-      print chunk
-      exit
-    }
-  }
-')
+# Extract --title value (macOS-compatible, no grep -P).
+#
+# Kept as the original non-greedy `[^"']*` form: PR titles are short,
+# single-line, and conventionally do NOT contain embedded `"` or `'`
+# (they're command-line arguments and gh would have shell-escape
+# friction). The greedy + flag-boundary fix used in the body extractors
+# (me2resh/apexyard#227) is NOT applied here on purpose — when the
+# command has a multi-line `--body "$(cat <<'EOF' ... EOF)"` after the
+# title, greedy match over-consumes the body content as part of the
+# title value. Non-greedy is correct for this position.
+TITLE=$(echo "$COMMAND" | sed -n 's/.*--title[[:space:]]*["'"'"']\([^"'"'"']*\)["'"'"'].*/\1/p' | head -1)
+if [ -z "$TITLE" ]; then
+  TITLE=$(echo "$COMMAND" | sed -n 's/.*--title[[:space:]]*\([^[:space:]]*\).*/\1/p' | head -1)
+fi
 
 # Validate PR title format if we can extract it
 # Accepts: type(<TICKET>): … or type(<TICKET>)!: … (breaking change)

--- a/.claude/hooks/verify-commit-refs.sh
+++ b/.claude/hooks/verify-commit-refs.sh
@@ -46,31 +46,58 @@ fi
 #
 # IMPORTANT: Claude and humans both commonly use multi-line -m arguments via
 # HEREDOC substitution like `git commit -m "$(cat <<EOF ... EOF)"`, which means
-# the literal -m value spans multiple lines in the command string. `sed -nE`
-# processes stdin line-by-line by default, so a regex like `-m "([^"]*)"`
-# cannot span lines and silently fails to match.
+# the literal -m value spans multiple lines in the command string. We use awk
+# with a line-by-line accumulator so the match runs against the whole logical
+# command, not one physical line.
 #
-# Fix: flatten the command string with `tr '\n' ' '` before sed processing.
-# The message then parses as a single logical line. The ref-pattern grep
-# below doesn't care about line breaks either way.
-#
-# Without this flattening, the hook was INERT for any multi-line commit —
-# which is the default shape for Claude-generated commits. Confirmed via
-# smoke test before the fix.
-COMMAND_FLAT=$(echo "$COMMAND" | tr '\n' ' ')
+# Quoted-value regex is GREEDY and anchored on the next flag boundary
+# (whitespace + `-<letter>`) or end-of-string. The earlier sed form
+# `-m "([^"]*)"` truncated at the first embedded double quote
+# (me2resh/apexyard#227), so commit messages whose body contained any
+# `"` (admin-notice strings, status labels in quotes, prose like "current
+# state") had their `Closes #N` / `Refs #N` references past the truncation
+# point go unverified. awk + greedy + boundary anchor matches the closing
+# `"` of the FLAG argument, not the first internal `"` inside the message.
 
-MSG=""
+extract_commit_msg() {
+  # $1 = whole command string. Prints the extracted -m value, empty if none.
+  printf '%s' "$1" | awk -v SQ="'" '
+    { buf = (NR == 1 ? $0 : buf "\n" $0) }
+    END {
+      s = buf
+      # Boundary terminator: whitespace + `-<letter>` (catches -F, -- flags,
+      # and short flags like -S / -s) or end-of-string. -m is the only flag
+      # before us in this branch, so any later -<letter> marks the end of
+      # the -m value.
+      # Single-quoted -m value, greedy.
+      re = "-m[[:space:]]+" SQ "(.*)" SQ "([[:space:]]+-[a-zA-Z]|[[:space:]]*$)"
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^-m[[:space:]]+" SQ, "", chunk)
+        sub(SQ "([[:space:]]+-[a-zA-Z].*)?$", "", chunk)
+        sub(SQ "[[:space:]]*$", "", chunk)
+        print chunk
+        exit
+      }
+      # Double-quoted -m value, greedy.
+      re = "-m[[:space:]]+\"(.*)\"([[:space:]]+-[a-zA-Z]|[[:space:]]*$)"
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^-m[[:space:]]+\"", "", chunk)
+        sub("\"([[:space:]]+-[a-zA-Z].*)?$", "", chunk)
+        sub("\"[[:space:]]*$", "", chunk)
+        print chunk
+        exit
+      }
+    }
+  '
+}
 
-# -m 'single quoted'
-MSG=$(echo "$COMMAND_FLAT" | sed -nE "s/.*-m[[:space:]]+'([^']*)'.*/\1/p" | head -1)
-
-# -m "double quoted"
-if [ -z "$MSG" ]; then
-  MSG=$(echo "$COMMAND_FLAT" | sed -nE 's/.*-m[[:space:]]+"([^"]*)".*/\1/p' | head -1)
-fi
+MSG=$(extract_commit_msg "$COMMAND")
 
 # -F <file> / --file <file>
 if [ -z "$MSG" ]; then
+  COMMAND_FLAT=$(echo "$COMMAND" | tr '\n' ' ')
   MSG_FILE=$(echo "$COMMAND_FLAT" | sed -nE 's/.*(-F|--file)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
   if [ -n "$MSG_FILE" ] && [ -f "$MSG_FILE" ]; then
     MSG=$(cat "$MSG_FILE")


### PR DESCRIPTION
## Summary

The awk + sed body/title extractors in three hooks all used the same non-greedy pattern to pull `--body` / `-m` values out of the raw `gh` / `git commit` command. The pattern truncates at the first embedded double-quote inside the value, so any body that quoted prose (admin-notice strings, status labels, prose like `current state`) lost every section heading past the first internal quote — and the hooks falsely reported them as missing. The friend running ApexYard hit this on a 12-ticket batch; every ticket whose body contained an embedded quote failed identically with `missing section: ## Acceptance Criteria` (or whichever section followed the truncation).

Switch the body extractors to a greedy match anchored on the next flag boundary (whitespace + `--<letter>` for the `gh` hooks, `-<letter>` for the `git commit` hook) or end-of-string. Awk consumes the whole command as a single buffer, so multi-line HEREDOC bodies parse correctly too. Title extractor in `validate-pr-create.sh` stays non-greedy on purpose — titles are short, single-line, and when followed by a multi-line `--body`, greedy over-consumes (see commit 2 for the self-inflicted reproduction of that exact problem).

Hooks fixed (per the issue's Affected files section):

- `.claude/hooks/validate-issue-structure.sh` — primary site, the bug repro
- `.claude/hooks/block-private-refs-in-public-repos.sh` — security tail: private refs in the back half of a quote-truncated body could slip past the leak gate. A new test confirms a registered project name in the post-quote half of a body is now correctly detected.
- `.claude/hooks/verify-commit-refs.sh` — commit messages with embedded quotes had `Closes #N` references past the first quote go unverified
- `.claude/hooks/validate-pr-create.sh` — title extractor LEFT AS NON-GREEDY (rationale in commit 2's message); the file was still touched only to add a clarifying comment about the deliberate choice

## Testing

Repro from the issue body — `[Chore]` with `do the thing` in `## Scope` quoted prose, then `## Acceptance Criteria` after it. Pre-fix: exit 2, missing section. Post-fix: exit 0.

All 28 hook test files green. New cases added:

```
test_validate_issue_structure.sh     :: 24 (was 19, +5)
test_block_private_refs.sh           :: 13 (was 10, +3)
test_verify_commit_refs_upstream.sh  :: 12 (was 9,  +3)
```

The new cases cover Chore / Feature / Bug bodies with embedded quotes, a negative confirming missing-section detection still fires when quotes are present, leak detection in the back half of a quoted body, a clean-body no-false-positive case, and commit messages with embedded quotes + post-quote `Closes #N`.

## Out of scope

- Backslash-escaped quotes (`\"...\"`) are still not parsed as content. Shell-quoted heredoc bodies do not produce backslash escapes, so the workaround for the exotic case stays `--body-file`.
- Shell-aware argv parsing (option 3 in the issue) — overkill. Greedy-anchor (option 1) closes the reported failure mode with a small awk regex change per hook.

Closes #227

---

## Glossary

| Term | Definition |
|------|------------|
| Body extractor | The awk/sed snippet in each hook that pulls the value of a body/message/title flag out of the raw command string Claude is about to run via Bash. The hooks scan it before the command executes. |
| Greedy match | A regex engine's preference to match the LONGEST possible substring (POSIX awk's `.*` is greedy by default). The opposite of non-greedy / lazy. |
| Flag-boundary anchor | A terminator regex (whitespace + next-flag) that tells the greedy match where the FLAG argument legitimately ends — the NEXT CLI flag's leading dashes. Lets the greedy quantifier swallow everything in between, including embedded quotes. |
| Leak-protection tail | The corollary security consequence of the truncation bug on `block-private-refs-in-public-repos.sh`: private registered-project names in the BACK half of a quote-truncated body were invisible to the gate, so they could be filed on a public framework ticket undetected. |
