### PR TITLE
feat(#299): /mutation-test skill + behaviour-quality sensor

### DIFF
--- a/.claude/hooks/tests/test_token_efficiency_wave1.sh
+++ b/.claude/hooks/tests/test_token_efficiency_wave1.sh
@@ -93,7 +93,8 @@ for f in "$SKILLS_DIR"/*/SKILL.md; do
     overs120=$((overs120 + 1))
   fi
 done
-echo "  Total: $total chars across 52 skills"
+skill_count=$(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d ! -name '_lib*' | wc -l | tr -d ' ')
+echo "  Total: $total chars across $skill_count skills"
 echo "  Soft warnings (121–200 chars): $overs120 (documented exception per AgDR-0044)"
 [ "$overs200" -eq 0 ] && green "  OK (hard cap)"
 

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -170,5 +170,18 @@
     "preferred_converter": "pandoc",
     "pdf_engine": "xelatex",
     "default_destination": "ask"
+  },
+
+  "mutation": {
+    "_comment": "Config for the /mutation-test skill. runner maps a detected language to its mutation-test tool; threshold is the mutation-score % below which /launch-check WARNs (not FAILs — mutation is a leading indicator, not a launch blocker). timeout_minutes caps a single run so a stuck runner can't hold up the whole milestone-boundary audit. See AgDR-0045.",
+    "runner": {
+      "ts": "stryker",
+      "js": "stryker",
+      "python": "mutpy",
+      "go": "go-mutesting",
+      "ruby": "mutant"
+    },
+    "threshold": 60,
+    "timeout_minutes": 90
   }
 }

--- a/.claude/skills/launch-check/SKILL.md
+++ b/.claude/skills/launch-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: launch-check
-description: Production readiness audit — 9-dimension go/no-go sweep (security, a11y, compliance, analytics, SEO, GEO, perf, monitoring, docs).
+description: Production readiness audit — 10-dimension go/no-go sweep (security, a11y, compliance, analytics, SEO, GEO, perf, monitoring, docs, behaviour-quality).
 disable-model-invocation: false
 argument-hint: "[project-path] | trend [project-path]"
 effort: high
@@ -8,13 +8,13 @@ effort: high
 
 # /launch-check — Production Readiness Audit
 
-Runs a 9-dimension sweep against a project and outputs a one-page verdict. Designed for milestone boundaries — epic completion, release cuts, launch prep — not per-PR use.
+Runs a 10-dimension sweep against a project and outputs a one-page verdict. Designed for milestone boundaries — epic completion, release cuts, launch prep — not per-PR use.
 
 **Invoke from** the project's workspace directory (`cd workspace/<project>/`) or pass the path as an argument: `/launch-check workspace/my-app`.
 
 **Two modes:**
 
-- `/launch-check [project-path]` — full audit (default). Runs all 9 dimensions, persists results to the per-project history store, and renders a "Trend (last 5 runs)" section when ≥ 2 prior runs exist.
+- `/launch-check [project-path]` — full audit (default). Runs all 10 dimensions, persists results to the per-project history store, and renders a "Trend (last 5 runs)" section when ≥ 2 prior runs exist.
 - `/launch-check trend [project-path]` — read-only trend report. Renders just the trend section from existing run files. Useful for "are we trending up?" without burning the audit cost. See § "Trend-only mode" below.
 
 ## Deep-dive companions
@@ -32,6 +32,7 @@ Each dimension has a dedicated expert skill for when you need to go deeper than 
 | Performance | `/launch-check` row 7 | **`/performance-audit`** — bundle, images, Core Web Vitals |
 | Monitoring | `/launch-check` row 8 | **`/monitoring-audit`** — observability and incident readiness |
 | Documentation | `/launch-check` row 9 | **`/docs-audit`** — Diataxis framework completeness |
+| Behaviour quality | `/launch-check` row 10 | **`/mutation-test`** — mutation-testing sensor; measures whether the test suite constrains behaviour, not just executes lines |
 
 When a dimension shows WARN or FAIL, tell the user: *"For a detailed analysis, run `/threat-model`"* (or the relevant expert skill).
 
@@ -53,6 +54,7 @@ LAUNCH CHECK — <project> @ <sha> (<date>)
 | 7  | Performance        | PASS   | Bundle < 200KB, LCP < 2.5s          |
 | 8  | Monitoring         | FAIL   | No health check endpoint found       |
 | 9  | Documentation      | PASS   | README updated this week             |
+| 10 | Behaviour quality  | WARN   | Mutation score 54% (threshold 60%)   |
 
 Verdict: CONDITIONAL GO (2 failures need resolution)
 
@@ -207,6 +209,22 @@ Covers two related sub-scopes: **GEO** (LLM citations — ChatGPT, Claude, Perpl
 **PASS if:** README has setup + run + deploy instructions, and was updated recently.
 **WARN if:** README exists but is stale (> 30 days behind code changes), or API undocumented.
 **FAIL if:** no README, or README is the default GitHub template.
+
+### 10. Behaviour quality (mutation testing)
+
+**What to check** (quick gate — full deep-dive lives in `/mutation-test`):
+
+- Read `.claude/project-config.json → mutation.threshold` (default 60% from `.claude/project-config.defaults.json`)
+- Check whether a recent mutation report exists at `projects/<name>/quality/mutation-<YYYY-MM-DD>.md` (within the last 30 days)
+- If the latest report's score < threshold → **WARN** (not FAIL — mutation is a leading indicator, not a launch blocker)
+- If **no recent report exists**, *offer* to dispatch to `/mutation-test` for a fresh run, but do **NOT** auto-run it during `/launch-check`. A mutation audit takes 20–40 minutes on a medium codebase — too slow to fold into the milestone-boundary sweep silently. The dimension reports **WARN** with the finding "no recent mutation report (run `/mutation-test` for a fresh number)".
+- If `mutation.runner` is `null` or the project's primary language has no recognised mutation runner installed: **auto-PASS** (the audit doesn't apply — same shape as SEO auto-PASS for non-web projects). Surface the gap as `INFO` in the finding column.
+
+**PASS if:** recent mutation report exists AND score ≥ threshold.
+**WARN if:** recent mutation report exists BUT score < threshold, OR no recent report (operator should run `/mutation-test`).
+**FAIL if:** never — mutation testing is advisory, not a launch blocker. See AgDR-0045 for the rationale.
+
+Auto-PASS for projects without a mutation runner installed (or where the language has no recognised dispatch — e.g. Rust at v1).
 
 ## Process
 

--- a/.claude/skills/mutation-test/SKILL.md
+++ b/.claude/skills/mutation-test/SKILL.md
@@ -193,7 +193,7 @@ Write to `<projects_dir>/<name>/quality/mutation-<YYYY-MM-DD>.md`. If a report f
 
 Report shape (six sections):
 
-```markdown
+````markdown
 # Mutation report — <project> — <YYYY-MM-DD>
 
 | Field | Value |
@@ -255,7 +255,7 @@ return a - b;
 - File-specific test gaps surfaced above
 - Equivalent-mutant suppression candidates (mutants the runner classified survived but that look semantically equivalent)
 - Runner-config tweaks (e.g. `stryker.conf.json` `ignorePatterns`)
-```
+````
 
 ### Step 8 — Emit a one-line verdict to stdout
 

--- a/.claude/skills/mutation-test/SKILL.md
+++ b/.claude/skills/mutation-test/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: mutation-test
+description: Mutation-testing sensor — language-dispatched (Stryker/MutPy/go-mutesting/mutant), milestone-cadence not per-PR, exit-3 graceful-degrade.
+argument-hint: "[project-path] [--language=ts|js|python|go|ruby] [--runner=<name>] [--threshold=<N>] [--check-only]"
+allowed-tools: Bash, Read, Glob, Grep, Write
+---
+
+# /mutation-test — Behaviour-Quality Sensor
+
+Runs **mutation testing** against a project to measure whether the test suite *constrains* behaviour, not just *executes* lines. Coverage % answers "did the test run this line?"; mutation testing answers "if I broke this line, would the test catch it?".
+
+Pairs with `/launch-check` (fans out to this skill at milestone boundaries) and complements the existing `> 80%` coverage gate from `.claude/rules/workflow-gates.md`. **Not** run per-PR — see § "When to use this" for the cadence rationale.
+
+## Runtime requirements
+
+| Dependency | Used for | Without it |
+|------------|----------|------------|
+| `bash` ≥ 4 | The skill itself | Required |
+| `git` | Project detection + path resolution | Required |
+| `stryker` (`@stryker-mutator/core`) | TS / JS mutation runner | Skill exits 3 with the install one-liner if TS/JS detected |
+| `mut.py` (MutPy) | Python mutation runner | Same shape |
+| `go-mutesting` | Go mutation runner | Same shape |
+| `mutant` (`mutant-rspec` / `mutant-minitest`) | Ruby mutation runner | Same shape |
+| `jq` | Stryker JSON report parsing | Required when Stryker is the chosen runner |
+
+Same disclosure shape as `/pdf` and `/process` — disclosed up front, surfaced when invoked, never silently fails.
+
+## Path resolution
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+projects_dir=$(portfolio_projects_dir)
+workspace_dir=$(portfolio_workspace_dir)
+```
+
+Defaults to single-fork mode. Split-portfolio v2 adopters resolve to the sibling private repo transparently. Don't hardcode `projects/` or `workspace/` literals.
+
+## Usage
+
+```
+/mutation-test                          # run against cwd (must be inside workspace/<name>/)
+/mutation-test workspace/example-app    # run against an explicit project path
+/mutation-test --language=python        # force the Python runner (skip detection)
+/mutation-test --runner=stryker         # force a specific runner regardless of language
+/mutation-test --threshold=70           # one-off threshold override (doesn't write to config)
+/mutation-test --check-only             # report which runners are installed, do nothing else
+```
+
+## When to use this
+
+| Trigger | Use `/mutation-test`? |
+|---------|----------------------|
+| Milestone boundary (epic done, release prep, launch check) | **Yes** — `/launch-check` dispatches automatically |
+| Quarterly health check | Yes — explicit invocation |
+| Weekly cron via CI workflow | Yes — adopter wires a scheduled workflow |
+| Per-PR pre-merge gate | **No** — too slow (20–40 min on a medium codebase). Rex + the coverage gate cover per-PR test quality. |
+| Pre-deploy smoke | No — use `/launch-check` for a full sweep instead |
+| After adding new test infrastructure | Yes — confirm the new tests actually constrain |
+| First-time on a brownfield project | Yes — expect a low score on the first run; treat it as a baseline |
+
+The skill is **NOT** wired to any pre-commit, pre-push, or merge-gate hook. It runs only when explicitly invoked or when `/launch-check` fans out to it.
+
+## Process
+
+### Step 1 — Resolve the project
+
+```bash
+PROJECT_PATH="${1:-$PWD}"
+if [ ! -d "$PROJECT_PATH" ]; then
+  echo "/mutation-test: project path not found: $PROJECT_PATH" >&2
+  exit 2
+fi
+cd "$PROJECT_PATH"
+```
+
+If invoked without an argument, use `$PWD`. If `$PWD` is the ops-fork root (contains `onboarding.yaml` or `.apexyard-fork`), refuse — the audit is for managed projects, not the framework repo itself.
+
+Resolve `<project-name>` from the path:
+
+1. If `$PROJECT_PATH` is under `<workspace_dir>/<name>/...` → `name` is that path segment.
+2. Otherwise fall back to `basename "$PROJECT_PATH"` and warn the operator to `/handover` for cross-machine trend continuity.
+
+### Step 2 — Detect the language
+
+File-count heuristic across the project tree (excluding `node_modules`, `.venv`, `vendor`, `dist`, `build`, `.next`):
+
+```bash
+ts_count=$(find . -type f \( -name '*.ts' -o -name '*.tsx' \) ! -path '*/node_modules/*' ! -path '*/dist/*' | wc -l)
+js_count=$(find . -type f \( -name '*.js' -o -name '*.jsx' -o -name '*.mjs' \) ! -path '*/node_modules/*' ! -path '*/dist/*' | wc -l)
+py_count=$(find . -type f -name '*.py' ! -path '*/.venv/*' ! -path '*/__pycache__/*' | wc -l)
+go_count=$(find . -type f -name '*.go' ! -path '*/vendor/*' | wc -l)
+rb_count=$(find . -type f -name '*.rb' ! -path '*/vendor/*' | wc -l)
+```
+
+The language with the highest count wins. TS and JS collapse into the same dispatch ("ts/js"). Ties: prefer the language with the matching config-block runner if set; otherwise prefer ts/js > python > go > ruby (alphabetical-of-the-popular-stack tiebreak).
+
+`--language=<lang>` overrides detection. Mixed-language projects audit only the dominant language in a single run; the report flags the other languages as "not audited in this run; re-run with `--language=<lang>` to cover them".
+
+### Step 3 — Pick the runner
+
+Read `mutation.runner` from `.claude/project-config.json` (merge over `.claude/project-config.defaults.json`):
+
+```json
+{
+  "mutation": {
+    "runner": {
+      "ts": "stryker",
+      "js": "stryker",
+      "python": "mutpy",
+      "go": "go-mutesting",
+      "ruby": "mutant"
+    },
+    "threshold": 60
+  }
+}
+```
+
+The configured runner wins. `--runner=<name>` flag wins over config. Otherwise use the default for the detected language.
+
+### Step 4 — Graceful-degradation check
+
+Before running anything, verify the chosen runner is installed:
+
+```bash
+case "$RUNNER" in
+  stryker)       command -v stryker      >/dev/null 2>&1 || RUNNER_MISSING=1 ;;
+  mutpy)         command -v mut.py       >/dev/null 2>&1 || RUNNER_MISSING=1 ;;
+  go-mutesting)  command -v go-mutesting >/dev/null 2>&1 || RUNNER_MISSING=1 ;;
+  mutant)        command -v mutant       >/dev/null 2>&1 || RUNNER_MISSING=1 ;;
+esac
+```
+
+If `RUNNER_MISSING=1`, print the install advisory and exit 3:
+
+```
+✗ No mutation tester installed for <language> (chosen runner: <RUNNER>).
+
+Per-language install one-liners:
+  TS / JS  — npm install --save-dev @stryker-mutator/core
+              (then add stryker.conf.json — see https://stryker-mutator.io/docs/stryker-js/)
+  Python   — pip install mutpy
+              (https://github.com/mutpy/mutpy)
+  Go       — go install github.com/zimmski/go-mutesting/cmd/go-mutesting@latest
+              (https://github.com/zimmski/go-mutesting)
+  Ruby     — gem install mutant-rspec   (or mutant-minitest)
+              (https://github.com/mbj/mutant)
+
+Install the runner for your project's language and re-run /mutation-test.
+This skill never bundles a mutation runner — same graceful-degrade shape
+as /pdf and /process.
+```
+
+Exit code **3**. Same shape as `/pdf` and `/process`. The rest of the framework is unaffected.
+
+`--check-only` reports which runners are installed without invoking any and exits 0 if at least one is, exit 3 if none.
+
+### Step 5 — Invoke the runner
+
+The dispatch table (skill resolves the per-runner invocation):
+
+| Runner | Invocation | Report shape consumed |
+|--------|-----------|-----------------------|
+| `stryker` | `npx stryker run --reporters json,clear-text` then `jq` the `reports/mutation/mutation.json` | JSON: `files.<path>.mutants[]` with `status` ∈ {Killed, Survived, Timeout, NoCoverage, CompileError, RuntimeError} |
+| `mutpy` | `mut.py --target <module> --unit-test <tests> --report-html out/` (or `--report yaml`) | Parse the YAML/HTML survivors list |
+| `go-mutesting` | `go-mutesting ./...` | Parse the trailing `PASS/FAIL` counts + per-mutant lines |
+| `mutant` | `mutant run` (project's `.mutant.yml` config) | Parse the summary table |
+
+The runner's stdout/stderr stream through (so operators can watch progress on long runs). The skill collects the report file at the end.
+
+**Timeout cap:** 90 minutes wall-clock. Beyond that, the skill kills the runner and emits an `incomplete` report flagging the time-out. (Configurable via `mutation.timeout_minutes`.)
+
+### Step 6 — Parse results
+
+Normalise the runner's output into a common record:
+
+```
+total_mutants    = sum of all mutant outcomes
+killed           = mutants the tests caught
+survived         = mutants the tests did NOT catch
+timed_out        = runner timed out before the test could finish
+no_coverage      = mutated line not exercised by any test
+compile_error    = mutant didn't compile (counts as killed in most conventions)
+runtime_error    = runner crashed on this mutant (skip)
+score_pct        = round(100 * killed / (total_mutants - no_coverage - runtime_error))
+```
+
+The denominator deliberately excludes `no_coverage` and `runtime_error` — the convention is to score only the mutants that were genuinely tested. `compile_error` counts as killed (Stryker's default; MutPy and go-mutesting align).
+
+### Step 7 — Render the report
+
+Write to `<projects_dir>/<name>/quality/mutation-<YYYY-MM-DD>.md`. If a report for today already exists, append `-NN` (start at `-01`) so re-runs don't clobber.
+
+Report shape (six sections):
+
+```markdown
+# Mutation report — <project> — <YYYY-MM-DD>
+
+| Field | Value |
+|-------|-------|
+| Project   | <name> |
+| Language  | <ts|js|python|go|ruby> |
+| Runner    | <stryker|mutpy|go-mutesting|mutant> |
+| Threshold | <N>% |
+| Command   | `<exact invocation>` |
+| Duration  | <HH:MM:SS> |
+
+## Score
+
+**<killed> / <denominator> = <score_pct>%** — <PASS|WARN below threshold of <N>%>
+
+## Summary
+
+| Outcome | Count | Notes |
+|---------|-------|-------|
+| Killed         | <N> | Test suite caught the mutation |
+| Survived       | <N> | **Test gap** — investigate top-5 below |
+| Timed out      | <N> | Counts as killed in most conventions |
+| No coverage    | <N> | Mutated line not exercised by any test |
+| Compile error  | <N> | Counts as killed |
+| Runtime error  | <N> | Excluded from score |
+
+## Top-5 survived mutants
+
+For each (up to five), with file:line, mutator name, original snippet, mutated snippet, why-it-survived hint:
+
+### 1. `src/foo.ts:42` — ArithmeticOperator (`+` → `-`)
+
+```ts
+// Original
+return a + b;
+
+// Mutated
+return a - b;
+```
+
+**Hint:** the test asserts `result` is a number, not the specific value. Tighten the assertion to `expect(result).toBe(5)`.
+
+### 2. ...
+
+(Up to 5 — if there are more, summarise the long tail as a count by mutator type.)
+
+## Trend (last 5 runs)
+
+| Date | Score | Threshold | Verdict |
+|------|-------|-----------|---------|
+| 2026-05-20 | 64% | 60% | PASS |
+| 2026-04-29 | 58% | 60% | WARN |
+| ...        | ...  | ...   | ...    |
+
+(Section omitted if there are no prior reports.)
+
+## Recommendations
+
+- File-specific test gaps surfaced above
+- Equivalent-mutant suppression candidates (mutants the runner classified survived but that look semantically equivalent)
+- Runner-config tweaks (e.g. `stryker.conf.json` `ignorePatterns`)
+```
+
+### Step 8 — Emit a one-line verdict to stdout
+
+Same scannable shape as `/launch-check`:
+
+```
+✓ MUTATION TEST — <project> — <score_pct>% (threshold <N>%) — PASS
+  Report: projects/<name>/quality/mutation-<YYYY-MM-DD>.md
+```
+
+or:
+
+```
+⚠ MUTATION TEST — <project> — <score_pct>% (threshold <N>%) — WARN
+  Below threshold. Top-5 survived mutants in:
+  projects/<name>/quality/mutation-<YYYY-MM-DD>.md
+```
+
+WARN does **not** block anything mechanically. The signal is advisory.
+
+### Step 9 — Optional auto-ticket offer
+
+```
+Want me to file a [Task] ticket to address the top survived mutants? [y/N]
+```
+
+If yes → run `/task` with the prefilled body (skill stays out of `gh issue create` directly; the structured-ticket gate fires through `/task`). If no → exit cleanly.
+
+## Config
+
+`.claude/project-config.defaults.json` ships a `mutation` block:
+
+```json
+"mutation": {
+  "runner": {
+    "ts": "stryker",
+    "js": "stryker",
+    "python": "mutpy",
+    "go": "go-mutesting",
+    "ruby": "mutant"
+  },
+  "threshold": 60,
+  "timeout_minutes": 90
+}
+```
+
+Adopters override per-project in `.claude/project-config.json`:
+
+```json
+{
+  "mutation": {
+    "threshold": 70,
+    "runner": { "python": "cosmic-ray" }
+  }
+}
+```
+
+(Per-key shallow-merge — overriding `runner.python` doesn't blow away the other languages' defaults.)
+
+## Rules
+
+1. **Never run per-PR.** The skill is milestone-boundary + on-demand + weekly-cron only. The framework does not wire it to any pre-commit, pre-push, or merge-gate hook.
+2. **Graceful-degrade on missing runner.** Exit 3 + advisory — never block adopters who don't want the audit. Same shape as `/pdf` and `/process`.
+3. **Report is dated + per-project.** `projects/<name>/quality/mutation-<YYYY-MM-DD>.md`. Re-runs on the same day append `-NN` rather than clobber.
+4. **Below-threshold is WARN, not FAIL.** Mutation testing is a leading indicator, not a launch blocker. The verdict surfaces the gap; the operator decides whether to address now or in the next sprint.
+5. **Run from inside the project workspace.** The skill checks `workspace/<name>/`, not the ops repo.
+6. **No ticket creation without explicit operator yes.** Step 9 offers; doesn't auto-file.
+7. **Mixed-language projects audit only the dominant language per run.** Re-run with `--language=<other>` to cover the rest.
+
+## Implementation notes
+
+| File | Purpose |
+|------|---------|
+| `.claude/skills/mutation-test/SKILL.md` | This file — the skill spec |
+| `.claude/skills/mutation-test/detect.sh` | Language detection + runner-availability check (shared between full and `--check-only` modes) |
+| `.claude/skills/mutation-test/tests/smoke.sh` | Language-detection + graceful-degradation + report-shape tests |
+| `.claude/project-config.defaults.json` → `mutation.*` | Default runner map + threshold + timeout |
+| `.claude/skills/launch-check/SKILL.md` § "10. Behaviour quality" | The launch-check dimension that dispatches here |
+
+Design rationale: see [`docs/agdr/AgDR-0045-mutation-test-skill.md`](../../../docs/agdr/AgDR-0045-mutation-test-skill.md).
+
+## See also
+
+- AgDR-0045 — runner choices, threshold rationale, why-not-per-PR, graceful-degrade pattern, report location convention
+- `.claude/skills/launch-check/SKILL.md` — milestone-boundary umbrella that fans out to this skill
+- `.claude/skills/pdf/SKILL.md` — the graceful-degrade shape this skill mirrors
+- `.claude/skills/process/SKILL.md` — sibling skill with the same exit-3 install-advisory pattern
+- `.claude/rules/workflow-gates.md` — the existing > 80% coverage gate that this skill complements (coverage = was-it-executed; mutation = does-it-constrain)

--- a/.claude/skills/mutation-test/detect.sh
+++ b/.claude/skills/mutation-test/detect.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# /mutation-test detect.sh — language detection + runner-availability check.
+#
+# Two responsibilities, shared between the full skill invocation and the
+# --check-only mode:
+#
+#   1. detect_language <project-dir>
+#        Echoes one of: ts, js, python, go, ruby, unknown
+#        Decision: file-count heuristic across the project tree, excluding
+#        node_modules / .venv / vendor / dist / build / .next.
+#        TS files contribute to "ts" (a TS-dominant project that also has
+#        sibling .js files reports "ts"); pure-JS reports "js".
+#
+#   2. check_runner <runner-name>
+#        Returns 0 if the runner is on PATH, 3 if not.
+#        Recognised runners: stryker, mutpy, go-mutesting, mutant.
+#
+# Also exposes print_install_advisory to keep the install one-liners in
+# one place (consumed by both detect.sh in --check-only and SKILL.md
+# Step 4 in the full flow).
+#
+# Usage:
+#   detect.sh --detect <project-dir>
+#   detect.sh --check <runner-name>
+#   detect.sh --check-only [<project-dir>]
+#   detect.sh --advisory
+#
+# Exit codes:
+#   0 — happy path (detection succeeded, runner present, advisory printed)
+#   2 — bad input / unsupported flag
+#   3 — no runner installed (graceful-degrade signal)
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# detect_language <project-dir>
+# ---------------------------------------------------------------------------
+detect_language() {
+  local dir="${1:-$PWD}"
+  if [ ! -d "$dir" ]; then
+    echo "detect.sh: project dir not found: $dir" >&2
+    return 2
+  fi
+
+  # Excludes match the well-known build / vendor dirs. Keeping the prune
+  # list short and explicit is more predictable than a chained -prune that
+  # tries to capture every framework's cache dir.
+  local prune='-not -path */node_modules/* -not -path */.venv/* -not -path */vendor/* -not -path */dist/* -not -path */build/* -not -path */.next/* -not -path */__pycache__/* -not -path */.git/*'
+
+  local ts_count js_count py_count go_count rb_count
+  # shellcheck disable=SC2086
+  ts_count=$(find "$dir" -type f \( -name '*.ts' -o -name '*.tsx' \) $prune 2>/dev/null | wc -l | tr -d ' ')
+  # shellcheck disable=SC2086
+  js_count=$(find "$dir" -type f \( -name '*.js' -o -name '*.jsx' -o -name '*.mjs' \) $prune 2>/dev/null | wc -l | tr -d ' ')
+  # shellcheck disable=SC2086
+  py_count=$(find "$dir" -type f -name '*.py' $prune 2>/dev/null | wc -l | tr -d ' ')
+  # shellcheck disable=SC2086
+  go_count=$(find "$dir" -type f -name '*.go' $prune 2>/dev/null | wc -l | tr -d ' ')
+  # shellcheck disable=SC2086
+  rb_count=$(find "$dir" -type f -name '*.rb' $prune 2>/dev/null | wc -l | tr -d ' ')
+
+  # Pick the language with the highest count. TS wins over JS when both
+  # are present; otherwise prefer the larger.
+  local max=0 winner="unknown"
+  if [ "$ts_count" -gt "$max" ]; then max="$ts_count"; winner="ts"; fi
+  if [ "$js_count" -gt "$max" ]; then max="$js_count"; winner="js"; fi
+  if [ "$py_count" -gt "$max" ]; then max="$py_count"; winner="python"; fi
+  if [ "$go_count" -gt "$max" ]; then max="$go_count"; winner="go"; fi
+  if [ "$rb_count" -gt "$max" ]; then max="$rb_count"; winner="ruby"; fi
+
+  # If TS and JS coexist and TS has any files, prefer TS even when JS
+  # numerically dominates (a TS project with compiled JS in src/ shouldn't
+  # report js). The check is "TS present" not "TS dominant".
+  if [ "$winner" = "js" ] && [ "$ts_count" -gt 0 ]; then
+    winner="ts"
+  fi
+
+  if [ "$max" -eq 0 ]; then
+    echo "unknown"
+    return 0
+  fi
+
+  echo "$winner"
+}
+
+# ---------------------------------------------------------------------------
+# check_runner <runner-name>
+# ---------------------------------------------------------------------------
+check_runner() {
+  local runner="${1:-}"
+  case "$runner" in
+    stryker)
+      if command -v stryker >/dev/null 2>&1; then return 0; fi
+      # Stryker is commonly run via npx, so accept npx + a local install.
+      if command -v npx >/dev/null 2>&1 && [ -f "node_modules/.bin/stryker" ]; then return 0; fi
+      return 3
+      ;;
+    mutpy)
+      command -v mut.py >/dev/null 2>&1 && return 0
+      return 3
+      ;;
+    go-mutesting)
+      command -v go-mutesting >/dev/null 2>&1 && return 0
+      return 3
+      ;;
+    mutant)
+      command -v mutant >/dev/null 2>&1 && return 0
+      return 3
+      ;;
+    "")
+      echo "detect.sh: --check requires a runner name (stryker|mutpy|go-mutesting|mutant)" >&2
+      return 2
+      ;;
+    *)
+      echo "detect.sh: unknown runner: $runner (recognised: stryker, mutpy, go-mutesting, mutant)" >&2
+      return 2
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# print_install_advisory
+# ---------------------------------------------------------------------------
+print_install_advisory() {
+  cat >&2 <<'MSG'
+✗ No mutation tester installed.
+
+Per-language install one-liners:
+  TS / JS  — npm install --save-dev @stryker-mutator/core
+              (then add stryker.conf.json — see https://stryker-mutator.io/docs/stryker-js/)
+  Python   — pip install mutpy
+              (https://github.com/mutpy/mutpy)
+  Go       — go install github.com/zimmski/go-mutesting/cmd/go-mutesting@latest
+              (https://github.com/zimmski/go-mutesting)
+  Ruby     — gem install mutant-rspec   (or mutant-minitest)
+              (https://github.com/mbj/mutant)
+
+Install the runner for your project's language and re-run /mutation-test.
+This skill never bundles a mutation runner — same graceful-degrade shape
+as /pdf and /process.
+MSG
+}
+
+# ---------------------------------------------------------------------------
+# CLI dispatch (when invoked directly, not sourced)
+# ---------------------------------------------------------------------------
+# Sourced-mode detection: when BASH_SOURCE differs from $0 (or the test
+# explicitly sources this file), skip the CLI dispatch and just expose
+# the functions.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  case "${1:-}" in
+    --detect)
+      shift
+      detect_language "${1:-$PWD}"
+      ;;
+    --check)
+      shift
+      check_runner "${1:-}"
+      ;;
+    --check-only)
+      shift
+      DIR="${1:-$PWD}"
+      LANG=$(detect_language "$DIR")
+      echo "detect.sh: language detected: $LANG"
+      echo "detect.sh: runner availability:"
+      any=0
+      for r in stryker mutpy go-mutesting mutant; do
+        if check_runner "$r" >/dev/null 2>&1; then
+          echo "  $r: yes"
+          any=1
+        else
+          echo "  $r: no"
+        fi
+      done
+      if [ "$any" -eq 0 ]; then
+        print_install_advisory
+        exit 3
+      fi
+      exit 0
+      ;;
+    --advisory)
+      print_install_advisory
+      ;;
+    --help|-h|"")
+      sed -n '1,32p' "$0" >&2
+      [ -z "${1:-}" ] && exit 2 || exit 0
+      ;;
+    *)
+      echo "detect.sh: unknown flag: $1" >&2
+      exit 2
+      ;;
+  esac
+fi

--- a/.claude/skills/mutation-test/tests/smoke.sh
+++ b/.claude/skills/mutation-test/tests/smoke.sh
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+# /mutation-test smoke test — language detection + graceful-degradation + report shape.
+#
+# Covers:
+#   1. Language detection — file-count heuristic across each supported language
+#   2. Mixed-language tie-breaking — TS files always win over JS
+#   3. Unknown / empty project handling — exits cleanly with "unknown"
+#   4. Runner check — known runner names accepted, unknown rejected
+#   5. Graceful degradation — exit 3 + advisory when no runner is installed
+#   6. --check-only mode — reports runner availability without running
+#   7. Report shape — the six-section structure documented in SKILL.md is
+#      buildable by the operator from a known-good payload
+#
+# Designed to run in any sandbox without network. Runner-installed checks
+# are guarded — the test passes whether or not stryker/mutpy/etc. happen
+# to be on the host PATH.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+DETECT="$SKILL_DIR/detect.sh"
+
+PASS=0
+FAIL=0
+SKIPPED=0
+
+ok()    { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad()   { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip()  { echo "  SKIP: $1"; SKIPPED=$((SKIPPED + 1)); }
+
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    ok "$label  (got: $got)"
+  else
+    bad "$label  (want: $want, got: $got)"
+  fi
+}
+
+assert_exit() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    ok "$label  (got exit $got)"
+  else
+    bad "$label  (want exit $want, got exit $got)"
+  fi
+}
+
+FIXTURE=$(mktemp -d -t mut-smoke-XXXXXX)
+trap 'rm -rf "$FIXTURE"' EXIT
+
+# ---------------------------------------------------------------------------
+# 1. Language detection — one fixture per language
+# ---------------------------------------------------------------------------
+echo ""
+echo "1) Language detection (file-count heuristic)"
+
+# Python-dominant fixture (5 .py + 0 others)
+PY_DIR="$FIXTURE/python-project"
+mkdir -p "$PY_DIR/src"
+for i in 1 2 3 4 5; do
+  echo "def f${i}(): return ${i}" > "$PY_DIR/src/mod${i}.py"
+done
+got=$("$DETECT" --detect "$PY_DIR")
+assert_eq "5 .py files → python" "python" "$got"
+
+# TS-dominant fixture
+TS_DIR="$FIXTURE/ts-project"
+mkdir -p "$TS_DIR/src"
+for i in 1 2 3 4 5 6; do
+  echo "export const v${i} = ${i};" > "$TS_DIR/src/mod${i}.ts"
+done
+got=$("$DETECT" --detect "$TS_DIR")
+assert_eq "6 .ts files → ts" "ts" "$got"
+
+# Pure-JS fixture
+JS_DIR="$FIXTURE/js-project"
+mkdir -p "$JS_DIR/src"
+for i in 1 2 3 4; do
+  echo "exports.v${i} = ${i};" > "$JS_DIR/src/mod${i}.js"
+done
+got=$("$DETECT" --detect "$JS_DIR")
+assert_eq "4 .js files (no .ts) → js" "js" "$got"
+
+# Go fixture
+GO_DIR="$FIXTURE/go-project"
+mkdir -p "$GO_DIR"
+for i in 1 2 3; do
+  echo "package main" > "$GO_DIR/file${i}.go"
+done
+got=$("$DETECT" --detect "$GO_DIR")
+assert_eq "3 .go files → go" "go" "$got"
+
+# Ruby fixture
+RB_DIR="$FIXTURE/ruby-project"
+mkdir -p "$RB_DIR"
+for i in 1 2 3 4; do
+  echo "class C${i}; end" > "$RB_DIR/c${i}.rb"
+done
+got=$("$DETECT" --detect "$RB_DIR")
+assert_eq "4 .rb files → ruby" "ruby" "$got"
+
+# Acceptance-criteria spec: 5 .py + 2 .ts → MutPy (python wins by count)
+MIXED_AC="$FIXTURE/ac-fixture"
+mkdir -p "$MIXED_AC/src"
+for i in 1 2 3 4 5; do
+  echo "def f${i}(): return ${i}" > "$MIXED_AC/src/mod${i}.py"
+done
+for i in 1 2; do
+  echo "export const v${i} = ${i};" > "$MIXED_AC/src/mod${i}.ts"
+done
+got=$("$DETECT" --detect "$MIXED_AC")
+assert_eq "AC fixture (5 .py + 2 .ts) → python (MutPy)" "python" "$got"
+
+# ---------------------------------------------------------------------------
+# 2. TS-wins-over-JS tie-breaker
+# ---------------------------------------------------------------------------
+echo ""
+echo "2) Mixed TS/JS tie-breaker"
+
+MIXED_DIR="$FIXTURE/mixed-ts-js"
+mkdir -p "$MIXED_DIR/src"
+# More .js than .ts, but the presence-of-TS rule should still pick TS
+for i in 1 2 3 4 5 6; do
+  echo "exports.v${i} = ${i};" > "$MIXED_DIR/src/mod${i}.js"
+done
+for i in 1 2; do
+  echo "export const t${i} = ${i};" > "$MIXED_DIR/src/t${i}.ts"
+done
+got=$("$DETECT" --detect "$MIXED_DIR")
+assert_eq "6 .js + 2 .ts → ts (presence-of-TS rule)" "ts" "$got"
+
+# ---------------------------------------------------------------------------
+# 3. Unknown / empty project
+# ---------------------------------------------------------------------------
+echo ""
+echo "3) Unknown / empty project handling"
+
+EMPTY_DIR="$FIXTURE/empty-project"
+mkdir -p "$EMPTY_DIR"
+got=$("$DETECT" --detect "$EMPTY_DIR")
+assert_eq "empty dir → unknown" "unknown" "$got"
+
+# Project with only .md files
+DOCS_DIR="$FIXTURE/docs-only"
+mkdir -p "$DOCS_DIR"
+echo "# Hello" > "$DOCS_DIR/README.md"
+echo "# Other" > "$DOCS_DIR/CHANGELOG.md"
+got=$("$DETECT" --detect "$DOCS_DIR")
+assert_eq "docs-only dir → unknown" "unknown" "$got"
+
+# node_modules exclusion — files inside node_modules don't count
+EXCL_DIR="$FIXTURE/excluded-deps"
+mkdir -p "$EXCL_DIR/src" "$EXCL_DIR/node_modules/some-lib"
+echo "exports.v = 1;" > "$EXCL_DIR/node_modules/some-lib/index.js"
+echo "exports.v = 2;" > "$EXCL_DIR/node_modules/some-lib/util.js"
+echo "exports.v = 3;" > "$EXCL_DIR/node_modules/some-lib/more.js"
+# But the project itself has one .py file — Python should still win
+echo "def f(): return 1" > "$EXCL_DIR/src/a.py"
+got=$("$DETECT" --detect "$EXCL_DIR")
+assert_eq "node_modules excluded → python wins on a single .py" "python" "$got"
+
+# ---------------------------------------------------------------------------
+# 4. Runner check — name validation
+# ---------------------------------------------------------------------------
+echo ""
+echo "4) Runner check — name validation"
+
+# Known runner names → exit 0 (if installed) or 3 (if not), but never 2
+for r in stryker mutpy go-mutesting mutant; do
+  set +e
+  "$DETECT" --check "$r" >/dev/null 2>&1
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ] || [ "$rc" -eq 3 ]; then
+    ok "runner $r → exit 0|3 (got: $rc)"
+  else
+    bad "runner $r → unexpected exit $rc"
+  fi
+done
+
+# Unknown runner → exit 2
+set +e
+"$DETECT" --check bogus-runner >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit "unknown runner → exit 2" 2 "$rc"
+
+# Missing name → exit 2
+set +e
+"$DETECT" --check >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit "--check with no name → exit 2" 2 "$rc"
+
+# ---------------------------------------------------------------------------
+# 5. Graceful degradation — exit 3 + advisory under stripped PATH
+# ---------------------------------------------------------------------------
+echo ""
+echo "5) Graceful degradation (exit 3 + advisory)"
+
+# Mock PATH to strip all four runners — same shape as /pdf's smoke test.
+STRIPPED_PATH_DIR=$(mktemp -d -t mut-stripped-path-XXXXXX)
+for tool in bash sh mktemp sed cat grep dirname basename mkdir chmod cd pwd echo cp mv rm ls test command find wc tr awk; do
+  src=$(command -v "$tool" 2>/dev/null || true)
+  if [ -n "$src" ]; then
+    ln -sf "$src" "$STRIPPED_PATH_DIR/$tool"
+  fi
+done
+
+# Verify none of the four runners leak through the stripped PATH
+strip_check() {
+  PATH="$STRIPPED_PATH_DIR" command -v "$1" >/dev/null 2>&1
+}
+if strip_check stryker || strip_check mut.py || strip_check go-mutesting || strip_check mutant; then
+  skip "could not strip PATH cleanly (a runner symlink leaked); skipping no-runner test"
+else
+  set +e
+  out=$(PATH="$STRIPPED_PATH_DIR" "$DETECT" --check-only "$PY_DIR" 2>&1)
+  rc=$?
+  set -e
+  assert_exit "no runner installed → exit 3" 3 "$rc"
+  if echo "$out" | grep -q "No mutation tester installed"; then
+    ok "advisory message names the gap"
+  else
+    bad "advisory did not mention 'No mutation tester installed' (got: $out)"
+  fi
+  if echo "$out" | grep -q "stryker-mutator"; then
+    ok "advisory includes the Stryker install one-liner"
+  else
+    bad "advisory missing the Stryker install one-liner (got: $out)"
+  fi
+  if echo "$out" | grep -q "mutpy"; then
+    ok "advisory includes the MutPy install one-liner"
+  else
+    bad "advisory missing the MutPy install one-liner (got: $out)"
+  fi
+  if echo "$out" | grep -q "go-mutesting"; then
+    ok "advisory includes the go-mutesting install one-liner"
+  else
+    bad "advisory missing the go-mutesting install one-liner (got: $out)"
+  fi
+  if echo "$out" | grep -q "mutant"; then
+    ok "advisory includes the mutant install one-liner"
+  else
+    bad "advisory missing the mutant install one-liner (got: $out)"
+  fi
+fi
+rm -rf "$STRIPPED_PATH_DIR"
+
+# Advisory-only flag
+set +e
+out=$("$DETECT" --advisory 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "No mutation tester installed"; then
+  ok "--advisory prints the install message and exits 0"
+else
+  bad "--advisory did not print the expected message (rc=$rc, out=$out)"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. --check-only mode — reports without running
+# ---------------------------------------------------------------------------
+echo ""
+echo "6) --check-only mode"
+
+set +e
+out=$("$DETECT" --check-only "$PY_DIR" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ] || [ "$rc" -eq 3 ]; then
+  ok "--check-only exits 0 (≥1 runner present) or 3 (none)  (got: $rc)"
+else
+  bad "--check-only exits $rc unexpectedly"
+fi
+if echo "$out" | grep -q "language detected: python"; then
+  ok "--check-only reports the detected language"
+else
+  bad "--check-only did not report language (got: $out)"
+fi
+if echo "$out" | grep -q "runner availability"; then
+  ok "--check-only reports runner availability"
+else
+  bad "--check-only did not report runner availability (got: $out)"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Report shape contract — the six-section structure
+# ---------------------------------------------------------------------------
+# The actual report rendering lives in the SKILL.md flow (model-driven).
+# This test pins the *contract* — given a known payload, the section
+# headings the operator-facing rendering must include.
+# ---------------------------------------------------------------------------
+echo ""
+echo "7) Report shape contract"
+
+REPORT_FIXTURE="$FIXTURE/sample-report.md"
+cat > "$REPORT_FIXTURE" <<'REPORT'
+# Mutation report — example-app — 2026-05-20
+
+| Field | Value |
+|-------|-------|
+| Project   | example-app |
+| Language  | python |
+| Runner    | mutpy |
+| Threshold | 60% |
+| Command   | `mut.py --target src --unit-test tests` |
+| Duration  | 00:23:14 |
+
+## Score
+
+**142 / 220 = 65%** — PASS
+
+## Summary
+
+| Outcome | Count | Notes |
+|---------|-------|-------|
+| Killed         | 142 | Test suite caught the mutation |
+| Survived       | 58  | Test gap — investigate top-5 below |
+| Timed out      | 8   | Counts as killed |
+| No coverage    | 12  | Mutated line not exercised |
+| Compile error  | 0   | n/a (Python) |
+| Runtime error  | 0   | Excluded from score |
+
+## Top-5 survived mutants
+
+### 1. `src/foo.py:42` — ArithmeticOperator (`+` → `-`)
+
+Original code; mutated code; hint.
+
+### 2. `src/bar.py:18` — RelationalOperator (`<` → `<=`)
+
+Original code; mutated code; hint.
+
+## Trend (last 5 runs)
+
+| Date | Score | Threshold | Verdict |
+|------|-------|-----------|---------|
+| 2026-05-20 | 65% | 60% | PASS |
+
+## Recommendations
+
+- Strengthen assertions in `tests/test_foo.py`
+REPORT
+
+required_sections="^# Mutation report
+^## Score
+^## Summary
+^## Top-5 survived mutants
+^## Trend
+^## Recommendations"
+
+while IFS= read -r section; do
+  if grep -q "$section" "$REPORT_FIXTURE"; then
+    ok "report includes section: ${section#^}"
+  else
+    bad "report missing section: ${section#^}"
+  fi
+done <<< "$required_sections"
+
+# Score line shape — "<killed> / <denominator> = <pct>%"
+if grep -qE '^\*\*[0-9]+ / [0-9]+ = [0-9]+%\*\*' "$REPORT_FIXTURE"; then
+  ok "score line matches the contract: **K / D = P%**"
+else
+  bad "score line does not match the contract"
+fi
+
+# Threshold + verdict line in the score section
+if grep -qE 'PASS|WARN below threshold' "$REPORT_FIXTURE"; then
+  ok "score section names the PASS/WARN verdict"
+else
+  bad "score section did not name the verdict"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "----------------------------------------"
+echo "Total: $((PASS + FAIL + SKIPPED))   Passed: $PASS   Failed: $FAIL   Skipped: $SKIPPED"
+echo "----------------------------------------"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "FAIL: /mutation-test smoke test had $FAIL failure(s)."
+  exit 1
+fi
+
+echo "OK: /mutation-test smoke test passed."
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,17 +188,17 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Rules | `.claude/rules/` | 11 modular rule files (AgDR triggers, code standards, git conventions, leak protection, parallel work, plan mode, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Handbooks | `handbooks/` | Adopter-authored coding standards consumed by Rex during code review. Discovery by path-convention (`architecture/` + `general/` always-load; `language/<lang>/` loads on diff-match). Advisory by default; opt in to blocking via `ENFORCEMENT: blocking` marker. See [`handbooks/README.md`](handbooks/README.md). |
 | Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer — Rex, Security Reviewer — Hatim, Dependency Auditor — Munir, PR Manager — Tariq, Ticket Manager — Idris) |
-| Skills | `.claude/skills/` | 52 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 53 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (52)
+### Available skills (53)
 
 One-line summary per skill; canonical details live in each `.claude/skills/<name>/SKILL.md`.
 
 | Skill | Purpose |
 |-------|---------|
 | `/setup` | First-run bootstrap — configure `onboarding.yaml` in 3 exchanges |
-| `/launch-check` | Production readiness audit — 9-dimension go/no-go sweep at milestone boundaries |
+| `/launch-check` | Production readiness audit — 10-dimension go/no-go sweep at milestone boundaries |
 | `/threat-model` | STRIDE threat modelling — spoofing, tampering, repudiation, disclosure, DoS, EoP |
 | `/accessibility-audit` | WCAG 2.1 AA accessibility audit — perceivable, operable, understandable, robust |
 | `/compliance-check` | GDPR + ePrivacy compliance — consent, privacy policy, data handling, user rights |
@@ -208,6 +208,7 @@ One-line summary per skill; canonical details live in each `.claude/skills/<name
 | `/performance-audit` | Performance audit — bundle size, images, lazy load, code split, Core Web Vitals |
 | `/monitoring-audit` | Observability audit — error tracking, health endpoints, alerting, runbooks |
 | `/docs-audit` | Diataxis docs audit — tutorials, how-to, reference, explanation |
+| `/mutation-test` | Mutation-testing sensor — Stryker/MutPy/go-mutesting/mutant; milestone cadence, exit-3 graceful-degrade |
 | `/start-ticket` | Declare an active ticket for this session (required before code edits) |
 | `/approve-merge` | Record per-PR CEO approval and merge (required by merge gate) |
 | `/approve-design` | Record per-PR design-review approval for UI PRs (required by design gate) |
@@ -285,7 +286,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Rules (modular, framework-wide) | `.claude/rules/` |
 | **Adopter handbooks** (consumed by Rex during code review) | `handbooks/` — see [`handbooks/README.md`](handbooks/README.md) for the discovery + advisory/blocking conventions |
 | Agents | `.claude/agents/` |
-| Skills (52 slash commands) | `.claude/skills/` |
+| Skills (53 slash commands) | `.claude/skills/` |
 | Hook wiring | `.claude/settings.json` |
 | **Per-project docs** | `projects/<name>/` |
 | **Live working copies** (gitignored) | `workspace/<name>/` |

--- a/docs/agdr/AgDR-0045-mutation-test-skill.md
+++ b/docs/agdr/AgDR-0045-mutation-test-skill.md
@@ -1,0 +1,149 @@
+# AgDR-0045 — `/mutation-test`: behaviour-quality sensor closes the behaviour-harness gap
+
+> In the context of the framework's existing coverage-% gate proving a weak signal for test-suite quality (100% coverage with `assert(true)` everywhere passes the gate but constrains no behaviour), facing the choice of which mutation testers to dispatch across, what threshold to set, how to surface results, and whether to run per-PR or on-demand, I decided to ship a **standalone `/mutation-test` skill** that dispatches across **Stryker (TS/JS), MutPy (Python), go-mutesting (Go), mutant (Ruby)** with a **default 60% threshold**, runs on **`/launch-check` / weekly cron / explicit invocation only** (never per-PR), graceful-degrades to **exit 3 + advisory** when no runner is installed, and writes a dated report to **`projects/<name>/quality/mutation-<YYYY-MM-DD>.md`** — accepting that mutation testing is a stricter measure than coverage and a slower one (30 min on a medium codebase), so the framework treats it as a milestone-boundary sensor, not a per-commit gate.
+
+## Context
+
+The framework already enforces a **> 80% coverage gate** on new code via `.claude/rules/workflow-gates.md` and the PR-quality checklist. But coverage % answers only one question — *"did the test run this line?"* — which is a necessary-but-not-sufficient signal for "the test suite constrains behaviour". The pathological case (100% coverage with `assert(true)` in every test) passes the gate and constrains nothing.
+
+Industry **behaviour harness** writing names this gap explicitly as the third regulation dimension after maintainability and architecture fitness:
+
+- **Maintainability harness** — ApexYard covers this well: Rex (code review agent), handbooks (advisory + blocking rules), `/codify-rule` (turning review comments into handbook entries).
+- **Architecture-fitness harness** — partially covered: `/c4`, `/dfd`, `/tech-vision`, `require-agdr-for-arch-changes.sh` gate.
+- **Behaviour harness** — the weakest dimension today. AI-generated tests plus a coverage % gate. No measure of whether the tests actually constrain behaviour.
+
+Mutation testing flips the question from *"did the test execute this line?"* to *"if I broke this line, would the test catch it?"*. A test that catches the mutation is a test that constrains behaviour; a test that doesn't is theatre. Mutation **score** (killed / total) is the headline number.
+
+Three live problems followed:
+
+1. **Which runner per language?** Mutation testers are heavily language-specific. Stryker dominates TS/JS, MutPy dominates Python, go-mutesting is the most-maintained Go option, mutant is Ruby's standard. There's no cross-language aggregator. The framework has to dispatch.
+2. **What threshold?** Coverage % gates at 80%. Mutation score is a stricter measure (a mutant that's semantically equivalent to the original survives even on perfect tests), so 80% is unreachable on most real codebases. Industry consensus from the mutation-testing community is 50–70%. The framework needs a defensible default.
+3. **Per-PR vs on-demand?** Mutation testing is slow — Stryker on a medium TS codebase takes 20–40 minutes. Running it on every PR would dominate CI time and force the gate to be a soft warning anyway. But the value is real, so the framework needs a delivery channel.
+
+## Options Considered
+
+### Axis 1 — Single runner vs language-dispatched
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Hardcode Stryker, document "TS/JS only" | Smallest skill surface. One install path. | Excludes every Python / Go / Ruby project in the portfolio. Doesn't match the framework's polyglot stance (handbooks/language/, golden-paths/, etc.). |
+| Language-dispatch across Stryker / MutPy / go-mutesting / mutant (chosen) | Adopter on any of the four supported languages gets the audit. Single skill surface from the operator's view. | One install per language to document. Each runner has different invocation, different report format, different config knobs — the dispatch table carries the variance. |
+| Wrap a polyglot meta-runner (e.g. some emerging cross-lang mutation tool) | One install, all languages. | No mature cross-language mutation runner exists at v1 time. The closest options are immature, slow, or single-language-disguised. |
+
+### Axis 2 — Default threshold
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Match coverage at 80% | Mental-model consistency. | Unreachable on real codebases — equivalent-mutant survivors push real-world scores into the 50–75% band. A 80% default would force adopters to either suppress equivalent mutants by hand (huge effort) or live with a permanently-red gate. |
+| 50% — lower bound of industry consensus | Easy to hit. Most existing test suites pass. | Too lenient — the value of the sensor is "find the gaps", and 50% means half the mutations slip. Adopters get false comfort. |
+| **60%** (chosen) | Middle of the industry-consensus band. Achievable on tests-as-actually-written-by-humans suites. Strict enough to surface real gaps. | Some idiomatic codebases (especially those heavy on equivalent-mutant patterns like simple getters/setters or unrolled-loop optimisations) sit naturally lower. Mitigated by per-project override via config. |
+| 70% — upper bound | Forces high-quality tests. | Pushes adopters into mutant-suppression configuration before the sensor pays off. |
+
+### Axis 3 — Per-PR vs on-demand vs milestone
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Per-PR (block merge on below-threshold) | Tight feedback loop. Same shape as the coverage gate. | A 30-minute audit on every PR is incompatible with normal review cadence. Even on a self-hosted runner pool, queuing dominates. Adopters would suppress or skip the gate. |
+| Per-PR (warn-only) | Tight feedback loop, no merge block. | Still 30 min of CI per PR. Adopters disable. |
+| **`/launch-check` + weekly cron + on-demand** (chosen) | Mutation testing fits the milestone-boundary shape exactly — measure at the moments where the answer changes adopter behaviour (epic completion, release prep, monthly health check). Doesn't burn per-PR CI minutes. | Slower feedback loop (typically weekly, not per-commit). A failing test that mutation testing would catch can land before the next audit. Mitigated by Rex's per-PR test-coverage advice + the existing coverage gate as the first-line defence. |
+| `/launch-check` only (no cron, no on-demand) | Single trigger to learn. | Adopters who want quarterly health-check trends don't get them without manually re-running. |
+
+### Axis 4 — Runner-missing behaviour
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Hard-fail (exit 1) when no runner installed | Forces install. | Punishes adopters who don't want the audit. Same dynamic as making pandoc a hard dep for `/pdf`. |
+| Silent skip | No friction. | Adopter never discovers the audit exists. |
+| **Exit 3 + install advisory** (chosen — matches `/pdf` and `/process`) | Adopter sees what's missing and the install one-liner. Skill stays slim — no runner is bundled into the framework. | One more skill with its own install-advisory shape. Mitigated by the uniformity: `/pdf`, `/process`, `/c4` (Mermaid lint), and now `/mutation-test` all use the same exit-3 pattern. |
+
+### Axis 5 — Report location
+
+| Option | Pros | Cons |
+|--------|------|------|
+| `projects/<name>/audits/mutation-test/<YYYY-MM-DD>.md` (full audit-family shape) | Matches `/launch-check`, `/threat-model`, `/security-review` — same persistence helper, same trend renderer. | The audit family expects `audit_run_persist` to drive a findings table with PASS/WARN/FAIL severities; mutation testing's output is more directly a score + survived-mutant catalogue. Forcing it into the audit-family shape loses information. |
+| **`projects/<name>/quality/mutation-<YYYY-MM-DD>.md`** (chosen — its own subdir under `quality/`) | Mutation reports are a distinct artefact class (score + survivors with code snippets), not a severity-graded audit. The `quality/` subdir leaves room for sibling behaviour-harness skills (e.g. a future `/property-test-coverage` audit) without forcing each into the audit-family shape. | One more subdir convention to learn. Mitigated by the `quality/` name being self-documenting. |
+| `projects/<name>/mutation/<YYYY-MM-DD>.md` (its own top-level subdir per skill) | Self-contained. | Proliferates per-skill subdirs — every new sensor would want one. The `quality/` umbrella is the right scope for sensors that aren't graded audits. |
+
+## Decision
+
+### Chosen on axis 1 — Language-dispatched
+
+The dispatch table:
+
+| Language | Runner | Detection signature | Install one-liner |
+|----------|--------|---------------------|-------------------|
+| TS / JS | Stryker | `*.ts` + `*.tsx` + `*.js` file count exceeds Python/Go/Ruby | `npm install --save-dev @stryker-mutator/core` |
+| Python | MutPy | `*.py` file count dominant; `pyproject.toml` or `setup.py` present | `pip install mutpy` |
+| Go | go-mutesting | `*.go` file count dominant; `go.mod` present | `go install github.com/zimmski/go-mutesting/cmd/go-mutesting@latest` |
+| Ruby | mutant | `*.rb` file count dominant; `Gemfile` present | `gem install mutant-rspec` (or `mutant-minitest`) |
+
+Language detection is a file-count heuristic. The configured runner (`mutation.runner` in `.claude/project-config.json`) wins when set; otherwise the language detection picks. Mixed-language projects (e.g. a TS frontend + Python backend) default to the dominant language and surface a note that the other language's coverage isn't audited in this run — the operator can re-run with `--language=python` to audit the other side.
+
+### Chosen on axis 2 — 60% default
+
+`mutation.threshold` defaults to `60` in `.claude/project-config.defaults.json`. Below-threshold reports flag in `/launch-check` output as `WARN` (not `FAIL` — see axis 3). Adopters override per-project in `.claude/project-config.json`.
+
+Operators who hit the threshold in their first run and want to push higher should bump it incrementally — a 60→70 jump usually surfaces a long tail of work that's better as multiple small PRs than one mutation-mass-fix PR.
+
+### Chosen on axis 3 — Milestone-boundary + on-demand only
+
+The skill is invoked in three ways:
+
+1. **`/launch-check` fans out to it** as a 10th dimension ("Behaviour quality"). Below-threshold projects get a `WARN` (not `FAIL`) in the verdict — the rationale being that mutation testing is a leading indicator, not a launch-blocker.
+2. **Weekly cron** (via a CI workflow the adopter wires in — example template in `golden-paths/pipelines/mutation-test.yml.example`). Cadence is the adopter's call.
+3. **Explicit `/mutation-test [project]`** invocation when the operator wants a fresh number.
+
+Per-PR is explicitly **out of scope**. Rex still does the per-PR test-quality review; the coverage gate still fires at 80%; mutation testing is the slower, deeper measure that lives one cadence above.
+
+### Chosen on axis 4 — Exit 3 + advisory
+
+When `command -v stryker / mut.py / go-mutesting / mutant` all return non-zero, the skill exits 3 with an advisory naming the install one-liner per language. Same shape as `/pdf` and `/process` (BPMN lint). Adopters who don't want the audit pay zero install cost.
+
+### Chosen on axis 5 — `projects/<name>/quality/mutation-<YYYY-MM-DD>.md`
+
+Six sections, in order:
+
+1. **Header** — date, runner, language detected, threshold, project, command invoked.
+2. **Score** — `killed / total = X%` with a PASS/WARN line against the threshold.
+3. **Summary table** — total mutants, killed, survived, timed-out, no-coverage, equivalent-suppressed.
+4. **Top-5 survived mutants** — per-mutant: file path, line, mutator name, original code snippet, mutated code snippet, why-it-survived hint.
+5. **Trend (optional)** — last 5 runs' scores, if any. Read from `projects/<name>/quality/mutation-*.md` (filename-based — no JSON-history dependency at v1).
+6. **Recommendations** — operator-actionable next steps (file-specific test gaps, equivalent-mutant suppression candidates, runner-config tweaks).
+
+## Consequences
+
+### Positive
+
+- **Closes the behaviour-harness gap** — adopters now have a sensor for "do the tests constrain behaviour?", not just "do the tests execute the lines?".
+- **Polyglot from day 1** — TS, Python, Go, Ruby covered. Adding a language is a row in the dispatch table + a runner one-liner.
+- **Zero install cost for non-users** — graceful-degrades the same way `/pdf` and `/process` do. Adopters who never want the audit are unaffected.
+- **Fits the milestone-boundary mental model** — `/launch-check` already covers nine dimensions; adding "Behaviour quality" as the tenth slots in cleanly without forcing a new audit cadence on adopters.
+- **Per-project threshold override** — adopters whose codebase legitimately sits below 60% (heavy equivalent-mutant patterns, large generated-code surface) can drop the threshold without forking the skill.
+
+### Negative
+
+- **30+ minute audit time** is a real cost. The framework mitigates by making the audit milestone-boundary-only, but adopters running it weekly are paying it weekly. There's no obvious shortcut at v1.
+- **Equivalent-mutant noise** — some survived mutants are semantically equivalent to the original (e.g. `i++` vs `i = i + 1`). The runner filters most, but the top-5 list will sometimes include false positives. The report's "why-it-survived hint" flags candidates for operator triage but can't suppress them automatically.
+- **Per-language runner divergence** — Stryker has a different config shape from MutPy from go-mutesting from mutant. The skill's dispatch table papers over the invocation difference, but operators who want to tune the runner deeply still need to learn the per-language tool. The skill names the docs URL in the report.
+- **Mixed-language projects audit only the dominant language** in a single run. Operators who care equally about a TS frontend and a Python backend need two runs (or `--language=...` overrides).
+- **No per-PR mutation gate** means a test-quality regression can land before the next audit catches it. Mitigated by Rex + the coverage gate, which remain the per-PR defences.
+
+### Migration / rollback
+
+- **No data migration needed** — the skill is additive. No existing artefacts touched.
+- **Rollback** is `git revert` of the introducing PR; no state in `.claude/session/` is created.
+- **Adopters with no mutation runner installed** see exit 3 + advisory; the rest of `/launch-check` (the other 9 dimensions) runs unaffected.
+
+## Artifacts
+
+- Issue: [me2resh/apexyard#299](https://github.com/me2resh/apexyard/issues/299)
+- PR: <to be filled at merge time>
+- Skill: `.claude/skills/mutation-test/SKILL.md`
+- Config defaults: `.claude/project-config.defaults.json` → `mutation.runner` map + `mutation.threshold`
+- Launch-check wiring: `.claude/skills/launch-check/SKILL.md` § "The 10 dimensions" + § "Deep-dive companions"
+- Tests: `.claude/skills/mutation-test/tests/smoke.sh`
+- Sibling patterns this AgDR reuses:
+  - AgDR-0034 — graceful-degradation shape (exit 3 + install advisory) from `/pdf`
+  - AgDR-0025 — `/process` graceful-degrade for `bpmnlint`
+  - AgDR-0043 — `/generative-engine-audit` sibling-skill pattern (dispatched from `/launch-check`)
+  - AgDR-0019 — audit artefact persistence (the `quality/` subdir is sibling to `audits/<dim>/` rather than nested, because mutation reports are score + catalogue, not severity-graded findings)


### PR DESCRIPTION
## Summary

- **Closes the behaviour-harness gap** — the framework's existing > 80% coverage gate answers "did the test run this line?" but not "if I broke this line, would the test catch it?". The new `/mutation-test` skill is the second question's sensor; below-threshold runs flag the test gaps coverage % silently masks.
- **Language-dispatched across four runners** — Stryker for TS/JS, MutPy for Python, go-mutesting for Go, mutant for Ruby. Detection is a file-count heuristic that excludes `node_modules` / `.venv` / `vendor` / build dirs; configured runners (`.claude/project-config.json → mutation.runner`) win over detection.
- **Default threshold 60%, not 80%** — coverage's threshold is unreachable on real codebases because equivalent-mutant survivors push real-world scores into the 50–75% band. 60% sits in the industry-consensus band, surfaces real gaps, and is per-project overridable. Below-threshold = WARN, not FAIL (mutation is a leading indicator, not a launch blocker).
- **Milestone-cadence, NOT per-PR** — a 20–40 min audit can't fit normal PR latency; we'd silently disable it. Three invocation paths: `/launch-check` fans out automatically as the 10th dimension; adopters wire a weekly CI cron; operators run `/mutation-test [project]` on demand. Rex + the coverage gate stay as the per-PR defences.
- **Graceful-degrades to exit 3 + advisory** when no runner is installed — same shape as `/pdf` and `/process` so adopters who never want the audit pay zero install cost. The advisory names the per-language install one-liner.
- **AgDR-0045** documents the five-axis decision space (single runner vs language-dispatched, threshold pick, per-PR vs milestone cadence, missing-runner behaviour, report location under `projects/<name>/quality/`).

## Testing

Validates locally via the smoke test:

```
bash .claude/skills/mutation-test/tests/smoke.sh
# 34/34 PASS — covers language detection across all 5 supported languages,
# TS-wins-over-JS tie-break, node_modules exclusion, runner-name validation,
# graceful-degradation exit-3 + advisory (stripped PATH), --check-only
# reporting, and the report-shape contract.
```

And the token-efficiency invariant test from AgDR-0044 stays green with the new skill in the table:

```
bash .claude/hooks/tests/test_token_efficiency_wave1.sh
# All Wave 1 invariants pass.
#   Invariant 1 — CLAUDE.md row ≤ 25 words (mutation-test row is 8 words)
#   Invariant 2 — SKILL.md description ≤ 200 chars (mutation-test is 139)
#   Invariant 3 — skill catalogued in CLAUDE.md
#   Invariant 4 — SessionStart banner ≤ 600 chars (unchanged)
```

Manual smoke against the worktree itself:

1. `bash .claude/skills/mutation-test/detect.sh --detect <some-dir>` returns the dominant language across the five supported languages.
2. `bash .claude/skills/mutation-test/detect.sh --check-only` reports runner availability and exits 3 with the install advisory if none are installed.
3. `bash .claude/skills/mutation-test/detect.sh --advisory` prints the install one-liners alone (useful for `/launch-check` to surface the gap when the mutation row hits the "no recent report + no runner" branch).

Closes #299

## Glossary

| Term | Definition |
|------|------------|
| Mutation testing | A test-quality measurement technique: deliberately introduce small code changes (mutants) and check whether the test suite catches them. Stricter than coverage % because it asks whether the test *constrains* behaviour, not just whether it *executes* the line. |
| Mutation score | Killed mutants / (total mutants − no-coverage − runtime-error). The framework's headline number for behaviour-harness strength. |
| Survived mutant | A mutation the test suite did NOT catch. Either a real test gap (the common case) or a semantically-equivalent mutant the runner couldn't filter (the rarer one). |
| Threshold | The mutation score % below which `/launch-check` flags WARN. Defaults to 60% — much lower than coverage's 80% because mutation score has an unreachable ceiling on real codebases. |
| Behaviour harness | The third regulation dimension in modern test-strategy writing (after maintainability and architecture fitness). The framework's previously-weakest dimension — covered until now only by AI-generated tests + a coverage % gate. |
| Stryker / MutPy / go-mutesting / mutant | The four language-specific mutation-test runners this skill dispatches across (TS/JS, Python, Go, Ruby respectively). |
| Equivalent mutant | A mutation that's semantically identical to the original code (e.g. `i++` vs `i = i + 1`). The runner filters most, but the report's "why-it-survived hint" flags candidates for operator triage. |
| Graceful degradation (exit 3) | The framework convention for skills that depend on optional external tools: when the tool is missing, exit 3 + print an install advisory naming the per-tool install one-liner. Same shape as `/pdf` (pandoc) and `/process` (BPMN lint). |