### PR TITLE
refactor(#302): sweep all 40 hook wrappers to v2-anchor-aware shape

### DIFF
--- a/.claude/hooks/link-custom-skills.sh
+++ b/.claude/hooks/link-custom-skills.sh
@@ -48,21 +48,28 @@ if [ "$IS_WINDOWS" -eq 0 ]; then
   esac
 fi
 
-# Resolve the ops-fork root by walking up from $PWD. Cheaper than the full
-# helper for the no-op cases (no helper sourced, no jq fork). The helper
-# walks the same path; we replicate that minimal logic here so the hook
-# stays useful even if the lib hasn't been installed yet on a fresh fork.
+# Resolve the ops-fork root via the shared helper (recognises both the v2
+# `.apexyard-fork` marker AND the legacy v1 anchor). Falls back to a small
+# inline walk-up with the same conditions if the helper is missing — same
+# graceful-degradation shape as check-jq-installed.sh / clear-bootstrap-marker.sh.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 ops_root=""
-cur="$PWD"
-while [ -n "$cur" ] && [ "$cur" != "/" ]; do
-  if [ -f "$cur/.apexyard-fork" ]; then
-    ops_root="$cur"; break
-  fi
-  if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
-    ops_root="$cur"; break
-  fi
-  cur=$(dirname "$cur")
-done
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  ops_root=$(resolve_ops_root "$PWD")
+else
+  cur="$PWD"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/.apexyard-fork" ]; then
+      ops_root="$cur"; break
+    fi
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      ops_root="$cur"; break
+    fi
+    cur=$(dirname "$cur")
+  done
+fi
 
 # Outside any apexyard fork → nothing to do.
 [ -z "$ops_root" ] && exit 0

--- a/.claude/hooks/tests/test_link_custom_skills.sh
+++ b/.claude/hooks/tests/test_link_custom_skills.sh
@@ -21,13 +21,14 @@ set -u
 HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/link-custom-skills.sh"
 LIB_PORTFOLIO_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-portfolio-paths.sh"
 LIB_CONFIG_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-read-config.sh"
+LIB_OPS_ROOT_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-ops-root.sh"
 DEFAULTS_SRC="$(cd "$(dirname "$0")/../.." && pwd)/project-config.defaults.json"
 
 if [ ! -f "$HOOK_SRC" ]; then
   echo "FAIL: hook not found at $HOOK_SRC" >&2
   exit 1
 fi
-if [ ! -f "$LIB_PORTFOLIO_SRC" ] || [ ! -f "$LIB_CONFIG_SRC" ] || [ ! -f "$DEFAULTS_SRC" ]; then
+if [ ! -f "$LIB_PORTFOLIO_SRC" ] || [ ! -f "$LIB_CONFIG_SRC" ] || [ ! -f "$LIB_OPS_ROOT_SRC" ] || [ ! -f "$DEFAULTS_SRC" ]; then
   echo "FAIL: prerequisite libs / defaults missing" >&2
   exit 1
 fi
@@ -37,11 +38,19 @@ FAIL=0
 FAILED_CASES=""
 
 # --------------------------------------------------------------------------
-# make_fork: build an isolated apexyard fork sandbox with the v2 marker,
-# the hook script, the portfolio + config libs, and the defaults file.
+# make_fork [--no-ops-root-lib]: build an isolated apexyard fork sandbox
+# with the v2 marker, the hook script, the portfolio + config libs, and
+# the defaults file. By default also copies _lib-ops-root.sh so the
+# refactor's primary lib-sourcing path is exercised. Pass
+# --no-ops-root-lib to omit it and force the graceful-degradation
+# fallback path (covered by case 7).
 # Returns the sandbox path on stdout.
 # --------------------------------------------------------------------------
 make_fork() {
+  local copy_ops_root=1
+  if [ "${1:-}" = "--no-ops-root-lib" ]; then
+    copy_ops_root=0
+  fi
   local sb
   sb=$(mktemp -d)
   sb=$(cd "$sb" && pwd -P)
@@ -68,6 +77,9 @@ MD
     cp "$HOOK_SRC"          .claude/hooks/link-custom-skills.sh
     cp "$LIB_PORTFOLIO_SRC" .claude/hooks/_lib-portfolio-paths.sh
     cp "$LIB_CONFIG_SRC"    .claude/hooks/_lib-read-config.sh
+    if [ "$copy_ops_root" -eq 1 ]; then
+      cp "$LIB_OPS_ROOT_SRC" .claude/hooks/_lib-ops-root.sh
+    fi
     cp "$DEFAULTS_SRC"      .claude/project-config.defaults.json
     chmod +x .claude/hooks/link-custom-skills.sh
 
@@ -291,6 +303,46 @@ ok=1
 echo "$out" | grep -q "linked 1 custom skill" || ok=0
 [ "$ok" -eq 1 ] && rc2=0 || rc2=1
 assert "case 6: subdir without SKILL.md is skipped; only valid skills linked" "$rc2"
+if [ "$ok" -ne 1 ]; then echo "  out: $out"; fi
+rm -rf "$SB" "$SIB"
+
+# ==========================================================================
+# Case 7: Graceful-degradation fallback — sandbox has NO _lib-ops-root.sh
+# (simulating an old framework version or a stripped-down adopter
+# install). The hook should fall back to its inline walk-up and still
+# link custom skills correctly.
+#
+# This case is the COMPLEMENT to cases 1-6: those exercise the primary
+# lib-sourcing path (because make_fork copies _lib-ops-root.sh by
+# default). Together they pin BOTH branches of the
+#   if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then ... else ... fi
+# discovery shape that link-custom-skills.sh (and several other hooks)
+# share.
+# ==========================================================================
+SB=$(make_fork --no-ops-root-lib)
+# Verify the lib really is missing in this sandbox.
+[ ! -f "$SB/.claude/hooks/_lib-ops-root.sh" ] || {
+  echo "FAIL: case 7 setup — _lib-ops-root.sh unexpectedly present"
+  exit 1
+}
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+mkdir -p "$SIB/custom-skills/fallback-skill"
+cat > "$SIB/custom-skills/fallback-skill/SKILL.md" <<'MD'
+---
+name: fallback-skill
+---
+MD
+cat > "$SB/.claude/project-config.json" <<JSON
+{ "portfolio": { "custom_skills_dir": "$SIB/custom-skills" } }
+JSON
+
+out=$(run_hook "$SB")
+ok=1
+[ -L "$SB/.claude/skills/fallback-skill" ] || ok=0
+echo "$out" | grep -q "linked 1 custom skill" || ok=0
+[ "$ok" -eq 1 ] && rc2=0 || rc2=1
+assert "case 7: graceful-degradation fallback works when _lib-ops-root.sh is absent" "$rc2"
 if [ "$ok" -ne 1 ]; then echo "  out: $out"; fi
 rm -rf "$SB" "$SIB"
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,31 +6,31 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/onboarding-check.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/onboarding-check.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-upstream-drift.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-upstream-drift.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-jq-installed.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-jq-installed.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-portfolio-config.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-portfolio-config.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/clear-bootstrap-marker.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/clear-bootstrap-marker.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/clear-issue-skill-marker.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/clear-issue-skill-marker.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ ! -f \"$r/.apexyard-fork\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/link-custom-skills.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/link-custom-skills.sh\"'"
           }
         ]
       }
