### PR TITLE
chore(#325): site/ count refresh + meta-tag polish + content-shape + markdown alternates

### DIFF
--- a/.claude/hooks/tests/test_site_counts.sh
+++ b/.claude/hooks/tests/test_site_counts.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Site framework-counts drift detection.
+#
+# Asserts that the count claims quoted in site/*.html (and the markdown
+# alternates site/*.md.gen, and llms.txt / llms-full.txt) match the actual
+# framework counts on disk for skills, hooks, and roles. Fails the PR if
+# any drift is detected; passes silently otherwise.
+#
+# Wired into CI via .github/workflows/site-counts-check.yml. Operators can
+# also run this locally before pushing: `bash .claude/hooks/tests/test_site_counts.sh`.
+#
+# Rationale: docs/agdr/AgDR-0046-site-counts-drift-prevention.md.
+
+set -u
+
+# Resolve the framework root — the test sits at .claude/hooks/tests/,
+# the framework root is two levels up.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FRAMEWORK_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+cd "$FRAMEWORK_ROOT" || {
+  echo "FAIL: could not cd to framework root ($FRAMEWORK_ROOT)" >&2
+  exit 1
+}
+
+# --- Compute actual counts ---------------------------------------------------
+
+actual_skills=$(find .claude/skills -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')
+actual_hooks=$(ls .claude/hooks/*.sh 2>/dev/null | grep -v '_lib\|/tests/' | wc -l | tr -d ' ')
+actual_roles=$(find roles -name '*.md' -not -name 'README*' -not -path '*/agdr/*' 2>/dev/null | wc -l | tr -d ' ')
+
+if [ "$actual_skills" = "0" ] || [ "$actual_hooks" = "0" ] || [ "$actual_roles" = "0" ]; then
+  echo "FAIL: one or more actual counts came out as zero — script is mis-positioned or framework layout changed:" >&2
+  echo "  skills=$actual_skills hooks=$actual_hooks roles=$actual_roles" >&2
+  exit 1
+fi
+
+echo "Actual framework counts:"
+echo "  skills: $actual_skills"
+echo "  hooks:  $actual_hooks"
+echo "  roles:  $actual_roles"
+echo
+
+# --- Scan site files for drift -----------------------------------------------
+
+DRIFT=0
+FILES_TO_SCAN=(
+  site/index.html
+  site/architecture.html
+  site/skills.html
+  site/index.md.gen
+  site/architecture.md.gen
+  site/skills.md.gen
+  site/llms.txt
+  site/llms-full.txt
+  site/skill.md
+)
+
+# Helper: scan a file for a regex like `<count> <noun>` and assert the count
+# matches the expected actual.
+#
+# Args: $1=file, $2=expected_count, $3=noun (singular/plural pattern), $4=label
+check_count() {
+  local file="$1"
+  local expected="$2"
+  local noun_pattern="$3"
+  local label="$4"
+
+  [ -f "$file" ] || return 0
+
+  # Match `<digits> <noun>` — case-insensitive, word-boundary on the noun.
+  # Surface every match so a drift report names file + the matched number.
+  local matches
+  matches=$(grep -inE "[0-9]+ +${noun_pattern}" "$file" 2>/dev/null || true)
+
+  [ -z "$matches" ] && return 0
+
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    # Extract the line number and the matched number.
+    local lineno num
+    lineno=$(echo "$line" | cut -d: -f1)
+    num=$(echo "$line" | grep -oE "[0-9]+ +${noun_pattern}" | head -1 | grep -oE '^[0-9]+')
+
+    [ -z "$num" ] && continue
+
+    # Skip per-line opt-outs: lines tagged with `<!-- counts-check: skip -->`
+    # or that contain "demo" / "demos" markers — these are illustrative
+    # walkthrough copy describing a SPECIFIC ticket flow (e.g. "this demo
+    # uses 6 skills"), not framework-total claims. The drift fence only
+    # cares about framework totals.
+    local line_content
+    line_content=$(echo "$line" | cut -d: -f3-)
+    if echo "$line_content" | grep -qE 'counts-check: *skip|demo__caption|<pre class="demo__body"'; then
+      continue
+    fi
+
+    # Small numbers (<10) are almost never framework totals — the framework
+    # has 19+ roles, 29+ hooks, 53+ skills. Pre-empts false positives in
+    # narrative copy ("6 skills read one registry file" etc.).
+    if [ "$num" -lt 10 ]; then
+      continue
+    fi
+
+    if [ "$num" != "$expected" ]; then
+      echo "DRIFT: $file:$lineno — claims $num $label, actual is $expected"
+      DRIFT=$((DRIFT + 1))
+    fi
+  done <<< "$matches"
+}
+
+for f in "${FILES_TO_SCAN[@]}"; do
+  # `N skills`  (covers "53 skills" anywhere; the most-quoted phrasing)
+  check_count "$f" "$actual_skills" "skills"            "skills"
+  # `N slash commands`  (the alternate phrasing on architecture.html + skills.html)
+  check_count "$f" "$actual_skills" "slash +commands?"   "slash commands"
+  # `N hooks`  + `N shell scripts` (the alternate phrasing in the layer card)
+  check_count "$f" "$actual_hooks"  "hooks"             "hooks"
+  check_count "$f" "$actual_hooks"  "shell +scripts?"    "shell scripts (hook count)"
+  check_count "$f" "$actual_hooks"  "shell +gates?"      "shell gates (hook count)"
+  check_count "$f" "$actual_hooks"  "mechanical +gates?" "mechanical gates (hook count)"
+  # `N roles`  (the role-count claim)
+  check_count "$f" "$actual_roles"  "roles?"            "roles"
+  check_count "$f" "$actual_roles"  "role +definitions" "role definitions"
+done
+
+# --- Verdict ------------------------------------------------------------------
+
+if [ "$DRIFT" -gt 0 ]; then
+  echo
+  echo "FAIL: $DRIFT count-drift mismatch(es) detected in site/ marketing copy."
+  echo
+  echo "To fix: update the offending file(s) so quoted counts match the actuals above."
+  echo "If you added a new skill/hook/role in this PR, the failure is expected — refresh"
+  echo "the counts in site/*.html, site/*.md.gen, and site/llms*.txt in the same PR."
+  exit 1
+fi
+
+echo "PASS: site framework counts match actuals across all scanned files."
+exit 0

--- a/.claude/hooks/tests/test_site_counts.sh
+++ b/.claude/hooks/tests/test_site_counts.sh
@@ -26,7 +26,7 @@ cd "$FRAMEWORK_ROOT" || {
 # --- Compute actual counts ---------------------------------------------------
 
 actual_skills=$(find .claude/skills -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')
-actual_hooks=$(ls .claude/hooks/*.sh 2>/dev/null | grep -v '_lib\|/tests/' | wc -l | tr -d ' ')
+actual_hooks=$(find .claude/hooks -maxdepth 1 -name '*.sh' ! -name '_lib*' 2>/dev/null | wc -l | tr -d ' ')
 actual_roles=$(find roles -name '*.md' -not -name 'README*' -not -path '*/agdr/*' 2>/dev/null | wc -l | tr -d ' ')
 
 if [ "$actual_skills" = "0" ] || [ "$actual_hooks" = "0" ] || [ "$actual_roles" = "0" ]; then

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -43,6 +43,7 @@ jobs:
             --exclude-loopback
             --exclude-private
             --accept 200,204,206,301,302,429
+            --base https://yard.apexscript.com/
             'site/index.html'
             '**/*.md'
           fail: true

--- a/.github/workflows/site-counts-check.yml
+++ b/.github/workflows/site-counts-check.yml
@@ -1,0 +1,25 @@
+name: site-counts-check
+
+# Fail the PR if the framework counts quoted in site/*.html drift from the
+# actual counts on disk (skills, hooks, roles). Catches drift at the moment
+# it's introduced rather than after it has compounded.
+#
+# See docs/agdr/AgDR-0046-site-counts-drift-prevention.md for the rationale.
+
+on:
+  pull_request:
+    paths:
+      - '.claude/skills/**'
+      - '.claude/hooks/**'
+      - 'roles/**'
+      - 'site/**'
+
+jobs:
+  site-counts-check:
+    name: site-counts drift detection
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run the drift-detection smoke test
+        run: bash .claude/hooks/tests/test_site_counts.sh

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -17,3 +17,13 @@ https://medium\.com/@sathishkraju/.*
 # Provision certificate), separate concern from any framework diff.
 https://me2resh\.com/?
 https://yard\.apexscript\.com/?
+
+# Root-relative paths in site/*.html — lychee can't resolve these locally
+# without a --base arg; they're valid at deploy time (Netlify serves
+# /favicon.* + /apple-touch-icon.png from site root, and /index.md /
+# /architecture.md / /skills.md via the _redirects rewrite to .md.gen).
+# Favicons themselves are TODOs per #326 (design pending) — the meta
+# tags reference target paths so they resolve as soon as files ship.
+^/favicon\.(ico|svg)$
+^/apple-touch-icon\.png$
+^/(index|architecture|skills)\.md$

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -15,15 +15,5 @@ https://medium\.com/@sathishkraju/.*
 # here so framework PRs aren't blocked on adopter-side DNS / cert config.
 # Fix is in Netlify dashboard (Site → Domain management → HTTPS →
 # Provision certificate), separate concern from any framework diff.
-https://me2resh\.com/?
-https://yard\.apexscript\.com/?
-
-# Root-relative paths in site/*.html — lychee can't resolve these locally
-# without a --base arg; they're valid at deploy time (Netlify serves
-# /favicon.* + /apple-touch-icon.png from site root, and /index.md /
-# /architecture.md / /skills.md via the _redirects rewrite to .md.gen).
-# Favicons themselves are TODOs per #326 (design pending) — the meta
-# tags reference target paths so they resolve as soon as files ship.
-^/favicon\.(ico|svg)$
-^/apple-touch-icon\.png$
-^/(index|architecture|skills)\.md$
+https://me2resh\.com.*
+https://yard\.apexscript\.com.*

--- a/docs/agdr/AgDR-0046-site-counts-drift-prevention.md
+++ b/docs/agdr/AgDR-0046-site-counts-drift-prevention.md
@@ -1,0 +1,61 @@
+# Site framework-counts drift prevention via CI workflow
+
+> In the context of marketing-site copy that mentions specific framework counts ("53 skills, 29 hooks, 19 roles"), facing recurring drift every time a skill or hook is added or removed, I decided to add a CI workflow that asserts the count claims in `site/*.html` against the real `find`/`ls` counts on every PR, plus a smoke-test invariant under `.claude/hooks/tests/`, to achieve fail-fast detection at the moment drift is introduced, accepting one extra job in the CI matrix and the maintenance overhead of keeping the assertion list in sync with new site files.
+
+## Context
+
+`site/index.html`, `site/architecture.html`, and `site/skills.html` quote specific framework counts in marketing copy and structured data — phrases like "53 skills", "29 hooks", "19 roles", "53 slash commands". These counts are right at the moment they're written and wrong shortly after. Every PR that adds or removes a skill (or a hook, or a role) silently drifts the public site one step further from reality.
+
+The drift was caught by the `/seo-audit` finding S13 + `/generative-engine-audit` follow-up: at audit time, site copy claimed 48 skills + 28 hooks while the framework was at 51/29 and climbing. The fix-once pattern doesn't work — within weeks of a manual refresh, the next PR re-introduces the drift. The decision is **how to make the drift self-healing**, not whether to refresh once.
+
+Three viable mechanisms were proposed in the ticket body for `#325`:
+
+1. Release-cut script (extends `.claude/skills/release/`)
+2. CI workflow (per-PR assertion)
+3. SessionStart advisory banner
+
+Each has a different blast radius and feedback latency.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Release-cut script | Catches drift at the moment it would ship; concentrated owner (the release author); reuses an existing skill | Drift accumulates between releases; the release author becomes a bottleneck for fixing other people's miscounts; release skill grows responsibility scope |
+| **CI workflow (chosen)** | Fail-loud per-PR; author who introduced drift fixes drift; no human-attention dependency; runs in seconds; trivially reproducible locally via the same `find`/`ls` commands; sibling pattern to existing `pr-title-check.yml` / `review-check.yml` | One more CI job to maintain; adds a new failure shape for PRs that legitimately add a skill but forget to refresh counts (mitigation: the failure message tells the author exactly which lines to update) |
+| SessionStart banner | Zero CI cost; visible to every operator | Banner-blindness is real; an operator sees "site/ counts drift" 50 times before fixing it; counts stay wrong while the framework keeps shipping; advisory by definition |
+
+The deciding factor is **feedback latency**. CI runs on every PR; the author sees the failure within minutes of pushing the commit that introduced the drift. Release-cut detection means drift can sit on `dev` for weeks before anyone notices. SessionStart is advisory and noisy. The CI shape closes the feedback loop tightest.
+
+The smoke-test invariant (`.claude/hooks/tests/test_site_counts.sh`) is an additive backstop that runs the same assertions as the CI workflow but is invokable locally — operators can run it before pushing, and it's part of the framework's own test suite so it never silently breaks.
+
+## Decision
+
+Chosen: **CI workflow (`.github/workflows/site-counts-check.yml`) plus a smoke-test invariant (`.claude/hooks/tests/test_site_counts.sh`)**, because per-PR feedback is the only mechanism that catches drift at the moment it's introduced rather than after it has compounded.
+
+The workflow runs on every PR that touches `.claude/skills/**`, `.claude/hooks/**`, `roles/**`, or `site/**`:
+
+1. Count `find .claude/skills -name SKILL.md | wc -l` → `actual_skills`
+2. Count `ls .claude/hooks/*.sh | grep -v "_lib\|/tests/" | wc -l` → `actual_hooks`
+3. Count `find roles -name "*.md" -not -name "README*" -not -path "*/agdr/*" | wc -l` → `actual_roles`
+4. Grep `site/*.html` for patterns like `>(\d+)< skills`, `>(\d+)< hooks`, `>(\d+)< roles`, `(\d+) slash commands`
+5. Assert every match equals the corresponding actual count
+6. On mismatch: fail the job with a one-line-per-drift report naming file + line + expected + actual
+
+The smoke-test invariant is the same assertion library, invokable as `bash .claude/hooks/tests/test_site_counts.sh` for pre-push verification.
+
+## Consequences
+
+- Adding a new skill, hook, or role now requires updating `site/*.html` in the same PR, or the PR fails CI
+- The failure message is self-explanatory (file + line + actual count), so the author can fix without consulting docs
+- The assertion list is centralised in the workflow — if a new countable claim is added to the site, the workflow needs a new pattern. This is a known maintenance cost.
+- The grep patterns are loose (`>\d+ skills`) on purpose to catch HTML, JSON-LD, and plain-text variants; this also means false matches (e.g. an unrelated `47 skills` in copy from another context) would need to be excluded by tightening the pattern or by adding a comment marker. v1 accepts that risk; if it bites, we tighten.
+- AI-consumer artifacts (`site/llms.txt`, `site/llms-full.txt`, the markdown alternates from `#332`) are also scanned, so the drift fence covers every public-facing copy of the counts.
+- SessionStart banner was considered as a secondary "you should know about this" surface and rejected — banners are advisory and accumulate noise without action. CI is the right shape.
+
+## Artifacts
+
+- `.github/workflows/site-counts-check.yml` — the CI workflow
+- `.claude/hooks/tests/test_site_counts.sh` — the smoke-test invariant
+- `site/index.html`, `site/architecture.html`, `site/skills.html` — count-refresh commit lands alongside this AgDR
+- Closes: `me2resh/apexyard#325`
+- Related findings: SEO-audit S13, GEO-audit (count claims appear in structured data)

--- a/site/_headers
+++ b/site/_headers
@@ -1,0 +1,30 @@
+# Netlify response headers for ApexYard marketing site.
+#
+# Advertise the Markdown alternate via the HTTP Link header (per RFC 8288).
+# Agents that read response headers — most do; it's cheap — discover the
+# markdown route without parsing HTML. Belt-and-braces: the same alternate
+# also appears as a <link rel="alternate" type="text/markdown"> tag inside
+# each HTML's <head>.
+
+/
+  Link: </index.md>; rel="alternate"; type="text/markdown"
+
+/index.html
+  Link: </index.md>; rel="alternate"; type="text/markdown"
+
+/architecture.html
+  Link: </architecture.md>; rel="alternate"; type="text/markdown"
+
+/skills.html
+  Link: </skills.md>; rel="alternate"; type="text/markdown"
+
+# Serve the markdown alternates with the right MIME type so curl / agents
+# see Content-Type: text/markdown instead of the default text/plain.
+/index.md
+  Content-Type: text/markdown; charset=utf-8
+
+/architecture.md
+  Content-Type: text/markdown; charset=utf-8
+
+/skills.md
+  Content-Type: text/markdown; charset=utf-8

--- a/site/_redirects
+++ b/site/_redirects
@@ -1,0 +1,11 @@
+# Netlify rewrite rules for ApexYard marketing site.
+#
+# Markdown alternates — coding agents (Claude Code / Cursor / Aider / Cline)
+# fetching a page for context pay the full HTML-chrome cost. The hand-written
+# clean-markdown alternates at /foo.md.gen serve as the lower-token version.
+# 200 = rewrite (URL stays /foo.md, content from /foo.md.gen) — NOT a redirect.
+# See site/index.md.gen, site/architecture.md.gen, site/skills.md.gen.
+
+/index.md            /index.md.gen           200
+/architecture.md     /architecture.md.gen    200
+/skills.md           /skills.md.gen          200

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -3,14 +3,18 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Architecture — ApexYard</title>
-<meta name="description" content="The ApexYard architecture at a glance — five layers (governance, capability, framework defaults, customisation overlay, per-project data) plus the optional split-portfolio private sibling repo. One fork governs every project.">
+<title>ApexYard Architecture — 5 layers + portfolio model</title>
+<meta name="description" content="ApexYard's 5-layer architecture — governance, capability, defaults, customisation, per-project data — plus the optional split-portfolio private sibling repo.">
 <link rel="canonical" href="https://yard.apexscript.com/architecture.html">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" href="/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="alternate" type="text/markdown" href="/architecture.md">
 
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="ApexYard">
 <meta property="og:url" content="https://yard.apexscript.com/architecture.html">
-<meta property="og:title" content="ApexYard — Architecture">
+<meta property="og:title" content="ApexYard Architecture — 5 layers + portfolio model">
 <meta property="og:description" content="Five layers in one ops fork — governance, capability, defaults, customisation overlay, per-project data. Plus the optional split-portfolio sibling repo for adopters on GitHub Free.">
 <meta property="og:image" content="https://yard.apexscript.com/og/architecture.png">
 <meta property="og:image:width" content="1200">
@@ -18,9 +22,31 @@
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:url" content="https://yard.apexscript.com/architecture.html">
-<meta name="twitter:title" content="ApexYard — Architecture">
+<meta name="twitter:title" content="ApexYard Architecture — 5 layers + portfolio model">
 <meta name="twitter:description" content="Five layers in one ops fork — governance, capability, defaults, customisation overlay, per-project data.">
 <meta name="twitter:image" content="https://yard.apexscript.com/og/architecture.png">
+
+<!-- Structured data: BreadcrumbList -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "ApexYard",
+      "item": "https://yard.apexscript.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Architecture",
+      "item": "https://yard.apexscript.com/architecture.html"
+    }
+  ]
+}
+</script>
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -275,6 +301,17 @@ a:hover { color: var(--accent); }
 @media (max-width: 900px) {
   .notes__inner { grid-template-columns: 1fr; }
 }
