### PR TITLE
fix(#317): /split-portfolio produces v2 layout + copy-onboarding semantics

### DIFF
--- a/.claude/hooks/tests/test_split_portfolio_v2_migration.sh
+++ b/.claude/hooks/tests/test_split_portfolio_v2_migration.sh
@@ -114,9 +114,15 @@ run_migration() {
 
     SIBLING_ROOT=$(dirname "$(jq -r '.portfolio.registry' .claude/project-config.json)")
 
-    # Move onboarding.yaml
+    # Copy onboarding.yaml (NOT move — see AgDR-0021 § H).
+    # Sibling becomes canonical; public-fork copy is untracked and left on
+    # disk as a legacy ops-root walk-up fallback / safety-net snapshot.
     if [ -f onboarding.yaml ] && [ ! -f "$SIBLING_ROOT/onboarding.yaml" ]; then
-      mv onboarding.yaml "$SIBLING_ROOT/onboarding.yaml"
+      cp -p onboarding.yaml "$SIBLING_ROOT/onboarding.yaml"
+      git rm --cached onboarding.yaml >/dev/null 2>&1 || true
+    elif [ -f "$SIBLING_ROOT/onboarding.yaml" ] && [ -f onboarding.yaml ]; then
+      # Idempotence: sibling is canonical, just ensure public-fork copy is untracked.
+      git rm --cached onboarding.yaml >/dev/null 2>&1 || true
     fi
 
     # Move workspace contents
@@ -176,13 +182,33 @@ fi
 run_migration "$SB/public"
 
 # Post-checks
-[ ! -f "$SB/public/onboarding.yaml" ] \
-  && mark_pass "onboarding.yaml moved out of public fork" \
-  || mark_fail "onboarding moved" "still present in public fork"
+#
+# onboarding.yaml: COPY semantics (refined #317, see AgDR-0021 § H).
+# Both copies exist, contents are identical, and the public-fork copy
+# is untracked (git rm --cached'd) so it can't drift into commits.
+[ -f "$SB/public/onboarding.yaml" ] \
+  && mark_pass "onboarding.yaml snapshot retained in public fork (copy semantics)" \
+  || mark_fail "onboarding snapshot retained" "missing from public fork"
 
 [ -f "$SB/private/onboarding.yaml" ] \
-  && mark_pass "onboarding.yaml landed in sibling private repo" \
+  && mark_pass "onboarding.yaml landed in sibling private repo (canonical)" \
   || mark_fail "onboarding landed" "missing in sibling repo"
+
+if [ -f "$SB/public/onboarding.yaml" ] && [ -f "$SB/private/onboarding.yaml" ]; then
+  if cmp -s "$SB/public/onboarding.yaml" "$SB/private/onboarding.yaml"; then
+    mark_pass "onboarding.yaml: public-fork snapshot matches sibling-repo canonical"
+  else
+    mark_fail "onboarding identical" "public-fork and sibling-repo copies differ"
+  fi
+fi
+
+# The public-fork copy must be UNTRACKED so future commits don't ship it.
+# `git ls-files` lists tracked paths only — empty output means untracked.
+if [ -z "$( cd "$SB/public" && git ls-files onboarding.yaml 2>/dev/null )" ]; then
+  mark_pass "onboarding.yaml untracked in public fork (git rm --cached applied)"
+else
+  mark_fail "onboarding untracked" "still tracked in public fork"
+fi
 
 [ ! -d "$SB/public/workspace/demo" ] \
   && mark_pass "workspace/demo moved out of public fork" \
@@ -282,6 +308,61 @@ if [ "$?" -eq 0 ]; then
   mark_pass "post-v2: resolve_ops_root finds the public fork via .apexyard-fork"
 else
   mark_fail "post-v2 ops_root" "see error above"
+fi
+
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 4: onboarding.yaml is COPIED (not moved) — explicit semantics check
+#
+# Refined in #317 (see AgDR-0021 § H): the public-fork onboarding.yaml is
+# left on disk as an untracked gitignored snapshot so the legacy ops-root
+# walk-up fallback (_lib-ops-root.sh) keeps working even if .apexyard-fork
+# is accidentally removed. The sibling-repo copy is canonical.
+#
+# This case modifies the public-fork copy AFTER migration and asserts the
+# sibling-repo copy is NOT affected — proves the two are independent files
+# (a `mv` followed by `cp` to recreate would have the same observable
+# pre-state but reading would still be a single canonical copy; this test
+# specifically pins that we have two real files on disk).
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d)
+SB=$(cd "$SB" && pwd -P)
+build_pre_v2 "$SB"
+
+# Capture pre-migration content for comparison
+ORIG_CONTENT=$(cat "$SB/public/onboarding.yaml")
+
+run_migration "$SB/public"
+
+# Sanity: both files exist after migration
+if [ ! -f "$SB/public/onboarding.yaml" ] || [ ! -f "$SB/private/onboarding.yaml" ]; then
+  mark_fail "case-4 sanity" "expected both copies of onboarding.yaml post-migration"
+else
+  # Modify the public-fork snapshot
+  echo "# touched by case 4" >> "$SB/public/onboarding.yaml"
+
+  # The sibling-repo copy must be untouched (independent file, not a hard link)
+  SIB_CONTENT=$(cat "$SB/private/onboarding.yaml")
+  if [ "$SIB_CONTENT" = "$ORIG_CONTENT" ]; then
+    mark_pass "copy-not-move: sibling-repo onboarding.yaml unaffected by public-fork edits"
+  else
+    mark_fail "copy semantics" "sibling-repo copy changed when public-fork copy was edited (hard link or move-with-symlink?)"
+  fi
+
+  # And both must be on disk simultaneously (the load-bearing semantic of copy vs move)
+  if [ -f "$SB/public/onboarding.yaml" ] && [ -f "$SB/private/onboarding.yaml" ]; then
+    mark_pass "copy-not-move: both public-fork and sibling-repo onboarding.yaml exist after migration"
+  else
+    mark_fail "both copies exist" "one of the copies is missing"
+  fi
+
+  # And the public-fork .gitignore must list onboarding.yaml so the snapshot can't drift back into commits
+  if grep -qxF onboarding.yaml "$SB/public/.gitignore"; then
+    mark_pass "copy-not-move: public-fork .gitignore lists onboarding.yaml (snapshot can't drift into commits)"
+  else
+    mark_fail "gitignore guards snapshot" "onboarding.yaml not in public-fork .gitignore"
+  fi
 fi
 
 rm -rf "$SB"

--- a/.claude/skills/split-portfolio/SKILL.md
+++ b/.claude/skills/split-portfolio/SKILL.md
@@ -102,6 +102,9 @@ Changes you will see:
   - This fork's main branch force-pushed
   - GitHub Issue / PR bodies on this fork that named registered projects redacted
   - .claude/project-config.json updated with a `portfolio:` block pointing at the sibling
+  - onboarding.yaml COPIED to the sibling (canonical) + untracked from the public fork
+  - workspace/<name>/ contents MOVED to the sibling (gigabytes — no point doubling disk)
+  - .apexyard-fork marker written + v2 portfolio keys added (split-portfolio v2 layout)
 
 Reversibility:
   - A backup-pre-rewrite branch is pushed before any rewrite (recoverable for 7 days)
@@ -260,7 +263,7 @@ EOF
 # Untrack any framework projects/README.md from upstream (it'll be replaced by the private sibling's content)
 git rm --cached -r projects 2>/dev/null || true
 
-# Write portfolio: block to project-config
+# Write portfolio: block to project-config (v2 keys added in Steps 9a–9d below)
 PRIVATE_REPO_REL="../<private-repo-name>"
 cat > .claude/project-config.json <<JSON
 {
@@ -279,6 +282,119 @@ git commit -m "chore: configure split-portfolio mode (#143 / #145)"
 If `.claude/project-config.json` already has a non-portfolio block, **merge** rather than overwrite — preserve existing keys.
 
 If it has a `portfolio:` block already, refuse and ask the operator to manually reconcile.
+
+#### Step 9a — Produce the v2 layout (onboarding.yaml + workspace + marker + v2 config keys)
+
+Steps 9a–9d extend the migration so the final fork is split-portfolio **v2**, not v1. Without these, adopters would land on the v1 layout and need a follow-up `/update` to migrate again. See [AgDR-0021](../../../docs/agdr/AgDR-0021-split-portfolio-v2-path-resolution.md) § "v1→v2 migration semantics" for the copy-vs-move rationale per file class.
+
+Resolve the sibling repo dir from the existing `portfolio.registry` path (the parent dir of the registry file is the sibling repo root):
+
+```bash
+SIBLING_ROOT=$(dirname "$(jq -r '.portfolio.registry' .claude/project-config.json)")
+# e.g. SIBLING_ROOT=../<private-repo-name>
+```
+
+Per-file-class confirmation — ask separately so the operator can defer either:
+
+```
+Copy onboarding.yaml to sibling private repo? [Y/n]
+Move workspace/<name>/ contents to sibling private repo? [Y/n]   # surfaces disk size: du -sh workspace
+```
+
+`onboarding.yaml` is **copied** (not moved): the file is small, the legacy tracker fallback at `_lib-ops-root.sh` still reads it as part of the legacy ops-root walk-up, and keeping a snapshot in the public fork is a safety net while the sibling-repo copy becomes the canonical source of truth. `workspace/<name>/` is **moved**: clones are gigabytes; doubling disk makes no sense.
+
+##### Copy onboarding.yaml (not move — see AgDR-0021 § H)
+
+```bash
+if [ -f onboarding.yaml ] && [ ! -f "$SIBLING_ROOT/onboarding.yaml" ]; then
+  # COPY (cp -p preserves mtimes/permissions). Sibling becomes canonical;
+  # public-fork copy is left as a snapshot and untracked below.
+  cp -p onboarding.yaml "$SIBLING_ROOT/onboarding.yaml"
+  ( cd "$SIBLING_ROOT" && git add onboarding.yaml )
+
+  # Untrack from the public fork so future commits don't ship it. The file
+  # is left on disk (gitignored by Step 9c) as a legacy-tool snapshot.
+  git rm --cached onboarding.yaml 2>/dev/null || true
+elif [ -f "$SIBLING_ROOT/onboarding.yaml" ] && [ -f onboarding.yaml ]; then
+  # Both present — surface and stop; operator reconciles.
+  printf 'WARNING: onboarding.yaml exists in BOTH the public fork and the sibling repo.\n' >&2
+  printf '  Reconcile manually (the sibling-repo copy is canonical) before re-running.\n' >&2
+  exit 1
+fi
+```
+
+Idempotence: if `onboarding.yaml` is already only in the sibling repo (and untracked in the public fork), this block is a no-op.
+
+#### Step 9b — Move workspace/<name>/ contents to the sibling
+
+```bash
+if [ -d workspace ] && [ "$(ls -A workspace 2>/dev/null)" ]; then
+  mkdir -p "$SIBLING_ROOT/workspace"
+  for entry in workspace/*; do
+    [ -e "$entry" ] || continue
+    name=$(basename "$entry")
+    # workspace/README.md is a framework artefact explaining the convention —
+    # it stays in the public fork. See AgDR-0021 § G.
+    if [ "$name" = "README.md" ]; then
+      continue
+    fi
+    if [ -e "$SIBLING_ROOT/workspace/$name" ]; then
+      echo "WARNING: workspace/$name exists in BOTH locations — skipped."
+      continue
+    fi
+    mv "$entry" "$SIBLING_ROOT/workspace/$name"
+  done
+fi
+```
+
+Idempotence: empty `workspace/` (no entries to move, or only `README.md` left) is a no-op.
+
+#### Step 9c — Extend .gitignore for v2 file classes
+
+```bash
+NEEDS=()
+grep -qxF onboarding.yaml .gitignore 2>/dev/null || NEEDS+=(onboarding.yaml)
+grep -qxF workspace .gitignore 2>/dev/null || NEEDS+=(workspace)
+
+if [ "${#NEEDS[@]}" -gt 0 ]; then
+  {
+    echo ""
+    echo "# Split-portfolio v2 (framework ≥ #242): onboarding + workspace live in the private sibling repo."
+    for n in "${NEEDS[@]}"; do echo "$n"; done
+  } >> .gitignore
+  git add .gitignore
+fi
+```
+
+#### Step 9d — Write the .apexyard-fork marker + v2 config-block keys
+
+The marker is **presence-only**: readers (every ops-root walk) MUST ignore content; only file presence matters. Writers MAY include a single explanatory line so `head .apexyard-fork` is informative — both `echo "# comment" > .apexyard-fork` and `touch .apexyard-fork` are valid. See [AgDR-0021](../../../docs/agdr/AgDR-0021-split-portfolio-v2-path-resolution.md) § B.
+
+```bash
+if [ ! -f .apexyard-fork ]; then
+  echo "# This file marks the directory as an ApexYard ops fork (split-portfolio v2)." > .apexyard-fork
+  git add .apexyard-fork
+fi
+```
+
+Add the four v2 keys to `.claude/project-config.json` — `onboarding`, `workspace_dir`, `custom_skills_dir`, `custom_handbooks_dir`. Use `jq` to merge so existing keys (Step 9's registry / projects_dir / ideas_backlog) are preserved, and `// $x` short-circuits if the operator already added a key by hand:
+
+```bash
+PCONFIG=.claude/project-config.json
+TMP=$(mktemp)
+jq --arg onb "$SIBLING_ROOT/onboarding.yaml" \
+   --arg ws  "$SIBLING_ROOT/workspace" \
+   --arg cs  "$SIBLING_ROOT/custom-skills" \
+   --arg ch  "$SIBLING_ROOT/custom-handbooks" \
+   '.portfolio.onboarding         = (.portfolio.onboarding         // $onb)
+    | .portfolio.workspace_dir    = (.portfolio.workspace_dir    // $ws)
+    | .portfolio.custom_skills_dir    = (.portfolio.custom_skills_dir    // $cs)
+    | .portfolio.custom_handbooks_dir = (.portfolio.custom_handbooks_dir // $ch)' \
+   "$PCONFIG" > "$TMP" && mv "$TMP" "$PCONFIG"
+git add "$PCONFIG"
+```
+
+Idempotence: re-running 9d is a no-op (existing key values are preserved via `// $x`; the marker write skips when present).
 
 #### Step 10 — Verify + cleanup
 
@@ -336,6 +452,10 @@ Re-running the skill on a partially-migrated fork picks up where it left off:
 | `backup-pre-rewrite` branch exists | Skip step 5 |
 | HEAD on main has no registry/projects | Skip steps 6 + 7 |
 | `.claude/project-config.json` already has portfolio block matching new layout | Skip step 9 |
+| `onboarding.yaml` already in sibling AND untracked in public fork | Skip step 9a |
+| `workspace/` empty (or only `README.md` left) in public fork | Skip step 9b |
+| `.gitignore` already lists both v2 entries | Skip step 9c |
+| `.apexyard-fork` present AND all four v2 config keys set | Skip step 9d |
 | All complete | Run --verify only and exit 0 |
 
 The `--dry-run` flag walks through every step printing the commands but executes none. Useful for the operator to preview the destructive ops before running real.

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -467,24 +467,31 @@ AND workspace/ to the private sibling repo too, so the public fork holds
 ONLY framework files + your customisations to skills/hooks/rules.
 
 Migrate now? This will:
-  - Move onboarding.yaml to the sibling private repo
-  - Move workspace/<name>/ contents to the sibling private repo
+  - COPY onboarding.yaml to the sibling private repo (sibling becomes
+    canonical) + untrack it from the public fork (snapshot left on disk)
+  - MOVE workspace/<name>/ contents to the sibling private repo
   - Add gitignore entries for both in the public fork
   - Write a .apexyard-fork marker (the v2 ops-fork anchor)
   - Add portfolio.{onboarding,workspace_dir} keys to .claude/project-config.json
 
-Files MOVED, not copied — destructive. Idempotent — if interrupted, re-run.
+onboarding.yaml is COPIED (not moved) — the file is small, the legacy
+ops-root walk still reads it as a fallback anchor, and a public-fork
+snapshot is a useful safety net while the sibling-repo copy becomes
+the source of truth. workspace/ is MOVED — clones are gigabytes; we
+don't double disk. See AgDR-0021 § "v1→v2 migration semantics".
+
+Idempotent — if interrupted, re-run.
 
 [Y / n / dry-run — show commands, don't execute]
 ```
 
 If `--dry-run` was passed to `/update`, force the dry-run branch automatically (print the commands the migration would run, do not execute, then continue to step 9).
 
-Per-file-class confirmation — ask separately for `onboarding.yaml` and `workspace/`, so the operator can move one and defer the other:
+Per-file-class confirmation — ask separately for `onboarding.yaml` and `workspace/`, so the operator can migrate one and defer the other:
 
 ```
-Move onboarding.yaml? [Y/n]
-Move workspace/? [Y/n]   # surfaces the disk size: du -sh workspace
+Copy onboarding.yaml to sibling private repo? [Y/n]
+Move workspace/?                              [Y/n]   # surfaces disk size: du -sh workspace
 ```
 
 #### Migration steps
@@ -496,25 +503,34 @@ SIBLING_ROOT=$(dirname "$(jq -r '.portfolio.registry' .claude/project-config.jso
 # e.g. SIBLING_ROOT=../apexyard-portfolio
 ```
 
-##### Move onboarding.yaml
+##### Copy onboarding.yaml (NOT move — see AgDR-0021 § "v1→v2 migration semantics")
 
 ```bash
 if [ -f onboarding.yaml ] && [ ! -f "$SIBLING_ROOT/onboarding.yaml" ]; then
-  mv onboarding.yaml "$SIBLING_ROOT/onboarding.yaml"
+  # COPY (cp -p preserves mtimes/permissions). The sibling-repo copy
+  # becomes the canonical source of truth; the public-fork copy is left
+  # on disk as a snapshot for the legacy ops-root walk-up fallback.
+  cp -p onboarding.yaml "$SIBLING_ROOT/onboarding.yaml"
   (cd "$SIBLING_ROOT" && git add onboarding.yaml)
+
+  # Untrack from the public fork so future commits don't ship it.
+  # The file stays on disk (gitignored in the next sub-step) as a
+  # legacy-tool snapshot.
+  git rm --cached onboarding.yaml 2>/dev/null || true
 elif [ -f "$SIBLING_ROOT/onboarding.yaml" ] && [ -f onboarding.yaml ]; then
-  # Both present — surface the conflict and stop. The operator picks.
-  # `exit 1` (not `return 1`) — this snippet runs at top-level in the
-  # operator's shell when invoked from the skill; `return` would fail
-  # outside a function. Wrap the whole step 8a in `( ... )` if you want
-  # the exit contained to a subshell.
-  printf 'WARNING: onboarding.yaml exists in BOTH the public fork and the sibling repo.\n' >&2
-  printf '  Resolve manually before re-running /update.\n' >&2
-  exit 1
+  # Both present — sibling is canonical; we still need to untrack the
+  # public-fork copy if it's currently tracked. Idempotent.
+  git rm --cached onboarding.yaml 2>/dev/null || true
 fi
 ```
 
-Idempotence: if `onboarding.yaml` is already only in the sibling repo, this block is a no-op.
+Idempotence: re-running this block on a v2 layout is a no-op (the second branch's `git rm --cached` returns non-zero when the file is already untracked, suppressed by `|| true`; the first branch is gated by the negated `[ ! -f "$SIBLING_ROOT/onboarding.yaml" ]`).
+
+**Why copy, not move?** Three reasons codified in AgDR-0021 § H:
+
+1. **Legacy ops-root walk-up fallback** — `_lib-ops-root.sh` checks `.apexyard-fork` first, but falls back to `onboarding.yaml + apexyard.projects.yaml` for un-migrated forks. Leaving a snapshot in the public fork keeps the legacy path working even if the marker is accidentally removed.
+2. **Safety net** — `onboarding.yaml` is small (KB, not GB). A duplicate on disk costs nothing meaningful and gives the operator a recoverable reference if the sibling repo is unreachable.
+3. **Canonical source of truth in the sibling** — the public-fork copy is untracked (`git rm --cached`) and gitignored, so it cannot drift into commits. The sibling repo's copy is the one /setup writes to and /handover reads.
 
 ##### Move workspace/
 

--- a/docs/agdr/AgDR-0021-split-portfolio-v2-path-resolution.md
+++ b/docs/agdr/AgDR-0021-split-portfolio-v2-path-resolution.md
@@ -37,9 +37,10 @@ Split-portfolio mode (introduced in AgDR-0010 / framework #145) moved the regist
 
 | Option | Pros | Cons |
 |---|---|---|
-| **`mv` (chosen)** | Atomic on the same filesystem; preserves inode, mtimes. No risk of stale copy left behind. | Cross-filesystem `mv` falls back to `cp+rm` under the hood (no guarantees mid-operation). For the v2 migration the public fork and the sibling repo are typically siblings on the same FS, so the atomic path is the common case. |
-| `cp` then `rm` (explicit two-step) | Operator-visible intermediate state. | Two failure points instead of one. Cross-FS this is what `mv` does anyway, but explicit `cp+rm` doesn't offer any advantage over letting `mv` do it. |
-| `rsync --remove-source-files` | Robust against interruption. | Heavy dependency for what `mv` does natively. Adds a tooling assumption. |
+| **`mv` for workspace/, `cp -p` + `git rm --cached` for onboarding.yaml (chosen — refined #317)** | Each file class gets the right semantics for its role. `workspace/` is gigabytes of clones — moving avoids doubling disk for no benefit. `onboarding.yaml` is small (KB) and acts as a legacy ops-root walk-up fallback, so a public-fork snapshot is a safety net rather than dead weight. Untracking via `git rm --cached` ensures the snapshot can't drift into commits. | Per-file-class semantics costs a sentence of doc explanation; the apparent inconsistency is intentional. |
+| `mv` for both (initial v2 design — superseded by #317) | Single recipe, atomic on common case. | Loses the legacy ops-root walk-up fallback if the marker is accidentally removed. Forces adopters to re-run `/update` if they need an `onboarding.yaml` snapshot back. Conflates "small config file" with "gigabytes of clones" — same hammer for two very different nails. |
+| `cp+rm` for both | Explicit two-step. | Doubles disk for `workspace/` (gigabytes); no compensating benefit. |
+| `rsync --remove-source-files` for both | Robust against interruption. | Heavy dependency for what `mv` does natively. Adds a tooling assumption. |
 
 ### E. v2-marker vs legacy-anchor precedence in `_lib-ops-root.sh`
 
@@ -70,7 +71,7 @@ Chosen — for all seven:
 **A.** Marker file `.apexyard-fork` at the public-fork root.
 **B.** Presence-only semantics; writers MAY include a one-line explanatory comment; readers MUST ignore content.
 **C.** Default-yes migration with per-file-class y/n confirmation + dry-run.
-**D.** `mv` (atomic on common case; cross-FS falls through to `cp+rm` via `mv` itself).
+**D.** Per-file-class semantics — `cp -p` + `git rm --cached` for `onboarding.yaml` (sibling becomes canonical, public-fork copy stays as a gitignored snapshot for the legacy ops-root fallback), `mv` for `workspace/` contents (gigabytes of clones — doubling disk has no benefit). Refined in #317; see § H below for the full rationale.
 **E.** v2-marker checked first; legacy `onboarding.yaml + apexyard.projects.yaml` pair as fallback for un-migrated forks.
 **F.** No symlink fallback for v2 additions; config block required (consistent with the framework-#145+ direction).
 **G.** `workspace/README.md` stays in the public fork during migration; both the skill and manual recipe special-case it.
@@ -82,6 +83,50 @@ Why this combination:
 3. **v2-precedence with legacy fallback** lets every adopter cohort work simultaneously. Single-fork adopters never touch the v2 path. v1-split-portfolio adopters work until they migrate. v2-migrated adopters benefit from the faster anchor.
 4. **No symlink for v2** keeps the surface small. Symlink mode is legacy from before the config block existed; pushing v2 there too would mean two parallel resolution paths forever.
 5. **`workspace/README.md` stays public** preserves the framework's documentation of its own convention without leaking adopter content.
+
+## H. v1→v2 migration semantics — per-file-class copy-vs-move (refined #317)
+
+The initial v2 implementation used `mv` for **both** `onboarding.yaml` and `workspace/`. In practice this had two problems:
+
+1. **Loss of the legacy ops-root fallback.** `_lib-ops-root.sh` checks the `.apexyard-fork` marker first, then falls back to the legacy `onboarding.yaml + apexyard.projects.yaml` pair for un-migrated forks. Moving `onboarding.yaml` out of the public fork removes the legacy anchor, so an operator who accidentally deletes `.apexyard-fork` after migration leaves the fork un-resolvable — until they manually `cp` the sibling-repo copy back.
+2. **`/split-portfolio` produces a v1 layout.** The single-fork → split-portfolio migration skill only handled the registry + `projects/` (the v1 file classes). Adopters who ran `/split-portfolio` after framework #242 landed in a fresh v1 layout, then had to run `/update` to reach v2 — a two-step migration where one was enough.
+
+### Refined semantics (per file class)
+
+| File class | Migration verb | Why |
+|---|---|---|
+| `onboarding.yaml` | **COPY** (`cp -p`) + `git rm --cached` from public fork + add to `.gitignore` | Small (KB). Legacy ops-root walk-up still reads it as a fallback anchor (`_lib-ops-root.sh`). The public-fork copy is left on disk as a snapshot — gitignored so it can't drift into commits, but available as a safety net if the sibling repo is unreachable or the `.apexyard-fork` marker is accidentally removed. The sibling-repo copy is the **canonical source of truth**; `/setup` writes to it, `/handover` reads from it. |
+| `workspace/<name>/` | **MOVE** (`mv`) | Clones are gigabytes. Doubling disk has no compensating benefit — there's no legacy code path that reads the public-fork copy, no safety net case that benefits, and the cost (gigabytes of duplicated git history) is real. `workspace/README.md` (framework artefact explaining the convention) stays in the public fork per § G. |
+
+### Post-state (after a clean v1→v2 migration)
+
+```
+PUBLIC FORK                                  SIBLING PRIVATE REPO
+.apexyard-fork                  ←─ marker    onboarding.yaml          ← canonical
+onboarding.yaml                 ←─ snapshot  workspace/
+  (gitignored, untracked)                      <project-1>/
+workspace/                                     <project-2>/
+  README.md (kept)                             ...
+.gitignore                      ← extended  apexyard.projects.yaml
+.claude/project-config.json     ← v2 keys   projects/
+                                              ...
+```
+
+The public fork has a snapshot of `onboarding.yaml` plus everything it needs to keep working under both the v2 anchor (`.apexyard-fork`) and the legacy fallback. The sibling repo has the canonical copies that every tool writes to going forward.
+
+### Where this refinement lands
+
+| File | Change |
+|---|---|
+| `.claude/skills/split-portfolio/SKILL.md` Steps 9a–9d | New sub-steps that produce the v2 layout in a single skill invocation. Without this, `/split-portfolio` landed adopters on v1 and they had to run `/update` to finish the migration. |
+| `.claude/skills/update/SKILL.md` Step 8a | `onboarding.yaml` switches from `mv` to `cp -p` + `git rm --cached`. `workspace/` stays as `mv`. The per-file-class confirmation prose updates accordingly. |
+| `.claude/hooks/tests/test_split_portfolio_v2_migration.sh` | Case 1 assertions extended (both copies of `onboarding.yaml` exist, contents are identical, public-fork copy is untracked, `.gitignore` carries the entry). New Case 4 explicitly pins the copy-not-move semantics. Case 2 (idempotence) extended to cover the new copy path. `workspace/` assertions unchanged. |
+
+### What we are explicitly NOT doing
+
+- **No re-tracking the public-fork `onboarding.yaml` later.** Once gitignored, it stays gitignored. The sibling-repo copy is canonical forever.
+- **No copy-semantics for other file classes** (`apexyard.projects.yaml`, `projects/`, etc.). Those went to the sibling under v1 already and there's no legacy fallback that wants them in the public fork.
+- **No symmetry-for-its-own-sake.** Adopters who think the two file classes should use the same verb are welcome to file an issue; the asymmetry is deliberate and we have artefact tests that pin it.
 
 ## Consequences
 


### PR DESCRIPTION
## Given / When / Then

**Given** a single-fork ApexYard adopter (registry + projects in the public fork) decides to migrate to split-portfolio mode for privacy
**When** they invoke `/split-portfolio` to perform the migration
**Then** *before this PR*, the skill moved only `apexyard.projects.yaml` + `projects/` to the new private sibling repo. It did NOT handle `onboarding.yaml`, did NOT move `workspace/<project>/` clones, did NOT write the `.apexyard-fork` marker, and did NOT add the four v2 config keys. Adopters landed on a **v1 layout** and had to run `/update` to complete the migration — two-step for what should be one.

This PR closes that gap, and refines the migration semantics: `onboarding.yaml` is now **copied**, not moved (per operator design call) so the sibling repo holds the canonical source of truth while the public fork keeps a gitignored snapshot for legacy tooling. `workspace/` keeps **move** semantics (gigs of clones — doubling disk makes no sense).

## Summary

- **`/split-portfolio` produces a v2 layout from the first run** — Steps 9a–9d added to the skill spec to copy `onboarding.yaml`, move `workspace/`, write the `.apexyard-fork` marker, and add the four v2 config keys (`onboarding`, `workspace_dir`, `custom_skills_dir`, `custom_handbooks_dir`). Per-file-class confirmation pattern (operator can defer either move independently).
- **`/update` step 8a aligned with the new semantics** — for adopters already in v1 layout migrating via `/update`, `onboarding.yaml` now uses `cp -p` + `git rm --cached` + `.gitignore` add (was `mv`). The conflict branch is now idempotent. `workspace/` keeps `mv`.
- **AgDR-0021 § H** — new section codifying the per-file-class semantics (copy onboarding for legacy-tool-fallback + safety + sibling-is-canonical; move workspace for size). Documents the two failure modes of the original `mv`-for-both design + refresh of Option D table + Decision § D summary.
- **`test_split_portfolio_v2_migration.sh` extended** — Case 1 assertions inverted/extended for the copy semantics, new Case 4 explicitly pins copy-not-move, run_migration helper updated. Test count 13 → 18 (5 new assertions, meets the ≥5 contract).

## Why this is P1

Non-GitHub-Pro adopters with any private project ARE the target audience for split-portfolio mode (per `docs/multi-project.md` § "Two setup modes"). The pre-PR behaviour produced a v1 layout that leaked the company name, mission, team list, and managed-project workspace clones onto the public fork until the operator separately ran `/update`. The window between `/split-portfolio` and `/update` is exactly where adopters could push the partial state and leak. Same shape as the precedent that's already happened in the framework's history. The copy-semantics refinement also makes the migration safer (no destructive `mv` for the canonical file — sibling gets the canonical, public fork keeps a snapshot that's gitignored).

## Testing

```bash
bash .claude/hooks/tests/test_split_portfolio_v2_migration.sh
```

**18/18 pass** (baseline 13/13; +5 new assertions covering copy-not-move semantics + `.gitignore` post-state + public-fork-untracked check).

## Out of scope (per the ticket)

- **`docs/multi-project.md` manual recipe update** — the manual recipe in § "Migrating from split-portfolio v1 to v2" still describes the older `mv` semantics for `onboarding.yaml`. AgDR-0021 § H now diverges from that prose. The implementing agent flagged this — happy to file a follow-up `[Docs]` ticket for the prose refresh; it's a tiny edit but worth a separate concern from the framework-spec change in this PR.
- **Per-team scoring weights for v1-detection** — the existing detection logic (`portfolio_is_v2`, "has portfolio block, no marker" pre-v2 detection) stays unchanged
- **Re-tracking the public-fork `onboarding.yaml`** — once gitignored, stays gitignored

## Note on implementation hygiene

The implementing agent flagged ~10 minutes of early debugging on an APFS / filesystem-cache mismatch (initially editing the main checkout path instead of the worktree path). Cleanly resolved before the commits landed — worktree state is correct and matches the pushed branch. Same shape as the worktree-cwd quirk on prior PRs.

## Glossary

| Term | Definition |
|------|------------|
| v1 layout | Pre-#242 split-portfolio shape: registry + `projects/` in private sibling; `onboarding.yaml` + `workspace/` in public fork |
| v2 layout | Post-#242 split-portfolio shape: registry + `projects/` + `onboarding.yaml` + `workspace/` all in private sibling; public fork carries only framework files + `.apexyard-fork` marker |
| `.apexyard-fork` marker | Presence-only file at the public-fork root that v2 hooks recognise as the ops-fork anchor (replaces the legacy v1 anchor pair of `onboarding.yaml + apexyard.projects.yaml`) |
| Copy-vs-move semantics | Per-file-class call: `onboarding.yaml` copied (legacy-tool fallback + sibling-canonical), `workspace/` moved (gigs of clones; doubling disk makes no sense). Codified in AgDR-0021 § H |
| Per-file-class confirmation | Operator can defer either move independently — the skill asks `Copy onboarding.yaml? [Y/n]` and `Move workspace/? [Y/n]` separately |

Closes #317
