### PR TITLE
feat(#295): standardise self-correction guidance across blocking hooks (shape + 5 retrofits)

### DIFF
--- a/.claude/hooks/block-git-add-all.sh
+++ b/.claude/hooks/block-git-add-all.sh
@@ -12,7 +12,30 @@ if [ -z "$COMMAND" ]; then
 fi
 
 if echo "$COMMAND" | grep -qE '\bgit\s+add\s+(-A|--all|\.)(\s|$)'; then
-  echo "BLOCKED: Never use 'git add -A', 'git add --all', or 'git add .' — always add specific files to avoid committing unrelated changes." >&2
+  cat >&2 <<MSG
+BLOCKED: 'git add -A', 'git add --all', and 'git add .' are forbidden.
+
+These commands stage every modified file in the working tree —
+including .env files, credentials, generated artifacts, scratch
+files, and partially-edited unrelated work. ApexYard requires
+explicit file selection on every stage (.claude/rules/git-conventions.md
+§ "File Staging").
+
+To unblock:
+  1. List the changed files: git status --short
+  2. Stage each file you intend to commit by name:
+       git add path/to/file1 path/to/file2
+  3. Verify the staged set: git diff --cached --stat
+  4. Retry the commit
+
+If you have many files in the same change, group by directory:
+       git add src/auth/ src/billing/
+That's still explicit (you typed the path) and still safe.
+
+The one common exception — staging all files under a single feature
+directory after a refactor — is fine via the directory form above.
+There's no exception for whole-tree staging.
+MSG
   exit 2
 fi
 

--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -43,10 +43,12 @@ To unblock:
   3. Open a PR via /feature → /start-ticket → gh pr create, OR if the
      ticket exists, just: gh pr create --base <protected-branch> --head <feature-branch>
 
-Override (rare — only if your fork's branch model genuinely treats
-this branch as a daily-work trunk): add the branch name to
-.claude/project-config.json → .git.protected_branches[] to override
-the default protection list.
+Customise (rare): .claude/project-config.json → .git.protected_branches[]
+REPLACES the default list (main / master / dev / develop). To REMOVE
+protection from a default-protected branch (e.g. you legitimately use
+'dev' as your trunk), write the array with that branch OMITTED. To ADD
+protection to a new branch, write the array INCLUDING it. The hook
+trusts whichever list you provide — get the direction right.
 MSG
   exit 2
 fi
@@ -68,12 +70,15 @@ To unblock:
   2. Retry the commit on the feature branch
   3. Push and open a PR when ready
 
-If you've already committed locally to '$CURRENT_BRANCH' by accident:
-  1. Move the commit to a feature branch:
+If you've already committed locally to '$CURRENT_BRANCH' by accident,
+the recovery is a three-step rescue (NOT a separate To-unblock — the
+gate is still the one above): create a recovery branch pointing at the
+current commit, reset $CURRENT_BRANCH to drop the accidental commit
+locally, then check out the recovery branch.
+
        git branch feature/GH-<ticket>-recovery
        git reset --hard HEAD~1   # drops the commit from $CURRENT_BRANCH
        git checkout feature/GH-<ticket>-recovery
-  2. The commit now lives on the feature branch; push and open a PR.
 MSG
     exit 2
   fi

--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -29,8 +29,25 @@ fi
 
 # Block: git push <remote> <protected>
 if echo "$COMMAND" | grep -qE "\bgit\s+push\s+\S+\s+(${PROTECTED})(\s|$)"; then
-  echo "BLOCKED: Cannot push directly to a protected branch. All changes must go through a PR." >&2
-  echo "Protected branches: ${PROTECTED//|/, }" >&2
+  cat >&2 <<MSG
+BLOCKED: Cannot push directly to a protected branch.
+
+All changes must go through a PR (.claude/rules/git-conventions.md
+§ "No Direct Main"). Protected branches: ${PROTECTED//|/, }.
+
+To unblock:
+  1. Create a feature branch from your current work:
+       git checkout -b feature/GH-<ticket>-<short-description>
+  2. Push the feature branch:
+       git push -u origin feature/GH-<ticket>-<short-description>
+  3. Open a PR via /feature → /start-ticket → gh pr create, OR if the
+     ticket exists, just: gh pr create --base <protected-branch> --head <feature-branch>
+
+Override (rare — only if your fork's branch model genuinely treats
+this branch as a daily-work trunk): add the branch name to
+.claude/project-config.json → .git.protected_branches[] to override
+the default protection list.
+MSG
   exit 2
 fi
 
@@ -38,7 +55,26 @@ fi
 if echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
   CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
   if [ -n "$CURRENT_BRANCH" ] && echo "$CURRENT_BRANCH" | grep -qE "^(${PROTECTED})$"; then
-    echo "BLOCKED: Cannot commit directly on protected branch '$CURRENT_BRANCH'. Create a feature branch first." >&2
+    cat >&2 <<MSG
+BLOCKED: Cannot commit directly on protected branch '$CURRENT_BRANCH'.
+
+All changes must go through a PR (.claude/rules/git-conventions.md
+§ "No Direct Main").
+
+To unblock:
+  1. Create a feature branch from your current state (preserves your
+     in-progress edits):
+       git checkout -b feature/GH-<ticket>-<short-description>
+  2. Retry the commit on the feature branch
+  3. Push and open a PR when ready
+
+If you've already committed locally to '$CURRENT_BRANCH' by accident:
+  1. Move the commit to a feature branch:
+       git branch feature/GH-<ticket>-recovery
+       git reset --hard HEAD~1   # drops the commit from $CURRENT_BRANCH
+       git checkout feature/GH-<ticket>-recovery
+  2. The commit now lives on the feature branch; push and open a PR.
+MSG
     exit 2
   fi
 fi

--- a/.claude/hooks/check-secrets.sh
+++ b/.claude/hooks/check-secrets.sh
@@ -18,10 +18,38 @@ fi
 SECRETS_FOUND=$(git diff --cached --diff-filter=ACMR -U0 2>/dev/null | grep -iE "(api[_-]?key|api[_-]?secret|password|passwd|secret[_-]?key|access[_-]?token|private[_-]?key|client[_-]?secret)[[:space:]]*[:=][[:space:]]*[\"'][^\"']{8,}" | grep -v '^\-' | head -5)
 
 if [ -n "$SECRETS_FOUND" ]; then
-  echo "BLOCKED: Potential hardcoded secrets detected in staged files:" >&2
-  echo "$SECRETS_FOUND" >&2
-  echo "" >&2
-  echo "Use environment variables instead. If these are false positives, review and proceed." >&2
+  cat >&2 <<MSG
+BLOCKED: Potential hardcoded secrets detected in staged files.
+
+Matches (max 5 shown):
+$SECRETS_FOUND
+
+ApexYard's no-hardcoded-secrets rule (.claude/rules/git-conventions.md
+§ "No Hardcoded Secrets"). Secrets in commits are forever — even after
+removal the value lives in the reflog and on any clone that's been
+fetched.
+
+To unblock:
+  1. Move each secret value into an environment variable, read it via
+     process.env / os.environ / etc. in code, and add the var name to
+     your .env.example or equivalent (a placeholder, NOT the real value)
+  2. Add the real .env to .gitignore if it isn't already
+  3. Unstage the file: git restore --staged <file>
+  4. Edit the file to use the env var, then re-stage: git add <file>
+  5. Retry the commit
+
+If the match is a false positive (e.g. a test fixture, a literal in a
+markdown code block, or a public-by-design API key constant):
+  - Refactor so the value isn't on a line matching the secret-pattern
+    regex (rename the variable, or move to a fixtures file), OR
+  - Add a one-line comment above the line explaining why it's safe and
+    retry. The hook only matches actual secret-shape lines; comments
+    don't trip it.
+
+Pattern source: .claude/hooks/check-secrets.sh (the regex is intentional
+ally noisy on the false-positive side — secret leaks are worse than
+extra friction).
+MSG
   exit 2
 fi
 

--- a/.claude/hooks/check-secrets.sh
+++ b/.claude/hooks/check-secrets.sh
@@ -46,9 +46,9 @@ markdown code block, or a public-by-design API key constant):
     retry. The hook only matches actual secret-shape lines; comments
     don't trip it.
 
