### PR TITLE
feat(#347): promote utility agents to per-agent model: frontmatter (Wave 2 PR 4)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,10 +1,11 @@
 ---
+# routing-config:override Rex bumped inherit → opus per AgDR-0050 § Axis 2 line 50 for PR diff review + handbook reasoning depth. Intentional framework-default change for Wave 2 PR 4 of #347.
 name: code-reviewer
 persona_name: Rex
 description: Expert code review specialist. Reviews PRs for quality, security, and standards compliance. Use proactively after code changes or when a PR needs review.
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit
-model: inherit
+model: opus
 ---
 
 # Code Reviewer Agent

--- a/.claude/agents/dependency-auditor.md
+++ b/.claude/agents/dependency-auditor.md
@@ -1,10 +1,11 @@
 ---
+# routing-config:override Munir bumped inherit → sonnet per AgDR-0050 § Axis 2 line 63 for pattern-matching across package files. Intentional framework-default change for Wave 2 PR 4 of #347.
 name: dependency-auditor
 persona_name: Munir
 description: Monitors dependencies for vulnerabilities, outdated packages, and license compliance. Run weekly or when package.json changes.
 tools: Bash, Read, Grep, Glob
 disallowedTools: Write, Edit
-model: inherit
+model: sonnet
 ---
 
 # Dependency Auditor Agent

--- a/.claude/agents/pr-manager.md
+++ b/.claude/agents/pr-manager.md
@@ -1,9 +1,10 @@
 ---
+# routing-config:override Tariq bumped inherit → sonnet per AgDR-0050 § Axis 2 line 64 for tool-call-heavy + narrative-quality PR body work. Intentional framework-default change for Wave 2 PR 4 of #347.
 name: pr-manager
 persona_name: Tariq
 description: Coordinates PR lifecycle from creation to merge. Enforces 2-review workflow, commit SHA verification, and auto-merge on human approval.
 tools: Bash, Read, Grep, Glob
-model: inherit
+model: sonnet
 ---
 
 # PR Manager Agent

--- a/.claude/agents/tests/test_agent_wrap_shape.sh
+++ b/.claude/agents/tests/test_agent_wrap_shape.sh
@@ -78,6 +78,22 @@ ROLE_AGENTS=(
   "data-engineer:sonnet:Anwar:data"
 )
 
+# Utility agents — no canonical role file under roles/<dept>/, but the model
+# baseline is set by AgDR-0050 § Axis 2 and locked in by this PR (Wave 2 PR 4
+# of #347). Each entry carries a `# routing-config:override` comment in its
+# YAML frontmatter so block-agent-routing-drift.sh accepts the intentional
+# inherit→<model> framework-default change. security-reviewer.md is included
+# here because PR 3's Hatim→Hakim consolidation already promoted it to opus
+# with the same escape-hatch shape.
+# Format: "<slug>:<expected_model>:<expected_persona_name>"
+UTILITY_AGENTS=(
+  "code-reviewer:opus:Rex"
+  "security-reviewer:opus:Hakim"
+  "dependency-auditor:sonnet:Munir"
+  "pr-manager:sonnet:Tariq"
+  "ticket-manager:sonnet:Idris"
+)
+
 # All 19 role files (path under roles/) + expected Activation mode Class.
 # Per AgDR-0050 § Axis 6 (HYBRID integration table).
 ROLE_CLASSES=(
@@ -194,6 +210,61 @@ for entry in "${ROLE_AGENTS[@]}"; do
 done
 
 # -----------------------------------------------------------------------------
+# Invariant 4b — utility agents: model + persona + escape-hatch comment.
+# Per AgDR-0050 § Axis 2, the 5 utility agents have explicit model: values
+# (not `inherit`) and carry a `# routing-config:override` comment in YAML
+# frontmatter so the drift guard accepts the intentional framework-default
+# change.
+# -----------------------------------------------------------------------------
+echo
+echo "== Utility-agent model + escape-hatch comment (AgDR-0050 § Axis 2)"
+for entry in "${UTILITY_AGENTS[@]}"; do
+  IFS=':' read -r slug expected_model expected_persona <<<"$entry"
+  agent_file="$AGENTS_DIR/${slug}.md"
+
+  if [ ! -f "$agent_file" ]; then
+    red "  FAIL: missing utility-agent file $agent_file"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  actual_model=$(get_frontmatter_value "$agent_file" "model")
+  if [ "$actual_model" = "inherit" ] || [ -z "$actual_model" ]; then
+    red "  FAIL: $slug — model=$actual_model (must be an explicit opus|sonnet|haiku per Axis 2; inherit is a regression)"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+  if [ "$actual_model" != "$expected_model" ]; then
+    red "  FAIL: $slug — model=$actual_model (expected $expected_model per matrix)"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  actual_persona=$(get_frontmatter_value "$agent_file" "persona_name")
+  if [ "$actual_persona" != "$expected_persona" ]; then
+    red "  FAIL: $slug — persona_name=$actual_persona (expected $expected_persona)"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  # Escape-hatch comment in the YAML frontmatter (between the two `---`
+  # markers, `#`-prefixed). The drift guard requires it for any agent file
+  # whose model: differs from the dev-baseline `inherit`. Uses POSIX char
+  # classes — \S isn't portable across awk implementations.
+  if ! awk '
+    /^---[[:space:]]*$/ { fm_count++; if (fm_count == 2) exit }
+    fm_count == 1 && /^[[:space:]]*#[[:space:]]*routing-config:override[[:space:]]+[^[:space:]]/ { found = 1 }
+    END { exit !found }
+  ' "$agent_file"; then
+    red "  FAIL: $slug — missing '# routing-config:override <reason>' comment in YAML frontmatter (drift guard will block any commit)"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  green "  PASS: $slug (utility, model=$actual_model, persona=$actual_persona, escape-hatch present)"
+done
+
+# -----------------------------------------------------------------------------
 # Invariant 5 + 6 — every role file has `## Activation mode` and declares
 # the matrix-correct Class value.
 # -----------------------------------------------------------------------------
@@ -248,5 +319,5 @@ if [ "$FAIL" -gt 0 ]; then
   red "FAIL: $FAIL invariant(s) failed"
   exit 1
 fi
-green "PASS: role-derived agent wrap-shape + 19-role Activation mode coverage"
+green "PASS: role-derived agent wrap-shape + utility-agent Axis 2 baselines + 19-role Activation mode coverage"
 exit 0

--- a/.claude/agents/ticket-manager.md
+++ b/.claude/agents/ticket-manager.md
@@ -1,9 +1,10 @@
 ---
+# routing-config:override Idris bumped inherit → sonnet per AgDR-0050 § Axis 2 line 65 for schema-conforming output + interactive ticket-interview work. Intentional framework-default change for Wave 2 PR 4 of #347. Local-model routing candidate per #348 spike.
 name: ticket-manager
 persona_name: Idris
 description: Creates and manages GitHub Issues in the project's own repo for all work tracking. Use when a new task is starting, a PR is being created, or work needs tracking.
 tools: Bash, Read
-model: inherit
+model: sonnet
 ---
 
 # Ticket Manager Agent

--- a/.claude/hooks/tests/test_agent_routing_sync_and_drift.sh
+++ b/.claude/hooks/tests/test_agent_routing_sync_and_drift.sh
@@ -135,6 +135,23 @@ persona_name: Karim
 # Karim — Backend Engineer
 MD
 
+    # Utility-agent fixture (Wave 2 PR 4 of #347). ticket-manager is the
+    # local-routing candidate per #348 spike. The routing mechanism doesn't
+    # distinguish utility vs role-derived agents — this fixture proves the
+    # SessionStart sync covers the utility class too.
+    cat > .claude/agents/ticket-manager.md <<'MD'
+---
+# routing-config:override Idris bumped inherit → sonnet per AgDR-0050 § Axis 2 line 65. Wave 2 PR 4 fixture.
+name: ticket-manager
+description: Ticket Manager wrapper.
+tools: Bash, Read
+model: sonnet
+persona_name: Idris
+---
+
+# Idris — Ticket Manager
+MD
+
     # Gitignore the framework-defaults snapshot + env dir (these are
     # adopter-local artefacts; the sync hook writes them on session start).
     cat > .gitignore <<'IGNORE'
@@ -379,6 +396,40 @@ if [ "$hook_exit" = "0" ]; then
   mark_pass "case 7: drift guard ACCEPTS clean-default commit (exit 0)"
 else
   mark_fail "case 7: drift guard clean default" "expected exit 0, got $hook_exit"
+fi
+rm -rf "$SB"
+
+# ===========================================================================
+# CASE 8 — utility-agent override: ticket-manager model sonnet → opus.
+# Verifies the routing mechanism doesn't distinguish utility from
+# role-derived agents (Wave 2 PR 4 of #347).
+# ===========================================================================
+SB=$(make_fork)
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  ticket-manager:
+    model: opus
+YAML
+
+banner_output=$(cd "$SB" && bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+
+after_tm=$(read_model_line "$SB/.claude/agents/ticket-manager.md")
+after_qa=$(read_model_line "$SB/.claude/agents/qa-engineer.md")
+defaults_snapshot_exists=0
+[ -f "$SB/.claude/agents/.framework-defaults.json" ] && defaults_snapshot_exists=1
+
+if [ "$after_tm" = "opus" ] && [ "$after_qa" = "haiku" ] \
+   && [ "$defaults_snapshot_exists" = "1" ] \
+   && echo "$banner_output" | grep -qE 'applied 1 agent-routing override'; then
+  # Confirm the snapshot recorded the framework default sonnet (not opus).
+  if grep -q '"ticket-manager":"sonnet"' "$SB/.claude/agents/.framework-defaults.json"; then
+    mark_pass "case 8: ticket-manager utility override sonnet→opus (qa-engineer untouched, snapshot records sonnet)"
+  else
+    mark_fail "case 8" "snapshot did not record ticket-manager=sonnet: $(cat "$SB/.claude/agents/.framework-defaults.json" 2>/dev/null)"
+  fi
+else
+  mark_fail "case 8: ticket-manager utility override" "after_tm=$after_tm qa=$after_qa snapshot=$defaults_snapshot_exists banner=[$banner_output]"
 fi
 rm -rf "$SB"
 


### PR DESCRIPTION
## Summary

- **4 utility agents promoted off `model: inherit` to explicit AgDR-0050 § Axis 2 baselines**: Rex (`code-reviewer.md`) inherit → opus per Axis 2 line 50 (PR diff review + handbook reasoning depth); Munir (`dependency-auditor.md`) inherit → sonnet per line 63 (pattern-matching across package files); Tariq (`pr-manager.md`) inherit → sonnet per line 64 (tool-call-heavy + PR body narrative quality); Idris (`ticket-manager.md`) inherit → sonnet per line 65 (schema-conforming output + interactive interview). Hakim was already promoted to opus in PR #360 as part of the Hatim→Hakim consolidation, completing the 5/5 utility-agent matrix.
- **Each frontmatter carries the `# routing-config:override` escape-hatch comment** inside the YAML frontmatter so `block-agent-routing-drift.sh` accepts the intentional inherit→<model> framework-default change rather than blocking it as adopter-leak. The comment names the agent, the AgDR line number, and the rationale — visible + auditable per AgDR-0040's escape-hatch convention. Each commit landed cleanly through the drift guard on the first attempt (no PR-3-style "wrong comment style" retry).
- **`test_agent_wrap_shape.sh` extended with a `UTILITY_AGENTS` array and a new "Invariant 4b" block** that asserts each utility agent has (a) explicit `model:` matching Axis 2, (b) correct `persona_name`, and (c) the escape-hatch comment in YAML frontmatter. Locks in the post-PR-4 baselines so a future revert-to-inherit trips the test instead of silently slipping. Bonus fix: the new awk uses POSIX `[[:space:]]` / `[^[:space:]]` instead of `\S` — `\S` isn't portable across awk implementations (macOS BSD awk silently treated it as a literal, masking the regex bug). Other awk blocks in the test file already use POSIX classes, so this is a one-time gotcha that's now closed.
- **`test_agent_routing_sync_and_drift.sh` extended with a ticket-manager fixture in `make_fork` + new CASE 8** that exercises a utility-agent override (ticket-manager sonnet → opus). Proves the routing-sync mechanism doesn't distinguish utility from role-derived agents — same hook, same rewrite, same snapshot path. 8/8 cases PASS.

## Testing

- [x] `bash .claude/agents/tests/test_agent_wrap_shape.sh` — PASS at 13 ROLE_AGENTS + 5 UTILITY_AGENTS + 19 ROLE_CLASSES.
- [x] `bash .claude/hooks/tests/test_agent_routing_sync_and_drift.sh` — PASS at 8/8 cases (case 8 new this PR).
- [x] Drift guard accepted both commits (`0961572` model changes + `637f2d9` test extensions) without blocking — verifies the escape-hatch comment placement is correct on all 4 utility files.
- [ ] Manual smoke (operator, post-merge): start a fresh session, observe Rex's review tone for any visible-model-bump effect on code-reviewer output quality. Not blocking this merge.
- [ ] Manual smoke (operator, post-merge): apply an `agent-routing.yaml` override (e.g. `ticket-manager: model: opus`) and confirm SessionStart sync rewrites `.claude/agents/ticket-manager.md`'s `model:` to `opus`; `git checkout` then restores `sonnet`. Not blocking.

## Glossary

| Term | Definition |
|------|------------|
| **UTILITY_AGENTS array** | New companion to `ROLE_AGENTS` in `test_agent_wrap_shape.sh`. Format `"<slug>:<expected_model>:<expected_persona_name>"`. Locks in AgDR-0050 § Axis 2 baselines for the 5 utility agents (Rex, Hakim, Munir, Tariq, Idris). Different from `ROLE_AGENTS` because utility agents don't have a canonical `roles/<dept>/<slug>.md` file — they're framework primitives, not role-derived personas. |
| **`# routing-config:override <reason>` escape hatch** | YAML-frontmatter comment recognised by `block-agent-routing-drift.sh` (regex `^[[:space:]]*#[[:space:]]*routing-config:override[[:space:]]+\S`). Used for intentional framework-default changes — e.g. this PR's 4 inherit→<model> bumps. The comment ships with the PR and makes the deliberate change visible. HTML `<!-- -->` form does NOT match — only the `#`-prefixed YAML comment form does (footgun from PR #360 is now documented in the test). |
| **Axis 2 baseline vs adopter override** | AgDR-0050 § Axis 2 ships per-agent default models in the framework (this PR makes the utility-agent defaults explicit). Adopters override per-agent via `agent-routing.yaml` in their private portfolio repo (or gitignored single-fork). The SessionStart sync hook (`apply-agent-routing.sh`, from #357) rewrites the agent file's `model:` line at session start; the drift guard prevents that rewrite from leaking into a commit. |
| **POSIX awk vs `\S`** | macOS BSD `awk` and other POSIX-strict implementations don't support `\S` (the Perl-style non-whitespace shorthand). They silently treat `\S` as a literal "S" character. The new test code uses `[^[:space:]]` instead — same semantics, portable across all awk implementations. |

Refs #347 (4/5 PRs now landed; PR 5 — role-trigger integration — is the last)
Refs #348 (Idris is one of three candidates for the local-routing feasibility spike)

## Note for the next reviewer

This PR keeps strictly to scope: 4 frontmatter promotions + 2 test extensions. No drive-by cleanups, no doc rewrites, no CLAUDE.md / site / AGENTS.md changes (agent count is unchanged — only model values change). Rex's 5 non-blocking suggestions on PR #360 (consolidation-exception test, stale Hatim in test file comment, AgDR-0018 lines 51+92 doc-debt, prose inaccuracy at security-reviewer.md:17, HTML-comment drift-guard footgun docs) are intentionally NOT included in this PR — they're tracked as follow-ups for a Wave-3 cleanup PR or discrete chore tickets.