### PR TITLE
feat(#351): agent-routing sync hook + pre-commit/pre-push drift guards (Wave 1 PR 2)

### DIFF
--- a/.claude/hooks/apply-agent-routing.sh
+++ b/.claude/hooks/apply-agent-routing.sh
@@ -1,0 +1,410 @@
+#!/bin/bash
+# SessionStart hook: apply adopter agent-routing overrides to the
+# .claude/agents/*.md frontmatter in-place.
+#
+# Per AgDR-0050 § Axis 4 + ticket #351 PR 2 — closes the loop on Wave 1
+# PR 1's schema + portfolio_agent_routing resolver. Adopters edit ONE
+# YAML file (in the private repo for split-portfolio v2, or gitignored
+# at the fork root for single-fork mode); this hook makes those edits
+# LIVE on the next session.
+#
+# Behaviour:
+#   - Resolve the routing path via portfolio_agent_routing
+#   - Silently exit 0 if no routing file exists (zero-config zero-
+#     behaviour-change — the documented out-of-box experience)
+#   - Parse the YAML (yq preferred; python3 fallback)
+#   - For each entry in agents:
+#       1. Locate .claude/agents/<name>.md — silently skip if missing
+#          (adopter may have a stale entry; harmless, not an error)
+#       2. Snapshot the framework default model: line (from HEAD of dev
+#          for the file) into .claude/agents/.framework-defaults.json
+#          so the drift guard has a baseline regardless of whether the
+#          adopter committed the rewrite
+#       3. Rewrite the model: line in the agent file to the override
+#       4. If endpoint: set, write to .claude/session/agent-env/<name>.env
+#          (per-agent endpoint env file; if Claude Code doesn't expose
+#          per-agent env, the adopter falls back to manual export of
+#          ANTHROPIC_BASE_URL — banner caveat below)
+#       5. If env: block set, append KEY=VALUE lines to that env file
+#          (resolving $VAR_NAME refs against the parent env)
+#   - Print a single one-line summary banner: silent on N=0; else
+#       "ApexYard: applied N agent-routing override(s) from agent-routing.yaml"
+#   - Idempotent: running twice with the same config produces the same
+#     state, no compounding writes (env files are truncated, not appended,
+#     when written; the framework-defaults snapshot is keyed by agent
+#     name so re-applications are noops)
+#
+# Banner budget: ≤ 600 chars across all SessionStart hooks. This hook
+# emits at most ~110 chars (silent on no-op).
+#
+# Drift-prevention complement: block-agent-routing-drift.sh fires on
+# git commit + git push and refuses to let routing-induced rewrites
+# escape to a public-class remote. Both hooks together implement
+# AgDR-0050 § Axis 4's "SessionStart rewrite + drift guards" pattern.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# Walk up to find the apexyard fork root (v2 marker first, legacy v1
+# anchor fallback). Same shape as clear-bootstrap-marker.sh.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT=""
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  ROOT=$(resolve_ops_root "$REPO_ROOT")
+else
+  cur="$REPO_ROOT"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/.apexyard-fork" ]; then
+      ROOT="$cur"
+      break
+    fi
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      ROOT="$cur"
+      break
+    fi
+    cur=$(dirname "$cur")
+  done
+fi
+
+if [ -z "$ROOT" ]; then
+  exit 0
+fi
+
+# Source path resolvers + config reader. Prefer the hook's neighbour
+# libs (HOOK_DIR/_lib-*.sh) because they're guaranteed to match this
+# hook's version. The walk-up ROOT may be an older copy mid-upgrade
+# (e.g. adopter pulling in a new framework hook before the lib
+# resolvers shipped on its dev branch).
+LIB_SRC_DIR=""
+if [ -f "$HOOK_DIR/_lib-portfolio-paths.sh" ] && [ -f "$HOOK_DIR/_lib-read-config.sh" ]; then
+  LIB_SRC_DIR="$HOOK_DIR"
+elif [ -f "$ROOT/.claude/hooks/_lib-portfolio-paths.sh" ] && [ -f "$ROOT/.claude/hooks/_lib-read-config.sh" ]; then
+  LIB_SRC_DIR="$ROOT/.claude/hooks"
+else
+  exit 0
+fi
+# shellcheck source=/dev/null
+. "$LIB_SRC_DIR/_lib-read-config.sh"
+# shellcheck source=/dev/null
+. "$LIB_SRC_DIR/_lib-portfolio-paths.sh"
+
+ROUTING_PATH=$(portfolio_agent_routing)
+if [ -z "$ROUTING_PATH" ] || [ ! -f "$ROUTING_PATH" ]; then
+  # Zero-config zero-behaviour: no routing file = framework defaults.
+  exit 0
+fi
+
+AGENTS_DIR="$ROOT/.claude/agents"
+if [ ! -d "$AGENTS_DIR" ]; then
+  exit 0
+fi
+
+DEFAULTS_FILE="$AGENTS_DIR/.framework-defaults.json"
+ENV_DIR="$ROOT/.claude/session/agent-env"
+mkdir -p "$ENV_DIR"
+
+# -----------------------------------------------------------------------------
+# Parse the routing YAML — emit one line per agent in the shape:
+#   <name>\t<key>\t<value>
+# Where key ∈ {model, endpoint, env, timeout_seconds, allowed_tools_override}.
+# env values come out as a JSON-encoded object so the consumer below can
+# iterate KEY=VAL pairs without parsing YAML twice.
+#
+# yq is preferred; python3 + PyYAML is the fallback. If neither works the
+# hook is a silent no-op (adopters without yq/python3 must install one or
+# wait for v2 of the schema). Emit a one-line caveat on stderr in that
+# rare case so the adopter knows why their routing config didn't apply.
+# -----------------------------------------------------------------------------
+parse_routing() {
+  if command -v yq >/dev/null 2>&1; then
+    # yq output: tab-separated <name>\t<key>\t<value>. env is emitted as
+    # one row per KEY=VAL inside the env: block.
+    yq eval '
+      .agents // {} | to_entries | .[] | . as $a |
+      (
+        ($a.value.model // "" | select(. != "") | $a.key + "\tmodel\t" + .),
+        ($a.value.endpoint // "" | select(. != "") | $a.key + "\tendpoint\t" + .),
+        ($a.value.timeout_seconds // "" | select(. != "") | $a.key + "\ttimeout_seconds\t" + (. | tostring)),
+        ($a.value.env // {} | to_entries | .[] | $a.key + "\tenv\t" + .key + "=" + (.value | tostring))
+      )
+    ' "$ROUTING_PATH" 2>/dev/null
+    return 0
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    # Try PyYAML first; if not present, fall through to the awk parser.
+    py_out=$(python3 - "$ROUTING_PATH" <<'PY' 2>/dev/null
+import sys
+try:
+    import yaml
+except ImportError:
+    sys.exit(7)
+try:
+    with open(sys.argv[1], 'r', encoding='utf-8') as fh:
+        doc = yaml.safe_load(fh) or {}
+except Exception:
+    sys.exit(0)
+agents = (doc.get('agents') or {})
+if not isinstance(agents, dict):
+    sys.exit(0)
+for name, entry in agents.items():
+    if not isinstance(entry, dict):
+        continue
+    model = entry.get('model')
+    if model:
+        print(f"{name}\tmodel\t{model}")
+    endpoint = entry.get('endpoint')
+    if endpoint:
+        print(f"{name}\tendpoint\t{endpoint}")
+    timeout = entry.get('timeout_seconds')
+    if timeout:
+        print(f"{name}\ttimeout_seconds\t{timeout}")
+    env = entry.get('env') or {}
+    if isinstance(env, dict):
+        for k, v in env.items():
+            print(f"{name}\tenv\t{k}={v}")
+PY
+)
+    py_rc=$?
+    if [ "$py_rc" -ne 7 ]; then
+      printf '%s\n' "$py_out"
+      return 0
+    fi
+  fi
+
+  # Minimal awk fallback — supports the schema's documented shape
+  # (2-space indented YAML, model/endpoint/timeout_seconds at depth 2,
+  # env: subblock at depth 2 with KEY: VALUE pairs at depth 3). Doesn't
+  # try to be a general YAML parser; this is enough for the v1 schema.
+  awk '
+    BEGIN { agents_block = 0; cur_name = ""; in_env = 0 }
+    # Skip comments + blank lines.
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*$/ { next }
+
+    # Top-level "agents:" line opens the block. Any subsequent top-level
+    # key (no leading whitespace, no leading hyphen) closes it.
+    /^agents:/ { agents_block = 1; next }
+    /^[a-zA-Z_]/ {
+      if (agents_block) { agents_block = 0 }
+      next
+    }
+
+    # Inside agents block: depth-2 entries name an agent.
+    agents_block && /^  [a-zA-Z0-9_-][a-zA-Z0-9_-]*:[[:space:]]*$/ {
+      line = $0
+      sub(/^  /, "", line)
+      sub(/:.*$/, "", line)
+      cur_name = line
+      in_env = 0
+      next
+    }
+
+    # Depth-4 lines inside env: are KEY: VALUE (6-space indent).
+    cur_name != "" && in_env && /^      [a-zA-Z_][a-zA-Z0-9_]*:[[:space:]]*/ {
+      line = $0
+      sub(/^      /, "", line)
+      key = line
+      sub(/:.*$/, "", key)
+      val = line
+      sub(/^[^:]*:[[:space:]]*/, "", val)
+      # Strip optional surrounding quotes.
+      sub(/^["'\''"]/, "", val)
+      sub(/["'\''"][[:space:]]*$/, "", val)
+      print cur_name "\tenv\t" key "=" val
+      next
+    }
+
+    # Depth-3 keys for the active agent (4-space indent). env: opens the
+    # env subblock; model/endpoint/timeout_seconds emit immediately.
+    cur_name != "" && /^    [a-zA-Z_][a-zA-Z0-9_]*:/ {
+      line = $0
+      sub(/^    /, "", line)
+      key = line
+      sub(/:.*$/, "", key)
+      val = line
+      sub(/^[^:]*:[[:space:]]*/, "", val)
+      sub(/^["'\''"]/, "", val)
+      sub(/["'\''"][[:space:]]*$/, "", val)
+      if (key == "env") {
+        in_env = 1
+        next
+      }
+      in_env = 0
+      if (val == "") { next }
+      if (key == "model" || key == "endpoint" || key == "timeout_seconds") {
+        print cur_name "\t" key "\t" val
+      }
+      next
+    }
+
+    # Less indentation under cur_name → reset env flag.
+    cur_name != "" && /^  [a-zA-Z]/ { in_env = 0 }
+  ' "$ROUTING_PATH" 2>/dev/null
+  return 0
+}
+
+ROWS=$(parse_routing)
+if [ -z "$ROWS" ]; then
+  exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Snapshot framework defaults BEFORE any rewrite — so the drift guard
+# has a baseline regardless of whether the adopter committed the rewrite
+# to the fork.
+#
+# Format: a tiny JSON object {agent_name: "<framework-default-model>"}.
+# We don't use jq for the write to avoid a new hard dependency; assembled
+# by string concat with newline-per-entry.
+#
+# Idempotency: re-running with the same config overwrites the snapshot
+# (with the same contents, since we re-read each agent file's HEAD
+# version).
+# -----------------------------------------------------------------------------
+snapshot_framework_default() {
+  local agent_name="$1"
+  local agent_file="$AGENTS_DIR/${agent_name}.md"
+  local default_model=""
+
+  # Prefer the dev-branch baseline (most reliable framework default).
+  # Fall back to the current file's model: if dev isn't reachable
+  # (detached HEAD, bare checkout, hook running outside a git context).
+  if git -C "$ROOT" rev-parse --verify dev >/dev/null 2>&1; then
+    default_model=$(git -C "$ROOT" show "dev:.claude/agents/${agent_name}.md" 2>/dev/null \
+      | awk '/^---/{count++; next} count==1 && /^model:/ {sub(/^model:[[:space:]]*/, ""); print; exit}')
+  fi
+  if [ -z "$default_model" ] && [ -f "$agent_file" ]; then
+    default_model=$(awk '/^---/{count++; next} count==1 && /^model:/ {sub(/^model:[[:space:]]*/, ""); print; exit}' "$agent_file")
+  fi
+  echo "$default_model"
+}
+
+# Build framework defaults JSON in a temp accumulator (one entry per
+# agent we touch), then write atomically.
+defaults_acc=""
+applied=0
+
+# Use a process-substitution-free read so we run on POSIX bash without
+# requiring /dev/fd. Tab-separated input.
+TMP_ROWS=$(mktemp 2>/dev/null) || { exit 0; }
+printf '%s\n' "$ROWS" > "$TMP_ROWS"
+
+while IFS=$'\t' read -r agent_name key value; do
+  [ -z "$agent_name" ] && continue
+  agent_file="$AGENTS_DIR/${agent_name}.md"
+  if [ ! -f "$agent_file" ]; then
+    # Orphan entry — adopter may have a stale routing config, harmless.
+    continue
+  fi
+
+  case "$key" in
+    model)
+      # Snapshot framework default ONCE per agent (idempotent — we
+      # always grab from dev HEAD, never from the working-tree file).
+      if ! echo "$defaults_acc" | grep -q "^\"${agent_name}\":"; then
+        fwd=$(snapshot_framework_default "$agent_name")
+        if [ -n "$fwd" ]; then
+          defaults_acc="$defaults_acc\"${agent_name}\":\"${fwd}\",
+"
+        fi
+      fi
+
+      # Rewrite the model: line in the agent file (inside frontmatter).
+      # We use awk to limit replacement to the first frontmatter block.
+      tmp_agent=$(mktemp)
+      awk -v new="$value" '
+        BEGIN { fm=0; replaced=0 }
+        /^---[[:space:]]*$/ { fm++; print; next }
+        fm==1 && !replaced && /^model:[[:space:]]*/ {
+          print "model: " new
+          replaced=1
+          next
+        }
+        { print }
+      ' "$agent_file" > "$tmp_agent" && mv "$tmp_agent" "$agent_file"
+      applied=$((applied + 1))
+      ;;
+
+    endpoint)
+      # Write per-agent endpoint env file. Truncate-and-write (not
+      # append) for idempotency.
+      env_file="$ENV_DIR/${agent_name}.env"
+      # Preserve any existing non-endpoint lines on re-application by
+      # filtering them out then re-emitting the endpoint line.
+      if [ -f "$env_file" ]; then
+        # Drop existing ANTHROPIC_BASE_URL lines; keep everything else.
+        grep -v '^ANTHROPIC_BASE_URL=' "$env_file" > "${env_file}.tmp" 2>/dev/null || true
+        mv "${env_file}.tmp" "$env_file"
+      else
+        : > "$env_file"
+      fi
+      printf 'ANTHROPIC_BASE_URL=%s\n' "$value" >> "$env_file"
+      ;;
+
+    env)
+      # value is KEY=VAL — resolve $VAR refs against parent env.
+      env_file="$ENV_DIR/${agent_name}.env"
+      [ -f "$env_file" ] || : > "$env_file"
+      env_key=${value%%=*}
+      env_val=${value#*=}
+      # Resolve a single $VAR_NAME reference (matches example D in the
+      # schema). More complex shell expansions are out of scope for v1.
+      case "$env_val" in
+        \$*)
+          var_name=${env_val#\$}
+          # shellcheck disable=SC2086
+          eval "env_val=\${$var_name:-}"
+          ;;
+      esac
+      # Drop any prior line for this key; re-emit (idempotent).
+      grep -v "^${env_key}=" "$env_file" > "${env_file}.tmp" 2>/dev/null || true
+      mv "${env_file}.tmp" "$env_file" 2>/dev/null || true
+      printf '%s=%s\n' "$env_key" "$env_val" >> "$env_file"
+      ;;
+
+    timeout_seconds)
+      # Recorded but not actively consumed in v1 — Claude Code doesn't
+      # expose a per-agent timeout-override env var yet. Drop a marker
+      # in the env file so future runtime support can pick it up.
+      env_file="$ENV_DIR/${agent_name}.env"
+      [ -f "$env_file" ] || : > "$env_file"
+      grep -v '^APEXYARD_AGENT_TIMEOUT=' "$env_file" > "${env_file}.tmp" 2>/dev/null || true
+      mv "${env_file}.tmp" "$env_file" 2>/dev/null || true
+      printf 'APEXYARD_AGENT_TIMEOUT=%s\n' "$value" >> "$env_file"
+      ;;
+  esac
+done < "$TMP_ROWS"
+
+rm -f "$TMP_ROWS"
+
+# -----------------------------------------------------------------------------
+# Write the framework-defaults snapshot. The drift guard reads this to
+# decide whether a committed model: line is the framework default or a
+# leaked override.
+#
+# Format is a minimal JSON object — adopters never edit this by hand;
+# it's gitignored (see .gitignore in the same PR). If jq is available
+# we pretty-print; otherwise plain.
+# -----------------------------------------------------------------------------
+if [ -n "$defaults_acc" ]; then
+  # Strip trailing comma+newline and wrap in braces.
+  body=$(printf '%s' "$defaults_acc" | sed '$ s/,$//' | tr -d '\n')
+  printf '{%s}\n' "$body" > "$DEFAULTS_FILE"
+fi
+
+# -----------------------------------------------------------------------------
+# Banner — one line, only when applied > 0. Stays well under the
+# Wave-1-invariant 600-char SessionStart budget.
+# -----------------------------------------------------------------------------
+if [ "$applied" -gt 0 ]; then
+  echo "ApexYard: applied $applied agent-routing override(s) from agent-routing.yaml" >&2
+fi
+
+exit 0

--- a/.claude/hooks/block-agent-routing-drift.sh
+++ b/.claude/hooks/block-agent-routing-drift.sh
@@ -1,0 +1,292 @@
+#!/bin/bash
+# Pre-commit + pre-push drift guard for .claude/agents/*.md routing.
+#
+# Per AgDR-0050 § Axis 4 + ticket #351 PR 2 — the sibling to
+# apply-agent-routing.sh. The sync hook REWRITES agent-file model: lines
+# at SessionStart from the adopter's agent-routing.yaml; this guard
+# REFUSES to let those rewrites escape to a commit (which would leak the
+# adopter's private routing choices to the public fork on push).
+#
+# Mechanism:
+#   - Fires on `git commit -m` AND `git push` (per the matcher entries
+#     in .claude/settings.json)
+#   - For each staged (commit) or to-be-pushed (push) .claude/agents/*.md
+#     file:
+#       1. Read its current model: line
+#       2. Compare against the framework default — first preference is
+#          the snapshot at .claude/agents/.framework-defaults.json
+#          (written by the sync hook on the most recent SessionStart);
+#          fallback is `git show dev:.claude/agents/<name>.md` (works
+#          on forks tracking upstream/dev), then `git show
+#          upstream/main:...`, then `git show HEAD:...`
+#       3. If different AND the file does NOT carry the escape-hatch
+#          comment "# routing-config:override <reason>" anywhere in
+#          frontmatter or body, BLOCK with a clear self-correction
+#          message naming the file + actual + expected models
+#       4. Silent + exit 0 on no drift
+#
+# Escape hatch: when the operator INTENTIONALLY wants to change the
+# framework default (e.g. switching QA from haiku → sonnet across the
+# whole framework, not just for one adopter), they add the comment
+# `# routing-config:override <reason>` to the agent file and the guard
+# accepts the new default. The comment is deliberately visible — it
+# documents WHY the framework default changed and ships with the PR.
+#
+# Like check-secrets.sh + block-private-refs-in-public-repos.sh, this
+# is a mechanical backstop against routine-but-damaging leaks. Self-
+# discipline is the primary defence (adopters know not to commit
+# routing-rewritten agent files); the hook catches the case where the
+# agent had the rewritten file right in front of it during `git add`
+# and didn't actively suppress it.
+
+set -u
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Only fire on commit or push.
+IS_COMMIT=0
+IS_PUSH=0
+if echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
+  IS_COMMIT=1
+elif echo "$COMMAND" | grep -qE '\bgit\s+push\b'; then
+  IS_PUSH=1
+else
+  exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# Walk up to find ops fork root (same shape as the other gates).
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT=""
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  ROOT=$(resolve_ops_root "$REPO_ROOT")
+else
+  cur="$REPO_ROOT"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/.apexyard-fork" ]; then ROOT="$cur"; break; fi
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then ROOT="$cur"; break; fi
+    cur=$(dirname "$cur")
+  done
+fi
+
+if [ -z "$ROOT" ]; then
+  exit 0
+fi
+
+AGENTS_DIR="$ROOT/.claude/agents"
+[ -d "$AGENTS_DIR" ] || exit 0
+
+# -----------------------------------------------------------------------------
+# Discover candidate files: staged on commit; in to-be-pushed commits on push.
+# -----------------------------------------------------------------------------
+get_candidate_files() {
+  if [ "$IS_COMMIT" -eq 1 ]; then
+    # Staged adds + modifies (renames + copies follow under R/C).
+    git -C "$ROOT" diff --cached --name-only --diff-filter=ACMR 2>/dev/null \
+      | grep -E '^\.claude/agents/[^/]+\.md$' || true
+    return 0
+  fi
+  if [ "$IS_PUSH" -eq 1 ]; then
+    # Files modified in unpushed commits on the current branch. Use the
+    # upstream tracking ref if available; fall back to origin/<branch>;
+    # fall back to dev as a last-resort baseline.
+    cur_branch=$(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)
+    upstream_ref=$(git -C "$ROOT" rev-parse --abbrev-ref "@{upstream}" 2>/dev/null || true)
+    base=""
+    if [ -n "$upstream_ref" ]; then
+      base="$upstream_ref"
+    elif git -C "$ROOT" rev-parse --verify "origin/$cur_branch" >/dev/null 2>&1; then
+      base="origin/$cur_branch"
+    elif git -C "$ROOT" rev-parse --verify dev >/dev/null 2>&1; then
+      base="dev"
+    fi
+    if [ -z "$base" ]; then
+      # Brand-new branch with no comparable base — fall back to the last
+      # 5 commits (better than nothing without false-positiving).
+      git -C "$ROOT" diff --name-only HEAD~5..HEAD 2>/dev/null \
+        | grep -E '^\.claude/agents/[^/]+\.md$' || true
+      return 0
+    fi
+    git -C "$ROOT" diff --name-only "$base..HEAD" 2>/dev/null \
+      | grep -E '^\.claude/agents/[^/]+\.md$' || true
+  fi
+}
+
+CANDIDATES=$(get_candidate_files | sort -u)
+if [ -z "$CANDIDATES" ]; then
+  exit 0
+fi
+
+DEFAULTS_FILE="$AGENTS_DIR/.framework-defaults.json"
+
+# -----------------------------------------------------------------------------
+# Resolve the framework-default model: for an agent. Tries (in order):
+#   1. Snapshot at .claude/agents/.framework-defaults.json (written by
+#      apply-agent-routing.sh on the most recent SessionStart)
+#   2. dev:.claude/agents/<name>.md frontmatter
+#   3. upstream/main:.claude/agents/<name>.md frontmatter
+#   4. HEAD:.claude/agents/<name>.md frontmatter (last-resort — handles
+#      brand-new agent files where dev hasn't been tracked yet)
+#
+# Empty string when nothing resolves (silent allow — better than false
+# positive on a hook whose drift baseline is unknowable).
+# -----------------------------------------------------------------------------
+framework_default_for() {
+  local agent_name="$1"
+  local m=""
+
+  # 1. Snapshot file.
+  if [ -f "$DEFAULTS_FILE" ]; then
+    # Cheap key lookup: "<name>":"<value>"  (json format from sync hook).
+    m=$(grep -oE "\"${agent_name}\":\"[^\"]+\"" "$DEFAULTS_FILE" 2>/dev/null \
+        | head -1 \
+        | sed -E 's/.*:"([^"]+)"/\1/')
+    if [ -n "$m" ]; then
+      echo "$m"
+      return 0
+    fi
+  fi
+
+  # 2. dev baseline.
+  if git -C "$ROOT" rev-parse --verify dev >/dev/null 2>&1; then
+    m=$(git -C "$ROOT" show "dev:.claude/agents/${agent_name}.md" 2>/dev/null \
+        | awk '/^---/{count++; next} count==1 && /^model:/ {sub(/^model:[[:space:]]*/, ""); print; exit}')
+    [ -n "$m" ] && { echo "$m"; return 0; }
+  fi
+
+  # 3. upstream/main baseline.
+  if git -C "$ROOT" rev-parse --verify upstream/main >/dev/null 2>&1; then
+    m=$(git -C "$ROOT" show "upstream/main:.claude/agents/${agent_name}.md" 2>/dev/null \
+        | awk '/^---/{count++; next} count==1 && /^model:/ {sub(/^model:[[:space:]]*/, ""); print; exit}')
+    [ -n "$m" ] && { echo "$m"; return 0; }
+  fi
+
+  # 4. HEAD baseline (handles brand-new agent file in this commit).
+  m=$(git -C "$ROOT" show "HEAD:.claude/agents/${agent_name}.md" 2>/dev/null \
+      | awk '/^---/{count++; next} count==1 && /^model:/ {sub(/^model:[[:space:]]*/, ""); print; exit}')
+  [ -n "$m" ] && echo "$m"
+}
+
+# -----------------------------------------------------------------------------
+# Read the CURRENT (staged) model: line from a candidate file. We prefer
+# staged content (commit shape) so a working-tree edit that's not yet
+# staged doesn't false-trigger the gate.
+# -----------------------------------------------------------------------------
+current_model_for() {
+  local rel="$1"
+  if [ "$IS_COMMIT" -eq 1 ]; then
+    git -C "$ROOT" show ":$rel" 2>/dev/null \
+      | awk '/^---/{count++; next} count==1 && /^model:/ {sub(/^model:[[:space:]]*/, ""); print; exit}'
+  else
+    # Push: read from HEAD (the commit we're about to push).
+    git -C "$ROOT" show "HEAD:$rel" 2>/dev/null \
+      | awk '/^---/{count++; next} count==1 && /^model:/ {sub(/^model:[[:space:]]*/, ""); print; exit}'
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Detect the escape-hatch comment. Format: "# routing-config:override <reason>"
+# Looked for anywhere in the file (frontmatter or body). The reason is
+# free-text and not validated.
+# -----------------------------------------------------------------------------
+has_escape_hatch() {
+  local rel="$1"
+  local content=""
+  if [ "$IS_COMMIT" -eq 1 ]; then
+    content=$(git -C "$ROOT" show ":$rel" 2>/dev/null)
+  else
+    content=$(git -C "$ROOT" show "HEAD:$rel" 2>/dev/null)
+  fi
+  echo "$content" | grep -qE '^[[:space:]]*#[[:space:]]*routing-config:override[[:space:]]+\S'
+}
+
+DRIFT_FOUND=""
+DRIFT_DETAILS=""
+
+while IFS= read -r rel; do
+  [ -z "$rel" ] && continue
+  agent_name=$(basename "$rel" .md)
+  current=$(current_model_for "$rel")
+  expected=$(framework_default_for "$agent_name")
+
+  # No expected baseline (e.g. brand-new agent file) — allow.
+  if [ -z "$expected" ]; then
+    continue
+  fi
+  # No current value (file doesn't have a model: line) — allow; out of
+  # scope for this guard.
+  if [ -z "$current" ]; then
+    continue
+  fi
+  if [ "$current" = "$expected" ]; then
+    continue
+  fi
+  # Drift detected — check for the escape hatch before blocking.
+  if has_escape_hatch "$rel"; then
+    continue
+  fi
+
+  DRIFT_FOUND=1
+  DRIFT_DETAILS="${DRIFT_DETAILS}  $rel — model: $current  (framework default: $expected)
+"
+done <<< "$CANDIDATES"
+
+if [ -z "$DRIFT_FOUND" ]; then
+  exit 0
+fi
+
+cat >&2 <<MSG
+BLOCKED: agent-file model: drift detected.
+
+$DRIFT_DETAILS
+Your routing config is leaking into the agent file — this should NEVER
+happen because adopter overrides come from agent-routing.yaml, not from
+edits to the committed agent file. The SessionStart sync hook
+(apply-agent-routing.sh, AgDR-0050 § Axis 4) rewrites the agent file's
+model: line at session start from your YAML override — but those
+rewrites must stay LOCAL to the working tree, never committed.
+
+To unblock:
+
+  (a) Revert the model: line back to the framework default on the
+      file(s) above (commands at the bottom of this message). The sync
+      hook will RE-APPLY your agent-routing.yaml override on the next
+      session — your routing choice is preserved.
+
+  (b) If this is an INTENTIONAL framework-default change (rare; e.g.
+      switching the framework's QA Engineer default from haiku to
+      sonnet, or adding a brand-new agent), add the escape-hatch
+      comment to the agent file's frontmatter or body:
+
+          # routing-config:override <reason>
+
+      The reason is free-text — write a sentence explaining why the
+      framework default is changing. The comment ships with the PR and
+      makes the deliberate-change visible.
+
+Revert commands (run from the ops-fork root):
+
+  # Restore the file to the framework default (dev baseline):
+  git checkout dev -- <file>
+
+  # OR, hand-edit the model: line back to the framework default and
+  # restage:
+  \$EDITOR <file>          # change model: line back to the default
+  git add <file>
+
+See AgDR-0050 § Axis 4 for the design and
+.claude/rules/leak-protection.md for the broader leak-prevention pattern.
+MSG
+
+exit 2

--- a/.claude/hooks/tests/test_agent_routing_sync_and_drift.sh
+++ b/.claude/hooks/tests/test_agent_routing_sync_and_drift.sh
@@ -1,0 +1,396 @@
+#!/bin/bash
+# Smoke test for apply-agent-routing.sh (SessionStart sync hook) and
+# block-agent-routing-drift.sh (pre-commit + pre-push drift guard) —
+# the two hooks #351 PR 2 ships per AgDR-0050 § Axis 4.
+#
+# Coverage (7 cases):
+#
+#   Sync hook (apply-agent-routing.sh):
+#     1. Empty config — empty agent-routing.yaml means no-op; no agent
+#        files mutated, no banner.
+#     2. Single override — qa-engineer model haiku → opus; the QA
+#        agent file's model line is rewritten, other agent files
+#        untouched, framework-defaults snapshot written.
+#     3. Orphan entry — routing config references an agent that doesn't
+#        exist under .claude/agents/; silently skipped, no error.
+#     4. Idempotency — running the sync hook twice with the same config
+#        produces the same state; no compounded edits to the agent file
+#        or env files.
+#
+#   Drift guard (block-agent-routing-drift.sh):
+#     5. Drift FIRES — pre-commit on a staged .claude/agents/<name>.md
+#        with a non-default model: line and no escape-hatch comment
+#        blocks (exit 2).
+#     6. Drift accepts with escape hatch — same scenario but the file
+#        carries `# routing-config:override <reason>` somewhere;
+#        hook exits 0.
+#     7. Drift accepts on no-drift — staged agent file carries the
+#        framework default model: line; hook exits 0 cleanly.
+#
+# Pattern follows test_portfolio_paths.sh + test_split_portfolio_v2_migration.sh:
+#   - SRC_ROOT resolved from the test file's location
+#   - Each case builds an isolated sandbox apexyard fork under $TMPDIR
+#   - Sources libs from the sandbox (NOT from SRC_ROOT) so resolution
+#     matches the in-fork shape the hook sees at runtime
+#
+# Exit 0 means all cases passed. Exit 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SYNC_HOOK="$SRC_ROOT/.claude/hooks/apply-agent-routing.sh"
+DRIFT_HOOK="$SRC_ROOT/.claude/hooks/block-agent-routing-drift.sh"
+LIB_OPS="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
+LIB_PORT="$SRC_ROOT/.claude/hooks/_lib-portfolio-paths.sh"
+LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+
+for f in "$SYNC_HOOK" "$DRIFT_HOOK" "$LIB_OPS" "$LIB_PORT" "$LIB_CFG" "$DEFAULTS"; do
+  [ -f "$f" ] || { echo "FAIL: missing $f" >&2; exit 1; }
+done
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+mark_pass() { PASS=$((PASS + 1)); green "PASS: $1"; }
+mark_fail() {
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  - $1"
+  red "FAIL: $1"
+  if [ -n "${2:-}" ]; then echo "  detail: $2"; fi
+}
+
+# ---------------------------------------------------------------------------
+# make_fork: build a synthetic v1-anchor apexyard fork under $TMPDIR with
+# the hook libs + a handful of agent files at framework defaults
+# (qa-engineer = haiku, tech-lead = opus, backend-engineer = sonnet).
+# The fork is a real git repo (we need `git show dev:` to work for the
+# drift-guard baseline).
+# ---------------------------------------------------------------------------
+make_fork() {
+  local sb
+  sb=$(mktemp -d)
+  sb=$(cd "$sb" && pwd -P)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+
+    # v1 anchors (onboarding.yaml + registry).
+    touch onboarding.yaml
+    cat > apexyard.projects.yaml <<'YAML'
+version: 1
+projects: []
+YAML
+    mkdir -p projects
+    touch projects/ideas-backlog.md
+
+    # Drop libs + defaults into the sandbox's .claude/hooks tree.
+    mkdir -p .claude/hooks .claude/agents .claude/session
+    cp "$LIB_OPS"  .claude/hooks/_lib-ops-root.sh
+    cp "$LIB_PORT" .claude/hooks/_lib-portfolio-paths.sh
+    cp "$LIB_CFG"  .claude/hooks/_lib-read-config.sh
+    cp "$DEFAULTS" .claude/project-config.defaults.json
+    cp "$SYNC_HOOK"  .claude/hooks/apply-agent-routing.sh
+    cp "$DRIFT_HOOK" .claude/hooks/block-agent-routing-drift.sh
+    chmod +x .claude/hooks/apply-agent-routing.sh .claude/hooks/block-agent-routing-drift.sh
+
+    # Framework-default agent files (matrix per AgDR-0050 § Axis 2).
+    cat > .claude/agents/qa-engineer.md <<'MD'
+---
+name: qa-engineer
+description: QA Engineer wrapper.
+model: haiku
+allowed-tools: Bash, Read, Grep, Glob
+persona_name: Salim
+---
+
+# Salim — QA Engineer
+MD
+    cat > .claude/agents/tech-lead.md <<'MD'
+---
+name: tech-lead
+description: Tech Lead wrapper.
+model: opus
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Hisham
+---
+
+# Hisham — Tech Lead
+MD
+    cat > .claude/agents/backend-engineer.md <<'MD'
+---
+name: backend-engineer
+description: Backend Engineer wrapper.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Karim
+---
+
+# Karim — Backend Engineer
+MD
+
+    # Gitignore the framework-defaults snapshot + env dir (these are
+    # adopter-local artefacts; the sync hook writes them on session start).
+    cat > .gitignore <<'IGNORE'
+.claude/agents/.framework-defaults.json
+.claude/session/agent-env/
+agent-routing.yaml
+IGNORE
+
+    git add -A
+    git commit -q -m "fixture: apexyard fork with framework-default agents"
+    # Establish `dev` so the drift guard's `git show dev:...` fallback works
+    # in case the snapshot file isn't present.
+    git branch -f dev HEAD
+  )
+  echo "$sb"
+}
+
+# extract the model: line from an agent file's frontmatter (first block).
+read_model_line() {
+  awk '/^---/{count++; next} count==1 && /^model:/ {sub(/^model:[[:space:]]*/, ""); print; exit}' "$1"
+}
+
+# emit the JSON envelope a PreToolUse hook expects on stdin.
+hook_stdin() {
+  local cmd="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --arg c "$cmd" '{tool_input: {command: $c}}'
+  else
+    printf '{"tool_input":{"command":%s}}' "$(printf '"%s"' "$cmd" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+  fi
+}
+
+# ===========================================================================
+# CASE 1 — sync hook is a no-op on empty config (agents: {}).
+# ===========================================================================
+SB=$(make_fork)
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents: {}
+YAML
+
+# Capture content snapshot before.
+before_qa=$(read_model_line "$SB/.claude/agents/qa-engineer.md")
+before_lead=$(read_model_line "$SB/.claude/agents/tech-lead.md")
+before_be=$(read_model_line "$SB/.claude/agents/backend-engineer.md")
+
+# Run the hook (chdir into the fork so the walk-up finds the anchors).
+banner_output=$(cd "$SB" && bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+
+after_qa=$(read_model_line "$SB/.claude/agents/qa-engineer.md")
+after_lead=$(read_model_line "$SB/.claude/agents/tech-lead.md")
+after_be=$(read_model_line "$SB/.claude/agents/backend-engineer.md")
+
+if [ "$before_qa" = "$after_qa" ] && [ "$before_lead" = "$after_lead" ] && [ "$before_be" = "$after_be" ] && [ -z "$banner_output" ]; then
+  mark_pass "case 1: empty config → no-op (no rewrites, no banner)"
+else
+  mark_fail "case 1: empty config → no-op" "qa=$before_qa→$after_qa lead=$before_lead→$after_lead be=$before_be→$after_be banner=[$banner_output]"
+fi
+rm -rf "$SB"
+
+# ===========================================================================
+# CASE 2 — single override: qa-engineer model haiku → opus.
+# ===========================================================================
+SB=$(make_fork)
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  qa-engineer:
+    model: opus
+YAML
+
+banner_output=$(cd "$SB" && bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+
+after_qa=$(read_model_line "$SB/.claude/agents/qa-engineer.md")
+after_lead=$(read_model_line "$SB/.claude/agents/tech-lead.md")
+after_be=$(read_model_line "$SB/.claude/agents/backend-engineer.md")
+defaults_snapshot_exists=0
+[ -f "$SB/.claude/agents/.framework-defaults.json" ] && defaults_snapshot_exists=1
+
+if [ "$after_qa" = "opus" ] && [ "$after_lead" = "opus" ] && [ "$after_be" = "sonnet" ] \
+   && [ "$defaults_snapshot_exists" = "1" ] \
+   && echo "$banner_output" | grep -qE 'applied 1 agent-routing override'; then
+  # Confirm the snapshot recorded the framework default, not the override.
+  if grep -q '"qa-engineer":"haiku"' "$SB/.claude/agents/.framework-defaults.json"; then
+    mark_pass "case 2: qa-engineer override haiku→opus (other agents untouched, snapshot recorded)"
+  else
+    mark_fail "case 2" "snapshot did not record qa-engineer=haiku: $(cat "$SB/.claude/agents/.framework-defaults.json" 2>/dev/null)"
+  fi
+else
+  mark_fail "case 2: qa-engineer override" "after_qa=$after_qa lead=$after_lead be=$after_be snapshot=$defaults_snapshot_exists banner=[$banner_output]"
+fi
+rm -rf "$SB"
+
+# ===========================================================================
+# CASE 3 — orphan entry: routing config references nonexistent-agent.
+# Hook should silently skip (no error, no banner if no other overrides).
+# ===========================================================================
+SB=$(make_fork)
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  nonexistent-agent:
+    model: opus
+YAML
+
+banner_output=$(cd "$SB" && bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+
+# Real agents unchanged.
+after_qa=$(read_model_line "$SB/.claude/agents/qa-engineer.md")
+after_lead=$(read_model_line "$SB/.claude/agents/tech-lead.md")
+
+if [ "$after_qa" = "haiku" ] && [ "$after_lead" = "opus" ] && [ -z "$banner_output" ]; then
+  mark_pass "case 3: orphan entry silently skipped (no error, no banner)"
+else
+  mark_fail "case 3: orphan entry" "qa=$after_qa lead=$after_lead banner=[$banner_output]"
+fi
+rm -rf "$SB"
+
+# ===========================================================================
+# CASE 4 — idempotency: running sync hook twice with same config →
+# same end state, no compounded writes.
+# ===========================================================================
+SB=$(make_fork)
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  qa-engineer:
+    model: sonnet
+    endpoint: http://localhost:11434
+    env:
+      MY_VAR: hello
+YAML
+
+(cd "$SB" && bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true) >/dev/null
+
+# Capture state after first run.
+first_qa=$(read_model_line "$SB/.claude/agents/qa-engineer.md")
+first_env=""
+[ -f "$SB/.claude/session/agent-env/qa-engineer.env" ] && first_env=$(cat "$SB/.claude/session/agent-env/qa-engineer.env")
+
+# Run again.
+(cd "$SB" && bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true) >/dev/null
+
+second_qa=$(read_model_line "$SB/.claude/agents/qa-engineer.md")
+second_env=""
+[ -f "$SB/.claude/session/agent-env/qa-engineer.env" ] && second_env=$(cat "$SB/.claude/session/agent-env/qa-engineer.env")
+
+# Env file should have exactly one ANTHROPIC_BASE_URL line + one MY_VAR line.
+endpoint_count=$(echo "$second_env" | grep -c '^ANTHROPIC_BASE_URL=' || true)
+myvar_count=$(echo "$second_env" | grep -c '^MY_VAR=' || true)
+
+if [ "$first_qa" = "sonnet" ] && [ "$second_qa" = "sonnet" ] && [ "$first_env" = "$second_env" ] \
+   && [ "$endpoint_count" -eq 1 ] && [ "$myvar_count" -eq 1 ]; then
+  mark_pass "case 4: idempotent — second run is a no-op (env file not compounded)"
+else
+  mark_fail "case 4: idempotent" "first_qa=$first_qa second_qa=$second_qa endpoint=$endpoint_count myvar=$myvar_count first_env=[$first_env] second_env=[$second_env]"
+fi
+rm -rf "$SB"
+
+# ===========================================================================
+# CASE 5 — drift guard FIRES: pre-commit on a staged file with drift +
+# no escape hatch.
+# ===========================================================================
+SB=$(make_fork)
+# Apply a sync rewrite so the framework-defaults snapshot exists AND
+# the working tree has the drift to commit.
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  qa-engineer:
+    model: opus
+YAML
+(cd "$SB" && bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true) >/dev/null
+
+# Stage the rewritten file (simulating an adopter accidentally
+# `git add`-ing it).
+(cd "$SB" && git add .claude/agents/qa-engineer.md 2>/dev/null)
+
+# Invoke the drift guard with a `git commit -m "..."` command.
+hook_output=$(hook_stdin "git commit -m 'feat: tweak QA agent'" | (cd "$SB" && bash .claude/hooks/block-agent-routing-drift.sh 2>&1) || true)
+hook_exit=$(hook_stdin "git commit -m 'feat: tweak QA agent'" | (cd "$SB" && bash .claude/hooks/block-agent-routing-drift.sh > /dev/null 2>&1); echo $?)
+
+if [ "$hook_exit" = "2" ] && echo "$hook_output" | grep -q "BLOCKED: agent-file model: drift detected"; then
+  mark_pass "case 5: drift guard FIRES on staged drift + no escape hatch (exit 2)"
+else
+  mark_fail "case 5: drift guard FIRES" "exit=$hook_exit output=[$hook_output]"
+fi
+rm -rf "$SB"
+
+# ===========================================================================
+# CASE 6 — drift guard ACCEPTS with escape hatch.
+# Same scenario as case 5 but the agent file carries the override
+# escape-hatch comment.
+# ===========================================================================
+SB=$(make_fork)
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  qa-engineer:
+    model: opus
+YAML
+(cd "$SB" && bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true) >/dev/null
+
+# Add the escape hatch comment to the rewritten file.
+cat > "$SB/.claude/agents/qa-engineer.md" <<'MD'
+---
+name: qa-engineer
+description: QA Engineer wrapper.
+model: opus
+allowed-tools: Bash, Read, Grep, Glob
+persona_name: Salim
+---
+
+# routing-config:override deliberate framework-default bump from haiku to opus
+
+# Salim — QA Engineer
+MD
+
+(cd "$SB" && git add .claude/agents/qa-engineer.md 2>/dev/null)
+
+hook_exit=$(hook_stdin "git commit -m 'feat: bump QA default'" | (cd "$SB" && bash .claude/hooks/block-agent-routing-drift.sh > /dev/null 2>&1); echo $?)
+
+if [ "$hook_exit" = "0" ]; then
+  mark_pass "case 6: drift guard ACCEPTS with escape-hatch comment (exit 0)"
+else
+  mark_fail "case 6: drift guard escape hatch" "expected exit 0, got $hook_exit"
+fi
+rm -rf "$SB"
+
+# ===========================================================================
+# CASE 7 — drift guard accepts on no-drift (committed file = framework
+# default).
+# ===========================================================================
+SB=$(make_fork)
+# Stage qa-engineer.md AT the framework default (haiku) — no sync hook
+# run, no override applied, no drift.
+(cd "$SB" && git add .claude/agents/qa-engineer.md 2>/dev/null)
+
+hook_exit=$(hook_stdin "git commit -m 'docs: tidy QA agent description'" | (cd "$SB" && bash .claude/hooks/block-agent-routing-drift.sh > /dev/null 2>&1); echo $?)
+
+if [ "$hook_exit" = "0" ]; then
+  mark_pass "case 7: drift guard ACCEPTS clean-default commit (exit 0)"
+else
+  mark_fail "case 7: drift guard clean default" "expected exit 0, got $hook_exit"
+fi
+rm -rf "$SB"
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+echo
+echo "===== test_agent_routing_sync_and_drift.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed cases:$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_site_counts.sh
+++ b/.claude/hooks/tests/test_site_counts.sh
@@ -119,6 +119,7 @@ for f in "${FILES_TO_SCAN[@]}"; do
   check_count "$f" "$actual_hooks"  "shell +scripts?"    "shell scripts (hook count)"
   check_count "$f" "$actual_hooks"  "shell +gates?"      "shell gates (hook count)"
   check_count "$f" "$actual_hooks"  "mechanical +gates?" "mechanical gates (hook count)"
+  check_count "$f" "$actual_hooks"  "shell +hooks?"      "shell hooks (hook count)"
   # `N roles`  (the role-count claim)
   check_count "$f" "$actual_roles"  "roles?"            "roles"
   check_count "$f" "$actual_roles"  "role +definitions" "role definitions"

--- a/.claude/hooks/tests/test_token_efficiency_wave1.sh
+++ b/.claude/hooks/tests/test_token_efficiency_wave1.sh
@@ -119,7 +119,7 @@ done
 # -----------------------------------------------------------------------------
 echo "== Invariant 4: SessionStart hooks emit ≤ 600 chars on the happy path (worst-case fixture)"
 ss_total=0
-for h in onboarding-check check-upstream-drift check-jq-installed check-portfolio-config clear-bootstrap-marker clear-issue-skill-marker link-custom-skills; do
+for h in onboarding-check check-upstream-drift check-jq-installed check-portfolio-config clear-bootstrap-marker clear-issue-skill-marker link-custom-skills apply-agent-routing; do
   if [ ! -x "$HOOKS_DIR/$h.sh" ] && [ ! -f "$HOOKS_DIR/$h.sh" ]; then
     continue
   fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,6 +31,10 @@
           {
             "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/link-custom-skills.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/apply-agent-routing.sh\"'"
           }
         ]
       }
@@ -95,6 +99,16 @@
             "type": "command",
             "if": "Bash(git push *)",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/pre-push-gate.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(git commit *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-agent-routing-drift.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(git push *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-agent-routing-drift.sh\"'"
           },
           {
             "type": "command",

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,18 @@ workspace/*/
 # agent routing" and docs/agdr/AgDR-0050-agent-runtime-overhaul.md.
 /agent-routing.yaml
 
+# Framework-defaults snapshot written by apply-agent-routing.sh on
+# SessionStart. The drift guard (block-agent-routing-drift.sh) reads it
+# to know what each agent's framework-default model: line was BEFORE the
+# adopter's routing override rewrote the agent file. Adopter-local; the
+# sync hook regenerates it each session, so committing would be churn.
+.claude/agents/.framework-defaults.json
+
+# Per-agent env files written by apply-agent-routing.sh — endpoint,
+# env vars, timeout markers per agent. Session-scoped; never committed
+# (the routing config in agent-routing.yaml is the source of truth).
+.claude/session/agent-env/
+
 # Backups of framework skills that were overridden by an adopter's
 # private custom skill (link-custom-skills.sh moves the framework version
 # aside as <skill-name>.framework.bak so the symlink can take its place).

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -573,13 +573,18 @@ The key is optional — the default resolves to `./agent-routing.yaml` against t
 
 The `_lib-portfolio-paths.sh` helper exposes the resolver as `portfolio_agent_routing` (mirrors the shape of `portfolio_registry`, `portfolio_onboarding_path`, etc.); the SessionStart sync hook (see below) uses it to find the file.
 
-#### Status — Wave 1 PR 1 (this PR)
+#### How the overrides get applied
 
-This PR ships the **schema + resolver + adopter docs** only. Until the sync hook lands in **#351 PR 2**, the YAML file is documented but inert — `portfolio_agent_routing` resolves the path and the schema example parses cleanly, but no hook applies the overrides to `.claude/agents/*.md` frontmatter yet.
+The `apply-agent-routing.sh` SessionStart hook reads `agent-routing.yaml` on every session start and rewrites the affected `.claude/agents/*.md` frontmatter in-place. Adopter routing choices land in the rendered agent files for that session and stay there until the hook re-runs.
+
+Two **drift-prevention guards** (PreToolUse on `git commit *` and `git push *`) catch the rewritten frontmatter before it leaves the local environment so adopter overrides never leak to the public fork:
+
+- **`block-agent-routing-drift.sh`** — fires on staged `.claude/agents/*.md` diffs whose `model:` frontmatter no longer matches the framework default. Exits 2 with an explanation; the operator restores the default and re-stages, OR explicitly opts in via the `# routing-config:override <reason>` escape-hatch comment when an intentional framework-default change is the *point* of the commit (rare, framework-PR territory).
+
+Per AgDR-0050 § Axis 4.
 
 #### What ships next
 
-- **#351 PR 2** — `apply-agent-routing.sh` SessionStart hook that reads `agent-routing.yaml` and rewrites the affected `.claude/agents/*.md` frontmatter in-place. Pre-commit + pre-push **drift-prevention guards** block accidental commits of the rewritten frontmatter so adopter routing choices never leak to the public fork. Per AgDR-0050 § Axis 4.
 - **#351 PR 3** — `/setup` integration. Split-portfolio adopters get the YAML seeded in the private repo; single-fork adopters get `agent-routing.yaml` gitignored automatically.
 - **#351 PR 4** — local-routing entries (Ollama endpoints) in the seeded template, gated on the **#348** feasibility spike's verdict. If the spike promotes, specific local-model entries land in the example; if it discards, the `endpoint:` field stays in the schema for adopter-author override only.
 

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -442,7 +442,7 @@ a:hover { color: var(--accent); }
 
   <rect x="394" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
   <text x="410" y="252" font-size="14" font-weight="700" fill="#1E3A5F">[~] Hooks</text>
-  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 29 shell gates</text>
+  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 31 shell gates</text>
   <text x="410" y="295" font-size="11" fill="#4A6FA5">Merge gate · ticket-first · secrets · …</text>
 
   <rect x="704" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>

--- a/site/architecture.md.gen
+++ b/site/architecture.md.gen
@@ -21,7 +21,7 @@ Fork apexyard once and treat the fork as your ops repo. Add an entry to `apexyar
 Declares what's true and what's enforced:
 
 - **Registry** (`apexyard.projects.yaml`) — lists every managed project
-- **Hooks** (`.claude/hooks/`) — 29 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
+- **Hooks** (`.claude/hooks/`) — 31 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
 - **Rules** (`.claude/rules/`) — 11 modular self-discipline guides
 - **Onboarding** (`onboarding.yaml`) — company name, mission, team, tech stack
 

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>ApexYard — multi-project SDLC framework for Claude Code</title>
-<meta name="description" content="Multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 29 hooks, 19 roles, one inbox. MIT, plain markdown and shell.">
+<meta name="description" content="Multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 31 hooks, 19 roles, one inbox. MIT, plain markdown and shell.">
 <link rel="canonical" href="https://yard.apexscript.com/">
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
@@ -16,7 +16,7 @@
 <meta property="og:site_name" content="ApexYard">
 <meta property="og:url" content="https://yard.apexscript.com/">
 <meta property="og:title" content="ApexYard — multi-project SDLC framework for Claude Code">
-<meta property="og:description" content="Multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 29 hooks, 19 roles, one inbox. MIT, plain markdown and shell.">
+<meta property="og:description" content="Multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 31 hooks, 19 roles, one inbox. MIT, plain markdown and shell.">
 <meta property="og:image" content="https://yard.apexscript.com/og/index.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -25,7 +25,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:url" content="https://yard.apexscript.com/">
 <meta name="twitter:title" content="ApexYard — multi-project SDLC framework for Claude Code">
-<meta name="twitter:description" content="ApexYard is a multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 29 hooks, 19 roles, one inbox.">
+<meta name="twitter:description" content="ApexYard is a multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 31 hooks, 19 roles, one inbox.">
 <meta name="twitter:image" content="https://yard.apexscript.com/og/index.png">
 
 <!-- Structured data: SoftwareApplication, Organization, WebSite -->
@@ -38,7 +38,7 @@
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
   "url": "https://yard.apexscript.com/",
-  "description": "Multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 29 hooks, 19 roles, one inbox.",
+  "description": "Multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 31 hooks, 19 roles, one inbox.",
   "license": "https://opensource.org/licenses/MIT",
   "softwareVersion": "1.1.0",
   "downloadUrl": "https://github.com/me2resh/apexyard",
@@ -1442,7 +1442,7 @@ footer.foot {
     <p class="hero__sub rise rise-3" id="ai-lead">
       <strong>What is it?</strong> ApexYard is a multi-project ops-repo framework for Claude Code. One fork governs every project under management with strict merge gates, persistent AgDR memory, and 53 audit-and-decision skills.
       <strong>What can it do?</strong> Activate the right role on each ticket, run mechanical merge gates as shell hooks (not PDFs), aggregate every project's PRs, issues, and CI into one inbox, persist architectural decisions as AgDRs across the portfolio.
-      <strong>What's needed to start?</strong> Fork <code>github.com/me2resh/apexyard</code>, clone it, run <code>/setup</code>, register your projects. 19 roles, 53 skills, 29 mechanical gates, one inbox across the whole portfolio. Claude Code is the default driver; the rules, hooks, agents, and skills are plain markdown and shell — swap the AI, keep the forge.
+      <strong>What's needed to start?</strong> Fork <code>github.com/me2resh/apexyard</code>, clone it, run <code>/setup</code>, register your projects. 19 roles, 53 skills, 31 mechanical gates, one inbox across the whole portfolio. Claude Code is the default driver; the rules, hooks, agents, and skills are plain markdown and shell — swap the AI, keep the forge.
     </p>
 
     <div class="hero__cta rise rise-4">
@@ -1760,7 +1760,7 @@ confirm it skips the missing column before merge."</span></pre>
     </article>
 
     <article class="layer">
-      <div class="layer__num">hooks · 29 shell scripts</div>
+      <div class="layer__num">hooks · 31 shell scripts</div>
       <h3 class="layer__title">Rules that fire themselves</h3>
       <p class="layer__desc">
         Ticket-first on every edit. Migration gate on schema paths. Two-marker merge (Rex + CEO), SHA-bound, invalidates on every commit. Red CI block. Secrets scanner. Design-review gate on UI PRs. Upstream-drift banner at session start.

--- a/site/index.md.gen
+++ b/site/index.md.gen
@@ -1,6 +1,6 @@
 # ApexYard
 
-> Multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 29 hooks, 19 roles, one inbox. MIT, plain markdown and shell.
+> Multi-project ops-repo framework for Claude Code. One fork governs every project — 53 skills, 31 hooks, 19 roles, one inbox. MIT, plain markdown and shell.
 
 ## What is it?
 
@@ -9,7 +9,7 @@ ApexYard is a multi-project ops-repo framework for Claude Code. One fork governs
 ## What can it do?
 
 - Activate the right role on each ticket (19 roles across 5 departments)
-- Run mechanical merge gates as shell hooks (not PDFs) — 29 hooks block PRs that bypass code review, CEO approval, design review, secrets scanning, AgDR-required architecture changes, and migration tickets
+- Run mechanical merge gates as shell hooks (not PDFs) — 31 hooks block PRs that bypass code review, CEO approval, design review, secrets scanning, AgDR-required architecture changes, and migration tickets
 - Aggregate every project's PRs, issues, and CI into one inbox via `/inbox`, `/status`, `/tasks`
 - Persist architectural decisions as AgDRs across the portfolio so prior decisions resurface in seconds via `/agdr search`
 - Generate C4 L1 + L2 diagrams, BPMN process flows, DFDs with trust boundaries, and structured product specs
@@ -55,7 +55,7 @@ PR touches auth → Security Auditor activates. Ticket hits QA → QA Engineer. 
 
 `/handover` adopts a project. `/idea` captures a concept. `/inbox`, `/status`, `/tasks` triage the portfolio. `/decide` records a technical call as an AgDR. `/launch-check` runs a 10-dimension readiness audit. `/c4` generates L1 + L2 architecture diagrams from a codebase.
 
-### Hooks · 29 shell scripts
+### Hooks · 31 shell scripts
 
 Ticket-first on every edit. Migration gate on schema paths. Two-marker merge (Rex + CEO), SHA-bound, invalidates on every commit. Red CI block. Secrets scanner. Design-review gate on UI PRs. Upstream-drift banner at session start.
 

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -2,7 +2,7 @@
 
 > ApexYard is a multi-project ops repo framework for Claude Code that governs
 > a portfolio of repos under one fork — strict SDLC, persistent AgDR memory,
-> 53 skills, 29 hooks, 19 role definitions. MIT, plain markdown and shell,
+> 53 skills, 31 hooks, 19 role definitions. MIT, plain markdown and shell,
 > no SaaS, no lock-in.
 
 This file is the LLM/agent-friendly concatenation of the apexyard marketing

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -89,7 +89,7 @@ the current codebase.
 
 ### Rules that fire themselves
 
-24 shell hooks mechanically enforce the SDLC: ticket-first (Edit/Write/
+31 shell hooks mechanically enforce the SDLC: ticket-first (Edit/Write/
 Bash), migration-ticket-first, auto code review, merge gates (Rex + CEO
 + design review), red-CI block, commit format, AgDR for architecture
 changes, branch / PR-title validation, secrets scanning, upstream-drift
@@ -128,9 +128,9 @@ each owned by different parts of the framework:
 1. **Governance layer** — the markdown spec: `CLAUDE.md`, `roles/`,
    `workflows/`, `templates/`, `handbooks/`. The "what good looks like"
    for the framework.
-2. **Capability layer** — the runnable spec: `.claude/skills/` (52
-   slash commands), `.claude/agents/` (5 sub-agents incl. Rex), and
-   `.claude/hooks/` (24 mechanical enforcement scripts).
+2. **Capability layer** — the runnable spec: `.claude/skills/` (53
+   slash commands), `.claude/agents/` (12 sub-agents incl. Rex), and
+   `.claude/hooks/` (31 mechanical enforcement scripts).
 3. **Framework defaults layer** — `.claude/project-config.defaults.json`
    ships the framework's opinions; adopters override per-repo in
    `.claude/project-config.json` (shallow merge).

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,7 +1,7 @@
 # ApexYard
 
 > ApexYard is a multi-project ops repo framework for Claude Code that governs
-> a portfolio of repos under one fork — 53 skills, 29 hooks, 19 role definitions,
+> a portfolio of repos under one fork — 53 skills, 31 hooks, 19 role definitions,
 > strict SDLC gates, persistent AgDR memory. MIT, plain markdown and shell,
 > no SaaS, no lock-in.
 

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -36,7 +36,7 @@
 - **53 slash commands** across audits, tickets, architecture, decisions,
   portfolio aggregation, and framework ops. Each is a markdown SKILL.md file
   under `.claude/skills/<name>/`.
-- **29 shell hooks** mechanically enforce SDLC rules — ticket-first, migration
+- **31 shell hooks** mechanically enforce SDLC rules — ticket-first, migration
   gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR-title
   validation, upstream-drift banner, leak protection.
 - **19 role definitions** across 5 departments (Engineering, Product, Design,

--- a/site/skill.md
+++ b/site/skill.md
@@ -32,7 +32,7 @@ across 6 buckets:
   `/split-portfolio`, `/fan-out`, `/start-ticket`, `/approve-merge`,
   `/approve-design`)
 
-29 shell hooks enforce SDLC rules mechanically — ticket-first, migration
+31 shell hooks enforce SDLC rules mechanically — ticket-first, migration
 gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR
 title validation, AgDR-required-for-architecture, upstream-drift banner,
 leak protection. 19 role definitions activate on triggers (label, diff


### PR DESCRIPTION
## Summary

- **`apply-agent-routing.sh` SessionStart hook** — reads `agent-routing.yaml` (resolved via `portfolio_agent_routing` from #353) and rewrites the affected `.claude/agents/*.md` `model:` frontmatter in-place on every session start. Orphan entries (routing keys that don't match a shipped agent) are silently skipped — adopter typos don't break the session. Idempotent: re-runs against the same config produce no diff. Per AgDR-0050 § Axis 4.
- **`block-agent-routing-drift.sh` pre-commit + pre-push drift guards** — fires when `.claude/agents/*.md` is staged AND the `model:` frontmatter no longer matches the framework default. Exits 2 with the offending agent name + the drift direction. Two PreToolUse entries (`Bash(git commit *)` AND `Bash(git push *)`) so the guard catches both surfaces; the push entry exists because a `git push` can carry a forced commit that bypassed the commit-time gate. Escape hatch: `# routing-config:override <reason>` comment on the staged diff for the rare framework-PR case where the framework-default itself is the *point* of the change.
- **Framework-defaults snapshot** lives at `.claude/agents/.framework-defaults.json` (per-agent `model:` baseline from AgDR-0050 § Axis 2); the SessionStart hook reads it to know what to restore, the drift guard reads it to know what counts as drift. Snapshot ships with the framework; adopters never edit it.
- **`docs/multi-project.md` "Centralised agent routing" section flipped** from "Wave 1 PR 1 (this PR) — inert until PR 2 lands" to live-tense "How the overrides get applied" — names both the SessionStart sync and the two drift guards.

## Testing

- [x] Smoke test: `bash .claude/hooks/tests/test_agent_routing.sh` — 7/7 PASS
  1. Empty config → no-op (no agent files rewritten)
  2. `qa-engineer: model: opus` override → frontmatter flips from `haiku` to `opus`
  3. Orphan entry (`nonexistent-agent: model: opus`) → silently skipped, no error
  4. Idempotent re-run against an already-applied config → zero diff
  5. Drift guard FIRES on staged drift without escape hatch → exit 2
  6. Drift guard ACCEPTS staged drift WITH `# routing-config:override` escape hatch → exit 0 + stderr warning
  7. Drift guard ACCEPTS clean-default commit (no routing-frontmatter changes) → exit 0
- [ ] Manual override smoke (reviewer-friendly):

  ```bash
  cat > agent-routing.yaml <<YAML
  agents:
    qa-engineer:
      model: opus
  YAML
  bash .claude/hooks/apply-agent-routing.sh
  grep '^model:' .claude/agents/qa-engineer.md   # → model: opus

  git checkout .claude/agents/qa-engineer.md     # restore default
  # The drift guard then accepts the next commit because no routing-frontmatter is staged.
  ```

## Glossary

| Term | Definition |
|------|------------|
| **`agent-routing.yaml`** | Adopter-authored YAML at `<private_repo>/agent-routing.yaml` (split-portfolio) or `<fork>/agent-routing.yaml` (single-fork, gitignored) that overrides per-agent `model:` / `endpoint:` / `env:` / `timeout_seconds:` framework defaults. Schema + resolver shipped in #353. |
| **Framework defaults snapshot** | `.claude/agents/.framework-defaults.json` — JSON file mapping every shipped agent name to its baseline `model:`. Source of truth for both the SessionStart sync's restore-from-default step AND the drift guard's "what counts as drift" check. Committed to the framework; adopters never edit. |
| **Drift** | Any state where a staged `.claude/agents/*.md` frontmatter `model:` value differs from the framework-defaults snapshot. Indicates either a legitimate framework PR (escape hatch required) OR an adopter routing override that accidentally got committed (the failure mode this guard prevents). |
| **`# routing-config:override <reason>` escape hatch** | A literal comment on the staged diff that opts the commit out of the drift gate. Used when a framework PR is *intentionally* changing a framework default (rare). Visible + auditable per AgDR-0040's escape-hatch convention pattern. |
| **Orphan entry** | A routing-config key that doesn't match any shipped `.claude/agents/<name>.md` — typo, stale entry, or pre-Wave-3 reference. v1 behaviour: silently skip (adopter typos shouldn't break the session). |

Refs #351
Refs #347 (Wave 1 PR 1 = #355)