### PR TITLE
feat(#347): class-aware role-trigger banner — HYBRID spawn vs in-thread (Wave 2 PR 5)

### DIFF
--- a/.claude/hooks/detect-role-trigger.sh
+++ b/.claude/hooks/detect-role-trigger.sh
@@ -39,8 +39,86 @@ HOOK_EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/nul
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 
 # ---------------------------------------------------------------------------
-# Helper: emit one banner line. Multiple triggers in a single call can
-# fire multiple banners.
+# Resolve REPO_ROOT once — needed by lookup_role_class for the role-file
+# read. Set early so it's available to all helpers below.
+# ---------------------------------------------------------------------------
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+
+# ---------------------------------------------------------------------------
+# Look up the `**Class**:` value from a role file's `## Activation mode`
+# section. Returns one of:
+#   - isolated-work-class
+#   - in-flow-class
+#   - in-flow-class (fallback when the file is missing, the section is
+#     absent, or the Class line can't be parsed — conservative fail-open
+#     so a malformed role file doesn't break trigger detection)
+#
+# Per AgDR-0050 § Axis 6's HYBRID integration: isolated-work-class roles
+# spawn a sub-agent; in-flow-class roles adopt the persona in-thread.
+# ---------------------------------------------------------------------------
+lookup_role_class() {
+  local rel="$1"
+  local path
+  if [ -n "$REPO_ROOT" ]; then
+    path="$REPO_ROOT/$rel"
+  else
+    path="$rel"
+  fi
+  [ -f "$path" ] || { echo "in-flow-class"; return; }
+
+  local class
+  class=$(awk '
+    /^## Activation mode/ { in_section = 1; next }
+    in_section && /^\*\*Class\*\*:/ {
+      sub("^\\*\\*Class\\*\\*:[[:space:]]*", "")
+      print
+      exit
+    }
+  ' "$path")
+
+  case "$class" in
+    isolated-work-class|in-flow-class) echo "$class" ;;
+    *) echo "in-flow-class" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Map a role-file path to the matching sub-agent slug (the value to pass
+# as `subagent_type` when spawning via the Agent tool).
+#
+# 1:1 by default — `roles/<dept>/<slug>.md` → `.claude/agents/<slug>.md`.
+# Exception: the Hatim→Hakim consolidation (#360) means
+# `roles/security/security-auditor.md` maps to the `security-reviewer`
+# agent file (the consolidation preserved the filename so `/security-review`
+# and `auto-code-review.sh` keep working). See AgDR-0050 § Axis 2 line 49.
+# ---------------------------------------------------------------------------
+agent_slug_for() {
+  local file="$1"
+  local stem
+  stem=$(basename "$file" .md)
+  case "$stem" in
+    security-auditor) echo "security-reviewer" ;;
+    *) echo "$stem" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Helper: emit one class-aware banner line. Multiple triggers in a single
+# call can fire multiple banners.
+#
+# Per AgDR-0050 § Axis 6, the banner shape depends on the role's
+# Activation Class:
+#
+#   isolated-work-class → instructs the agent to SPAWN the sub-agent via
+#     the Agent tool with `subagent_type: <slug>`. Used for roles whose
+#     work benefits from isolated context + tool restriction (Head-of-X,
+#     Tech Lead, QA, SRE, Security Auditor, Pen Tester, Data Analyst,
+#     etc.).
+#
+#   in-flow-class → instructs the agent to ADOPT the persona in-thread.
+#     Used for roles that work tightly alongside the main thread
+#     (Backend / Frontend / Platform Engineer, Product Manager, UI / UX
+#     Designer, Data Engineer).
 #
 # Args:
 #   $1 — role display name (e.g. "Security Auditor")
@@ -49,8 +127,17 @@ TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 # ---------------------------------------------------------------------------
 emit_banner() {
   local role="$1" file="$2" reason="$3"
-  printf 'ROLE TRIGGER: %s activates per .claude/rules/role-triggers.md (%s). Read %s and adopt the role before continuing.\n' \
-    "$role" "$reason" "$file" >&2
+  local class agent_slug
+  class=$(lookup_role_class "$file")
+  agent_slug=$(agent_slug_for "$file")
+
+  if [ "$class" = "isolated-work-class" ]; then
+    printf 'ROLE TRIGGER: %s activates per .claude/rules/role-triggers.md (%s). Isolated-work-class — SPAWN the sub-agent via the Agent tool with subagent_type: %s. Canonical role at %s, agent wrapper at .claude/agents/%s.md. Per AgDR-0050 § Axis 6.\n' \
+      "$role" "$reason" "$agent_slug" "$file" "$agent_slug" >&2
+  else
+    printf 'ROLE TRIGGER: %s activates per .claude/rules/role-triggers.md (%s). In-flow-class — adopt the persona IN-THREAD. Read %s before continuing. Per AgDR-0050 § Axis 6.\n' \
+      "$role" "$reason" "$file" >&2
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/.claude/hooks/tests/test_detect_role_trigger.sh
+++ b/.claude/hooks/tests/test_detect_role_trigger.sh
@@ -204,6 +204,69 @@ else
   FAIL=$((FAIL+1)); FAILED="${FAILED}non-blocking "
 fi
 
+# --- (4) HYBRID class-aware banner — AgDR-0050 § Axis 6 (Wave 2 PR 5) --------
+# Each banner now includes either "Isolated-work-class — SPAWN the sub-agent"
+# or "In-flow-class — adopt the persona IN-THREAD" depending on the matched
+# role's **Class** value in its role file. Verifies the class lookup actually
+# fires + the security-auditor → security-reviewer slug exception.
+
+# 4a. Security Auditor (isolated-work-class) — banner instructs SPAWN with
+#     subagent_type: security-reviewer (NOT security-auditor; the
+#     Hatim→Hakim consolidation in PR #360 kept the filename).
+in=$(jq -nc \
+  --arg p "src/auth/login.ts" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "hybrid class-aware: Security Auditor → isolated-work-class banner" 0 \
+  "Isolated-work-class.*subagent_type: security-reviewer" "$in"
+
+# 4b. Platform Engineer (in-flow-class) — banner instructs in-thread
+#     adoption. The CI/CD diff path triggers this role.
+in=$(jq -nc \
+  --arg p ".github/workflows/ci.yml" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "hybrid class-aware: Platform Engineer → in-flow-class banner" 0 \
+  "Platform Engineer.*In-flow-class.*adopt the persona IN-THREAD" "$in"
+
+# 4c. Tech Lead (isolated-work-class) — banner instructs SPAWN with
+#     subagent_type: tech-lead. Triggered by edits under docs/agdr/.
+in=$(jq -nc \
+  --arg p "docs/agdr/AgDR-0099-example.md" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "hybrid class-aware: Tech Lead → isolated-work-class banner" 0 \
+  "Tech Lead.*Isolated-work-class.*subagent_type: tech-lead" "$in"
+
+# 4d. QA Engineer (isolated-work-class) — banner instructs SPAWN with
+#     subagent_type: qa-engineer. Triggered by `gh issue edit --add-label qa`.
+in=$(jq -nc \
+  --arg c "gh issue edit 42 --add-label qa" \
+  '{hook_event_name:"PreToolUse", tool_name:"Bash", tool_input:{command:$c}}')
+run_case "hybrid class-aware: QA Engineer → isolated-work-class banner" 0 \
+  "QA Engineer.*Isolated-work-class.*subagent_type: qa-engineer" "$in"
+
+# 4e. Prompted Backend Engineer (in-flow-class) — banner instructs
+#     in-thread adoption.
+in=$(jq -nc \
+  --arg prm "act as the backend engineer and refactor this handler" \
+  '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
+run_case "hybrid class-aware: Backend Engineer prompted → in-flow-class banner" 0 \
+  "Backend Engineer.*In-flow-class.*adopt the persona IN-THREAD" "$in"
+
+# 4f. Prompted UX Designer (in-flow-class) — banner instructs in-thread
+#     adoption.
+in=$(jq -nc \
+  --arg prm "put on your UX Designer hat for this flow review" \
+  '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
+run_case "hybrid class-aware: UX Designer prompted → in-flow-class banner" 0 \
+  "Ux Designer.*In-flow-class.*adopt the persona IN-THREAD" "$in"
+
+# 4g. Prompted Pen Tester (isolated-work-class) — banner instructs SPAWN
+#     with subagent_type: penetration-tester.
+in=$(jq -nc \
+  --arg prm "as the pen tester, dry-run an exploit on the new endpoint" \
+  '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
+run_case "hybrid class-aware: Pen Tester prompted → isolated-work-class banner" 0 \
+  "Pen Tester.*Isolated-work-class.*subagent_type: penetration-tester" "$in"
+
 # --- Summary -----------------------------------------------------------------
 
 echo ""

--- a/.claude/rules/role-triggers.md
+++ b/.claude/rules/role-triggers.md
@@ -138,6 +138,17 @@ Self-discipline (the agent remembering to read the role file when the rule fires
 
 Same advisory shape as `check-upstream-drift.sh` — non-blocking, exit 0 always. The banner cannot force the agent to adopt the role, but it removes the "I forgot the rule applied here" failure mode.
 
+#### Class-aware banner (HYBRID, AgDR-0050 § Axis 6 — live since #347 PR 5)
+
+Each banner reads the matched role's `**Class**:` value from the `## Activation mode` section of the role file and emits one of two shapes:
+
+- **Isolated-work-class** (12 roles: Heads-of-X, Tech Lead, QA Engineer, SRE, Security Auditor, Pen Tester, Product Analyst, Data Analyst): the banner instructs the agent to **SPAWN the sub-agent via the Agent tool** with `subagent_type: <slug>`, naming both the canonical role file at `roles/<dept>/<role>.md` and the agent wrapper at `.claude/agents/<slug>.md`. Per AgDR-0050 § Axis 6, isolated work benefits from isolated context + tool restriction.
+- **In-flow-class** (7 roles: Backend / Frontend / Platform Engineer, Product Manager, UI / UX Designer, Data Engineer): the banner instructs the agent to **adopt the persona IN-THREAD** by reading `roles/<dept>/<role>.md`. Per AgDR-0050 § Axis 6, in-flow work loses too much shared context if spawned out-of-thread.
+
+One naming exception: the Security Auditor role (`roles/security/security-auditor.md`) maps to the `security-reviewer` agent slug, not `security-auditor`. This is the Hatim→Hakim consolidation from PR #360 — the agent filename was preserved so `/security-review` and the auto-fire trigger keep working. The hook handles the exception via `agent_slug_for()`.
+
+The class lookup is conservative: if the role file is missing or the `**Class**:` line can't be parsed, the banner falls back to in-flow-class shape. Better to under-trigger sub-agent spawn than to incorrectly suggest one for an unclassified role.
+
 Triggers wired in v1 (me2resh/apexyard#206):
 
 | Trigger family | Hook event | Detection | Role |


### PR DESCRIPTION
## Summary

- **`detect-role-trigger.sh` now emits class-aware banners** per AgDR-0050 § Axis 6's HYBRID design. When a trigger fires, the hook reads the matched role's `**Class**:` value from the `## Activation mode` section of its role file and emits one of two banner shapes: **isolated-work-class** → "SPAWN the sub-agent via the Agent tool with `subagent_type: <slug>`"; **in-flow-class** → "adopt the persona IN-THREAD". This closes #347 — the 5-PR wave plan is now complete (PRs 1-4 promoted the 18 role-derived agents + 4 utility agents to sub-agents with explicit models; PR 5 wires the auto-triggers to actually spawn them for isolated-work-class roles).
- **New `lookup_role_class()` + `agent_slug_for()` helpers**. `lookup_role_class` parses `**Class**:` from a role file's `## Activation mode` section; falls back to `in-flow-class` on any failure (missing file, missing section, unparseable value) — conservative fail-open so a malformed role file doesn't break trigger detection. `agent_slug_for` maps role-file path → agent `subagent_type` slug; 1:1 by default but with one explicit exception: `security-auditor.md` → `security-reviewer` (the Hatim→Hakim consolidation from PR #360 kept the agent filename so `/security-review` + `auto-code-review.sh` keep working).
- **`emit_banner()` restructured** to look up class + slug from the file argument and emit the appropriate shape. Caller signatures unchanged — every existing call site still passes `(role, file, reason)`; the helper does the class-aware fan-out internally. This means the existing 19 tests' broad regexes (`ROLE TRIGGER:.*Security Auditor`) all still PASS as a strict-extension check.
- **7 new tests in `test_detect_role_trigger.sh`** cover both class shapes across all three trigger families (path, label, prompted): Security Auditor → isolated-work-class with `security-reviewer` slug (NOT `security-auditor` — the consolidation exception); Platform Engineer → in-flow-class; Tech Lead → isolated-work-class; QA Engineer → isolated-work-class via label; Backend Engineer prompted → in-flow-class; UX Designer prompted → in-flow-class; Pen Tester prompted → isolated-work-class. 26/26 total PASS.
- **`.claude/rules/role-triggers.md` mechanical-backstop section** documents the live HYBRID design: both banner shapes, the 12-vs-7 role split (12 isolated-work-class, 7 in-flow-class), and the security-auditor → security-reviewer slug exception.

## Testing

- [x] `bash .claude/hooks/tests/test_detect_role_trigger.sh` — PASS at 26/26 (19 prior + 7 new class-aware).
- [x] `bash .claude/agents/tests/test_agent_wrap_shape.sh` — PASS at 13 ROLE_AGENTS + 5 UTILITY_AGENTS + 19 ROLE_CLASSES (all 19 role files have correct `**Class**:` values that the new lookup reads).
- [ ] Manual smoke (operator, post-merge): edit a file under `auth/`, observe Rex emits the new "SPAWN with subagent_type: security-reviewer" banner shape (not the old advisory "Read the role file" shape). Not blocking.
- [ ] Manual smoke (operator, post-merge): say "act as the Backend Engineer", observe the new "In-flow-class — adopt the persona IN-THREAD" shape. Not blocking.

## Glossary

| Term | Definition |
|------|------------|
| **HYBRID role-trigger integration** | The AgDR-0050 § Axis 6 design: isolated-work-class roles spawn a sub-agent (full isolated context + tool restriction); in-flow-class roles adopt the persona in-thread (shared context with the main thread). The class is declared per-role in the `## Activation mode` section of the role file. The trigger hook reads the class and emits the appropriate banner shape. |
| **Class lookup** | `lookup_role_class()` reads `**Class**:` from a role file's `## Activation mode` section. Returns `isolated-work-class` / `in-flow-class` / `in-flow-class` (fail-open fallback). Conservative: better to under-trigger sub-agent spawn than to incorrectly suggest one for an unclassified role. |
| **Agent slug exception** | `agent_slug_for(roles/security/security-auditor.md)` returns `security-reviewer`, not `security-auditor`. This is the only non-1:1 mapping in the framework. Rationale: the Hatim→Hakim consolidation from PR #360 kept the agent filename so `/security-review` + `auto-code-review.sh` + `.claude/rules/role-triggers.md` references stayed working. |
| **Strict-extension test posture** | The existing 19 tests in `test_detect_role_trigger.sh` use broad regexes like `ROLE TRIGGER:.*Security Auditor` that match BOTH the old and new banner shapes. No existing test regex needed updating — the new banner is a strict extension. The 7 new tests assert the class-aware extension specifically. |

## Closes #347

This is the 5th and final PR of the #347 wave plan from AgDR-0050. With PR 5 merged, the framework's auto-triggers no longer just remind operators that a role activated — they actually drive sub-agent spawn for the 12 isolated-work-class roles, which is what the AgDR-0050 design called for.

Refs #347
Refs #353 / #355 / #356 / #357 / #360 / #361 (prior PRs in the wave)