### PR TITLE
feat(#280): declare jq as a hard dependency — Option A

### DIFF
--- a/.claude/hooks/check-jq-installed.sh
+++ b/.claude/hooks/check-jq-installed.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# SessionStart advisory: warn once per session when `jq` is missing on a
+# fork that has any project-config file present.
+#
+# Many framework hooks call `jq` to read `.claude/project-config.json`
+# and `.claude/project-config.defaults.json` for adopter overrides
+# (`.ui_paths`, `.ui_paths_exclude`, `.tracker.*`, `.migration_paths`,
+# `.ticket.bootstrap_skills`, etc.). Without jq those reads silently
+# return empty (`jq … 2>/dev/null`), the hook falls back to the
+# framework default, and the adopter's override has zero effect. No
+# error, no warning — a silently-degraded fork.
+#
+# Surfacing the gap at SessionStart turns the failure into a one-line
+# banner the operator can act on, instead of a buried, invisible
+# fallback. Same advisory shape as check-upstream-drift.sh:
+# non-blocking, exit 0 always.
+#
+# Silent exit paths (no output, no error):
+#   - jq is on PATH (the happy path — most adopters)
+#   - No ops fork can be located (caller isn't inside an apexyard tree)
+#   - No project-config file is present at the resolved ops root (so
+#     there's literally nothing for hooks to read overrides from; the
+#     fork is on framework defaults regardless of jq's presence)
+#
+# Banner emits only when jq is genuinely missing AND a project-config
+# file exists, i.e. the silently-degraded state the rule is trying to
+# surface.
+
+# Skip silently when jq is already installed — the common case.
+if command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Resolve the ops-fork root via the shared helper. Falls back to a small
+# inline walk-up if the helper is missing (older forks, or this hook
+# running against an unrelated git repo where the helper hasn't been
+# copied in yet).
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+ops_root=""
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  ops_root=$(resolve_ops_root "$PWD")
+else
+  r="$PWD"
+  while [ -n "$r" ] && [ "$r" != "/" ]; do
+    if [ -f "$r/.apexyard-fork" ]; then
+      ops_root="$r"; break
+    fi
+    if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
+      ops_root="$r"; break
+    fi
+    r=$(dirname "$r")
+  done
+fi
+
+# If we couldn't find an ops fork, this session isn't an apexyard
+# session — stay silent.
+if [ -z "$ops_root" ]; then
+  exit 0
+fi
+
+# If neither project-config file exists at the ops root, hooks have
+# nothing to read overrides from and the missing jq is harmless. Stay
+# silent — surfacing it would be noise.
+if [ ! -f "$ops_root/.claude/project-config.json" ] && \
+   [ ! -f "$ops_root/.claude/project-config.defaults.json" ]; then
+  exit 0
+fi
+
+cat >&2 <<'MSG'
+ApexYard: jq is not installed. Hooks that read project-config overrides
+(`.ui_paths`, `.ui_paths_exclude`, `.tracker.*`, `.migration_paths`,
+`.ticket.bootstrap_skills`, etc.) will silently fall back to framework
+defaults. Install jq to make overrides take effect:
+  brew install jq        # macOS
+  apt-get install jq     # Debian / Ubuntu
+  dnf install jq         # Fedora
+  https://jqlang.org/download/   # other platforms
+Or skip if you don't override any defaults.
+MSG
+
+exit 0

--- a/.claude/hooks/tests/test_check_jq_installed.sh
+++ b/.claude/hooks/tests/test_check_jq_installed.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/check-jq-installed.sh — SessionStart
+# advisory that warns when `jq` is missing on a fork that has any
+# project-config file present.
+#
+# Each case:
+#   - builds an isolated sandbox under $TMPDIR with a synthetic ops-fork
+#     layout (legacy v1 anchor: onboarding.yaml + apexyard.projects.yaml)
+#   - toggles jq's presence by either using the real PATH (jq present)
+#     OR a stub PATH where `jq` resolves to a non-existent binary
+#     (jq absent)
+#   - optionally drops a project-config file into the ops fork
+#   - runs the hook from the ops-fork dir
+#   - asserts banner output / silence
+#
+# Cases covered:
+#   1. jq present → silent exit 0 (regardless of config presence)
+#   2. jq missing + project-config.json present → warning emitted
+#   3. jq missing + project-config.defaults.json present → warning emitted
+#   4. jq missing + no project-config file → silent exit 0 (nothing to
+#      degrade, banner would be noise)
+#   5. jq missing + not inside any ops fork → silent exit 0
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/check-jq-installed.sh"
+LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-ops-root.sh"
+PASS=0
+FAIL=0
+FAILED=""
+
+if [ ! -f "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found at $HOOK_SRC" >&2
+  exit 1
+fi
+
+# Build a synthetic ops-fork layout under $1 with a legacy v1 anchor:
+#   $1/onboarding.yaml
+#   $1/apexyard.projects.yaml
+#   $1/.claude/hooks/check-jq-installed.sh   (copy of the source hook)
+#   $1/.claude/hooks/_lib-ops-root.sh        (copy of the shared lib)
+build_fork() {
+  local fk="$1"
+  mkdir -p "$fk/.claude/hooks"
+  : > "$fk/onboarding.yaml"
+  : > "$fk/apexyard.projects.yaml"
+  cp "$HOOK_SRC" "$fk/.claude/hooks/check-jq-installed.sh"
+  chmod +x "$fk/.claude/hooks/check-jq-installed.sh"
+  if [ -f "$LIB_SRC" ]; then
+    cp "$LIB_SRC" "$fk/.claude/hooks/_lib-ops-root.sh"
+  fi
+}
+
+# Run the hook from $1 (ops fork dir) with jq either visible (when
+# $2 is "present") or hidden (when $2 is "missing"). For the "missing"
+# case we point PATH at a directory containing a stub `jq` that's a
+# non-executable placeholder file — `command -v` walks PATH looking
+# for an executable, finds the stub, and reports it missing because
+# it's not +x. This sidesteps both the "where is jq actually
+# installed" problem and the "exported functions don't propagate to a
+# fresh bash" problem with `command` overrides.
+#
+# We keep the rest of PATH so coreutils (bash, mktemp, grep, cat, ...)
+# remain reachable.
+run_hook_from() {
+  local fk="$1" mode="$2"
+  case "$mode" in
+    present)
+      ( cd "$fk" || exit 1; bash .claude/hooks/check-jq-installed.sh 2>&1 )
+      ;;
+    missing)
+      # Two-stage approach: first try a PATH-only mask (works on macOS
+      # where jq is in /opt/homebrew/bin or /usr/local/bin and absent
+      # from /usr/bin); fall through to a `command` function override
+      # if jq is still reachable via PATH (true on Linux where jq is
+      # typically packaged into /usr/bin). Each approach has a quirk:
+      #   - PATH-only: cheapest, works in a child bash process.
+      #   - command override: works regardless of where jq lives, but
+      #     requires sourcing the hook into a subshell so the function
+      #     stays in scope. We use `bash -c '… . "$2"'` for that.
+      ( cd "$fk" || exit 1
+        PATH="/usr/bin:/bin"
+        if ! command -v jq >/dev/null 2>&1; then
+          bash .claude/hooks/check-jq-installed.sh 2>&1
+        else
+          bash -c '
+            command() {
+              if [ "$1" = "-v" ] && [ "$2" = "jq" ]; then
+                return 1
+              fi
+              builtin command "$@"
+            }
+            cd "$1" || exit 1
+            . .claude/hooks/check-jq-installed.sh
+          ' _ "$fk" 2>&1
+        fi
+      )
+      ;;
+  esac
+}
+
+assert() {
+  local label="$1" expected_pattern="$2" output="$3"
+  if [ -z "$expected_pattern" ]; then
+    if [ -z "$output" ]; then
+      echo "PASS [$label] — silent"
+      PASS=$((PASS+1)); return
+    fi
+    echo "FAIL [$label] — expected silent, got: $output" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "; return
+  fi
+  if echo "$output" | grep -qE "$expected_pattern"; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1)); return
+  fi
+  echo "FAIL [$label] — expected /$expected_pattern/, got: $output" >&2
+  FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+}
+
+# CASE 1: jq present + project-config present → silent
+case_jq_present_silent() {
+  local fk; fk=$(mktemp -d)/fork
+  build_fork "$fk"
+  : > "$fk/.claude/project-config.json"
+  # Real PATH carries jq (assumption: the dev box running these tests
+  # has jq installed — same assumption used by the rest of the test
+  # suite). If jq is missing here, the test environment itself is
+  # broken; the test result reflects that honestly.
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "SKIP [jq present case] — jq is not installed in the test environment" >&2
+    rm -rf "$(dirname "$fk")"
+    return
+  fi
+  assert "jq present + project-config.json → silent" "" "$(run_hook_from "$fk" "present")"
+  rm -rf "$(dirname "$fk")"
+}
+
+# CASE 2: jq missing + project-config.json present → warning
+case_jq_missing_with_config() {
+  local fk; fk=$(mktemp -d)/fork
+  build_fork "$fk"
+  : > "$fk/.claude/project-config.json"
+  assert "jq missing + project-config.json → warning fires" "jq is not installed" "$(run_hook_from "$fk" "missing")"
+  rm -rf "$(dirname "$fk")"
+}
+
+# CASE 3: jq missing + project-config.defaults.json present → warning
+case_jq_missing_with_defaults() {
+  local fk; fk=$(mktemp -d)/fork
+  build_fork "$fk"
+  : > "$fk/.claude/project-config.defaults.json"
+  assert "jq missing + project-config.defaults.json → warning fires" "jq is not installed" "$(run_hook_from "$fk" "missing")"
+  rm -rf "$(dirname "$fk")"
+}
+
+# CASE 4: jq missing + no project-config file → silent
+case_jq_missing_no_config() {
+  local fk; fk=$(mktemp -d)/fork
+  build_fork "$fk"
+  # Intentionally no project-config.{,defaults.}json
+  assert "jq missing + no project-config → silent" "" "$(run_hook_from "$fk" "missing")"
+  rm -rf "$(dirname "$fk")"
+}
+
+# CASE 5: jq missing + not inside any ops fork → silent
+case_jq_missing_no_ops_root() {
+  local outside; outside=$(mktemp -d)
+  # Walk-up from a tmp dir might find an ancestor ops fork on a dev
+  # box. If it does, this case is ambiguous; document the skip rather
+  # than fail spuriously. We pass the hook the absolute path so its
+  # `dirname "$0"` resolves to the real hook dir, but invoke from
+  # $outside so the ops-root walk starts elsewhere.
+  local out
+  out=$(
+    PATH="/usr/bin:/bin"
+    if ! command -v jq >/dev/null 2>&1; then
+      cd "$outside" && bash "$HOOK_SRC" 2>&1
+    else
+      bash -c '
+        command() {
+          if [ "$1" = "-v" ] && [ "$2" = "jq" ]; then
+            return 1
+          fi
+          builtin command "$@"
+        }
+        cd "$1" || exit 1
+        . "$2"
+      ' _ "$outside" "$HOOK_SRC" 2>&1
+    fi
+  )
+  if [ -z "$out" ]; then
+    echo "PASS [jq missing + outside ops fork → silent]"
+    PASS=$((PASS+1))
+  else
+    # The walk found an ancestor ops fork with a config file present.
+    # That's a legitimate (different) state — not a regression. Note it.
+    echo "SKIP [jq missing + outside ops fork] — walk-up found an ancestor ops fork (output: $out)" >&2
+  fi
+  rm -rf "$outside"
+}
+
+case_jq_present_silent
+case_jq_missing_with_config
+case_jq_missing_with_defaults
+case_jq_missing_no_config
+case_jq_missing_no_ops_root
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,10 @@
           },
           {
             "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-jq-installed.sh\"'"
+          },
+          {
+            "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-portfolio-config.sh\"'"
           },
           {

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -30,6 +30,31 @@ Re-running `/setup` on an already-configured fork shows the current config and a
 
 ## Process
 
+### Step −1: Pre-flight — refuse if `jq` is missing (REQUIRED)
+
+`/setup` (and every framework hook that reads `.claude/project-config.json` overrides) depends on `jq`. Without it, override reads silently fall back to defaults — the adopter's `.ui_paths`, `.tracker.*`, `.migration_paths`, etc. have zero effect and there's no error to debug. Refuse to proceed until jq is on PATH so the operator never sees the silently-degraded state.
+
+Run this **before any other tool call** in the skill:
+
+```bash
+if ! command -v jq >/dev/null 2>&1; then
+  cat <<'MSG'
+✗ ApexYard requires `jq` for reading project-config overrides, but it's not installed.
+
+Install instructions:
+  macOS:   brew install jq
+  Debian:  apt-get install jq
+  Fedora:  dnf install jq
+  Other:   https://jqlang.org/download/
+
+Once installed, re-run /setup.
+MSG
+  exit 1
+fi
+```
+
+The sibling `check-jq-installed.sh` SessionStart hook surfaces the same gap as a one-line banner outside `/setup` so a fork that's already configured (and never re-runs `/setup`) still sees the warning. See AgDR-0038 for the design rationale.
+
 ### Step 0: Mark this session as bootstrap (REQUIRED)
 
 `/setup` runs BEFORE any portfolio is configured, so no project tickets can exist yet. The `require-active-ticket.sh` PreToolUse hook would otherwise block every Edit / Write / Bash-write the skill needs to make. To stay coherent with the ticket-first rule without forcing adopters to file a placeholder ticket against nothing, the skill writes a one-line marker at `.claude/session/active-bootstrap` containing the skill name. The hook reads the marker and exempts skills listed in `ticket.bootstrap_skills` (in `.claude/project-config.defaults.json` — `setup` is on the default list).

--- a/docs/agdr/AgDR-0038-jq-as-hard-dependency.md
+++ b/docs/agdr/AgDR-0038-jq-as-hard-dependency.md
@@ -1,0 +1,78 @@
+# AgDR-0038 — `jq` as a hard dependency (declare + check + warn)
+
+> In the context of 22+ framework hooks reading `.claude/project-config.json` via `jq` to honour adopter overrides, facing the failure mode where a jq-less machine silently degrades every override to the framework default with no error and no warning, I decided to **declare `jq` as a hard dependency** with **`/setup` pre-flight detection**, a **SessionStart advisory hook**, and a **prerequisite line in `docs/getting-started.md`**, accepting that locked-down corporate environments without jq install rights cannot run the framework until they get jq onto PATH.
+
+## Context
+
+Framework hooks lean on `jq` to read adopter overrides from `.claude/project-config.json` and `.claude/project-config.defaults.json`. A non-exhaustive sample of what depends on it: `.ui_paths` + `.ui_paths_exclude` (design-review gate), `.tracker.*` (multi-tracker dispatch — AgDR-0033), `.migration_paths` (migration gate), `.ticket.bootstrap_skills` (bootstrap exemption — AgDR-0011), `.ticket.create_command_patterns` (skill-gated ticket-create — AgDR-0030), `.git.protected_branches`, `.leak_protection.public_framework_repos`, etc. All of those reads route through `_lib-read-config.sh → config_get → jq … 2>/dev/null`.
+
+The failure mode surfaced on 2026-05-18 in an adopter fork: a `.ui_paths` override was added to silence a design-review-gate false positive on a non-UI `.jsx` file. The override appeared to have no effect because `jq` wasn't installed on the machine. `jq … 2>/dev/null` returned empty, the hook silently fell back to the default UI-paths array, the false positive kept firing. No error, no warning, no log line — just an invisible "your override doesn't work, and we won't tell you why".
+
+This is a **class problem**, not a one-off: every adopter override that travels through `_lib-read-config.sh` silently degrades on jq-less machines. The cost of leaving it alone scales with the number of overrides the framework adds over time, and any new hook that consumes config inherits the same silent-degradation behaviour by default.
+
+The decision space had two live options.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A — declare `jq` as a hard dependency** (this AgDR) | Simplest possible mechanism. Explicit failure beats silent degradation — the operator sees a clear error message at `/setup` time, or a one-line SessionStart banner if jq disappears later. Zero changes to hook internals; `_lib-read-config.sh` stays the way it is. Detection cost is one `command -v jq` per invocation site. jq is broadly available — `brew install jq` / `apt-get install jq` / `dnf install jq` / Windows via choco or scoop, ~5s install on the happy path. | Locked-down corporate environments that can't easily install new system packages can't run ApexYard until jq is on PATH. Dependency-management burden lives with the adopter. |
+| **B — implement a jq-free fallback inside `_lib-read-config.sh`** | No new install burden on the adopter — the framework "just works" on a fresh machine with only Python 3 installed (which is true for every modern Linux distro, macOS, and most CI images). | Two JSON parsers to maintain (jq path + Python path), with the Python path getting less testing because most CI runs hit jq. Subtle semantic differences (jq's filter language vs `json.loads()` + dict access) become a long-term tax — every new override key has to work in both parsers. Dependency-management burden shifts onto the framework. Adds latency on the Python path (Python startup is ~50-100ms; jq is <10ms). Doesn't fix the broader pattern (any future hook adding a new external dep faces the same fallback-or-fail choice). |
+
+The earlier framework patterns — Mermaid lint (`_lib-mermaid-lint.sh`), BPMN lint (`/process` skill), PDF converter dispatch (AgDR-0034 / `/pdf`) — all chose **graceful degrade with a single advisory at use time**, NOT a multi-tool dispatch inside the core library. That precedent argues for A: surface the missing dep loudly, keep the lib path single.
+
+## Decision
+
+Chosen: **Option A — declare `jq` as a hard dependency**, because:
+
+1. **Explicit failure beats silent degradation.** The whole point of this AgDR is that the adopter was burned by a silent fallback. A noisy "jq missing" banner is strictly better than an invisibly-ignored override, even if it costs them one `brew install jq`.
+2. **Dependency-management burden shifts to adopters either way.** Option B looks like it removes the burden, but the Python fallback path is itself a dep (`python3` on PATH, JSON-shaped dicts matching jq's filter semantics). Adopters who don't have jq are usually adopters who have constrained installs in general; if they can install Python, they can install jq. The shift is illusory.
+3. **Simpler is the right shape for a class problem.** Every hook reading config already calls `config_get`. Adding a single pre-flight check (in `/setup`) + a single SessionStart advisory (a new hook) + a single prerequisite doc line covers every override key, current and future. No per-key changes, no parser-compatibility tests, no two-codepaths-to-maintain.
+4. **jq is genuinely broadly available.** The framework's target audience (CTOs, engineering leads on macOS / Linux / WSL) almost always has jq one package-manager command away. The hard-dep cost is small in practice.
+
+Where the failure surfaces:
+
+| Surface | Mechanism | What the operator sees |
+|---------|-----------|-----------------------|
+| First-run `/setup` | Pre-flight `command -v jq` check; refuses with exit 1 + install instructions before any state-mutating step. | `✗ ApexYard requires jq for reading project-config overrides…` |
+| Every SessionStart (after first-run) | New advisory hook `check-jq-installed.sh` mirrors `check-upstream-drift.sh` shape — exits 0 always, prints a one-line banner if jq is missing AND a project-config file exists. | `ApexYard: jq is not installed. Hooks that read project-config overrides… will silently fall back to framework defaults.` |
+| Onboarding docs | `docs/getting-started.md § Prerequisites` lists `jq` alongside `gh`. | One bullet in the prerequisites list with install instructions. |
+
+The SessionStart hook **does not block** — it's an advisory in the same vein as `check-upstream-drift.sh`. Blocking on jq-missing at SessionStart would brick the session for an adopter who happens to be running `/threat-model` or `/audit-deps` and doesn't touch any overrides — disproportionate. The banner lets them choose: install jq now, or accept that any active overrides aren't taking effect.
+
+## Consequences
+
+### Positive
+
+- **Visible failure mode.** Silent degradation becomes a clear refusal at `/setup` and a one-line banner at every SessionStart after. The adopter cannot miss it.
+- **`_lib-read-config.sh` stays single-path.** No parallel JSON parser to maintain, no semantic drift between two paths, no per-key compatibility tests. New override keys "just work" with no extra plumbing.
+- **Uniform with existing graceful-degrade patterns.** Mermaid lint, BPMN lint, PDF converter dispatch — all of them surface missing deps loudly at use time rather than rewriting the core library. This decision matches that shape and is easy to teach.
+- **Zero per-hook changes.** The 22+ hooks calling `config_get` need no edits. The mitigation lives at three discrete points (`/setup`, the new SessionStart hook, the docs).
+- **Cheap to roll back.** If Option B becomes preferred later, the SessionStart hook can be removed and `_lib-read-config.sh` can grow a Python fallback — no decisions in this AgDR foreclose that future.
+
+### Negative
+
+- **Locked-down corporate environments without jq install rights are blocked.** A team behind a paranoid IT department that doesn't whitelist jq cannot run the framework until they whitelist it. The README + AgDR-0038 give them the request-this-package case to take to IT, but the unblock is on their side.
+- **Adopter who never overrides anything still pays the install cost.** Even forks that run on pure framework defaults need jq on PATH to avoid the SessionStart banner. Mitigation: the banner is opt-out-of-warning style — "Or skip if you don't override any defaults." reads as permission to ignore for those adopters.
+- **A new SessionStart hook is one more bootstrap dep.** Adds ~10ms to SessionStart (one `command -v jq` + an `ops_root` walk). Negligible, but non-zero.
+- **Behaviour change for adopters who were inadvertently relying on silent fallback** (i.e. their overrides were never being honoured but they didn't know). This is the right change — they should know — but it surfaces as a "wait, what?" moment when they first run a new session after upgrading.
+
+### Migration / rollback
+
+- **No data migration needed.** This is additive: new hook + new doc line + new `/setup` pre-flight step.
+- **Rollback** is `git revert` of the introducing PR. No state in `.claude/session/` is created. Adopters who had jq-less forks continue to work (silently degraded) the way they always did.
+- **Adopters who hit the SessionStart banner and don't want it** can either install jq (the intended path) or stop using ApexYard. There's no escape-hatch env var in v1 — adding one (`APEXYARD_ALLOW_NO_JQ=1`) is a follow-up if real adopter pressure surfaces; for now the explicit refusal is the point.
+
+## Artifacts
+
+- PR: <to be filled at merge time>
+- Issue: [me2resh/apexyard#280](https://github.com/me2resh/apexyard/issues/280)
+- Skill: `.claude/skills/setup/SKILL.md` (new Step −1 pre-flight check)
+- Hook: `.claude/hooks/check-jq-installed.sh` (new SessionStart advisory)
+- Hook wiring: `.claude/settings.json` (new SessionStart entry, sibling to `check-upstream-drift.sh`)
+- Tests: `.claude/hooks/tests/test_check_jq_installed.sh`
+- Docs: `docs/getting-started.md § Prerequisites` (new bullet)
+- Sibling patterns this AgDR reuses:
+  - AgDR-0005 — tag-based upstream drift detection (same SessionStart advisory shape, exit 0 always)
+  - AgDR-0034 — `/pdf` converter dispatch (same "loud at use time, no fallback in core lib" pattern)
+  - `_lib-mermaid-lint.sh` — same shape, npx-fallback case for a different external dep

--- a/docs/agdr/AgDR-0038-jq-as-hard-dependency.md
+++ b/docs/agdr/AgDR-0038-jq-as-hard-dependency.md
@@ -1,3 +1,10 @@
+---
+title: jq as a hard dependency (declare + check + warn)
+category: architecture
+status: accepted
+date: 2026-05-19
+---
+
 # AgDR-0038 — `jq` as a hard dependency (declare + check + warn)
 
 > In the context of 22+ framework hooks reading `.claude/project-config.json` via `jq` to honour adopter overrides, facing the failure mode where a jq-less machine silently degrades every override to the framework default with no error and no warning, I decided to **declare `jq` as a hard dependency** with **`/setup` pre-flight detection**, a **SessionStart advisory hook**, and a **prerequisite line in `docs/getting-started.md`**, accepting that locked-down corporate environments without jq install rights cannot run the framework until they get jq onto PATH.

--- a/docs/agdr/AgDR-0038-jq-as-hard-dependency.md
+++ b/docs/agdr/AgDR-0038-jq-as-hard-dependency.md
@@ -1,10 +1,3 @@
----
-title: jq as a hard dependency (declare + check + warn)
-category: architecture
-status: accepted
-date: 2026-05-19
----
-
 # AgDR-0038 — `jq` as a hard dependency (declare + check + warn)
 
 > In the context of 22+ framework hooks reading `.claude/project-config.json` via `jq` to honour adopter overrides, facing the failure mode where a jq-less machine silently degrades every override to the framework default with no error and no warning, I decided to **declare `jq` as a hard dependency** with **`/setup` pre-flight detection**, a **SessionStart advisory hook**, and a **prerequisite line in `docs/getting-started.md`**, accepting that locked-down corporate environments without jq install rights cannot run the framework until they get jq onto PATH.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,6 +9,7 @@ Short version of the setup flow. For the full walkthrough (directory layout, dai
 - A GitHub account and an org you can fork into
 - [Claude Code](https://claude.com/claude-code) installed
 - [GitHub CLI (`gh`)](https://cli.github.com) installed (optional but recommended)
+- [`jq`](https://jqlang.org/download/) installed — required. Framework hooks use jq to read `.claude/project-config.json` overrides; without it your overrides silently no-op. `brew install jq` / `apt-get install jq` / `dnf install jq` depending on platform. `/setup` refuses to run without it, and a SessionStart banner surfaces the gap if jq disappears later. See [AgDR-0038](agdr/AgDR-0038-jq-as-hard-dependency.md) for the rationale.
 - Basic familiarity with Claude Code's `CLAUDE.md` system
 
 ---


### PR DESCRIPTION
## Summary

- Declares `jq` as a hard dependency for ApexYard (Option A from #280's design discussion).
- New SessionStart hook `check-jq-installed.sh` emits a one-line warning if `jq` is missing AND a project-config exists (silent otherwise — no false alarms on clean adopters).
- `/setup` skill refuses with a clear install message if `jq` isn't on `PATH`.
- `docs/getting-started.md` lists `jq` in Prerequisites.
- AgDR-0038 captures the design rationale (Option A vs Option B / Python fallback).
- 5 smoke tests for the new hook (jq present → silent; jq missing + config present → warn; jq missing + no config → silent; etc.).

## Why

ApexYard hooks read `.claude/project-config.json` via `jq`. On a machine without `jq` installed, those reads silently fail (`jq ... 2>/dev/null` returns empty), hooks fall back to defaults, and adopter overrides have no effect. **No error, no warning, no log line.** Surfaced 2026-05-18 by an adopter whose `.ui_paths` override never took effect because `jq` wasn't installed — they only discovered it by tracing why the design-review-gate kept firing.

Option A (declared hard-dep with explicit failure) was chosen over Option B (Python fallback inside `_lib-read-config.sh`) per the CEO's call: simpler, more explicit, and `jq` is broadly available across the adopter base. Full rationale: [`docs/agdr/AgDR-0038-jq-as-hard-dependency.md`](https://github.com/me2resh/apexyard/blob/feature/GH-280-jq-hard-dependency/docs/agdr/AgDR-0038-jq-as-hard-dependency.md).

## Testing

- 5 smoke tests in `.claude/hooks/tests/test_check_jq_installed.sh` covering the matrix of (jq present/missing) × (config present/missing).
- `bash -n` syntax-check on the new hook and tests passes.
- Manually verified `/setup` refusal flow when `jq` is masked from `PATH`.
- The new SessionStart hook adds ~10ms to session start (one `command -v jq` + ops-root walk-up).

## Out of Scope

- **Option B** (Python fallback) — explicitly chosen against; see AgDR-0038.
- Changing `_lib-read-config.sh` to use anything other than `jq`.
- Bundling `jq` with ApexYard installer.

## Glossary

| Term | Definition |
|------|------------|
| `jq` | Command-line JSON processor used by ApexYard hooks to read `.claude/project-config.json` for adopter overrides (`.ui_paths`, `.git.protected_branches`, `.ticket.required_sections`, `.migration_paths`, etc.) |
| Hard dependency | A tool the framework requires to function; missing it is an explicit failure, not silent degradation |
| SessionStart hook | A non-blocking advisory hook (`exit 0` always) that runs on every Claude Code session start to surface drift / health concerns. `check-jq-installed.sh` joins `check-upstream-drift.sh` in this class |
| AgDR | Agent Decision Record — captures the why behind a non-obvious technical choice |

Closes #280
