### PR TITLE
feat(#351): agent-routing.yaml schema + portfolio_agent_routing resolver (Wave 1 PR 1)

### DIFF
--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -15,6 +15,7 @@
 #   ideas_backlog=$(portfolio_ideas_backlog)
 #   onboarding=$(portfolio_onboarding_path)         # framework ≥ #242
 #   workspace_dir=$(portfolio_workspace_dir)        # framework ≥ #242
+#   agent_routing=$(portfolio_agent_routing)        # framework ≥ #351
 #   portfolio_validate || echo "broken: $(portfolio_validate)"
 #
 # All resolvers output absolute paths. Relative config values resolve
@@ -38,6 +39,7 @@
 #   workspace_dir → ./workspace
 #   custom_skills_dir    → ./custom-skills      (split-portfolio v2 + #243)
 #   custom_handbooks_dir → ./custom-handbooks   (split-portfolio v2 + #243)
+#   agent_routing → ./agent-routing.yaml        (#351, may not exist)
 #
 # Caching: results cached per-process in shell vars to avoid repeat jq
 # calls. Same pattern as _CONFIG_CACHE in _lib-read-config.sh.
@@ -261,6 +263,44 @@ portfolio_custom_handbooks_dir() {
 }
 
 # ------------------------------------------------------------------------------
+# Public: portfolio_agent_routing
+#   Resolves the path to the adopter's agent-routing.yaml — the
+#   centralised per-agent model + endpoint override surface (AgDR-0050
+#   Axis 3, ticket #351).
+#
+#   Split-portfolio (v2) mode: the file lives in the sibling private
+#   repo and is resolved via .portfolio.agent_routing in
+#   .claude/project-config.json (e.g.
+#   ../<fork>-portfolio/agent-routing.yaml).
+#
+#   Single-fork mode: the file lives at the fork root and is gitignored
+#   (adopter-specific routing choices stay local; never leak to the
+#   public fork). The default resolves to ./agent-routing.yaml relative
+#   to the ops-fork root.
+#
+#   Unlike the other portfolio resolvers, this one is allowed to point
+#   at a non-existent file — the absence of agent-routing.yaml means
+#   "no overrides; framework defaults apply", which is the documented
+#   out-of-box behaviour. Callers that need "exists or empty" should
+#   test [ -f "$(portfolio_agent_routing)" ] themselves.
+#
+#   Returns: absolute path to agent-routing.yaml (may not exist yet).
+#
+#   Default: ./agent-routing.yaml (relative to ops-fork root)
+# ------------------------------------------------------------------------------
+_PORTFOLIO_AGENT_ROUTING_CACHE=""
+portfolio_agent_routing() {
+  if [ -n "$_PORTFOLIO_AGENT_ROUTING_CACHE" ]; then
+    echo "$_PORTFOLIO_AGENT_ROUTING_CACHE"
+    return 0
+  fi
+  local raw
+  raw=$(_portfolio_get '.portfolio.agent_routing' './agent-routing.yaml')
+  _PORTFOLIO_AGENT_ROUTING_CACHE=$(_portfolio_resolve "$raw")
+  echo "$_PORTFOLIO_AGENT_ROUTING_CACHE"
+}
+
+# ------------------------------------------------------------------------------
 # Public: portfolio_validate
 #   Sanity-check that resolved paths are actually usable.
 #   On success: prints nothing, returns 0.
@@ -386,6 +426,7 @@ portfolio_clear_cache() {
   _PORTFOLIO_WORKSPACE_DIR_CACHE=""
   _PORTFOLIO_CUSTOM_SKILLS_DIR_CACHE=""
   _PORTFOLIO_CUSTOM_HANDBOOKS_DIR_CACHE=""
+  _PORTFOLIO_AGENT_ROUTING_CACHE=""
 }
 
 # ------------------------------------------------------------------------------

--- a/.claude/hooks/tests/test_portfolio_agent_routing.sh
+++ b/.claude/hooks/tests/test_portfolio_agent_routing.sh
@@ -1,0 +1,304 @@
+#!/bin/bash
+# Smoke tests for portfolio_agent_routing in
+# .claude/hooks/_lib-portfolio-paths.sh + the schema validity of the
+# shipped agent-routing.yaml.example.
+#
+# Coverage (per ticket #351, AgDR-0050 Axis 3):
+#   1. Default (no config, no file) resolves to ./agent-routing.yaml
+#      at the fork root — empty/non-existent file is tolerated by the
+#      resolver (unlike the registry, which must exist).
+#   2. Single-fork mode: a fork-root agent-routing.yaml resolves to
+#      the absolute fork-root path.
+#   3. Split-portfolio v2 mode: explicit override pointing at the
+#      sibling private repo's agent-routing.yaml resolves correctly.
+#   4. Relative override resolves against the fork root.
+#   5. portfolio_clear_cache resets the cached value.
+#   6. The shipped agent-routing.yaml.example parses as valid YAML
+#      (when yq is available; minimal grep check otherwise).
+#
+# Each case builds an isolated sandbox apexyard fork under $TMPDIR and
+# sources the helper + asserts behaviour.
+#
+# Exit 0 means all cases passed. Exit 1 on first failure.
+
+set -u
+
+LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-portfolio-paths.sh"
+CONFIG_LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-read-config.sh"
+DEFAULTS_SRC="$(cd "$(dirname "$0")/../.." && pwd)/project-config.defaults.json"
+EXAMPLE_SRC="$(cd "$(dirname "$0")/../../.." && pwd)/agent-routing.yaml.example"
+
+if [ ! -f "$LIB_SRC" ]; then
+  echo "FAIL: helper not found at $LIB_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$CONFIG_LIB_SRC" ]; then
+  echo "FAIL: config lib not found at $CONFIG_LIB_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$DEFAULTS_SRC" ]; then
+  echo "FAIL: defaults file not found at $DEFAULTS_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$EXAMPLE_SRC" ]; then
+  echo "FAIL: example file not found at $EXAMPLE_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# make_fork: build an isolated apexyard fork sandbox with the hook lib +
+# shared config lib + defaults file + minimal registry / projects_dir.
+# Returns the sandbox path on stdout.
+# ---------------------------------------------------------------------------
+make_fork() {
+  local sb
+  sb=$(mktemp -d)
+  # Canonicalize for macOS — same shape as test_portfolio_paths.sh.
+  sb=$(cd "$sb" && pwd -P)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+
+    # Required marker files for "this is an apexyard fork"
+    touch onboarding.yaml
+    cat > apexyard.projects.yaml <<'YAML'
+version: 1
+projects:
+  - name: example
+    repo: example/example
+YAML
+
+    mkdir -p projects
+    cat > projects/ideas-backlog.md <<'MD'
+# Ideas Backlog
+MD
+
+    mkdir -p .claude/hooks
+    cp "$LIB_SRC" .claude/hooks/_lib-portfolio-paths.sh
+    cp "$CONFIG_LIB_SRC" .claude/hooks/_lib-read-config.sh
+    cp "$DEFAULTS_SRC" .claude/project-config.defaults.json
+
+    git add -A
+    git commit -q -m "test fixture"
+  )
+  echo "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# run_case <name> <sandbox> <bash-snippet>: source the libs in a fresh
+# subshell rooted at <sandbox> and run the snippet. The snippet asserts
+# behaviour + exits 0 on pass, non-zero on fail.
+# ---------------------------------------------------------------------------
+run_case() {
+  local name="$1"
+  local sb="$2"
+  local snippet="$3"
+  local out rc
+
+  out=$(
+    cd "$sb" || exit 99
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-read-config.sh
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-portfolio-paths.sh
+    portfolio_clear_cache
+    eval "$snippet"
+  )
+  rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    PASS=$((PASS + 1))
+    green "PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  - $name"
+    red "FAIL: $name"
+    if [ -n "$out" ]; then
+      echo "  output: $out"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: default — resolver returns ./agent-routing.yaml at the fork
+# root even when the file does NOT exist (caller-tolerant of absence).
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+run_case "default: agent_routing resolves to fork-rooted absolute path (file absent)" "$SB" '
+r=$(portfolio_agent_routing)
+expected="'"$SB"'/agent-routing.yaml"
+if [ "$r" = "$expected" ]; then
+  # Absent is OK for this resolver — verify the path does not exist yet.
+  if [ ! -f "$r" ]; then
+    exit 0
+  else
+    echo "expected absent file at $r"
+    exit 1
+  fi
+else
+  echo "got=$r expected=$expected"
+  exit 1
+fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 2: single-fork mode — agent-routing.yaml at fork root.
+# Resolver returns the absolute path; the file exists.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents: {}
+YAML
+run_case "single-fork: agent-routing.yaml at fork root resolves + exists" "$SB" '
+r=$(portfolio_agent_routing)
+expected="'"$SB"'/agent-routing.yaml"
+if [ "$r" = "$expected" ] && [ -f "$r" ]; then
+  exit 0
+else
+  echo "got=$r expected=$expected exists=$([ -f "$r" ] && echo y || echo n)"
+  exit 1
+fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 3: split-portfolio v2 — explicit override in project-config.json
+# points at the sibling private repo's agent-routing.yaml.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+cat > "$SIB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  qa-engineer:
+    model: sonnet
+YAML
+cat > "$SB/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "agent_routing": "$SIB/agent-routing.yaml"
+  }
+}
+JSON
+run_case "split-portfolio v2: agent_routing override → sibling repo path" "$SB" '
+r=$(portfolio_agent_routing)
+expected="'"$SIB"'/agent-routing.yaml"
+if [ "$r" = "$expected" ] && [ -f "$r" ]; then
+  exit 0
+else
+  echo "got=$r expected=$expected exists=$([ -f "$r" ] && echo y || echo n)"
+  exit 1
+fi
+'
+rm -rf "$SB" "$SIB"
+
+# ---------------------------------------------------------------------------
+# Case 4: relative override resolves against fork root (same shape as the
+# other portfolio resolvers — see test_portfolio_paths.sh Case 3).
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+mkdir -p "$SB/config"
+cat > "$SB/config/agent-routing.yaml" <<'YAML'
+version: 1
+agents: {}
+YAML
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{
+  "portfolio": {
+    "agent_routing": "./config/agent-routing.yaml"
+  }
+}
+JSON
+run_case "relative-override: agent_routing resolves against fork root" "$SB" '
+r=$(portfolio_agent_routing)
+expected="'"$SB"'/config/agent-routing.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 5: portfolio_clear_cache resets the agent_routing cache.
+# Same shape as the existing clear_cache case in test_portfolio_paths.sh.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+run_case "cache: clear_cache resets agent_routing resolver state" "$SB" '
+inner=$(
+  source .claude/hooks/_lib-read-config.sh
+  source .claude/hooks/_lib-portfolio-paths.sh
+  portfolio_clear_cache
+  portfolio_agent_routing >/dev/null   # populates cache
+  cat > .claude/project-config.json <<JSON
+{"portfolio": {"agent_routing": "/elsewhere/agent-routing.yaml"}}
+JSON
+  portfolio_clear_cache
+  _CONFIG_CACHE=""
+  portfolio_agent_routing
+)
+case "$inner" in
+  "/elsewhere/agent-routing.yaml") exit 0 ;;
+esac
+echo "expected /elsewhere/agent-routing.yaml after clear_cache; got: $inner"
+exit 1
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 6: the shipped agent-routing.yaml.example parses as valid YAML
+# (and is on disk). With yq available we run a full parse; without yq we
+# fall back to a minimal grep check for the required top-level keys.
+# ---------------------------------------------------------------------------
+if command -v yq >/dev/null 2>&1; then
+  if yq eval '.' "$EXAMPLE_SRC" >/dev/null 2>&1; then
+    PASS=$((PASS + 1))
+    green "PASS: agent-routing.yaml.example parses as valid YAML (yq)"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  - agent-routing.yaml.example parses as valid YAML (yq)"
+    red "FAIL: agent-routing.yaml.example does not parse as valid YAML"
+  fi
+  # Confirm the documented top-level keys are present.
+  has_version=$(yq eval 'has("version")' "$EXAMPLE_SRC" 2>/dev/null)
+  has_agents=$(yq eval 'has("agents")'  "$EXAMPLE_SRC" 2>/dev/null)
+  if [ "$has_version" = "true" ] && [ "$has_agents" = "true" ]; then
+    PASS=$((PASS + 1))
+    green "PASS: agent-routing.yaml.example has 'version' and 'agents' top-level keys"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  - agent-routing.yaml.example missing top-level keys"
+    red "FAIL: agent-routing.yaml.example missing top-level keys (version=$has_version agents=$has_agents)"
+  fi
+else
+  if grep -q '^version:' "$EXAMPLE_SRC" && grep -q '^agents:' "$EXAMPLE_SRC"; then
+    PASS=$((PASS + 1))
+    green "PASS: agent-routing.yaml.example has 'version:' and 'agents:' (grep fallback; yq not installed)"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  - agent-routing.yaml.example schema check (grep)"
+    red "FAIL: agent-routing.yaml.example missing 'version:' or 'agents:' top-level key"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "===== test_portfolio_agent_routing.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed cases:$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@
 workspace/*/
 !workspace/README.md
 
+# Adopter-specific agent routing (single-fork mode; split-portfolio mode
+# keeps this in the private repo). See docs/multi-project.md § "Centralised
+# agent routing" and docs/agdr/AgDR-0050-agent-runtime-overhaul.md.
+/agent-routing.yaml
+
 # Backups of framework skills that were overridden by an adopter's
 # private custom skill (link-custom-skills.sh moves the framework version
 # aside as <skill-name>.framework.bak so the symlink can take its place).

--- a/agent-routing.yaml.example
+++ b/agent-routing.yaml.example
@@ -1,0 +1,151 @@
+# =============================================================================
+# ApexYard agent-routing config — adopter's per-agent model + endpoint overrides
+# =============================================================================
+#
+# This file is the **adopter customisation surface** for ApexYard's 24
+# Claude Code sub-agents (19 role-derived personas + 5 utility agents).
+# It lets you override the framework's shipped per-agent model defaults
+# (e.g. switch the QA Engineer from Haiku to Sonnet, or route the Data
+# Analyst through a local Ollama endpoint) in ONE central file kept in
+# your private portfolio repo.
+#
+# See docs/agdr/AgDR-0050-agent-runtime-overhaul.md § Axis 3 for the
+# design and docs/multi-project.md § "Centralised agent routing" for
+# the adopter setup guide.
+#
+# -----------------------------------------------------------------------------
+# File location
+# -----------------------------------------------------------------------------
+#
+#   Split-portfolio (v2): <private_repo>/agent-routing.yaml
+#                         (committed to your private sibling repo;
+#                         resolved via .portfolio.agent_routing in
+#                         .claude/project-config.json)
+#
+#   Single-fork:          <fork>/agent-routing.yaml
+#                         (gitignored — adopter-specific routing
+#                         choices stay local to the machine)
+#
+# Rename this file from `.example` to `agent-routing.yaml` at the
+# resolved location once you've filled it in.
+#
+# -----------------------------------------------------------------------------
+# Semantics
+# -----------------------------------------------------------------------------
+#
+# - An empty `agents: {}` block is identical to "no file" — the public
+#   fork ships with framework default models that work out-of-box.
+# - Omitted agents inherit the framework default from
+#   .claude/agents/<name>.md frontmatter.
+# - At SessionStart, the sync hook (ships in PR 2) rewrites the affected
+#   .claude/agents/*.md frontmatter in-place. Pre-commit + pre-push
+#   guards (PR 2) catch accidental commits of the rewritten frontmatter
+#   so adopter routing choices never leak to the public fork.
+#
+# Until PR 2 lands, authoring this file is documented but inert — the
+# YAML is parsed by the schema validator and `portfolio_agent_routing`
+# resolver, but no hook applies it yet.
+#
+
+# Schema version. Bump if breaking changes are introduced.
+version: 1
+
+# -----------------------------------------------------------------------------
+# Agents
+# -----------------------------------------------------------------------------
+# Map of agent name → override entry. Agent names match the filename
+# (without `.md`) under .claude/agents/, e.g. `qa-engineer`, `tech-lead`,
+# `code-reviewer`, `backend-engineer`.
+#
+# Per-entry fields:
+#
+#   model                  REQUIRED for an override entry. The model
+#                          specifier (e.g. `opus`, `sonnet`, `haiku`,
+#                          `ollama/qwen2.5-coder:14b`, or
+#                          `bedrock/anthropic.claude-opus-4-7`).
+#
+#   endpoint               OPTIONAL. URL of an alternative inference
+#                          endpoint (e.g. a LiteLLM proxy fronting
+#                          Ollama). At SessionStart the sync hook sets
+#                          ANTHROPIC_BASE_URL to this value so Claude
+#                          Code routes the agent's invocations through
+#                          the proxy. v1 is session-scoped — all agents
+#                          on a session share the endpoint. Per-agent
+#                          invocation env scoping is deferred to v2.
+#                          The specific local-model entries (Ollama
+#                          recommendations) are gated on the #348
+#                          feasibility spike and ship in #351 PR 4.
+#
+#   env                    OPTIONAL. Map of environment variables set
+#                          for the agent's invocations. Supports
+#                          $VAR_NAME refs to the parent shell's env.
+#
+#   timeout_seconds        OPTIONAL. Override the framework default
+#                          invocation timeout for this agent.
+#
+#   allowed_tools_override OPTIONAL (advanced). YAML list of tool names
+#                          that replaces the agent's shipped
+#                          allowed-tools list. Default = keep the
+#                          shipped list. Use sparingly — the shipped
+#                          list is curated per agent.
+
+agents: {}
+
+# -----------------------------------------------------------------------------
+# Examples (commented — copy + edit one of these to override an agent)
+# -----------------------------------------------------------------------------
+#
+# Example A — single-agent model override (remote Claude API):
+#
+#   agents:
+#     qa-engineer:
+#       model: sonnet            # framework default is haiku; override
+#                                # to sonnet for a higher-recall AC run
+#
+# Example B — multiple model overrides:
+#
+#   agents:
+#     tech-lead:
+#       model: opus              # framework default; rarely overridden
+#     backend-engineer:
+#       model: sonnet            # framework default; explicit pin
+#     data-analyst:
+#       model: sonnet            # bump from haiku for richer SQL output
+#
+# Example C — local routing via LiteLLM proxy + Ollama:
+#
+#   agents:
+#     ticket-manager:
+#       model: ollama/qwen2.5-coder:14b
+#       endpoint: http://localhost:11434  # LiteLLM proxy
+#     data-analyst:
+#       model: ollama/llama3.1:8b
+#       endpoint: http://localhost:11434
+#
+# Example D — Bedrock / Vertex routing with env vars:
+#
+#   agents:
+#     security-auditor:
+#       model: bedrock/anthropic.claude-opus-4-7
+#       env:
+#         AWS_REGION: eu-west-2
+#         AWS_PROFILE: $APEXYARD_AWS_PROFILE
+#
+# Example E — invocation timeout override:
+#
+#   agents:
+#     pen-tester:
+#       model: opus
+#       timeout_seconds: 180     # framework default is 60s; allow
+#                                # deeper adversarial exploration
+#
+# Example F — advanced: tool-list override (use sparingly):
+#
+#   agents:
+#     qa-engineer:
+#       model: haiku
+#       allowed_tools_override:
+#         - Read
+#         - Grep
+#         - Glob
+#         - Bash

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -511,6 +511,88 @@ Next code review, Rex globs both `handbooks/architecture/*.md` AND `<private>/cu
 - **A `/custom-skill` authoring helper.** Manual `cp framework-skill custom-skills/...` + edit is fine for v1.
 - **Multi-version handbook conflict resolution.** Operator's prose responsibility.
 
+### Centralised agent routing — `agent-routing.yaml`
+
+ApexYard ships 24 Claude Code sub-agents (19 role-derived personas + 5 utility agents — Rex, Hatim, Munir, Tariq, Idris). The framework picks sensible per-agent model defaults from the matrix in [AgDR-0050 § Axis 2](agdr/AgDR-0050-agent-runtime-overhaul.md) (Opus for depth + reasoning, Sonnet for the majority + tool-use-heavy, Haiku for checklist-shaped repeatable work). Adopters override those defaults — switch the QA Engineer to Sonnet for higher-recall AC runs, route the Data Analyst through a local Ollama endpoint, raise the Pen Tester's invocation timeout — via a single YAML file kept in the private portfolio repo.
+
+This sibling pattern to **Custom templates** (path-mirroring overrides; see AgDR-0023) and **Custom skills + handbooks** above puts every adopter-specific routing choice in one centrally-edited surface, source-controlled in the private repo, never leaking to the public fork.
+
+#### File location
+
+| Mode | Path | Visibility |
+| --- | --- | --- |
+| **Split-portfolio (v2)** | `<private_repo>/agent-routing.yaml` | Private — committed to the sibling repo, resolved via `.portfolio.agent_routing` in `.claude/project-config.json` |
+| **Single-fork** | `<fork>/agent-routing.yaml` | Local — gitignored by the framework (`/agent-routing.yaml` in `.gitignore`), never pushed to the public fork |
+
+Seed from the framework example:
+
+```bash
+# Split-portfolio:
+cp ~/ops/apexyard/agent-routing.yaml.example ~/ops/apexyard-portfolio/agent-routing.yaml
+
+# Single-fork:
+cp ~/ops/apexyard/agent-routing.yaml.example ~/ops/apexyard/agent-routing.yaml
+```
+
+Edit the file; the schema is self-documented inside the example. An empty `agents: {}` block is identical to "no file" — adopters get framework defaults out-of-box.
+
+#### Schema (per-entry fields)
+
+The full reference lives in [`agent-routing.yaml.example`](../agent-routing.yaml.example). One-line summary per field:
+
+| Field | Required? | Purpose |
+| --- | --- | --- |
+| `model` | yes (for an override entry) | Model specifier — `opus` / `sonnet` / `haiku` / `ollama/<spec>` / `bedrock/<spec>` |
+| `endpoint` | no | Alternative inference endpoint (e.g. LiteLLM proxy URL); session-scoped — sets `ANTHROPIC_BASE_URL` at SessionStart |
+| `env` | no | Map of environment variables for the agent's invocations; supports `$VAR_NAME` refs |
+| `timeout_seconds` | no | Override the framework default invocation timeout |
+| `allowed_tools_override` | no (advanced) | Replace the agent's shipped `allowed-tools` list — use sparingly |
+
+Worked examples (single-agent override, multiple overrides, local routing via Ollama + LiteLLM, Bedrock with AWS env, timeout override) are in the example file.
+
+#### Config-block wiring (split-portfolio v2)
+
+Add the `agent_routing` key to your existing `portfolio:` block alongside the v2 + #243 keys:
+
+```json
+{
+  "portfolio": {
+    "registry":             "../apexyard-portfolio/apexyard.projects.yaml",
+    "projects_dir":         "../apexyard-portfolio/projects",
+    "ideas_backlog":        "../apexyard-portfolio/projects/ideas-backlog.md",
+    "onboarding":           "../apexyard-portfolio/onboarding.yaml",
+    "workspace_dir":        "../apexyard-portfolio/workspace",
+    "custom_skills_dir":    "../apexyard-portfolio/custom-skills",
+    "custom_handbooks_dir": "../apexyard-portfolio/custom-handbooks",
+    "agent_routing":        "../apexyard-portfolio/agent-routing.yaml"
+  }
+}
+```
+
+The key is optional — the default resolves to `./agent-routing.yaml` against the ops-fork root. Single-fork adopters can leave it unset and just keep `agent-routing.yaml` at the fork root (gitignored).
+
+The `_lib-portfolio-paths.sh` helper exposes the resolver as `portfolio_agent_routing` (mirrors the shape of `portfolio_registry`, `portfolio_onboarding_path`, etc.); the SessionStart sync hook (see below) uses it to find the file.
+
+#### Status — Wave 1 PR 1 (this PR)
+
+This PR ships the **schema + resolver + adopter docs** only. Until the sync hook lands in **#351 PR 2**, the YAML file is documented but inert — `portfolio_agent_routing` resolves the path and the schema example parses cleanly, but no hook applies the overrides to `.claude/agents/*.md` frontmatter yet.
+
+#### What ships next
+
+- **#351 PR 2** — `apply-agent-routing.sh` SessionStart hook that reads `agent-routing.yaml` and rewrites the affected `.claude/agents/*.md` frontmatter in-place. Pre-commit + pre-push **drift-prevention guards** block accidental commits of the rewritten frontmatter so adopter routing choices never leak to the public fork. Per AgDR-0050 § Axis 4.
+- **#351 PR 3** — `/setup` integration. Split-portfolio adopters get the YAML seeded in the private repo; single-fork adopters get `agent-routing.yaml` gitignored automatically.
+- **#351 PR 4** — local-routing entries (Ollama endpoints) in the seeded template, gated on the **#348** feasibility spike's verdict. If the spike promotes, specific local-model entries land in the example; if it discards, the `endpoint:` field stays in the schema for adopter-author override only.
+
+#### Out of scope (v1)
+
+- **Mixed remote + local routing on one session.** v1 is single-endpoint per session — all agents on a session share the configured `ANTHROPIC_BASE_URL` or none do. Per-agent invocation env scoping is deferred to v2 (AgDR-0050 § Axis 5 + Risks).
+- **Per-task / per-invocation model overrides.** `claude --model <m>` already exists for one-off use; this file is the persistent surface.
+- **A web UI / CLI for editing the routing config.** Adopters edit YAML.
+- **Auto-detection of local endpoints.** Adopters declare them.
+- **Cost dashboards / per-agent usage tracking.** Separate concern; file if needed once running data exists.
+
+Design rationale: [AgDR-0050](agdr/AgDR-0050-agent-runtime-overhaul.md) (axes 3-5). Prior-art for the "adopter customisation layer in the private repo" pattern: [AgDR-0023 — custom-templates override semantics](agdr/AgDR-0023-custom-templates-override-semantics.md). Prior-art for the SessionStart-driven file rewrites that PR 2 will use: [AgDR-0041](agdr/AgDR-0041-sessionstart-v2-anchor-sweep.md).
+
 ### Migrating from split-portfolio v1 to v2
 
 If you adopted split-portfolio mode before framework #242, your fork is on the v1 layout: `apexyard.projects.yaml` and `projects/` resolve to the sibling private repo (good), but `onboarding.yaml` and `workspace/` are still in the public fork. The v2 migration moves both to the private repo too, and writes the new `.apexyard-fork` anchor.


### PR DESCRIPTION
## Summary

- **Adds `agent-routing.yaml.example`** at the framework root — the schema spec for the centralised per-agent model + endpoint override surface (AgDR-0050 Axis 3). Documents required + optional fields (`model`, `endpoint`, `env`, `timeout_seconds`, `allowed_tools_override`) with worked examples (single-agent override, multiple overrides, local routing via Ollama + LiteLLM, Bedrock + AWS env, timeout bump). Empty `agents: {}` block is identical to "no file" — adopters get framework defaults out-of-box.
- **Adds `portfolio_agent_routing` resolver** to `_lib-portfolio-paths.sh` — mirrors the existing `portfolio_registry` / `portfolio_onboarding_path` shape (cache var, default fallback via `_portfolio_get`, absolute-path output via `_portfolio_resolve`). Caller-tolerant of a non-existent file: absence means "framework defaults apply", which is the documented out-of-box behaviour. Resolves the split-portfolio v2 path via `.portfolio.agent_routing` in `.claude/project-config.json`; default is `./agent-routing.yaml` against the ops-fork root.
- **Gitignores `/agent-routing.yaml` at the fork root** so single-fork adopters' routing choices never accidentally leak to the public fork — sibling pattern to `.claude/project-config.json` and `workspace/*/` already in `.gitignore`. Split-portfolio adopters keep it in the private repo via the config block instead.
- **`docs/multi-project.md` gains a "Centralised agent routing" section** between "Private custom skills + handbooks" and "Migrating from split-portfolio v1 to v2" — slots in as a sibling private-repo customisation surface alongside custom-templates / custom-skills / custom-handbooks. Tabulates the file location for both modes, the per-entry schema, the config-block wiring, and an explicit wave plan (sync hook in PR 2, `/setup` integration in PR 3, local-routing entries gated on #348 in PR 4).
- **No sync hook yet — ships in #351 PR 2.** Until `apply-agent-routing.sh` lands the YAML file is documented but inert: `portfolio_agent_routing` resolves the path and the schema example parses cleanly, but no hook applies overrides to `.claude/agents/*.md` frontmatter. PR 2 also adds the pre-commit + pre-push **drift-prevention guards** that block accidental commits of the rewritten frontmatter.

Per AgDR-0050-agent-runtime-overhaul.

## Testing

- `bash .claude/hooks/tests/test_portfolio_agent_routing.sh` — 6/6 PASS locally (default path tolerates absence; single-fork file resolves + exists; split-portfolio v2 override → sibling repo path; relative override resolves against fork root; `portfolio_clear_cache` resets cache; `agent-routing.yaml.example` parses + has documented top-level keys via grep fallback / yq when available).
- `bash .claude/hooks/tests/test_portfolio_paths.sh` — 38/38 PASS (no regression to the existing resolvers).
- `bash .claude/hooks/tests/test_token_efficiency_wave1.sh` — all 4 Wave 1 invariants PASS (CLAUDE.md skill-table compactness, SKILL.md description budget, no orphan skills, SessionStart banner ≤ 600 chars).
- Manual: confirmed `agent-routing.yaml.example` is renamed-from-example shape (same as `apexyard.projects.yaml.example`) — `.gitignore` covers `/agent-routing.yaml` but not the `.example` so the schema spec ships with the framework.

Refs #351

## Glossary

| Term | Definition |
|------|------------|
| Agent-routing config | The centralised `agent-routing.yaml` file — adopter's single-file surface for overriding the framework's per-agent model defaults across all 24 sub-agents (19 role-derived + 5 utility). Schema per AgDR-0050 Axis 3. |
| Framework default | The per-agent model assignment shipped by the framework in `.claude/agents/<name>.md` frontmatter — from the 24-entry matrix in AgDR-0050 Axis 2 (Opus 5 / Sonnet 17 / Haiku 2). Adopters override per agent; omitting an agent from the config inherits the default. |
| `portfolio_agent_routing` | New resolver in `_lib-portfolio-paths.sh` that returns the absolute path to `agent-routing.yaml` — sibling to `portfolio_registry`, `portfolio_onboarding_path`, etc. Caller-tolerant of a non-existent file; that's the documented "no overrides" case. |
| Endpoint override | The `endpoint:` field in a routing entry — sets `ANTHROPIC_BASE_URL` at SessionStart (PR 2) so an agent routes through an alternative inference endpoint (e.g. LiteLLM proxy fronting Ollama). v1 is session-scoped: all agents on a session share the endpoint or none do (per AgDR-0050 Axis 5 + Risks). |
| Sync hook | Forward-ref to `apply-agent-routing.sh` — the SessionStart hook shipping in **#351 PR 2** that reads `agent-routing.yaml` and rewrites the affected `.claude/agents/*.md` frontmatter in-place. This PR ships the schema + resolver + docs only; the file is inert until PR 2 lands. |
| Drift prevention | Forward-ref to the pre-commit + pre-push guards shipping in **#351 PR 2** — block accidental commits of routing-config-driven `model:` rewrites so adopter routing choices never leak to the public fork. Operator escape hatch via a `# routing-config:override <reason>` comment (per AgDR-0050 § Axis 4). |