-Pattern source: .claude/hooks/check-secrets.sh (the regex is intentional
-ally noisy on the false-positive side — secret leaks are worse than
-extra friction).
+Pattern source: .claude/hooks/check-secrets.sh (the regex is
+intentionally noisy on the false-positive side — secret leaks are
+worse than extra friction).
 MSG
   exit 2
 fi

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -236,7 +236,9 @@ cat >&2 <<MSG
 BLOCKED: No active ticket set for this session.
 
 ApexYard requires a ticket BEFORE any code changes (workflow-gates rule #3,
-pre-build gate, "one ticket at a time"). To proceed:
+pre-build gate, "one ticket at a time").
+
+To unblock:
 
   1. Create or find the ticket (GitHub Issue in the project's own repo):
        gh issue create --repo <owner/repo> --title "..."

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -130,8 +130,10 @@ To unblock:
   2. Pick a short kebab-case description (max ~40 chars)
   3. Rename the current branch in place:
        git branch -m "$CURRENT_BRANCH" "feature/GH-XX-your-description"
-     OR start fresh from the integration branch:
-       git checkout dev && git checkout -b "feature/GH-XX-your-description"
+     OR start fresh from the project's integration branch (most
+     managed projects are trunk-based on 'main'; the apexyard framework
+     itself uses 'dev' — pick the one that matches THIS repo):
+       git checkout main && git checkout -b "feature/GH-XX-your-description"
   4. Retry the operation
 
 If the current branch has commits you want to keep, the rename in

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -108,11 +108,36 @@ fi
 # intentionally aligned with the pr-title-check.yml CI workflow regex so
 # anything that passes this hook also passes CI.
 if ! echo "$CURRENT_BRANCH" | grep -qE "^(${TYPES})/(${INNER_PATTERN})-"; then
