### PR TITLE
feat(#268): skill-gated ticket-create hook (multi-tracker)

### DIFF
--- a/.claude/hooks/clear-issue-skill-marker.sh
+++ b/.claude/hooks/clear-issue-skill-marker.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SessionStart hook: clear any stale ticket-skill marker from a previous
+# session.
+#
+# The marker at .claude/session/active-issue-skill signals to
+# require-skill-for-issue-create.sh that a structured ticket-creating skill
+# (/task, /feature, /bug, /spike, /migration, /investigation, /idea) is in
+# progress and that raw ticket-create CLI calls should be allowed through.
+# Skills are responsible for writing the marker on entry and removing it on
+# completion — but if a skill is interrupted (terminal closed, agent killed,
+# network failure), the marker can be left behind, silently exempting the
+# next session from the skill-gate.
+#
+# This hook runs at SessionStart and removes the marker if present. If the
+# user is genuinely resuming a ticket skill, they re-invoke it and the skill
+# writes the marker again.
+#
+# Mirror of clear-bootstrap-marker.sh. See AgDR-0030 and me2resh/apexyard#268.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT=""
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  ROOT=$(resolve_ops_root "$REPO_ROOT")
+else
+  cur="$REPO_ROOT"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/.apexyard-fork" ]; then
+      ROOT="$cur"
+      break
+    fi
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      ROOT="$cur"
+      break
+    fi
+    cur=$(dirname "$cur")
+  done
+fi
+
+if [ -z "$ROOT" ]; then
+  exit 0
+fi
+
+MARKER="$ROOT/.claude/session/active-issue-skill"
+if [ -f "$MARKER" ]; then
+  stale_skill=$(tr -d '[:space:]' < "$MARKER" 2>/dev/null || echo "(unreadable)")
+  rm -f "$MARKER"
+  echo "ApexYard: cleared stale ticket-skill marker (was: $stale_skill) from a previous session." >&2
+fi
+
+exit 0

--- a/.claude/hooks/require-skill-for-issue-create.sh
+++ b/.claude/hooks/require-skill-for-issue-create.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# require-skill-for-issue-create.sh — block raw ticket-creation CLIs unless
+# invoked from inside one of the structured ticket skills (/task, /feature,
+# /bug, /spike, /migration, /investigation, /idea).
+#
+# Wired as PreToolUse:Bash. Reads stdin as the Claude Code hook JSON payload.
+# Tracker-agnostic by construction: only the matcher list knows about specific
+# CLIs (`gh issue create`, `gh api repos/.../issues`, `linear issue create`,
+# `jira issue create`, `asana task create`, etc.), and the list is sourced
+# from `.claude/project-config.defaults.json` → `ticket.create_command_patterns`
+# (adopters extend via `.claude/project-config.json` shallow-merge).
+#
+# Resolution:
+#   1. If the command does not match any configured pattern → exit 0 (no-op).
+#   2. If the bootstrap-skill marker (.claude/session/active-bootstrap) is
+#      present AND the active skill is on the bootstrap_skills list → exit 0.
+#      (Keeps `/handover` and friends able to file their bookkeeping tickets.)
+#   3. If the ticket-skill marker (.claude/session/active-issue-skill) is
+#      present → exit 0 (a structured skill is in flight).
+#   4. If APEXYARD_ALLOW_RAW_TICKET_CREATE=1 → exit 0 with a stderr warning.
+#   5. Otherwise → BLOCK with a clear message naming the 7 skill alternatives.
+#
+# See AgDR-0030 and me2resh/apexyard#268.
+
+set -u
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Discover ops root (mirror of clear-bootstrap-marker.sh / require-active-ticket.sh).
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+OPS_ROOT=""
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  OPS_ROOT=$(resolve_ops_root "${REPO_ROOT:-$PWD}")
+else
+  cur="${REPO_ROOT:-$PWD}"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/.apexyard-fork" ]; then OPS_ROOT="$cur"; break; fi
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      OPS_ROOT="$cur"; break
+    fi
+    cur=$(dirname "$cur")
+  done
+fi
+MARKER_HOME="${OPS_ROOT:-${REPO_ROOT:-.}}"
+
+# Read the configured matcher list. Patterns are substrings; if no patterns
+# are configured (no defaults file, jq missing), the hook is a no-op.
+PATTERNS=""
+if [ -f "$HOOK_DIR/_lib-read-config.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-read-config.sh"
+  if command -v config_get >/dev/null 2>&1; then
+    PATTERNS=$(config_get '.ticket.create_command_patterns[]' 2>/dev/null)
+  fi
+fi
+if [ -z "$PATTERNS" ]; then
+  exit 0
+fi
+
+# Normalise the command for matching: collapse whitespace.
+NORM_CMD=$(echo "$COMMAND" | tr -s '[:space:]' ' ')
+
+# Match patterns at a COMMAND BOUNDARY only — at the start of the line,
+# or immediately after a shell command separator (`;`, `&&`, `||`, `|`).
+# Substring-anywhere matching false-positives on commit messages or
+# scripts that mention the pattern in prose, e.g.
+# `git commit -m "...mentions gh issue create..."`.
+MATCHED=""
+while IFS= read -r pat; do
+  [ -z "$pat" ] && continue
+  case "$NORM_CMD" in
+    "$pat"*|*"; $pat"*|*"&& $pat"*|*"|| $pat"*|*"| $pat"*)
+      MATCHED="$pat"; break ;;
+  esac
+done <<EOF
+$PATTERNS
+EOF
+
+if [ -z "$MATCHED" ]; then
+  exit 0
+fi
+
+# Bootstrap-skill exemption — same shape as require-active-ticket.sh.
+BOOTSTRAP_MARKER="$MARKER_HOME/.claude/session/active-bootstrap"
+if [ -f "$BOOTSTRAP_MARKER" ]; then
+  active_bootstrap=$(tr -d '[:space:]' < "$BOOTSTRAP_MARKER" 2>/dev/null)
+  if [ -n "$active_bootstrap" ] && command -v config_get >/dev/null 2>&1; then
+    if config_get '.ticket.bootstrap_skills[]' 2>/dev/null | grep -qwF "$active_bootstrap"; then
+      exit 0
+    fi
+  fi
+fi
+
+# Ticket-skill marker — a structured skill is in flight.
+SKILL_MARKER="$MARKER_HOME/.claude/session/active-issue-skill"
+if [ -f "$SKILL_MARKER" ]; then
+  active_skill=$(tr -d '[:space:]' < "$SKILL_MARKER" 2>/dev/null)
+  if [ -n "$active_skill" ]; then
+    exit 0
+  fi
+fi
+
+# Env-var escape hatch.
+if [ "${APEXYARD_ALLOW_RAW_TICKET_CREATE:-0}" = "1" ]; then
+  echo "WARN: APEXYARD_ALLOW_RAW_TICKET_CREATE=1 — bypassing skill-gated ticket-create hook (matched pattern: '$MATCHED')." >&2
+  exit 0
+fi
+
+cat >&2 <<MSG
+BLOCKED: Raw ticket-create CLI detected (matched pattern: "$MATCHED").
+
+ApexYard requires that every ticket be filed through a structured skill so it
+conforms to the skill's contract (driver/scope/AC for /task; user story/AC for
+/feature; etc.). Re-run via one of:
+
+  /feature        — user-facing feature (user story + acceptance criteria)
+  /bug            — bug report (Given/When/Then + repro + severity)
+  /task           — technical task (driver + scope + acceptance criteria)
+  /spike          — hypothesis-driven, time-boxed exploration
+  /migration      — DB / schema migration ticket + migration AgDR
+  /investigation  — sustained root-cause investigation (live-doc workflow)
+  /idea           — new product idea (added to the ideas backlog)
+
+If you genuinely need to bypass the gate (recovery scenario, broken skill,
+emergency ticket), re-run with the env-var escape hatch:
+
+  APEXYARD_ALLOW_RAW_TICKET_CREATE=1 <your command>
+
+To extend the matcher list for a different tracker (Linear, Jira, Asana,
+custom), add patterns under .claude/project-config.json →
+ticket.create_command_patterns (shallow-merges with defaults).
+
+See AgDR-0030-skill-gated-ticket-create.md and me2resh/apexyard#268.
+MSG
+exit 2