@@ -41,15 +41,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-migration-ticket.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-migration-ticket.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
           }
         ]
       },
@@ -59,134 +59,134 @@
           {
             "type": "command",
             "if": "Bash(git add *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-git-add-all.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-git-add-all.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-main-push.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-main-push.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-branch-name.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-branch-name.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-secrets.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-secrets.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/verify-commit-refs.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/verify-commit-refs.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-commit-format.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-commit-format.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-agdr-for-arch-changes.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-agdr-for-arch-changes.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/pre-push-gate.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/pre-push-gate.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-skill-for-issue-create.sh\"'"
-          },
-          {
-            "type": "command",
-            "if": "Bash(gh issue create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/suggest-ticket-template.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-skill-for-issue-create.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh issue create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-issue-structure.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/suggest-ticket-template.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh issue create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-issue-structure.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh issue create *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-pr-create.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-pr-create.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-agdr-for-arch-pr.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-agdr-for-arch-pr.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh issue comment *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr comment *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh api *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr merge *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-unreviewed-merge.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-unreviewed-merge.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh api *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-unreviewed-merge.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-unreviewed-merge.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr merge *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh api *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr merge *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh api *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-migration-ticket.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-migration-ticket.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh issue edit *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
           }
         ]
       }
@@ -196,7 +196,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
           }
         ]
       }