+.notes__inner h2 {
+  grid-column: 1 / -1;
+  font-size: clamp(20px, 2.2vw, 26px);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 1.25rem 0 0.25rem;
+  color: var(--ink);
+}
+.notes__inner h2:first-of-type {
+  margin-top: 0;
+}
 .note {
   border: 1px solid var(--rule);
   padding: 1.25rem 1.4rem;
@@ -355,9 +392,10 @@ a:hover { color: var(--accent); }
         <span>one fork, five layers, optional sibling repo</span>
       </div>
       <h1>Architecture</h1>
-      <p class="tagline">
-        A multi-project forge for Claude Code — governance, capability, customisation, and per-project data in one fork.
-        The diagram below is the canonical mental model.
+      <p class="tagline" id="ai-lead">
+        <strong>What is it?</strong> ApexYard governs a portfolio of repos as one organisation: 5 layers (governance, capability, framework defaults, customisation overlay, per-project data) plus an optional split-portfolio private-sibling repo.
+        <strong>What can it do?</strong> One ops fork holds the registry, hooks, rules, skills, agents, templates, and handbooks; managed projects clone in as gitignored workspace dirs.
+        <strong>What's needed to start?</strong> Fork apexyard, register your projects, and read this page if you're deciding how to lay out the fork for your team. The diagram below is the canonical mental model.
       </p>
       <p class="meta">
         See also: <a href="index.html">overview</a> · <a href="skills.html">skills</a> · <a href="https://github.com/me2resh/apexyard/blob/main/docs/multi-project.md" target="_blank" rel="noopener">setup guide ↗</a>
@@ -404,7 +442,7 @@ a:hover { color: var(--accent); }
 
   <rect x="394" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
   <text x="410" y="252" font-size="14" font-weight="700" fill="#1E3A5F">[~] Hooks</text>
-  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 26 shell gates</text>
+  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 29 shell gates</text>
   <text x="410" y="295" font-size="11" fill="#4A6FA5">Merge gate · ticket-first · secrets · …</text>
 
   <rect x="704" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
@@ -422,7 +460,7 @@ a:hover { color: var(--accent); }
 
   <rect x="84" y="373" width="600" height="100" fill="#DDE9DD" stroke="#2D6A4F" stroke-width="1.3"/>
   <text x="100" y="402" font-size="15" font-weight="700" fill="#1B4332">[/] Skills</text>
-  <text x="100" y="425" font-size="12" fill="#1A1612">.claude/skills/  ·  48 slash commands</text>
+  <text x="100" y="425" font-size="12" fill="#1A1612">.claude/skills/  ·  53 slash commands</text>
   <text x="100" y="447" font-size="11" fill="#52796F">/feature  /handover  /c4  /threat-model  /process  /dfd  /journey  /update  /release  …</text>
 
   <rect x="704" y="373" width="600" height="100" fill="#DDE9DD" stroke="#2D6A4F" stroke-width="1.3"/>
@@ -577,6 +615,8 @@ a:hover { color: var(--accent); }
   <section class="notes">
     <div class="notes__inner">
 
+      <h2>What is the ApexYard architecture?</h2>
+
       <div class="note">
         <h3>The 5-layer model</h3>
         <p>
@@ -586,21 +626,6 @@ a:hover { color: var(--accent); }
           <strong>Customisation</strong> is your overrides; the <span class="kw">red border</span> in
           the diagram is the override semantic. <strong>Per-project data</strong> lives at the bottom
           — one entry per row in the registry.
-        </p>
-      </div>
-
-      <div class="note">
-        <h3>One fork, every project</h3>
-        <p>
-          You fork ApexYard once and treat the fork as your ops repo. Every project you want
-          governed gets a row in <code>apexyard.projects.yaml</code> and a folder under
-          <code>projects/&lt;name&gt;/</code>. Skills like <code>/inbox</code>,
-          <code>/status</code>, and <code>/tasks</code> aggregate across the registry — one
-          command surveys the whole portfolio.
-        </p>
-        <p>
-          Live working copies (<code>workspace/&lt;name&gt;/</code>) are gitignored from the fork
-          itself; each is a real clone of the managed repo with its own branches, PRs, and CI.
         </p>
       </div>
 
@@ -618,8 +643,25 @@ a:hover { color: var(--accent); }
         </p>
       </div>
 
+      <h2>How does the portfolio model work?</h2>
+
+      <div class="note">
+        <h3>One fork, every project</h3>
+        <p>
+          You fork ApexYard once and treat the fork as your ops repo. Every project you want
+          governed gets a row in <code>apexyard.projects.yaml</code> and a folder under
+          <code>projects/&lt;name&gt;/</code>. Skills like <code>/inbox</code>,
+          <code>/status</code>, and <code>/tasks</code> aggregate across the registry — one
+          command surveys the whole portfolio.
+        </p>
+        <p>
+          Live working copies (<code>workspace/&lt;name&gt;/</code>) are gitignored from the fork
+          itself; each is a real clone of the managed repo with its own branches, PRs, and CI.
+        </p>
+      </div>
+
       <div class="note note--wide">
-        <h3>Optional private sibling</h3>
+        <h3>Optional private sibling repo</h3>
         <p>
           The <strong>dashed box on the right</strong> is opt-in. Adopters on GitHub Free who don't want
           portfolio names on a public fork put the registry, onboarding, <code>projects/</code>, <code>workspace/</code>,

--- a/site/architecture.md.gen
+++ b/site/architecture.md.gen
@@ -1,0 +1,86 @@
+# ApexYard Architecture
+
+> Five layers (governance, capability, defaults, customisation, per-project data) inside one ops fork — plus an optional split-portfolio private sibling repo. The canonical mental model for ApexYard adopters.
+
+## What is it?
+
+ApexYard governs a portfolio of repos as one organisation. The architecture is a 5-layer model inside a single fork of `me2resh/apexyard`, plus an optional private-sibling repo for adopters who don't want portfolio names on a public GitHub.
+
+## What can it do?
+
+A single ops fork holds the registry, hooks, rules, skills, agents, templates, and handbooks. Managed projects clone in as gitignored workspace dirs. Cross-project portfolio skills (`/inbox`, `/status`, `/tasks`) aggregate across the registry.
+
+## What's needed to start?
+
+Fork apexyard once and treat the fork as your ops repo. Add an entry to `apexyard.projects.yaml` for every project you want governed. Skills resolve transparently whether you're in single-fork or split-portfolio mode.
+
+## The 5-layer model
+
+### Layer 1 — Governance (slate-blue in the diagram)
+
+Declares what's true and what's enforced:
+
+- **Registry** (`apexyard.projects.yaml`) — lists every managed project
+- **Hooks** (`.claude/hooks/`) — 29 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
+- **Rules** (`.claude/rules/`) — 11 modular self-discipline guides
+- **Onboarding** (`onboarding.yaml`) — company name, mission, team, tech stack
+
+### Layer 2 — Capability (forest-green)
+
+What the agent can DO:
+
+- **Skills** (`.claude/skills/`) — 53 slash commands: `/feature`, `/handover`, `/c4`, `/threat-model`, `/process`, `/dfd`, `/journey`, `/update`, `/release`, and 44 more
+- **Agents** (`.claude/agents/`) — 5 specialised sub-agents: Rex (code review), Hatim (security), Munir (deps), Tariq (PR), Idris (tickets)
+
+### Layer 3 — Framework defaults (ochre)
+
+Ships out of the box:
+
+- **Templates** (`templates/`) — PRD, AgDR, technical-design, C4 context/container, DFD, vision, spike, migration, investigation, idea
+- **Handbooks** (`handbooks/`) — `architecture/`, `general/`, `language/<lang>/` — Rex consults during code review
+
+### Layer 4 — Customisation overlay (accent red — overrides)
+
+- **`custom-templates/`** — path-mirror override, wins over framework on collision
+- **`custom-skills/`** — symlinked into `.claude/skills/`; framework version moves to `.framework.bak` on collision
+- **`custom-handbooks/`** — additive: Rex reads BOTH layers; same path conventions as framework
+
+### Layer 5 — Per-project data (plum — one entry per row in the registry)
+
+- **`projects/<name>/`** (committed) — ApexYard's view: README, roadmap, handover-assessment, PRDs, architecture/ (C4, DFD, vision), journeys, processes (BPMN), feature-inventory, audits, updates, docs/agdr/
+- **`workspace/<name>/`** (gitignored) — live git clones of the managed repos; cd into to do code work; LSP-aware skills run here
+
+The test for *"which side does this doc go?"* is: would it follow the code if the project spun out tomorrow? YES → `workspace/<name>/docs/`. NO → `projects/<name>/`.
+
+## How does the portfolio model work?
+
+### Single-fork mode (default)
+
+One repo: your fork of `me2resh/apexyard`. Registry + projects + onboarding + workspace all live in the fork. Best for fully-public portfolios or GitHub Pro/Team/Enterprise (which support private forks of public repos).
+
+### Split-portfolio mode (v2)
+
+Two repos: the public framework fork + a separate private repo for the portfolio. Resolved via a `portfolio:` config block in `.claude/project-config.json`. The public fork holds only framework files plus your customisations; the private sibling holds portfolio data, company config, and managed-project clones. Use this if you're on GitHub Free with any project you don't want named publicly.
+
+## Optional private sibling repo (the dashed box in the diagram)
+
+When v2 is enabled, skills resolve these paths from the sibling repo transparently:
+
+- `apexyard.projects.yaml` (registry)
+- `projects/` (per-project docs)
+- `onboarding.yaml` (company config)
+- `workspace/` (managed-project clones)
+- `custom-templates/`, `custom-skills/`, `custom-handbooks/` (customisation overlay)
+
+The public fork carries a `.apexyard-fork` marker file as the anchor. Every framework hook that walks up to find the ops fork looks for this marker first (legacy `onboarding.yaml + apexyard.projects.yaml` pair stays as a fallback during the transition window).
+
+## Full setup walkthrough
+
+Read [`docs/multi-project.md`](https://github.com/me2resh/apexyard/blob/main/docs/multi-project.md) for the full step-by-step setup, daily workflow, upgrade flow, and FAQ.
+
+## Links
+
+- Home: <https://yard.apexscript.com/index.md>
+- Skills: <https://yard.apexscript.com/skills.md>
+- GitHub: <https://github.com/me2resh/apexyard>
+- Setup guide: <https://github.com/me2resh/apexyard/blob/main/docs/multi-project.md>

--- a/site/favicons/README.md
+++ b/site/favicons/README.md
@@ -1,0 +1,30 @@
+# Favicons — design TODO
+
+The site HTML references three favicon files via `<link rel="icon">` and `<link rel="apple-touch-icon">` tags in every page's `<head>`. The meta tags are in place now so they'll work as soon as the binary files deploy alongside the HTML.
+
+## Required files
+
+| File | Path | Size | Format | Linked from |
+|------|------|------|--------|-------------|
+| ICO favicon | `site/favicon.ico` | 16×16 / 32×32 multi-resolution | ICO (legacy browsers) | `<link rel="icon" href="/favicon.ico" sizes="any">` |
+| SVG favicon | `site/favicon.svg` | scalable | SVG (modern browsers + dark-mode aware) | `<link rel="icon" href="/favicon.svg" type="image/svg+xml">` |
+| Apple touch icon | `site/apple-touch-icon.png` | 180×180 | PNG (iOS home-screen) | `<link rel="apple-touch-icon" href="/apple-touch-icon.png">` |
+
+## Design brief
+
+- **Mark**: stylised "AY" monogram, OR the apexyard logo mark — sharp corners, no gradients, no shadows (matches the site's terminal-native brutalism aesthetic)
+- **Palette**: monochrome on transparent background; the warning-red accent (`#C8321A`) is optional as a single accent stroke
+- **Aesthetic match**: same visual language as the existing `og/*.png` social cards already shipped in `site/og/`
+- **SVG specifics**: include a `@media (prefers-color-scheme: dark)` rule so the favicon adapts to the user's OS theme (same trick the site CSS uses for the cream → ink colour flip)
+
+## Status
+
+**TODO — design pending.** The three meta tags are wired into all three HTML pages (`index.html`, `architecture.html`, `skills.html`) so the moment the binaries land in `site/`, browser tabs and bookmark icons start working with zero further HTML changes. Same pattern as the `og:image` PNGs handled in PR #337 — meta tags reference the target paths; design follows.
+
+## How to validate when the files land
+
+1. Drop the three files at `site/favicon.ico`, `site/favicon.svg`, `site/apple-touch-icon.png`
+2. Deploy and visit `https://yard.apexscript.com/` in a fresh browser tab; check the tab favicon renders
+3. Run `curl -I https://yard.apexscript.com/favicon.ico` — expect `200 OK` with `Content-Type: image/x-icon` (or `image/vnd.microsoft.icon`)
+4. Add the site to an iOS home screen — confirm the 180×180 apple-touch icon renders cleanly
+5. Toggle OS dark mode and confirm the SVG variant flips appropriately (if the SVG includes the dark-mode media query)

--- a/site/index.html
+++ b/site/index.html
@@ -3,16 +3,20 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>ApexYard - where projects get forged</title>
-<meta name="description" content="SDLC-as-code for founders who ship alone, or companies standing up AI-enabled squads. One ops repo governs all your projects. 48 skills, 28 hooks, 19 roles. MIT, plain markdown and shell, Claude Code native.">
+<title>ApexYard — multi-project SDLC framework for Claude Code</title>
+<meta name="description" content="Multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 29 hooks, 19 roles, one inbox. MIT, plain markdown and shell.">
 <link rel="canonical" href="https://yard.apexscript.com/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" href="/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="alternate" type="text/markdown" href="/index.md">
 
 <!-- Open Graph -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="ApexYard">
 <meta property="og:url" content="https://yard.apexscript.com/">
-<meta property="og:title" content="ApexYard - where projects get forged">
-<meta property="og:description" content="SDLC-as-code for founders who ship alone, or companies standing up AI-enabled squads. One ops repo governs all your projects. MIT, plain markdown and shell.">
+<meta property="og:title" content="ApexYard — multi-project SDLC framework for Claude Code">
+<meta property="og:description" content="Multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 29 hooks, 19 roles, one inbox. MIT, plain markdown and shell.">
 <meta property="og:image" content="https://yard.apexscript.com/og/index.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -20,9 +24,61 @@
 <!-- Twitter / X -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:url" content="https://yard.apexscript.com/">
-<meta name="twitter:title" content="ApexYard - where projects get forged">
-<meta name="twitter:description" content="SDLC-as-code for founders who ship alone, or companies standing up AI-enabled squads. MIT, plain markdown and shell.">
+<meta name="twitter:title" content="ApexYard — multi-project SDLC framework for Claude Code">
+<meta name="twitter:description" content="ApexYard is a multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 29 hooks, 19 roles, one inbox.">
 <meta name="twitter:image" content="https://yard.apexscript.com/og/index.png">
+
+<!-- Structured data: SoftwareApplication, Organization, WebSite -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "ApexYard",
+  "alternateName": "apexyard",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Cross-platform",
+  "url": "https://yard.apexscript.com/",
+  "description": "Multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 29 hooks, 19 roles, one inbox.",
+  "license": "https://opensource.org/licenses/MIT",
+  "softwareVersion": "1.1.0",
+  "downloadUrl": "https://github.com/me2resh/apexyard",
+  "author": {
+    "@type": "Person",
+    "name": "Ahmed Abdelaliem",
+    "url": "https://me2resh.com"
+  },
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "ApexYard",
+  "url": "https://yard.apexscript.com/",
+  "logo": "https://yard.apexscript.com/favicon.svg",
+  "sameAs": [
+    "https://github.com/me2resh/apexyard"
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "ApexYard",
+  "url": "https://yard.apexscript.com/",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": "https://github.com/me2resh/apexyard/search?q={search_term_string}",
+    "query-input": "required name=search_term_string"
+  }
+}
+</script>
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -1383,8 +1439,10 @@ footer.foot {
       Built by <a href="https://me2resh.com" target="_blank" rel="noopener">me2resh</a>
     </p>
 
-    <p class="hero__sub rise rise-3">
-      SDLC-as-code for founders who ship alone, or companies standing up AI-enabled squads. One ops-repo fork governs <em>all</em> your products. Rules that can't be argued with - they're shell hooks, not PDFs. 19 roles, 48 skills, 28 mechanical gates, one inbox across the whole portfolio. Claude Code is the default driver; the rules, hooks, agents, and skills are plain markdown and shell - swap the AI, keep the forge.
+    <p class="hero__sub rise rise-3" id="ai-lead">
+      <strong>What is it?</strong> ApexYard is a multi-project ops-repo framework for Claude Code. One fork governs every project under management with strict merge gates, persistent AgDR memory, and 53 audit-and-decision skills.
+      <strong>What can it do?</strong> Activate the right role on each ticket, run mechanical merge gates as shell hooks (not PDFs), aggregate every project's PRs, issues, and CI into one inbox, persist architectural decisions as AgDRs across the portfolio.
+      <strong>What's needed to start?</strong> Fork <code>github.com/me2resh/apexyard</code>, clone it, run <code>/setup</code>, register your projects. 19 roles, 53 skills, 29 mechanical gates, one inbox across the whole portfolio. Claude Code is the default driver; the rules, hooks, agents, and skills are plain markdown and shell — swap the AI, keep the forge.
     </p>
 
     <div class="hero__cta rise rise-4">
@@ -1491,11 +1549,11 @@ footer.foot {
         <span>Role definitions across 5 departments</span>
       </div>
       <div class="hero__metric">
-        <strong>39</strong>
+        <strong>53</strong>
         <span>Skills (slash commands)</span>
       </div>
       <div class="hero__metric">
-        <strong>24</strong>
+        <strong>29</strong>
         <span>Mechanical gates (shell hooks)</span>
       </div>
       <div class="hero__metric">
@@ -1531,7 +1589,7 @@ footer.foot {
 
   <div class="section__head">
     <span class="section__num">01 / QUICKSTART</span>
-    <h2 class="section__title">Get started in three steps</h2>
+    <h2 class="section__title">How do I get started?</h2>
     <p class="section__lede">
       From fork to first command. Everything is public; no invite needed.
     </p>
@@ -1578,7 +1636,7 @@ claude
 
   <div class="section__head">
     <span class="section__num">02 / WALKTHROUGHS</span>
-    <h2 class="section__title">What it actually feels like to use</h2>
+    <h2 class="section__title">What does using apexyard look like in practice?</h2>
     <p class="section__lede">
       Three flows - one for a feature, one for the portfolio, one for a risky change. Each starts with a specific pain and ends with the exact gates that handled it.
     </p>
@@ -1677,7 +1735,7 @@ confirm it skips the missing column before merge."</span></pre>
 
   <div class="section__head">
     <span class="section__num">04 / WHAT'S IN THE BOX</span>
-    <h2 class="section__title">What you can actually do</h2>
+    <h2 class="section__title">What can apexyard do?</h2>
     <p class="section__lede">
       Everything below is already wired in your fork. Nothing to install, nothing to configure beyond <code>/setup</code>.
     </p>
@@ -1694,15 +1752,15 @@ confirm it skips the missing column before merge."</span></pre>
     </article>
 
     <article class="layer">
-      <div class="layer__num">skills · 33 slash commands</div>
+      <div class="layer__num">skills · 53 slash commands</div>
       <h3 class="layer__title">One prompt, one thing</h3>
       <p class="layer__desc">
-        <code>/handover</code> adopts a project. <code>/idea</code> captures a concept. <code>/inbox</code>, <code>/status</code>, <code>/tasks</code> triage the portfolio. <code>/decide</code> records a technical call as an AgDR. <code>/launch-check</code> runs an 8-dimension readiness audit. <code>/c4</code> generates L1 + L2 architecture diagrams from a codebase.
+        <code>/handover</code> adopts a project. <code>/idea</code> captures a concept. <code>/inbox</code>, <code>/status</code>, <code>/tasks</code> triage the portfolio. <code>/decide</code> records a technical call as an AgDR. <code>/launch-check</code> runs a 10-dimension readiness audit. <code>/c4</code> generates L1 + L2 architecture diagrams from a codebase.
       </p>
     </article>
 
     <article class="layer">
-      <div class="layer__num">hooks · 18 shell scripts</div>
+      <div class="layer__num">hooks · 29 shell scripts</div>
       <h3 class="layer__title">Rules that fire themselves</h3>
       <p class="layer__desc">
         Ticket-first on every edit. Migration gate on schema paths. Two-marker merge (Rex + CEO), SHA-bound, invalidates on every commit. Red CI block. Secrets scanner. Design-review gate on UI PRs. Upstream-drift banner at session start.

--- a/site/index.md.gen
+++ b/site/index.md.gen
@@ -1,0 +1,87 @@
+# ApexYard
+
+> Multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 29 hooks, 19 roles, one inbox. MIT, plain markdown and shell.
+
+## What is it?
+
+ApexYard is a multi-project ops-repo framework for Claude Code. One fork governs every project under management with strict merge gates, persistent AgDR memory, and 53 audit-and-decision skills.
+
+## What can it do?
+
+- Activate the right role on each ticket (19 roles across 5 departments)
+- Run mechanical merge gates as shell hooks (not PDFs) — 29 hooks block PRs that bypass code review, CEO approval, design review, secrets scanning, AgDR-required architecture changes, and migration tickets
+- Aggregate every project's PRs, issues, and CI into one inbox via `/inbox`, `/status`, `/tasks`
+- Persist architectural decisions as AgDRs across the portfolio so prior decisions resurface in seconds via `/agdr search`
+- Generate C4 L1 + L2 diagrams, BPMN process flows, DFDs with trust boundaries, and structured product specs
+
+## What's needed to start?
+
+1. Fork `github.com/me2resh/apexyard` on GitHub
+2. Clone the fork locally — it IS your ops repo, no nested installs, no symlinks
+3. Run `/setup` in Claude Code — three exchanges to configure company, team, and tech stack
+4. Register projects via `/handover <repo>` for adoption, or `/idea` to capture new concepts
+
+## Get started in three steps
+
+### 1. Star, fork, clone
+
+```bash
+gh repo fork me2resh/apexyard --clone
+cd apexyard
+git remote add upstream https://github.com/me2resh/apexyard.git
+```
+
+### 2. Claude, /setup
+
+```bash
+cd apexyard
+claude
+/setup
+# three questions → onboarding.yaml is configured
+```
+
+### 3. Adopt, or originate
+
+- `/handover <repo-url>` — existing project → assessment + registry + architecture stub
+- `/idea` — new concept → ideas-backlog.md, optional GitHub issue
+
+## What you can actually do
+
+### Roles · 19
+
+PR touches auth → Security Auditor activates. Ticket hits QA → QA Engineer. Migration edit → Data Engineer + migration AgDR. Each role has CAN / CANNOT lists — it won't step outside its lane.
+
+### Skills · 53 slash commands
+
+`/handover` adopts a project. `/idea` captures a concept. `/inbox`, `/status`, `/tasks` triage the portfolio. `/decide` records a technical call as an AgDR. `/launch-check` runs a 10-dimension readiness audit. `/c4` generates L1 + L2 architecture diagrams from a codebase.
+
+### Hooks · 29 shell scripts
+
+Ticket-first on every edit. Migration gate on schema paths. Two-marker merge (Rex + CEO), SHA-bound, invalidates on every commit. Red CI block. Secrets scanner. Design-review gate on UI PRs. Upstream-drift banner at session start.
+
+### Agents · 5 sub-agents
+
+- **Rex** (code review) checks architecture + tests + AgDR links + glossary
+- **Hatim** (security) flags auth / crypto / secrets
+- **Munir** (deps) scans vulnerabilities + licences
+- **Tariq** (PR manager) and **Idris** (ticket manager) handle the orchestration
+
+### Portfolio · one fork, N products
+
+`apexyard.projects.yaml` at your fork root lists every repo you manage. Skills like `/inbox`, `/status`, `/tasks`, `/stakeholder-update` aggregate across it. One prompt, every project. Add a project with `/handover`; sync with upstream via `/update`.
+
+### CI · 7 golden-path workflows
+
+At `golden-paths/pipelines/`: `ci.yml`, `code-quality.yml`, `security.yml`, `dependency-audit.yml`, `pr-title-check.yml`, `review-check.yml`, `seo-check.yml`. Copy what you need into each project's `.github/workflows/`.
+
+## Manifesto
+
+Every pull request ties to a ticket. Every ticket has acceptance criteria. Code review validates against those criteria, and QA verifies the result in a separate pass before the ticket closes.
+
+## Links
+
+- GitHub: <https://github.com/me2resh/apexyard>
+- Releases: <https://github.com/me2resh/apexyard/releases>
+- Setup guide: <https://github.com/me2resh/apexyard/blob/main/docs/multi-project.md>
+- Architecture: <https://yard.apexscript.com/architecture.md>
+- Skills: <https://yard.apexscript.com/skills.md>

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -2,7 +2,7 @@
 
 > ApexYard is a multi-project ops repo framework for Claude Code that governs
 > a portfolio of repos under one fork — strict SDLC, persistent AgDR memory,
-> 52 skills, 24 hooks, 19 role definitions. MIT, plain markdown and shell,
+> 53 skills, 29 hooks, 19 role definitions. MIT, plain markdown and shell,
 > no SaaS, no lock-in.
 
 This file is the LLM/agent-friendly concatenation of the apexyard marketing
@@ -82,7 +82,7 @@ the operator can see who's driving each piece of work.
 
 ### One prompt, one thing
 
-52 slash commands, each scoped to one capability. `/feature` files a
+53 slash commands, each scoped to one capability. `/feature` files a
 structured feature ticket; `/migration` produces a labelled ticket + a
 migration AgDR; `/threat-model` runs the STRIDE 6-category audit on
 the current codebase.
@@ -184,7 +184,7 @@ disallows changing a public fork's visibility after the fact).
 
 # Skills (https://yard.apexscript.com/skills.html)
 
-The full ApexYard slash-command surface — 52 skills, organised by
+The full ApexYard slash-command surface — 53 skills, organised by
 purpose. Each is a markdown SKILL.md file under `.claude/skills/<name>/`.
 
 ## Setup & onboarding

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,7 +1,7 @@
 # ApexYard
 
 > ApexYard is a multi-project ops repo framework for Claude Code that governs
-> a portfolio of repos under one fork — 52 skills, 24 hooks, 19 role definitions,
+> a portfolio of repos under one fork — 53 skills, 29 hooks, 19 role definitions,
 > strict SDLC gates, persistent AgDR memory. MIT, plain markdown and shell,
 > no SaaS, no lock-in.
 
@@ -9,7 +9,7 @@
 
 - [Home](https://yard.apexscript.com/) — what apexyard is, why fork it, daily workflow
 - [Architecture](https://yard.apexscript.com/architecture.html) — the 5-layer model + portfolio model
-- [Skills](https://yard.apexscript.com/skills.html) — full slash-command reference (52 skills)
+- [Skills](https://yard.apexscript.com/skills.html) — full slash-command reference (53 skills)
 
 ## Full-content companion
 
@@ -33,10 +33,10 @@
 - **Portfolio model.** One registry (`apexyard.projects.yaml`) lists every repo
   under management. Skills like `/inbox`, `/status`, `/tasks` aggregate
   across the portfolio in ~1 second.
-- **52 slash commands** across audits, tickets, architecture, decisions,
+- **53 slash commands** across audits, tickets, architecture, decisions,
   portfolio aggregation, and framework ops. Each is a markdown SKILL.md file
   under `.claude/skills/<name>/`.
-- **24 shell hooks** mechanically enforce SDLC rules — ticket-first, migration
+- **29 shell hooks** mechanically enforce SDLC rules — ticket-first, migration
   gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR-title
   validation, upstream-drift banner, leak protection.
 - **19 role definitions** across 5 departments (Engineering, Product, Design,

--- a/site/skill.md
+++ b/site/skill.md
@@ -13,7 +13,7 @@
 ApexYard is an SDLC-as-code framework for AI-driven dev teams. One fork
 governs a portfolio of repos under one organisation; strict merge gates
 (code-reviewer agent + per-PR CEO approval); persistent AgDR (Agent
-Decision Record) memory across every managed project; 52 slash commands
+Decision Record) memory across every managed project; 53 slash commands
 across 6 buckets:
 
 - **Audits** (`/launch-check`, `/threat-model`, `/accessibility-audit`,
@@ -32,7 +32,7 @@ across 6 buckets:
   `/split-portfolio`, `/fan-out`, `/start-ticket`, `/approve-merge`,
   `/approve-design`)
 
-24 shell hooks enforce SDLC rules mechanically — ticket-first, migration
+29 shell hooks enforce SDLC rules mechanically — ticket-first, migration
 gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR
 title validation, AgDR-required-for-architecture, upstream-drift banner,
 leak protection. 19 role definitions activate on triggers (label, diff

--- a/site/skills.html
+++ b/site/skills.html
@@ -2,11 +2,17 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Skills — ApexYard</title>
+<title>ApexYard Skills — 53 slash commands for Claude Code</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content="The full ApexYard slash-command surface — 48 skills, what each one does, and how to invoke it.">
-<meta property="og:title" content="ApexYard skills">
-<meta property="og:description" content="48 slash commands available in any apexyard-managed project. Run any of these in a Claude Code session inside your fork.">
+<meta name="description" content="ApexYard ships 53 slash commands across audits, tickets, architecture, decisions, portfolio, and framework ops. Drop into any Claude Code session.">
+<link rel="canonical" href="https://yard.apexscript.com/skills.html">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" href="/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="alternate" type="text/markdown" href="/skills.md">
+
+<meta property="og:title" content="ApexYard Skills — 53 slash commands for Claude Code">
+<meta property="og:description" content="53 slash commands available in any apexyard-managed project. Run any of these in a Claude Code session inside your fork.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://yard.apexscript.com/skills.html">
 <meta property="og:site_name" content="ApexYard">
@@ -16,9 +22,31 @@
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:url" content="https://yard.apexscript.com/skills.html">
-<meta name="twitter:title" content="ApexYard skills">
-<meta name="twitter:description" content="The full ApexYard slash-command surface — 52 skills, what each one does, and how to invoke it.">
+<meta name="twitter:title" content="ApexYard Skills — 53 slash commands for Claude Code">
+<meta name="twitter:description" content="The full ApexYard slash-command surface — 53 skills, what each one does, and how to invoke it.">
 <meta name="twitter:image" content="https://yard.apexscript.com/og/skills.png">
+
+<!-- Structured data: BreadcrumbList -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "ApexYard",
+      "item": "https://yard.apexscript.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Skills",
+      "item": "https://yard.apexscript.com/skills.html"
+    }
+  ]
+}
+</script>
 <style>
 /* ============================================================
    ApexYard skills page — mirrors site/index.html design tokens.
@@ -357,14 +385,13 @@ main {
     <div class="page-header__inner">
       <div class="page-header__eyebrow">
         <span class="pill">apexyard / skills</span>
-        <span>48 slash commands · invoke from any Claude Code session</span>
+        <span>53 slash commands · invoke from any Claude Code session</span>
       </div>
       <h1>Skills</h1>
-      <p class="tagline">
-        Every skill ships in <code>.claude/skills/&lt;name&gt;/SKILL.md</code> and is invoked from a
-        Claude Code session as <code>/&lt;name&gt;</code>. Mechanical hooks in <code>.claude/hooks/</code>
-        gate their effects on the rest of the SDLC — <code>/approve-merge</code> writes a marker that
-        <code>block-unreviewed-merge.sh</code> then verifies before the merge actually runs.
+      <p class="tagline" id="ai-lead">
+        <strong>What is it?</strong> ApexYard ships 53 slash commands across six buckets (setup, daily ops, tickets &amp; ideas, specs &amp; decisions, review &amp; merge, architecture, production-readiness audits, workflow primitives, communications).
+        <strong>What can it do?</strong> Each <code>/&lt;name&gt;</code> is a structured workflow with guardrails — mechanical hooks in <code>.claude/hooks/</code> gate the effects on the rest of the SDLC, so <code>/approve-merge</code> writes a marker that <code>block-unreviewed-merge.sh</code> verifies before the merge actually runs.
+        <strong>What's needed to start?</strong> Browse below; invoke any from a Claude Code session inside an apexyard fork. Every skill ships in <code>.claude/skills/&lt;name&gt;/SKILL.md</code>.
       </p>
       <p class="meta">
         New here? Start with <a href="#setup"><code>/setup</code></a> on a fresh fork, then
@@ -388,7 +415,7 @@ main {
   </section>
 
   <section class="section" id="setup">
-    <h2>Setup &amp; onboarding</h2>
+    <h2>Which skills help me set up?</h2>
     <p class="section__intro">Get a fresh fork running, adopt external repos into the portfolio, keep the framework in sync with upstream.</p>
 
     <article class="skill">
@@ -425,7 +452,7 @@ main {
   </section>
 
   <section class="section" id="daily">
-    <h2>Daily ops</h2>
+    <h2>Which skills run during daily ops?</h2>
     <p class="section__intro">Where am I, what needs my attention, what should I do next.</p>
 
     <article class="skill">
@@ -450,7 +477,7 @@ main {
   </section>
 
   <section class="section" id="tickets">
-    <h2>Tickets &amp; ideas</h2>
+    <h2>How do I file structured tickets and ideas?</h2>
     <p class="section__intro">Capture work — from a half-formed idea through a structured ticket the team can pick up.</p>
 
     <article class="skill">
@@ -535,7 +562,7 @@ main {
   </section>
 
   <section class="section" id="specs">
-    <h2>Specs &amp; decisions</h2>
+    <h2>How do I capture specs and technical decisions?</h2>
     <p class="section__intro">Turn validated ideas into PRDs; record technical decisions as durable artefacts.</p>
 
     <article class="skill">
@@ -564,7 +591,7 @@ main {
   </section>
 
   <section class="section" id="review">
-    <h2>Code review &amp; merge</h2>
+    <h2>How does code review and merge get gated?</h2>
     <p class="section__intro">The mechanical merge gate — Rex review, security audit, CEO approval, design review, dependency audit. Each writes a marker the merge hook verifies.</p>
 
     <article class="skill">
@@ -609,7 +636,7 @@ main {
   </section>
 
   <section class="section" id="architecture">
-    <h2>Architecture &amp; dev tools</h2>
+    <h2>Which skills generate architecture and dev artefacts?</h2>
     <p class="section__intro">Diagram the system; debug what's broken with structure rather than ad-hoc patching.</p>
 
     <article class="skill">
@@ -670,7 +697,7 @@ main {
   </section>
 
   <section class="section" id="audits">
-    <h2>Production-readiness audits</h2>
+    <h2>Which audits check production readiness?</h2>
     <p class="section__intro"><code>/launch-check</code> runs the full sweep at milestone boundaries; the dimension-specific audits below are the deep-dive companions.</p>
 
     <article class="skill">
@@ -747,7 +774,7 @@ main {
   </section>
 
   <section class="section" id="workflow">
-    <h2>Workflow primitives</h2>
+    <h2>What workflow primitives are available?</h2>
     <p class="section__intro">Enable, parallelise, release.</p>
 
     <article class="skill">
@@ -776,7 +803,7 @@ main {
   </section>
 
   <section class="section" id="comms">
-    <h2>Communications</h2>
+    <h2>How do I generate roadmap and stakeholder communications?</h2>
     <p class="section__intro">Roadmap planning + stakeholder updates synthesised from the activity stream.</p>
 
     <article class="skill">
@@ -797,7 +824,7 @@ main {
   </section>
 
   <section class="section" id="deprecated">
-    <h2>Deprecated</h2>
+    <h2>Which skills are deprecated?</h2>
     <p class="section__intro">Kept for redirect-only behaviour while in-flight invocations migrate.</p>
 
     <article class="skill is-deprecated">

--- a/site/skills.md.gen
+++ b/site/skills.md.gen
@@ -1,0 +1,124 @@
+# ApexYard Skills
+
+> 53 slash commands across audits, tickets, architecture, decisions, portfolio, and framework ops. Drop into your Claude Code session inside an apexyard fork.
+
+## What is it?
+
+ApexYard ships 53 slash commands across six buckets: setup & onboarding, daily ops, tickets & ideas, specs & decisions, code review & merge, architecture & dev tools, production-readiness audits, workflow primitives, communications.
+
+## What can it do?
+
+Each `/<name>` is a structured workflow with guardrails. Mechanical hooks in `.claude/hooks/` gate the effects on the rest of the SDLC — `/approve-merge` writes a marker that `block-unreviewed-merge.sh` verifies before the merge actually runs. Every skill ships in `.claude/skills/<name>/SKILL.md`.
+
+## What's needed to start?
+
+Browse below; invoke any skill from a Claude Code session inside an apexyard fork. New here? Start with `/setup` on a fresh fork, then `/feature` or `/idea` to capture work, then `/code-review` and `/approve-merge` when a PR is ready to ship.
+
+---
+
+## Which skills help me set up?
+
+Get a fresh fork running, adopt external repos into the portfolio, keep the framework in sync with upstream.
+
+- `/setup [--reset]` — First-run framework bootstrap for a new ApexYard fork. Three exchanges (describe stack, accept defaults, customise) and the fork is configured.
+- `/handover <name> [path-or-url]` — Onboard an external repo into ApexYard management. Reads the target, synthesises a structured handover assessment, and tells you which roles, workflows, and hooks should activate. Scores harnessability across 5 codebase dimensions.
+- `/update [--dry-run] [--rebase]` — Sync the ApexYard fork with upstream. Previews pending commits, creates a sync branch (direct push to main is blocked), merges or rebases, walks per-file conflicts.
+- `/split-portfolio [--verify] [--dry-run]` — Migrate from single-fork to split-portfolio mode (public framework + private portfolio).
+
+## Which skills run during daily ops?
+
+Portfolio-wide triage, project status, attention items.
+
+- `/projects` — List all managed projects with status, branch, open PRs, open issue counts.
+- `/inbox` — Items needing your attention across the portfolio: PRs, assigned issues, comments, blockers.
+- `/status [--briefing | -b]` — Per-project git + CI snapshot; `--briefing` for the 4-line compact form (active workspace, ticket, branch, role).
+- `/tasks` — Aggregated, scored, sorted task list across the portfolio with direct URLs.
+
+## How do I file structured tickets and ideas?
+
+Structured-ticket skills enforce minimum schemas (driver, scope, ACs) so tracker entries are reviewable as data, not free-text.
+
+- `/feature` — Create a structured feature ticket (user story + acceptance criteria + design notes).
+- `/bug` — Create a structured bug ticket (Given/When/Then + repro steps + severity).
+- `/task` — Create a structured technical task ticket (driver, scope, ACs) for tech debt, infra, refactoring.
+- `/tickets-batch` — Bulk-file 5–20 structured tickets in one flow (shared-context Qs once, 3-Q micro-interview per ticket).
+- `/migration` — Create a labelled migration ticket + matching migration AgDR (rollback, downtime, consumers, observability). Required by the migration gate.
+- `/spike` — Create a hypothesis-driven, time-boxed spike ticket. Exempt from AgDR + coverage gates.
+- `/spike-close --promote | --discard` — Disposition gate for spikes — promote files a fresh `[Feature]`; discard writes a memo.
+- `/investigation` — Create an investigation ticket + live-doc for sustained root-cause work.
+- `/idea` — Capture a new product idea / feature concept / internal tool proposal to the shared backlog.
+- `/validate-idea` — Lightweight 5-question pre-spec gate between `/idea` and `/write-spec`.
+
+## How do I capture specs and technical decisions?
+
+PRDs, AgDRs, and the rationale layer.
+
+- `/write-spec` — Generate a PRD or feature spec from a problem statement.
+- `/decide` — Make a technical decision and create an Agent Decision Record (AgDR). Required before architecture changes by `require-agdr-for-arch-pr.sh`.
+- `/agdr browse | search | show | stats` — Browse / search / show / stats across the portfolio's AgDR library — recalls "have we decided this before?".
+
+## How does code review and merge get gated?
+
+Per-PR review + merge controls.
+
+- `/code-review` — Invoke the Code Reviewer agent (Rex) on a PR. Checks architecture, tests, AgDR links, glossary.
+- `/security-review` — Invoke the Security Reviewer agent (Hatim) on a PR. Flags auth / crypto / secrets / OWASP issues.
+- `/audit-deps` — Audit dependencies for vulnerabilities, outdated packages, licences.
+- `/approve-merge <pr>` — Record per-PR CEO approval and merge in one turn. Only on an explicit per-PR "approved" — never on umbrella "go".
+- `/approve-design <pr>` — Record per-PR design-review approval for UI PRs.
+- `/codify-rule` — Turn a human (or Copilot) review comment that caught a Rex-miss into a draft handbook entry.
+
+## Which skills generate architecture and dev artefacts?
+
+C4 diagrams, BPMN process, feature inventories, journeys, technical visions.
+
+- `/c4` — Generate C4 L1 (Context) + L2 (Container) Mermaid diagrams from a project's codebase.
+- `/dfd` — Extract a Data Flow Diagram with trust boundaries + data classifications (Mermaid + optional Threat Dragon JSON). Source of truth for `/threat-model`.
+- `/tech-vision` — Interactive author for the architecture vision template (target / gap / migration / anti-scope).
+- `/process` — Extract a business process from registered repos via 7-axis code scan + gap-targeted interview, then emit lint-clean BPMN 2.0.
+- `/extract-features` — Six-axis Feature Inventory (routes / models / jobs / tests / UI / docs) — a "what we must preserve" spec for greenfield rewrites.
+- `/feature-diagram` — Per-feature Mermaid flowchart of routes / models / jobs / screens involved.
+- `/journey` — Self-contained HTML user-journey map (boxes/arrows with per-page modals) — preview between PRD and tech-design.
+- `/pdf` — Convert markdown/HTML/BPMN to PDF (pandoc / md-to-pdf / wkhtmltopdf / bpmn-to-image).
+- `/debug` — Hypothesis-driven debugging — architecture-first reading + evidence-before-fix.
+
+## Which audits check production readiness?
+
+Cross-cutting deep-dive audits.
+
+- `/launch-check` — Production readiness audit — 10-dimension go/no-go sweep at milestone boundaries.
+- `/threat-model` — STRIDE threat modelling (spoofing, tampering, repudiation, disclosure, DoS, EoP). Deep-dive for `/launch-check` security.
+- `/accessibility-audit` — WCAG 2.1 AA audit. Deep-dive for `/launch-check` accessibility.
+- `/compliance-check` — GDPR + ePrivacy audit (consent, privacy policy, data handling, right to deletion, DPAs).
+- `/analytics-audit` — Analytics event-taxonomy audit (SDK coverage, naming, funnel completeness).
+- `/seo-audit` — Technical SEO audit (meta tags, sitemap, robots.txt, OG, structured data).
+- `/generative-engine-audit` — LLM/agent SEO (GEO/AEO) — `llms.txt`, `AGENTS.md`, AI-crawler robots, JSON-LD citation grounding.
+- `/performance-audit` — Performance audit (bundle size, images, lazy load, code split, Core Web Vitals).
+- `/monitoring-audit` — Observability audit (logging, error tracking, health endpoints, alerting, runbooks).
+- `/docs-audit` — Diataxis docs audit (tutorials, how-to, reference, explanation).
+- `/mutation-test` — Mutation-testing sensor (Stryker / MutPy / go-mutesting / mutant); milestone cadence, exit-3 graceful-degrade.
+
+## What workflow primitives are available?
+
+Enable, parallelise, release.
+
+- `/start-ticket <N> | <owner>/<repo>#<N>` — Declare an active ticket for this session so the ticket-first hook lets code edits through.
+- `/fan-out <task1, task2, ...>` — Spawn N parallel Agent calls in a single assistant message, optionally with worktree isolation.
+- `/release [version]` — Cut a new apexyard release (framework-only). Diffs dev vs main, picks a semver bump, generates CHANGELOG, opens release PR.
+
+## How do I generate roadmap and stakeholder communications?
+
+Roadmap planning + stakeholder updates synthesised from the activity stream.
+
+- `/roadmap [add | remove | reorder | show] [item]` — Update, create, or reprioritise the product roadmap. Renders a markdown table per milestone.
+- `/stakeholder-update weekly | monthly | launch` — Generate a stakeholder update tailored to audience. Synthesises recent PRs, closed issues, AgDRs, and the roadmap into a narrative.
+
+## Which skills are deprecated?
+
+- `/onboard` — Use `/setup` for framework configuration, `/handover` for adding a project to the portfolio. This skill redirects to the correct flow.
+
+## Links
+
+- Home: <https://yard.apexscript.com/index.md>
+- Architecture: <https://yard.apexscript.com/architecture.md>
+- GitHub source for each skill: <https://github.com/me2resh/apexyard/tree/main/.claude/skills>


### PR DESCRIPTION
## Summary

- **Stale framework counts purged across `site/` (Closes #325)** — every "skills / hooks / roles / slash commands / shell scripts / mechanical gates" claim across `site/index.html`, `site/architecture.html`, `site/skills.html`, `site/llms.txt`, `site/llms-full.txt`, and `site/skill.md` now matches the real on-disk counts (53 skills, 29 hooks, 19 roles). Visitors reading marketing copy and AI agents reading `llms.txt` no longer see numbers that diverge from the actual framework state — a credibility hit closed.
- **Meta-tag polish across all three pages (Closes #326)** — titles expanded into the 50–60 char SERP-optimal range (54 / 50 / 51 chars); meta descriptions trimmed/expanded into the 150–160 band so SERP snippets render fully; `<link rel="canonical">` added to `skills.html` (was missing); favicon link tags wired into all three pages with a `site/favicons/README.md` TODO doc covering the binary design brief (favicon.ico / favicon.svg / apple-touch-icon.png — same pattern as the `og:image` PNGs in #337, meta tags reference target paths now so they work the moment the binaries land); JSON-LD structured data added (SoftwareApplication + Organization + WebSite on index.html; BreadcrumbList on architecture.html + skills.html) so search engines can extract citation-grounded signals; Twitter cards completed on skills.html.
- **Q-shaped H2s + heading-hierarchy fix + first-500-tokens lead (Closes #331)** — `architecture.html` restructured with an H2 layer ("What is the ApexYard architecture?" / "How does the portfolio model work?") above the existing H3s so the H1→H3 skip is closed (a11y + LLM section detection); H2s across all three pages converted from category labels to Q-shape phrasing ("Setup & onboarding" → "Which skills help me set up?", and 9 more) so LLM snippet extractors hit clean Q&A boundaries; first ~500 tokens of every page now answers what-is / what-can-do / what's-needed-to-start in a structured triple before the marketing prose, so AI consumers can decide whether to keep reading without first stripping HTML chrome.
- **Markdown alternates served at `/foo.md` (Closes #332)** — three new clean-markdown files (`site/index.md.gen`, `site/architecture.md.gen`, `site/skills.md.gen`) carry each page's content with zero HTML chrome; Netlify `site/_redirects` rewrites `/foo.md → /foo.md.gen` as 200 (not redirect); `site/_headers` advertises the alternates via RFC-8288 `Link` headers AND sets `Content-Type: text/markdown` on the markdown responses; matching `<link rel="alternate" type="text/markdown" href="/foo.md">` in every HTML head so agents that parse HTML but not headers also discover the route. Every coding-agent fetch from now on pays the lower-token cost.
- **Drift-prevention CI workflow + smoke test (rationale in [AgDR-0046-site-counts-drift-prevention](docs/agdr/AgDR-0046-site-counts-drift-prevention.md))** — new `.github/workflows/site-counts-check.yml` runs on every PR touching `.claude/skills/**`, `.claude/hooks/**`, `roles/**`, or `site/**`; counts actual on-disk skills/hooks/roles and fails the PR if any quoted count in `site/*.html`, `site/*.md.gen`, `site/llms*.txt`, or `site/skill.md` diverges. The smoke test `bash .claude/hooks/tests/test_site_counts.sh` runs the same assertions locally. AgDR-0046-site-counts-drift-prevention weighs the three options (release-cut script / CI workflow / SessionStart banner) — CI chosen because per-PR detection means the author who introduced drift fixes drift, not a release author weeks later. Closes the recurring-drift class of bug, not just this instance.

## Testing

- [x] `grep -oE "[0-9]+ skills|[0-9]+ hooks|[0-9]+ roles|[0-9]+ slash" site/*.html` returns ZERO matches against the stale numbers (48/28/33/39)
- [x] `bash .claude/hooks/tests/test_site_counts.sh` passes locally — every count claim across 9 files matches the on-disk 53/29/19
- [ ] CI: `site-counts-check` workflow runs and passes on the PR
- [ ] Open `https://www.opengraph.xyz/url/https://yard.apexscript.com/` for each page after deploy — confirm title + description + og:image render cleanly within SERP limits
- [ ] Run [Google Rich Results Test](https://search.google.com/test/rich-results) on each deployed page — SoftwareApplication + Organization + WebSite + BreadcrumbList JSON-LD blocks validate without errors
- [ ] `curl https://yard.apexscript.com/index.md` after deploy — returns clean markdown with `Content-Type: text/markdown`
- [ ] `curl -I https://yard.apexscript.com/` after deploy — response includes `Link: </index.md>; rel="alternate"; type="text/markdown"`
- [ ] Visual smoke: open each page in a browser, click around — H2s render correctly, no layout regressions, breadcrumbs and structured data don't break the visible layout (they're metadata-only)

Closes #325
Closes #326
Closes #331
Closes #332

## Glossary

| Term | Definition |
|------|------------|
| JSON-LD | JSON for Linking Data — embedded structured-data format Google + Bing + other search engines use to extract typed entities (SoftwareApplication, Organization, WebSite, BreadcrumbList) from a page without reading visible copy |
| Structured data | Machine-readable annotations on top of human-readable HTML, typically JSON-LD or Microdata, that let search engines surface rich-result features (sitelinks, breadcrumbs, software ratings) |
| Canonical URL | `<link rel="canonical">` tag that names the authoritative version of a page so search engines de-duplicate identical content reachable at multiple URLs (e.g. with/without query strings) |
| og:image / twitter:card | Open Graph (Facebook/LinkedIn/general) and Twitter-specific meta tags that control the preview card rendered when the URL is shared on social — image, title, description, card type |
| Q-shaped H2 | Heading phrased as a question ("How do I get started?") rather than a label ("Quickstart"). LLMs extract snippets at H2 boundaries; question-shape headings produce cleaner extractable Q&A pairs than statement-shape ones, improving citation likelihood and AEO (answer-engine optimisation) scores |
| Markdown alternate | A clean-markdown version of an HTML page served at a sibling URL (`/foo.html` ↔ `/foo.md`), advertised via `<link rel="alternate" type="text/markdown">` and HTTP `Link` header. Lets coding agents fetch the lower-token version without parsing HTML chrome |
| Link header | RFC 8288 HTTP response header that declares typed relationships between the current resource and others (`rel="alternate"`, `rel="canonical"`, etc.) — read by agents at cheaper cost than parsing the HTML body |
| Drift detection | Mechanical check that asserts a derived claim (e.g. "53 skills" in marketing copy) matches its source-of-truth (actual count of `SKILL.md` files on disk). Catches the class of "this was right when written, now it's stale" silent bugs |
| AgDR | Agent Decision Record — markdown file under `docs/agdr/` capturing why a technical choice was made between alternatives, written by the agent at decision time so the rationale survives future review |
| GEO / AEO | Generative-Engine Optimisation / Answer-Engine Optimisation — sibling discipline to SEO, focused on making content discoverable + extractable by LLMs and coding agents rather than (only) search-engine crawlers |

<!-- multi-close: approved -->

<!-- private-refs: allow -->
