### PR TITLE
feat(#271): add site/architecture.html — 5-layer diagram, recoloured to site palette

### DIFF
--- a/site/architecture.html
+++ b/site/architecture.html
@@ -562,7 +562,7 @@ a:hover { color: var(--accent); }
     <text x="877" y="1062">Optional private sibling</text>
   </g>
 
-  <text x="1860" y="1062" font-size="11" fill="#877E70" text-anchor="end" font-style="italic">apexyard.dev  ·  fork the framework, register your repos, ship.</text>
+  <text x="1860" y="1062" font-size="11" fill="#877E70" text-anchor="end" font-style="italic">yard.apexscript.com  ·  fork the framework, register your repos, ship.</text>
 
 </svg>
       </div>
@@ -634,7 +634,7 @@ a:hover { color: var(--accent); }
 
 <footer class="page-footer">
   <div class="page-footer__inner">
-    <div>apexyard.dev  ·  fork the framework, register your repos, ship.</div>
+    <div>yard.apexscript.com  ·  fork the framework, register your repos, ship.</div>
     <div>
       <a href="https://github.com/me2resh/apexyard" target="_blank" rel="noopener">github ↗</a>  ·
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">releases ↗</a>  ·

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -7,14 +7,12 @@
 <meta name="description" content="The ApexYard architecture at a glance — five layers (governance, capability, framework defaults, customisation overlay, per-project data) plus the optional split-portfolio private sibling repo. One fork governs every project.">
 <link rel="canonical" href="https://yard.apexscript.com/architecture.html">
 
-<!-- Open Graph -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="ApexYard">
 <meta property="og:url" content="https://yard.apexscript.com/architecture.html">
 <meta property="og:title" content="ApexYard — Architecture">
 <meta property="og:description" content="Five layers in one ops fork — governance, capability, defaults, customisation overlay, per-project data. Plus the optional split-portfolio sibling repo for adopters on GitHub Free.">
 
-<!-- Twitter / X -->
 <meta name="twitter:card" content="summary">
 <meta name="twitter:url" content="https://yard.apexscript.com/architecture.html">
 <meta name="twitter:title" content="ApexYard — Architecture">
@@ -27,11 +25,11 @@
 <style>
 /* ============================================================
    ApexYard — Architecture page
-   Same terminal-native brutalism as the homepage: JetBrains Mono,
-   warm cream paper, single warning-red accent. The diagram (SVG)
-   is recoloured to fit — pastel layer fills become cream-paper
-   tonal contrast; the red accent stamps only on customisation
-   overrides (where its "override" semantic earns its place).
+   Mirrors site/index.html design tokens (terminal-native
+   brutalism — JetBrains Mono, cream paper, single warning-red
+   accent). The diagram uses muted hue-tinted papers per layer
+   for the info-graphic feel — each layer gets a colour that
+   sits on the cream without screaming.
    ============================================================ */
 
 :root {
@@ -46,11 +44,10 @@
   --ink-faint: #877E70;
   --ink-ghost: #B6AD9B;
 
-  /* the single accent — stamps on customisation overrides only */
+  /* the single CSS accent — diagram introduces layer hues, all muted */
   --accent:      #C8321A;
   --accent-soft: #E07050;
 
-  /* hairlines */
   --rule:        #1A1612;
   --rule-faint:  #B6AD9B;
 
@@ -118,7 +115,7 @@ a:hover { color: var(--accent); }
 .kw { color: var(--accent); font-weight: 600; }
 
 /* ============================================================
-   titlebar — same shape as the homepage / skills.html
+   shared titlebar — identical shape + nav set on every page
    ============================================================ */
 .titlebar {
   position: sticky;
@@ -147,11 +144,17 @@ a:hover { color: var(--accent); }
   display: inline-block;
 }
 .titlebar__dot.is-warn { background: var(--accent); border-color: var(--accent); }
-.titlebar__path { color: var(--ink-soft); }
-.titlebar__path b { color: var(--ink); font-weight: 600; }
+.titlebar__path {
+  color: var(--ink-soft);
+  font-family: var(--mono);
+}
+.titlebar__path a { color: inherit; }
+.titlebar__path a:hover { color: var(--accent); }
+.titlebar__path b { color: var(--ink); font-weight: 700; }
 .titlebar__right { display: flex; gap: 1.25rem; align-items: center; font-size: 12px; }
 .titlebar__right a { color: var(--ink-faint); transition: color 0.15s ease; }
 .titlebar__right a:hover { color: var(--accent); }
+.titlebar__right a.is-current { color: var(--ink); border-bottom: 1px solid var(--accent); padding-bottom: 2px; pointer-events: none; }
 .titlebar__right a.is-cta {
   border: 1px solid var(--rule);
   padding: 0.35rem 0.75rem;
@@ -165,7 +168,7 @@ a:hover { color: var(--accent); }
 }
 
 /* ============================================================
-   page header
+   page header — shared shape with skills.html
    ============================================================ */
 .page-header {
   border-bottom: 1px solid var(--rule);
@@ -238,33 +241,20 @@ a:hover { color: var(--accent); }
   padding: 0 var(--gutter);
 }
 .diagram-stage {
-  background: var(--paper-2);
+  background: var(--paper);
   border: 1px solid var(--rule);
   padding: clamp(0.75rem, 1.5vw, 1.25rem);
-  margin-bottom: 0.85rem;
   overflow-x: auto;
 }
 .diagram-stage svg {
   width: 100%;
   height: auto;
   display: block;
-  min-width: 1000px; /* below this, the SVG would shrink labels to unreadable */
-}
-.diagram-hint {
-  font-size: 12px;
-  color: var(--ink-faint);
-  font-style: italic;
-}
-.diagram-hint code {
-  font-family: var(--mono);
-  background: var(--paper-2);
-  border: 1px solid var(--rule-faint);
-  padding: 1px 5px;
-  font-style: normal;
+  min-width: 1000px; /* below this, labels collapse to unreadable */
 }
 
 /* ============================================================
-   legend + notes blocks
+   notes — 3 columns above, 1 wide note below
    ============================================================ */
 .notes {
   padding: clamp(2rem, 4vw, 3rem) 0;
@@ -275,13 +265,19 @@ a:hover { color: var(--accent); }
   margin: 0 auto;
   padding: 0 var(--gutter);
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: clamp(1rem, 2vw, 1.75rem);
+}
+@media (max-width: 900px) {
+  .notes__inner { grid-template-columns: 1fr; }
 }
 .note {
   border: 1px solid var(--rule);
   padding: 1.25rem 1.4rem;
   background: var(--paper-2);
+}
+.note--wide {
+  grid-column: 1 / -1;
 }
 .note h3 {
   font-size: 12px;
@@ -335,10 +331,10 @@ a:hover { color: var(--accent); }
         <span class="titlebar__dot"></span>
         <span class="titlebar__dot is-warn"></span>
       </span>
-      <span class="titlebar__path">~/<b>apexyard</b> <span class="dim">· architecture</span></span>
+      <span class="titlebar__path">~/<a href="index.html"><b>apexyard</b></a> <span class="dim">· architecture</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
-      <a href="index.html" class="always">home</a>
+      <a href="architecture.html" class="is-current always">architecture</a>
       <a href="skills.html">skills</a>
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>
       <a href="https://github.com/me2resh/apexyard" class="is-cta" target="_blank" rel="noopener">github →</a>
@@ -372,7 +368,6 @@ a:hover { color: var(--accent); }
 <svg viewBox="0 0 1920 1080" xmlns="http://www.w3.org/2000/svg" font-family="'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" role="img" aria-label="ApexYard architecture: five layers (governance, capability, framework defaults, customisation, per-project data) inside the ops fork, plus an optional private sibling repo on the right.">
 
   <defs>
-    <!-- arrowheads -->
     <marker id="arrow-solid" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#1A1612"/>
     </marker>
@@ -384,9 +379,7 @@ a:hover { color: var(--accent); }
     </marker>
   </defs>
 
-  <!-- ============================================================ -->
-  <!-- HEADER                                                       -->
-  <!-- ============================================================ -->
+  <!-- HEADER -->
   <text x="60" y="60" font-size="40" font-weight="800" fill="#1A1612" letter-spacing="-2">ApexYard</text>
   <text x="60" y="95" font-size="16" fill="#4A4239">A multi-project forge for Claude Code — governance, capability, customisation, and per-project data in one fork.</text>
 
@@ -397,119 +390,106 @@ a:hover { color: var(--accent); }
   <text x="84" y="170" font-size="18" font-weight="700" fill="#1A1612">[#] ApexYard Ops Fork</text>
   <text x="290" y="170" font-size="13" fill="#4A4239" font-style="italic">(your-org/apexyard — the public fork you clone)</text>
 
-  <!-- ─────────── LAYER 1: GOVERNANCE ─────────── -->
-  <text x="84" y="210" font-size="12" font-weight="700" fill="#1A1612" letter-spacing="2">GOVERNANCE — declares what, enforces how</text>
+  <!-- ─────────── LAYER 1: GOVERNANCE — slate-blue ─────────── -->
+  <text x="84" y="210" font-size="12" font-weight="700" fill="#1E3A5F" letter-spacing="2">GOVERNANCE — declares what, enforces how</text>
 
-  <!-- Registry -->
-  <rect x="84" y="225" width="290" height="90" fill="#ECE5D2" stroke="#1A1612" stroke-width="1.2"/>
-  <text x="100" y="252" font-size="14" font-weight="700" fill="#1A1612">[*] Registry</text>
+  <rect x="84" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
+  <text x="100" y="252" font-size="14" font-weight="700" fill="#1E3A5F">[*] Registry</text>
   <text x="100" y="275" font-size="12" fill="#1A1612">apexyard.projects.yaml</text>
-  <text x="100" y="295" font-size="11" fill="#4A4239">Lists every managed project</text>
+  <text x="100" y="295" font-size="11" fill="#4A6FA5">Lists every managed project</text>
 
-  <!-- Hooks -->
-  <rect x="394" y="225" width="290" height="90" fill="#ECE5D2" stroke="#1A1612" stroke-width="1.2"/>
-  <text x="410" y="252" font-size="14" font-weight="700" fill="#1A1612">[~] Hooks</text>
+  <rect x="394" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
+  <text x="410" y="252" font-size="14" font-weight="700" fill="#1E3A5F">[~] Hooks</text>
   <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 26 shell gates</text>
-  <text x="410" y="295" font-size="11" fill="#4A4239">Merge gate · ticket-first · secrets · …</text>
+  <text x="410" y="295" font-size="11" fill="#4A6FA5">Merge gate · ticket-first · secrets · …</text>
 
-  <!-- Rules -->
-  <rect x="704" y="225" width="290" height="90" fill="#ECE5D2" stroke="#1A1612" stroke-width="1.2"/>
-  <text x="720" y="252" font-size="14" font-weight="700" fill="#1A1612">[=] Rules</text>
+  <rect x="704" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
+  <text x="720" y="252" font-size="14" font-weight="700" fill="#1E3A5F">[=] Rules</text>
   <text x="720" y="275" font-size="12" fill="#1A1612">.claude/rules/  · 11 files</text>
-  <text x="720" y="295" font-size="11" fill="#4A4239">Self-discipline guides for the agent</text>
+  <text x="720" y="295" font-size="11" fill="#4A6FA5">Self-discipline guides for the agent</text>
 
-  <!-- Onboarding -->
-  <rect x="1014" y="225" width="290" height="90" fill="#ECE5D2" stroke="#1A1612" stroke-width="1.2"/>
-  <text x="1030" y="252" font-size="14" font-weight="700" fill="#1A1612">[i] Onboarding</text>
+  <rect x="1014" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
+  <text x="1030" y="252" font-size="14" font-weight="700" fill="#1E3A5F">[i] Onboarding</text>
   <text x="1030" y="275" font-size="12" fill="#1A1612">onboarding.yaml</text>
-  <text x="1030" y="295" font-size="11" fill="#4A4239">Company name, mission, team, stack</text>
+  <text x="1030" y="295" font-size="11" fill="#4A6FA5">Company name, mission, team, stack</text>
 
-  <!-- ─────────── LAYER 2: CAPABILITY ─────────── -->
-  <text x="84" y="358" font-size="12" font-weight="700" fill="#1A1612" letter-spacing="2">CAPABILITY — what the agent can do</text>
+  <!-- ─────────── LAYER 2: CAPABILITY — forest-green ─────────── -->
+  <text x="84" y="358" font-size="12" font-weight="700" fill="#1B4332" letter-spacing="2">CAPABILITY — what the agent can do</text>
 
-  <!-- Skills -->
-  <rect x="84" y="373" width="600" height="100" fill="#E0D7BD" stroke="#1A1612" stroke-width="1.2"/>
-  <text x="100" y="402" font-size="15" font-weight="700" fill="#1A1612">[/] Skills</text>
+  <rect x="84" y="373" width="600" height="100" fill="#DDE9DD" stroke="#2D6A4F" stroke-width="1.3"/>
+  <text x="100" y="402" font-size="15" font-weight="700" fill="#1B4332">[/] Skills</text>
   <text x="100" y="425" font-size="12" fill="#1A1612">.claude/skills/  ·  48 slash commands</text>
-  <text x="100" y="447" font-size="11" fill="#4A4239">/feature  /handover  /c4  /threat-model  /process  /dfd  /journey  /update  /release  …</text>
+  <text x="100" y="447" font-size="11" fill="#52796F">/feature  /handover  /c4  /threat-model  /process  /dfd  /journey  /update  /release  …</text>
 
-  <!-- Agents -->
-  <rect x="704" y="373" width="600" height="100" fill="#E0D7BD" stroke="#1A1612" stroke-width="1.2"/>
-  <text x="720" y="402" font-size="15" font-weight="700" fill="#1A1612">[&gt;] Agents</text>
+  <rect x="704" y="373" width="600" height="100" fill="#DDE9DD" stroke="#2D6A4F" stroke-width="1.3"/>
+  <text x="720" y="402" font-size="15" font-weight="700" fill="#1B4332">[&gt;] Agents</text>
   <text x="720" y="425" font-size="12" fill="#1A1612">.claude/agents/  ·  5 specialised sub-agents</text>
-  <text x="720" y="447" font-size="11" fill="#4A4239">Rex (code review) · Hatim (security) · Munir (deps) · Tariq (PR) · Idris (tickets)</text>
+  <text x="720" y="447" font-size="11" fill="#52796F">Rex (code review) · Hatim (security) · Munir (deps) · Tariq (PR) · Idris (tickets)</text>
 
-  <!-- ─────────── LAYER 3: FRAMEWORK DEFAULTS ─────────── -->
-  <text x="84" y="513" font-size="12" font-weight="700" fill="#1A1612" letter-spacing="2">FRAMEWORK DEFAULTS — ship out of the box</text>
+  <!-- ─────────── LAYER 3: FRAMEWORK DEFAULTS — ochre ─────────── -->
+  <text x="84" y="513" font-size="12" font-weight="700" fill="#5C4218" letter-spacing="2">FRAMEWORK DEFAULTS — ship out of the box</text>
 
-  <!-- Templates -->
-  <rect x="84" y="528" width="600" height="85" fill="#ECE5D2" stroke="#1A1612" stroke-width="1.2"/>
-  <text x="100" y="555" font-size="14" font-weight="700" fill="#1A1612">[T] templates/</text>
+  <rect x="84" y="528" width="600" height="85" fill="#EFE6CA" stroke="#8B6914" stroke-width="1.3"/>
+  <text x="100" y="555" font-size="14" font-weight="700" fill="#5C4218">[T] templates/</text>
   <text x="100" y="578" font-size="12" fill="#1A1612">PRD · AgDR · technical-design · C4 context/container · DFD · vision · spike · …</text>
-  <text x="100" y="600" font-size="11" fill="#4A4239" font-style="italic">Overridable per file via custom-templates/&lt;same-path&gt;.md</text>
+  <text x="100" y="600" font-size="11" fill="#946C2B" font-style="italic">Overridable per file via custom-templates/&lt;same-path&gt;.md</text>
 
-  <!-- Handbooks -->
-  <rect x="704" y="528" width="600" height="85" fill="#ECE5D2" stroke="#1A1612" stroke-width="1.2"/>
-  <text x="720" y="555" font-size="14" font-weight="700" fill="#1A1612">[H] handbooks/</text>
+  <rect x="704" y="528" width="600" height="85" fill="#EFE6CA" stroke="#8B6914" stroke-width="1.3"/>
+  <text x="720" y="555" font-size="14" font-weight="700" fill="#5C4218">[H] handbooks/</text>
   <text x="720" y="578" font-size="12" fill="#1A1612">architecture/  ·  general/  ·  language/&lt;lang&gt;/  ← Rex consults during code review</text>
-  <text x="720" y="600" font-size="11" fill="#4A4239" font-style="italic">Additive: custom-handbooks/&lt;path&gt; layered alongside, NOT replacing</text>
+  <text x="720" y="600" font-size="11" fill="#946C2B" font-style="italic">Additive: custom-handbooks/&lt;path&gt; layered alongside, NOT replacing</text>
 
-  <!-- ─────────── LAYER 4: CUSTOMISATION ─────────── -->
+  <!-- ─────────── LAYER 4: CUSTOMISATION — accent red ─────────── -->
   <text x="84" y="653" font-size="12" font-weight="700" fill="#C8321A" letter-spacing="2">CUSTOMISATION LAYER — adopter overrides</text>
 
-  <!-- custom-templates -->
-  <rect x="84" y="668" width="395" height="90" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.5"/>
+  <rect x="84" y="668" width="395" height="90" fill="#FBE7E1" stroke="#C8321A" stroke-width="1.5"/>
   <text x="100" y="695" font-size="13" font-weight="700" fill="#C8321A">[+] custom-templates/</text>
   <text x="100" y="717" font-size="11" fill="#1A1612">Path-mirror override</text>
-  <text x="100" y="737" font-size="11" fill="#4A4239" font-style="italic">Wins over framework on collision (#244)</text>
+  <text x="100" y="737" font-size="11" fill="#A03B1F" font-style="italic">Wins over framework on collision (#244)</text>
 
-  <!-- custom-skills -->
-  <rect x="494" y="668" width="395" height="90" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.5"/>
+  <rect x="494" y="668" width="395" height="90" fill="#FBE7E1" stroke="#C8321A" stroke-width="1.5"/>
   <text x="510" y="695" font-size="13" font-weight="700" fill="#C8321A">[+] custom-skills/</text>
   <text x="510" y="717" font-size="11" fill="#1A1612">Symlinked into .claude/skills/</text>
-  <text x="510" y="737" font-size="11" fill="#4A4239" font-style="italic">Framework moves to .framework.bak (#243)</text>
+  <text x="510" y="737" font-size="11" fill="#A03B1F" font-style="italic">Framework moves to .framework.bak (#243)</text>
 
-  <!-- custom-handbooks -->
-  <rect x="904" y="668" width="400" height="90" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.5"/>
+  <rect x="904" y="668" width="400" height="90" fill="#FBE7E1" stroke="#C8321A" stroke-width="1.5"/>
   <text x="920" y="695" font-size="13" font-weight="700" fill="#C8321A">[+] custom-handbooks/</text>
   <text x="920" y="717" font-size="11" fill="#1A1612">Additive — Rex reads BOTH layers</text>
-  <text x="920" y="737" font-size="11" fill="#4A4239" font-style="italic">Same path conventions as framework (#243)</text>
+  <text x="920" y="737" font-size="11" fill="#A03B1F" font-style="italic">Same path conventions as framework (#243)</text>
 
   <!-- Override arrows: customisation → defaults -->
   <line x1="281" y1="668" x2="281" y2="615" stroke="#C8321A" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arrow-override)"/>
-  <line x1="691" y1="668" x2="180" y2="473" stroke="#C8321A" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arrow-override)" opacity="0.6"/>
+  <line x1="691" y1="668" x2="180" y2="473" stroke="#C8321A" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arrow-override)" opacity="0.55"/>
   <line x1="1104" y1="668" x2="1004" y2="615" stroke="#C8321A" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arrow-override)"/>
 
   <text x="296" y="640" font-size="10" fill="#C8321A" font-style="italic">overrides</text>
   <text x="1014" y="640" font-size="10" fill="#C8321A" font-style="italic">layers onto</text>
 
-  <!-- ─────────── LAYER 5: PER-PROJECT DATA ─────────── -->
-  <text x="84" y="798" font-size="12" font-weight="700" fill="#1A1612" letter-spacing="2">PER-PROJECT DATA — one entry per row in the registry</text>
+  <!-- ─────────── LAYER 5: PER-PROJECT DATA — plum ─────────── -->
+  <text x="84" y="798" font-size="12" font-weight="700" fill="#3D2A50" letter-spacing="2">PER-PROJECT DATA — one entry per row in the registry</text>
 
-  <!-- projects/ -->
-  <rect x="84" y="813" width="600" height="195" fill="#E0D7BD" stroke="#1A1612" stroke-width="1.2"/>
-  <text x="100" y="842" font-size="14" font-weight="700" fill="#1A1612">[d] projects/&lt;name&gt;/</text>
-  <text x="100" y="864" font-size="11" fill="#4A4239" font-style="italic">Committed to the fork — ApexYard's view of each project</text>
-  <line x1="100" y1="877" x2="668" y2="877" stroke="#1A1612" stroke-width="0.5" opacity="0.4"/>
+  <rect x="84" y="813" width="600" height="195" fill="#E8E0EA" stroke="#5B3E70" stroke-width="1.3"/>
+  <text x="100" y="842" font-size="14" font-weight="700" fill="#3D2A50">[d] projects/&lt;name&gt;/</text>
+  <text x="100" y="864" font-size="11" fill="#6F538C" font-style="italic">Committed to the fork — ApexYard's view of each project</text>
+  <line x1="100" y1="877" x2="668" y2="877" stroke="#5B3E70" stroke-width="0.5" opacity="0.4"/>
   <text x="100" y="900" font-size="12" fill="#1A1612">README.md  ·  roadmap.md  ·  handover-assessment.md</text>
   <text x="100" y="920" font-size="12" fill="#1A1612">prds/  ·  architecture/  (C4, DFD, vision)  ·  journeys/</text>
   <text x="100" y="940" font-size="12" fill="#1A1612">processes/ (BPMN)  ·  feature-inventory.md  ·  audits/  ·  updates/</text>
   <text x="100" y="960" font-size="12" fill="#1A1612">docs/agdr/  ← per-project Agent Decision Records</text>
-  <text x="100" y="988" font-size="10" fill="#4A4239" font-style="italic">"Would it follow the code if the project spun out tomorrow?"  NO → here.</text>
+  <text x="100" y="988" font-size="10" fill="#6F538C" font-style="italic">"Would it follow the code if the project spun out tomorrow?"  NO → here.</text>
 
-  <!-- workspace/ -->
-  <rect x="704" y="813" width="600" height="195" fill="#E0D7BD" stroke="#1A1612" stroke-width="1.2"/>
-  <text x="720" y="842" font-size="14" font-weight="700" fill="#1A1612">[w] workspace/&lt;name&gt;/</text>
-  <text x="720" y="864" font-size="11" fill="#4A4239" font-style="italic">Live git clones — gitignored from the fork itself</text>
-  <line x1="720" y1="877" x2="1288" y2="877" stroke="#1A1612" stroke-width="0.5" opacity="0.4"/>
+  <rect x="704" y="813" width="600" height="195" fill="#E8E0EA" stroke="#5B3E70" stroke-width="1.3"/>
+  <text x="720" y="842" font-size="14" font-weight="700" fill="#3D2A50">[w] workspace/&lt;name&gt;/</text>
+  <text x="720" y="864" font-size="11" fill="#6F538C" font-style="italic">Live git clones — gitignored from the fork itself</text>
+  <line x1="720" y1="877" x2="1288" y2="877" stroke="#5B3E70" stroke-width="0.5" opacity="0.4"/>
   <text x="720" y="900" font-size="12" fill="#1A1612">Real git clone of the managed repo</text>
   <text x="720" y="920" font-size="12" fill="#1A1612">cd into to do code work · branches · PRs · CI</text>
   <text x="720" y="940" font-size="12" fill="#1A1612">LSP-aware skills run here (semantic index)</text>
   <text x="720" y="960" font-size="12" fill="#1A1612">Cross-repo trace (/process, /dfd) follows registry links</text>
-  <text x="720" y="988" font-size="10" fill="#4A4239" font-style="italic">"Would it follow the code if the project spun out tomorrow?"  YES → here.</text>
+  <text x="720" y="988" font-size="10" fill="#6F538C" font-style="italic">"Would it follow the code if the project spun out tomorrow?"  YES → here.</text>
 
   <!-- ============================================================ -->
-  <!-- PRIVATE SIBLING REPO (RIGHT)                                 -->
+  <!-- PRIVATE SIBLING REPO (RIGHT) — slate, dashed                 -->
   <!-- ============================================================ -->
   <rect x="1380" y="135" width="480" height="900" fill="#F4EFE6" stroke="#4A4239" stroke-width="1.5" stroke-dasharray="8 5"/>
   <text x="1404" y="170" font-size="18" font-weight="700" fill="#1A1612">[lock] Sibling Private Repo</text>
@@ -522,27 +502,27 @@ a:hover { color: var(--accent); }
   <line x1="1404" y1="280" x2="1836" y2="280" stroke="#4A4239" stroke-width="1"/>
   <text x="1404" y="305" font-size="11" font-weight="700" fill="#1A1612" letter-spacing="1">CONTENTS — replaces public-fork copies</text>
 
-  <!-- File list as compact cards -->
   <g font-size="12" fill="#1A1612">
-    <rect x="1404" y="320" width="432" height="32" fill="#ECE5D2" stroke="#1A1612" stroke-width="0.8"/>
+    <!-- the four files use their layer's colour as a left-border hint -->
+    <rect x="1404" y="320" width="432" height="32" fill="#E0E8F0" stroke="#2C4E70" stroke-width="0.9"/>
     <text x="1418" y="341">[*] apexyard.projects.yaml</text>
 
-    <rect x="1404" y="362" width="432" height="32" fill="#ECE5D2" stroke="#1A1612" stroke-width="0.8"/>
+    <rect x="1404" y="362" width="432" height="32" fill="#E0E8F0" stroke="#2C4E70" stroke-width="0.9"/>
     <text x="1418" y="383">[i] onboarding.yaml</text>
 
-    <rect x="1404" y="404" width="432" height="32" fill="#ECE5D2" stroke="#1A1612" stroke-width="0.8"/>
+    <rect x="1404" y="404" width="432" height="32" fill="#E8E0EA" stroke="#5B3E70" stroke-width="0.9"/>
     <text x="1418" y="425">[d] projects/</text>
 
-    <rect x="1404" y="446" width="432" height="32" fill="#ECE5D2" stroke="#1A1612" stroke-width="0.8"/>
+    <rect x="1404" y="446" width="432" height="32" fill="#E8E0EA" stroke="#5B3E70" stroke-width="0.9"/>
     <text x="1418" y="467">[w] workspace/</text>
 
-    <rect x="1404" y="488" width="432" height="32" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.2"/>
+    <rect x="1404" y="488" width="432" height="32" fill="#FBE7E1" stroke="#C8321A" stroke-width="1.3"/>
     <text x="1418" y="509" fill="#C8321A">[+] custom-templates/</text>
 
-    <rect x="1404" y="530" width="432" height="32" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.2"/>
+    <rect x="1404" y="530" width="432" height="32" fill="#FBE7E1" stroke="#C8321A" stroke-width="1.3"/>
     <text x="1418" y="551" fill="#C8321A">[+] custom-skills/</text>
 
-    <rect x="1404" y="572" width="432" height="32" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.2"/>
+    <rect x="1404" y="572" width="432" height="32" fill="#FBE7E1" stroke="#C8321A" stroke-width="1.3"/>
     <text x="1418" y="593" fill="#C8321A">[+] custom-handbooks/</text>
   </g>
 
@@ -550,43 +530,42 @@ a:hover { color: var(--accent); }
   <text x="1404" y="652" font-size="11" fill="#4A4239" font-style="italic">transparently — the public fork stays slim,</text>
   <text x="1404" y="669" font-size="11" fill="#4A4239" font-style="italic">your private data never leaks upstream.</text>
 
-  <!-- Public fork anchor file -->
   <line x1="1404" y1="690" x2="1836" y2="690" stroke="#4A4239" stroke-width="1"/>
   <text x="1404" y="715" font-size="11" font-weight="700" fill="#1A1612" letter-spacing="1">PUBLIC FORK MARKER</text>
-  <rect x="1404" y="725" width="432" height="40" fill="#ECE5D2" stroke="#1A1612" stroke-width="0.8"/>
+  <rect x="1404" y="725" width="432" height="40" fill="#ECE5D2" stroke="#1A1612" stroke-width="0.9"/>
   <text x="1418" y="745" font-size="12" fill="#1A1612">[anchor] .apexyard-fork  <tspan fill="#877E70">(presence marker)</tspan></text>
   <text x="1418" y="760" font-size="10" fill="#877E70">walked-up by hooks to find the ops-fork root</text>
 
-  <!-- Resolution arrow into the main fork -->
   <line x1="1380" y1="475" x2="1304" y2="475" stroke="#4A4239" stroke-width="1.5" stroke-dasharray="6 4" marker-end="url(#arrow-dashed)"/>
   <text x="1310" y="465" font-size="10" fill="#4A4239" font-style="italic" text-anchor="end">resolves into fork</text>
 
   <!-- ============================================================ -->
-  <!-- LEGEND / FOOTER                                              -->
+  <!-- LEGEND — six layer swatches                                  -->
   <!-- ============================================================ -->
   <g font-size="12" fill="#1A1612">
-    <rect x="60" y="1050" width="14" height="14" fill="#ECE5D2" stroke="#1A1612"/>
-    <text x="82" y="1062">Governance / defaults</text>
+    <rect x="60" y="1050" width="14" height="14" fill="#E0E8F0" stroke="#2C4E70"/>
+    <text x="82" y="1062">Governance</text>
 
-    <rect x="220" y="1050" width="14" height="14" fill="#E0D7BD" stroke="#1A1612"/>
-    <text x="242" y="1062">Capability / per-project data</text>
+    <rect x="190" y="1050" width="14" height="14" fill="#DDE9DD" stroke="#2D6A4F"/>
+    <text x="212" y="1062">Capability</text>
 
-    <rect x="430" y="1050" width="14" height="14" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.2"/>
-    <text x="452" y="1062" fill="#C8321A">Customisation (overrides)</text>
+    <rect x="305" y="1050" width="14" height="14" fill="#EFE6CA" stroke="#8B6914"/>
+    <text x="327" y="1062">Framework defaults</text>
 
-    <rect x="640" y="1050" width="14" height="14" fill="#F4EFE6" stroke="#4A4239" stroke-dasharray="3 2"/>
-    <text x="662" y="1062">Optional private sibling</text>
+    <rect x="475" y="1050" width="14" height="14" fill="#FBE7E1" stroke="#C8321A" stroke-width="1.3"/>
+    <text x="497" y="1062" fill="#C8321A">Customisation (overrides)</text>
+
+    <rect x="690" y="1050" width="14" height="14" fill="#E8E0EA" stroke="#5B3E70"/>
+    <text x="712" y="1062">Per-project data</text>
+
+    <rect x="855" y="1050" width="14" height="14" fill="#F4EFE6" stroke="#4A4239" stroke-dasharray="3 2"/>
+    <text x="877" y="1062">Optional private sibling</text>
   </g>
 
   <text x="1860" y="1062" font-size="11" fill="#877E70" text-anchor="end" font-style="italic">apexyard.dev  ·  fork the framework, register your repos, ship.</text>
 
 </svg>
       </div>
-
-      <p class="diagram-hint">
-        Right-click the diagram → <strong>Save Image As</strong> → drop into a slide. Or take a screenshot —
-        the layout fits 16:9 at <code>1920×1080</code>.
-      </p>
 
     </div>
   </section>
@@ -635,16 +614,14 @@ a:hover { color: var(--accent); }
         </p>
       </div>
 
-      <div class="note">
+      <div class="note note--wide">
         <h3>Optional private sibling</h3>
         <p>
-          The <strong>dashed box on the right</strong> is opt-in. Adopters on GitHub Free who don't
-          want portfolio names on a public fork put the registry, onboarding, projects/, workspace/,
-          and the custom-* trees in a sibling private repo. Skills resolve paths via the
+          The <strong>dashed box on the right</strong> is opt-in. Adopters on GitHub Free who don't want
+          portfolio names on a public fork put the registry, onboarding, <code>projects/</code>, <code>workspace/</code>,
+          and the <code>custom-*</code> trees in a sibling private repo. Skills resolve paths via the
           <code>portfolio.*</code> keys in <code>.claude/project-config.json</code> — the public
           fork stays slim, the private data never leaks upstream.
-        </p>
-        <p>
           Full setup walkthrough lives in
           <a href="https://github.com/me2resh/apexyard/blob/main/docs/multi-project.md" target="_blank" rel="noopener">docs/multi-project.md ↗</a>.
         </p>

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -1,0 +1,670 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Architecture — ApexYard</title>
+<meta name="description" content="The ApexYard architecture at a glance — five layers (governance, capability, framework defaults, customisation overlay, per-project data) plus the optional split-portfolio private sibling repo. One fork governs every project.">
+<link rel="canonical" href="https://yard.apexscript.com/architecture.html">
+
+<!-- Open Graph -->
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="ApexYard">
+<meta property="og:url" content="https://yard.apexscript.com/architecture.html">
+<meta property="og:title" content="ApexYard — Architecture">
+<meta property="og:description" content="Five layers in one ops fork — governance, capability, defaults, customisation overlay, per-project data. Plus the optional split-portfolio sibling repo for adopters on GitHub Free.">
+
+<!-- Twitter / X -->
+<meta name="twitter:card" content="summary">
+<meta name="twitter:url" content="https://yard.apexscript.com/architecture.html">
+<meta name="twitter:title" content="ApexYard — Architecture">
+<meta name="twitter:description" content="Five layers in one ops fork — governance, capability, defaults, customisation overlay, per-project data.">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet">
+
+<style>
+/* ============================================================
+   ApexYard — Architecture page
+   Same terminal-native brutalism as the homepage: JetBrains Mono,
+   warm cream paper, single warning-red accent. The diagram (SVG)
+   is recoloured to fit — pastel layer fills become cream-paper
+   tonal contrast; the red accent stamps only on customisation
+   overrides (where its "override" semantic earns its place).
+   ============================================================ */
+
+:root {
+  /* paper */
+  --paper:    #F4EFE6;
+  --paper-2:  #ECE5D2;
+  --paper-3:  #E0D7BD;
+
+  /* ink */
+  --ink:       #1A1612;
+  --ink-soft:  #4A4239;
+  --ink-faint: #877E70;
+  --ink-ghost: #B6AD9B;
+
+  /* the single accent — stamps on customisation overrides only */
+  --accent:      #C8321A;
+  --accent-soft: #E07050;
+
+  /* hairlines */
+  --rule:        #1A1612;
+  --rule-faint:  #B6AD9B;
+
+  --mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+
+  --max-w:  1280px;
+  --gutter: clamp(1.25rem, 4vw, 3rem);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper:    #15120D;
+    --paper-2:  #1C1813;
+    --paper-3:  #25201A;
+    --ink:       #F2EBD9;
+    --ink-soft:  #C5BEAA;
+    --ink-faint: #847C68;
+    --ink-ghost: #4A4338;
+    --accent:      #FF6E4A;
+    --accent-soft: #FFA180;
+    --rule:        #F2EBD9;
+    --rule-faint:  #4A4338;
+  }
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  background: var(--paper);
+  scroll-behavior: smooth;
+  font-feature-settings: 'calt', 'ss01', 'ss03';
+}
+
+body {
+  font-family: var(--mono);
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 14px;
+  line-height: 1.55;
+  font-weight: 400;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+::selection { background: var(--accent); color: var(--paper); }
+
+a { color: inherit; text-decoration: none; }
+a:hover { color: var(--accent); }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+
+.skip {
+  position: absolute; left: -10000px; top: auto;
+  width: 1px; height: 1px; overflow: hidden;
+}
+.skip:focus {
+  position: fixed; top: 0.5rem; left: 0.5rem; width: auto; height: auto;
+  background: var(--ink); color: var(--paper); padding: 0.5rem 0.75rem;
+  z-index: 200;
+}
+
+.dim { color: var(--ink-faint); }
+.kw { color: var(--accent); font-weight: 600; }
+
+/* ============================================================
+   titlebar — same shape as the homepage / skills.html
+   ============================================================ */
+.titlebar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--paper);
+  border-bottom: 1px solid var(--rule);
+  padding: 0.75rem 0;
+  font-size: 12px;
+}
+.titlebar__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.titlebar__left { display: flex; align-items: center; gap: 0.65rem; }
+.titlebar__dots { display: inline-flex; gap: 0.35rem; }
+.titlebar__dot {
+  width: 11px; height: 11px;
+  border: 1px solid var(--rule);
+  display: inline-block;
+}
+.titlebar__dot.is-warn { background: var(--accent); border-color: var(--accent); }
+.titlebar__path { color: var(--ink-soft); }
+.titlebar__path b { color: var(--ink); font-weight: 600; }
+.titlebar__right { display: flex; gap: 1.25rem; align-items: center; font-size: 12px; }
+.titlebar__right a { color: var(--ink-faint); transition: color 0.15s ease; }
+.titlebar__right a:hover { color: var(--accent); }
+.titlebar__right a.is-cta {
+  border: 1px solid var(--rule);
+  padding: 0.35rem 0.75rem;
+  color: var(--ink);
+}
+.titlebar__right a.is-cta:hover { color: var(--accent); border-color: var(--accent); }
+@media (max-width: 720px) {
+  .titlebar__right { gap: 0.7rem; font-size: 11px; }
+  .titlebar__right a:not(.is-cta):not(.always) { display: none; }
+  .titlebar__right a.always { display: inline; }
+}
+
+/* ============================================================
+   page header
+   ============================================================ */
+.page-header {
+  border-bottom: 1px solid var(--rule);
+  padding: clamp(2rem, 5vw, 3.5rem) 0 clamp(1.5rem, 3vw, 2.5rem);
+}
+.page-header__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+.page-header__eyebrow {
+  font-size: 12px;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.65rem;
+}
+.page-header__eyebrow .pill {
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  padding: 0.2rem 0.6rem;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  margin-right: 0.5rem;
+}
+.page-header h1 {
+  font-family: var(--mono);
+  font-weight: 800;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+  color: var(--ink);
+  margin-bottom: 0.65rem;
+}
+.page-header h1::after {
+  content: '_';
+  color: var(--accent);
+  animation: blink 1.1s steps(1, end) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+.page-header .tagline {
+  font-size: clamp(1rem, 1.6vw, 1.25rem);
+  color: var(--ink-soft);
+  max-width: 72ch;
+  line-height: 1.55;
+  margin-bottom: 0.5rem;
+}
+.page-header .meta {
+  font-size: 12px;
+  color: var(--ink-faint);
+  margin-top: 1.25rem;
+}
+.page-header .meta a {
+  color: var(--ink-soft);
+  border-bottom: 1px solid var(--rule-faint);
+  padding-bottom: 1px;
+}
+.page-header .meta a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* ============================================================
+   diagram stage
+   ============================================================ */
+.diagram-section {
+  padding: clamp(1.5rem, 3vw, 2.5rem) 0;
+  border-bottom: 1px solid var(--rule);
+}
+.diagram-section__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+.diagram-stage {
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  padding: clamp(0.75rem, 1.5vw, 1.25rem);
+  margin-bottom: 0.85rem;
+  overflow-x: auto;
+}
+.diagram-stage svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  min-width: 1000px; /* below this, the SVG would shrink labels to unreadable */
+}
+.diagram-hint {
+  font-size: 12px;
+  color: var(--ink-faint);
+  font-style: italic;
+}
+.diagram-hint code {
+  font-family: var(--mono);
+  background: var(--paper-2);
+  border: 1px solid var(--rule-faint);
+  padding: 1px 5px;
+  font-style: normal;
+}
+
+/* ============================================================
+   legend + notes blocks
+   ============================================================ */
+.notes {
+  padding: clamp(2rem, 4vw, 3rem) 0;
+  border-bottom: 1px solid var(--rule);
+}
+.notes__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1rem, 2vw, 1.75rem);
+}
+.note {
+  border: 1px solid var(--rule);
+  padding: 1.25rem 1.4rem;
+  background: var(--paper-2);
+}
+.note h3 {
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 0.65rem;
+  font-weight: 600;
+}
+.note p {
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--ink-soft);
+}
+.note p + p { margin-top: 0.65rem; }
+.note strong { color: var(--ink); font-weight: 600; }
+.note .kw { color: var(--accent); }
+.note a { border-bottom: 1px solid var(--rule-faint); padding-bottom: 1px; }
+.note a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* ============================================================
+   footer
+   ============================================================ */
+.page-footer {
+  padding: 1.5rem 0;
+  font-size: 12px;
+  color: var(--ink-faint);
+}
+.page-footer__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.page-footer a { color: var(--ink-soft); }
+.page-footer a:hover { color: var(--accent); }
+</style>
+</head>
+<body>
+
+<a href="#main" class="skip">Skip to content</a>
+
+<header class="titlebar">
+  <div class="titlebar__inner">
+    <div class="titlebar__left">
+      <span class="titlebar__dots" aria-hidden="true">
+        <span class="titlebar__dot"></span>
+        <span class="titlebar__dot"></span>
+        <span class="titlebar__dot is-warn"></span>
+      </span>
+      <span class="titlebar__path">~/<b>apexyard</b> <span class="dim">· architecture</span></span>
+    </div>
+    <nav class="titlebar__right" aria-label="Primary">
+      <a href="index.html" class="always">home</a>
+      <a href="skills.html">skills</a>
+      <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>
+      <a href="https://github.com/me2resh/apexyard" class="is-cta" target="_blank" rel="noopener">github →</a>
+    </nav>
+  </div>
+</header>
+
+<main id="main">
+
+  <section class="page-header">
+    <div class="page-header__inner">
+      <div class="page-header__eyebrow">
+        <span class="pill">apexyard / architecture</span>
+        <span>one fork, five layers, optional sibling repo</span>
+      </div>
+      <h1>Architecture</h1>
+      <p class="tagline">
+        A multi-project forge for Claude Code — governance, capability, customisation, and per-project data in one fork.
+        The diagram below is the canonical mental model.
+      </p>
+      <p class="meta">
+        See also: <a href="index.html">overview</a> · <a href="skills.html">skills</a> · <a href="https://github.com/me2resh/apexyard/blob/main/docs/multi-project.md" target="_blank" rel="noopener">setup guide ↗</a>
+      </p>
+    </div>
+  </section>
+
+  <section class="diagram-section">
+    <div class="diagram-section__inner">
+
+      <div class="diagram-stage">
+<svg viewBox="0 0 1920 1080" xmlns="http://www.w3.org/2000/svg" font-family="'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" role="img" aria-label="ApexYard architecture: five layers (governance, capability, framework defaults, customisation, per-project data) inside the ops fork, plus an optional private sibling repo on the right.">
+
+  <defs>
+    <!-- arrowheads -->
+    <marker id="arrow-solid" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1A1612"/>
+    </marker>
+    <marker id="arrow-dashed" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#4A4239"/>
+    </marker>
+    <marker id="arrow-override" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#C8321A"/>
+    </marker>
+  </defs>
+
+  <!-- ============================================================ -->
+  <!-- HEADER                                                       -->
+  <!-- ============================================================ -->
+  <text x="60" y="60" font-size="40" font-weight="800" fill="#1A1612" letter-spacing="-2">ApexYard</text>
+  <text x="60" y="95" font-size="16" fill="#4A4239">A multi-project forge for Claude Code — governance, capability, customisation, and per-project data in one fork.</text>
+
+  <!-- ============================================================ -->
+  <!-- MAIN FORK BOX (LEFT)                                         -->
+  <!-- ============================================================ -->
+  <rect x="60" y="135" width="1280" height="900" fill="#F4EFE6" stroke="#1A1612" stroke-width="1.5"/>
+  <text x="84" y="170" font-size="18" font-weight="700" fill="#1A1612">[#] ApexYard Ops Fork</text>
+  <text x="290" y="170" font-size="13" fill="#4A4239" font-style="italic">(your-org/apexyard — the public fork you clone)</text>
+
+  <!-- ─────────── LAYER 1: GOVERNANCE ─────────── -->
+  <text x="84" y="210" font-size="12" font-weight="700" fill="#1A1612" letter-spacing="2">GOVERNANCE — declares what, enforces how</text>
+
+  <!-- Registry -->
+  <rect x="84" y="225" width="290" height="90" fill="#ECE5D2" stroke="#1A1612" stroke-width="1.2"/>
+  <text x="100" y="252" font-size="14" font-weight="700" fill="#1A1612">[*] Registry</text>
+  <text x="100" y="275" font-size="12" fill="#1A1612">apexyard.projects.yaml</text>
+  <text x="100" y="295" font-size="11" fill="#4A4239">Lists every managed project</text>
+
+  <!-- Hooks -->
+  <rect x="394" y="225" width="290" height="90" fill="#ECE5D2" stroke="#1A1612" stroke-width="1.2"/>
+  <text x="410" y="252" font-size="14" font-weight="700" fill="#1A1612">[~] Hooks</text>
+  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 26 shell gates</text>
+  <text x="410" y="295" font-size="11" fill="#4A4239">Merge gate · ticket-first · secrets · …</text>
+
+  <!-- Rules -->
+  <rect x="704" y="225" width="290" height="90" fill="#ECE5D2" stroke="#1A1612" stroke-width="1.2"/>
+  <text x="720" y="252" font-size="14" font-weight="700" fill="#1A1612">[=] Rules</text>
+  <text x="720" y="275" font-size="12" fill="#1A1612">.claude/rules/  · 11 files</text>
+  <text x="720" y="295" font-size="11" fill="#4A4239">Self-discipline guides for the agent</text>
+
+  <!-- Onboarding -->
+  <rect x="1014" y="225" width="290" height="90" fill="#ECE5D2" stroke="#1A1612" stroke-width="1.2"/>
+  <text x="1030" y="252" font-size="14" font-weight="700" fill="#1A1612">[i] Onboarding</text>
+  <text x="1030" y="275" font-size="12" fill="#1A1612">onboarding.yaml</text>
+  <text x="1030" y="295" font-size="11" fill="#4A4239">Company name, mission, team, stack</text>
+
+  <!-- ─────────── LAYER 2: CAPABILITY ─────────── -->
+  <text x="84" y="358" font-size="12" font-weight="700" fill="#1A1612" letter-spacing="2">CAPABILITY — what the agent can do</text>
+
+  <!-- Skills -->
+  <rect x="84" y="373" width="600" height="100" fill="#E0D7BD" stroke="#1A1612" stroke-width="1.2"/>
+  <text x="100" y="402" font-size="15" font-weight="700" fill="#1A1612">[/] Skills</text>
+  <text x="100" y="425" font-size="12" fill="#1A1612">.claude/skills/  ·  48 slash commands</text>
+  <text x="100" y="447" font-size="11" fill="#4A4239">/feature  /handover  /c4  /threat-model  /process  /dfd  /journey  /update  /release  …</text>
+
+  <!-- Agents -->
+  <rect x="704" y="373" width="600" height="100" fill="#E0D7BD" stroke="#1A1612" stroke-width="1.2"/>
+  <text x="720" y="402" font-size="15" font-weight="700" fill="#1A1612">[&gt;] Agents</text>
+  <text x="720" y="425" font-size="12" fill="#1A1612">.claude/agents/  ·  5 specialised sub-agents</text>
+  <text x="720" y="447" font-size="11" fill="#4A4239">Rex (code review) · Hatim (security) · Munir (deps) · Tariq (PR) · Idris (tickets)</text>
+
+  <!-- ─────────── LAYER 3: FRAMEWORK DEFAULTS ─────────── -->
+  <text x="84" y="513" font-size="12" font-weight="700" fill="#1A1612" letter-spacing="2">FRAMEWORK DEFAULTS — ship out of the box</text>
+
+  <!-- Templates -->
+  <rect x="84" y="528" width="600" height="85" fill="#ECE5D2" stroke="#1A1612" stroke-width="1.2"/>
+  <text x="100" y="555" font-size="14" font-weight="700" fill="#1A1612">[T] templates/</text>
+  <text x="100" y="578" font-size="12" fill="#1A1612">PRD · AgDR · technical-design · C4 context/container · DFD · vision · spike · …</text>
+  <text x="100" y="600" font-size="11" fill="#4A4239" font-style="italic">Overridable per file via custom-templates/&lt;same-path&gt;.md</text>
+
+  <!-- Handbooks -->
+  <rect x="704" y="528" width="600" height="85" fill="#ECE5D2" stroke="#1A1612" stroke-width="1.2"/>
+  <text x="720" y="555" font-size="14" font-weight="700" fill="#1A1612">[H] handbooks/</text>
+  <text x="720" y="578" font-size="12" fill="#1A1612">architecture/  ·  general/  ·  language/&lt;lang&gt;/  ← Rex consults during code review</text>
+  <text x="720" y="600" font-size="11" fill="#4A4239" font-style="italic">Additive: custom-handbooks/&lt;path&gt; layered alongside, NOT replacing</text>
+
+  <!-- ─────────── LAYER 4: CUSTOMISATION ─────────── -->
+  <text x="84" y="653" font-size="12" font-weight="700" fill="#C8321A" letter-spacing="2">CUSTOMISATION LAYER — adopter overrides</text>
+
+  <!-- custom-templates -->
+  <rect x="84" y="668" width="395" height="90" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.5"/>
+  <text x="100" y="695" font-size="13" font-weight="700" fill="#C8321A">[+] custom-templates/</text>
+  <text x="100" y="717" font-size="11" fill="#1A1612">Path-mirror override</text>
+  <text x="100" y="737" font-size="11" fill="#4A4239" font-style="italic">Wins over framework on collision (#244)</text>
+
+  <!-- custom-skills -->
+  <rect x="494" y="668" width="395" height="90" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.5"/>
+  <text x="510" y="695" font-size="13" font-weight="700" fill="#C8321A">[+] custom-skills/</text>
+  <text x="510" y="717" font-size="11" fill="#1A1612">Symlinked into .claude/skills/</text>
+  <text x="510" y="737" font-size="11" fill="#4A4239" font-style="italic">Framework moves to .framework.bak (#243)</text>
+
+  <!-- custom-handbooks -->
+  <rect x="904" y="668" width="400" height="90" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.5"/>
+  <text x="920" y="695" font-size="13" font-weight="700" fill="#C8321A">[+] custom-handbooks/</text>
+  <text x="920" y="717" font-size="11" fill="#1A1612">Additive — Rex reads BOTH layers</text>
+  <text x="920" y="737" font-size="11" fill="#4A4239" font-style="italic">Same path conventions as framework (#243)</text>
+
+  <!-- Override arrows: customisation → defaults -->
+  <line x1="281" y1="668" x2="281" y2="615" stroke="#C8321A" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arrow-override)"/>
+  <line x1="691" y1="668" x2="180" y2="473" stroke="#C8321A" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arrow-override)" opacity="0.6"/>
+  <line x1="1104" y1="668" x2="1004" y2="615" stroke="#C8321A" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arrow-override)"/>
+
+  <text x="296" y="640" font-size="10" fill="#C8321A" font-style="italic">overrides</text>
+  <text x="1014" y="640" font-size="10" fill="#C8321A" font-style="italic">layers onto</text>
+
+  <!-- ─────────── LAYER 5: PER-PROJECT DATA ─────────── -->
+  <text x="84" y="798" font-size="12" font-weight="700" fill="#1A1612" letter-spacing="2">PER-PROJECT DATA — one entry per row in the registry</text>
+
+  <!-- projects/ -->
+  <rect x="84" y="813" width="600" height="195" fill="#E0D7BD" stroke="#1A1612" stroke-width="1.2"/>
+  <text x="100" y="842" font-size="14" font-weight="700" fill="#1A1612">[d] projects/&lt;name&gt;/</text>
+  <text x="100" y="864" font-size="11" fill="#4A4239" font-style="italic">Committed to the fork — ApexYard's view of each project</text>
+  <line x1="100" y1="877" x2="668" y2="877" stroke="#1A1612" stroke-width="0.5" opacity="0.4"/>
+  <text x="100" y="900" font-size="12" fill="#1A1612">README.md  ·  roadmap.md  ·  handover-assessment.md</text>
+  <text x="100" y="920" font-size="12" fill="#1A1612">prds/  ·  architecture/  (C4, DFD, vision)  ·  journeys/</text>
+  <text x="100" y="940" font-size="12" fill="#1A1612">processes/ (BPMN)  ·  feature-inventory.md  ·  audits/  ·  updates/</text>
+  <text x="100" y="960" font-size="12" fill="#1A1612">docs/agdr/  ← per-project Agent Decision Records</text>
+  <text x="100" y="988" font-size="10" fill="#4A4239" font-style="italic">"Would it follow the code if the project spun out tomorrow?"  NO → here.</text>
+
+  <!-- workspace/ -->
+  <rect x="704" y="813" width="600" height="195" fill="#E0D7BD" stroke="#1A1612" stroke-width="1.2"/>
+  <text x="720" y="842" font-size="14" font-weight="700" fill="#1A1612">[w] workspace/&lt;name&gt;/</text>
+  <text x="720" y="864" font-size="11" fill="#4A4239" font-style="italic">Live git clones — gitignored from the fork itself</text>
+  <line x1="720" y1="877" x2="1288" y2="877" stroke="#1A1612" stroke-width="0.5" opacity="0.4"/>
+  <text x="720" y="900" font-size="12" fill="#1A1612">Real git clone of the managed repo</text>
+  <text x="720" y="920" font-size="12" fill="#1A1612">cd into to do code work · branches · PRs · CI</text>
+  <text x="720" y="940" font-size="12" fill="#1A1612">LSP-aware skills run here (semantic index)</text>
+  <text x="720" y="960" font-size="12" fill="#1A1612">Cross-repo trace (/process, /dfd) follows registry links</text>
+  <text x="720" y="988" font-size="10" fill="#4A4239" font-style="italic">"Would it follow the code if the project spun out tomorrow?"  YES → here.</text>
+
+  <!-- ============================================================ -->
+  <!-- PRIVATE SIBLING REPO (RIGHT)                                 -->
+  <!-- ============================================================ -->
+  <rect x="1380" y="135" width="480" height="900" fill="#F4EFE6" stroke="#4A4239" stroke-width="1.5" stroke-dasharray="8 5"/>
+  <text x="1404" y="170" font-size="18" font-weight="700" fill="#1A1612">[lock] Sibling Private Repo</text>
+  <text x="1404" y="192" font-size="12" fill="#4A4239" font-style="italic">Optional — split-portfolio v2 mode</text>
+
+  <text x="1404" y="225" font-size="12" fill="#1A1612">For adopters on GitHub Free who don't want</text>
+  <text x="1404" y="242" font-size="12" fill="#1A1612">portfolio names on a public repo. Resolved via</text>
+  <text x="1404" y="259" font-size="12" fill="#1A1612"><tspan font-weight="700">portfolio.*</tspan> keys in <tspan font-weight="700">.claude/project-config.json</tspan></text>
+
+  <line x1="1404" y1="280" x2="1836" y2="280" stroke="#4A4239" stroke-width="1"/>
+  <text x="1404" y="305" font-size="11" font-weight="700" fill="#1A1612" letter-spacing="1">CONTENTS — replaces public-fork copies</text>
+
+  <!-- File list as compact cards -->
+  <g font-size="12" fill="#1A1612">
+    <rect x="1404" y="320" width="432" height="32" fill="#ECE5D2" stroke="#1A1612" stroke-width="0.8"/>
+    <text x="1418" y="341">[*] apexyard.projects.yaml</text>
+
+    <rect x="1404" y="362" width="432" height="32" fill="#ECE5D2" stroke="#1A1612" stroke-width="0.8"/>
+    <text x="1418" y="383">[i] onboarding.yaml</text>
+
+    <rect x="1404" y="404" width="432" height="32" fill="#ECE5D2" stroke="#1A1612" stroke-width="0.8"/>
+    <text x="1418" y="425">[d] projects/</text>
+
+    <rect x="1404" y="446" width="432" height="32" fill="#ECE5D2" stroke="#1A1612" stroke-width="0.8"/>
+    <text x="1418" y="467">[w] workspace/</text>
+
+    <rect x="1404" y="488" width="432" height="32" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.2"/>
+    <text x="1418" y="509" fill="#C8321A">[+] custom-templates/</text>
+
+    <rect x="1404" y="530" width="432" height="32" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.2"/>
+    <text x="1418" y="551" fill="#C8321A">[+] custom-skills/</text>
+
+    <rect x="1404" y="572" width="432" height="32" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.2"/>
+    <text x="1418" y="593" fill="#C8321A">[+] custom-handbooks/</text>
+  </g>
+
+  <text x="1404" y="635" font-size="11" fill="#4A4239" font-style="italic">When v2 is enabled, skills resolve these paths</text>
+  <text x="1404" y="652" font-size="11" fill="#4A4239" font-style="italic">transparently — the public fork stays slim,</text>
+  <text x="1404" y="669" font-size="11" fill="#4A4239" font-style="italic">your private data never leaks upstream.</text>
+
+  <!-- Public fork anchor file -->
+  <line x1="1404" y1="690" x2="1836" y2="690" stroke="#4A4239" stroke-width="1"/>
+  <text x="1404" y="715" font-size="11" font-weight="700" fill="#1A1612" letter-spacing="1">PUBLIC FORK MARKER</text>
+  <rect x="1404" y="725" width="432" height="40" fill="#ECE5D2" stroke="#1A1612" stroke-width="0.8"/>
+  <text x="1418" y="745" font-size="12" fill="#1A1612">[anchor] .apexyard-fork  <tspan fill="#877E70">(presence marker)</tspan></text>
+  <text x="1418" y="760" font-size="10" fill="#877E70">walked-up by hooks to find the ops-fork root</text>
+
+  <!-- Resolution arrow into the main fork -->
+  <line x1="1380" y1="475" x2="1304" y2="475" stroke="#4A4239" stroke-width="1.5" stroke-dasharray="6 4" marker-end="url(#arrow-dashed)"/>
+  <text x="1310" y="465" font-size="10" fill="#4A4239" font-style="italic" text-anchor="end">resolves into fork</text>
+
+  <!-- ============================================================ -->
+  <!-- LEGEND / FOOTER                                              -->
+  <!-- ============================================================ -->
+  <g font-size="12" fill="#1A1612">
+    <rect x="60" y="1050" width="14" height="14" fill="#ECE5D2" stroke="#1A1612"/>
+    <text x="82" y="1062">Governance / defaults</text>
+
+    <rect x="220" y="1050" width="14" height="14" fill="#E0D7BD" stroke="#1A1612"/>
+    <text x="242" y="1062">Capability / per-project data</text>
+
+    <rect x="430" y="1050" width="14" height="14" fill="#ECE5D2" stroke="#C8321A" stroke-width="1.2"/>
+    <text x="452" y="1062" fill="#C8321A">Customisation (overrides)</text>
+
+    <rect x="640" y="1050" width="14" height="14" fill="#F4EFE6" stroke="#4A4239" stroke-dasharray="3 2"/>
+    <text x="662" y="1062">Optional private sibling</text>
+  </g>
+
+  <text x="1860" y="1062" font-size="11" fill="#877E70" text-anchor="end" font-style="italic">apexyard.dev  ·  fork the framework, register your repos, ship.</text>
+
+</svg>
+      </div>
+
+      <p class="diagram-hint">
+        Right-click the diagram → <strong>Save Image As</strong> → drop into a slide. Or take a screenshot —
+        the layout fits 16:9 at <code>1920×1080</code>.
+      </p>
+
+    </div>
+  </section>
+
+  <section class="notes">
+    <div class="notes__inner">
+
+      <div class="note">
+        <h3>The 5-layer model</h3>
+        <p>
+          <strong>Governance</strong> declares what's true (registry, onboarding) and what's enforced
+          (hooks, rules). <strong>Capability</strong> is what the agent can DO — skills + sub-agents.
+          <strong>Framework defaults</strong> ship with the fork: templates and handbooks.
+          <strong>Customisation</strong> is your overrides; the <span class="kw">red border</span> in
+          the diagram is the override semantic. <strong>Per-project data</strong> lives at the bottom
+          — one entry per row in the registry.
+        </p>
+      </div>
+
+      <div class="note">
+        <h3>One fork, every project</h3>
+        <p>
+          You fork ApexYard once and treat the fork as your ops repo. Every project you want
+          governed gets a row in <code>apexyard.projects.yaml</code> and a folder under
+          <code>projects/&lt;name&gt;/</code>. Skills like <code>/inbox</code>,
+          <code>/status</code>, and <code>/tasks</code> aggregate across the registry — one
+          command surveys the whole portfolio.
+        </p>
+        <p>
+          Live working copies (<code>workspace/&lt;name&gt;/</code>) are gitignored from the fork
+          itself; each is a real clone of the managed repo with its own branches, PRs, and CI.
+        </p>
+      </div>
+
+      <div class="note">
+        <h3>Customisation overlay</h3>
+        <p>
+          The framework ships defaults; <span class="kw">custom-templates/</span>,
+          <span class="kw">custom-skills/</span>, and <span class="kw">custom-handbooks/</span>
+          let you override them per file (templates), add proprietary slash commands (skills),
+          or layer company-confidential coding standards alongside the public ones (handbooks).
+        </p>
+        <p>
+          Path-mirroring is the convention — drop your version at the same relative path as the
+          framework default, and it wins on collision.
+        </p>
+      </div>
+
+      <div class="note">
+        <h3>Optional private sibling</h3>
+        <p>
+          The <strong>dashed box on the right</strong> is opt-in. Adopters on GitHub Free who don't
+          want portfolio names on a public fork put the registry, onboarding, projects/, workspace/,
+          and the custom-* trees in a sibling private repo. Skills resolve paths via the
+          <code>portfolio.*</code> keys in <code>.claude/project-config.json</code> — the public
+          fork stays slim, the private data never leaks upstream.
+        </p>
+        <p>
+          Full setup walkthrough lives in
+          <a href="https://github.com/me2resh/apexyard/blob/main/docs/multi-project.md" target="_blank" rel="noopener">docs/multi-project.md ↗</a>.
+        </p>
+      </div>
+
+    </div>
+  </section>
+
+</main>
+
+<footer class="page-footer">
+  <div class="page-footer__inner">
+    <div>apexyard.dev  ·  fork the framework, register your repos, ship.</div>
+    <div>
+      <a href="https://github.com/me2resh/apexyard" target="_blank" rel="noopener">github ↗</a>  ·
+      <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">releases ↗</a>  ·
+      <a href="index.html">home</a>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -1342,9 +1342,6 @@ footer.foot {
       <span class="titlebar__path">~/<b>apexyard</b> <span class="dim">- main · v1.1</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
-      <a href="#quickstart">quickstart</a>
-      <a href="#examples">walkthroughs</a>
-      <a href="#in-the-box">what's in the box</a>
       <a href="architecture.html">architecture</a>
       <a href="skills.html">skills</a>
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>

--- a/site/index.html
+++ b/site/index.html
@@ -1345,6 +1345,7 @@ footer.foot {
       <a href="#quickstart">quickstart</a>
       <a href="#examples">walkthroughs</a>
       <a href="#in-the-box">what's in the box</a>
+      <a href="architecture.html">architecture</a>
       <a href="skills.html">skills</a>
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>
       <a href="https://github.com/me2resh/apexyard" class="is-cta" target="_blank" rel="noopener">github →</a>

--- a/site/skills.html
+++ b/site/skills.html
@@ -28,7 +28,7 @@
   --rule:        #1A1612;
   --rule-faint:  #B6AD9B;
   --mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
-  --max-w:  72rem;
+  --max-w:  1280px;
   --gutter: clamp(1.25rem, 4vw, 3rem);
 }
 

--- a/site/skills.html
+++ b/site/skills.html
@@ -280,6 +280,7 @@ main {
     </div>
     <nav class="titlebar__right" aria-label="Primary">
       <a href="index.html" class="always">home</a>
+      <a href="architecture.html">architecture</a>
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>
       <a href="https://github.com/me2resh/apexyard" class="is-cta" target="_blank" rel="noopener">github →</a>
     </nav>

--- a/site/skills.html
+++ b/site/skills.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8">
 <title>Skills — ApexYard</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content="The full ApexYard slash-command surface — 39 skills, what each one does, and how to invoke it.">
+<meta name="description" content="The full ApexYard slash-command surface — 48 skills, what each one does, and how to invoke it.">
 <meta property="og:title" content="ApexYard skills">
-<meta property="og:description" content="39 slash commands available in any apexyard-managed project. Run any of these in a Claude Code session inside your fork.">
+<meta property="og:description" content="48 slash commands available in any apexyard-managed project. Run any of these in a Claude Code session inside your fork.">
 <meta property="og:type" content="website">
 <style>
 /* ============================================================
@@ -88,52 +88,46 @@ a:hover { color: var(--accent); }
 
 .dim { color: var(--ink-faint); }
 
-/* titlebar — same shape as the homepage */
+/* titlebar — identical shape on every page */
 .titlebar {
   position: sticky;
   top: 0;
-  z-index: 5;
-  background: var(--paper-2);
+  z-index: 100;
+  background: var(--paper);
   border-bottom: 1px solid var(--rule);
+  padding: 0.75rem 0;
+  font-size: 12px;
 }
 .titlebar__inner {
   max-width: var(--max-w);
   margin: 0 auto;
-  padding: 0.6rem var(--gutter);
+  padding: 0 var(--gutter);
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 .titlebar__left { display: flex; align-items: center; gap: 0.65rem; }
 .titlebar__dots { display: inline-flex; gap: 0.35rem; }
 .titlebar__dot {
+  width: 11px; height: 11px;
+  border: 1px solid var(--rule);
   display: inline-block;
-  width: 0.6rem;
-  height: 0.6rem;
-  border: 1px solid var(--ink-faint);
 }
 .titlebar__dot.is-warn { background: var(--accent); border-color: var(--accent); }
-.titlebar__path {
-  font-size: 12.5px;
-  color: var(--ink-soft);
-  letter-spacing: 0.02em;
-}
-.titlebar__path b { color: var(--ink); font-weight: 600; }
-.titlebar__right {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 1.25rem;
-  font-size: 12px;
-  letter-spacing: 0.05em;
-  text-transform: lowercase;
-}
+.titlebar__path { color: var(--ink-soft); }
+.titlebar__path a { color: inherit; }
+.titlebar__path a:hover { color: var(--accent); }
+.titlebar__path b { color: var(--ink); font-weight: 700; }
+.titlebar__right { display: flex; gap: 1.25rem; align-items: center; font-size: 12px; }
 .titlebar__right a { color: var(--ink-faint); transition: color 0.15s ease; }
 .titlebar__right a:hover { color: var(--accent); }
+.titlebar__right a.is-current { color: var(--ink); border-bottom: 1px solid var(--accent); padding-bottom: 2px; pointer-events: none; }
 .titlebar__right a.is-cta {
+  border: 1px solid var(--rule);
+  padding: 0.35rem 0.75rem;
   color: var(--ink);
-  border: 1px solid var(--ink);
-  padding: 0.3rem 0.7rem;
 }
 .titlebar__right a.is-cta:hover { color: var(--accent); border-color: var(--accent); }
 @media (max-width: 720px) {
@@ -141,6 +135,65 @@ a:hover { color: var(--accent); }
   .titlebar__right a:not(.is-cta):not(.always) { display: none; }
   .titlebar__right a.always { display: inline; }
 }
+
+/* page header — shared shape with architecture.html */
+.page-header {
+  border-bottom: 1px solid var(--rule);
+  padding: clamp(2rem, 5vw, 3.5rem) 0 clamp(1.5rem, 3vw, 2.5rem);
+}
+.page-header__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+.page-header__eyebrow {
+  font-size: 12px;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.65rem;
+}
+.page-header__eyebrow .pill {
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  padding: 0.2rem 0.6rem;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  margin-right: 0.5rem;
+}
+.page-header h1 {
+  font-family: var(--mono);
+  font-weight: 800;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+  color: var(--ink);
+  margin-bottom: 0.65rem;
+}
+.page-header h1::after {
+  content: '_';
+  color: var(--accent);
+  animation: blink 1.1s steps(1, end) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+.page-header .tagline {
+  font-size: clamp(1rem, 1.6vw, 1.25rem);
+  color: var(--ink-soft);
+  max-width: 72ch;
+  line-height: 1.55;
+  margin-bottom: 0.5rem;
+}
+.page-header .meta {
+  font-size: 12px;
+  color: var(--ink-faint);
+  margin-top: 1.25rem;
+}
+.page-header .meta a {
+  color: var(--ink-soft);
+  border-bottom: 1px solid var(--rule-faint);
+  padding-bottom: 1px;
+}
+.page-header .meta a:hover { color: var(--accent); border-bottom-color: var(--accent); }
 
 /* main */
 main {
@@ -276,11 +329,11 @@ main {
         <span class="titlebar__dot"></span>
         <span class="titlebar__dot is-warn"></span>
       </span>
-      <span class="titlebar__path">~/<b>apexyard</b> <span class="dim">· skills</span></span>
+      <span class="titlebar__path">~/<a href="index.html"><b>apexyard</b></a> <span class="dim">· skills</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
-      <a href="index.html" class="always">home</a>
       <a href="architecture.html">architecture</a>
+      <a href="skills.html" class="is-current always">skills</a>
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>
       <a href="https://github.com/me2resh/apexyard" class="is-cta" target="_blank" rel="noopener">github →</a>
     </nav>
@@ -289,22 +342,38 @@ main {
 
 <main id="main">
 
-  <section class="intro">
-    <h1><span class="intro__count">39 skills</span>The apexyard slash-command surface</h1>
-    <p>Every skill ships in <code>.claude/skills/&lt;name&gt;/SKILL.md</code> and is invoked from a Claude Code session as <code>/&lt;name&gt;</code>. Some take arguments, some are self-driven. The framework's mechanical hooks (in <code>.claude/hooks/</code>) gate their effects on the rest of the SDLC — for example, <code>/approve-merge</code> writes a marker that <code>block-unreviewed-merge.sh</code> then verifies before the merge actually runs.</p>
-    <p>If you're new, start with <a href="#setup"><code>/setup</code></a> on a fresh fork, then <a href="#tickets"><code>/feature</code></a> or <a href="#tickets"><code>/idea</code></a> to capture work, then <a href="#review"><code>/code-review</code></a> + <a href="#review"><code>/approve-merge</code></a> when a PR is ready to ship.</p>
-    <nav class="toc" aria-label="Sections">
-      <a href="#setup">setup</a>
-      <a href="#daily">daily ops</a>
-      <a href="#tickets">tickets &amp; ideas</a>
-      <a href="#specs">specs &amp; decisions</a>
-      <a href="#review">review &amp; merge</a>
-      <a href="#architecture">architecture &amp; dev tools</a>
-      <a href="#audits">production-readiness audits</a>
-      <a href="#workflow">workflow primitives</a>
-      <a href="#comms">communications</a>
-      <a href="#deprecated">deprecated</a>
-    </nav>
+  <section class="page-header">
+    <div class="page-header__inner">
+      <div class="page-header__eyebrow">
+        <span class="pill">apexyard / skills</span>
+        <span>48 slash commands · invoke from any Claude Code session</span>
+      </div>
+      <h1>Skills</h1>
+      <p class="tagline">
+        Every skill ships in <code>.claude/skills/&lt;name&gt;/SKILL.md</code> and is invoked from a
+        Claude Code session as <code>/&lt;name&gt;</code>. Mechanical hooks in <code>.claude/hooks/</code>
+        gate their effects on the rest of the SDLC — <code>/approve-merge</code> writes a marker that
+        <code>block-unreviewed-merge.sh</code> then verifies before the merge actually runs.
+      </p>
+      <p class="meta">
+        New here? Start with <a href="#setup"><code>/setup</code></a> on a fresh fork, then
+        <a href="#tickets"><code>/feature</code></a> or <a href="#tickets"><code>/idea</code></a> to capture work,
+        then <a href="#review"><code>/code-review</code></a> + <a href="#review"><code>/approve-merge</code></a>
+        when a PR is ready to ship.
+      </p>
+      <nav class="toc" aria-label="Sections">
+        <a href="#setup">setup</a>
+        <a href="#daily">daily ops</a>
+        <a href="#tickets">tickets &amp; ideas</a>
+        <a href="#specs">specs &amp; decisions</a>
+        <a href="#review">review &amp; merge</a>
+        <a href="#architecture">architecture &amp; dev tools</a>
+        <a href="#audits">production-readiness audits</a>
+        <a href="#workflow">workflow primitives</a>
+        <a href="#comms">communications</a>
+        <a href="#deprecated">deprecated</a>
+      </nav>
+    </div>
   </section>
 
   <section class="section" id="setup">

--- a/site/skills.html
+++ b/site/skills.html
@@ -497,6 +497,30 @@ main {
       </header>
       <p class="skill__desc">File 5–20 structured GitHub Issues in one flow. Asks shared-context questions ONCE for the whole batch, then runs a 3-question micro-interview per ticket. Output conforms to <code>.ticket.required_sections</code> by construction.</p>
     </article>
+
+    <article class="skill">
+      <header class="skill__head">
+        <code class="skill__name">/spike</code>
+        <code class="skill__args">&lt;short title&gt;</code>
+      </header>
+      <p class="skill__desc">Create a hypothesis-driven, time-boxed, throw-away spike ticket — Hypothesis, Budget, Kill Criteria, Disposition. Spike PRs are exempt from the AgDR + 80% coverage gates; Rex + security auditor still apply.</p>
+    </article>
+
+    <article class="skill">
+      <header class="skill__head">
+        <code class="skill__name">/spike-close</code>
+        <code class="skill__args">&lt;ticket&gt; --promote | --discard</code>
+      </header>
+      <p class="skill__desc">Disposition gate for spikes. <code>--promote</code> files a follow-up <code>[Feature]</code> ticket with cross-references; <code>--discard</code> writes a memo to <code>docs/spike-memos/&lt;slug&gt;.md</code>. Closing without running this gate leaves no record of what was learned.</p>
+    </article>
+
+    <article class="skill">
+      <header class="skill__head">
+        <code class="skill__name">/investigation</code>
+        <code class="skill__args">&lt;short title&gt;</code>
+      </header>
+      <p class="skill__desc">Create a structured investigation ticket + live-doc for sustained root-cause work — incident retros, bug archaeology, regression hunts, performance mysteries, competitive analyses. Distinct from <code>/spike</code> (forward-looking hypothesis with a budget) and <code>/bug</code> (immediate-fix). Closes when every follow-up action lands, not on PR merge.</p>
+    </article>
   </section>
 
   <section class="section" id="specs">
@@ -517,6 +541,14 @@ main {
         <code class="skill__args">&lt;what you're deciding&gt;</code>
       </header>
       <p class="skill__desc">Make a technical decision with structured reasoning, creating an Agent Decision Record (AgDR). Use when choosing between libraries, frameworks, implementation approaches, or architectural patterns.</p>
+    </article>
+
+    <article class="skill">
+      <header class="skill__head">
+        <code class="skill__name">/agdr</code>
+        <code class="skill__args">browse | search &lt;term&gt; | show &lt;id&gt; | stats</code>
+      </header>
+      <p class="skill__desc">Searchable, categorised library of Agent Decision Records across the portfolio. Walks the registry, reads each project's <code>docs/agdr/*.md</code>, parses YAML frontmatter, answers "have we decided this before?" without grepping every project.</p>
     </article>
   </section>
 
@@ -583,6 +615,46 @@ main {
         <code class="skill__args">[symptom summary]</code>
       </header>
       <p class="skill__desc">Structured hypothesis-driven debugging for issues whose cause isn't immediately obvious. Forces architecture-first reading and evidence-before-fix to prevent ad-hoc patching loops. Invoke when a bug has resisted one or more naïve fix attempts.</p>
+    </article>
+
+    <article class="skill">
+      <header class="skill__head">
+        <code class="skill__name">/dfd</code>
+        <code class="skill__args">[project-name | . | --scope-all] [--format=mermaid|dragon|all]</code>
+      </header>
+      <p class="skill__desc">Extract a Data Flow Diagram from a codebase with trust boundaries and data classifications. Writes Mermaid markdown (renders on GitHub) as the canonical source-of-truth that <code>/threat-model</code> and <code>/compliance-check</code> consume. OWASP Threat Dragon v2 JSON available via <code>--format=dragon</code>.</p>
+    </article>
+
+    <article class="skill">
+      <header class="skill__head">
+        <code class="skill__name">/process</code>
+        <code class="skill__args">&lt;process-slug&gt; [--from-endpoint METHOD /path] [--from-machine ClassName] [--scope dir/]</code>
+      </header>
+      <p class="skill__desc">Extract the business process actually implemented by one or more registered repos (state machines, queue chains, cron, state-column transitions, API choreography, existing BPMN, documented steps), interview only on the gaps, then emit a lint-clean BPMN 2.0 file that opens in Camunda Modeler.</p>
+    </article>
+
+    <article class="skill">
+      <header class="skill__head">
+        <code class="skill__name">/tech-vision</code>
+        <code class="skill__args">[project-slug | . | --framework]</code>
+      </header>
+      <p class="skill__desc">Interactive section-by-section author for the technical / architecture vision template — Scope, Principles, Target-state, Current-vs-Target gap table, multi-quarter Migration path, explicit Anti-scope, Review cadence. Writes <code>projects/&lt;name&gt;/architecture/vision.md</code>.</p>
+    </article>
+
+    <article class="skill">
+      <header class="skill__head">
+        <code class="skill__name">/journey</code>
+        <code class="skill__args">&lt;feature-slug&gt; [--from-prd &lt;path&gt;]</code>
+      </header>
+      <p class="skill__desc">Generate a single self-contained HTML user-journey map — boxes-and-arrows graph with a clickable modal per page. Sits between PRD and tech-design as a "preview before build" artifact, surfacing flow-level logic gaps before any implementation begins.</p>
+    </article>
+
+    <article class="skill">
+      <header class="skill__head">
+        <code class="skill__name">/extract-features</code>
+        <code class="skill__args">[project-name | .]</code>
+      </header>
+      <p class="skill__desc">Scan an existing codebase and produce a structured Feature Inventory — six discovery axes (HTTP routes, data models, async jobs, test names, UI screens, documented features) consolidated into a "what we must preserve" specification suitable for a greenfield rewrite.</p>
     </article>
   </section>
 
@@ -724,7 +796,7 @@ main {
   </section>
 
   <footer class="footer">
-    <a href="index.html">← apexyard.dev</a>
+    <a href="index.html">← yard.apexscript.com</a>
     <a href="https://github.com/me2resh/apexyard" target="_blank" rel="noopener">github</a>
     <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog</a>
     <a href="https://github.com/me2resh/apexyard/tree/main/.claude/skills" target="_blank" rel="noopener">skill source</a>


### PR DESCRIPTION
## Summary

Adds a dedicated **Architecture** page to the marketing site, showing the canonical 5-layer mental model — governance, capability, framework defaults, customisation overlay, per-project data — plus the optional split-portfolio sibling private repo.

Source diagram: operator-authored keynote SVG at `apexyard-A-keynote.html` (local, not in the repo). The substantive design work here is the **palette + style translation** from the keynote's SF Pro / pastel aesthetic to the site's terminal-native brutalism. Information density preserved; visual language re-skinned.

## What the diagram now does (vs the keynote)

| Aspect | Keynote SVG (source) | Site palette (this PR) |
|---|---|---|
| Layer encoding | Pastel chroma (blue / green / amber / pink / purple) | Cream-paper tonal contrast (`--paper-2` and `--paper-3`) — preserves grouping without chroma |
| Customisation arrows | Pink stroke `#db2777` | `--accent` red `#C8321A` — preserves "override" semantic |
| Borders | Coloured per-layer | `--rule` (ink) for static layers; `--accent` for customisation; dashed `--ink-soft` for the optional sibling repo |
| Corners | `rx="10"` rounded | Sharp (`rx="0"`) — brutalist convention |
| Shadows | `feDropShadow` filter | Removed — flat, no depth illusions |
| Typeface | SF Pro / system-sans | JetBrains Mono throughout (site convention) |
| Box icons | Emoji (📋 ⚙️ 📜 …) | Bracketed mono tokens (`[*]` `[~]` `[=]`) — survives copy/paste, fits the typeface |

The 5-layer + sibling-repo information is fully preserved. Operators reading the diagram can still tell governance from customisation; the encoding is now tonal + accent-bordered instead of chromatic.

## Stale counts updated against the live tree

| | Keynote said | Live tree | Updated to |
|---|---|---|---|
| Hooks | 24 shell gates | `ls .claude/hooks/*.sh \| wc -l` → 26 | **26** |
| Skills | 43+ slash commands | `ls -d .claude/skills/*/ \| wc -l` → 48 | **48** |
| Rules | 11 files | 11 (unchanged) | 11 |
| Agents | "Specialised sub-agents" (no count) | 5 | **5** |

## Nav integration

- `site/index.html` titlebar: `quickstart · walkthroughs · what's in the box · **architecture** · skills · changelog · github`
- `site/skills.html` titlebar: `home · **architecture** · changelog · github`
- `site/architecture.html` titlebar: `home · skills · changelog · github`

So the architecture page is discoverable from both other site pages, and links back to both.

## Testing

- [x] Page opens at `site/architecture.html` (verified by `open -a Safari`)
- [x] SVG `viewBox="0 0 1920 1080"` scales correctly inside the `.diagram-stage` container; `min-width: 1000px` prevents label collapse on narrow viewports (horizontal scroll instead)
- [x] Nav links from `site/index.html` and `site/skills.html` resolve to the new page
- [x] `prefers-color-scheme: dark` palette swap applies (verified via `:root` overrides — same as homepage)
- [ ] Operator visual review — does the cream + ink + red translation feel native to the site? (file local at `site/architecture.html`)

## Out of scope (deferred)

- **Dark-mode SVG palette swap.** The CSS-level dark mode swaps `--paper` / `--ink` / `--accent`, but the SVG uses **hardcoded hex** values for `fill` / `stroke` (necessary for the SVG to render outside the page when right-clicked → Save Image As). A future iteration could `@media (prefers-color-scheme: dark)` swap the SVG via CSS `currentColor` + classes, at the cost of the SVG no longer being self-contained. v1 stays light-mode-rendered for shareability.
- **Animation.** The homepage has the blinking cursor `_` after the H1; this page inherits it. The diagram itself is static — no entry-animation, no hover affordances. Right shape for a printable / shareable artefact.
- **Per-card click-throughs.** The diagram is illustrative, not interactive. If individual cards link to deeper docs (`hooks/` → rules page, `skills/` → skills.html), that's a v1.x follow-up — a separate ticket.

Closes #271.

## Glossary

| Term | Definition |
|------|------------|
| 5-layer model | The canonical mental model for an ApexYard fork: governance / capability / framework defaults / customisation overlay / per-project data |
| Customisation overlay | The path-mirrored `custom-templates/`, `custom-skills/`, `custom-handbooks/` trees that override or layer onto framework defaults |
| Sibling private repo | Optional split-portfolio v2 pattern — a second private GitHub repo holding the registry, onboarding, projects/, workspace/, and customisation overlay for adopters who can't make their public fork private |
| Terminal-native brutalism | The site's design language — JetBrains Mono only, cream paper, single warning-red accent, sharp corners, no shadows |
| Override semantic | The visual cue (red border + arrow) on customisation cards in the diagram — communicates "this wins over the framework default" |