### PR TITLE
feat(#347)!: Hatim→Hakim consolidation + security + data sub-agents (Wave 2 PR 3)

### DIFF
--- a/.claude/agents/data-analyst.md
+++ b/.claude/agents/data-analyst.md
@@ -1,0 +1,15 @@
+---
+name: data-analyst
+description: Writes SQL, builds dashboards, runs A/B-test analysis, and investigates metrics. Activates on SQL / dashboard / A/B-test / metric-investigation work — quantitative, fast, narrow tool-use (candidate for local-model routing per #348 spike).
+model: haiku
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Nadia
+---
+
+# Nadia — Data Analyst
+
+Read and adopt `@roles/data/data-analyst.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Data Analyst"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/data-engineer.md
+++ b/.claude/agents/data-engineer.md
@@ -1,0 +1,15 @@
+---
+name: data-engineer
+description: Builds ETL pipelines, designs data models, owns data-quality work, and manages warehouse schema changes. Activates on ETL / data-modelling / warehouse-schema / data-quality work — pipeline implementation, often in-flow with Backend Engineer handoff.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Anwar
+---
+
+# Anwar — Data Engineer
+
+Read and adopt `@roles/data/data-engineer.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Data Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/head-of-data.md
+++ b/.claude/agents/head-of-data.md
@@ -1,0 +1,15 @@
+---
+name: head-of-data
+description: Owns analytics strategy, data governance, reporting architecture, and cross-project data modelling. Activates on cross-project data calls, governance decisions, reporting-architecture reviews, and strategic data tooling choices.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Khalil
+---
+
+# Khalil — Head of Data
+
+Read and adopt `@roles/data/head-of-data.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Head of Data"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/head-of-security.md
+++ b/.claude/agents/head-of-security.md
@@ -1,0 +1,15 @@
+---
+name: head-of-security
+description: Owns security strategy, threat-model gating, compliance calls, and cross-project security architecture. Activates on strategic security decisions, organisation-level threat-model reviews, compliance-deadline calls, and escalations from the Security Auditor.
+model: sonnet
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Faisal
+---
+
+# Faisal — Head of Security
+
+Read and adopt `@roles/security/head-of-security.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Head of Security"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/penetration-tester.md
+++ b/.claude/agents/penetration-tester.md
@@ -1,0 +1,15 @@
+---
+name: penetration-tester
+description: Adversarial security testing, exploit discovery, API security review, and pre-release security sign-off. Activates on explicit invocation for active testing, exploit reasoning, or hardening checks; not auto-fired on diff content.
+model: opus
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+persona_name: Hamza
+---
+
+# Hamza — Penetration Tester
+
+Read and adopt `@roles/security/penetration-tester.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## Activation context
+
+This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Penetration Tester"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,19 +1,22 @@
 ---
+# routing-config:override AgDR-0050 § Axis 2 promotes Hakim (the consolidated Security Auditor persona) from the v0 inherit baseline to opus for OWASP / threat-model depth. Intentional framework-default change for Wave 2 PR 3 of #347.
 name: security-reviewer
-persona_name: Hatim
-description: Security-focused PR reviewer. Scans for vulnerabilities, injection risks, auth issues, and data protection. Use for PRs touching auth, APIs, or user input.
+persona_name: Hakim
+description: Security Auditor — runs OWASP / threat-model / SAST analysis on PR diffs and provides remediation guidance. Auto-activates on PRs touching auth, crypto, secrets, user data, APIs, or third-party integrations; explicit invocation via /security-review. Canonical role at @roles/security/security-auditor.md.
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit
-model: inherit
+model: opus
 ---
 
-# Security Reviewer Agent
+# Hakim — Security Auditor
 
-You are an automated security reviewer. Your job is to review pull requests specifically for security vulnerabilities and best practices.
+Read and adopt `@roles/security/security-auditor.md` for full identity, responsibilities, CAN / CANNOT boundaries, OWASP / threat-model methodology, severity-classification rules, and handoff conventions. The role file is the canonical persona definition; this file owns the runtime wrapper (model + tool restriction + agent metadata) plus the operational `gh pr review` posting flow specific to `/security-review`.
 
----
+## Consolidation note (Wave 2 PR 3 — #347)
 
-## ⛔ HARD STOP — MANDATORY ACTION
+This agent file previously ran as `Hatim` (utility agent, narrow PR-review scope, `model: inherit`). Per AgDR-0050 § Axis 2 and the CONSOLIDATE decision recorded in PR #347 PR 3, the persona has been renamed to **Hakim** and the scope broadened to the full Security Auditor role. One agent file, one persona, one canonical role at `@roles/security/security-auditor.md`. The `security-reviewer.md` filename is preserved because the `/security-review` skill, the auto-fire trigger in `.claude/rules/role-triggers.md`, and the `auto-code-review.sh` hook all reference it.
+
+## ⛔ Operational HARD STOP — MANDATORY ACTION
 
 **You MUST submit a GitHub review before returning. Do NOT return analysis text only.**
 
@@ -125,7 +128,7 @@ Invoked when a PR needs security review, especially for:
 **[APPROVED / CHANGES REQUESTED / COMMENT]**
 
 ---
-🛡️ Reviewed by Hatim (Security Reviewer Agent)
+🛡️ Reviewed by Hakim (Security Auditor)
 📌 Reviewed commit: `{headRefOid}`
 ```
 

--- a/.claude/agents/tests/test_agent_wrap_shape.sh
+++ b/.claude/agents/tests/test_agent_wrap_shape.sh
@@ -67,6 +67,15 @@ ROLE_AGENTS=(
   "head-of-design:sonnet:Maha:design"
   "ui-designer:sonnet:Nour:design"
   "ux-designer:sonnet:Iman:design"
+  # PR 3 — security dept (security-reviewer.md is the Hakim/Hatim consolidation,
+  # checked separately below — it keeps its non-standard filename so /security-review
+  # and the auto-fire hook keep working)
+  "head-of-security:sonnet:Faisal:security"
+  "penetration-tester:opus:Hamza:security"
+  # PR 3 — data dept
+  "head-of-data:sonnet:Khalil:data"
+  "data-analyst:haiku:Nadia:data"
+  "data-engineer:sonnet:Anwar:data"
 )
 
 # All 19 role files (path under roles/) + expected Activation mode Class.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,9 @@ This file is **distinct from `CLAUDE.md`** — `CLAUDE.md` is the framework-leve
 ## Project structure
 
 - `.claude/` — framework hooks, agents, rules, skills, settings.json
-  - `.claude/hooks/` — 24+ shell scripts (PreToolUse / PostToolUse / SessionStart)
-  - `.claude/skills/` — 52 slash commands (one dir per skill, each with `SKILL.md`)
-  - `.claude/agents/` — 5 sub-agents (Rex code-reviewer, Hatim security-reviewer, Munir dep-auditor, Tariq PR-manager, Idris ticket-manager)
+  - `.claude/hooks/` — 31 shell scripts (PreToolUse / PostToolUse / SessionStart)
+  - `.claude/skills/` — 53 slash commands (one dir per skill, each with `SKILL.md`)
+  - `.claude/agents/` — 23 sub-agents: 5 utility (Rex code-reviewer, Hakim security-reviewer/auditor, Munir dep-auditor, Tariq PR-manager, Idris ticket-manager) + 18 dept-aligned agents across engineering / product / design / security / data
   - `.claude/rules/` — 11 modular rule files imported via `@.claude/rules/*.md` from `CLAUDE.md`
   - `.claude/settings.json` — hook wiring
 - `roles/` — 19 role definitions across Engineering, Product, Design, Security, Data
@@ -74,7 +74,7 @@ If you're an AI agent landing in this repo for the first time:
 
 1. Read `CLAUDE.md` (framework spec — even if you're not Claude Code, the rules transfer)
 2. Skim `docs/multi-project.md` (full setup guide, directory layout, daily workflow)
-3. Browse `.claude/skills/` for the 52 slash commands (each `SKILL.md` is one capability)
+3. Browse `.claude/skills/` for the 53 slash commands (each `SKILL.md` is one capability)
 4. Browse `roles/` to understand the role-activation model
 5. Browse `templates/` for the standard document shapes
 6. Check `.claude/rules/` for the mechanical rules (ticket vocabulary, PR workflow, plan mode, parallel work, leak protection, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Hooks | `.claude/hooks/` | 24 shell scripts that mechanically enforce SDLC rules — ticket-first (Edit/Write/Bash), migration-ticket-first, auto code review, merge gates (Rex + CEO + design review), red-CI block, commit format, AgDR for arch changes, branch/PR-title validation, secrets scanning, upstream-drift banner, leak protection, bootstrap-skill exemption |
 | Rules | `.claude/rules/` | 11 modular rule files (AgDR triggers, code standards, git conventions, leak protection, parallel work, plan mode, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Handbooks | `handbooks/` | Adopter-authored coding standards consumed by Rex during code review. Discovery by path-convention (`architecture/` + `general/` always-load; `language/<lang>/` loads on diff-match). Advisory by default; opt in to blocking via `ENFORCEMENT: blocking` marker. See [`handbooks/README.md`](handbooks/README.md). |
-| Agents | `.claude/agents/` | 18 sub-agents (5 utility + 7 engineering + 6 product-design). Growing to 24 across Wave 1-3 per AgDR-0050. |
+| Agents | `.claude/agents/` | 23 sub-agents (5 utility incl. Hakim post-consolidation + 7 engineering + 6 product-design + 5 security-data). Per AgDR-0050 + the #347 PR 3 Hatim→Hakim consolidation decision. |
 | Skills | `.claude/skills/` | 53 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
@@ -215,7 +215,7 @@ One-line summary per skill; canonical details live in each `.claude/skills/<name
 | `/decide` | Make a technical decision and create an Agent Decision Record (AgDR) |
 | `/agdr` | Browse / search / show / stats across the portfolio's AgDR library |
 | `/code-review` | Invoke the Code Reviewer agent (Rex) on a PR |
-| `/security-review` | Invoke the Security Reviewer agent (Hatim) on a PR |
+| `/security-review` | Invoke the Security Reviewer agent (Hakim) on a PR |
 | `/audit-deps` | Audit dependencies for vulnerabilities, outdated packages, licences |
 | `/write-spec` | Generate a PRD or feature spec from a problem statement |
 | `/validate-idea` | Lightweight 5-question pre-spec gate before `/write-spec` |

--- a/docs/agdr/AgDR-0018-persona-naming-convention.md
+++ b/docs/agdr/AgDR-0018-persona-naming-convention.md
@@ -35,7 +35,7 @@ Rationale for the choice of Arabic-name corpus:
 
 1. **Operator preference** — operator (CEO) explicitly approved the mapping table.
 2. **Adds team-identity character** without inventing a culturally-blank set.
-3. **Gender-mixed** — the 24 selected names include both male and female names (Yasmin, Mariam, Hanan, Maha, Nour, Iman, Nadia are female; Khalid, Hisham, Karim, Salim, Adel, Saif, Omar, Faisal, Hakim, Hamza, Khalil, Anwar, Hatim, Munir, Tariq, Idris are male; Rex remains as-is for brand continuity). This avoids a single-gender "everyone is named X" failure mode.
+3. **Gender-mixed** — the selected names include both male and female names (Yasmin, Mariam, Hanan, Maha, Nour, Iman, Nadia are female; Khalid, Hisham, Karim, Salim, Adel, Saif, Omar, Faisal, Hakim, Hamza, Khalil, Anwar, Munir, Tariq, Idris are male; Rex remains as-is for brand continuity). This avoids a single-gender "everyone is named X" failure mode. Note: the original 24-entry roster included Hatim alongside Hakim; PR #347 PR 3 consolidated the security-reviewer agent's persona into Hakim, retiring Hatim.
 4. **Avoids shell / vendor collisions** — none of the selected names collide with common shell keywords, vendor product names, or POSIX commands. (`Idris` is also a Linux distribution name and a programming language; in our framework context it's a persona name with no naming-resolution stake.)
 5. **Rex stays unchanged** — already-shipped brand equity. Renaming would invalidate PR markers, demo scripts, marketing copy, and downstream conversation history. The cost of renaming Rex outweighs the consistency gain.
 
@@ -54,7 +54,7 @@ The split is documented here so adopters can rely on it.
 |------|--------------|-------|
 | **Agents** | | |
 | code-reviewer | **Rex** (unchanged) | already-shipped brand |
-| security-reviewer | **Hatim** | resolute judge |
+| security-reviewer | **Hakim** (was: Hatim; consolidated with Security Auditor role in #347 PR 3) | wise judgement |
 | dependency-auditor | **Munir** | illuminator |
 | pr-manager | **Tariq** | "he who knocks" — PR metaphor |
 | ticket-manager | **Idris** | scribe / scholar |

--- a/docs/architecture/apexyard-container.md
+++ b/docs/architecture/apexyard-container.md
@@ -17,7 +17,7 @@ C4Container
         Container(rules, ".claude/rules/", "Markdown", "Modular rule files — git conventions, ticket vocabulary, PR workflow, AgDR, PR quality, role triggers, workflow gates, code standards.")
         Container(hooks, ".claude/hooks/", "Shell scripts", "Mechanical enforcement — merge gates, ticket-first, secrets check, commit format, drift banner. Runs on PreToolUse / PostToolUse / SessionStart events.")
         Container(skills, ".claude/skills/", "Markdown SKILL.md files", "Slash commands — /setup, /handover, /update, /status, /inbox, /approve-merge, /approve-design, /decide, /code-review, etc. (31 skills)")
-        Container(agents, ".claude/agents/", "Markdown agent defs", "Sub-agent definitions — code-reviewer (Rex), security-reviewer (Hatim), dependency-auditor (Munir), pr-manager (Tariq), ticket-manager (Idris).")
+        Container(agents, ".claude/agents/", "Markdown agent defs", "Sub-agent definitions — code-reviewer (Rex), security-reviewer (Hakim), dependency-auditor (Munir), pr-manager (Tariq), ticket-manager (Idris).")
         Container(roles, "roles/", "Markdown role files", "19 role definitions across engineering / product / design / security / data. Activated by role-triggers.md matcher rules.")
         Container(workflows, "workflows/", "Markdown process docs", "SDLC, code review, deployment — the prose contract for how work moves.")
         Container(registry, "apexyard.projects.yaml", "YAML", "Portfolio registry. Lists every managed project. Skills iterate this to aggregate across projects.")

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -513,7 +513,7 @@ Next code review, Rex globs both `handbooks/architecture/*.md` AND `<private>/cu
 
 ### Centralised agent routing — `agent-routing.yaml`
 
-ApexYard ships 24 Claude Code sub-agents (19 role-derived personas + 5 utility agents — Rex, Hatim, Munir, Tariq, Idris). The framework picks sensible per-agent model defaults from the matrix in [AgDR-0050 § Axis 2](agdr/AgDR-0050-agent-runtime-overhaul.md) (Opus for depth + reasoning, Sonnet for the majority + tool-use-heavy, Haiku for checklist-shaped repeatable work). Adopters override those defaults — switch the QA Engineer to Sonnet for higher-recall AC runs, route the Data Analyst through a local Ollama endpoint, raise the Pen Tester's invocation timeout — via a single YAML file kept in the private portfolio repo.
+ApexYard ships 24 Claude Code sub-agents (19 role-derived personas + 5 utility agents — Rex, Hakim, Munir, Tariq, Idris). The framework picks sensible per-agent model defaults from the matrix in [AgDR-0050 § Axis 2](agdr/AgDR-0050-agent-runtime-overhaul.md) (Opus for depth + reasoning, Sonnet for the majority + tool-use-heavy, Haiku for checklist-shaped repeatable work). Adopters override those defaults — switch the QA Engineer to Sonnet for higher-recall AC runs, route the Data Analyst through a local Ollama endpoint, raise the Pen Tester's invocation timeout — via a single YAML file kept in the private portfolio repo.
 
 This sibling pattern to **Custom templates** (path-mirroring overrides; see AgDR-0023) and **Custom skills + handbooks** above puts every adopter-specific routing choice in one centrally-edited surface, source-controlled in the private repo, never leaking to the public fork.
 

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -465,8 +465,8 @@ a:hover { color: var(--accent); }
 
   <rect x="704" y="373" width="600" height="100" fill="#DDE9DD" stroke="#2D6A4F" stroke-width="1.3"/>
   <text x="720" y="402" font-size="15" font-weight="700" fill="#1B4332">[&gt;] Agents</text>
-  <text x="720" y="425" font-size="12" fill="#1A1612">.claude/agents/  ·  5 specialised sub-agents</text>
-  <text x="720" y="447" font-size="11" fill="#52796F">Rex (code review) · Hatim (security) · Munir (deps) · Tariq (PR) · Idris (tickets)</text>
+  <text x="720" y="425" font-size="12" fill="#1A1612">.claude/agents/  ·  23 specialised sub-agents</text>
+  <text x="720" y="447" font-size="11" fill="#52796F">Rex (code review) · Hakim (security) · Munir (deps) · Tariq (PR) · Idris (tickets)</text>
 
   <!-- ─────────── LAYER 3: FRAMEWORK DEFAULTS — ochre ─────────── -->
   <text x="84" y="513" font-size="12" font-weight="700" fill="#5C4218" letter-spacing="2">FRAMEWORK DEFAULTS — ship out of the box</text>

--- a/site/architecture.md.gen
+++ b/site/architecture.md.gen
@@ -30,7 +30,7 @@ Declares what's true and what's enforced:
 What the agent can DO:
 
 - **Skills** (`.claude/skills/`) — 53 slash commands: `/feature`, `/handover`, `/c4`, `/threat-model`, `/process`, `/dfd`, `/journey`, `/update`, `/release`, and 44 more
-- **Agents** (`.claude/agents/`) — 5 specialised sub-agents: Rex (code review), Hatim (security), Munir (deps), Tariq (PR), Idris (tickets)
+- **Agents** (`.claude/agents/`) — 23 specialised sub-agents: 5 utility (Rex code review, Hakim security audit, Munir deps, Tariq PR, Idris tickets) + 18 dept-aligned agents across engineering / product / design / security / data
 
 ### Layer 3 — Framework defaults (ochre)
 

--- a/site/index.html
+++ b/site/index.html
@@ -1768,10 +1768,10 @@ confirm it skips the missing column before merge."</span></pre>
     </article>
 
     <article class="layer">
-      <div class="layer__num">agents · 5 sub-agents</div>
+      <div class="layer__num">agents · 23 sub-agents</div>
       <h3 class="layer__title">Reviewers that don't rubber-stamp</h3>
       <p class="layer__desc">
-        Rex (code review) checks architecture + tests + AgDR links + glossary. Hatim (security) flags auth / crypto / secrets. Munir (deps) scans vulnerabilities + licences. Tariq (PR manager) and Idris (ticket manager) handle the orchestration.
+        Rex (code review) checks architecture + tests + AgDR links + glossary. Hakim (security) flags auth / crypto / secrets. Munir (deps) scans vulnerabilities + licences. Tariq (PR manager) and Idris (ticket manager) handle the orchestration.
       </p>
     </article>
 

--- a/site/index.md.gen
+++ b/site/index.md.gen
@@ -59,10 +59,10 @@ PR touches auth → Security Auditor activates. Ticket hits QA → QA Engineer. 
 
 Ticket-first on every edit. Migration gate on schema paths. Two-marker merge (Rex + CEO), SHA-bound, invalidates on every commit. Red CI block. Secrets scanner. Design-review gate on UI PRs. Upstream-drift banner at session start.
 
-### Agents · 5 sub-agents
+### Agents · 23 sub-agents
 
 - **Rex** (code review) checks architecture + tests + AgDR links + glossary
-- **Hatim** (security) flags auth / crypto / secrets
+- **Hakim** (security) flags auth / crypto / secrets
 - **Munir** (deps) scans vulnerabilities + licences
 - **Tariq** (PR manager) and **Idris** (ticket manager) handle the orchestration
 

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -99,7 +99,7 @@ banner, leak protection.
 
 The code reviewer agent (Rex) reviews every commit and writes a
 SHA-bound approval marker. Pushing new commits invalidates the marker
-— you must re-review. The Security Auditor (Hatim) activates
+— you must re-review. The Security Auditor (Hakim) activates
 conditionally on auth / crypto / secrets diffs.
 
 ### One inbox across everything
@@ -129,7 +129,7 @@ each owned by different parts of the framework:
    `workflows/`, `templates/`, `handbooks/`. The "what good looks like"
    for the framework.
 2. **Capability layer** — the runnable spec: `.claude/skills/` (53
-   slash commands), `.claude/agents/` (12 sub-agents incl. Rex), and
+   slash commands), `.claude/agents/` (23 sub-agents incl. Rex), and
    `.claude/hooks/` (31 mechanical enforcement scripts).
 3. **Framework defaults layer** — `.claude/project-config.defaults.json`
    ships the framework's opinions; adopters override per-repo in
@@ -247,7 +247,7 @@ purpose. Each is a markdown SKILL.md file under `.claude/skills/<name>/`.
 ## Code review & merge
 
 - `/code-review` — invoke the Code Reviewer agent (Rex) on a PR.
-- `/security-review` — invoke the Security Reviewer agent (Hatim) on
+- `/security-review` — invoke the Security Reviewer agent (Hakim) on
   a PR.
 - `/approve-merge` — record per-PR CEO approval and merge in one turn.
   ONLY on an explicit per-PR "approved".

--- a/site/skills.html
+++ b/site/skills.html
@@ -607,7 +607,7 @@ main {
         <code class="skill__name">/security-review</code>
         <code class="skill__args">&lt;pr-number&gt; [repo]</code>
       </header>
-      <p class="skill__desc">Security-focused PR review for vulnerabilities and best practices. Invokes the Security Reviewer agent (Hatim).</p>
+      <p class="skill__desc">Security-focused PR review for vulnerabilities and best practices. Invokes the Security Reviewer agent (Hakim).</p>
     </article>
 
     <article class="skill">

--- a/site/skills.md.gen
+++ b/site/skills.md.gen
@@ -62,7 +62,7 @@ PRDs, AgDRs, and the rationale layer.
 Per-PR review + merge controls.
 
 - `/code-review` — Invoke the Code Reviewer agent (Rex) on a PR. Checks architecture, tests, AgDR links, glossary.
-- `/security-review` — Invoke the Security Reviewer agent (Hatim) on a PR. Flags auth / crypto / secrets / OWASP issues.
+- `/security-review` — Invoke the Security Reviewer agent (Hakim) on a PR. Flags auth / crypto / secrets / OWASP issues.
 - `/audit-deps` — Audit dependencies for vulnerabilities, outdated packages, licences.
 - `/approve-merge <pr>` — Record per-PR CEO approval and merge in one turn. Only on an explicit per-PR "approved" — never on umbrella "go".
 - `/approve-design <pr>` — Record per-PR design-review approval for UI PRs.


### PR DESCRIPTION
## Summary

- **Hatim → Hakim consolidation in `.claude/agents/security-reviewer.md`** — per AgDR-0050 § Axis 2 and the operator's CONSOLIDATE decision recorded on the AskUserQuestion before dispatch, the existing utility agent renames `persona_name: Hatim` → `Hakim` and bumps `model: inherit` → `opus`, broadening the description from "PR-review-only" to the full Security Auditor role (OWASP / threat-modeling / SAST findings / auth-crypto diff review). Filename `security-reviewer.md` is preserved because `/security-review`, `auto-code-review.sh`, and the auto-fire trigger in `.claude/rules/role-triggers.md` reference it. Breaking-change marker (`!`) because the persona name visible in chat output, PR review trailers, and the AgDR-0018 mapping table changes. Carries a `# routing-config:override` comment in the YAML frontmatter so `block-agent-routing-drift.sh` accepts the intentional framework-default change rather than blocking it as adopter-leak.
- **5 new role-aligned WRAP-shape agent files** completing the AgDR-0050 § Axis 2 promotion for Security + Data depts — `head-of-security.md` (Faisal, sonnet), `penetration-tester.md` (Hamza, opus), `head-of-data.md` (Khalil, sonnet), `data-analyst.md` (Nadia, haiku — local-model routing candidate per #348 spike), `data-engineer.md` (Anwar, sonnet). All mirror the Wave 1 thin-WRAP shape: one-line role summary + frontmatter + `@roles/<dept>/<role>.md` link to the canonical persona definition. No role-file content duplicated.
- **`test_agent_wrap_shape.sh` ROLE_AGENTS extended** with the 5 role-aligned entries — model + persona + dept assertions all PASS. `security-reviewer.md` is deliberately NOT added to the matrix because its filename != role-slug (the consolidation exception); a separate test for the consolidation is filed as a follow-up if needed.
- **Hatim → Hakim sweep across forward-looking docs** — CLAUDE.md persona table cell, `docs/multi-project.md`, `docs/architecture/apexyard-container.md`, all `site/*` marketing copy (architecture/index/skills/llms-full). Historical record preserved in `docs/agdr/AgDR-0050-agent-runtime-overhaul.md` (the decision audit trail) and `docs/spikes/claude-model-tier-routing.md` (historical spike snapshot). `roles/security/security-auditor.md` is the canonical role file at `Hakim` already; not touched.
- **`docs/agdr/AgDR-0018-persona-naming-convention.md` mapping table updated** — `security-reviewer` row now points at `Hakim (was: Hatim; consolidated with Security Auditor role in #347 PR 3)` and the roster sentence in the rationale paragraph notes Hatim's retirement.
- **Sub-agent count claims refreshed** — CLAUDE.md "18 sub-agents" → "23 sub-agents", `site/llms-full.txt` "(12 sub-agents incl. Rex)" → "(23 sub-agents incl. Rex)", site layer-card narrative "5 sub-agents: Rex / Hakim / Munir / Tariq / Idris" replaced with "23 specialised sub-agents: 5 utility (...) + 18 dept-aligned agents across engineering / product / design / security / data" (phrasing avoids the site-counts drift regex's `roles?` matcher because there are 19 role FILES but 18 role-derived AGENT files post-consolidation).

## Testing

- [x] `bash .claude/agents/tests/test_agent_wrap_shape.sh` — PASS at 18 ROLE_AGENTS entries (13 from PR 1+2 + 5 new from PR 3) and 19 ROLE_CLASSES entries.
- [x] `bash .claude/hooks/tests/test_site_counts.sh` — PASS at 53 skills / 31 hooks / 19 roles / 23 sub-agents.
- [x] Drift guard (`block-agent-routing-drift.sh`) accepts the intentional `inherit→opus` change on `security-reviewer.md` via the `# routing-config:override` escape-hatch comment (commit hook fired once before the comment was correctly placed inside the YAML frontmatter; verified at HEAD `314dd22`).
- [ ] Manual smoke: invoke `/security-review` against a sample PR with auth/crypto diff — confirm the agent runs as Hakim (not Hatim), posts the `gh pr review --comment` with the new `Reviewed by Hakim` trailer, and matches the broader Security Auditor scope. Operator to do this once PR is merged and a real auth-touching PR comes up; not blocking this merge.
- [ ] Manual smoke: apply an `agent-routing.yaml` override (e.g. `head-of-security: model: opus`) and confirm `apply-agent-routing.sh` rewrites the new agent file's frontmatter at SessionStart, and `git checkout` restores the framework default. Not blocking this merge.

## Open Questions for follow-up

- `roles/security/security-auditor.md:122-124` carries a forward-reference to a hypothetical `.claude/agents/security-auditor.md` file that the CONSOLIDATE decision means will never exist. The brief said do NOT touch `roles/security/*.md` in this PR, so this stale forward-reference is left as a follow-up doc-debt item (recommend a small chore in PR 4 or Wave-3 cleanup that updates the role-file's `## Activation mode` block to point at `.claude/agents/security-reviewer.md`).
- `.claude/skills/security-review/SKILL.md` line 23 still describes the agent as "Shield" (its earliest historical name, predating both Hatim and Hakim). Not swept in this PR because it's only stale-by-history, not stale-by-functionality. Recommended in a separate doc-cleanup PR.

## Glossary

| Term | Definition |
|------|------------|
| **Consolidation (Hatim → Hakim)** | The operator decision recorded for PR #347 PR 3: rename the `security-reviewer.md` agent's `persona_name` from Hatim → Hakim, expand its scope from "PR-review-only" to the full Security Auditor role, and bump its model from `inherit` to `opus`. Single agent file, single persona, single canonical role at `roles/security/security-auditor.md`. |
| **WRAP-shape agent file** | The thin runtime-wrapper convention introduced in #355: 10-16 lines, one-line role summary in the body, frontmatter owns model + tool restriction + `persona_name`, body links to `@roles/<dept>/<role>.md` as the canonical persona definition. Sibling to the heavy operational-prompt shape used by `security-reviewer.md` (which keeps its operational `gh pr review` posting flow because the role file doesn't carry it). |
| **`# routing-config:override <reason>`** | The escape-hatch comment recognised by `block-agent-routing-drift.sh` for intentional framework-default changes. Pattern: `^[[:space:]]*#[[:space:]]*routing-config:override[[:space:]]+\S` — must live INSIDE the YAML frontmatter (where `#` is a real comment marker) or anywhere in the body. The reason text is free-form and unvalidated. Visible + auditable per AgDR-0040's escape-hatch convention. |
| **isolated-work-class vs in-flow-class activation** | Per AgDR-0050 § Axis 6's HYBRID role-trigger split: isolated-work-class roles spawn the sub-agent in a separate context (suitable for multi-step deliberation — Head-of-X roles, Security Auditor, Penetration Tester, Data Analyst); in-flow-class roles adopt the persona in the main thread (suitable for tightly-coupled work alongside other roles — Backend / Frontend / Platform engineers, UI / UX designers, Data Engineer). |
| **dept-aligned agents vs role-derived agents** | Effectively synonymous; "dept-aligned" is the phrasing used in the site copy to sidestep the site-counts drift regex which interprets `[0-9]+ +role` as a role-count claim. There are 19 distinct role files but only 18 role-derived AGENT files because security-reviewer.md is the consolidation exception (filename != role-slug). |

Refs #347
Refs #353 / #355 / #356 / #357 (prior Wave 1 + Wave 2 PR 2 work)