@@ -208,12 +208,12 @@
           {
             "type": "command",
             "if": "Bash(gh pr create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/auto-code-review.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/auto-code-review.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/warn-stale-review-markers.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/warn-stale-review-markers.sh\"'"
           }
         ]
       }

--- a/docs/agdr/AgDR-0041-sessionstart-v2-anchor-sweep.md
+++ b/docs/agdr/AgDR-0041-sessionstart-v2-anchor-sweep.md
@@ -1,0 +1,104 @@
+# SessionStart hook wrappers must recognise both ops-fork anchors
+
+> In the context of split-portfolio v2 (framework #242) moving `onboarding.yaml` from the public fork to the private sibling repo, facing every SessionStart / PreToolUse / PostToolUse wrapper in `.claude/settings.json` walking up looking for `onboarding.yaml` only, I decided to sweep every wrapper to recognise BOTH `.apexyard-fork` AND `onboarding.yaml` (whichever appears first, mirroring `_lib-ops-root.sh`), to achieve a single canonical wrapper shape that works under single-fork, split-portfolio v1, AND split-portfolio v2 layouts, accepting that wrappers can't source the helper directly (they run as `bash -c`, no `$0` script path) so the v2 anchor check is inlined verbatim instead of via the lib.
+
+## Context
+
+Pre-#242, every adopter's ops fork had `onboarding.yaml` + `apexyard.projects.yaml` at the root. The walk-up shape baked into every `.claude/settings.json` hook wrapper was:
+
+```bash
+r=$PWD; while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != / ]; do r=${r%/*}; done; exec "$r/.claude/hooks/<name>.sh"
+```
+
+#242 (split-portfolio v2) moved `onboarding.yaml` and `apexyard.projects.yaml` into the private sibling repo. The public fork is anchored solely by the new `.apexyard-fork` marker file. Inside a v2 fork, the legacy walk-up:
+
+- Never finds `onboarding.yaml` going up the tree (it's now in a sibling repo)
+- Walks all the way to `/`
+- At `/`, the loop guard `[ "$r" != / ]` becomes false → exit, then `exec "$r/.claude/hooks/<name>.sh"` becomes `exec "/.claude/hooks/<name>.sh"` which doesn't exist → exec fails silently
+- OR: on shells where `${r%/*}` on a single-segment path returns the empty string, `r=""`, the guard `[ "" != / ]` stays true and the loop runs forever — confirmed in testing: 50 iterations stuck at `r=""`
+
+Either failure mode means v2 adopters get **zero SessionStart banners**: no upstream-drift, no jq-missing, no portfolio-config-broken, no onboarding-not-run, no bootstrap-marker sweep, no custom-skill linking. Silent regression for the entire v2 layout.
+
+The same legacy walk-up appears in 35+ PreToolUse / PostToolUse entries — same failure mode applies. v2 forks under PreToolUse get no migration-ticket check, no ticket-first gate, no AGdR check, no merge gates, no leak protection, no anything.
+
+PR #300 (the `check-jq-installed.sh` hook) shipped using the same legacy shape, and Rex caught it during code review — surfacing this as a framework-wide bug rather than a single new-hook bug. Filed as #302.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Source `_lib-ops-root.sh` from the wrapper** | Single source of truth for the anchor check; can't drift. | `bash -c '...'` has no `$0` script path (`$0` is `bash`), so `dirname "$0"` doesn't yield the hooks dir. You'd have to walk up yourself first to find the lib, defeating the point. Rejected. |
+| **B. Inline the v2-aware walk-up in every wrapper** | Self-contained; matches what the lib does internally; one canonical shape. | Logic duplicated across ~35 wrapper entries; if the anchor set changes again, both the lib and every wrapper need updating. Acceptable: anchors don't change every release. |
+| **C. Replace wrappers with a single dispatch script (`.claude/hooks/_dispatch.sh <name>`)** | DRY — anchor check lives in one place. | Adds an extra hop on every hook invocation; introduces a script lookup before any hook can run; failure modes get worse if the dispatch script itself can't be located. Defer. |
+| **D. Drop the wrapper walk entirely, exec from `$PWD/.claude/hooks/<name>.sh`** | Simpler. | Breaks when the operator works in `workspace/<project>/` — `$PWD` is the project clone, not the ops fork. Project clones don't have framework hooks. Rejected. |
+
+## Decision
+
+Chosen: **Option B — inline the v2-aware walk-up in every wrapper**, with three explicit checks:
+
+```bash
+r=$PWD; \
+while [ ! -f "$r/.apexyard-fork" ] && \
+      [ ! -f "$r/onboarding.yaml" ] && \
+      [ -n "$r" ] && \
+      [ "$r" != / ]; do \
+  r=${r%/*}; \
+done; \
+exec "$r/.claude/hooks/<name>.sh"
+```
+
+Three deliberate properties:
+
+1. **`.apexyard-fork` checked first.** Cheapest test (single `-f` against a marker that, by convention, only ever sits at the ops-fork root) and the v2 anchor. Mirrors `_lib-ops-root.sh`.
+2. **`onboarding.yaml` checked second as the legacy v1 fallback.** This is a relaxation from `_lib-ops-root.sh`'s v1 check (which requires BOTH `onboarding.yaml` AND `apexyard.projects.yaml`). The wrapper's job is to find the dir containing `.claude/hooks/<name>.sh`, not to establish "this is definitely the ops fork" — checking either marker is sufficient because the hook itself can re-resolve ops-root via the lib if it needs framework state. Reducing to one check makes the wrapper shorter without losing safety.
+3. **`[ -n "$r" ]` guard.** Closes the empty-string infinite-loop failure mode: when `${r%/*}` on `/foo` yields `""`, the loop must exit. The legacy shape didn't have this and would either hang or fall through depending on shell semantics.
+
+The wrapper's only job remains: find the dir containing `.claude/hooks/<name>.sh` and exec it. The hook does any further framework-state resolution via `_lib-ops-root.sh` internally — that pattern is well-established in `check-portfolio-config.sh`, `clear-bootstrap-marker.sh`, `clear-issue-skill-marker.sh`, `check-jq-installed.sh`, and (post-this-AgDR) `link-custom-skills.sh`.
+
+## Consequences
+
+- **No regression for v1 adopters.** Single-fork and split-portfolio v1 forks have `onboarding.yaml` at the root; the wrapper finds it the same as before.
+- **v2 adopters get the same banners + hooks as v1.** `.apexyard-fork` is at the v2 fork root; the wrapper finds it first and exec's the hook. SessionStart banners, PreToolUse gates, PostToolUse follow-ups all fire correctly under v2.
+- **No more silent infinite-loop on v2 forks that somehow lack both anchors** (a misconfigured fork or a test fixture). The `-n "$r"` guard makes the loop exit cleanly with `r=""`, and the subsequent `exec ""/.claude/hooks/<name>.sh` fails fast in a visible way.
+- **New SessionStart hooks must ship with the v2-aware wrapper from day one.** This AgDR is the citation. PR review should reject new entries that use the legacy shape — Rex catches it as a `settings.json` diff red flag.
+- **`link-custom-skills.sh` no longer maintains its own private walk-up.** It now sources `_lib-ops-root.sh` with the same graceful-degradation fallback as `check-jq-installed.sh` and `clear-bootstrap-marker.sh`. One canonical shape across all hooks that resolve ops-root internally.
+- **Future anchor changes are an N+1 edit problem.** If v3 introduces a new anchor file, every wrapper needs updating again. Acceptable cost; this is rare and well-flagged (the wrapper sweep is documented in this AgDR + the `_lib-ops-root.sh` header).
+
+## Canonical wrapper shape
+
+For every future SessionStart / PreToolUse / PostToolUse entry in `.claude/settings.json`:
+
+```bash
+bash -c 'r=$PWD;while [ ! -f "$r/.apexyard-fork" ] && [ ! -f "$r/onboarding.yaml" ] && [ -n "$r" ] && [ "$r" != / ];do r=${r%/*};done;exec "$r/.claude/hooks/<hook-name>.sh"'
+```
+
+For every hook script that needs to resolve framework state (write to `<ops_root>/.claude/session/...`, read `<ops_root>/.claude/project-config.json`, etc.):
+
+```bash
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  ops_root=$(resolve_ops_root "$PWD")
+else
+  # Graceful-degradation fallback: inline walk-up with both anchors.
+  ops_root=""
+  cur="$PWD"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/.apexyard-fork" ]; then ops_root="$cur"; break; fi
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      ops_root="$cur"; break
+    fi
+    cur=$(dirname "$cur")
+  done
+fi
+```
+
+The fallback's v1 check requires BOTH `onboarding.yaml` AND `apexyard.projects.yaml` — stricter than the wrapper because the hook is now establishing canonical ops-root, not just finding a script path.
+
+## Artifacts
+
+- GitHub issue: [me2resh/apexyard#302](https://github.com/me2resh/apexyard/issues/302)
+- Branch: `refactor/GH-302-sessionstart-v2-sweep`
+- Related: AgDR-0019 (v2 layout introduction); `_lib-ops-root.sh` lib header documents the helper itself.
+- PR #300 (`check-jq-installed.sh`) was the immediate trigger — Rex caught the legacy shape during code review and surfaced the framework-wide gap.

--- a/docs/agdr/AgDR-0041-sessionstart-v2-anchor-sweep.md
+++ b/docs/agdr/AgDR-0041-sessionstart-v2-anchor-sweep.md
@@ -10,7 +10,7 @@ Pre-#242, every adopter's ops fork had `onboarding.yaml` + `apexyard.projects.ya
 r=$PWD; while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != / ]; do r=${r%/*}; done; exec "$r/.claude/hooks/<name>.sh"
 ```
 
-#242 (split-portfolio v2) moved `onboarding.yaml` and `apexyard.projects.yaml` into the private sibling repo. The public fork is anchored solely by the new `.apexyard-fork` marker file. Inside a v2 fork, the legacy walk-up:
+PR #242 (split-portfolio v2) moved `onboarding.yaml` and `apexyard.projects.yaml` into the private sibling repo. The public fork is anchored solely by the new `.apexyard-fork` marker file. Inside a v2 fork, the legacy walk-up:
 
 - Never finds `onboarding.yaml` going up the tree (it's now in a sibling repo)
 - Walks all the way to `/`
@@ -31,6 +31,7 @@ PR #300 (the `check-jq-installed.sh` hook) shipped using the same legacy shape, 
 | **B. Inline the v2-aware walk-up in every wrapper** | Self-contained; matches what the lib does internally; one canonical shape. | Logic duplicated across ~35 wrapper entries; if the anchor set changes again, both the lib and every wrapper need updating. Acceptable: anchors don't change every release. |
 | **C. Replace wrappers with a single dispatch script (`.claude/hooks/_dispatch.sh <name>`)** | DRY — anchor check lives in one place. | Adds an extra hop on every hook invocation; introduces a script lookup before any hook can run; failure modes get worse if the dispatch script itself can't be located. Defer. |
 | **D. Drop the wrapper walk entirely, exec from `$PWD/.claude/hooks/<name>.sh`** | Simpler. | Breaks when the operator works in `workspace/<project>/` — `$PWD` is the project clone, not the ops fork. Project clones don't have framework hooks. Rejected. |
+| **E. Push the walk into the Claude Code runtime — runtime resolves hook paths from the ops-fork root, not from `$PWD` via `bash -c`** | Cleanest — no inline walk in any wrapper, no dispatch hop, no lib-sourcing dance. The runtime already knows where the project root is. | Needs an upstream Claude Code change (settings.json semantics + how hook commands are resolved). Out of this PR's scope. Defer; this AgDR's Option B is the right shape until the runtime grows that ability. |
 
 ## Decision
 

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -415,9 +415,11 @@ Most ApexYard skills (`/projects`, `/inbox`, `/status`, `/tasks`, `/stakeholder-
 
 Framework session state — active-ticket markers, code-review approvals, CEO approvals, the bootstrap-skill marker — always lives at `<ops_fork_root>/.claude/session/`. **Not** inside any `workspace/<project>/` clone.
 
-This matters when you `cd workspace/<project>/` to do project-specific work: even though `git rev-parse --show-toplevel` from inside the clone returns the project clone (not the ops fork), the framework's hooks, agents, and skills (Rex, `/start-ticket`, `/approve-merge`, the merge-gate hooks) all walk up to find the ops fork (looking for both `onboarding.yaml` AND `apexyard.projects.yaml`) and write/read session state from there. The `_lib-ops-root.sh` helper (added in me2resh/apexyard#229 + #230) centralises this walk so all components agree on the canonical path.
+This matters when you `cd workspace/<project>/` to do project-specific work: even though `git rev-parse --show-toplevel` from inside the clone returns the project clone (not the ops fork), the framework's hooks, agents, and skills (Rex, `/start-ticket`, `/approve-merge`, the merge-gate hooks) all walk up to find the ops fork and write/read session state from there. The `_lib-ops-root.sh` helper (added in me2resh/apexyard#229 + #230, extended for v2 in #242) centralises the walk and recognises BOTH the v2 `.apexyard-fork` marker AND the legacy v1 pair (`onboarding.yaml + apexyard.projects.yaml`) — so all components agree on the canonical path under either layout.
 
-You'll never need to manage session-state files by hand. If you ever see a "BLOCKED: PR has no recorded code-reviewer approval" error after the agent visibly approved, check that BOTH `onboarding.yaml` AND `apexyard.projects.yaml` exist at the ops fork root — the walk needs both files present to identify the fork.
+The same dual-anchor rule applies to the `.claude/settings.json` hook wrappers themselves (every `SessionStart` / `PreToolUse` / `PostToolUse` entry walks up to locate `.claude/hooks/<name>.sh` before exec'ing it). Adopters writing new entries — or framework PRs adding new SessionStart hooks — should use the canonical v2-aware wrapper documented in [`AgDR-0041`](agdr/AgDR-0041-sessionstart-v2-anchor-sweep.md). The old `onboarding.yaml`-only walk-up shape silently fails on v2 forks.
+
+You'll never need to manage session-state files by hand. If you ever see a "BLOCKED: PR has no recorded code-reviewer approval" error after the agent visibly approved, check that at least one of the ops-fork anchors is present at the fork root: `.apexyard-fork` (v2) OR both `onboarding.yaml` AND `apexyard.projects.yaml` (v1).
 
 ### Upstream sync under split mode
 

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -419,6 +419,8 @@ This matters when you `cd workspace/<project>/` to do project-specific work: eve
 
 The same dual-anchor rule applies to the `.claude/settings.json` hook wrappers themselves (every `SessionStart` / `PreToolUse` / `PostToolUse` entry walks up to locate `.claude/hooks/<name>.sh` before exec'ing it). Adopters writing new entries — or framework PRs adding new SessionStart hooks — should use the canonical v2-aware wrapper documented in [`AgDR-0041`](agdr/AgDR-0041-sessionstart-v2-anchor-sweep.md). The old `onboarding.yaml`-only walk-up shape silently fails on v2 forks.
 
+> **Note on wrapper-level v1 detection laxness.** The wrappers accept `onboarding.yaml` alone as the v1 anchor, while `_lib-ops-root.sh` (the in-hook resolver) requires BOTH `onboarding.yaml` AND `apexyard.projects.yaml`. This is deliberate: the wrapper only needs to locate `.claude/hooks/<name>.sh` and `exec` it, so a single marker suffices. The hook itself does the stricter canonical ops-root check internally via the lib. See [AgDR-0041](agdr/AgDR-0041-sessionstart-v2-anchor-sweep.md) § "Decision" point 2 for the full rationale.
+
 You'll never need to manage session-state files by hand. If you ever see a "BLOCKED: PR has no recorded code-reviewer approval" error after the agent visibly approved, check that at least one of the ops-fork anchors is present at the fork root: `.apexyard-fork` (v2) OR both `onboarding.yaml` AND `apexyard.projects.yaml` (v1).
 
 ### Upstream sync under split mode


### PR DESCRIPTION
## Summary

- **Swept all 40 hook wrappers in `.claude/settings.json`** to the canonical v2-anchor-aware shape — every wrapper now finds the ops fork via either `.apexyard-fork` (v2) OR `onboarding.yaml` (legacy v1 fallback), with the empty-`r` guard that legacy shape lacked.
- **Refactored `.claude/hooks/link-custom-skills.sh`** to source `_lib-ops-root.sh` with graceful-degradation fallback, replacing its private inline walk-up. One fewer place that needs to change when the anchor convention evolves.
- **Documented the canonical wrapper shape** in `AgDR-0041` so future hook authors copy from the right template — including a clear options-table entry on why the seemingly-cleaner "source the lib from the wrapper" path (Option A) doesn't actually work (`bash -c '…'` invocations set `$0=bash`, so `dirname "$0"` returns `.`).
- **Cross-linked from `docs/multi-project.md`** § "Where session-state files live" so adopters reading the operator docs land on the same explanation.

40 wrappers swept: 7 SessionStart (including the newly-shipped `check-jq-installed.sh` SessionStart entry that landed on `origin/dev` between worktree creation and merge), 30 PreToolUse, 2 PostToolUse, 1 UserPromptSubmit.

## Why

The v2 split-portfolio layout (introduced in `me2resh/apexyard#242`) moved `onboarding.yaml` to the private sibling repo and added `.apexyard-fork` as the new presence-only marker for the public fork. `_lib-ops-root.sh` was updated then, but the inline walk-up boilerplate copy-pasted across all 40 `settings.json` hook wrappers wasn't — they still look for `onboarding.yaml` AND `apexyard.projects.yaml` as the legacy v1 anchor pair. The hooks themselves work fine (most source `_lib-ops-root.sh` internally), but the wrapper that *finds* the hooks file fails on a v2-only fork — the walk never terminates because neither file exists. #302 closes that gap.

The legacy wrapper shape also has an `r != ""` infinite-loop hole (when `${r%/*}` reduces to empty before hitting `/`); the canonical shape fixes that too via the explicit `[ -n "$r" ]` guard.

## Testing

- [x] `jq . .claude/settings.json` clean (validates JSON after the sweep)
- [x] Simulated v2-only fork layout (only `.apexyard-fork` present, no legacy pair) — walk finds the right dir on every wrapper
- [x] Simulated no-anchors layout — empty-`r` guard exits cleanly (legacy shape would infinite-loop; confirmed 50+ iterations against the old shape)
- [x] `test_ops_root.sh` 8/8
- [x] `test_check_jq_installed.sh` 5/5
- [x] `test_link_custom_skills.sh` 7/7 (case 7 added in fix-up — exercises the graceful-degradation fallback when `_lib-ops-root.sh` is absent; cases 1–6 now exercise the primary lib-sourcing path that the refactor introduces)
- [x] `test_portfolio_paths.sh` 38/38
- [x] `test_split_portfolio_v2_migration.sh` 13/13
- [x] `test_check_upstream_drift.sh` 5/5

## Out of scope

- **Migrating every hook script** to source `_lib-ops-root.sh` for its own internal walks. Many already do (~10); the rest do private inline walks that are correct (they read `$PWD` at hook-fire time, which is what the hook semantics expect). Sweeping those is a separate ticket if we want it.
- **Eliminating the wrapper-level walk entirely** by making `claude` resolve hook paths from the ops-fork root. That would need an upstream change to the Claude Code runtime, not a framework change.

## Glossary

| Term | Definition |
|------|------------|
| v2 anchor | The `.apexyard-fork` marker file at the ops-fork root (introduced in #242 for split-portfolio v2). Presence-only — content is ignored. |
| v1 anchor | The legacy pair `onboarding.yaml` + `apexyard.projects.yaml`. Still recognised as fallback for un-migrated forks during the transition window. |
| Wrapper walk | The bash one-liner inside each `settings.json` hook entry that walks up from `$PWD` to find the ops fork, then `exec`s the actual hook script. |
| Canonical shape | The standardised wrapper one-liner documented in AgDR-0041 — every new SessionStart / PreToolUse / PostToolUse hook should copy this verbatim. |

Closes #302

