### PR TITLE
feat(#347): promote product + design roles to sub-agents (Wave 3 PR 2)

### DIFF
--- a/.claude/agents/head-of-design.md
+++ b/.claude/agents/head-of-design.md
@@ -1,0 +1,15 @@
+---
+name: head-of-design
+description: Owns the design system, UX principles, and visual standards across products. Activates on design-system changes, UX principles decisions, or cross-project visual-standards calls.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Maha
+---
+
+# Maha — Head of Design
+
+Read and adopt `@roles/design/head-of-design.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Head of Design"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/head-of-product.md
+++ b/.claude/agents/head-of-product.md
@@ -1,0 +1,15 @@
+---
+name: head-of-product
+description: Owns product strategy, roadmap prioritisation, and feasibility studies. Activates on roadmap prioritisation, feasibility calls, strategic product decisions, or cross-product resource allocation.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Omar
+---
+
+# Omar — Head of Product
+
+Read and adopt `@roles/product/head-of-product.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Head of Product"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/product-analyst.md
+++ b/.claude/agents/product-analyst.md
@@ -1,0 +1,15 @@
+---
+name: product-analyst
+description: Provides data-driven insights, market research, and competitive analysis to support product decisions and feasibility studies. Activates on market research, competitive analysis, metric investigation, or data-driven product calls.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Hanan
+---
+
+# Hanan — Product Analyst
+
+Read and adopt `@roles/product/product-analyst.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Product Analyst"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -1,0 +1,15 @@
+---
+name: product-manager
+description: Translates approved product strategy into detailed PRDs with acceptance criteria, coordinates with Design and Engineering, and removes delivery blockers. Activates on PRD creation, user-story breakdown, acceptance-criteria authoring, or sprint planning.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Mariam
+---
+
+# Mariam — Product Manager
+
+Read and adopt `@roles/product/product-manager.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Product Manager"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/tests/test_agent_wrap_shape.sh
+++ b/.claude/agents/tests/test_agent_wrap_shape.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
-# Smoke test for the 7 engineering-department sub-agent wrappers shipped
-# in me2resh/apexyard#347 PR 1, plus the `## Activation mode` section
-# coverage on all 19 role files. Per AgDR-0050 Axis 1 (WRAP), Axis 2
-# (default model matrix), and Axis 6 (HYBRID role-trigger integration).
+# Smoke test for the role-derived sub-agent wrappers shipped under
+# me2resh/apexyard#347, plus the `## Activation mode` section coverage
+# on all 19 role files. Per AgDR-0050 Axis 1 (WRAP), Axis 2 (default
+# model matrix), and Axis 6 (HYBRID role-trigger integration).
+#
+# Wave history:
+#   - #347 PR 1 (merged): engineering dept (7 agents) + `## Activation
+#     mode` section on all 19 role files.
+#   - #347 PR 2: product + design depts (6 agents) — covered here.
+#   - #347 PR 3 (upcoming): security + data depts (6 agents).
+#   - #347 PR 4 (upcoming): utility-agent `model:` frontmatter
+#     (Rex / Hatim / Munir / Tariq / Idris).
 #
 # Invariants pinned here:
 #
-#   1. All 7 engineering agent files exist at .claude/agents/<slug>.md
-#   2. Each engineering agent file has the required frontmatter fields:
+#   1. All currently-shipped role-derived agent files exist at
+#      .claude/agents/<slug>.md
+#   2. Each agent file has the required frontmatter fields:
 #      name, description, model, allowed-tools, persona_name
 #   3. Each model value is one of `opus | sonnet | haiku`
 #   4. Each agent file's body references the role file
-#      `@roles/engineering/<role>.md` (the WRAP contract — agent files
+#      `@roles/<dept>/<role>.md` (the WRAP contract — agent files
 #      are thin wrappers that delegate identity to roles/)
 #   5. All 19 role files have a `## Activation mode` section
 #   6. Each role file's `## Activation mode` section declares a `Class:`
@@ -21,7 +30,7 @@
 # dirname, red/green helpers, FAIL counter, exit 0/1). No external
 # test framework.
 #
-# Usage: bash .claude/agents/tests/test_engineering_agents_wrap_shape.sh
+# Usage: bash .claude/agents/tests/test_agent_wrap_shape.sh
 # Exit 0 on success, 1 on any failure.
 
 set -u
@@ -37,16 +46,27 @@ FAIL=0
 red()    { printf '\033[31m%s\033[0m\n' "$*"; }
 green()  { printf '\033[32m%s\033[0m\n' "$*"; }
 
-# 7 engineering agents shipped in #347 PR 1.
-# Format: "<slug>:<expected_model>:<expected_persona_name>"
-ENG_AGENTS=(
-  "head-of-engineering:opus:Khalid"
-  "tech-lead:opus:Hisham"
-  "backend-engineer:sonnet:Karim"
-  "frontend-engineer:sonnet:Yasmin"
-  "qa-engineer:haiku:Salim"
-  "platform-engineer:sonnet:Adel"
-  "sre:opus:Saif"
+# 13 role-derived agents shipped to date (#347 PR 1 + PR 2).
+# Format: "<slug>:<expected_model>:<expected_persona_name>:<dept>"
+# <dept> is the subdir under roles/ that hosts the canonical role file.
+# The agent body must reference `@roles/<dept>/<slug>.md`.
+ROLE_AGENTS=(
+  # PR 1 — engineering dept
+  "head-of-engineering:opus:Khalid:engineering"
+  "tech-lead:opus:Hisham:engineering"
+  "backend-engineer:sonnet:Karim:engineering"
+  "frontend-engineer:sonnet:Yasmin:engineering"
+  "qa-engineer:haiku:Salim:engineering"
+  "platform-engineer:sonnet:Adel:engineering"
+  "sre:opus:Saif:engineering"
+  # PR 2 — product dept
+  "head-of-product:sonnet:Omar:product"
+  "product-manager:sonnet:Mariam:product"
+  "product-analyst:sonnet:Hanan:product"
+  # PR 2 — design dept
+  "head-of-design:sonnet:Maha:design"
+  "ui-designer:sonnet:Nour:design"
+  "ux-designer:sonnet:Iman:design"
 )
 
 # All 19 role files (path under roles/) + expected Activation mode Class.
@@ -98,15 +118,13 @@ get_frontmatter_value() {
 }
 
 # -----------------------------------------------------------------------------
-# Invariant 1 + 2 + 3 + 4 — engineering agent files: existence, frontmatter,
-# model value in matrix, role-file reference present.
+# Invariant 1 + 2 + 3 + 4 — role-derived agent files: existence, frontmatter,
+# model value in matrix, role-file reference present (per-dept path).
 # -----------------------------------------------------------------------------
-echo "== Engineering agent wrap-shape (AgDR-0050 § Axis 1 + 2)"
-for entry in "${ENG_AGENTS[@]}"; do
-  slug="${entry%%:*}"
-  rest="${entry#*:}"
-  expected_model="${rest%%:*}"
-  expected_persona="${rest#*:}"
+echo "== Role-derived agent wrap-shape (AgDR-0050 § Axis 1 + 2)"
+for entry in "${ROLE_AGENTS[@]}"; do
+  # Parse the 4-field entry safely (slug, model, persona, dept).
+  IFS=':' read -r slug expected_model expected_persona dept <<<"$entry"
   agent_file="$AGENTS_DIR/${slug}.md"
 
   # Invariant 1: file exists
@@ -154,16 +172,16 @@ for entry in "${ENG_AGENTS[@]}"; do
     continue
   fi
 
-  # Invariant 4: body references @roles/engineering/<slug>.md
+  # Invariant 4: body references @roles/<dept>/<slug>.md
   # Note: the SRE role file is at roles/engineering/sre.md (no -engineer
   # suffix); the agent slug matches. All others map 1:1.
-  if ! grep -q "@roles/engineering/${slug}.md" "$agent_file"; then
-    red "  FAIL: $slug — missing @roles/engineering/${slug}.md reference in body"
+  if ! grep -q "@roles/${dept}/${slug}.md" "$agent_file"; then
+    red "  FAIL: $slug — missing @roles/${dept}/${slug}.md reference in body"
     FAIL=$((FAIL + 1))
     continue
   fi
 
-  green "  PASS: $slug (model=$actual_model, persona=$actual_persona)"
+  green "  PASS: $slug (dept=$dept, model=$actual_model, persona=$actual_persona)"
 done
 
 # -----------------------------------------------------------------------------
@@ -221,5 +239,5 @@ if [ "$FAIL" -gt 0 ]; then
   red "FAIL: $FAIL invariant(s) failed"
   exit 1
 fi
-green "PASS: engineering agent wrap-shape + 19-role Activation mode coverage"
+green "PASS: role-derived agent wrap-shape + 19-role Activation mode coverage"
 exit 0

--- a/.claude/agents/ui-designer.md
+++ b/.claude/agents/ui-designer.md
@@ -1,0 +1,15 @@
+---
+name: ui-designer
+description: Defines the visual language and component specifications that guide UI implementation. Activates on visual design, component specifications, design tokens, or pixel-level work.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Nour
+---
+
+# Nour — UI Designer
+
+Read and adopt `@roles/design/ui-designer.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as UI Designer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/ux-designer.md
+++ b/.claude/agents/ux-designer.md
@@ -1,0 +1,15 @@
+---
+name: ux-designer
+description: Focuses on user flows, information architecture, and usability — documenting journeys and ensuring products are intuitive and efficient. Activates on user flows, information architecture, usability review, or wireframing.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Iman
+---
+
+# Iman — UX Designer
+
+Read and adopt `@roles/design/ux-designer.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as UX Designer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Hooks | `.claude/hooks/` | 24 shell scripts that mechanically enforce SDLC rules — ticket-first (Edit/Write/Bash), migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner, leak protection, bootstrap-skill exemption |
 | Rules | `.claude/rules/` | 11 modular rule files (AgDR triggers, code standards, git conventions, leak protection, parallel work, plan mode, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Handbooks | `handbooks/` | Adopter-authored coding standards consumed by Rex during code review. Discovery by path-convention (`architecture/` + `general/` always-load; `language/<lang>/` loads on diff-match). Advisory by default; opt in to blocking via `ENFORCEMENT: blocking` marker. See [`handbooks/README.md`](handbooks/README.md). |
-| Agents | `.claude/agents/` | 12 sub-agents (5 utility: Rex, Hatim, Munir, Tariq, Idris; 7 engineering: Khalid, Hisham, Karim, Yasmin, Salim, Adel, Saif). Growing to 24 per AgDR-0050. |
+| Agents | `.claude/agents/` | 18 sub-agents (5 utility + 7 engineering + 6 product-design). Growing to 24 across Wave 1-3 per AgDR-0050. |
 | Skills | `.claude/skills/` | 53 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 


### PR DESCRIPTION
## Summary

- **Six new product + design sub-agent wrappers** — Omar (Head of Product), Mariam (Product Manager), Hanan (Product Analyst), Maha (Head of Design), Nour (UI Designer), Iman (UX Designer). Each is a thin runtime wrapper that delegates identity to the canonical role file in `roles/<dept>/<slug>.md` (Axis 1 WRAP shape from AgDR-0050). Operators can now `Agent(subagent_type: "product-manager")` etc. instead of relying solely on in-thread persona adoption.
- **All sonnet, full toolset** — every entry in the AgDR-0050 § Axis 2 default-model matrix maps the 6 product + design personas to `sonnet`; allowed-tools is the standard `Bash, Read, Edit, Write, Grep, Glob` superset (matches the engineering-dept defaults, not the QA-engineer read-only carve-out). Adopters re-route per agent via `agent-routing.yaml` once #351 PR 2 ships the SessionStart sync hook.
- **`## Activation mode` already on each role file** — PR 1 added the section to all 19 roles (engineering, product, design, security, data) as part of its churn. This PR adds wrappers only and does NOT touch role files. The class assignments (Omar/Hanan/Maha = isolated-work-class; Mariam/Nour/Iman = in-flow-class) match Axis 6 exactly and are re-verified by invariant 6 of the smoke test on every run.
- **Smoke-test scope expansion** — `test_engineering_agents_wrap_shape.sh` renamed to `test_agent_wrap_shape.sh` (no longer dept-pinned) and its agent matrix grows from 7 → 13 entries with a new `dept` field per row so the `@roles/<dept>/<slug>.md` reference check is per-dept aware. Test header documents the wave progression (PR 1 → PR 2 → PR 3 → PR 4) so future contributors see the growth arc.
- **Wave progression — PR 2 of 5 for ticket #347** — count refresh in CLAUDE.md (12 → 18 agents) reflects the new total post-merge, stays under the 25-word Wave 1 invariant, and surfaces the "growing to 24 across Wave 1-3" framing so the target reads as a planned arc rather than a still-pending one-shot. Per AgDR-0050-agent-runtime-overhaul.

## Testing

- `bash .claude/agents/tests/test_agent_wrap_shape.sh` — PASS (13 agent wrappers verified across 4 invariants: existence + frontmatter completeness + model-matrix match + role-file body reference; plus 19 role files verified for `## Activation mode` Class coverage)
- `bash .claude/hooks/tests/test_token_efficiency_wave1.sh` — PASS (Wave 1 invariants 1-4 all green; CLAUDE.md agent-count row stays at 19 words, well under the 25-word cap)
- Spot-checked `.claude/agents/head-of-product.md` frontmatter shape — matches the PR 1 `.claude/agents/tech-lead.md` template exactly (name / description / model: sonnet / allowed-tools / persona_name: Omar)

Refs #347

## Glossary

| Term | Definition |
|------|------------|
| Wrap shape (WRAP) | The Axis 1 file-shape decision from AgDR-0050: `roles/<dept>/<slug>.md` stays canonical for persona definition; `.claude/agents/<slug>.md` is a thin runtime wrapper owning model + tool-restriction + agent metadata only. |
| Isolated-work-class | Axis 6 role category that spawns a dedicated sub-agent on trigger (heads-of, analysts, auditors) — full context isolation + per-agent model assignment. |
| In-flow-class | Axis 6 role category that adopts the persona in-thread on trigger (engineers, PMs, designers doing ship-the-code work) — shared context with the main thread wins over isolation. |
| Wave 3 PR 2 | This PR in the AgDR-0050 wave plan: Wave 1 was PR 1 (engineering + role-file Activation-mode section); Wave 3 is the parallel-shippable group of PR 2 (this) + PR 3 + PR 4 + #351 PR 2. |