### PR TITLE
docs(#336): align docs/multi-project.md v1→v2 manual recipe with AgDR-0021 § H copy-onboarding semantics

### DIFF
--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -530,18 +530,22 @@ AND workspace/ to the private sibling repo too, so the public fork holds
 ONLY framework files + your customisations to skills/hooks/rules.
 
 Migrate now? This will:
-  - Move onboarding.yaml to the sibling private repo
+  - Copy onboarding.yaml to the sibling private repo (sibling becomes canonical;
+    public fork keeps a gitignored snapshot for legacy tooling)
   - Move workspace/<name>/ contents to the sibling private repo
   - Add gitignore entries for both in the public fork
   - Write a .apexyard-fork marker (the v2 ops-fork anchor)
   - Add portfolio.{onboarding,workspace_dir} keys to .claude/project-config.json
 
-Files MOVED, not copied — destructive. Idempotent — if interrupted, re-run.
+Per-file-class semantics: onboarding.yaml is COPIED (small text file, sibling is
+the canonical source of truth); workspace/ is MOVED (size constraint — clones
+are potentially gigabytes, doubling disk usage makes no sense). Idempotent — if
+interrupted, re-run. Per AgDR-0021 § H.
 
 [Y / n / dry-run — show commands, don't execute]
 ```
 
-The migration is **per-file-class confirmable** (move `onboarding.yaml`? Y/N; move `workspace/`? Y/N), so you can defer one and migrate the other. It's also **idempotent** — if you re-run `/update` later, the migration is a no-op.
+The migration is **per-file-class confirmable** (copy `onboarding.yaml`? Y/N; move `workspace/`? Y/N), so you can defer one and migrate the other. It's also **idempotent** — if you re-run `/update` later, the migration is a no-op. The mixed copy / move semantics are deliberate — see [AgDR-0021 § H](agdr/AgDR-0021-split-portfolio-v2-path-resolution.md) for the rationale (small text files like `onboarding.yaml` benefit from a public-fork snapshot for legacy tooling; large directories like `workspace/` would waste disk if duplicated).
 
 `/update --dry-run` walks through the migration steps without executing them, useful for previewing what would change.
 
@@ -559,15 +563,20 @@ git add onboarding.yaml workspace
 git commit -m "chore: receive onboarding + workspace from public fork (split-portfolio v2)"
 ```
 
-**What if you want to migrate by hand?** Run the same steps the `/update` skill runs:
+**What if you want to migrate by hand?** Run the same steps the `/update` skill runs (per AgDR-0021 § H — `onboarding.yaml` uses **copy** semantics, `workspace/` uses **move**):
 
 ```bash
 cd ~/ops/apexyard
 
 SIBLING=../apexyard-portfolio   # adjust to your sibling-dir name
 
-# Move the two file classes
-mv onboarding.yaml "$SIBLING/onboarding.yaml"
+# Copy onboarding.yaml — sibling becomes canonical source of truth; public
+# fork keeps a gitignored snapshot for legacy tooling (per AgDR-0021 § H).
+cp -p onboarding.yaml "$SIBLING/onboarding.yaml"
+git rm --cached onboarding.yaml 2>/dev/null || true
+
+# Move workspace/<name>/ contents — size constraint (clones are potentially
+# gigabytes; duplicating wastes disk).
 mkdir -p "$SIBLING/workspace"
 for entry in workspace/*; do
   [ -e "$entry" ] || continue
@@ -576,7 +585,8 @@ for entry in workspace/*; do
   mv "$entry" "$SIBLING/workspace/$name"
 done
 
-# Update .gitignore in the public fork
+# Update .gitignore in the public fork (must include onboarding.yaml so the
+# kept-but-gitignored snapshot doesn't get committed alongside customisations).
 cat >> .gitignore <<'IGNORE'
 
 # Split-portfolio v2 (framework ≥ #242)


### PR DESCRIPTION
## Summary

- **Realigns the v1→v2 migration manual recipe with AgDR-0021 § H copy-semantics** — PR #335 changed `onboarding.yaml` from `mv` to `cp -p` + `git rm --cached` + gitignore add (sibling becomes canonical; public fork keeps a gitignored snapshot). The framework spec landed aligned in #335; this doc was deliberately deferred to keep that PR tight. Every adopter following the by-hand recipe between #335 landing and today would get the older `mv` shape and end up with a different state than the `/update` skill produces. This PR closes that drift.
- **3 specific places fixed**: the `/update` example prompt (line 533), the per-file-class confirmation prose (line 544), the by-hand recipe `cp -p` + `git rm --cached` block (line 562). Each carries an inline reference to AgDR-0021 § H so future-readers see the rationale (`onboarding.yaml` is small + sibling-canonical + snapshot-friendly; `workspace/` is too big to duplicate, hence `mv`).
- **High-level intent paragraphs unchanged** (lines 180, 528) — they use "moves" as conceptual language describing v2 layout intent, with copy/move semantics specified immediately below. Reading the section as a whole, no ambiguity. Targeted edits only.
- **Non-blocking follow-up from Rex's review of #335** — Rex spotted the stale prose during #335 review and suggested a docs follow-up; the operator filed #336 then so #335 could merge tight, this PR closes the loop.

## Testing

- `npx markdownlint-cli2@0.13.0 docs/multi-project.md` → 0 errors
- `grep -n -i "mv.*onboarding\.yaml" docs/multi-project.md` → 0 matches (only acceptable form is `cp -p` now)
- Manual diff-read: 24 lines changed, all in the v1→v2 migration section
- AgDR-0021 § H content unchanged (this PR is doc-only)

Closes #336

## Glossary

| Term | Definition |
|------|------------|
| Copy semantics (onboarding.yaml) | `cp -p` to sibling + `git rm --cached` in public fork + add to `.gitignore`. Sibling holds canonical source of truth; public fork keeps a gitignored snapshot for legacy tooling |
| Move semantics (workspace/) | `mv` to sibling. Size constraint — clones are potentially gigabytes; duplicating them would waste disk |
| Per-file-class confirmable | `/update` asks Y/N per file class (copy onboarding? Y/N; move workspace? Y/N), so operator can defer one and migrate the other |
| Manual fallback recipe | The "migrate by hand" prose for adopters on framework versions that predate `/update`'s automatic v1→v2 step 8a. Should match AgDR-0021 § H |
| AgDR-0021 § H | Source-of-truth section for v1→v2 migration per-file-class semantics, landed via PR #335 |
| v2 ops-fork anchor | The `.apexyard-fork` marker file at the public-fork root — replaces the legacy `onboarding.yaml + apexyard.projects.yaml` pair for v2 detection |

Refs #335 (the spec landing that this doc PR now matches) / Rex review suggestion #1 on #335

**AgDR not applicable.** Doc-only PR. The trigger-path files the hook flags (`topologies/*`, `.github/workflows/extract-subpacks-on-release.yml`) all landed via already-merged PRs #346 + #344 and are NOT touched by this PR. The diff-vs-main reports them; the actual diff-vs-dev is the single-file `docs/multi-project.md` change shown above. No new architecture decision; the underlying call lives in AgDR-0021 § H (referenced in the body).

<!-- agdr: not-applicable -->
