### PR TITLE
feat(#351): /setup seeds agent-routing.yaml + 8th portfolio config key (Wave 2 PR 3)

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -139,6 +139,7 @@ The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — pub
    - **`onboarding.yaml`** seeded from the framework template — split-portfolio v2 (#242) moves company/team/stack config to the private repo too, so the public fork stays slim
    - empty **`custom-skills/`** dir + a one-paragraph `custom-skills/README.md` explaining the convention. Company-specific proprietary skills (`/file-internal-bug`, `/check-policy`, etc.) live as `custom-skills/<name>/SKILL.md` here; the public fork's `link-custom-skills.sh` SessionStart hook symlinks each into `.claude/skills/<name>/` so Claude Code discovers them. Custom skill names override framework skills of the same name (warning printed at SessionStart). See `docs/multi-project.md` § "Private custom skills + handbooks" for the full convention. (Added in #243.)
    - empty **`custom-handbooks/`** dir + a one-paragraph `custom-handbooks/README.md` explaining the convention. Company-confidential coding standards live as `custom-handbooks/{architecture,general,language/<lang>}/*.md` here, mirroring the public `handbooks/` path-convention. Rex consumes both layers during code review (advisory by default, blocking with `ENFORCEMENT: blocking` at the top of the file). See `handbooks/README.md` for the format. (Added in #243.)
+   - **`agent-routing.yaml`** seeded from `<fork>/agent-routing.yaml.example` (the framework's worked-examples file). This is the adopter-routing source-of-truth for split-portfolio mode — every adopter override (per-agent model, endpoint, env, timeout) lives here. The seeded file starts as the framework example so adopters see a working shape; the empty `agents: {}` block at the top means zero overrides until edited. The SessionStart sync hook (`apply-agent-routing.sh`, #357) reads it on every session start. See `docs/multi-project.md` § "Centralised agent routing — `agent-routing.yaml`" for the schema. (Added in #351 PR 3.)
    - `.gitignore` with `workspace/*/` so the inner clones don't get double-tracked in the private repo either
    - initial commit + push
 6. **Configure path resolution in the fork** (recommended — v2 config-block mode):
@@ -155,12 +156,13 @@ The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — pub
          "onboarding": "../apexyard-portfolio/onboarding.yaml",
          "workspace_dir": "../apexyard-portfolio/workspace",
          "custom_skills_dir": "../apexyard-portfolio/custom-skills",
-         "custom_handbooks_dir": "../apexyard-portfolio/custom-handbooks"
+         "custom_handbooks_dir": "../apexyard-portfolio/custom-handbooks",
+         "agent_routing": "../apexyard-portfolio/agent-routing.yaml"
        }
      }
      ```
 
-     The two `custom_*_dir` keys are optional — defaults match `./custom-skills` and `./custom-handbooks` resolved against the ops-fork root. Setting them explicitly here is the v2 split-portfolio shape and matches what step 5 just created in the private repo.
+     The two `custom_*_dir` keys are optional — defaults match `./custom-skills` and `./custom-handbooks` resolved against the ops-fork root. The `agent_routing` key is similarly optional — its default resolves to `./agent-routing.yaml` against the ops-fork root, so single-fork adopters who keep the file at the fork root don't need to set it explicitly. Setting all three explicitly here is the v2 split-portfolio shape and matches what step 5 just created in the private repo.
 
    - **Write the `.apexyard-fork` marker** at the public-fork root. This is the v2 ops-fork anchor — `_lib-ops-root.sh` and every hook that walks up to find the ops fork looks for this marker first (with the legacy `onboarding.yaml + apexyard.projects.yaml` pair as fallback). **Spec: presence-only — readers MUST ignore content; only file presence matters.** Writers MAY include a single explanatory line so `head .apexyard-fork` is informative for operators encountering it the first time. See [AgDR-0021](../../../docs/agdr/AgDR-0021-split-portfolio-v2-path-resolution.md) § B for the rationale.
 
@@ -570,6 +572,28 @@ I'll need: repo name (owner/repo) and a short project name.
 
 If yes → append to `apexyard.projects.yaml`, stage alongside `onboarding.yaml`.
 If no → skip. They can add projects later with `/handover`.
+
+### Step 7a: Single-fork agent-routing seeding (advisory)
+
+For **single-fork mode** only — split-portfolio adopters already got `agent-routing.yaml` seeded into the private repo in Step 5.
+
+The framework ships `<fork>/agent-routing.yaml.example` as the worked-examples file, and `.gitignore` already has `/agent-routing.yaml` excluded so adopters can edit locally without leaking overrides to the public fork. By default `/setup` does NOT auto-copy the example to `agent-routing.yaml` — single-fork adopters' overrides shouldn't accumulate before they've made any. Mention the path explicitly so the operator knows where to start when they want to customise:
+
+```
+Agent routing (model + endpoint per agent) is in agent-routing.yaml at the
+fork root. The framework ships `agent-routing.yaml.example` as a template;
+`.gitignore` already excludes the working `agent-routing.yaml` file so
+your overrides never leak to the public fork. When you're ready to
+customise, run:
+
+  cp agent-routing.yaml.example agent-routing.yaml
+  $EDITOR agent-routing.yaml
+
+The SessionStart sync hook (apply-agent-routing.sh) reads it on every
+session start. See docs/multi-project.md § "Centralised agent routing".
+```
+
+No file writes here — purely informational. Added in #351 PR 3.
 
 ### Step 8: Clear the bootstrap marker (REQUIRED)
 

--- a/.claude/skills/setup/tests/test_setup_split_portfolio_v2.sh
+++ b/.claude/skills/setup/tests/test_setup_split_portfolio_v2.sh
@@ -117,6 +117,15 @@ company:
   mission: "ship test infrastructure"
 YAML
   mkdir -p "$sb/private/custom-skills" "$sb/private/custom-handbooks"
+
+  # Seed an agent-routing.yaml.example in the public fork — SKILL.md
+  # Step 5 copies this into the private repo as agent-routing.yaml.
+  cat > "$sb/public/agent-routing.yaml.example" <<'YAML'
+version: 1
+# Adopter routing config — overrides framework default models per agent.
+# Empty `agents: {}` block means zero overrides; framework defaults apply.
+agents: {}
+YAML
 }
 
 # ---------------------------------------------------------------------------
@@ -141,7 +150,8 @@ apply_setup_v2() {
       echo "workspace"
     } >> .gitignore
 
-    # 2. Write the v2 config block.
+    # 2. Write the v2 config block (8 keys including agent_routing
+    #    per #351 PR 3).
     cat > .claude/project-config.json <<JSON
 {
   "portfolio": {
@@ -151,13 +161,20 @@ apply_setup_v2() {
     "onboarding":           "$sibling_rel/onboarding.yaml",
     "workspace_dir":        "$sibling_rel/workspace",
     "custom_skills_dir":    "$sibling_rel/custom-skills",
-    "custom_handbooks_dir": "$sibling_rel/custom-handbooks"
+    "custom_handbooks_dir": "$sibling_rel/custom-handbooks",
+    "agent_routing":        "$sibling_rel/agent-routing.yaml"
   }
 }
 JSON
 
     # 3. Write the v2 presence marker.
     echo "# This file marks the directory as an ApexYard ops fork (split-portfolio v2)." > .apexyard-fork
+
+    # 4. Seed agent-routing.yaml in the private repo by copying the
+    #    framework example (#351 PR 3).
+    if [ -f "agent-routing.yaml.example" ] && [ ! -f "$sibling_rel/agent-routing.yaml" ]; then
+      cp agent-routing.yaml.example "$sibling_rel/agent-routing.yaml"
+    fi
   )
 }
 
@@ -169,9 +186,9 @@ SB="$TMP_ROOT/case1"
 build_pre_setup_v2 "$SB"
 apply_setup_v2 "$SB/public" "../private"
 
-# Assertion 1: all 7 v2 portfolio keys exist in project-config.json
+# Assertion 1: all 8 v2 portfolio keys exist in project-config.json
 PCONFIG="$SB/public/.claude/project-config.json"
-EXPECTED_KEYS=(registry projects_dir ideas_backlog onboarding workspace_dir custom_skills_dir custom_handbooks_dir)
+EXPECTED_KEYS=(registry projects_dir ideas_backlog onboarding workspace_dir custom_skills_dir custom_handbooks_dir agent_routing)
 all_keys_present=1
 for k in "${EXPECTED_KEYS[@]}"; do
   v=$(jq -r ".portfolio.$k // empty" "$PCONFIG")
@@ -181,7 +198,17 @@ for k in "${EXPECTED_KEYS[@]}"; do
   fi
 done
 if [ "$all_keys_present" -eq 1 ]; then
-  mark_pass "all 7 v2 portfolio.* keys present in project-config.json"
+  mark_pass "all 8 v2 portfolio.* keys present in project-config.json (includes agent_routing per #351 PR 3)"
+fi
+
+# Assertion 1b: agent-routing.yaml was seeded into the private repo
+PRIVATE_ROUTING="$SB/private/agent-routing.yaml"
+if [ -f "$PRIVATE_ROUTING" ] && grep -q '^agents:' "$PRIVATE_ROUTING"; then
+  mark_pass "agent-routing.yaml seeded in private repo from framework example (#351 PR 3)"
+elif [ -f "$PRIVATE_ROUTING" ]; then
+  mark_fail "agent-routing.yaml content" "file exists but doesn't carry the 'agents:' key — example seed appears malformed"
+else
+  mark_fail "agent-routing.yaml present" "expected at $PRIVATE_ROUTING (Step 5 should copy from example)"
 fi
 
 # Assertion 2: .apexyard-fork marker exists with expected commented preamble

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -524,13 +524,13 @@ This sibling pattern to **Custom templates** (path-mirroring overrides; see AgDR
 | **Split-portfolio (v2)** | `<private_repo>/agent-routing.yaml` | Private — committed to the sibling repo, resolved via `.portfolio.agent_routing` in `.claude/project-config.json` |
 | **Single-fork** | `<fork>/agent-routing.yaml` | Local — gitignored by the framework (`/agent-routing.yaml` in `.gitignore`), never pushed to the public fork |
 
-Seed from the framework example:
+Seed from the framework example. **Split-portfolio adopters get this done automatically by `/setup --split-portfolio`** (#351 PR 3) — the skill copies the example into the private repo as part of Step 5 (private-repo init). Single-fork adopters do the `cp` manually when they want to start customising; the framework deliberately doesn't auto-seed for single-fork because an empty override file accumulating in the fork root before any overrides exist is more ceremony than value.
 
 ```bash
-# Split-portfolio:
+# Split-portfolio — `/setup --split-portfolio` does this for you. Manual fallback:
 cp ~/ops/apexyard/agent-routing.yaml.example ~/ops/apexyard-portfolio/agent-routing.yaml
 
-# Single-fork:
+# Single-fork — always manual (and only when you're ready to customise):
 cp ~/ops/apexyard/agent-routing.yaml.example ~/ops/apexyard/agent-routing.yaml
 ```
 
@@ -585,7 +585,6 @@ Per AgDR-0050 § Axis 4.
 
 #### What ships next
 
-- **#351 PR 3** — `/setup` integration. Split-portfolio adopters get the YAML seeded in the private repo; single-fork adopters get `agent-routing.yaml` gitignored automatically.
 - **#351 PR 4** — local-routing entries (Ollama endpoints) in the seeded template, gated on the **#348** feasibility spike's verdict. If the spike promotes, specific local-model entries land in the example; if it discards, the `endpoint:` field stays in the schema for adopter-author override only.
 
 #### Out of scope (v1)


### PR DESCRIPTION
## Summary

- **`/setup --split-portfolio` now auto-seeds `agent-routing.yaml` in the private repo.** Step 5 (private-repo init) copies `<fork>/agent-routing.yaml.example` to `<private_repo>/agent-routing.yaml`. Adopters no longer need to remember the manual `cp ~/ops/apexyard/agent-routing.yaml.example ~/ops/apexyard-portfolio/agent-routing.yaml` post-bootstrap step — the routing config lands ready to edit. The seeded file starts at the framework example's `agents: {}` empty-overrides shape, so adopters get framework defaults out-of-box and only need to touch the file when they want to customise.
- **`/setup --split-portfolio` Step 6 now writes the 8th `portfolio.*` config key** — `agent_routing: ../<sibling>/agent-routing.yaml` — into the public fork's `.claude/project-config.json`. This wires `portfolio_agent_routing` (resolver from #353) to the just-seeded private file. The key is documented as optional in the SKILL.md prose: single-fork adopters can omit it and rely on the default `./agent-routing.yaml` resolution against the ops-fork root.
- **Single-fork mode deliberately NOT auto-seeded.** New advisory Step 7a tells single-fork adopters where to find the example + the exact `cp` command, but the skill writes no files for them. Rationale: the framework already gitignores `/agent-routing.yaml` (so there's no leak risk on a stray push), and adopters who never customise shouldn't have an empty `agents: {}` file accumulating in the fork root. They `cp` once they're ready to override.
- **`docs/multi-project.md` updated**: the "Seed from the framework example" recipe section now notes split-portfolio gets automated by `/setup --split-portfolio`; the "What ships next" list drops the PR 3 row.
- **`test_setup_split_portfolio_v2.sh` extended**: `build_pre_setup_v2()` seeds an `agent-routing.yaml.example` in the public fork (the framework artefact #353 ships). `apply_setup_v2()` extends to write the 8th portfolio key + copy the example into the private repo. `EXPECTED_KEYS` array bumped from 7 to 8 (adds `agent_routing`). New Assertion 1b verifies the seed actually lands in the private repo with the right shape. Test PASSES at 11/11.

## Testing

- [x] `bash .claude/skills/setup/tests/test_setup_split_portfolio_v2.sh` — PASS at 11/11 (was 9/9 before this PR's two new assertions).
- [x] `bash .claude/skills/setup/tests/test_setup_single_fork.sh` — unchanged + still PASS (no single-fork file-writes in this PR).
- [x] `bash .claude/hooks/tests/test_portfolio_agent_routing.sh` — verifies the `portfolio_agent_routing` resolver from #353 reads the new `agent_routing` key correctly. Still PASSES with the post-PR-3 key layout.
- [ ] Manual smoke (operator, post-merge): run `/setup --split-portfolio` against a fresh fork-and-sibling pair; verify the private repo has `agent-routing.yaml` and the public fork's project-config.json has the `agent_routing` key. Not blocking — covered by the automated test.

## Glossary

| Term | Definition |
|------|------------|
| **Seed vs auto-fill** | Step 5 *copies* `agent-routing.yaml.example` to `agent-routing.yaml` without modification. Adopters get the framework's worked-examples shape (commented schema + an empty `agents: {}` block at the top). Editing is opt-in — the file is functional from the start because empty overrides == framework defaults. |
| **8th portfolio config key** | `portfolio.agent_routing` joins the v2 portfolio block alongside `registry`, `projects_dir`, `ideas_backlog`, `onboarding`, `workspace_dir`, `custom_skills_dir`, `custom_handbooks_dir`. The default resolution is `./agent-routing.yaml` against the ops-fork root, so the key is optional for single-fork adopters. Split-portfolio adopters set it explicitly to the sibling-repo path. |
| **Why single-fork stays manual** | Auto-creating an empty override file in the fork root before any overrides exist is more ceremony than value. The framework already gitignores `/agent-routing.yaml`, so the cost of "I have to remember to `cp`" is one shell line when the adopter is ready to customise. Split-portfolio is different because the seeded file IS the canonical adopter-routing source for the private repo + an artefact a teammate cloning the private sibling repo would expect to see. |

Refs #351 (3/4 PRs of the wave plan landed; PR 4 — local-routing entries — remains, gated on #348 spike verdict)