### PR TITLE
test(#318): /setup + /update step 8a test infrastructure

### DIFF
--- a/.claude/skills/setup/tests/README.md
+++ b/.claude/skills/setup/tests/README.md
@@ -1,0 +1,41 @@
+# `/setup` tests
+
+Sandbox-based regression tests for the `/setup` skill's file-state outcomes. Each test builds a synthetic fork under `mktemp -d`, runs the file-state actions the SKILL.md prescribes, then asserts the post-state matches the spec.
+
+## What's tested
+
+| Test | Covers | Reference in `SKILL.md` |
+|------|--------|-------------------------|
+| `test_setup_split_portfolio_v2.sh` | Split-portfolio v2 setup branch — config block with all 7 `portfolio.*` keys, `.apexyard-fork` marker, gitignore additions, `portfolio_validate` happy, `portfolio_is_v2` true, `resolve_ops_root` walks via the marker | Step 2b (config-block mode) + AgDR-0021 § B |
+| `test_setup_single_fork.sh` | Single-fork setup branch — placeholder replacement in `onboarding.yaml`, marker written even in single-fork mode, no `portfolio:` block (defaults apply), in-fork registry resolution | Step 6 (single-fork branch) |
+| `test_setup_reset.sh` | `--reset` flag — restore `onboarding.yaml` to the framework template defaults, idempotent on re-run | Step 1 (`--reset` mode detection) |
+
+## What's NOT tested
+
+`/setup`'s interactive prompts (Step 2 "describe your stack", Step 2a privacy gate, Step 2c LSP enablement) are out of scope — they're operator-interactive and OS / shell-dependent. The tests target the file-state outcomes that survive every branch of the interactive flow.
+
+The LSP enablement step (Step 2c) is doubly out of scope: it installs language-server binaries and mutates shell rc files. Driving that in a sandbox would require mock prerequisites (npm / pipx / go / rustup) that the framework can't ship.
+
+## Running
+
+```bash
+# Individual test
+bash .claude/skills/setup/tests/test_setup_split_portfolio_v2.sh
+
+# All setup tests
+for t in .claude/skills/setup/tests/test_*.sh; do bash "$t" || exit 1; done
+```
+
+## Adding a new test
+
+1. Copy the closest existing test as a starting shape.
+2. Match the conventions from `.claude/hooks/tests/test_split_portfolio_v2_migration.sh` (the canonical sandbox-test reference):
+   - `set -u` at the top
+   - `ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"` to resolve the fork root from the test file's location (four `..` for `setup/tests/test_*.sh`)
+   - `red()` / `green()` color helpers + per-case `==` banner echos
+   - `mark_pass` / `mark_fail` + a per-test `PASS` / `FAIL` counter
+   - Sandbox dir via `mktemp -d`
+   - `trap 'rm -rf "$TMP_ROOT"' EXIT` (single-quoted trap, double-quoted variable — shellcheck SC2064)
+   - Exit 0 on all-pass, 1 on any fail
+3. Source `_lib-portfolio-paths.sh` from the sandbox's `.claude/hooks/` copy (NOT the live fork's) — copying the libs into the sandbox via the `cp "$LIB_*"` lines keeps the test hermetic.
+4. Call `portfolio_clear_cache` before each new assertion that re-resolves portfolio paths; otherwise the per-process cache will return stale state from an earlier case.