--- a/.claude/hooks/tests/test_require_skill_for_issue_create.sh
+++ b/.claude/hooks/tests/test_require_skill_for_issue_create.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# Tests for require-skill-for-issue-create.sh (me2resh/apexyard#268, AgDR-0030).
+#
+# Mirrors the sandbox shape of test_require_active_ticket_bash.sh:
+#   - per-case sandbox with onboarding.yaml + empty registry + hook + libs
+#   - synthetic PreToolUse Bash JSON via jq
+#   - assert exit code and (optionally) stderr regex
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/require-skill-for-issue-create.sh"
+LIB_OPS="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
+LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+
+for f in "$HOOK_SRC" "$LIB_CFG" "$DEFAULTS"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: required source missing: $f" >&2
+    exit 1
+  fi
+done
+# _lib-ops-root.sh is optional — the hook has an inline fallback walk.
+HAVE_LIB_OPS=0
+[ -f "$LIB_OPS" ] && HAVE_LIB_OPS=1
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    : > onboarding.yaml
+    : > apexyard.projects.yaml
+    git add onboarding.yaml apexyard.projects.yaml
+    git commit -q -m "init"
+  )
+  mkdir -p "$sb/.claude/hooks" "$sb/.claude/session"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/require-skill-for-issue-create.sh"
+  [ "$HAVE_LIB_OPS" = "1" ] && cp "$LIB_OPS" "$sb/.claude/hooks/_lib-ops-root.sh"
+  cp "$LIB_CFG" "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$DEFAULTS" "$sb/.claude/project-config.defaults.json"
+  chmod +x "$sb/.claude/hooks/require-skill-for-issue-create.sh"
+  echo "$sb"
+}
+
+run_case() {
+  local label="$1" want_rc="$2" want_stderr_regex="$3" input="$4" sb="$5" env_var="${6:-}"
+  local got_stderr got_rc
+  if [ -n "$env_var" ]; then
+    got_stderr=$(cd "$sb" && echo "$input" | env "$env_var" bash .claude/hooks/require-skill-for-issue-create.sh 2>&1 >/dev/null)
+  else
+    got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/require-skill-for-issue-create.sh 2>&1 >/dev/null)
+  fi
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:200})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# --- Marker absent → BLOCK on each default matcher --------------------------
+
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "gh issue create --repo foo/bar --title x --body y" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "gh issue create blocked w/o marker" 2 "BLOCKED" "$in" "$sb"
+
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "gh api repos/foo/bar/issues -f title=x -f body=y" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "gh api repos/.../issues blocked w/o marker" 2 "BLOCKED" "$in" "$sb"
+
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "linear issue create --title x" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "linear issue create blocked w/o marker" 2 "BLOCKED" "$in" "$sb"
+
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "jira issue create --summary x" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "jira issue create blocked w/o marker" 2 "BLOCKED" "$in" "$sb"
+
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "asana task create --name x" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "asana task create blocked w/o marker" 2 "BLOCKED" "$in" "$sb"
+
+# --- Marker present → ALLOW on each default matcher ------------------------
+
+sb=$(make_sandbox); echo "feature" > "$sb/.claude/session/active-issue-skill"
+in=$(jq -nc --arg c "gh issue create --repo foo/bar --title x" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "gh issue create allowed with skill marker" 0 "" "$in" "$sb"
+
+sb=$(make_sandbox); echo "task" > "$sb/.claude/session/active-issue-skill"
+in=$(jq -nc --arg c "gh api repos/foo/bar/issues -f title=x" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "gh api allowed with skill marker" 0 "" "$in" "$sb"
+
+sb=$(make_sandbox); echo "bug" > "$sb/.claude/session/active-issue-skill"
+in=$(jq -nc --arg c "linear issue create --title x" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "linear allowed with skill marker" 0 "" "$in" "$sb"
+
+# --- Non-matching commands → no-op -----------------------------------------
+
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "gh issue view 42" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "gh issue view is no-op" 0 "" "$in" "$sb"
+
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo hello world" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "echo is no-op" 0 "" "$in" "$sb"
+
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "ls -la" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "ls is no-op" 0 "" "$in" "$sb"
+
+# --- Non-Bash tools → no-op ------------------------------------------------
+
+sb=$(make_sandbox)
+in=$(jq -nc --arg p "/tmp/foo" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "Edit tool is no-op" 0 "" "$in" "$sb"
+
+# --- Bootstrap-skill exemption ---------------------------------------------
+
+sb=$(make_sandbox); echo "handover" > "$sb/.claude/session/active-bootstrap"
+in=$(jq -nc --arg c "gh issue create --repo foo/bar --title x" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "gh issue create allowed during handover bootstrap" 0 "" "$in" "$sb"
+
+sb=$(make_sandbox); echo "setup" > "$sb/.claude/session/active-bootstrap"
+in=$(jq -nc --arg c "gh issue create --repo foo/bar --title x" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "gh issue create allowed during setup bootstrap" 0 "" "$in" "$sb"
+
+# An UNLISTED bootstrap skill should NOT grant the exemption — blocked.
+sb=$(make_sandbox); echo "some-random-skill" > "$sb/.claude/session/active-bootstrap"
+in=$(jq -nc --arg c "gh issue create --repo foo/bar --title x" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "gh issue create blocked when bootstrap marker is non-listed" 2 "BLOCKED" "$in" "$sb"
+
+# --- Env-var escape hatch --------------------------------------------------
+
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "gh issue create --repo foo/bar --title x" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "env-var escape hatch allows with warning" 0 "APEXYARD_ALLOW_RAW_TICKET_CREATE=1" "$in" "$sb" "APEXYARD_ALLOW_RAW_TICKET_CREATE=1"
+
+# --- Custom matcher via project-config override -----------------------------
+
+sb=$(make_sandbox)
+cat > "$sb/.claude/project-config.json" <<'JSON'
+{
+  "ticket": {
+    "bootstrap_skills": ["setup", "handover", "update", "split-portfolio"],
+    "create_command_patterns": [
+      "gh issue create",
+      "mycorp-tracker new"
+    ]
+  }
+}
+JSON
+in=$(jq -nc --arg c "mycorp-tracker new --title x" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "custom matcher 'mycorp-tracker new' enforced" 2 "BLOCKED" "$in" "$sb"
+
+# --- Empty marker → no exemption (treated as no marker) --------------------
+
+sb=$(make_sandbox); : > "$sb/.claude/session/active-issue-skill"
+in=$(jq -nc --arg c "gh issue create --repo foo/bar --title x" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "empty skill marker → blocked" 2 "BLOCKED" "$in" "$sb"
+
+# --- Summary --------------------------------------------------------------
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -33,6 +33,15 @@
       "handover",
       "update",
       "split-portfolio"
+    ],
+    "_create_command_patterns_comment": "Raw ticket-create CLI shapes that require-skill-for-issue-create.sh blocks unless a structured ticket skill (/task, /feature, /bug, /spike, /migration, /investigation, /idea) is in flight (marker at .claude/session/active-issue-skill). Tracker-agnostic: extend this list in .claude/project-config.json for Linear, Jira, Asana, or custom trackers. Patterns are matched as substrings of the (whitespace-collapsed) bash command. See AgDR-0030 and me2resh/apexyard#268.",
+    "create_command_patterns": [
+      "gh issue create",
+      "gh api repos/",
+      "linear issue create",
+      "jira issue create",
+      "jira create",
+      "asana task create"
     ]
   },
 

--- a/.claude/rules/ticket-vocabulary.md
+++ b/.claude/rules/ticket-vocabulary.md
@@ -107,6 +107,7 @@ This rule is primarily self-discipline. It is also backed up by two mechanical h
 |------|-------|-----------------|
 | `validate-pr-create.sh` | `PreToolUse` on `gh pr create` | PR titles that reference an issue number which doesn't exist in the tracker repo |
 | `verify-commit-refs.sh` | `PreToolUse` on `git commit -m / -F` | Commit messages with `Closes #N` / `Refs #N` / `Fixes #N` / `Resolves #N` pointing at issues that don't exist |
+| `require-skill-for-issue-create.sh` (#268) | `PreToolUse` on `Bash` | Raw ticket-create CLI calls (`gh issue create`, `gh api repos/...`, `linear issue create`, `jira issue create`, `asana task create`, custom) that bypass the structured skills (`/task`, `/feature`, `/bug`, `/spike`, `/migration`, `/investigation`, `/idea`). Tracker-agnostic — extend the matcher list via `.claude/project-config.json → ticket.create_command_patterns` for Linear, Jira, Asana, or your own tracker. Operator escape hatch: `APEXYARD_ALLOW_RAW_TICKET_CREATE=1`. See AgDR-0030. |
 
 Both hooks block at the moment the fabricated reference would be committed to a durable artifact (PR title, commit message). They cannot see conversation prose — that's why the rule comes first and the hooks are labeled **backstops**, not the primary fix.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,10 @@
           },
           {
             "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/clear-issue-skill-marker.sh\"'"
+          },
+          {
+            "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ ! -f \"$r/.apexyard-fork\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/link-custom-skills.sh\"'"
           }
         ]
@@ -87,6 +91,10 @@
             "type": "command",
             "if": "Bash(git push *)",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/pre-push-gate.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-skill-for-issue-create.sh\"'"
           },
           {
             "type": "command",

--- a/.claude/skills/bug/SKILL.md
+++ b/.claude/skills/bug/SKILL.md
@@ -31,6 +31,24 @@ Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projec
 
 ## Process
 
+### 0. Write the active-issue-skill marker (REQUIRED — me2resh/apexyard#268)
+
+Before any `gh issue create` (or other tracker CLI), write this skill's name to the active-issue-skill marker so `require-skill-for-issue-create.sh` lets the command through. At skill entry:
+
+```bash
+ops_root="$(r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;echo $r)"
+mkdir -p "$ops_root/.claude/session"
+echo "bug" > "$ops_root/.claude/session/active-issue-skill"
+```
+
+Remove the marker on **every** exit path (success, early-exit, user cancel, error):
+
+```bash
+rm -f "$ops_root/.claude/session/active-issue-skill"
+```
+
+The `clear-issue-skill-marker.sh` SessionStart hook sweeps stale markers from killed sessions, but a clean exit should never leave one behind. See AgDR-0030.
+
 ### 1. Resolve the target repo
 
 Read `.claude/session/current-ticket` to determine which repo we're working in. If no active ticket, check `apexyard.projects.yaml` for managed projects. If only one project, use it. If multiple, ask:

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -31,6 +31,24 @@ Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projec
 
 ## Process
 
+### 0. Write the active-issue-skill marker (REQUIRED — me2resh/apexyard#268)
+
+Before any `gh issue create` (or other tracker CLI), write this skill's name to the active-issue-skill marker so `require-skill-for-issue-create.sh` lets the command through. At skill entry:
+
+```bash
+ops_root="$(r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;echo $r)"
+mkdir -p "$ops_root/.claude/session"
+echo "feature" > "$ops_root/.claude/session/active-issue-skill"
+```
+
+Remove the marker on **every** exit path (success, early-exit, user cancel, error):
+
+```bash
+rm -f "$ops_root/.claude/session/active-issue-skill"
+```
+
+The `clear-issue-skill-marker.sh` SessionStart hook sweeps stale markers from killed sessions, but a clean exit should never leave one behind. See AgDR-0030.
+
 ### 1. Resolve the target repo
 
 Read `.claude/session/current-ticket` to determine which repo we're working in. If no active ticket, check `apexyard.projects.yaml` for managed projects. If only one project, use it. If multiple, ask:

--- a/.claude/skills/idea/SKILL.md
+++ b/.claude/skills/idea/SKILL.md
@@ -37,6 +37,24 @@ If the file doesn't exist yet, create it with a header and a table.
 
 ## Process
 
+### 0. Write the active-issue-skill marker (REQUIRED — me2resh/apexyard#268)
+
+Before any `gh issue create` (or other tracker CLI), write this skill's name to the active-issue-skill marker so `require-skill-for-issue-create.sh` lets the command through. At skill entry:
+
+```bash
+ops_root="$(r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;echo $r)"
+mkdir -p "$ops_root/.claude/session"
+echo "idea" > "$ops_root/.claude/session/active-issue-skill"
+```
+
+Remove the marker on **every** exit path (success, early-exit, user cancel, error):
+
+```bash
+rm -f "$ops_root/.claude/session/active-issue-skill"
+```
+
+The `clear-issue-skill-marker.sh` SessionStart hook sweeps stale markers from killed sessions, but a clean exit should never leave one behind. See AgDR-0030.
+
 ### 1. Parse the title
 
 Take the title from `$ARGUMENTS`. If empty, ask:

--- a/.claude/skills/investigation/SKILL.md
+++ b/.claude/skills/investigation/SKILL.md
@@ -34,6 +34,24 @@ Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projec
 
 ## Process
 
+### 0. Write the active-issue-skill marker (REQUIRED — me2resh/apexyard#268)
+
+Before any `gh issue create` (or other tracker CLI), write this skill's name to the active-issue-skill marker so `require-skill-for-issue-create.sh` lets the command through. At skill entry:
+
+```bash
+ops_root="$(r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;echo $r)"
+mkdir -p "$ops_root/.claude/session"
+echo "investigation" > "$ops_root/.claude/session/active-issue-skill"
+```
+
+Remove the marker on **every** exit path (success, early-exit, user cancel, error):
+
+```bash
+rm -f "$ops_root/.claude/session/active-issue-skill"
+```
+
+The `clear-issue-skill-marker.sh` SessionStart hook sweeps stale markers from killed sessions, but a clean exit should never leave one behind. See AgDR-0030.
+
 ### 1. Resolve the target project
 
 Read `.claude/session/current-ticket` to determine the active project context. Then:

--- a/.claude/skills/migration/SKILL.md
+++ b/.claude/skills/migration/SKILL.md
@@ -44,6 +44,24 @@ Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projec
 
 ## Process
 
+### 0. Write the active-issue-skill marker (REQUIRED — me2resh/apexyard#268)
+
+Before any `gh issue create` (or other tracker CLI), write this skill's name to the active-issue-skill marker so `require-skill-for-issue-create.sh` lets the command through. At skill entry:
+
+```bash
+ops_root="$(r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;echo $r)"
+mkdir -p "$ops_root/.claude/session"
+echo "migration" > "$ops_root/.claude/session/active-issue-skill"
+```
+
+Remove the marker on **every** exit path (success, early-exit, user cancel, error):
+
+```bash
+rm -f "$ops_root/.claude/session/active-issue-skill"
+```
+
+The `clear-issue-skill-marker.sh` SessionStart hook sweeps stale markers from killed sessions, but a clean exit should never leave one behind. See AgDR-0030.
+
 ### 1. Resolve the target project
 
 If the user passed `<project>`, use that. Otherwise:

--- a/.claude/skills/spike/SKILL.md
+++ b/.claude/skills/spike/SKILL.md
@@ -33,6 +33,24 @@ Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projec
 
 ## Process
 
+### 0. Write the active-issue-skill marker (REQUIRED — me2resh/apexyard#268)
+
+Before any `gh issue create` (or other tracker CLI), write this skill's name to the active-issue-skill marker so `require-skill-for-issue-create.sh` lets the command through. At skill entry:
+
+```bash
+ops_root="$(r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;echo $r)"
+mkdir -p "$ops_root/.claude/session"
+echo "spike" > "$ops_root/.claude/session/active-issue-skill"
+```
+
+Remove the marker on **every** exit path (success, early-exit, user cancel, error):
+
+```bash
+rm -f "$ops_root/.claude/session/active-issue-skill"
+```
+
+The `clear-issue-skill-marker.sh` SessionStart hook sweeps stale markers from killed sessions, but a clean exit should never leave one behind. See AgDR-0030.
+
 ### 1. Resolve the target repo
 
 Read `.claude/session/current-ticket` to determine which repo we're working in. If no active ticket, check `apexyard.projects.yaml` for managed projects. If only one project, use it. If multiple, ask:

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -31,6 +31,24 @@ Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projec
 
 ## Process
 
+### 0. Write the active-issue-skill marker (REQUIRED — me2resh/apexyard#268)
+
+Before any `gh issue create` (or other tracker CLI), write this skill's name to the active-issue-skill marker so `require-skill-for-issue-create.sh` lets the command through. At skill entry:
+
+```bash
+ops_root="$(r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;echo $r)"
+mkdir -p "$ops_root/.claude/session"
+echo "task" > "$ops_root/.claude/session/active-issue-skill"
+```
+
+Remove the marker on **every** exit path (success, early-exit, user cancel, error):
+
+```bash
+rm -f "$ops_root/.claude/session/active-issue-skill"
+```
+
+The `clear-issue-skill-marker.sh` SessionStart hook sweeps stale markers from killed sessions, but a clean exit should never leave one behind. See AgDR-0030.
+
 ### 1. Resolve the target repo
 
 Read `.claude/session/current-ticket` to determine which repo we're working in. If no active ticket, check `apexyard.projects.yaml` for managed projects. If only one project, use it. If multiple, ask:

--- a/docs/agdr/AgDR-0030-skill-gated-ticket-create.md
+++ b/docs/agdr/AgDR-0030-skill-gated-ticket-create.md
@@ -1,0 +1,65 @@
+---
+status: accepted
+date: 2026-05-17
+deciders: framework maintainer
+related: me2resh/apexyard#268, AgDR-0011-bootstrap-skill-exemption.md
+---
+
+# AgDR-0030 — Skill-gated ticket-create (multi-tracker)
+
+> In the context of agents silently bypassing the structured ticket skills (`/task`, `/feature`, `/bug`, `/spike`, `/migration`, `/investigation`, `/idea`) by calling raw `gh issue create` (and parallel CLIs on Linear / Jira / Asana / etc.), facing the risk that ad-hoc tickets ship without the interview the skill's contract enforces (driver/scope/AC, user story/AC, Given/When/Then, hypothesis/budget/kill-criteria, etc.), I decided to add a `PreToolUse:Bash` hook that blocks raw ticket-create CLIs unless a skill-marker is in flight, with the matcher list config-driven so adopters extend it for non-GitHub trackers without code changes, to achieve "every ticket conforms to its skill's contract by construction", accepting the cost of one extra hook in the chain plus the operator-managed marker lifecycle inside the seven ticket skills.
+
+## Context
+
+`validate-issue-structure.sh` (#192) catches *missing prefix / missing sections* in already-drafted ticket bodies. It does **not** catch the upstream failure: the agent skipped the structured-skill interview entirely and drafted a body free-hand. me2resh/apexyard#265 and #266 were both filed via raw `gh issue create` because the interactive skills "felt heavy for context the operator had already provided" — exactly the silent-bypass-for-throughput failure mode the [Invoke matching skills](MEMORY) feedback was meant to prevent.
+
+The framework is also multi-tracker by design. Per `docs/multi-project.md` § FAQ ("Can I use this with Linear / Jira / etc.?"), adopters set per-project `ticket_prefix` and may use Linear, Jira, Asana, or another tracker. The gate must not bake `gh`/GitHub in as the only CLI shape.
+
+The bootstrap-skill exemption (AgDR-0011) already establishes the marker-file pattern for "this skill is in flight, exempt me from a gate" — `.claude/session/active-bootstrap` + `clear-bootstrap-marker.sh` SessionStart cleaner + config-driven `ticket.bootstrap_skills` list. Mirroring that pattern keeps the framework internally consistent.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Skill-marker + config-driven matcher list** (chosen) | Mirrors existing bootstrap-exemption pattern; tracker-agnostic by construction; adopters extend matcher list without touching framework code; env-var escape hatch for recovery scenarios | Adds a hook to the chain; each ticket skill must manage the marker (write on entry, clean on exit); stale markers possible if a skill crashes (mitigated by SessionStart cleaner) |
+| Bake `gh issue create` in as the only matched shape | Simplest possible hook | Useless for Linear/Jira/Asana adopters; bakes GitHub assumption into a framework that explicitly supports multi-tracker |
+| Block at PR/commit time (downstream) instead of at create time | One less hook | Tickets are already filed; reverting requires gh issue close + recreate; the agent's bypass already happened |
+| Require an `--allow-raw` flag on the CLI | No env var to remember | Unknown flag is rejected by gh/linear/jira/asana — would need a wrapper, which itself requires adoption discipline |
+| Permanent config-block bypass (`ticket.allow_raw: true`) | Easy to flip per adopter | Wrong shape — the bypass should be per-session (rare), not per-adopter (always-on) |
+
+## Decision
+
+Chosen: **skill-marker + config-driven matcher list**, because it (a) mirrors the existing bootstrap-skill exemption (AgDR-0011) so the framework stays internally consistent; (b) is tracker-agnostic by construction — only the matcher list knows about specific CLIs and adopters extend it via shallow-merge in `.claude/project-config.json`; and (c) supports the recovery scenario through a per-session env-var escape hatch (`APEXYARD_ALLOW_RAW_TICKET_CREATE=1`) with a visible stderr warning.
+
+Concretely:
+
+1. New hook `.claude/hooks/require-skill-for-issue-create.sh` (PreToolUse:Bash). Reads `ticket.create_command_patterns` from project config; substring-matches the (whitespace-collapsed) bash command. On match:
+   - If bootstrap marker present AND active bootstrap skill is on `ticket.bootstrap_skills` → allow (e.g. `/handover` filing its bookkeeping issues).
+   - Else if `.claude/session/active-issue-skill` present → allow (one of the seven ticket skills is in flight).
+   - Else if `APEXYARD_ALLOW_RAW_TICKET_CREATE=1` → allow with stderr warning.
+   - Else → BLOCK with exit 2 and a clear message naming the seven skill alternatives + the env-var bypass.
+
+2. New SessionStart hook `.claude/hooks/clear-issue-skill-marker.sh` (mirror of `clear-bootstrap-marker.sh`) sweeps stale markers from killed sessions.
+
+3. New config key `ticket.create_command_patterns` in `project-config.defaults.json` with default patterns covering GitHub CLI (`gh issue create`, `gh api repos/`), Linear (`linear issue create`), Jira (`jira issue create`, `jira create`), Asana (`asana task create`). Adopters extend via shallow-merge.
+
+4. The seven ticket skills (`/task`, `/feature`, `/bug`, `/spike`, `/migration`, `/investigation`, `/idea`) each write `.claude/session/active-issue-skill` on entry and remove it on completion / cancel.
+
+## Consequences
+
+- Every new ticket from a Claude Code session is filed through a structured skill that runs the contract-shaped interview, OR through an explicitly-acknowledged env-var bypass. No more silent ad-hoc filings.
+- Adopters on Linear / Jira / Asana / custom trackers extend the matcher list in `.claude/project-config.json` without touching framework code.
+- Marker lifecycle is operator-managed inside the seven ticket skills — if a skill is updated to add new exit paths, the marker-cleanup step must be added to each. The SessionStart cleaner is the safety net for the crash-mid-skill failure mode.
+- Bootstrap-skill exemption continues to work — `/handover` filing tickets for newly-adopted projects is unaffected because the bootstrap marker takes precedence.
+- `validate-issue-structure.sh` continues to compose downstream: it validates body structure; this hook validates origin. Both fire on `gh issue create`.
+- Multi-tracker scope deliberately leaves `validate-issue-structure.sh` GitHub-specific for now (it parses `gh` flags). Broadening that hook is a separate follow-up.
+
+## Artifacts
+
+- Issue: [me2resh/apexyard#268](https://github.com/me2resh/apexyard/issues/268)
+- PR: `feat(#268): skill-gated ticket-create hook (multi-tracker)` against `dev`
+- New hook: `.claude/hooks/require-skill-for-issue-create.sh`
+- New SessionStart hook: `.claude/hooks/clear-issue-skill-marker.sh`
+- Config: `.claude/project-config.defaults.json` → `ticket.create_command_patterns`
+- Tests: `.claude/hooks/tests/test_require_skill_for_issue_create.sh`
+- Related: AgDR-0011 (bootstrap-skill exemption — the pattern this mirrors)

--- a/docs/agdr/AgDR-0030-skill-gated-ticket-create.md
+++ b/docs/agdr/AgDR-0030-skill-gated-ticket-create.md
@@ -11,7 +11,7 @@ related: me2resh/apexyard#268, AgDR-0011-bootstrap-skill-exemption.md
 
 ## Context
 
-`validate-issue-structure.sh` (#192) catches *missing prefix / missing sections* in already-drafted ticket bodies. It does **not** catch the upstream failure: the agent skipped the structured-skill interview entirely and drafted a body free-hand. me2resh/apexyard#265 and #266 were both filed via raw `gh issue create` because the interactive skills "felt heavy for context the operator had already provided" — exactly the silent-bypass-for-throughput failure mode the [Invoke matching skills](MEMORY) feedback was meant to prevent.
+`validate-issue-structure.sh` (#192) catches *missing prefix / missing sections* in already-drafted ticket bodies. It does **not** catch the upstream failure: the agent skipped the structured-skill interview entirely and drafted a body free-hand. me2resh/apexyard#265 and #266 were both filed via raw `gh issue create` because the interactive skills "felt heavy for context the operator had already provided" — exactly the silent-bypass-for-throughput failure mode the **"Invoke matching skills"** operator-feedback memory was meant to prevent.
 
 The framework is also multi-tracker by design. Per `docs/multi-project.md` § FAQ ("Can I use this with Linear / Jira / etc.?"), adopters set per-project `ticket_prefix` and may use Linear, Jira, Asana, or another tracker. The gate must not bake `gh`/GitHub in as the only CLI shape.
 


### PR DESCRIPTION
## Summary

Mechanical enforcement of the "tickets file through structured skills, not raw CLIs" contract. Blocks raw ticket-create commands on `gh`, `linear`, `jira`, `asana` (and any adopter-extension via project-config) unless one of the 7 structured ticket skills is in flight via a session marker.

This supersedes the parallel agent implementation in #274 — that PR was filed from a stale dev base (predating `/spike` + `/investigation` skills), so its diff included ~70 unintended "reverts". This PR ships the same design on current dev, with the matcher tightened to anchor at command boundaries (was false-positiving on prose-in-quotes inside commit messages).

## Components

| File | Role |
|---|---|
| `.claude/hooks/require-skill-for-issue-create.sh` | PreToolUse:Bash gate — reads `ticket.create_command_patterns` from project-config, matches at command-boundary (start-of-line or after `;`/`&&`/`||`/`|`), checks for `active-issue-skill` marker, honours bootstrap exemption + env-var escape hatch |
| `.claude/hooks/clear-issue-skill-marker.sh` | SessionStart cleaner — mirror of `clear-bootstrap-marker.sh`. Sweeps stale `active-issue-skill` markers from killed sessions |
| `.claude/project-config.defaults.json` | Adds `ticket.create_command_patterns` (6 defaults: gh, gh-api, linear, jira variants, asana). Adopters extend via `.claude/project-config.json` shallow merge |
| `.claude/settings.json` | Wires both hooks into the right events |
| 7 ticket SKILL.md files | Step 0 marker-write block at entry + cleanup on exit. Covers `/task`, `/feature`, `/bug`, `/spike`, `/migration`, `/investigation`, `/idea` |
| `.claude/rules/ticket-vocabulary.md` | Backstop-enforcement table row documents the new hook + multi-tracker matcher list |
| `docs/agdr/AgDR-0030-skill-gated-ticket-create.md` | Design rationale, mirror-of-bootstrap-exemption pattern, tracker-agnostic decision |
| `.claude/hooks/tests/test_require_skill_for_issue_create.sh` | 18-case test suite, all passing |

## Why anchored matching (not substring)

The earlier substring matcher false-positived on `git commit -m "feat: see gh issue create"` — the literal phrase "gh issue create" appears in the quoted text but is not a command invocation. After tightening, the pattern must appear at the start of the line or right after a shell separator. This still catches:

- `gh issue create --repo foo/bar` ← actual command ✓
- `cd /tmp && gh issue create --repo foo/bar` ← after `&&` ✓
- `gh pr view 1; gh issue create --repo foo/bar` ← after `;` ✓

…and correctly ignores:

- `git commit -m "see also: gh issue create"` ← inside a quoted string ✓
- `echo "tip: run gh issue create"` ← inside a quoted echo ✓

## Tests

```
$ bash .claude/hooks/tests/test_require_skill_for_issue_create.sh
... PASS: 18   FAIL: 0
```

Covers all 5 default matchers in blocked-without-marker and allowed-with-marker shape, bootstrap exemption (listed + non-listed bootstrap skills), env-var escape hatch (`APEXYARD_ALLOW_RAW_TICKET_CREATE=1`), custom matcher via project-config override, empty-marker handling, Edit/non-matching no-ops.

## Out of scope (follow-ups)

- **Tightening `gh api repos/` pattern** — currently catches any `gh api repos/...` call, including read-only `gh api repos/foo/bar/issues/123` (issue view). A regex-aware matcher could narrow to `gh api repos/.*/issues\s*-X POST` shape; deferred until a real false-positive surfaces.
- **Closing #274** — supersedes-by-PR; will close once this lands.

## Testing

- [x] All 18 hook tests pass
- [x] Anchored matcher false-positive fix verified manually with quoted-prose command
- [x] True positive (actual `gh issue create`) still fires
- [x] Marker write + cleanup flow tested end-to-end (this PR's commit itself uses it)
- [ ] Operator verification — run `/feature` after this lands, verify the gate doesn't block

Closes #268.

## Glossary

| Term | Definition |
|------|------------|
| Skill marker | A file at `.claude/session/active-<purpose>` that a skill writes on entry and removes on exit, signalling to hooks that the skill is in progress |
| Bootstrap exemption | The existing pattern (`.claude/session/active-bootstrap`) that lets `/setup`, `/handover`, `/update`, `/split-portfolio` run before the portfolio is configured |
| Tracker | The system where issues / tickets live — GitHub, Linear, Jira, Asana, etc. The framework defaults to GitHub today but should not assume it |
| Anchored matcher | A substring matcher that only fires at command-boundary positions (start-of-line, after `;`/`&&`/`||`/`|`) — not anywhere in the command string |