### PR TITLE
docs(#354): /debug 'when to invoke' sidebar in workflows/sdlc.md Phase 3

### DIFF
--- a/workflows/sdlc.md
+++ b/workflows/sdlc.md
@@ -167,6 +167,16 @@ RIGHT:
    - Testing: How to verify
 ```
 
+> **Sidebar — when to invoke `/debug` (and when NOT to).** The `/debug` skill is for bugs that **resisted naïve fix attempts**, not every bug. Three tiers, matched to bug class:
+>
+> | Class | Workflow |
+> |---|---|
+> | **Simple bug** — clear repro, obvious cause, one-line fix | `/bug` → fix → PR. **No `/debug`.** The cost of hypothesis-tree ceremony exceeds the fix cost. |
+> | **Resistant bug** — naïve fix didn't hold OR cause unclear after grep + Read | `/bug` → **`/debug`** → fix → PR. Forces architecture-first reading + evidence-before-fix. Prevents shotgun debugging. |
+> | **Sustained mystery** — multi-session archaeology, performance puzzle, regression hunt, incident retro | `/investigation` (live-doc workflow) — different skill entirely. Days of effort, cross-session continuity matters. See `.claude/skills/investigation/SKILL.md`. |
+>
+> Self-check before `/debug`: have I tried the obvious fix? Did it work? If NO → `/debug`. If didn't try yet → try the obvious thing first. Same shape as `/spike` from Phase 1 — file when you genuinely don't know; just code when you do.
+
 ### Exit Criteria
 
 - Code complete


### PR DESCRIPTION
## Summary

- **`workflows/sdlc.md` Phase 3 (Build) gains a `/debug` "when to invoke" sidebar** between the Development Flow code block and Exit Criteria — same callout shape as Phase 1's existing `/spike` sidebar. Operators reading the SDLC docs no longer have to infer from `/debug`'s skill spec that the skill is for bugs that **resisted naïve fix attempts**, not every bug.
- **3-tier bug-class table** captures the actual decision: **Simple bug** → just `/bug` + fix (no `/debug` — hypothesis-tree ceremony exceeds the one-line fix cost). **Resistant bug** → `/bug` + `/debug` + fix (architecture-first reading + evidence-before-fix prevents shotgun debugging). **Sustained mystery** → `/investigation` (different skill — live-doc, days, cross-session continuity).
- **Self-check operator decision rule** mirrors the `/spike` framing: "have I tried the obvious fix? Did it work? If NO → `/debug`. If didn't try yet → try the obvious thing first." Single discipline for two skills (`/spike` + `/debug`) reduces the cognitive load of "which one applies."
- **Cross-references** to `/investigation` (sustained-mystery sibling) and `/spike` (analogous file-when-uncertain pattern) per the ticket's AC.

## Testing

- [x] `npx markdownlint-cli2@0.13.0 workflows/sdlc.md` — 0 errors, exit 0 (per the ticket AC).
- [x] No regression on existing Phase 3 content — additive single-block insertion only. `git diff dev...HEAD -- workflows/sdlc.md` shows `+10/-0`.
- [ ] Manual smoke (operator, post-merge): re-read the Phase 3 section flow + the new sidebar; confirm the placement reads naturally (Development Flow → sidebar → Exit Criteria). Not blocking.

## Glossary

| Term | Definition |
|------|------------|
| **Resistant bug** | A bug where the obvious fix attempt didn't hold, or the cause remains unclear after a round of `grep` + `Read`. Distinct from a "simple bug" (clear repro, obvious cause) and a "sustained mystery" (multi-session, requires live-doc continuity). The middle tier — where `/debug`'s hypothesis-tree + architecture-first reading earns its ceremony cost. |
| **Shotgun debugging** | The failure mode `/debug` prevents — making speculative fixes without evidence + verifying-after-the-fact rather than evidence-first. Common in resistant bugs where the operator skips the "what does the architecture say?" step and goes straight to trying changes. |
| **Sidebar / callout convention** | The framework's prose pattern for "decision rules adopters need at this phase boundary, not buried in skill specs." Same shape as the existing `/spike` sidebar in Phase 1. Block-quote first, table second, self-check last, cross-references in the closing sentence. |

Closes #354

Refs `.claude/skills/debug/SKILL.md`, `.claude/skills/investigation/SKILL.md`, `.claude/skills/spike/SKILL.md` (the three skill specs the sidebar cross-references)