### PR TITLE
feat(#284): /pdf — export any doc with destination prompt

### DIFF
--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -156,5 +156,12 @@
     "workspace_dir": "./workspace",
     "custom_skills_dir": "./custom-skills",
     "custom_handbooks_dir": "./custom-handbooks"
+  },
+
+  "pdf": {
+    "_comment": "Config for the /pdf skill. preferred_converter picks between pandoc / md-to-pdf / wkhtmltopdf when multiple are installed (null = first available in the dispatch order). pdf_engine is passed to pandoc as --pdf-engine; common values are xelatex (best Unicode), pdflatex (smaller install), wkhtmltopdf (no LaTeX needed but degraded typography). default_destination is used when /pdf is invoked with --no-prompt — one of 'workspace' (project repo docs/), 'projects' (ops fork projects/<name>/pdfs/), 'keep' (next to source), or 'ask' (require the interactive prompt; passing --no-prompt with this value is an error). See AgDR-0034.",
+    "preferred_converter": "pandoc",
+    "pdf_engine": "xelatex",
+    "default_destination": "ask"
   }
 }

--- a/.claude/skills/pdf/SKILL.md
+++ b/.claude/skills/pdf/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: pdf
+description: Convert a framework-generated doc to PDF, with destination prompt for project docs/ vs ops projects/. Supports markdown, HTML, and BPMN inputs via pandoc / md-to-pdf / wkhtmltopdf / bpmn-to-image. Graceful-degrades when no converter is installed (exit 3 with advisory). Mirrors the "would it follow the code if the project spun out?" rule from docs/multi-project.md.
+argument-hint: "<input-file> [--no-prompt] [--converter=pandoc|md-to-pdf|wkhtmltopdf] [--destination=workspace|projects|keep|<path>] [--project=<name>]"
+allowed-tools: Bash, Read, Write
+---
+
+# /pdf — Export Any Doc to PDF
+
+Convert a framework-generated document (markdown, HTML, BPMN) to PDF for sharing with non-technical stakeholders, board members, customers, or auditors.
+
+Sits alongside `/c4` (Mermaid markdown), `/dfd` (Mermaid markdown), `/tech-vision` (markdown), `/write-spec` (PRD markdown), `/journey` (self-contained HTML), `/process` (BPMN XML), and the audit family (`/threat-model`, `/launch-check`, etc., all of which write dated markdown audits). Those skills emit a single source-of-truth artefact in its native format; `/pdf` is the dedicated bridge to PDF for the moments when prose isn't enough.
+
+## The destination question
+
+A PDF can land in one of two places, and the answer depends on whether the doc should **travel with the code** if the project spun out tomorrow. This mirrors the existing rule in `docs/multi-project.md`:
+
+| If YES (travels with the code) | If NO (ApexYard's view) |
+|---|---|
+| Project's own repo: `workspace/<name>/docs/` | Ops fork: `projects/<name>/pdfs/` |
+| Examples: API spec, deployment runbook, internal sequence | Examples: handover assessment, stakeholder update, launch-check verdict |
+
+The skill **asks**, doesn't guess. The 4-option prompt below covers every common case.
+
+## Usage
+
+```
+/pdf projects/curios-dog/architecture/vision.md
+/pdf workspace/curios-dog/docs/architecture/context.md
+/pdf projects/curios-dog/audits/security/2026-05-19.md
+/pdf projects/curios-dog/journeys/checkout-v2.html
+/pdf projects/curios-dog/processes/onboarding.bpmn
+/pdf <input> --no-prompt                  # use default_destination from config
+/pdf <input> --converter=pandoc           # force a specific converter
+/pdf <input> --destination=workspace      # skip the prompt, write to workspace/<name>/docs/
+/pdf <input> --destination=projects       # skip the prompt, write to projects/<name>/pdfs/
+/pdf <input> --destination=keep           # skip the prompt, keep next to source
+/pdf <input> --destination=/absolute/path/out.pdf  # explicit path
+/pdf <input> --project=curios-dog         # override auto-detected project name
+```
+
+## Path resolution
+
+Read `workspace_dir` and `projects_dir` from `.claude/hooks/_lib-portfolio-paths.sh` so split-portfolio adopters resolve to the sibling private repo transparently:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+projects_dir=$(portfolio_projects_dir)
+workspace_dir=$(portfolio_workspace_dir)
+```
+
+Defaults to single-fork (`./projects`, `./workspace`). Don't hardcode literal `projects/` or `workspace/` paths in the bash blocks below — let the helper resolve whichever mode the adopter is in.
+
+## Process
+
+### 1. Resolve the input file
+
+```bash
+INPUT="$1"
+if [ ! -f "$INPUT" ]; then
+  echo "/pdf: input file not found: $INPUT" >&2
+  exit 2
+fi
+# Absolute path for downstream resolution
+ABS_INPUT=$(cd "$(dirname "$INPUT")" && pwd)/$(basename "$INPUT")
+```
+
+### 2. Sniff the input format
+
+By extension:
+
+| Extension | Format |
+|-----------|--------|
+| `.md`, `.markdown` | Markdown |
+| `.html`, `.htm` | HTML |
+| `.bpmn`, `.bpmn20.xml` | BPMN |
+
+Anything else → exit 2 with a clear "unsupported input format" message + the supported list.
+
+### 3. Auto-detect `<name>` from the input path
+
+The destination prompt needs a project name to fill in. Inference order:
+
+1. If `--project=<name>` was passed → use it.
+2. If `ABS_INPUT` is under `<projects_dir>/<name>/...` → `name` is the path segment after `projects_dir`.
+3. If `ABS_INPUT` is under `<workspace_dir>/<name>/...` → `name` is the path segment after `workspace_dir`.
+4. If neither matched (e.g. cwd is ops-fork root and input is `docs/foo.md`) → `name` is **unresolved**. The prompt will show "(no project — supply via --project)" in slots 1 + 2, and slots 3 + 4 remain valid.
+
+### 4. Show the destination prompt
+
+Always show this prompt unless `--no-prompt` or `--destination=...` was passed.
+
+```
+Where should the PDF land?
+
+  (1) workspace/<name>/docs/<stem>.pdf  ← travels with the code
+  (2) projects/<name>/pdfs/<stem>.pdf   ← ApexYard's view
+  (3) <custom path>                     ← anywhere
+  (k) keep next to source               ← <input-dir>/<stem>.pdf
+
+  Hint: pick (1) if a downstream reader of the project repo would want
+  this PDF (API spec, deployment runbook). Pick (2) if it's framework
+  context (handover, stakeholder update, audit). Pick (k) when in doubt.
+
+> 
+```
+
+When `<name>` couldn't be resolved, slots (1) and (2) print as `(no project — supply via --project)` and accepting them prompts for a name.
+
+### 5. Compute the output path
+
+```bash
+STEM=$(basename "$INPUT")
+STEM="${STEM%.*}"   # strip the extension
+```
+
+Filename rule:
+
+- Default → `<stem>.pdf`
+- **Audit-class outputs**: if `ABS_INPUT` matches `<projects_dir>/<name>/audits/<dim>/<YYYY-MM-DD>.md` (the dated-subdir convention from AgDR-0019), keep the date in the filename — the stem already contains it, so `<stem>.pdf` is correct as-is. No special case needed.
+
+By destination:
+
+| Destination | Output path |
+|---|---|
+| `1` / `workspace` | `<workspace_dir>/<name>/docs/<stem>.pdf` |
+| `2` / `projects` | `<projects_dir>/<name>/pdfs/<stem>.pdf` |
+| `3` / `<path>` | the operator-supplied path (relative to cwd, or absolute) |
+| `k` / `keep` | `<dir-of-input>/<stem>.pdf` |
+
+If the parent dir doesn't exist, `mkdir -p` it.
+
+If the output file already exists, ask the operator: overwrite (`o`), pick a new path (`n`), or quit (`q`). No silent overwrite.
+
+### 6. Run the converter
+
+Delegate to `convert.sh` (the skill's converter-dispatch helper). It takes `--from`, `--to`, optional `--converter=<name>`, optional `--pdf-engine=<eng>`, and outputs to `--out`.
+
+```bash
+SKILL_DIR="$(dirname "$(realpath "$0")")"
+"$SKILL_DIR/convert.sh" \
+  --from="$ABS_INPUT" \
+  --to="$OUT" \
+  ${CONVERTER:+--converter="$CONVERTER"} \
+  ${PDF_ENGINE:+--pdf-engine="$PDF_ENGINE"}
+RC=$?
+```
+
+`convert.sh` exit codes:
+
+- `0` — converted cleanly
+- `1` — conversion failed (offending converter output streamed to stderr)
+- `2` — bad input / unsupported format
+- `3` — no converter available; advisory printed to stderr naming each install option. The skill propagates this exit code.
+
+### 7. Report
+
+On success:
+
+```
+✓ PDF written: <OUT>
+  Source:     <ABS_INPUT>
+  Format:     <markdown|html|bpmn> → PDF
+  Converter:  <pandoc|md-to-pdf|wkhtmltopdf|bpmn-to-image+pandoc>
+  Size:       <size>
+```
+
+On exit 3:
+
+```
+✗ No PDF converter is installed.
+
+Markdown inputs can use:
+  • pandoc           — brew install pandoc (or apt-get install pandoc)
+                       For best output also install xelatex (mactex / texlive-xetex)
+  • md-to-pdf (npm)  — npm install -g md-to-pdf  (or run via npx, no install)
+
+HTML inputs can use:
+  • wkhtmltopdf      — brew install --cask wkhtmltopdf
+  • pandoc           — same as above (uses its HTML reader)
+
+BPMN inputs need a two-step pipeline:
+  • bpmn-to-image (npm) → SVG → pandoc → PDF
+
+Install at least one of the above and re-run /pdf.
+```
+
+The skill **does not silently fall back** to leaving you without a PDF — it explicitly exits 3 so the operator knows the gap and can fix it.
+
+## Config
+
+`.claude/project-config.defaults.json` ships a `pdf` block:
+
+```json
+"pdf": {
+  "preferred_converter": "pandoc",
+  "pdf_engine": "xelatex",
+  "default_destination": "ask"
+}
+```
+
+- `preferred_converter` — when both pandoc and a fallback are installed, prefer this one. `null` means "first one found in the dispatch order".
+- `pdf_engine` — passed to pandoc as `--pdf-engine=<engine>`. Common values: `xelatex` (best Unicode), `pdflatex` (smaller install), `wkhtmltopdf` (no LaTeX needed but degraded typography).
+- `default_destination` — used when `--no-prompt` is passed. Must be one of `workspace`, `projects`, `keep`, or `ask`. `ask` with `--no-prompt` is an error (the skill exits 2 — operator must change config or drop `--no-prompt`).
+
+Adopters override in `.claude/project-config.json`:
+
+```json
+{
+  "pdf": {
+    "preferred_converter": "md-to-pdf",
+    "default_destination": "keep"
+  }
+}
+```
+
+## Rules
+
+1. **Always ask about destination** unless `--no-prompt` or `--destination=...` was passed. The "would it follow the code?" question is genuinely contextual; guessing wrong creates landed-in-the-wrong-repo cleanup work.
+2. **Never silently overwrite** an existing PDF. Always prompt or require `--destination=<explicit-path>` which the operator owns.
+3. **Graceful degrade only on missing dep, not on conversion failure**. Missing converter → exit 3 + advisory. Converter installed but threw an error → exit 1 + propagate the converter's stderr. The two are different failure modes with different fixes.
+4. **Source format detection by extension only**. We don't sniff content (would add complexity for marginal value — operators know what they're converting).
+5. **No special-case templates**. v1 uses the converter's defaults. Custom LaTeX templates, branded header/footer, etc. are out of scope (separate ticket).
+6. **No batch mode**. One input → one PDF. If the operator needs ten, they loop in shell. Keeps the skill's destination-prompt logic single-purpose.
+
+## When to use this
+
+| Trigger | Use `/pdf`? |
+|---------|-------------|
+| Board needs a one-pager PDF of a PRD | Yes |
+| Sharing an audit verdict with a customer | Yes |
+| Customer-facing API documentation | Yes (write to `workspace/<name>/docs/`) |
+| Internal stakeholder update | Yes (write to `projects/<name>/pdfs/`) |
+| Quick-share a diagram from `/c4` for a meeting | Yes (use `keep` to drop next to the source) |
+| Replace the source markdown with the PDF | No — the source stays canonical; PDF is a render |
+| Batch-converting 50 audit reports | No — loop `/pdf` in shell, the skill stays single-input |
+
+## Out of scope (v1)
+
+- **`--pdf` flag on each doc-emitting skill** that converts at write-time. Cleaner one-command UX but couples every doc skill to the converter dep. Standalone `/pdf` is v1; per-skill integration can land in v1.5 if operator usage demands it.
+- **Custom LaTeX templates / branding / headers / footers**. Use system pandoc defaults for v1.
+- **Batch export across multiple inputs**. Loop in shell.
+- **Auto-watch + regenerate on source change**. Out of scope.
+- **PDF accessibility audit** (tagged structure, alt-text propagation). The accessibility-audit skill covers the source markdown; PDF accessibility is a downstream concern.
+
+## See also
+
+- AgDR-0034 — converter dispatch + destination prompt rationale + standalone-skill vs flag-on-each-skill decision
+- `docs/multi-project.md` § "Architecture diagrams" — the "would it follow the code?" rule extended to PDF outputs
+- `.claude/skills/process/lint.sh` — graceful-degrade-on-missing-dep pattern that this skill mirrors for converter detection
+- `.claude/skills/_lib-mermaid-lint.sh` — same pattern, npx-fallback case

--- a/.claude/skills/pdf/convert.sh
+++ b/.claude/skills/pdf/convert.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# /pdf convert.sh — converter dispatch for the /pdf skill.
+#
+# Detects which PDF converters are available on the operator's machine
+# and runs the right one for the input format. Graceful-degrades when
+# none are installed (exit 3 + advisory message), matching the shape of
+# .claude/skills/process/lint.sh and _lib-mermaid-lint.sh.
+#
+# Usage:
+#   convert.sh --from=<input> --to=<output.pdf>
+#              [--converter=pandoc|md-to-pdf|wkhtmltopdf|bpmn-to-image]
+#              [--pdf-engine=<engine>]
+#              [--check-only]
+#
+# Exit codes:
+#   0 — converted cleanly (or --check-only and at least one converter found)
+#   1 — conversion failed (the converter's stderr is streamed through)
+#   2 — bad input / unsupported format / missing flags
+#   3 — no converter available (advisory printed; install at least one)
+#
+# Design:
+#   - Markdown: prefer pandoc → md-to-pdf
+#   - HTML:     prefer wkhtmltopdf → pandoc → md-to-pdf (deepest fallback)
+#   - BPMN:     two-step pipeline (bpmn-to-image → SVG → pandoc → PDF)
+#
+# Per-skill wrappers can override the dispatch order via --converter.
+
+set -uo pipefail
+
+FROM=""
+TO=""
+CONVERTER=""
+PDF_ENGINE=""
+CHECK_ONLY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --from=*)        FROM="${1#--from=}"; shift ;;
+    --to=*)          TO="${1#--to=}"; shift ;;
+    --converter=*)   CONVERTER="${1#--converter=}"; shift ;;
+    --pdf-engine=*)  PDF_ENGINE="${1#--pdf-engine=}"; shift ;;
+    --check-only)    CHECK_ONLY=1; shift ;;
+    --help|-h)
+      sed -n '2,22p' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "convert.sh: unknown flag: $1" >&2
+      exit 2
+      ;;
+    *)
+      echo "convert.sh: unexpected positional arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Detect available converters (cached in variables)
+# ---------------------------------------------------------------------------
+have_pandoc=0
+have_wkhtmltopdf=0
+have_npx=0
+command -v pandoc       >/dev/null 2>&1 && have_pandoc=1
+command -v wkhtmltopdf  >/dev/null 2>&1 && have_wkhtmltopdf=1
+command -v npx          >/dev/null 2>&1 && have_npx=1
+
+print_install_advisory() {
+  cat >&2 <<MSG
+convert.sh: no PDF converter installed.
+
+Markdown inputs can use:
+  • pandoc           — brew install pandoc (or apt-get install pandoc)
+                       For best output also install xelatex (mactex / texlive-xetex)
+  • md-to-pdf (npm)  — npm install -g md-to-pdf  (or run via npx, no install)
+
+HTML inputs can use:
+  • wkhtmltopdf      — brew install --cask wkhtmltopdf
+  • pandoc           — same as above (uses its HTML reader)
+  • md-to-pdf (npm)  — npm install -g md-to-pdf  (chromium under the hood)
+
+BPMN inputs need a two-step pipeline:
+  • bpmn-to-image (npm) → SVG → pandoc → PDF
+
+Install at least one of the above and re-run /pdf.
+MSG
+}
+
+# ---------------------------------------------------------------------------
+# --check-only: just report what's available, exit 0/3 accordingly
+# ---------------------------------------------------------------------------
+if [ "$CHECK_ONLY" = "1" ]; then
+  echo "convert.sh: converter availability"
+  echo "  pandoc:       $([ $have_pandoc       -eq 1 ] && echo yes || echo no)"
+  echo "  wkhtmltopdf:  $([ $have_wkhtmltopdf  -eq 1 ] && echo yes || echo no)"
+  echo "  npx (md-to-pdf, bpmn-to-image): $([ $have_npx -eq 1 ] && echo yes || echo no)"
+  if [ "$have_pandoc" -eq 0 ] && [ "$have_wkhtmltopdf" -eq 0 ] && [ "$have_npx" -eq 0 ]; then
+    print_install_advisory
+    exit 3
+  fi
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Validate inputs for normal (non-check-only) mode
+# ---------------------------------------------------------------------------
+if [ -z "$FROM" ] || [ -z "$TO" ]; then
+  echo "convert.sh: --from and --to are required" >&2
+  exit 2
+fi
+if [ ! -f "$FROM" ]; then
+  echo "convert.sh: input file not found: $FROM" >&2
+  exit 2
+fi
+
+# Resolve absolute paths so converters that change cwd still work.
+FROM_ABS=$(cd "$(dirname "$FROM")" && pwd)/$(basename "$FROM")
+TO_DIR=$(dirname "$TO")
+mkdir -p "$TO_DIR"
+TO_ABS=$(cd "$TO_DIR" && pwd)/$(basename "$TO")
+
+# ---------------------------------------------------------------------------
+# Sniff input format
+# ---------------------------------------------------------------------------
+FORMAT=""
+case "$FROM" in
+  *.md|*.markdown)        FORMAT="markdown" ;;
+  *.html|*.htm)           FORMAT="html" ;;
+  *.bpmn|*.bpmn20.xml)    FORMAT="bpmn" ;;
+  *)
+    echo "convert.sh: unsupported input format for $FROM (supported: .md, .markdown, .html, .htm, .bpmn, .bpmn20.xml)" >&2
+    exit 2
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Determine which converter to use
+# ---------------------------------------------------------------------------
+chosen=""
+
+choose_for_markdown() {
+  if [ -n "$CONVERTER" ]; then
+    case "$CONVERTER" in
+      pandoc)
+        if [ "$have_pandoc" -eq 1 ]; then chosen="pandoc"; return; fi
+        echo "convert.sh: --converter=pandoc requested but pandoc is not installed" >&2
+        exit 3
+        ;;
+      md-to-pdf)
+        if [ "$have_npx" -eq 1 ]; then chosen="md-to-pdf"; return; fi
+        echo "convert.sh: --converter=md-to-pdf requested but npx is not available (need Node + npm)" >&2
+        exit 3
+        ;;
+      wkhtmltopdf)
+        echo "convert.sh: --converter=wkhtmltopdf is for HTML inputs, not markdown" >&2
+        exit 2
+        ;;
+      *)
+        echo "convert.sh: --converter=$CONVERTER is not valid for markdown (use pandoc or md-to-pdf)" >&2
+        exit 2
+        ;;
+    esac
+  fi
+  if [ "$have_pandoc" -eq 1 ]; then chosen="pandoc"; return; fi
+  if [ "$have_npx"    -eq 1 ]; then chosen="md-to-pdf"; return; fi
+  print_install_advisory
+  exit 3
+}
+
+choose_for_html() {
+  if [ -n "$CONVERTER" ]; then
+    case "$CONVERTER" in
+      wkhtmltopdf)
+        if [ "$have_wkhtmltopdf" -eq 1 ]; then chosen="wkhtmltopdf"; return; fi
+        echo "convert.sh: --converter=wkhtmltopdf requested but it is not installed" >&2
+        exit 3
+        ;;
+      pandoc)
+        if [ "$have_pandoc" -eq 1 ]; then chosen="pandoc-html"; return; fi
+        echo "convert.sh: --converter=pandoc requested but pandoc is not installed" >&2
+        exit 3
+        ;;
+      md-to-pdf)
+        if [ "$have_npx" -eq 1 ]; then chosen="md-to-pdf-html"; return; fi
+        echo "convert.sh: --converter=md-to-pdf requested but npx is not available" >&2
+        exit 3
+        ;;
+      *)
+        echo "convert.sh: --converter=$CONVERTER is not valid for html" >&2
+        exit 2
+        ;;
+    esac
+  fi
+  if [ "$have_wkhtmltopdf" -eq 1 ]; then chosen="wkhtmltopdf"; return; fi
+  if [ "$have_pandoc"      -eq 1 ]; then chosen="pandoc-html"; return; fi
+  if [ "$have_npx"         -eq 1 ]; then chosen="md-to-pdf-html"; return; fi
+  print_install_advisory
+  exit 3
+}
+
+choose_for_bpmn() {
+  # BPMN always needs npx for bpmn-to-image, and either pandoc or
+  # wkhtmltopdf for the SVG → PDF stage.
+  if [ "$have_npx" -eq 0 ]; then
+    cat >&2 <<MSG
+convert.sh: BPMN → PDF requires npx (Node + npm) for bpmn-to-image.
+  Install Node (https://nodejs.org), then re-run /pdf.
+MSG
+    exit 3
+  fi
+  if [ "$have_pandoc" -eq 0 ] && [ "$have_wkhtmltopdf" -eq 0 ]; then
+    cat >&2 <<MSG
+convert.sh: BPMN → PDF needs pandoc or wkhtmltopdf for the SVG → PDF stage.
+  Install one of:
+    • pandoc        — brew install pandoc
+    • wkhtmltopdf   — brew install --cask wkhtmltopdf
+MSG
+    exit 3
+  fi
+  chosen="bpmn-to-image+pandoc"
+}
+
+case "$FORMAT" in
+  markdown) choose_for_markdown ;;
+  html)     choose_for_html ;;
+  bpmn)     choose_for_bpmn ;;
+esac
+
+echo "convert.sh: input=$FORMAT  converter=$chosen  out=$TO_ABS" >&2
+
+# ---------------------------------------------------------------------------
+# Run the chosen converter
+# ---------------------------------------------------------------------------
+WORK=$(mktemp -d -t pdf-convert-XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+
+case "$chosen" in
+  pandoc)
+    # Markdown → PDF via pandoc. --pdf-engine is overridable.
+    eng_flag=""
+    if [ -n "$PDF_ENGINE" ]; then
+      eng_flag="--pdf-engine=$PDF_ENGINE"
+    fi
+    if pandoc "$FROM_ABS" -o "$TO_ABS" $eng_flag; then
+      exit 0
+    fi
+    echo "convert.sh: pandoc conversion failed for $FROM_ABS" >&2
+    exit 1
+    ;;
+
+  md-to-pdf)
+    # Markdown → PDF via the md-to-pdf npm package (chromium-backed).
+    # --as-html-only off → emit the PDF directly.
+    # Use a tmp output then move so md-to-pdf doesn't fight us on cwd.
+    tmp_out="$WORK/out.pdf"
+    if npx -y md-to-pdf --pdf-output-folder "$WORK" --dest-name out.pdf "$FROM_ABS" >&2; then
+      if [ -f "$tmp_out" ]; then
+        mv "$tmp_out" "$TO_ABS"
+        exit 0
+      fi
+      # Some versions of md-to-pdf output as <basename>.pdf in the folder.
+      basename_pdf="$WORK/$(basename "${FROM_ABS%.*}").pdf"
+      if [ -f "$basename_pdf" ]; then
+        mv "$basename_pdf" "$TO_ABS"
+        exit 0
+      fi
+      echo "convert.sh: md-to-pdf ran but no PDF appeared in $WORK" >&2
+      exit 1
+    fi
+    echo "convert.sh: md-to-pdf conversion failed for $FROM_ABS" >&2
+    exit 1
+    ;;
+
+  wkhtmltopdf)
+    if wkhtmltopdf --quiet "$FROM_ABS" "$TO_ABS"; then
+      exit 0
+    fi
+    echo "convert.sh: wkhtmltopdf conversion failed for $FROM_ABS" >&2
+    exit 1
+    ;;
+
+  pandoc-html)
+    eng_flag=""
+    if [ -n "$PDF_ENGINE" ]; then
+      eng_flag="--pdf-engine=$PDF_ENGINE"
+    fi
+    if pandoc --from html "$FROM_ABS" -o "$TO_ABS" $eng_flag; then
+      exit 0
+    fi
+    echo "convert.sh: pandoc HTML→PDF conversion failed for $FROM_ABS" >&2
+    exit 1
+    ;;
+
+  md-to-pdf-html)
+    # md-to-pdf accepts HTML when --as-pdf and a chromium backend are
+    # configured. We use it as a last-resort HTML→PDF path.
+    tmp_out="$WORK/out.pdf"
+    if npx -y md-to-pdf --pdf-output-folder "$WORK" --dest-name out.pdf "$FROM_ABS" >&2; then
+      if [ -f "$tmp_out" ]; then
+        mv "$tmp_out" "$TO_ABS"
+        exit 0
+      fi
+      basename_pdf="$WORK/$(basename "${FROM_ABS%.*}").pdf"
+      if [ -f "$basename_pdf" ]; then
+        mv "$basename_pdf" "$TO_ABS"
+        exit 0
+      fi
+      echo "convert.sh: md-to-pdf produced no PDF for HTML input" >&2
+      exit 1
+    fi
+    echo "convert.sh: md-to-pdf HTML→PDF conversion failed for $FROM_ABS" >&2
+    exit 1
+    ;;
+
+  bpmn-to-image+pandoc)
+    # Step 1: BPMN → SVG via bpmn-to-image.
+    svg_out="$WORK/diagram.svg"
+    if ! npx -y bpmn-to-image --no-title "${FROM_ABS}:${svg_out}" >&2; then
+      echo "convert.sh: bpmn-to-image failed for $FROM_ABS" >&2
+      exit 1
+    fi
+    if [ ! -f "$svg_out" ]; then
+      echo "convert.sh: bpmn-to-image produced no SVG at $svg_out" >&2
+      exit 1
+    fi
+    # Step 2: SVG → PDF via pandoc (or wkhtmltopdf via an HTML wrap).
+    if [ "$have_pandoc" -eq 1 ]; then
+      # Wrap the SVG in markdown so pandoc emits a one-page PDF with the diagram.
+      wrapper_md="$WORK/wrap.md"
+      cat > "$wrapper_md" <<MD
+# $(basename "${FROM_ABS%.*}")
+
+![](${svg_out})
+MD
+      eng_flag=""
+      if [ -n "$PDF_ENGINE" ]; then
+        eng_flag="--pdf-engine=$PDF_ENGINE"
+      fi
+      if pandoc "$wrapper_md" -o "$TO_ABS" $eng_flag; then
+        exit 0
+      fi
+      echo "convert.sh: pandoc SVG→PDF wrap failed" >&2
+      exit 1
+    fi
+    if [ "$have_wkhtmltopdf" -eq 1 ]; then
+      wrapper_html="$WORK/wrap.html"
+      cat > "$wrapper_html" <<HTML
+<!doctype html><html><body><img src="${svg_out}" /></body></html>
+HTML
+      if wkhtmltopdf --quiet --enable-local-file-access "$wrapper_html" "$TO_ABS"; then
+        exit 0
+      fi
+      echo "convert.sh: wkhtmltopdf SVG→PDF wrap failed" >&2
+      exit 1
+    fi
+    echo "convert.sh: no SVG→PDF backend (pandoc / wkhtmltopdf)" >&2
+    exit 1
+    ;;
+
+  *)
+    echo "convert.sh: internal error — chosen=$chosen" >&2
+    exit 2
+    ;;
+esac

--- a/.claude/skills/pdf/tests/smoke.sh
+++ b/.claude/skills/pdf/tests/smoke.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# /pdf smoke test — converter dispatch + destination resolution.
+#
+# Covers:
+#   1. Format sniffing  (.md, .html, .bpmn, unsupported)
+#   2. Missing-flag handling  (no --from / --to)
+#   3. Missing-input handling  (--from points at a nonexistent file)
+#   4. Missing-converter graceful degrade (mocked PATH; exit 3 + advisory)
+#   5. --check-only reports without converting
+#   6. Markdown → PDF via pandoc, when pandoc is installed (skipped otherwise)
+#   7. HTML → PDF via wkhtmltopdf, when installed (skipped otherwise)
+#   8. Destination resolution helper for each of the 4 prompt options
+#
+# Designed to run in any sandbox without network — pandoc / wkhtmltopdf /
+# npx invocations are guarded by `command -v` checks and skip cleanly when
+# missing. The missing-converter test (#4) deliberately mocks PATH to remove
+# every converter, so it passes uniformly across CI shapes.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+CONVERT="$SKILL_DIR/convert.sh"
+
+PASS=0
+FAIL=0
+SKIPPED=0
+
+ok()    { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad()   { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip()  { echo "  SKIP: $1"; SKIPPED=$((SKIPPED + 1)); }
+
+assert_exit() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    ok "$label  (got exit $got)"
+  else
+    bad "$label  (want exit $want, got $got)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture: a tmp dir with sample inputs in each supported format.
+# ---------------------------------------------------------------------------
+FIXTURE=$(mktemp -d -t pdf-smoke-XXXXXX)
+trap 'rm -rf "$FIXTURE"' EXIT
+
+cat > "$FIXTURE/sample.md" <<'MD'
+# Sample Doc
+
+This is a smoke-test fixture for /pdf.
+
+## Section
+
+Some prose here. Lorem ipsum.
+
+| Col A | Col B |
+|-------|-------|
+| 1     | 2     |
+MD
+
+cat > "$FIXTURE/sample.html" <<'HTML'
+<!doctype html>
+<html><head><meta charset="utf-8"><title>Sample</title></head>
+<body><h1>Sample Doc</h1><p>HTML smoke-test fixture.</p></body></html>
+HTML
+
+cat > "$FIXTURE/sample.bpmn" <<'BPMN'
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="http://example.com/smoke">
+  <bpmn:process id="p1" isExecutable="false">
+    <bpmn:startEvent id="s1" name="Start" />
+    <bpmn:endEvent id="e1" name="End" />
+    <bpmn:sequenceFlow id="f1" sourceRef="s1" targetRef="e1" />
+  </bpmn:process>
+</bpmn:definitions>
+BPMN
+
+cat > "$FIXTURE/sample.unsupported" <<'TXT'
+plain text — not a supported PDF input
+TXT
+
+# ---------------------------------------------------------------------------
+# 1. Format sniffing
+# ---------------------------------------------------------------------------
+echo ""
+echo "1) Format sniffing"
+
+# Unsupported extension → exit 2
+set +e
+out=$("$CONVERT" --from="$FIXTURE/sample.unsupported" --to="$FIXTURE/out.pdf" 2>&1)
+rc=$?
+set -e
+assert_exit "unsupported extension exits 2" 2 "$rc"
+if echo "$out" | grep -q "unsupported input format"; then
+  ok "unsupported extension error message names the issue"
+else
+  bad "unsupported extension error did not mention 'unsupported input format' (got: $out)"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Missing-flag handling
+# ---------------------------------------------------------------------------
+echo ""
+echo "2) Missing-flag handling"
+
+set +e
+"$CONVERT" --to="$FIXTURE/out.pdf" >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit "missing --from exits 2" 2 "$rc"
+
+set +e
+"$CONVERT" --from="$FIXTURE/sample.md" >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit "missing --to exits 2" 2 "$rc"
+
+# ---------------------------------------------------------------------------
+# 3. Missing-input handling
+# ---------------------------------------------------------------------------
+echo ""
+echo "3) Missing-input handling"
+
+set +e
+"$CONVERT" --from="$FIXTURE/does-not-exist.md" --to="$FIXTURE/out.pdf" >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit "nonexistent input file exits 2" 2 "$rc"
+
+# ---------------------------------------------------------------------------
+# 4. Missing-converter graceful degrade (exit 3 + advisory)
+# ---------------------------------------------------------------------------
+echo ""
+echo "4) Missing-converter graceful degrade"
+
+# Build a stripped PATH with only the core binaries convert.sh needs
+# (mktemp, sed, cat, grep, dirname, basename, mkdir, chmod, command...).
+# This forces convert.sh into the "no converter installed" branch
+# regardless of what's actually on the host.
+STRIPPED_PATH_DIR=$(mktemp -d -t pdf-stripped-path-XXXXXX)
+for tool in bash sh mktemp sed cat grep dirname basename mkdir chmod cd pwd echo cp mv rm ls test command; do
+  src=$(command -v "$tool" 2>/dev/null || true)
+  if [ -n "$src" ]; then
+    ln -sf "$src" "$STRIPPED_PATH_DIR/$tool"
+  fi
+done
+
+# Verify that none of the three converters resolve under the stripped PATH.
+strip_check() {
+  PATH="$STRIPPED_PATH_DIR" command -v "$1" >/dev/null 2>&1
+}
+if strip_check pandoc || strip_check wkhtmltopdf || strip_check npx; then
+  skip "could not strip PATH cleanly (a converter symlink leaked); skipping no-converter test"
+else
+  set +e
+  out=$(PATH="$STRIPPED_PATH_DIR" "$CONVERT" --from="$FIXTURE/sample.md" --to="$FIXTURE/out.pdf" 2>&1)
+  rc=$?
+  set -e
+  assert_exit "no converter installed exits 3" 3 "$rc"
+  if echo "$out" | grep -q "no PDF converter installed"; then
+    ok "advisory message names the install steps"
+  else
+    bad "advisory did not mention 'no PDF converter installed' (got: $out)"
+  fi
+fi
+
+rm -rf "$STRIPPED_PATH_DIR"
+
+# ---------------------------------------------------------------------------
+# 5. --check-only mode
+# ---------------------------------------------------------------------------
+echo ""
+echo "5) --check-only reports without converting"
+set +e
+out=$("$CONVERT" --check-only 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ] || [ "$rc" -eq 3 ]; then
+  ok "--check-only exits 0 (≥1 converter present) or 3 (none)  (got: $rc)"
+else
+  bad "--check-only exits $rc (expected 0 or 3)"
+fi
+if echo "$out" | grep -q "converter availability"; then
+  ok "--check-only output names the converters"
+else
+  bad "--check-only output did not include 'converter availability'"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Markdown → PDF via pandoc (skipped if pandoc absent)
+# ---------------------------------------------------------------------------
+echo ""
+echo "6) Markdown → PDF via pandoc"
+if command -v pandoc >/dev/null 2>&1; then
+  set +e
+  "$CONVERT" --from="$FIXTURE/sample.md" --to="$FIXTURE/out-md.pdf" --converter=pandoc 2>/dev/null
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ] && [ -s "$FIXTURE/out-md.pdf" ]; then
+    ok "pandoc produced a non-empty PDF"
+  elif [ "$rc" -eq 1 ]; then
+    skip "pandoc is installed but conversion failed (likely missing pdf-engine — install xelatex or pass --pdf-engine=pdflatex)"
+  else
+    bad "pandoc invocation exited $rc unexpectedly"
+  fi
+else
+  skip "pandoc not installed — install via brew install pandoc"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. HTML → PDF via wkhtmltopdf (skipped if absent)
+# ---------------------------------------------------------------------------
+echo ""
+echo "7) HTML → PDF via wkhtmltopdf"
+if command -v wkhtmltopdf >/dev/null 2>&1; then
+  set +e
+  "$CONVERT" --from="$FIXTURE/sample.html" --to="$FIXTURE/out-html.pdf" --converter=wkhtmltopdf 2>/dev/null
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ] && [ -s "$FIXTURE/out-html.pdf" ]; then
+    ok "wkhtmltopdf produced a non-empty PDF"
+  else
+    bad "wkhtmltopdf invocation exited $rc unexpectedly"
+  fi
+else
+  skip "wkhtmltopdf not installed — install via brew install --cask wkhtmltopdf"
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Destination resolution helper
+# ---------------------------------------------------------------------------
+# Verifies that for each of the 4 destination options, the helper inside
+# this test resolves the same path the SKILL.md describes. This is the
+# *contract* the skill obeys when constructing OUT in step 5.
+#
+# We replicate the resolution logic in this test (rather than trying to
+# invoke the SKILL.md flow) because the actual prompt-driven slot picker
+# lives in the model's read of SKILL.md — there's no separate destination
+# resolver binary. So we lock the *expected behaviour* via this test.
+# ---------------------------------------------------------------------------
+echo ""
+echo "8) Destination resolution (4 prompt options)"
+
+PROJECTS_DIR_ROOT="$FIXTURE/ops/projects"
+WORKSPACE_DIR_ROOT="$FIXTURE/ops/workspace"
+mkdir -p "$PROJECTS_DIR_ROOT/myproject/audits/security" "$WORKSPACE_DIR_ROOT/myproject/docs"
+
+# Input lives at projects/myproject/audits/security/2026-05-19.md → name="myproject", stem="2026-05-19"
+AUDIT_INPUT="$PROJECTS_DIR_ROOT/myproject/audits/security/2026-05-19.md"
+cp "$FIXTURE/sample.md" "$AUDIT_INPUT"
+
+resolve_dest() {
+  # Args: dest_opt, input_path, project_name, projects_dir, workspace_dir
+  local opt="$1" input="$2" name="$3" pdir="$4" wdir="$5"
+  local stem
+  stem=$(basename "$input")
+  stem="${stem%.*}"
+  case "$opt" in
+    1|workspace) echo "$wdir/$name/docs/$stem.pdf" ;;
+    2|projects)  echo "$pdir/$name/pdfs/$stem.pdf" ;;
+    k|keep)      echo "$(dirname "$input")/$stem.pdf" ;;
+    *) echo "" ;;
+  esac
+}
+
+want="$WORKSPACE_DIR_ROOT/myproject/docs/2026-05-19.pdf"
+got=$(resolve_dest 1 "$AUDIT_INPUT" myproject "$PROJECTS_DIR_ROOT" "$WORKSPACE_DIR_ROOT")
+if [ "$want" = "$got" ]; then ok "option 1 → workspace/<name>/docs/"; else bad "option 1 mismatch  want=$want  got=$got"; fi
+
+want="$PROJECTS_DIR_ROOT/myproject/pdfs/2026-05-19.pdf"
+got=$(resolve_dest 2 "$AUDIT_INPUT" myproject "$PROJECTS_DIR_ROOT" "$WORKSPACE_DIR_ROOT")
+if [ "$want" = "$got" ]; then ok "option 2 → projects/<name>/pdfs/"; else bad "option 2 mismatch  want=$want  got=$got"; fi
+
+want="$PROJECTS_DIR_ROOT/myproject/audits/security/2026-05-19.pdf"
+got=$(resolve_dest k "$AUDIT_INPUT" myproject "$PROJECTS_DIR_ROOT" "$WORKSPACE_DIR_ROOT")
+if [ "$want" = "$got" ]; then ok "option k → next to source"; else bad "option k mismatch  want=$want  got=$got"; fi
+
+# Option 3 is an operator-supplied custom path — verify the helper accepts
+# the literal through-pass shape (not destination-rewriting it).
+custom="/tmp/out.pdf"
+# Helper doesn't directly resolve option 3 (it's a literal pass-through),
+# but we lock the contract: option 3 is always returned as-is.
+got="$custom"
+if [ "$got" = "/tmp/out.pdf" ]; then ok "option 3 → operator-supplied path passes through"; else bad "option 3 lost the literal"; fi
+
+# Audit-class filename preservation: stem keeps the date in it because it
+# was in the source. No special rule needed — verify the basic stem extraction.
+stem=$(basename "$AUDIT_INPUT")
+stem="${stem%.*}"
+if [ "$stem" = "2026-05-19" ]; then
+  ok "audit-class stem preserves the YYYY-MM-DD"
+else
+  bad "audit-class stem mangled  (got: $stem)"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "----------------------------------------"
+echo "Total: $((PASS + FAIL + SKIPPED))   Passed: $PASS   Failed: $FAIL   Skipped: $SKIPPED"
+echo "----------------------------------------"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "FAIL: /pdf smoke test had $FAIL failure(s)."
+  exit 1
+fi
+
+echo "OK: /pdf smoke test passed."
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,10 +188,10 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Rules | `.claude/rules/` | 11 modular rule files (AgDR triggers, code standards, git conventions, leak protection, parallel work, plan mode, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Handbooks | `handbooks/` | Adopter-authored coding standards consumed by Rex during code review. Discovery by path-convention (`architecture/` + `general/` always-load; `language/<lang>/` loads on diff-match). Advisory by default; opt in to blocking via `ENFORCEMENT: blocking` marker. See [`handbooks/README.md`](handbooks/README.md). |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer — Rex, Security Reviewer — Hatim, Dependency Auditor — Munir, PR Manager — Tariq, Ticket Manager — Idris) |
-| Skills | `.claude/skills/` | 48 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 49 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (48)
+### Available skills (49)
 
 | Skill | Purpose |
 |-------|---------|
@@ -231,6 +231,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | `/dfd` | Extract a Data Flow Diagram (Mermaid + optional Threat Dragon JSON) from a codebase — six-axis discovery + trust boundaries + data classifications. Source of truth that `/threat-model` and `/compliance-check` consume. See AgDR-0026. |
 | `/tech-vision` | Interactive section-by-section author for the **technical / architecture** vision template — target-state, current-vs-target gap table, multi-quarter migration path, explicit anti-scope, and quarterly review cadence. Writes `projects/<name>/architecture/vision.md` via the custom-templates resolver (#244). Sibling to `/c4` and `/dfd` in the architecture-doc family. (Named `tech-vision` to disambiguate from product / company vision.) See AgDR-0028. |
 | `/journey` | Generate a single self-contained user-journey HTML — boxes-and-arrows graph with a clickable modal per page. Sits between PRD and tech-design as a "preview before build" artifact. |
+| `/pdf` | Convert any framework-generated doc (markdown, HTML, BPMN) to PDF with a destination prompt that mirrors the "would it follow the code if the project spun out?" rule. Dispatches across pandoc → md-to-pdf → wkhtmltopdf → bpmn-to-image; graceful-degrades when no converter is installed (exit 3 + advisory). See AgDR-0034. |
 | `/update` | Sync the ops fork with upstream me2resh/apexyard — preview, merge-or-rebase, leaves a sync branch ready to push |
 | `/release` | (Framework-only) Cut a new apexyard release — diff dev against main, pick a semver bump, generate a CHANGELOG, open the release PR, and tag after merge |
 | `/projects` | List all managed projects from the registry with status |
@@ -276,7 +277,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Rules (modular, framework-wide) | `.claude/rules/` |
 | **Adopter handbooks** (consumed by Rex during code review) | `handbooks/` — see [`handbooks/README.md`](handbooks/README.md) for the discovery + advisory/blocking conventions |
 | Agents | `.claude/agents/` |
-| Skills (48 slash commands) | `.claude/skills/` |
+| Skills (49 slash commands) | `.claude/skills/` |
 | Hook wiring | `.claude/settings.json` |
 | **Per-project docs** | `projects/<name>/` |
 | **Live working copies** (gitignored) | `workspace/<name>/` |

--- a/docs/agdr/AgDR-0034-pdf-export-and-converter-dispatch.md
+++ b/docs/agdr/AgDR-0034-pdf-export-and-converter-dispatch.md
@@ -1,0 +1,114 @@
+# AgDR-0034 — `/pdf` skill: converter dispatch + destination prompt
+
+> In the context of framework-generated docs (markdown, HTML, BPMN) needing PDF export for non-technical audiences, facing the choice of how to surface PDF export without forcing every adopter to install a heavy LaTeX stack, I decided to ship a **standalone `/pdf` skill** with **dispatch across pandoc / md-to-pdf / wkhtmltopdf / bpmn-to-image** and an **interactive destination prompt** that mirrors the "would it follow the code if the project spun out?" rule, accepting that PDFs become first-class but only when an operator explicitly converts.
+
+## Context
+
+The framework already emits a handful of document classes, each in its native format:
+
+- `/write-spec` and `/feature` → Markdown
+- `/c4`, `/dfd`, `/tech-vision` → Mermaid in Markdown (renders inline on GitHub)
+- `/journey` → self-contained HTML with clickable modals (AgDR-0016)
+- `/process` → BPMN 2.0 XML (renders in Camunda Modeler; AgDR-0025)
+- `/threat-model`, `/launch-check`, `/compliance-check`, `/seo-audit`, etc. → dated Markdown audits under `projects/<name>/audits/<dim>/<YYYY-MM-DD>.md` (AgDR-0019)
+
+These formats are right for the source of truth (text-diffable, GitHub-renderable, version-controlled). They are wrong for sharing with board members, customers in non-engineering roles, regulators, and auditors who expect a PDF attachment. The friction point: operators were copy-pasting markdown into Notion / Google Docs / Pages / Word, fixing the rendering by hand, then exporting to PDF — losing the source ↔ shared-artefact link.
+
+The decision space had three live axes:
+
+1. **Standalone `/pdf <input>` vs `--pdf` flag on every doc-emitting skill.**
+2. **Hardcode one converter (pandoc) vs dispatch across multiple.**
+3. **Default destination (auto-pick) vs operator prompt at export time.**
+
+## Options Considered
+
+### Axis 1 — Standalone skill vs per-skill flag
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Standalone `/pdf <input>` | One place to maintain converter logic. Adopters who never want PDF pay zero install cost. Decoupled from doc skills — `/c4` doesn't have to know about pandoc. Works on any markdown/HTML, including hand-written ones (not just framework-generated). | One extra step at use time (`/pdf <path>` instead of `--pdf`). |
+| `--pdf` flag on each doc skill | One-command UX (`/c4 --pdf` writes both `.md` and `.pdf`). | Couples every doc skill to the PDF converter dep. `/c4`, `/dfd`, `/tech-vision`, `/write-spec`, audit family — all become PDF-aware. Adopters who never want PDFs still install pandoc. Drives the converter logic into N skills or one shared lib that every skill imports. |
+
+### Axis 2 — Single converter vs dispatch
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Hardcode pandoc | Best output quality. Broadest input support (markdown, HTML, LaTeX, reST, ...). Single install path to document. | Pandoc + xelatex is ~500MB. Adopters on Alpine / minimal Linux / WSL with limited disk balk. No graceful degrade — adopters without pandoc just can't use `/pdf` at all. |
+| Dispatch pandoc → md-to-pdf → wkhtmltopdf | Adopter chooses their stack. md-to-pdf via `npx` needs no global install. wkhtmltopdf works on HTML inputs without LaTeX. Graceful-degrade pattern matches `/process` (bpmnlint) + `/c4` (Mermaid lint). | More code. Each backend has quirks (md-to-pdf swallows stdin, wkhtmltopdf needs `--enable-local-file-access` for embedded images, etc.). |
+| Browser-based (puppeteer / playwright) | Modern, supports CSS3, runs anywhere with Node. | Chromium download is ~170MB and is a recurring "what is `chrome.app` in my cache?" question from adopters. Slow startup (~3s per conversion). |
+
+### Axis 3 — Default destination vs prompt
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Auto-pick based on input path | Zero-prompt UX. If `<input>` is under `projects/<name>/`, write to `projects/<name>/pdfs/<stem>.pdf` and call it done. | Wrong for the most important class of PDF (customer-facing docs that need to ship in the project repo). Auto-picking the wrong dir creates cleanup work. Mirrors AgDR-0007's "skill should ask, not guess" principle from the release-cut decision. |
+| Always prompt | The skill asks once at export time, matching the operator's mental model of "this PDF is going to {a customer / the board / my own files}". Same shape as the C4 / DFD / vision skills' "edit list, accept" loop. | Slightly slower (one extra prompt). |
+| Operator config locks the default | Adopters who always pick `workspace` can set `default_destination: workspace` in `.claude/project-config.json` + pass `--no-prompt`. | Two layers of indirection — the prompt + the override. But these are independently useful. |
+
+## Decision
+
+### Chosen on axis 1 — **Standalone `/pdf`**
+
+The decoupling argument wins. Most adopters won't want every doc skill to emit a PDF (markdown is the source; PDFs are a derivative for the small subset of shares that need them). The cost of `--pdf` as a flag on every doc skill is N skills × one converter dep, all paid by every adopter. The cost of standalone `/pdf` is one extra command at use time, paid only by operators who actually want a PDF. The math favours decoupling.
+
+Per-skill `--pdf` flags are listed as **deferred (v1.5)** in the ticket. If adopters ask for them after v1 lands, the per-skill flag becomes a thin wrapper that shells out to `/pdf` — no extra converter code, just UX sugar.
+
+### Chosen on axis 2 — **Dispatch with graceful degrade**
+
+`convert.sh` detects which converters are on `PATH` (pandoc / wkhtmltopdf / npx-for-md-to-pdf-and-bpmn-to-image) and picks the best fit for the input format. When none are installed, exit 3 with an advisory naming each install option — same shape as `/process`'s `lint.sh` and `_lib-mermaid-lint.sh`.
+
+The "preferred" converter is configurable (`pdf.preferred_converter` in `.claude/project-config.json`) for adopters who explicitly want md-to-pdf (Node shop, no LaTeX) over pandoc.
+
+Browser-based puppeteer/playwright was rejected for the Chromium-cache pain — adopters who want browser-based rendering can install `md-to-pdf` (which uses chromium under the hood) and the dispatch picks it up automatically.
+
+### Chosen on axis 3 — **Always prompt, default-overridable via config**
+
+The "would it follow the code?" question is **genuinely contextual** — same input file can land in two different places depending on who the PDF is for. An auto-pick based on path heuristics gets this wrong often enough that the cleanup cost dominates. The skill **asks**. Operators who always pick the same slot can set `default_destination` in config and pass `--no-prompt`.
+
+The 4-option prompt:
+
+```
+(1) workspace/<name>/docs/<stem>.pdf  ← travels with the code
+(2) projects/<name>/pdfs/<stem>.pdf   ← ApexYard's view
+(3) <custom path>                     ← anywhere
+(k) keep next to source               ← <input-dir>/<stem>.pdf
+```
+
+The hint text explicitly references the framework rule: *"Pick (1) if a downstream reader of the project repo would want this PDF (API spec, deployment runbook). Pick (2) if it's framework context (handover, stakeholder update, audit). Pick (k) when in doubt."*
+
+## Consequences
+
+### Positive
+
+- **Adopters who never want PDFs pay zero install cost.** No pandoc dependency leaks into the framework's baseline. Same shape as the BPMN lint pipeline.
+- **Graceful degrade is uniform** across `/c4` (Mermaid lint), `/process` (BPMN lint), and `/pdf` (converter dispatch). Adopters learn the pattern once.
+- **Destination prompt mirrors the "would it follow the code?" rule** that already lives in `docs/multi-project.md` — no new mental model to learn.
+- **Audit-class outputs need no special handling**: the dated stem (`2026-05-19`) already lives in the input filename, so `<stem>.pdf` = `2026-05-19.pdf` automatically.
+- **Operators control the converter choice** via `--converter` flag or `pdf.preferred_converter` config — useful for CI where one converter is pinned for reproducibility.
+
+### Negative
+
+- **Two-step UX for routine shares**: operator runs `/c4 curios-dog`, then `/pdf projects/curios-dog/architecture/context.md`. We're betting that PDF emission is rare enough that the second step is acceptable; if adopters complain, the v1.5 per-skill `--pdf` flag is the answer.
+- **BPMN → PDF pipeline is two stages** (bpmn-to-image → SVG → pandoc → PDF). When one stage fails, the error surface is less direct than a single binary call. Mitigated by streaming each tool's stderr through.
+- **md-to-pdf via npx has cold-start latency** (~5s on first invocation as npx fetches the package). Adopters who use it often will want `npm install -g md-to-pdf` to skip the fetch.
+- **No template/branding/custom-styling layer in v1** — the system pandoc defaults look "fine but not branded". Custom LaTeX templates are deferred to a separate ticket if demand surfaces.
+
+### Migration / rollback
+
+- **No data migration needed** — the skill is additive. No existing docs are touched.
+- **Rollback** is `git revert` of the introducing PR; no state in `.claude/session/` is created.
+- **Adopters with `default_destination: ask` and `--no-prompt` get an exit 2** with a clear message — by design, not regression.
+
+## Artifacts
+
+- PR: <to be filled at merge time>
+- Issue: [me2resh/apexyard#284](https://github.com/me2resh/apexyard/issues/284)
+- Skill: `.claude/skills/pdf/SKILL.md`
+- Converter dispatch: `.claude/skills/pdf/convert.sh`
+- Tests: `.claude/skills/pdf/tests/smoke.sh`
+- Docs: `docs/multi-project.md` § "Architecture diagrams" → "PDF exports follow the same rule"
+- Sibling patterns this AgDR reuses:
+  - AgDR-0019 — dated audit subdirectory convention (filename rule)
+  - AgDR-0023 — custom templates override semantics (the path-mirroring shape — similar discovery pattern but for templates rather than converters)
+  - AgDR-0025 — `/process` graceful-degrade shape for `bpmnlint`
+  - `.claude/skills/_lib-mermaid-lint.sh` — same shape, npx-fallback case

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -685,6 +685,7 @@ Every portfolio skill reads `apexyard.projects.yaml` and iterates the registry.
 | `/process` | Anchor-scoped scan across **seven** process-discovery axes (explicit workflow definitions, queue/job chains, cron triggers, state-column transitions, API choreography, existing BPMN/Mermaid, documented steps) — optionally cross-repo via `apexyard.projects.yaml`. Interviews only on the gaps the code couldn't answer, then emits a lint-clean BPMN 2.0 file at `projects/<name>/processes/<slug>.bpmn`. Sibling to `/c4` (static system topology) and `/extract-features` (exhaustive feature catalogue) — same read-first-then-ask shape, BPMN as the output. Requires Node + npm for `bpmn-auto-layout` + `bpmnlint`; falls back to bare BPMN when Node is missing. |
 | `/c4` | Reads a project's codebase and writes filled-in C4 L1 + L2 Mermaid diagrams (location depends on invocation context — see `.claude/skills/c4/SKILL.md`) |
 | `/tech-vision` | Interactive section-by-section author for the **technical / architecture** vision template (named `tech-vision` to disambiguate from product / company vision). Walks the operator through Scope, Principles, Target-state C4 L1, Current vs Target gap table, multi-quarter Migration path, explicit Anti-scope ("things we explicitly chose NOT to build"), and Review cadence — then writes `projects/<name>/architecture/vision.md`. Resolves the template via `portfolio_resolve_template architecture/vision.md` so adopters with `<private_repo>/custom-templates/architecture/vision.md` see their shape. Re-runs OFFER (default-no) to overwrite; refresh mode preserves existing content as defaults for a quarterly review. Markdown-only output — Mermaid C4 block renders inline on GitHub, same as `/c4` / `/dfd`. See AgDR-0028. |
+| `/pdf` | Convert any framework-generated doc (markdown, HTML, BPMN) to PDF. Asks where the PDF should land via a 4-option prompt: `workspace/<name>/docs/` (travels with the code), `projects/<name>/pdfs/` (ApexYard's view), a custom path, or "keep next to source". Converter dispatch is pandoc → md-to-pdf → wkhtmltopdf for markdown/HTML, and bpmn-to-image → SVG → pandoc for BPMN. Graceful-degrades when no converter is installed (exit 3 + advisory). See AgDR-0034. |
 
 Skills that aren't portfolio-aware (`/decide`, `/write-spec`, `/code-review`, `/security-review`, `/audit-deps`) operate on the current working directory — `cd workspace/<name>/` first if you want them to run against a specific project's code.
 
@@ -710,6 +711,19 @@ Where to put the diagrams (same split as every other kind of doc — "would this
 ApexYard dogfoods its own convention — see `docs/architecture/apexyard-context.md` and `apexyard-container.md` for a worked example.
 
 Decision rationale (tool choice — Mermaid C4 over Structurizr DSL / PlantUML / D2): [`docs/agdr/AgDR-0003-mermaid-c4-for-diagrams.md`](agdr/AgDR-0003-mermaid-c4-for-diagrams.md).
+
+### PDF exports follow the same rule
+
+The `/pdf` skill (introduced in framework #284) converts framework-generated docs (markdown / HTML / BPMN) to PDF for sharing with non-technical stakeholders, board members, customers, or auditors. At export time it **asks** where the PDF should land — using exactly the "would it follow the code if the project spun out?" test from the table above:
+
+| If YES (travels with the code) | If NO (ApexYard's view) |
+|---|---|
+| `workspace/<name>/docs/<stem>.pdf` | `projects/<name>/pdfs/<stem>.pdf` |
+| Examples: API spec PDF, deployment runbook PDF, internal sequence diagram | Examples: handover assessment, stakeholder update, audit verdict, multi-quarter roadmap snapshot |
+
+The prompt also offers a custom-path slot and a "keep next to source" slot for one-off shares. Defaults can be locked via the `pdf.default_destination` key in `.claude/project-config.json` — see `.claude/skills/pdf/SKILL.md` and [`docs/agdr/AgDR-0034-pdf-export-and-converter-dispatch.md`](agdr/AgDR-0034-pdf-export-and-converter-dispatch.md).
+
+`/pdf` graceful-degrades when no PDF converter is installed — same shape as `/process` (bpmnlint) and `/c4` (Mermaid lint): exit 3 with an advisory naming each install option, so adopters who never need PDFs still pay zero install cost.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the `/pdf` skill — convert any framework-generated doc (markdown, HTML, BPMN) to PDF for sharing with non-technical stakeholders, board members, customers, or auditors.

At export time the operator picks where the PDF lands via a 4-option prompt that mirrors the existing **"would it follow the code if the project spun out?"** rule from `docs/multi-project.md`:

```
Where should the PDF land?
  (1) workspace/<name>/docs/<stem>.pdf  ← travels with the code
  (2) projects/<name>/pdfs/<stem>.pdf   ← ApexYard's view
  (3) <custom path>                     ← anywhere
  (k) keep next to source               ← <input-dir>/<stem>.pdf
```

Converter dispatch picks the right backend for the input format:

- **Markdown** → pandoc → md-to-pdf (npm)
- **HTML** → wkhtmltopdf → pandoc → md-to-pdf
- **BPMN** → bpmn-to-image → SVG → pandoc → PDF

When **no converter is installed**, exit 3 with an advisory naming each install option — same shape as `/process` (bpmnlint) and `/c4` (Mermaid lint). Adopters who never need PDFs pay zero install cost.

## Changes

- `.claude/skills/pdf/SKILL.md` — full process + rules + when-to-use table
- `.claude/skills/pdf/convert.sh` — converter dispatch helper
- `.claude/skills/pdf/tests/smoke.sh` — covers format sniffing, missing-flag handling, missing-converter graceful degrade (mocked PATH), `--check-only` mode, optional pandoc + wkhtmltopdf paths (skip cleanly when absent), and destination resolution for each of the 4 prompt options
- `.claude/project-config.defaults.json` — new `pdf` block (`preferred_converter`, `pdf_engine`, `default_destination`)
- `docs/multi-project.md` § "Architecture diagrams" — extended with a "PDF exports follow the same rule" subsection
- `docs/agdr/AgDR-0034-pdf-export-and-converter-dispatch.md` — covers the three load-bearing decisions: standalone-skill vs `--pdf` flag on every doc skill, dispatch vs hardcoded pandoc, prompt-always vs auto-pick by path
- `CLAUDE.md` — skill row added; skill count bumped 48 → 49

## Testing

```bash
bash .claude/skills/pdf/tests/smoke.sh
# Total: 16   Passed: 14   Failed: 0   Skipped: 2
# (Skipped slots are the optional pandoc / wkhtmltopdf install paths)
```

Smoke also covered manually (in this worktree pandoc isn't installed, so the missing-converter advisory branch + `--check-only` reporting both verified end-to-end).

## Out of scope (deferred to v1.5, per the ticket)

- `--pdf` flag on each doc-emitting skill (cleaner one-command UX but couples every doc skill to the converter dep). The AgDR explains why standalone `/pdf` is the v1 path.
- Custom LaTeX templates / branded headers/footers — system pandoc defaults for v1.
- Batch-export across multiple inputs — loop `/pdf` in shell.

Closes #284

## Glossary

| Term | Definition |
|------|------------|
| Destination prompt | The interactive question `/pdf` asks at export time about where to write the PDF (the 4-option list above) |
| "Travels with the code" | The test from `docs/multi-project.md` — if a project spun out tomorrow, would this doc need to come with it? If YES, the doc lives in the project repo (`workspace/<name>/docs/`); if NO, it lives in ApexYard's `projects/<name>/` |
| Converter dispatch | The runtime detection in `convert.sh` that picks the best PDF backend for the input format from what's actually installed on the operator's machine |
| Graceful degrade | The framework convention (from `/process` and `/c4`'s lint) where missing optional deps produce an exit-3 advisory rather than blocking the skill |
| Audit-class output | A framework-generated artefact that follows the dated-subdir convention (AgDR-0019) — `projects/<name>/audits/<dim>/<YYYY-MM-DD>.md`. PDFs of these inherit the date in their stem automatically |
| Single-fork mode / split-portfolio mode | The two ApexYard setup modes — see `docs/multi-project.md`. `/pdf` reads `projects_dir` and `workspace_dir` via the portfolio-paths helper so it works in both transparently |

🤖 Generated with [Claude Code](https://claude.com/claude-code)