### PR TITLE
feat(#347): promote engineering-dept roles to sub-agents + Activation mode (Wave 1 PR 1)

### DIFF
--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -1,0 +1,15 @@
+---
+name: backend-engineer
+description: Implements domain logic, APIs, and infrastructure following clean architecture principles. Activates during the Build phase on backend code (domain / application / infrastructure layers), API work, or database schema changes.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Karim
+---
+
+# Karim — Backend Engineer
+
+Read and adopt `@roles/engineering/backend-engineer.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Backend Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -1,0 +1,15 @@
+---
+name: frontend-engineer
+description: Builds user interfaces following the design system — accessible, performant, and delightful. Activates during the Build phase on UI code, component work, design-system integration, or accessibility review.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Yasmin
+---
+
+# Yasmin — Frontend Engineer
+
+Read and adopt `@roles/engineering/frontend-engineer.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Frontend Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/head-of-engineering.md
+++ b/.claude/agents/head-of-engineering.md
@@ -1,0 +1,15 @@
+---
+name: head-of-engineering
+description: Owns engineering strategy, architecture standards, and engineering culture across the portfolio. Activates on architecture review, new tech stack additions, cross-project engineering calls, and Tech Lead escalations.
+model: opus
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Khalid
+---
+
+# Khalid — Head of Engineering
+
+Read and adopt `@roles/engineering/head-of-engineering.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Head of Engineering"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/platform-engineer.md
+++ b/.claude/agents/platform-engineer.md
@@ -1,0 +1,15 @@
+---
+name: platform-engineer
+description: Builds and maintains infrastructure, CI/CD pipelines, and developer tooling — the platform that lets engineers ship fast and safely. Activates on CI/CD pipeline changes, developer tooling, infrastructure-as-code work, or golden-path templates.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Adel
+---
+
+# Adel — Platform Engineer
+
+Read and adopt `@roles/engineering/platform-engineer.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Platform Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -1,0 +1,17 @@
+---
+name: qa-engineer
+description: Verifies acceptance criteria on merged PRs, triages bugs, runs regression checks, and signs off tickets before they move to Done. Activates when a ticket enters the QA state after merge. Read-only by design — QA verifies, doesn't ship.
+model: haiku
+allowed-tools: Bash, Read, Grep, Glob
+persona_name: Salim
+---
+
+# Salim — QA Engineer
+
+Read and adopt `@roles/engineering/qa-engineer.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+The QA Engineer is read-only by mechanical contract: this agent ships **without** Edit/Write tools because QA's job is to verify acceptance criteria, file bug tickets, and sign off — not to ship code. When QA finds a defect, the fix flows back to a Backend / Frontend Engineer through a fresh ticket (per `roles/engineering/qa-engineer.md` § "If QA Finds Issues" and `workflows/sdlc.md` § "Phase 5: QA Verification").
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table (notably: ticket moved to `qa` label), plus prompted activation ("act as QA Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/sre.md
+++ b/.claude/agents/sre.md
@@ -1,0 +1,15 @@
+---
+name: sre
+description: Ensures systems are reliable, observable, and resilient — applies engineering to operational problems. Activates on production incidents, SLO breaches, monitoring / alerting work, or on-call rotation.
+model: opus
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Saif
+---
+
+# Saif — Site Reliability Engineer (SRE)
+
+Read and adopt `@roles/engineering/sre.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as SRE"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -1,0 +1,15 @@
+---
+name: tech-lead
+description: Bridges architecture and implementation — authors technical designs, leads code reviews, mentors engineers, and owns technical quality for a domain. Activates on technical design, planning phase, code review approval gate, or task breakdown.
+model: opus
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Hisham
+---
+
+# Hisham — Tech Lead
+
+Read and adopt `@roles/engineering/tech-lead.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Tech Lead"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/tests/test_engineering_agents_wrap_shape.sh
+++ b/.claude/agents/tests/test_engineering_agents_wrap_shape.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# Smoke test for the 7 engineering-department sub-agent wrappers shipped
+# in me2resh/apexyard#347 PR 1, plus the `## Activation mode` section
+# coverage on all 19 role files. Per AgDR-0050 Axis 1 (WRAP), Axis 2
+# (default model matrix), and Axis 6 (HYBRID role-trigger integration).
+#
+# Invariants pinned here:
+#
+#   1. All 7 engineering agent files exist at .claude/agents/<slug>.md
+#   2. Each engineering agent file has the required frontmatter fields:
+#      name, description, model, allowed-tools, persona_name
+#   3. Each model value is one of `opus | sonnet | haiku`
+#   4. Each agent file's body references the role file
+#      `@roles/engineering/<role>.md` (the WRAP contract — agent files
+#      are thin wrappers that delegate identity to roles/)
+#   5. All 19 role files have a `## Activation mode` section
+#   6. Each role file's `## Activation mode` section declares a `Class:`
+#      value matching the AgDR-0050 § Axis 6 table exactly
+#
+# Test style follows the framework convention (set -u, ROOT from
+# dirname, red/green helpers, FAIL counter, exit 0/1). No external
+# test framework.
+#
+# Usage: bash .claude/agents/tests/test_engineering_agents_wrap_shape.sh
+# Exit 0 on success, 1 on any failure.
+
+set -u
+
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+
+AGENTS_DIR="$ROOT/.claude/agents"
+ROLES_DIR="$ROOT/roles"
+
+FAIL=0
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+
+# 7 engineering agents shipped in #347 PR 1.
+# Format: "<slug>:<expected_model>:<expected_persona_name>"
+ENG_AGENTS=(
+  "head-of-engineering:opus:Khalid"
+  "tech-lead:opus:Hisham"
+  "backend-engineer:sonnet:Karim"
+  "frontend-engineer:sonnet:Yasmin"
+  "qa-engineer:haiku:Salim"
+  "platform-engineer:sonnet:Adel"
+  "sre:opus:Saif"
+)
+
+# All 19 role files (path under roles/) + expected Activation mode Class.
+# Per AgDR-0050 § Axis 6 (HYBRID integration table).
+ROLE_CLASSES=(
+  "engineering/head-of-engineering.md:isolated-work-class"
+  "engineering/tech-lead.md:isolated-work-class"
+  "engineering/backend-engineer.md:in-flow-class"
+  "engineering/frontend-engineer.md:in-flow-class"
+  "engineering/qa-engineer.md:isolated-work-class"
+  "engineering/platform-engineer.md:in-flow-class"
+  "engineering/sre.md:isolated-work-class"
+  "product/head-of-product.md:isolated-work-class"
+  "product/product-manager.md:in-flow-class"
+  "product/product-analyst.md:isolated-work-class"
+  "design/head-of-design.md:isolated-work-class"
+  "design/ui-designer.md:in-flow-class"
+  "design/ux-designer.md:in-flow-class"
+  "security/head-of-security.md:isolated-work-class"
+  "security/security-auditor.md:isolated-work-class"
+  "security/penetration-tester.md:isolated-work-class"
+  "data/head-of-data.md:isolated-work-class"
+  "data/data-analyst.md:isolated-work-class"
+  "data/data-engineer.md:in-flow-class"
+)
+
+# Helper: extract the value of a YAML frontmatter key from the first
+# `---`-delimited block of a file. Trims surrounding whitespace.
+# Returns empty string if not found.
+get_frontmatter_value() {
+  local file="$1" key="$2"
+  awk -v key="$key" '
+    BEGIN { in_fm = 0; fm_count = 0 }
+    /^---[[:space:]]*$/ {
+      fm_count++
+      if (fm_count == 1) { in_fm = 1; next }
+      if (fm_count == 2) { in_fm = 0; exit }
+    }
+    in_fm == 1 {
+      # Match "key: value" (allow leading whitespace, key boundary)
+      if (match($0, "^[[:space:]]*" key "[[:space:]]*:")) {
+        # Strip everything up to and including the first colon
+        sub("^[[:space:]]*" key "[[:space:]]*:[[:space:]]*", "")
+        print
+        exit
+      }
+    }
+  ' "$file"
+}
+
+# -----------------------------------------------------------------------------
+# Invariant 1 + 2 + 3 + 4 — engineering agent files: existence, frontmatter,
+# model value in matrix, role-file reference present.
+# -----------------------------------------------------------------------------
+echo "== Engineering agent wrap-shape (AgDR-0050 § Axis 1 + 2)"
+for entry in "${ENG_AGENTS[@]}"; do
+  slug="${entry%%:*}"
+  rest="${entry#*:}"
+  expected_model="${rest%%:*}"
+  expected_persona="${rest#*:}"
+  agent_file="$AGENTS_DIR/${slug}.md"
+
+  # Invariant 1: file exists
+  if [ ! -f "$agent_file" ]; then
+    red "  FAIL: missing agent file $agent_file"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  # Invariant 2: required frontmatter keys present
+  missing=""
+  for key in name description model allowed-tools persona_name; do
+    val=$(get_frontmatter_value "$agent_file" "$key")
+    if [ -z "$val" ]; then
+      missing="$missing $key"
+    fi
+  done
+  if [ -n "$missing" ]; then
+    red "  FAIL: $slug — missing frontmatter keys:$missing"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  # Invariant 3: model value is one of opus / sonnet / haiku
+  actual_model=$(get_frontmatter_value "$agent_file" "model")
+  case "$actual_model" in
+    opus|sonnet|haiku) ;;
+    *)
+      red "  FAIL: $slug — model=$actual_model (must be opus|sonnet|haiku)"
+      FAIL=$((FAIL + 1))
+      continue
+      ;;
+  esac
+  if [ "$actual_model" != "$expected_model" ]; then
+    red "  FAIL: $slug — model=$actual_model (expected $expected_model per matrix)"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  # Invariant 3b: persona_name matches the matrix
+  actual_persona=$(get_frontmatter_value "$agent_file" "persona_name")
+  if [ "$actual_persona" != "$expected_persona" ]; then
+    red "  FAIL: $slug — persona_name=$actual_persona (expected $expected_persona)"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  # Invariant 4: body references @roles/engineering/<slug>.md
+  # Note: the SRE role file is at roles/engineering/sre.md (no -engineer
+  # suffix); the agent slug matches. All others map 1:1.
+  if ! grep -q "@roles/engineering/${slug}.md" "$agent_file"; then
+    red "  FAIL: $slug — missing @roles/engineering/${slug}.md reference in body"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  green "  PASS: $slug (model=$actual_model, persona=$actual_persona)"
+done
+
+# -----------------------------------------------------------------------------
+# Invariant 5 + 6 — every role file has `## Activation mode` and declares
+# the matrix-correct Class value.
+# -----------------------------------------------------------------------------
+echo
+echo "== Role-file ## Activation mode coverage (AgDR-0050 § Axis 6)"
+for entry in "${ROLE_CLASSES[@]}"; do
+  rel="${entry%%:*}"
+  expected_class="${entry#*:}"
+  role_file="$ROLES_DIR/$rel"
+
+  if [ ! -f "$role_file" ]; then
+    red "  FAIL: missing role file $role_file"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  if ! grep -q '^## Activation mode' "$role_file"; then
+    red "  FAIL: $rel — missing '## Activation mode' section"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  # Extract the Class value. Format in the file:
+  #   **Class**: <class-value>
+  # Look from the Activation-mode section to end-of-file.
+  actual_class=$(awk '
+    /^## Activation mode/ { in_section = 1; next }
+    in_section && /^\*\*Class\*\*:/ {
+      sub("^\\*\\*Class\\*\\*:[[:space:]]*", "")
+      print
+      exit
+    }
+  ' "$role_file")
+
+  if [ -z "$actual_class" ]; then
+    red "  FAIL: $rel — '## Activation mode' present but '**Class**:' line missing"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  if [ "$actual_class" != "$expected_class" ]; then
+    red "  FAIL: $rel — Class=$actual_class (expected $expected_class per AgDR-0050 § Axis 6)"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  green "  PASS: $rel ($actual_class)"
+done
+
+echo
+if [ "$FAIL" -gt 0 ]; then
+  red "FAIL: $FAIL invariant(s) failed"
+  exit 1
+fi
+green "PASS: engineering agent wrap-shape + 19-role Activation mode coverage"
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Hooks | `.claude/hooks/` | 24 shell scripts that mechanically enforce SDLC rules — ticket-first (Edit/Write/Bash), migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner, leak protection, bootstrap-skill exemption |
 | Rules | `.claude/rules/` | 11 modular rule files (AgDR triggers, code standards, git conventions, leak protection, parallel work, plan mode, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Handbooks | `handbooks/` | Adopter-authored coding standards consumed by Rex during code review. Discovery by path-convention (`architecture/` + `general/` always-load; `language/<lang>/` loads on diff-match). Advisory by default; opt in to blocking via `ENFORCEMENT: blocking` marker. See [`handbooks/README.md`](handbooks/README.md). |
-| Agents | `.claude/agents/` | Specialised sub-agents (Code Reviewer — Rex, Security Reviewer — Hatim, Dependency Auditor — Munir, PR Manager — Tariq, Ticket Manager — Idris) |
+| Agents | `.claude/agents/` | 12 sub-agents (5 utility: Rex, Hatim, Munir, Tariq, Idris; 7 engineering: Khalid, Hisham, Karim, Yasmin, Salim, Adel, Saif). Growing to 24 per AgDR-0050. |
 | Skills | `.claude/skills/` | 53 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 

--- a/roles/data/data-analyst.md
+++ b/roles/data/data-analyst.md
@@ -119,3 +119,13 @@ Every analysis should have:
 - Cannot find reliable data for key questions
 - Analysis reveals significant business risk
 - Need access to additional data sources
+
+## Activation mode
+
+**Class**: isolated-work-class
+
+**Sub-agent file**: `.claude/agents/data-analyst.md` (ships in #347 PR 3; will use model `haiku` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: once PR 3 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/data-analyst.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+
+**Rationale**: SQL / dashboard runs — Haiku-cheap, isolated.

--- a/roles/data/data-engineer.md
+++ b/roles/data/data-engineer.md
@@ -108,3 +108,13 @@ Examples:
 - Capacity constraints approaching
 - Schema changes needed across systems
 - Security concern with data handling
+
+## Activation mode
+
+**Class**: in-flow-class
+
+**Sub-agent file**: `.claude/agents/data-engineer.md` (ships in #347 PR 3; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; once PR 3 lands, the sub-agent CAN be invoked manually via the Agent tool for parallel / isolated work.
+
+**Rationale**: pipeline / ETL implementation is in-flight build work.

--- a/roles/data/head-of-data.md
+++ b/roles/data/head-of-data.md
@@ -84,3 +84,13 @@ You are the Head of Data. You lead analytics strategy, data infrastructure, and 
 - Infrastructure capacity constraints
 - Privacy/compliance concerns with data handling
 - Budget needed for new data tools
+
+## Activation mode
+
+**Class**: isolated-work-class
+
+**Sub-agent file**: `.claude/agents/head-of-data.md` (ships in #347 PR 3; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: once PR 3 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-data.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+
+**Rationale**: strategy; sparse.

--- a/roles/design/head-of-design.md
+++ b/roles/design/head-of-design.md
@@ -92,3 +92,13 @@ When reviewing UI implementations:
 - Technical constraints significantly impact experience
 - Major brand/visual direction change needed
 - Accessibility cannot be achieved within constraints
+
+## Activation mode
+
+**Class**: isolated-work-class
+
+**Sub-agent file**: `.claude/agents/head-of-design.md` (ships in #347 PR 2; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: once PR 2 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-design.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+
+**Rationale**: design-system decisions; sparse.

--- a/roles/design/ui-designer.md
+++ b/roles/design/ui-designer.md
@@ -106,3 +106,13 @@ When reviewing implementations, be specific:
 - New visual pattern doesn't fit system
 - Accessibility conflict with visual design
 - Significant departure from established style
+
+## Activation mode
+
+**Class**: in-flow-class
+
+**Sub-agent file**: `.claude/agents/ui-designer.md` (ships in #347 PR 2; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; once PR 2 lands, the sub-agent CAN be invoked manually via the Agent tool for parallel / isolated work.
+
+**Rationale**: component spec authoring is conversational.

--- a/roles/design/ux-designer.md
+++ b/roles/design/ux-designer.md
@@ -113,3 +113,13 @@ Error states:
 - Discovered usability issue in launched feature
 - Conflicting requirements affect UX
 - Need user research budget
+
+## Activation mode
+
+**Class**: in-flow-class
+
+**Sub-agent file**: `.claude/agents/ux-designer.md` (ships in #347 PR 2; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; once PR 2 lands, the sub-agent CAN be invoked manually via the Agent tool for parallel / isolated work.
+
+**Rationale**: user flow + IA is iterative.

--- a/roles/engineering/backend-engineer.md
+++ b/roles/engineering/backend-engineer.md
@@ -100,3 +100,13 @@ Before creating a PR:
 - Significant deviation from design needed
 - Security concern discovered
 - Performance issue identified
+
+## Activation mode
+
+**Class**: in-flow-class
+
+**Sub-agent file**: `.claude/agents/backend-engineer.md` (shipped in #347 PR 1; uses model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; sub-agent CAN be invoked manually via the Agent tool for parallel / isolated work.
+
+**Rationale**: the engineer IS the operator's hands during build; sub-agent would lose in-flight context.

--- a/roles/engineering/frontend-engineer.md
+++ b/roles/engineering/frontend-engineer.md
@@ -108,3 +108,13 @@ Before creating a PR:
 - Performance problems
 - Accessibility conflict with design
 - Blocked by backend work
+
+## Activation mode
+
+**Class**: in-flow-class
+
+**Sub-agent file**: `.claude/agents/frontend-engineer.md` (shipped in #347 PR 1; uses model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; sub-agent CAN be invoked manually via the Agent tool for parallel / isolated work.
+
+**Rationale**: same as Backend — the engineer IS the operator's hands during build; sub-agent would lose in-flight context.

--- a/roles/engineering/head-of-engineering.md
+++ b/roles/engineering/head-of-engineering.md
@@ -109,3 +109,13 @@ Before shipping, ensure:
 - Security/compliance concern
 - Major production incident
 - Significant technical debt accumulation
+
+## Activation mode
+
+**Class**: isolated-work-class
+
+**Sub-agent file**: `.claude/agents/head-of-engineering.md` (shipped in #347 PR 1; uses model `opus` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-engineering.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return.
+
+**Rationale**: strategy / architecture review — sparse triggers, deep reasoning, sub-agent isolation fits.

--- a/roles/engineering/platform-engineer.md
+++ b/roles/engineering/platform-engineer.md
@@ -129,3 +129,13 @@ Before deploying infrastructure:
 - Major outage affecting multiple services
 - Capacity limits approaching
 - New cloud service evaluation needed
+
+## Activation mode
+
+**Class**: in-flow-class
+
+**Sub-agent file**: `.claude/agents/platform-engineer.md` (shipped in #347 PR 1; uses model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; sub-agent CAN be invoked manually via the Agent tool for parallel / isolated work.
+
+**Rationale**: CI / golden-path edits happen in-flight as part of build phases.

--- a/roles/engineering/qa-engineer.md
+++ b/roles/engineering/qa-engineer.md
@@ -220,3 +220,13 @@ In Progress --> In Review --> QA --> Done
 - Cannot reproduce reported issue
 - Critical bug found close to release
 - Test infrastructure broken
+
+## Activation mode
+
+**Class**: isolated-work-class
+
+**Sub-agent file**: `.claude/agents/qa-engineer.md` (shipped in #347 PR 1; uses model `haiku` + restricted tools per AgDR-0050 Axis 2 — read-only by design, no Edit/Write)
+
+**On trigger**: the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/qa-engineer.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return.
+
+**Rationale**: AC verification is sandboxable + repeatable; Haiku-cheap.

--- a/roles/engineering/sre.md
+++ b/roles/engineering/sre.md
@@ -149,3 +149,13 @@ For each service:
 - Security breach suspected
 - Data loss occurred
 - Error budget exhausted
+
+## Activation mode
+
+**Class**: isolated-work-class
+
+**Sub-agent file**: `.claude/agents/sre.md` (shipped in #347 PR 1; uses model `opus` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/sre.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return.
+
+**Rationale**: incident response is bounded + needs isolated diagnosis context.

--- a/roles/engineering/tech-lead.md
+++ b/roles/engineering/tech-lead.md
@@ -131,3 +131,13 @@ Decisions still needed.
 - Estimates exceed expectations significantly
 - Team is blocked
 - Quality issues in production
+
+## Activation mode
+
+**Class**: isolated-work-class
+
+**Sub-agent file**: `.claude/agents/tech-lead.md` (shipped in #347 PR 1; uses model `opus` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/tech-lead.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return.
+
+**Rationale**: architectural design + AgDR authoring needs isolated context; the operator drives implementation in-thread.

--- a/roles/product/head-of-product.md
+++ b/roles/product/head-of-product.md
@@ -81,3 +81,13 @@ When evaluating ideas or features, consider:
 - Conflict between departments on priority
 - Major roadmap change needed
 - Resource constraints blocking critical work
+
+## Activation mode
+
+**Class**: isolated-work-class
+
+**Sub-agent file**: `.claude/agents/head-of-product.md` (ships in #347 PR 2; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: once PR 2 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-product.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+
+**Rationale**: strategy / roadmap; sparse.

--- a/roles/product/product-analyst.md
+++ b/roles/product/product-analyst.md
@@ -87,3 +87,13 @@ You are a Product Analyst. You provide data-driven insights to support product d
 - Cannot find reliable data for key assumptions
 - Research requires paid tools or services
 - Findings contradict current strategy
+
+## Activation mode
+
+**Class**: isolated-work-class
+
+**Sub-agent file**: `.claude/agents/product-analyst.md` (ships in #347 PR 2; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: once PR 2 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/product-analyst.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+
+**Rationale**: quantitative reporting — sub-agent + Sonnet for isolation.

--- a/roles/product/product-manager.md
+++ b/roles/product/product-manager.md
@@ -91,3 +91,13 @@ Before submitting a PRD for review:
 - Blocker not resolved within 24 hours
 - Customer feedback suggests major pivot needed
 - Engineering pushes back on feasibility
+
+## Activation mode
+
+**Class**: in-flow-class
+
+**Sub-agent file**: `.claude/agents/product-manager.md` (ships in #347 PR 2; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; once PR 2 lands, the sub-agent CAN be invoked manually via the Agent tool for parallel / isolated work.
+
+**Rationale**: PRD authoring is conversational + iterative — shared context wins.

--- a/roles/security/head-of-security.md
+++ b/roles/security/head-of-security.md
@@ -109,3 +109,13 @@ Enforce:
 - Compliance violation discovered
 - External security report received
 - Security incident ongoing
+
+## Activation mode
+
+**Class**: isolated-work-class
+
+**Sub-agent file**: `.claude/agents/head-of-security.md` (ships in #347 PR 3; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: once PR 3 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-security.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+
+**Rationale**: strategy; sparse.

--- a/roles/security/penetration-tester.md
+++ b/roles/security/penetration-tester.md
@@ -135,3 +135,13 @@ You are a Penetration Tester who thinks like an attacker. Your job is to find ex
 - Data exposure discovered
 - Authentication bypass confirmed
 - Multiple chained vulnerabilities create severe risk
+
+## Activation mode
+
+**Class**: isolated-work-class
+
+**Sub-agent file**: `.claude/agents/penetration-tester.md` (ships in #347 PR 3; will use model `opus` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: once PR 3 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/penetration-tester.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+
+**Rationale**: adversarial exploration benefits from isolation.

--- a/roles/security/security-auditor.md
+++ b/roles/security/security-auditor.md
@@ -112,3 +112,13 @@ For every PR:
 - Pattern of recurring security issues
 - Third-party dependency with known exploit
 - Suspected data breach indicators
+
+## Activation mode
+
+**Class**: isolated-work-class
+
+**Sub-agent file**: `.claude/agents/security-auditor.md` (ships in #347 PR 3; will use model `opus` + restricted tools per AgDR-0050 Axis 2)
+
+**On trigger**: once PR 3 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/security-auditor.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism — and the existing Hatim utility agent (`.claude/agents/security-reviewer.md`) remains available via `/security-review`.
+
+**Rationale**: OWASP / threat-model depth needs isolated context — matches existing Hatim utility agent pattern.


### PR DESCRIPTION
## Summary

- **7 engineering-dept sub-agent wrappers shipped at `.claude/agents/`** (head-of-engineering, tech-lead, backend-engineer, frontend-engineer, qa-engineer, platform-engineer, sre) — promotes the engineering personas from passive markdown role docs to first-class Claude Code sub-agents with explicit model assignment and tool restriction. Wave 1 PR 1 of the agent-runtime-overhaul shipped against AgDR-0050.
- **Agent files are THIN WRAPPERS per AgDR-0050 § Axis 1** — each file owns only `name` / `description` / `model` / `allowed-tools` / `persona_name` frontmatter + a body that references `@roles/engineering/<role>.md`. The persona definition stays in `roles/`; agent files are the runtime overlay. Zero content duplication, so a persona edit lands in one place and the wrapper stays inert.
- **Default model matrix per AgDR-0050 § Axis 2** — `opus` for depth (Khalid, Hisham, Saif), `sonnet` for implementation default (Karim, Yasmin, Adel), `haiku` for repeatable checklist work (Salim, QA Engineer). QA also ships **without** Edit/Write per its read-only contract: QA verifies, doesn't ship; the fix flows back to an engineer through a fresh ticket. Adopters override per-agent via the routing config landing in #351 (Wave 1 PR 1 of that ticket runs in parallel).
- **`## Activation mode` section added to all 19 role files per AgDR-0050 § Axis 6** — every persona definition now declares its activation class explicitly (isolated-work-class for 12 roles like QA / Pen Tester / Data Analyst / all 5 Heads of / Security Auditor / Tech Lead; in-flow-class for 7 roles like Backend / Frontend Engineer / Platform Engineer / PM / Designers / Data Engineer). Closes the gap where the hybrid sub-agent vs in-thread choice lived only in the AgDR body — operators can now see at a glance whether activating a role spawns an isolated sub-agent or adopts the persona in-thread.
- **Smoke test at `.claude/agents/tests/test_engineering_agents_wrap_shape.sh`** pins 26 invariants (agent files exist, frontmatter complete, model values in the matrix, role-file references present, all 19 role files declare a `## Activation mode` Class matching the AgDR table). First test under `.claude/agents/tests/`; style matches `.claude/hooks/tests/` (set -u, ROOT from dirname, red/green helpers, FAIL counter, exit 0/1). All PASS at this commit.
- **CLAUDE.md "Agents" row refreshed** from "5 sub-agents" to "12 sub-agents (5 utility + 7 engineering). Growing to 24 per AgDR-0050." Stays within the Wave 1 ≤ 25-word budget on table rows per AgDR-0044; `test_token_efficiency_wave1.sh` continues to pass (all four invariants OK).

This is **Wave 1 PR 1 of 4** for #347. Per the AgDR-0050 PR plan: PR 1 (this) + #351 PR 1 are parallelisable. PR 2 ships the product + design agents (6); PR 3 ships security + data (6) + Hatim/Hakim consolidation decision; PR 4 adds `model:` frontmatter to the 5 utility agents (Rex, Hatim, Munir, Tariq, Idris); PR 5 wires `detect-role-trigger.sh` to spawn sub-agents for isolated-work-class roles. The role-trigger integration is deliberately deferred to PR 5 — until then, the `## Activation mode` sections document the intended state, and in-thread role-adoption remains the active mechanism for un-shipped roles.

Per AgDR-0050-agent-runtime-overhaul.

## Testing

- [x] `bash .claude/agents/tests/test_engineering_agents_wrap_shape.sh` — all 26 invariants PASS (7 engineering agents pass file-exists + frontmatter shape + model-matrix + role-reference; all 19 role files pass `## Activation mode` Class match)
- [x] `bash .claude/hooks/tests/test_token_efficiency_wave1.sh` — all four Wave 1 invariants PASS (CLAUDE.md skill-table row word-count, SKILL.md description char budget, skill catalogue completeness, SessionStart banner char budget)
- [x] Manual: `head -8 .claude/agents/qa-engineer.md` shows `model: haiku` + `allowed-tools: Bash, Read, Grep, Glob` (NO Edit/Write — read-only by mechanical contract per `roles/engineering/qa-engineer.md`)
- [x] Manual: `head -8 .claude/agents/tech-lead.md` shows `model: opus`, `persona_name: Hisham`
- [x] Manual: `grep -c "## Activation mode" roles/*/*.md | wc -l` returns 19 (every role file gained the section)

Refs #347

## Glossary

| Term | Definition |
|------|------------|
| WRAP (AgDR-0050 § Axis 1) | The file-shape decision for promoting roles to sub-agents: persona definition stays in `roles/<dept>/<role>.md`; the runtime wrapper at `.claude/agents/<slug>.md` owns only frontmatter (`model`, `allowed-tools`, `persona_name`) plus a body that references the role file. Zero content duplication. |
| isolated-work-class | Per AgDR-0050 § Axis 6, the activation class for roles whose work benefits from a separate sub-agent context — QA verification, pen testing, data analysis, Heads-of strategy calls, Security Auditor reviews, Tech Lead architectural design. Activation spawns the sub-agent; the main thread folds in the verdict. |
| in-flow-class | Per AgDR-0050 § Axis 6, the activation class for roles whose work is conversational + iterative + lives in the main-thread context — Backend / Frontend / Platform / Data Engineers, Product Manager, UI / UX Designers. Activation adopts the persona in-thread; sub-agent CAN still be invoked manually via the Agent tool for parallel work. |
| `persona_name` frontmatter field | YAML frontmatter key in agent files (introduced in #204 / AgDR-0018) that carries the short Arabic persona identifier (Khalid / Hisham / Karim / Yasmin / Salim / Adel / Saif for engineering). Surfaces in the `▸ Activating <name> (<role>) for #<ticket>` activation-marker line. |
| Framework default model matrix (AgDR-0050 § Axis 2) | The 24-entry table assigning each role a default model (`opus` / `sonnet` / `haiku`). Opus for depth + reasoning; Sonnet for implementation + tool-use-heavy work; Haiku for repeatable checklist-shaped work. Adopters override per-agent via the routing config landing in #351. |
| Wave 1 invariants (AgDR-0044) | Token-efficiency invariants pinned by `.claude/hooks/tests/test_token_efficiency_wave1.sh` — CLAUDE.md skill-table row ≤ 25 words, SKILL.md `description:` ≤ 200 chars hard / ≤ 120 soft, every skill catalogued in CLAUDE.md, SessionStart banner ≤ 600 chars. This PR adjusts the Agents row to a 23-word description so it stays under the row-length cap. |