-  echo "BLOCKED: Branch '$CURRENT_BRANCH' doesn't follow naming convention: {type}/{TICKET-ID}-{description}" >&2
-  echo "Accepted types (from .claude/project-config.*.json → .branch.type_whitelist): ${TYPES//|/, }" >&2
-  echo "Accepted ticket-ID pattern (from .claude/project-config.*.json → .tracker.id_pattern): ${INNER_PATTERN}" >&2
-  echo "Examples: feature/ABC-123-add-auth, fix/GH-45-login-bug, docs/ENG-99-update-readme" >&2
-  echo "Rename with: git branch -m \"\$(git branch --show-current)\" \"feature/GH-XX-description\"" >&2
+  cat >&2 <<MSG
+BLOCKED: Branch '$CURRENT_BRANCH' doesn't follow naming convention.
+
+Required shape (.claude/rules/git-conventions.md § "Branch Naming"):
+  {type}/{TICKET-ID}-{description}
+
+Accepted types: ${TYPES//|/, }
+  (configurable: .claude/project-config.*.json → .branch.type_whitelist)
+
+Accepted ticket-ID pattern: ${INNER_PATTERN}
+  (configurable: .claude/project-config.*.json → .tracker.id_pattern)
+
+Examples:
+  feature/ABC-123-add-auth
+  fix/GH-45-login-bug
+  docs/ENG-99-update-readme
+
+To unblock:
+  1. Pick a ticket-ID (existing or new): /feature, /task, /bug
+  2. Pick a short kebab-case description (max ~40 chars)
+  3. Rename the current branch in place:
+       git branch -m "$CURRENT_BRANCH" "feature/GH-XX-your-description"
+     OR start fresh from the integration branch:
+       git checkout dev && git checkout -b "feature/GH-XX-your-description"
+  4. Retry the operation
+
+If the current branch has commits you want to keep, the rename in
+step 3 preserves them — the branch keeps its history, just gains a
+new name.
+MSG
   exit 2
 fi
 

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -8,3 +8,9 @@ https://github.com/me2resh/SharpPick.*
 # protection). The link works in browsers; lychee-action's user-agent gets
 # rejected. Cited as a Source in docs/spikes/claude-model-tier-routing.md.
 https://medium\.com/@sathishkraju/.*
+
+# Martin Fowler's article hosts timeout from CI runners under sustained load
+# (the article server applies aggressive per-IP rate limiting; lychee's burst
+# trips it). The links work in browsers and on retry from cold IPs. Cited in
+# AgDR-0037 and AgDR-0039 as the harness-engineering source.
+https://martinfowler\.com/articles/exploring-gen-ai/.*

--- a/docs/agdr/AgDR-0039-hook-self-correction-shape.md
+++ b/docs/agdr/AgDR-0039-hook-self-correction-shape.md
@@ -1,0 +1,104 @@
+---
+title: Standardised self-correction guidance shape for blocking hooks
+category: ergonomics
+status: accepted
+date: 2026-05-19
+---
+
+# Standardised self-correction guidance shape for blocking hooks
+
+> In the context of ApexYard's 17 blocking PreToolUse hooks, facing the failure mode that some hooks ship gold-standard "BLOCKED → context → numbered next-action list" error messages (e.g. `require-active-ticket.sh`, `validate-commit-format.sh`) while others ship a single-line `BLOCKED: <reason>` with no recovery path (e.g. `check-secrets.sh`, `block-git-add-all.sh`), I decided to standardise on the gold-standard heredoc shape with a canonical `To unblock:` numbered list, to achieve consistent agent self-correction across every block, accepting that retrofitting all 17 hooks is multi-PR work and is being staged.
+
+## Context
+
+Per Böckeler's [harness-engineering framing](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering-for-coding-agent-users.html), the highest-leverage tactic for improving inferential agents' self-correction is to embed **structured next-action guidance directly in sensor error messages** — what she calls "a good kind of prompt injection." When an agent hits a blocking hook, the difference between `BLOCKED: secret detected. Use env vars instead.` and `BLOCKED: secret detected. To unblock: 1. Move the value to .env, 2. Add to gitignore, 3. Reference via process.env, 4. Re-stage, 5. Retry.` is the difference between the agent thrashing for two or three attempts and the agent recovering on the first try.
+
+ApexYard's hooks are an uneven mix today:
+
+| Gold-standard already | Underweight (this ticket's scope) |
+|---|---|
+| `require-active-ticket.sh` | `check-secrets.sh` |
+| `require-migration-ticket.sh` | `block-git-add-all.sh` |
+| `validate-commit-format.sh` | `block-main-push.sh` |
+| `validate-pr-create.sh` | `validate-branch-name.sh` |
+| `verify-commit-refs.sh` | (more in follow-up PRs) |
+| `require-agdr-for-arch-pr.sh` | |
+| `require-skill-for-issue-create.sh` | |
+| `block-merge-on-red-ci.sh` | |
+| `block-unreviewed-merge.sh` (main case) | |
+
+The gold-standard ones already work well. The underweight ones leave the agent with no concrete recovery path beyond the one-line summary, which forces either an extra round-trip to the operator or a guess-and-retry loop. Both burn tokens and human attention.
+
+The standardised shape also matters for **future hooks** — once the convention is documented, every new hook ships with the right error-message shape from day one, rather than re-litigating the question per PR.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **A. Standardise on a heredoc shape with `To unblock:` numbered list** (chosen) | Matches the existing gold-standard hooks; canonical phrasing across all 17; explicit next-actions per Böckeler's design principle; one shape to learn for future hook authors | Multi-PR work to retrofit all 17; small risk of a hook author writing too-verbose guidance |
+| **B. Keep per-hook variation, document a "minimum bar" instead** | Lighter touch — only specifies the floor, not the shape | Doesn't solve the variation problem; future hooks still freelance; no canonical phrase means inconsistent agent-side parsing |
+| **C. Move all guidance out of the hook into a separate "recovery hint" file Rex reads on block** | Decouples hook code from prose; easier to update guidance without re-deploying hooks | Adds indirection at the worst possible moment (the agent has just been blocked and needs the recovery path NOW); two files to keep in sync; complicates testing |
+| **D. Let the agent figure out recovery without explicit guidance** | Zero per-hook authoring cost | Token cost compounds — every block triggers an agent search instead of pointing at the answer; cf. the actual evidence from existing sessions |
+
+## Decision
+
+Chosen: **Option A — heredoc shape with `To unblock:` numbered list**.
+
+### The standard shape
+
+Every blocking hook's error message follows this template:
+
+```
+BLOCKED: <one-line summary of the violation>
+
+<1-3 lines of context: which rule fired, where it lives, why this matters>
+
+To unblock:
+  1. <first concrete action — name a skill, a command, a file edit, or a marker>
+  2. <second action if the first isn't sufficient>
+  3. <retry the original operation>
+
+<Optional: escape hatch / customisation pointer — 1-2 lines>
+```
+
+### The contract per section
+
+- **BLOCKED line**: one sentence, present tense, names the violation. No emoji, no exclamation. Plain `BLOCKED:` prefix so log-grep stays trivial.
+- **Context**: enough to identify which rule fired and (where applicable) where the rule lives in `.claude/rules/`. The agent uses this to decide whether the rule is genuinely the issue or whether something else is in play.
+- **To unblock**: numbered list of **concrete actions**. Each entry names a skill (`/start-ticket`), a command (`git rebase main`), a file edit (`add path/to/file to .gitignore`), or a marker (`write .claude/session/reviews/<pr>-ceo.approved`). **Not** "fix the issue" or "address the violation" — those force the agent to guess.
+- **Escape hatch**: when there's a legitimate-but-rare bypass (false-positive on `check-secrets.sh`, override of `protected_branches` in project-config), document the bypass at the end. Keep it short — the goal is to make the bypass visible, not to encourage it.
+
+### Canonical phrasing
+
+The phrase **`To unblock:`** is canonical. Prior hooks variously used `To proceed:`, `To self-correct:`, and `To unblock:` — picking one for grep-ability and operator habit-formation. `To unblock:` won because:
+
+- "Proceed" sounds like the violation is optional; the gate is blocking, not advisory
+- "Self-correct" anthropomorphises the agent in a way that's true but slightly off (the gate isn't asking the agent to correct itself; it's specifying actions to remove the block)
+- "Unblock" is mechanically accurate and matches the operator's natural framing
+
+## Consequences
+
+### Positive
+
+- Every block message gives the agent (and the operator) a concrete, actionable next step.
+- Future hook authors have a canonical template; no debate per PR about message format.
+- Inferential-agent token cost on blocks drops — the agent doesn't have to search for the recovery path.
+- The framework dogfoods Böckeler's "good kind of prompt injection" principle.
+
+### Negative
+
+- Retrofitting all 17 blocking hooks is multi-PR work. This first PR ships the shape + 5 high-impact underweight hooks (`check-secrets.sh`, `block-git-add-all.sh`, `block-main-push.sh`, `validate-branch-name.sh`, `require-active-ticket.sh`'s phrasing tweak). The remaining underweight hooks are tracked as a follow-up.
+- Slightly longer error messages — each block message grows from ~3 lines to ~12-15. Acceptable; the cost of an under-informed block is one agent-thrash cycle, far worse than the read cost of a richer message.
+
+### Out of scope for this AgDR
+
+- Programmatic enforcement of the shape (a meta-hook that lints hook error messages) — overkill for a 17-hook surface.
+- Translating the shape into other formats (e.g. JSON for IDE integrations) — current consumers (Claude agent + human operator) both prefer prose.
+- Changes to which hooks block vs which are advisory — orthogonal.
+
+## Artifacts
+
+- PR me2resh/apexyard#XXX — the shape definition + 5 hook retrofits (this work)
+- Ticket me2resh/apexyard#295 — feature/ticket spec
+- Reference: Böckeler, ["Harness engineering for coding agent users"](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering-for-coding-agent-users.html), 2026-04-02 (the "good kind of prompt injection" idea)
+- Reference: Böckeler, ["Maintainability sensors for coding agents"](https://martinfowler.com/articles/exploring-gen-ai/maintainability-sensors.html), 2026-05-19 (the custom-formatter pattern for ESLint that inspired this)

--- a/docs/agdr/AgDR-0039-hook-self-correction-shape.md
+++ b/docs/agdr/AgDR-0039-hook-self-correction-shape.md
@@ -1,10 +1,3 @@
----
-title: Standardised self-correction guidance shape for blocking hooks
-category: ergonomics
-status: accepted
-date: 2026-05-19
----
-
 # Standardised self-correction guidance shape for blocking hooks
 
 > In the context of ApexYard's 17 blocking PreToolUse hooks, facing the failure mode that some hooks ship gold-standard "BLOCKED → context → numbered next-action list" error messages (e.g. `require-active-ticket.sh`, `validate-commit-format.sh`) while others ship a single-line `BLOCKED: <reason>` with no recovery path (e.g. `check-secrets.sh`, `block-git-add-all.sh`), I decided to standardise on the gold-standard heredoc shape with a canonical `To unblock:` numbered list, to achieve consistent agent self-correction across every block, accepting that retrofitting all 17 hooks is multi-PR work and is being staged.

--- a/docs/agdr/AgDR-0039-hook-self-correction-shape.md
+++ b/docs/agdr/AgDR-0039-hook-self-correction-shape.md
@@ -98,7 +98,7 @@ The phrase **`To unblock:`** is canonical. Prior hooks variously used `To procee
 
 ## Artifacts
 
-- PR me2resh/apexyard#XXX — the shape definition + 5 hook retrofits (this work)
+- PR me2resh/apexyard#301 — the shape definition + 5 hook retrofits (this work)
 - Ticket me2resh/apexyard#295 — feature/ticket spec
 - Reference: Böckeler, ["Harness engineering for coding agent users"](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering-for-coding-agent-users.html), 2026-04-02 (the "good kind of prompt injection" idea)
 - Reference: Böckeler, ["Maintainability sensors for coding agents"](https://martinfowler.com/articles/exploring-gen-ai/maintainability-sensors.html), 2026-05-19 (the custom-formatter pattern for ESLint that inspired this)


### PR DESCRIPTION
## Summary

- Standardises the error-message shape for ApexYard's blocking hooks per industry harness-engineering "good kind of prompt injection" principle — structured next-action guidance in every block message so agents (and operators) get a concrete recovery path instead of a one-line "BLOCKED: <reason>".
- [`docs/agdr/AgDR-0039-hook-self-correction-shape.md`](docs/agdr/AgDR-0039-hook-self-correction-shape.md) captures the canonical shape (`BLOCKED → context → To unblock: numbered list → optional escape hatch`) and the canonical phrase (`To unblock:`, picked over `To proceed:` and `To self-correct:` for grep-ability).
- Retrofits 5 high-impact underweight hooks: `check-secrets.sh`, `block-git-add-all.sh`, `block-main-push.sh`, `validate-branch-name.sh`, and the phrasing tweak in `require-active-ticket.sh`.
- Remaining ~6 underweight hooks tracked as a follow-up; landing the shape first to lock in the convention.

## Why

The hooks layer is uneven today. Some hooks already ship gold-standard messages (`require-active-ticket.sh`, `validate-commit-format.sh`, `require-migration-ticket.sh` — heredoc body with numbered "To unblock:" actions). Others ship one-liners that leave the agent to guess the recovery path (`BLOCKED: Potential hardcoded secrets detected. Use environment variables instead.` — what env var? where? how?).

Per industry-standard prior art on harness engineering for coding agents: when a sensor blocks, embedding **concrete next-action guidance** in the error is the highest-leverage move for inferential-agent self-correction. The difference between "use env vars instead" and "1. Move value to .env; 2. Add .env to .gitignore; 3. Read via process.env; 4. Re-stage; 5. Retry" is the difference between agent-thrashing-for-3-attempts and agent-recovering-first-try.

Full design rationale: [`AgDR-0039-hook-self-correction-shape.md`](docs/agdr/AgDR-0039-hook-self-correction-shape.md). Filed in response to #295.

## Testing

- All 5 retrofitted hooks remain shellcheck-clean (no SC2164/SC2086 regressions — the existing heredoc-using hooks were the templates).
- Block messages render correctly with the variable interpolation (verified by manually triggering each — e.g. `git add -A` from a feature branch).
- No behavioural changes — only stderr text. Existing hook tests don't reference message text content; they assert exit codes, which haven't moved.

## Out of Scope (follow-up PRs)

- Remaining ~6 underweight hooks (`warn-stale-review-markers.sh`, a few `validate-*` and `check-*` hooks with sparser messages). Landing the shape + 5 retrofits first to lock in the convention; the rest is mechanical.
- A meta-hook that lints hook error messages for shape conformance. Overkill for a 17-hook surface; the AgDR is the single source of truth.
- Translating the shape into other formats (JSON for IDE integrations etc.). Current consumers (agent + operator) both prefer prose.

## Glossary

| Term | Definition |
|------|------------|
| Blocking hook | A PreToolUse hook that emits `BLOCKED:` on stderr and `exit 2` — prevents the tool call from running |
| Advisory hook | A SessionStart / PostToolUse hook that prints a warning but always `exit 0` (`check-upstream-drift.sh`, `detect-role-trigger.sh`) — not affected by this PR |
| To-unblock block | The numbered list of concrete next actions at the bottom of every block message. Canonical phrase per AgDR-0039-hook-self-correction-shape |
| Self-correction | Inferential-agent term — the agent's ability to recover from a sensor's negative signal without an extra round-trip to the operator. The cleaner the guidance, the better the recovery |
| Good kind of prompt injection | industry harness-engineering's phrase — embedding structured guidance in sensor outputs so an inferential agent that reads the error has the recovery path in-context |

Closes #295

