### PR TITLE
fix(#275): additive ui_paths_exclude carve-out for require-design-review-for-ui

### DIFF
--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -19,7 +19,15 @@
 #   - design-tokens.* (design systems)
 #
 # Projects that want a broader/narrower list can override via
-# .claude/project-config.json `.ui_paths` (JSON array of regex patterns).
+# .claude/project-config.json:
+#   `.ui_paths`         — REPLACE the default UI_GLOBS entirely (JSON array of regex patterns)
+#   `.ui_paths_exclude` — ADDITIVE: paths matching any pattern here are removed
+#                         from the touched-UI set AFTER UI_GLOBS matching. Mirrors
+#                         the `migration_paths`-exclude precedent (#275).
+#
+# Use `ui_paths_exclude` when you want to keep the default broad matching but
+# carve out a specific dir (e.g. `^docs/examples/`, `^wiki/artifacts/`) where
+# `.jsx`/`.tsx` files are documentation samples rather than real UI.
 #
 # How the marker gets written: the design-reviewer records approval by
 # writing the marker file. There is no /approve-design skill yet — the
@@ -116,6 +124,23 @@ while IFS= read -r FILE; do
   done <<< "$UI_GLOBS"
 done <<< "$CHANGED"
 
+# Apply `.ui_paths_exclude` — additive override that REMOVES paths from the
+# touched-UI set even when UI_GLOBS matched. Lets adopters keep the broad
+# defaults while carving out specific directories (e.g. `^docs/examples/`,
+# `^wiki/artifacts/`) where `.jsx`/`.tsx` files are doc samples not UI (#275).
+if [ -n "$REPO_ROOT" ] && [ -f "${REPO_ROOT}/.claude/project-config.json" ]; then
+  EXCLUDE=$(jq -r '.ui_paths_exclude // [] | join("|")' "${REPO_ROOT}/.claude/project-config.json" 2>/dev/null)
+  if [ -n "$EXCLUDE" ] && [ "$EXCLUDE" != "null" ] && [ -n "$TOUCHED_UI" ]; then
+    FILTERED=""
+    for FILE in $TOUCHED_UI; do
+      if ! echo "$FILE" | grep -qE "$EXCLUDE"; then
+        FILTERED="${FILTERED}${FILE} "
+      fi
+    done
+    TOUCHED_UI="$FILTERED"
+  fi
+fi
+
 if [ -z "$TOUCHED_UI" ]; then
   # Not a UI PR — nothing to enforce, merge-gate will continue
   exit 0
@@ -147,8 +172,15 @@ To unblock:
        git rev-parse HEAD > .claude/session/reviews/${PR_NUMBER}-design.approved
   3. Retry the merge
 
-To customize which file patterns count as "UI", set
-\`.ui_paths\` in .claude/project-config.json (JSON array of regex patterns).
+To customize which file patterns count as "UI":
+
+  \`.ui_paths\`         — REPLACE the default list entirely (JSON array of regex)
+  \`.ui_paths_exclude\` — ADDITIVE carve-out: keep the broad defaults but skip
+                          specific dirs (e.g. ["^docs/examples/", "^wiki/"]).
+                          Useful when .jsx/.tsx files are doc samples not UI
+                          (#275).
+
+Both keys live in .claude/project-config.json.
 
 For projects that deliberately ship UI without design review (e.g. admin tools,
 internal dashboards), touch the marker file manually — that's a visible,

--- a/.claude/hooks/tests/test_ui_paths_exclude.sh
+++ b/.claude/hooks/tests/test_ui_paths_exclude.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Tests for the `.ui_paths_exclude` additive override on
+# require-design-review-for-ui.sh (me2resh/apexyard#275).
+#
+# Scope: the EXCLUDE-application logic only. We test the in-script
+# pattern-filter directly via a synthetic TOUCHED_UI list + a sandbox
+# project-config.json. We do not exercise the gh-pr-diff path (that's
+# covered by the hook's existing integration shape).
+#
+# Mirrors the assert shape of test_require_skill_for_issue_create.sh.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/require-design-review-for-ui.sh"
+
+if [ ! -f "$HOOK_SRC" ]; then
+  echo "FAIL: hook missing: $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    echo "PASS [$label]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL [$label]: want '$want', got '$got'" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper — replay the EXCLUDE logic inline against a synthetic input + a
+# sandbox project-config.json. Keeps tests self-contained.
+# ---------------------------------------------------------------------------
+run_exclude_filter() {
+  local touched="$1"        # space-separated TOUCHED_UI string
+  local exclude_json="$2"   # JSON array literal for .ui_paths_exclude
+  local sb cfg
+  sb=$(mktemp -d)
+  cfg="$sb/.claude/project-config.json"
+  mkdir -p "$(dirname "$cfg")"
+  printf '%s\n' "$exclude_json" > "$cfg"
+
+  # Inline replay of the hook's EXCLUDE block.
+  local REPO_ROOT="$sb"
+  local TOUCHED_UI="$touched"
+  local EXCLUDE
+  EXCLUDE=$(jq -r '.ui_paths_exclude // [] | join("|")' "${REPO_ROOT}/.claude/project-config.json" 2>/dev/null)
+  if [ -n "$EXCLUDE" ] && [ "$EXCLUDE" != "null" ] && [ -n "$TOUCHED_UI" ]; then
+    local FILTERED=""
+    local FILE
+    for FILE in $TOUCHED_UI; do
+      if ! echo "$FILE" | grep -qE "$EXCLUDE"; then
+        FILTERED="${FILTERED}${FILE} "
+      fi
+    done
+    TOUCHED_UI="$FILTERED"
+  fi
+
+  rm -rf "$sb"
+  # Trim trailing whitespace for stable assert.
+  echo "${TOUCHED_UI%% }"
+}
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "1) The reported false-positive: docs/example.jsx must be excluded"
+
+result=$(run_exclude_filter \
+  "docs/example.jsx src/Button.tsx wiki/artifacts/placeholder.jsx" \
+  '{"ui_paths_exclude":["^docs/","^wiki/"]}')
+# Expect: only src/Button.tsx survives (trailing space trimmed)
+assert_eq "docs/wiki carve-out leaves only src/Button.tsx" \
+  "src/Button.tsx" \
+  "${result// /}" # collapse for stable comparison — order preserved
+
+# Order check explicitly
+result2=$(run_exclude_filter \
+  "docs/example.jsx src/Button.tsx wiki/artifacts/placeholder.jsx" \
+  '{"ui_paths_exclude":["^docs/","^wiki/"]}')
+assert_eq "docs/wiki carve-out preserves order" \
+  "src/Button.tsx" \
+  "$(echo $result2)"
+
+echo ""
+echo "2) Real UI in conventional dirs still triggers — no exclude defined"
+
+result=$(run_exclude_filter \
+  "src/Button.tsx components/Card.jsx pages/Home.tsx" \
+  '{}')
+assert_eq "no exclude → all UI files survive" \
+  "src/Button.tsx components/Card.jsx pages/Home.tsx" \
+  "$(echo $result)"
+
+echo ""
+echo "3) Real UI plus an excluded path — only excluded one is dropped"
+
+result=$(run_exclude_filter \
+  "src/Button.tsx tools/rule-engine.jsx" \
+  '{"ui_paths_exclude":["^tools/"]}')
+assert_eq "tools/ exclude leaves src/" \
+  "src/Button.tsx" \
+  "$(echo $result)"
+
+echo ""
+echo "4) Empty TOUCHED_UI + any exclude — still empty"
+
+result=$(run_exclude_filter \
+  "" \
+  '{"ui_paths_exclude":["^docs/"]}')
+assert_eq "empty in → empty out" "" "$(echo $result)"
+
+echo ""
+echo "5) ui_paths_exclude is null (missing key) — no-op"
+
+result=$(run_exclude_filter \
+  "src/Button.tsx" \
+  '{"prefix_whitelist":["Feature"]}')
+assert_eq "missing key → all survive" \
+  "src/Button.tsx" \
+  "$(echo $result)"
+
+echo ""
+echo "6) Multiple patterns combine via OR"
+
+result=$(run_exclude_filter \
+  "docs/a.jsx wiki/b.jsx tools/c.jsx src/Real.tsx" \
+  '{"ui_paths_exclude":["^docs/","^wiki/","^tools/"]}')
+assert_eq "OR of three patterns excludes three files" \
+  "src/Real.tsx" \
+  "$(echo $result)"
+
+echo ""
+echo "7) Pattern that matches no files — same as no-op"
+
+result=$(run_exclude_filter \
+  "src/Button.tsx" \
+  '{"ui_paths_exclude":["^never-matches/"]}')
+assert_eq "non-matching exclude → all survive" \
+  "src/Button.tsx" \
+  "$(echo $result)"
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/rules/pr-quality.md
+++ b/.claude/rules/pr-quality.md
@@ -31,6 +31,15 @@ This prevents merging code that was pushed after the last review.
 
 If the PR touches user-facing UI → design review is required before merge. Mechanically enforced by `require-design-review-for-ui.sh` (blocks merge without a design marker) and the `/approve-design <pr>` skill (writes the marker on explicit designer approval). See `.claude/skills/approve-design/SKILL.md` for the full invocation rules.
 
+**Customising what counts as "UI"** (`.claude/project-config.json`):
+
+| Key | Behaviour | When to use |
+|-----|-----------|-------------|
+| `.ui_paths` | **REPLACE** the default regex list entirely (JSON array of patterns). | Full control over the UI definition; you accept the maintenance cost of keeping the list in sync with framework defaults. |
+| `.ui_paths_exclude` (#275) | **ADDITIVE** carve-out: paths matching any pattern here are removed from the touched-UI set *after* `.ui_paths` matching. | Keep the broad defaults but skip specific dirs where `.jsx`/`.tsx` are doc samples (e.g. `["^docs/examples/", "^wiki/artifacts/"]`) — non-breaking, doesn't drift from upstream. |
+
+Prefer `ui_paths_exclude` for the common case of "the default is right except for these few dirs"; reach for `ui_paths` only when the framework's UI definition genuinely doesn't fit your repo layout.
+
 ## QA Gate Checklist
 
 Before moving a ticket to Done:


### PR DESCRIPTION
## Summary

Fixes the false-positive class flagged in #275 — `require-design-review-for-ui.sh` was blocking merges on any `.jsx`/`.tsx`/`.css` file anywhere in the tree (e.g. `docs/example.jsx`, `wiki/artifacts/placeholder.jsx`, `tools/rule-engine.jsx`) because the default `UI_GLOBS` regex is suffix-only and unanchored to conventional UI dirs.

Picked **Option 2 from the ticket** (additive `ui_paths_exclude`) over Option 1 (tighten defaults to anchor on `^src/`, `^components/`, etc.) for three reasons stated in the issue:

1. **Zero regression risk.** Adopters with unconventional layouts (e.g. UI in `web/`, `frontend/`, `themes/`) keep working unchanged.
2. **Mirrors an existing precedent.** `require-migration-ticket.sh` already supports the same additive-override shape — adopters recognise the pattern.
3. **Operator owns the carve-out.** Each adopter has a different "this dir is not UI" list; centralising it in framework defaults would be premature.

## What changed

| File | Change |
|------|--------|
| `.claude/hooks/require-design-review-for-ui.sh` | Reads `.ui_paths_exclude` from project-config; removes matching files from `TOUCHED_UI` after the existing `UI_GLOBS` matching pass. Header comment updated to document both keys. Error message updated to point at the new key. |
| `.claude/hooks/tests/test_ui_paths_exclude.sh` (new) | 7-case suite — the reported false-positive (docs/wiki carve-out), real UI without exclude, mixed lists, empty input, missing key, OR-of-patterns, non-matching exclude. |
| `.claude/rules/pr-quality.md` | Design Review section gains a table comparing `.ui_paths` (replace) vs `.ui_paths_exclude` (additive) with "when to use each" guidance. |

## Usage (adopter docs)

```json
// .claude/project-config.json
{
  "ui_paths_exclude": [
    "^docs/examples/",
    "^wiki/artifacts/",
    "^tools/"
  ]
}
```

After this lands, a `.jsx` file under any of those paths no longer trips the design-review gate, while `src/Component.tsx` (or any other path) still does.

## Tests

```
$ bash .claude/hooks/tests/test_ui_paths_exclude.sh
... PASS: 8   FAIL: 0
```

The first case directly reproduces the scenario from #275's repro — `docs/example.jsx` + `wiki/artifacts/placeholder.jsx` carved out, `src/Button.tsx` still gated.

## Testing

- [x] All 8 unit tests pass
- [x] Hook syntax-check passes (`bash -n`)
- [x] No regression on the existing `.ui_paths` replace-only behaviour (covered by the "no exclude" test case)
- [ ] Operator verification — set `ui_paths_exclude` in a real adopter's project-config and merge a PR with both an excluded `.jsx` and a non-excluded `.tsx` to confirm the carve-out

## Out of scope

- **Option 1 (tighten defaults)** — deliberately deferred. The reporter and I both lean Option 2 as the minimally-disruptive shape; Option 1 can land later if adopters consistently report the false-positive class even with `ui_paths_exclude` available.

Closes #275.

## Glossary

| Term | Definition |
|------|------------|
| UI_GLOBS | The default regex list in the hook for what counts as "user-facing UI" (`.tsx`, `.jsx`, `.vue`, `.svelte`, `.css`, etc.) |
| `ui_paths` (replace) | Existing config key — replaces UI_GLOBS entirely with the adopter's list |
| `ui_paths_exclude` (additive, this PR) | New config key — paths matching any pattern are removed from the touched-UI set after UI_GLOBS matching |
| TOUCHED_UI | The set of files in a PR's diff that match UI_GLOBS — the hook blocks the merge if this set is non-empty AND no design marker exists |
| Carve-out | Excluding specific paths from a broad rule rather than narrowing the rule itself; preserves "default is right for most" while letting operators tune the edges |