--- a/.claude/skills/setup/tests/test_setup_reset.sh
+++ b/.claude/skills/setup/tests/test_setup_reset.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Sandbox-based test for the /setup --reset flag
+# (`/setup` SKILL.md § Step 1 — "Check current state" + `--reset` case).
+#
+# The --reset flag clears onboarding.yaml back to the template defaults
+# so the operator can re-run /setup from a clean slate. This test:
+#
+#   1. Builds a sandbox fork with a CUSTOMISED onboarding.yaml (real
+#      company name, placeholder gone) — i.e. /setup has already run
+#      against this fork at some point.
+#   2. Applies the --reset semantics (overwrite onboarding.yaml with the
+#      framework template defaults).
+#   3. Asserts the post-state matches the original template (placeholder
+#      back in place, ready for a fresh /setup run).
+#
+# Out of scope: testing the --reset interactive prompt branch in Step 1
+# (operator-interactive, not file-state). The file-state outcome IS what
+# matters for regression coverage.
+#
+# Exit 0 on all-pass, 1 on any fail.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+TEMPLATE_SRC="$ROOT/onboarding.yaml"
+
+if [ ! -f "$TEMPLATE_SRC" ]; then
+  echo "FAIL: framework template $TEMPLATE_SRC not found" >&2
+  exit 1
+fi
+
+# Sanity check — the live framework template still ships the expected
+# placeholder. If this ever changes, this test (and the SKILL.md
+# detection grep) must change too.
+if ! grep -q '"Your Company Name"' "$TEMPLATE_SRC"; then
+  echo "FAIL: framework onboarding.yaml lacks the 'Your Company Name' placeholder — template detection grep in SKILL.md Step 1 is broken" >&2
+  exit 1
+fi
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+mark_pass() { green "  ok   $1"; PASS=$((PASS+1)); }
+mark_fail() {
+  red "  FAIL $1: $2" >&2
+  FAIL=$((FAIL+1))
+  FAILED_CASES="$FAILED_CASES\n  - $1"
+}
+
+TMP_ROOT=$(mktemp -d)
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# ---------------------------------------------------------------------------
+# Fixture: a fork where /setup has ALREADY run — onboarding.yaml carries
+# a real company name + non-placeholder values.
+# ---------------------------------------------------------------------------
+build_post_setup_fork() {
+  local sb="$1"
+  mkdir -p "$sb"
+
+  cat > "$sb/onboarding.yaml" <<'YAML'
+# ApexYard Onboarding (post-setup state)
+company:
+  name: "ApexScript"
+  mission: "Property management SaaS"
+  values:
+    - "Quality over speed"
+YAML
+}
+
+# ---------------------------------------------------------------------------
+# Apply the --reset semantics: overwrite onboarding.yaml with the
+# framework template defaults (read from $TEMPLATE_SRC — the same file
+# `/setup` copies from upstream).
+# ---------------------------------------------------------------------------
+apply_setup_reset() {
+  local fork="$1"
+  cp "$TEMPLATE_SRC" "$fork/onboarding.yaml"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: --reset on a configured fork restores the template defaults
+# ---------------------------------------------------------------------------
+echo "== Case 1: /setup --reset clears onboarding.yaml back to template defaults"
+SB="$TMP_ROOT/case1"
+build_post_setup_fork "$SB"
+
+# Pre-state sanity: customised content present, placeholder absent
+if grep -q '"ApexScript"' "$SB/onboarding.yaml"; then
+  mark_pass "pre-state: configured fork has real company name"
+else
+  mark_fail "pre-state customised" "expected ApexScript in onboarding.yaml"
+  exit 1
+fi
+if grep -q '"Your Company Name"' "$SB/onboarding.yaml"; then
+  mark_fail "pre-state placeholder absent" "placeholder unexpectedly present pre-reset"
+  exit 1
+else
+  mark_pass "pre-state: placeholder absent (real config in place)"
+fi
+
+apply_setup_reset "$SB"
+
+# Assertion 1: customised values are gone after reset
+if grep -q '"ApexScript"' "$SB/onboarding.yaml"; then
+  mark_fail "customised values cleared" "ApexScript still present after --reset"
+else
+  mark_pass "customised company name cleared from onboarding.yaml"
+fi
+
+# Assertion 2: placeholder is back — the SKILL.md Step 1 detection grep
+# (`grep -q '"Your Company Name"'`) re-fires, treating the fork as fresh.
+if grep -q '"Your Company Name"' "$SB/onboarding.yaml"; then
+  mark_pass "placeholder restored — SKILL.md Step 1 detection grep will re-fire"
+else
+  mark_fail "placeholder restored" "expected 'Your Company Name' back in onboarding.yaml"
+fi
+
+# Assertion 3: post-reset onboarding.yaml content matches the framework template
+if diff -q "$TEMPLATE_SRC" "$SB/onboarding.yaml" >/dev/null 2>&1; then
+  mark_pass "post-reset onboarding.yaml matches the framework template byte-for-byte"
+else
+  mark_fail "template match" "post-reset content differs from $TEMPLATE_SRC"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: --reset is idempotent — running it twice is a no-op
+# ---------------------------------------------------------------------------
+echo "== Case 2: --reset is idempotent (re-running yields same state)"
+SHA_BEFORE=$(shasum "$SB/onboarding.yaml" | awk '{print $1}')
+apply_setup_reset "$SB"
+SHA_AFTER=$(shasum "$SB/onboarding.yaml" | awk '{print $1}')
+if [ "$SHA_BEFORE" = "$SHA_AFTER" ]; then
+  mark_pass "second --reset is a no-op (sha unchanged)"
+else
+  mark_fail "idempotent reset" "sha changed: $SHA_BEFORE → $SHA_AFTER"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "===== test_setup_reset.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:%b\n' "$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/skills/setup/tests/test_setup_single_fork.sh
+++ b/.claude/skills/setup/tests/test_setup_single_fork.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# Sandbox-based test for the /setup single-fork branch
+# (`/setup` SKILL.md § Step 6 — "Write onboarding.yaml + the .apexyard-fork marker"
+#  in single-fork mode).
+#
+# Single-fork setup is the simpler path: edit onboarding.yaml in place to
+# replace placeholder values, write the .apexyard-fork marker, and do
+# NOT write a portfolio: config block (single-fork uses the in-fork
+# defaults for all five resolver paths).
+#
+# This test simulates a fresh fork where the operator has just answered
+# the Step 2 questions ("describe your stack"), then applies the
+# Step 6 file-state actions, then asserts:
+#
+#   - onboarding.yaml has the company.name placeholder replaced
+#   - .apexyard-fork marker present (idempotent — written even in
+#     single-fork mode, per AgDR-0021 § B + SKILL.md Step 6)
+#   - .claude/project-config.json is NOT written (single-fork mode
+#     uses defaults entirely)
+#   - portfolio_validate succeeds against the in-fork defaults
+#
+# Exit 0 on all-pass, 1 on any fail.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+LIB_OPS="$ROOT/.claude/hooks/_lib-ops-root.sh"
+LIB_PORT="$ROOT/.claude/hooks/_lib-portfolio-paths.sh"
+LIB_CFG="$ROOT/.claude/hooks/_lib-read-config.sh"
+DEFAULTS="$ROOT/.claude/project-config.defaults.json"
+
+for f in "$LIB_OPS" "$LIB_PORT" "$LIB_CFG" "$DEFAULTS"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: missing $f" >&2
+    exit 1
+  fi
+done
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+mark_pass() { green "  ok   $1"; PASS=$((PASS+1)); }
+mark_fail() {
+  red "  FAIL $1: $2" >&2
+  FAIL=$((FAIL+1))
+  FAILED_CASES="$FAILED_CASES\n  - $1"
+}
+
+TMP_ROOT=$(mktemp -d)
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# ---------------------------------------------------------------------------
+# Fixture: a fresh single-fork with placeholder onboarding.yaml + minimal
+# in-fork registry + projects/ dir. Mirrors the layout an adopter who
+# JUST forked apexyard would have before invoking /setup.
+# ---------------------------------------------------------------------------
+build_pre_setup_single_fork() {
+  local sb="$1"
+  mkdir -p "$sb/.claude/hooks" "$sb/projects"
+
+  # Placeholder onboarding.yaml (matches the framework template detector
+  # in SKILL.md Step 1: `grep -q '"Your Company Name"' onboarding.yaml`).
+  cat > "$sb/onboarding.yaml" <<'YAML'
+# ApexYard Onboarding
+company:
+  name: "Your Company Name"
+  mission: "What you're building and why"
+YAML
+
+  # Minimal in-fork registry.
+  cat > "$sb/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects: []
+YAML
+
+  cat > "$sb/projects/ideas-backlog.md" <<'MD'
+# Ideas Backlog
+MD
+
+  cp "$LIB_OPS"  "$sb/.claude/hooks/_lib-ops-root.sh"
+  cp "$LIB_PORT" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  cp "$LIB_CFG"  "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$DEFAULTS" "$sb/.claude/project-config.defaults.json"
+
+  (
+    cd "$sb" \
+      && git init -q \
+      && git config user.email "t@t.t" \
+      && git config user.name "t" \
+      && git add -A \
+      && git commit -q -m "fresh single-fork (pre-setup)"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Apply the SKILL.md Step 6 single-fork actions:
+#   - Replace the company.name placeholder with a real value
+#   - Write the .apexyard-fork presence marker
+#   - Do NOT write a portfolio: config block
+# ---------------------------------------------------------------------------
+apply_setup_single_fork() {
+  local fork="$1"
+  local company_name="$2"
+
+  (
+    cd "$fork" || exit 99
+    # Use sed -i.bak for macOS / GNU compat.
+    sed -i.bak "s/\"Your Company Name\"/\"$company_name\"/" onboarding.yaml
+    rm -f onboarding.yaml.bak
+
+    if [ ! -f .apexyard-fork ]; then
+      echo "# This file marks the directory as an ApexYard ops fork." > .apexyard-fork
+    fi
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: single-fork setup writes placeholder replacement + marker only
+# ---------------------------------------------------------------------------
+echo "== Case 1: /setup single-fork branch fills placeholders + writes marker"
+SB="$TMP_ROOT/case1"
+build_pre_setup_single_fork "$SB"
+
+# Pre-state sanity: placeholder is present
+if grep -q '"Your Company Name"' "$SB/onboarding.yaml"; then
+  mark_pass "pre-state: company.name placeholder detected"
+else
+  mark_fail "pre-state placeholder" "expected placeholder in onboarding.yaml"
+  exit 1
+fi
+
+apply_setup_single_fork "$SB" "ApexScript"
+
+# Assertion 1: onboarding.yaml has real company name, placeholder gone
+if grep -q '"ApexScript"' "$SB/onboarding.yaml"; then
+  mark_pass "onboarding.yaml has real company name written in"
+else
+  mark_fail "onboarding company name" "ApexScript not found in onboarding.yaml"
+fi
+if grep -q '"Your Company Name"' "$SB/onboarding.yaml"; then
+  mark_fail "placeholder cleared" "placeholder still present after setup"
+else
+  mark_pass "placeholder cleared from onboarding.yaml"
+fi
+
+# Assertion 2: .apexyard-fork marker present (single-fork mode also gets
+# the marker per SKILL.md Step 6 + AgDR-0021 § B)
+if [ -f "$SB/.apexyard-fork" ]; then
+  mark_pass ".apexyard-fork marker present even in single-fork mode"
+else
+  mark_fail "marker present" ".apexyard-fork missing"
+fi
+
+# Assertion 3: NO portfolio: config block — single-fork mode relies on defaults
+if [ -f "$SB/.claude/project-config.json" ]; then
+  # If it exists, it must NOT have a .portfolio key
+  if command -v jq >/dev/null 2>&1; then
+    has_portfolio=$(jq -r 'has("portfolio")' "$SB/.claude/project-config.json" 2>/dev/null)
+    if [ "$has_portfolio" = "true" ]; then
+      mark_fail "no portfolio block in single-fork" "project-config.json has a portfolio: key"
+    else
+      mark_pass "no portfolio: block written in single-fork mode (defaults apply)"
+    fi
+  else
+    mark_pass "no portfolio: block (jq absent, presence-only check)"
+  fi
+else
+  mark_pass "no .claude/project-config.json written in single-fork mode"
+fi
+
+# Assertion 4: portfolio_validate succeeds — in-fork defaults resolve correctly
+(
+  cd "$SB" || exit 1
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-read-config.sh
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-portfolio-paths.sh
+  portfolio_clear_cache
+  if portfolio_validate >/dev/null 2>&1; then
+    exit 0
+  else
+    err=$(portfolio_validate 2>&1)
+    echo "validate failed: $err" >&2
+    exit 1
+  fi
+)
+if [ "$?" -eq 0 ]; then
+  mark_pass "portfolio_validate happy on single-fork post-setup state"
+else
+  mark_fail "portfolio_validate single-fork" "see error above"
+fi
+
+# Assertion 5: registry is the in-fork file (resolved through defaults)
+(
+  cd "$SB" || exit 1
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-read-config.sh
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-portfolio-paths.sh
+  portfolio_clear_cache
+  reg=$(portfolio_registry)
+  [ "$reg" = "$SB/apexyard.projects.yaml" ] || {
+    echo "expected $SB/apexyard.projects.yaml, got $reg" >&2
+    exit 1
+  }
+  exit 0
+)
+if [ "$?" -eq 0 ]; then
+  mark_pass "portfolio_registry resolves to in-fork apexyard.projects.yaml"
+else
+  mark_fail "registry resolution" "see error above"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "===== test_setup_single_fork.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:%b\n' "$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/skills/setup/tests/test_setup_split_portfolio_v2.sh
+++ b/.claude/skills/setup/tests/test_setup_split_portfolio_v2.sh
@@ -1,0 +1,279 @@
+#!/bin/bash
+# Sandbox-based test for the /setup split-portfolio v2 setup branch
+# (`/setup` SKILL.md § Step 2b — "Walk through split-portfolio mode").
+#
+# `/setup` is a markdown skill, not a shell script, so this test does
+# NOT drive the interactive prompts. Instead it runs the file-state
+# steps the skill prescribes against a synthetic fork + sibling
+# private-repo pair, then asserts the post-state matches the v2
+# layout expectations from AgDR-0021 § B:
+#
+#   - All 7 v2 portfolio.* config keys land in .claude/project-config.json
+#     (registry, projects_dir, ideas_backlog, onboarding, workspace_dir,
+#      custom_skills_dir, custom_handbooks_dir)
+#   - .apexyard-fork presence marker exists at the public-fork root with
+#     the expected commented preamble (presence-only readers, AgDR-0021 § B)
+#   - .gitignore has the 4 v2 paths excluded
+#     (apexyard.projects.yaml, projects, onboarding.yaml, workspace)
+#   - portfolio_validate succeeds on the post-state
+#
+# Companion to test_split_portfolio_v2_migration.sh (which tests the
+# v1→v2 migration recipe inside /update step 8a). This one targets
+# fresh /setup invocations on a brand-new fork.
+#
+# Exit 0 on all-pass, 1 on any fail.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+LIB_OPS="$ROOT/.claude/hooks/_lib-ops-root.sh"
+LIB_PORT="$ROOT/.claude/hooks/_lib-portfolio-paths.sh"
+LIB_CFG="$ROOT/.claude/hooks/_lib-read-config.sh"
+DEFAULTS="$ROOT/.claude/project-config.defaults.json"
+
+for f in "$LIB_OPS" "$LIB_PORT" "$LIB_CFG" "$DEFAULTS"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: missing $f" >&2
+    exit 1
+  fi
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not installed; /setup v2 branch uses jq for config writes" >&2
+  exit 0
+fi
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+mark_pass() { green "  ok   $1"; PASS=$((PASS+1)); }
+mark_fail() {
+  red "  FAIL $1: $2" >&2
+  FAIL=$((FAIL+1))
+  FAILED_CASES="$FAILED_CASES\n  - $1"
+}
+
+TMP_ROOT=$(mktemp -d)
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# ---------------------------------------------------------------------------
+# Fixture builder: a fresh public fork + sibling private repo with the
+# v2 layout pre-built BUT the v2 marker and config block NOT YET written.
+# The test then runs the SKILL.md Step 2b file-state actions and asserts
+# the post-state.
+# ---------------------------------------------------------------------------
+build_pre_setup_v2() {
+  local sb="$1"
+  mkdir -p "$sb/public/.claude/hooks" "$sb/public/.claude"
+  mkdir -p "$sb/private/projects" "$sb/private/workspace"
+
+  # Public fork: framework files only — onboarding.yaml is still the
+  # placeholder template, apexyard.projects.yaml NOT in the fork (lives
+  # in the sibling private repo for v2 split-portfolio adopters).
+  cat > "$sb/public/onboarding.yaml" <<'YAML'
+company:
+  name: "Your Company Name"
+YAML
+
+  cp "$LIB_OPS"  "$sb/public/.claude/hooks/_lib-ops-root.sh"
+  cp "$LIB_PORT" "$sb/public/.claude/hooks/_lib-portfolio-paths.sh"
+  cp "$LIB_CFG"  "$sb/public/.claude/hooks/_lib-read-config.sh"
+  cp "$DEFAULTS" "$sb/public/.claude/project-config.defaults.json"
+
+  cat > "$sb/public/.gitignore" <<'IGNORE'
+node_modules/
+*.log
+IGNORE
+
+  # Init the public fork as a git repo so portfolio_root finds toplevel.
+  (
+    cd "$sb/public" \
+      && git init -q \
+      && git config user.email "t@t.t" \
+      && git config user.name "t" \
+      && git add -A \
+      && git commit -q -m "fresh public fork (pre-v2-setup)"
+  )
+
+  # Sibling private repo: registry + projects/ + workspace/ + onboarding.yaml
+  cat > "$sb/private/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects: []
+defaults:
+  status: active
+  ticket_prefix: GH
+YAML
+  cat > "$sb/private/projects/ideas-backlog.md" <<'MD'
+# Ideas Backlog
+MD
+  cat > "$sb/private/onboarding.yaml" <<'YAML'
+company:
+  name: "Test Co"
+  mission: "ship test infrastructure"
+YAML
+  mkdir -p "$sb/private/custom-skills" "$sb/private/custom-handbooks"
+}
+
+# ---------------------------------------------------------------------------
+# Apply the SKILL.md Step 2b post-questionnaire file-state actions.
+# Mirrors the bash blocks in `.claude/skills/setup/SKILL.md` § Step 2b
+# (recommended v2 config-block mode).
+# ---------------------------------------------------------------------------
+apply_setup_v2() {
+  local public="$1"
+  local sibling_rel="$2"   # e.g. "../private"
+
+  (
+    cd "$public" || exit 99
+
+    # 1. Append v2 gitignore lines.
+    {
+      echo ""
+      echo "# Portfolio data lives in a separate private repo (split-portfolio v2)."
+      echo "apexyard.projects.yaml"
+      echo "projects"
+      echo "onboarding.yaml"
+      echo "workspace"
+    } >> .gitignore
+
+    # 2. Write the v2 config block.
+    cat > .claude/project-config.json <<JSON
+{
+  "portfolio": {
+    "registry":             "$sibling_rel/apexyard.projects.yaml",
+    "projects_dir":         "$sibling_rel/projects",
+    "ideas_backlog":        "$sibling_rel/projects/ideas-backlog.md",
+    "onboarding":           "$sibling_rel/onboarding.yaml",
+    "workspace_dir":        "$sibling_rel/workspace",
+    "custom_skills_dir":    "$sibling_rel/custom-skills",
+    "custom_handbooks_dir": "$sibling_rel/custom-handbooks"
+  }
+}
+JSON
+
+    # 3. Write the v2 presence marker.
+    echo "# This file marks the directory as an ApexYard ops fork (split-portfolio v2)." > .apexyard-fork
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: full v2 setup branch — assert all 7 keys + marker + gitignore
+# ---------------------------------------------------------------------------
+echo "== Case 1: /setup v2 setup branch writes v2 layout"
+SB="$TMP_ROOT/case1"
+build_pre_setup_v2 "$SB"
+apply_setup_v2 "$SB/public" "../private"
+
+# Assertion 1: all 7 v2 portfolio keys exist in project-config.json
+PCONFIG="$SB/public/.claude/project-config.json"
+EXPECTED_KEYS=(registry projects_dir ideas_backlog onboarding workspace_dir custom_skills_dir custom_handbooks_dir)
+all_keys_present=1
+for k in "${EXPECTED_KEYS[@]}"; do
+  v=$(jq -r ".portfolio.$k // empty" "$PCONFIG")
+  if [ -z "$v" ]; then
+    mark_fail "v2 key $k present" "key missing from project-config.json"
+    all_keys_present=0
+  fi
+done
+if [ "$all_keys_present" -eq 1 ]; then
+  mark_pass "all 7 v2 portfolio.* keys present in project-config.json"
+fi
+
+# Assertion 2: .apexyard-fork marker exists with expected commented preamble
+MARKER="$SB/public/.apexyard-fork"
+if [ -f "$MARKER" ]; then
+  mark_pass ".apexyard-fork marker present at fork root"
+else
+  mark_fail "marker present" "$MARKER missing"
+fi
+if [ -f "$MARKER" ] && head -n 1 "$MARKER" | grep -q "ApexYard ops fork (split-portfolio v2)"; then
+  mark_pass ".apexyard-fork carries the expected commented preamble"
+else
+  mark_fail "marker content" "preamble line missing or wrong"
+fi
+
+# Assertion 3: .gitignore has 4 v2 paths excluded
+GI="$SB/public/.gitignore"
+for path in apexyard.projects.yaml projects onboarding.yaml workspace; do
+  if grep -qxF "$path" "$GI"; then
+    mark_pass ".gitignore excludes '$path'"
+  else
+    mark_fail "gitignore exclude $path" "missing from $GI"
+  fi
+done
+
+# Assertion 4: portfolio_validate succeeds on the post-state
+(
+  cd "$SB/public" || exit 1
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-read-config.sh
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-portfolio-paths.sh
+  portfolio_clear_cache
+  if portfolio_validate >/dev/null 2>&1; then
+    exit 0
+  else
+    err=$(portfolio_validate 2>&1)
+    echo "validate failed: $err" >&2
+    exit 1
+  fi
+)
+if [ "$?" -eq 0 ]; then
+  mark_pass "portfolio_validate happy on post-setup v2 layout"
+else
+  mark_fail "portfolio_validate" "see error above"
+fi
+
+# Assertion 5: portfolio_is_v2 returns 0 (true) on the post-state
+(
+  cd "$SB/public" || exit 1
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-read-config.sh
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-portfolio-paths.sh
+  portfolio_clear_cache
+  if portfolio_is_v2; then
+    exit 0
+  else
+    exit 1
+  fi
+)
+if [ "$?" -eq 0 ]; then
+  mark_pass "portfolio_is_v2 detects the post-setup state as v2"
+else
+  mark_fail "portfolio_is_v2 detection" "expected v2 but got v1/single-fork"
+fi
+
+# Assertion 6: ops-root walk finds the public fork via .apexyard-fork
+# (proves the v2 layout works even though onboarding+registry are not in
+#  the public fork)
+(
+  # shellcheck source=/dev/null
+  . "$LIB_OPS"
+  out=$(cd "$SB/public" && resolve_ops_root)
+  [ "$out" = "$SB/public" ] || { echo "ops_root expected $SB/public got $out" >&2; exit 1; }
+  exit 0
+)
+if [ "$?" -eq 0 ]; then
+  mark_pass "resolve_ops_root finds public fork via .apexyard-fork marker"
+else
+  mark_fail "resolve_ops_root" "see error above"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "===== test_setup_split_portfolio_v2.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:%b\n' "$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/skills/update/tests/test_step_8a_wiring.sh
+++ b/.claude/skills/update/tests/test_step_8a_wiring.sh
@@ -1,0 +1,543 @@
+#!/bin/bash
+# Integration test for /update step 8a wiring — verify the v1→v2
+# migration is OFFERED only on pre-v2 split-portfolio adopters, and
+# silently no-ops on v2 + single-fork forks.
+#
+# Distinct from test_split_portfolio_v2_migration.sh (which tests the
+# migration BODY — `cp -p` of onboarding (copy-not-move per AgDR-0021 § H),
+# `mv` of workspace contents, `.apexyard-fork` write, gitignore additions,
+# jq config-block update, idempotence).
+# This test pins the INVOCATION/DETECTION logic from
+# `.claude/skills/update/SKILL.md` § 8a:
+#
+#   V2_NEEDED=0  if portfolio_is_v2   (already v2)
+#   V2_NEEDED=0  if no .portfolio.registry key   (single-fork)
+#   V2_NEEDED=1  if .portfolio.registry present AND no .apexyard-fork
+#                marker  (pre-v2 split-portfolio adopter)
+#
+# Plus the --dry-run branch which prints the migration plan but does
+# not mutate state.
+#
+# Four detection branches under test:
+#
+#   Case 1: v2 fork (has .apexyard-fork marker + portfolio block)
+#           → V2_NEEDED=0 → silent no-op, no state change
+#   Case 2: single-fork (no portfolio block at all)
+#           → V2_NEEDED=0 → silent no-op, no state change
+#   Case 3: pre-v2 split-portfolio (portfolio block, no .apexyard-fork)
+#           → V2_NEEDED=1 → migration applies, state changes match v2 spec
+#   Case 4: --dry-run on a pre-v2 split-portfolio
+#           → V2_NEEDED=1 → plan printed, NO state change
+#
+# Exit 0 on all-pass, 1 on any fail.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+LIB_OPS="$ROOT/.claude/hooks/_lib-ops-root.sh"
+LIB_PORT="$ROOT/.claude/hooks/_lib-portfolio-paths.sh"
+LIB_CFG="$ROOT/.claude/hooks/_lib-read-config.sh"
+DEFAULTS="$ROOT/.claude/project-config.defaults.json"
+
+for f in "$LIB_OPS" "$LIB_PORT" "$LIB_CFG" "$DEFAULTS"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: missing $f" >&2
+    exit 1
+  fi
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not installed; step 8a detection uses jq" >&2
+  exit 0
+fi
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+mark_pass() { green "  ok   $1"; PASS=$((PASS+1)); }
+mark_fail() {
+  red "  FAIL $1: $2" >&2
+  FAIL=$((FAIL+1))
+  FAILED_CASES="$FAILED_CASES\n  - $1"
+}
+
+TMP_ROOT=$(mktemp -d)
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# ---------------------------------------------------------------------------
+# Fixture: public fork + sibling private repo in v1 split-portfolio layout
+# (registry + projects/ in the sibling, onboarding + workspace still in the
+# public fork, NO .apexyard-fork marker yet). Mirrors what an adopter on
+# framework < #242 had before /update ≥ #242 offers them the migration.
+# ---------------------------------------------------------------------------
+build_pre_v2_split() {
+  local sb="$1"
+  mkdir -p "$sb/public/.claude/hooks" "$sb/public/workspace/demo"
+  mkdir -p "$sb/private/projects"
+
+  cat > "$sb/public/onboarding.yaml" <<'YAML'
+company:
+  name: "Test Co"
+YAML
+  echo "demo workspace content" > "$sb/public/workspace/demo/README.md"
+
+  cp "$LIB_OPS"  "$sb/public/.claude/hooks/_lib-ops-root.sh"
+  cp "$LIB_PORT" "$sb/public/.claude/hooks/_lib-portfolio-paths.sh"
+  cp "$LIB_CFG"  "$sb/public/.claude/hooks/_lib-read-config.sh"
+  cp "$DEFAULTS" "$sb/public/.claude/project-config.defaults.json"
+
+  cat > "$sb/public/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "registry": "../private/apexyard.projects.yaml",
+    "projects_dir": "../private/projects",
+    "ideas_backlog": "../private/projects/ideas-backlog.md"
+  }
+}
+JSON
+
+  cat > "$sb/public/.gitignore" <<'IGNORE'
+node_modules/
+*.log
+IGNORE
+
+  (
+    cd "$sb/public" \
+      && git init -q \
+      && git config user.email "t@t.t" \
+      && git config user.name "t" \
+      && git add -A \
+      && git commit -q -m "v1 split-portfolio fixture"
+  )
+
+  cat > "$sb/private/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: demo
+    repo: example/demo
+YAML
+  cat > "$sb/private/projects/ideas-backlog.md" <<'MD'
+# Ideas Backlog
+MD
+}
+
+# ---------------------------------------------------------------------------
+# Fixture: v2 split-portfolio adopter — same as build_pre_v2_split, but
+# the .apexyard-fork marker exists at the public-fork root AND the
+# portfolio block already carries the v2 keys (onboarding + workspace
+# resolved into the sibling repo).
+# ---------------------------------------------------------------------------
+build_v2_split() {
+  local sb="$1"
+  mkdir -p "$sb/public/.claude/hooks"
+  mkdir -p "$sb/private/projects" "$sb/private/workspace/demo"
+
+  cp "$LIB_OPS"  "$sb/public/.claude/hooks/_lib-ops-root.sh"
+  cp "$LIB_PORT" "$sb/public/.claude/hooks/_lib-portfolio-paths.sh"
+  cp "$LIB_CFG"  "$sb/public/.claude/hooks/_lib-read-config.sh"
+  cp "$DEFAULTS" "$sb/public/.claude/project-config.defaults.json"
+
+  cat > "$sb/public/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "registry":      "../private/apexyard.projects.yaml",
+    "projects_dir":  "../private/projects",
+    "ideas_backlog": "../private/projects/ideas-backlog.md",
+    "onboarding":    "../private/onboarding.yaml",
+    "workspace_dir": "../private/workspace"
+  }
+}
+JSON
+
+  cat > "$sb/public/.gitignore" <<'IGNORE'
+node_modules/
+*.log
+
+# Split-portfolio v2
+apexyard.projects.yaml
+projects
+onboarding.yaml
+workspace
+IGNORE
+
+  echo "# v2 anchor" > "$sb/public/.apexyard-fork"
+
+  (
+    cd "$sb/public" \
+      && git init -q \
+      && git config user.email "t@t.t" \
+      && git config user.name "t" \
+      && git add -A \
+      && git commit -q -m "v2 split-portfolio fixture"
+  )
+
+  cat > "$sb/private/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: demo
+    repo: example/demo
+YAML
+  cat > "$sb/private/projects/ideas-backlog.md" <<'MD'
+# Ideas Backlog
+MD
+  cat > "$sb/private/onboarding.yaml" <<'YAML'
+company:
+  name: "Test Co"
+YAML
+  echo "demo workspace content" > "$sb/private/workspace/demo/README.md"
+}
+
+# ---------------------------------------------------------------------------
+# Fixture: single-fork adopter — onboarding + registry both in the fork,
+# no portfolio: config block at all. Step 8a should silently skip.
+# ---------------------------------------------------------------------------
+build_single_fork() {
+  local sb="$1"
+  mkdir -p "$sb/.claude/hooks" "$sb/projects" "$sb/workspace"
+
+  cat > "$sb/onboarding.yaml" <<'YAML'
+company:
+  name: "Test Co"
+YAML
+  cat > "$sb/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects: []
+YAML
+  cat > "$sb/projects/ideas-backlog.md" <<'MD'
+# Ideas Backlog
+MD
+
+  cp "$LIB_OPS"  "$sb/.claude/hooks/_lib-ops-root.sh"
+  cp "$LIB_PORT" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  cp "$LIB_CFG"  "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$DEFAULTS" "$sb/.claude/project-config.defaults.json"
+
+  # Either no project-config.json at all OR one without a portfolio block.
+  # Test both shapes — start with no override file.
+
+  (
+    cd "$sb" \
+      && git init -q \
+      && git config user.email "t@t.t" \
+      && git config user.name "t" \
+      && git add -A \
+      && git commit -q -m "single-fork fixture"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# detect_v2_needed: mirrors the detection logic from SKILL.md § 8a.
+# Returns 0 if migration is needed, 1 if not.
+#
+# Reads inside the candidate fork dir (caller is expected to have cd'd
+# into it).
+# ---------------------------------------------------------------------------
+detect_v2_needed() {
+  local fork="$1"
+  (
+    cd "$fork" || return 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-read-config.sh
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-portfolio-paths.sh
+    portfolio_clear_cache
+
+    if portfolio_is_v2; then
+      return 1
+    fi
+    if ! jq -e '.portfolio.registry' .claude/project-config.json >/dev/null 2>&1; then
+      return 1
+    fi
+    return 0
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Snapshot a fork's relevant file state so we can detect mutation. Records
+# the SHA of onboarding.yaml + workspace tree + .gitignore + the absence
+# of .apexyard-fork.
+# ---------------------------------------------------------------------------
+snapshot_state() {
+  local fork="$1"
+  (
+    cd "$fork" || return 1
+    {
+      # Per-file SHAs (only files that step 8a would touch)
+      for path in onboarding.yaml .gitignore .apexyard-fork .claude/project-config.json; do
+        if [ -e "$path" ]; then
+          shasum "$path" 2>/dev/null
+        else
+          echo "ABSENT $path"
+        fi
+      done
+      # workspace tree listing (step 8a moves entries)
+      find workspace -mindepth 1 2>/dev/null | LC_ALL=C sort
+    }
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: v2 fork — step 8a silently no-ops
+# ---------------------------------------------------------------------------
+echo "== Case 1: v2 fork (has .apexyard-fork + v2 portfolio block) → no-op"
+SB="$TMP_ROOT/case1"
+build_v2_split "$SB"
+
+if detect_v2_needed "$SB/public"; then
+  mark_fail "v2 detection" "V2_NEEDED=1 on a v2 fork (expected 0)"
+else
+  mark_pass "V2_NEEDED=0 on v2 fork (silent skip)"
+fi
+
+# Verify portfolio_is_v2 returns true on this fixture
+(
+  cd "$SB/public" || exit 1
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-read-config.sh
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-portfolio-paths.sh
+  portfolio_clear_cache
+  portfolio_is_v2 || exit 1
+)
+if [ "$?" -eq 0 ]; then
+  mark_pass "portfolio_is_v2 returns true on v2 fixture"
+else
+  mark_fail "portfolio_is_v2 on v2" "expected true"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: single-fork — step 8a silently no-ops
+# ---------------------------------------------------------------------------
+echo "== Case 2: single-fork (no portfolio block) → no-op"
+SB="$TMP_ROOT/case2"
+build_single_fork "$SB"
+
+# Create the file with no portfolio key — exercise the empty-override
+# branch of the jq detection.
+echo '{"_comment": "no portfolio block"}' > "$SB/.claude/project-config.json"
+
+if detect_v2_needed "$SB"; then
+  mark_fail "single-fork detection" "V2_NEEDED=1 on a single-fork (expected 0)"
+else
+  mark_pass "V2_NEEDED=0 on single-fork (no portfolio block — silent skip)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3: pre-v2 split → migration fires + state matches v2 spec
+# ---------------------------------------------------------------------------
+echo "== Case 3: pre-v2 split-portfolio → migration fires"
+SB="$TMP_ROOT/case3"
+build_pre_v2_split "$SB"
+
+if detect_v2_needed "$SB/public"; then
+  mark_pass "V2_NEEDED=1 on pre-v2 split-portfolio (migration applies)"
+else
+  mark_fail "pre-v2 detection" "V2_NEEDED=0 on pre-v2 split (expected 1)"
+fi
+
+# Apply the migration body (mirrors SKILL.md § 8a Migration steps).
+# IMPORTANT: this is a deliberate mirror, not a call into a separate
+# library — test_step_8a_wiring is the WIRING test; the migration body
+# is exercised exhaustively by test_split_portfolio_v2_migration.sh.
+(
+  cd "$SB/public" || exit 99
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-read-config.sh
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-portfolio-paths.sh
+
+  SIBLING_ROOT=$(dirname "$(jq -r '.portfolio.registry' .claude/project-config.json)")
+
+  # Copy onboarding.yaml — NOT move (copy-not-move semantics, AgDR-0021 § H,
+  # landed in PR #317 / ticket #319 cross-reference). Sibling becomes the
+  # canonical copy; public-fork snapshot is left in place and untracked via
+  # `git rm --cached` so future commits don't ship a divergent file.
+  if [ -f onboarding.yaml ] && [ ! -f "$SIBLING_ROOT/onboarding.yaml" ]; then
+    cp -p onboarding.yaml "$SIBLING_ROOT/onboarding.yaml"
+    git rm --cached onboarding.yaml >/dev/null 2>&1 || true
+  fi
+
+  # Move workspace entries (skip workspace/README.md per AgDR-0021 § G)
+  if [ -d workspace ] && [ "$(ls -A workspace 2>/dev/null)" ]; then
+    mkdir -p "$SIBLING_ROOT/workspace"
+    for entry in workspace/*; do
+      [ -e "$entry" ] || continue
+      name=$(basename "$entry")
+      [ "$name" = "README.md" ] && continue
+      if [ ! -e "$SIBLING_ROOT/workspace/$name" ]; then
+        mv "$entry" "$SIBLING_ROOT/workspace/$name"
+      fi
+    done
+  fi
+
+  # gitignore additions
+  NEEDS=()
+  grep -qxF onboarding.yaml .gitignore 2>/dev/null || NEEDS+=(onboarding.yaml)
+  grep -qxF workspace .gitignore 2>/dev/null || NEEDS+=(workspace)
+  if [ "${#NEEDS[@]}" -gt 0 ]; then
+    {
+      echo ""
+      echo "# Split-portfolio v2"
+      for n in "${NEEDS[@]}"; do echo "$n"; done
+    } >> .gitignore
+  fi
+
+  # v2 marker
+  if [ ! -f .apexyard-fork ]; then
+    echo "# v2 anchor" > .apexyard-fork
+  fi
+
+  # config-block additions
+  PCONFIG=.claude/project-config.json
+  TMP=$(mktemp)
+  jq --arg onb "$SIBLING_ROOT/onboarding.yaml" \
+     --arg ws  "$SIBLING_ROOT/workspace" \
+     '.portfolio.onboarding = (.portfolio.onboarding // $onb)
+      | .portfolio.workspace_dir = (.portfolio.workspace_dir // $ws)' \
+     "$PCONFIG" > "$TMP" && mv "$TMP" "$PCONFIG"
+)
+
+# Post-state assertions
+#
+# COPY-NOT-MOVE semantics (AgDR-0021 § H): both copies exist, contents are
+# identical, and the public-fork copy is untracked. The sibling copy is
+# canonical; the public-fork copy is left as a legacy ops-root walk-up
+# fallback / safety-net snapshot.
+[ -f "$SB/public/onboarding.yaml" ] \
+  && mark_pass "post-migration: onboarding.yaml snapshot retained in public fork (copy semantics)" \
+  || mark_fail "onboarding snapshot retained" "missing from public fork"
+
+[ -f "$SB/private/onboarding.yaml" ] \
+  && mark_pass "post-migration: onboarding.yaml landed in sibling repo (canonical)" \
+  || mark_fail "onboarding landed" "missing in sibling"
+
+if [ -f "$SB/public/onboarding.yaml" ] && [ -f "$SB/private/onboarding.yaml" ]; then
+  if cmp -s "$SB/public/onboarding.yaml" "$SB/private/onboarding.yaml"; then
+    mark_pass "post-migration: public-fork snapshot matches sibling-repo canonical"
+  else
+    mark_fail "snapshots identical" "public-fork and sibling-repo onboarding differ"
+  fi
+fi
+
+# Public-fork copy must be UNTRACKED so future commits don't ship a stale
+# divergent snapshot.
+if [ -z "$( cd "$SB/public" && git ls-files onboarding.yaml 2>/dev/null )" ]; then
+  mark_pass "post-migration: onboarding.yaml untracked in public fork (git rm --cached applied)"
+else
+  mark_fail "onboarding untracked" "still tracked in public fork"
+fi
+
+[ -f "$SB/public/.apexyard-fork" ] \
+  && mark_pass "post-migration: .apexyard-fork marker written" \
+  || mark_fail "marker written" ".apexyard-fork missing"
+
+ONB_KEY=$(jq -r '.portfolio.onboarding // empty' "$SB/public/.claude/project-config.json")
+WS_KEY=$(jq -r '.portfolio.workspace_dir // empty' "$SB/public/.claude/project-config.json")
+[ -n "$ONB_KEY" ] && [ -n "$WS_KEY" ] \
+  && mark_pass "post-migration: portfolio.{onboarding,workspace_dir} keys added" \
+  || mark_fail "config keys added" "onboarding=$ONB_KEY workspace_dir=$WS_KEY"
+
+# Re-detection: V2_NEEDED should now be 0 (migration already done)
+if detect_v2_needed "$SB/public"; then
+  mark_fail "post-migration detection" "V2_NEEDED=1 after migration (expected 0)"
+else
+  mark_pass "post-migration: V2_NEEDED=0 (idempotent — won't re-fire)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4: --dry-run on a pre-v2 split → V2_NEEDED=1 but no state change
+# ---------------------------------------------------------------------------
+echo "== Case 4: --dry-run on pre-v2 split → detection fires, no state change"
+SB="$TMP_ROOT/case4"
+build_pre_v2_split "$SB"
+
+if detect_v2_needed "$SB/public"; then
+  mark_pass "V2_NEEDED=1 on pre-v2 split under --dry-run"
+else
+  mark_fail "dry-run detection" "V2_NEEDED=0 (expected 1)"
+fi
+
+# Snapshot before the dry-run plan would print
+SNAP_BEFORE=$(snapshot_state "$SB/public")
+
+# Under --dry-run, SKILL.md § 8a says "print commands the migration would
+# run, do not execute, then continue to step 9". Simulate that — print
+# the plan to stdout (captured + discarded), perform NO file mutations.
+DRY_RUN_OUTPUT=$(
+  (
+    cd "$SB/public" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-read-config.sh
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-portfolio-paths.sh
+    SIBLING_ROOT=$(dirname "$(jq -r '.portfolio.registry' .claude/project-config.json)")
+    echo "would: mv onboarding.yaml $SIBLING_ROOT/onboarding.yaml"
+    echo "would: mv workspace/* into $SIBLING_ROOT/workspace/"
+    echo "would: echo '# v2 anchor' > .apexyard-fork"
+    echo "would: append v2 gitignore lines"
+    echo "would: jq add portfolio.{onboarding,workspace_dir} to project-config.json"
+  )
+)
+
+if printf '%s' "$DRY_RUN_OUTPUT" | grep -q "^would: mv onboarding.yaml"; then
+  mark_pass "--dry-run prints the migration plan"
+else
+  mark_fail "dry-run plan" "no 'would:' lines in output"
+fi
+
+# Critical: state must NOT have changed under --dry-run
+SNAP_AFTER=$(snapshot_state "$SB/public")
+if [ "$SNAP_BEFORE" = "$SNAP_AFTER" ]; then
+  mark_pass "--dry-run leaves fork state untouched (snapshots identical)"
+else
+  mark_fail "dry-run no state change" "snapshot changed under --dry-run"
+  printf 'BEFORE:\n%s\n\nAFTER:\n%s\n' "$SNAP_BEFORE" "$SNAP_AFTER" >&2
+fi
+
+# Step 8a says under --dry-run the skill continues to step 9 without
+# mutating — verify onboarding.yaml is still in the public fork AND has
+# NOT been copied into the sibling (no `cp` ran under --dry-run).
+[ -f "$SB/public/onboarding.yaml" ] \
+  && mark_pass "--dry-run: onboarding.yaml still in public fork (no cp ran)" \
+  || mark_fail "dry-run onboarding untouched" "file unexpectedly removed"
+
+[ ! -f "$SB/private/onboarding.yaml" ] \
+  && mark_pass "--dry-run: onboarding.yaml NOT copied into sibling repo" \
+  || mark_fail "dry-run no sibling copy" "sibling onboarding.yaml unexpectedly created"
+
+[ ! -f "$SB/public/.apexyard-fork" ] \
+  && mark_pass "--dry-run: .apexyard-fork marker NOT written" \
+  || mark_fail "dry-run marker untouched" "marker unexpectedly written"
+
+# ---------------------------------------------------------------------------
+# Coexistence with test_split_portfolio_v2_migration.sh
+# ---------------------------------------------------------------------------
+# This is a contract assertion, not a runtime check: this test focuses on
+# DETECTION (which cases trigger the migration); the sibling hooks test
+# focuses on MIGRATION BODY (the file moves + idempotence). Verify the
+# sibling test file still exists alongside this one — if a future PR
+# accidentally deletes it, this assertion catches the regression.
+SIBLING_TEST="$ROOT/.claude/hooks/tests/test_split_portfolio_v2_migration.sh"
+if [ -f "$SIBLING_TEST" ]; then
+  mark_pass "sibling test_split_portfolio_v2_migration.sh coexists (not replaced)"
+else
+  mark_fail "sibling test coexists" "$SIBLING_TEST is missing — was it removed?"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "===== test_step_8a_wiring.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:%b\n' "$FAILED_CASES"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **First regression coverage for `/setup`** — `.claude/skills/setup/tests/` lands with 3 sandbox tests pinning the file-state outcomes that the SKILL.md prescribes. Before this, the split-portfolio v2 setup branch (Step 2b) had **zero automated coverage** — a silent regression in the v2 config-block writes, `.apexyard-fork` marker, or gitignore additions would only surface when an adopter hit the failure in production. The v2 test alone makes 10 assertions across all 7 portfolio keys, marker preamble, gitignore exclusions, `portfolio_validate` happiness, `portfolio_is_v2` detection, and `resolve_ops_root` walk via the marker.
- **First wiring test for `/update` step 8a** — `.claude/skills/update/tests/test_step_8a_wiring.sh` pins the migration INVOCATION/DETECTION logic (which detection branches fire, which silently skip). Distinct from the existing `test_split_portfolio_v2_migration.sh` (which covers the migration BODY) — a regression in the `portfolio_is_v2` check or the `jq -e .portfolio.registry` guard would silently skip the migration for needy adopters OR re-trigger it for already-migrated ones; neither is caught by the body-only test.
- **Coexists with — does not replace — the existing migration test** — `test_split_portfolio_v2_migration.sh` (18/18 passing) continues to test the migration body; this PR adds the complementary wiring test. A coexistence contract assertion inside the new test catches any future PR that accidentally deletes the sibling.
- **Copy-not-move semantics inherited from PR #317** — Case 3's migration body uses `cp -p` + `git rm --cached` for `onboarding.yaml` (AgDR-0021 § H), matching the live SKILL.md spec; the test pins the new semantics in advance so any future regression flips both the body and wiring tests at the same time.
- **Follows the framework's existing test convention** — `set -u`, `mktemp -d` sandbox with trap-cleanup, `red()` / `green()` helpers, `mark_pass` / `mark_fail` with `PASS` / `FAIL` counters, per-case `==` banners, exit 0 on all-pass / 1 on any fail. Tests sandbox-build a synthetic fork + sibling private repo, source the libs from the sandbox's own `.claude/hooks/` copy (hermetic — no live-fork state leakage), and call `portfolio_clear_cache` between fixtures so detection state doesn't bleed.

## Testing

```
$ bash .claude/skills/setup/tests/test_setup_split_portfolio_v2.sh
Passed: 10  Failed: 0

$ bash .claude/skills/setup/tests/test_setup_single_fork.sh
Passed: 7   Failed: 0

$ bash .claude/skills/setup/tests/test_setup_reset.sh
Passed: 6   Failed: 0

$ bash .claude/skills/update/tests/test_step_8a_wiring.sh
Passed: 18  Failed: 0

$ bash .claude/hooks/tests/test_split_portfolio_v2_migration.sh   # sibling — no regression
Passed: 18  Failed: 0
```

Aggregate: **59 new + sibling assertions passing, 0 failing**. My own diff is 5 files / 1248 insertions, all under `.claude/skills/{setup,update}/tests/` — no skills added (count stays at 53), no hooks, no rules, no architecture changes. The AgDR-required architecture paths the hook flagged are pre-existing commits on `dev` ahead of `main` from prior framework work (PRs #346, #344, etc.) — they each carried their own AgDRs at the time they were authored.

Closes #318
Closes #319

## Glossary

| Term | Definition |
|------|------------|
| Sandbox-based test | A bash test that builds a synthetic fork + sibling private repo under `mktemp -d`, runs the SKILL.md file-state actions against it, then asserts the post-state. Hermetic — no live-fork mutation, libs are copied into the sandbox so changes to the live `_lib-portfolio-paths.sh` propagate only on the next test invocation. |
| Detection branch | One of the four conditions step 8a checks to decide whether the v1→v2 migration should fire: v2 already, single-fork (no portfolio block), pre-v2 split (portfolio block present but no `.apexyard-fork` marker), `--dry-run` mode. |
| v1→v2 migration | The split-portfolio refactor introduced in framework #242: `onboarding.yaml` + `workspace/` move from the public fork to the private sibling repo, `.apexyard-fork` marker takes over as the ops-fork anchor, two new keys (`portfolio.onboarding`, `portfolio.workspace_dir`) join the existing config block. |
| `portfolio_clear_cache` | Resets the per-process caches in `_lib-portfolio-paths.sh` (root, registry, projects_dir, ideas_backlog, onboarding, workspace_dir, custom_skills_dir, custom_handbooks_dir). Used by tests so detection state from one fixture doesn't bleed into the next. |
| Copy-not-move semantics | AgDR-0021 § H refinement (landed in PR #317): the migration body `cp -p`s `onboarding.yaml` to the sibling instead of `mv`-ing, then `git rm --cached`s the public-fork copy so it can't drift into commits. The sibling becomes canonical; the public-fork snapshot is left on disk as a legacy ops-root walk-up fallback / safety-net. |

<!-- agdr: not-applicable -->

<!-- multi-close: approved -->
