### PR TITLE
feat(#327): clean URLs without .html via Netlify _redirects rewrites

### DIFF
--- a/site/_redirects
+++ b/site/_redirects
@@ -9,3 +9,11 @@
 /index.md            /index.md.gen           200
 /architecture.md     /architecture.md.gen    200
 /skills.md           /skills.md.gen          200
+
+# Clean URLs — drop the .html suffix from /architecture and /skills.
+# Both forms work (200 rewrite preserves URL the user sees + backwards compat
+# for old bookmarks pointing at the .html form). Canonical is the clean form
+# per #327 + the SEO-audit S14 finding.
+
+/architecture        /architecture.html      200
+/skills              /skills.html            200

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>ApexYard Architecture — 5 layers + portfolio model</title>
 <meta name="description" content="ApexYard's 5-layer architecture — governance, capability, defaults, customisation, per-project data — plus the optional split-portfolio private sibling repo.">
-<link rel="canonical" href="https://yard.apexscript.com/architecture.html">
+<link rel="canonical" href="https://yard.apexscript.com/architecture">
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
@@ -13,7 +13,7 @@
 
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="ApexYard">
-<meta property="og:url" content="https://yard.apexscript.com/architecture.html">
+<meta property="og:url" content="https://yard.apexscript.com/architecture">
 <meta property="og:title" content="ApexYard Architecture — 5 layers + portfolio model">
 <meta property="og:description" content="Five layers in one ops fork — governance, capability, defaults, customisation overlay, per-project data. Plus the optional split-portfolio sibling repo for adopters on GitHub Free.">
 <meta property="og:image" content="https://yard.apexscript.com/og/architecture.png">
@@ -21,7 +21,7 @@
 <meta property="og:image:height" content="630">
 
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:url" content="https://yard.apexscript.com/architecture.html">
+<meta name="twitter:url" content="https://yard.apexscript.com/architecture">
 <meta name="twitter:title" content="ApexYard Architecture — 5 layers + portfolio model">
 <meta name="twitter:description" content="Five layers in one ops fork — governance, capability, defaults, customisation overlay, per-project data.">
 <meta name="twitter:image" content="https://yard.apexscript.com/og/architecture.png">
@@ -42,7 +42,7 @@
       "@type": "ListItem",
       "position": 2,
       "name": "Architecture",
-      "item": "https://yard.apexscript.com/architecture.html"
+      "item": "https://yard.apexscript.com/architecture"
     }
   ]
 }
@@ -372,11 +372,11 @@ a:hover { color: var(--accent); }
         <span class="titlebar__dot"></span>
         <span class="titlebar__dot is-warn"></span>
       </span>
-      <span class="titlebar__path">~/<a href="index.html"><b>apexyard</b></a> <span class="dim">· architecture</span></span>
+      <span class="titlebar__path">~/<a href="/"><b>apexyard</b></a> <span class="dim">· architecture</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
-      <a href="architecture.html" class="is-current always">architecture</a>
-      <a href="skills.html">skills</a>
+      <a href="/architecture" class="is-current always">architecture</a>
+      <a href="/skills">skills</a>
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>
       <a href="https://github.com/me2resh/apexyard" class="is-cta" target="_blank" rel="noopener">github →</a>
     </nav>
@@ -398,7 +398,7 @@ a:hover { color: var(--accent); }
         <strong>What's needed to start?</strong> Fork apexyard, register your projects, and read this page if you're deciding how to lay out the fork for your team. The diagram below is the canonical mental model.
       </p>
       <p class="meta">
-        See also: <a href="index.html">overview</a> · <a href="skills.html">skills</a> · <a href="https://github.com/me2resh/apexyard/blob/main/docs/multi-project.md" target="_blank" rel="noopener">setup guide ↗</a>
+        See also: <a href="/">overview</a> · <a href="/skills">skills</a> · <a href="https://github.com/me2resh/apexyard/blob/main/docs/multi-project.md" target="_blank" rel="noopener">setup guide ↗</a>
       </p>
     </div>
   </section>
@@ -684,7 +684,7 @@ a:hover { color: var(--accent); }
     <div>
       <a href="https://github.com/me2resh/apexyard" target="_blank" rel="noopener">github ↗</a>  ·
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">releases ↗</a>  ·
-      <a href="index.html">home</a>
+      <a href="/">home</a>
     </div>
   </div>
 </footer>

--- a/site/index.html
+++ b/site/index.html
@@ -1402,8 +1402,8 @@ footer.foot {
       <span class="titlebar__path">~/<b>apexyard</b> <span class="dim">- main · v1.1</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
-      <a href="architecture.html">architecture</a>
-      <a href="skills.html">skills</a>
+      <a href="/architecture">architecture</a>
+      <a href="/skills">skills</a>
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>
       <a href="https://github.com/me2resh/apexyard" class="is-cta" target="_blank" rel="noopener">github →</a>
     </nav>

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -118,7 +118,7 @@ check, and SEO check. Copy whichever you need.
 
 ---
 
-# Architecture (https://yard.apexscript.com/architecture.html)
+# Architecture (https://yard.apexscript.com/architecture)
 
 ## The 5-layer model
 
@@ -182,7 +182,7 @@ disallows changing a public fork's visibility after the fact).
 
 ---
 
-# Skills (https://yard.apexscript.com/skills.html)
+# Skills (https://yard.apexscript.com/skills)
 
 The full ApexYard slash-command surface — 53 skills, organised by
 purpose. Each is a markdown SKILL.md file under `.claude/skills/<name>/`.

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -8,8 +8,8 @@
 ## Pages
 
 - [Home](https://yard.apexscript.com/) — what apexyard is, why fork it, daily workflow
-- [Architecture](https://yard.apexscript.com/architecture.html) — the 5-layer model + portfolio model
-- [Skills](https://yard.apexscript.com/skills.html) — full slash-command reference (53 skills)
+- [Architecture](https://yard.apexscript.com/architecture) — the 5-layer model + portfolio model
+- [Skills](https://yard.apexscript.com/skills) — full slash-command reference (53 skills)
 
 ## Full-content companion
 

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -6,12 +6,12 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://yard.apexscript.com/architecture.html</loc>
+    <loc>https://yard.apexscript.com/architecture</loc>
     <lastmod>2026-05-20</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://yard.apexscript.com/skills.html</loc>
+    <loc>https://yard.apexscript.com/skills</loc>
     <lastmod>2026-05-20</lastmod>
     <priority>0.8</priority>
   </url>

--- a/site/skills.html
+++ b/site/skills.html
@@ -5,7 +5,7 @@
 <title>ApexYard Skills — 53 slash commands for Claude Code</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="ApexYard ships 53 slash commands across audits, tickets, architecture, decisions, portfolio, and framework ops. Drop into any Claude Code session.">
-<link rel="canonical" href="https://yard.apexscript.com/skills.html">
+<link rel="canonical" href="https://yard.apexscript.com/skills">
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
@@ -14,14 +14,14 @@
 <meta property="og:title" content="ApexYard Skills — 53 slash commands for Claude Code">
 <meta property="og:description" content="53 slash commands available in any apexyard-managed project. Run any of these in a Claude Code session inside your fork.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://yard.apexscript.com/skills.html">
+<meta property="og:url" content="https://yard.apexscript.com/skills">
 <meta property="og:site_name" content="ApexYard">
 <meta property="og:image" content="https://yard.apexscript.com/og/skills.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:url" content="https://yard.apexscript.com/skills.html">
+<meta name="twitter:url" content="https://yard.apexscript.com/skills">
 <meta name="twitter:title" content="ApexYard Skills — 53 slash commands for Claude Code">
 <meta name="twitter:description" content="The full ApexYard slash-command surface — 53 skills, what each one does, and how to invoke it.">
 <meta name="twitter:image" content="https://yard.apexscript.com/og/skills.png">
@@ -42,7 +42,7 @@
       "@type": "ListItem",
       "position": 2,
       "name": "Skills",
-      "item": "https://yard.apexscript.com/skills.html"
+      "item": "https://yard.apexscript.com/skills"
     }
   ]
 }
@@ -368,11 +368,11 @@ main {
         <span class="titlebar__dot"></span>
         <span class="titlebar__dot is-warn"></span>
       </span>
-      <span class="titlebar__path">~/<a href="index.html"><b>apexyard</b></a> <span class="dim">· skills</span></span>
+      <span class="titlebar__path">~/<a href="/"><b>apexyard</b></a> <span class="dim">· skills</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
-      <a href="architecture.html">architecture</a>
-      <a href="skills.html" class="is-current always">skills</a>
+      <a href="/architecture">architecture</a>
+      <a href="/skills" class="is-current always">skills</a>
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>
       <a href="https://github.com/me2resh/apexyard" class="is-cta" target="_blank" rel="noopener">github →</a>
     </nav>
@@ -834,7 +834,7 @@ main {
   </section>
 
   <footer class="footer">
-    <a href="index.html">← yard.apexscript.com</a>
+    <a href="/">← yard.apexscript.com</a>
     <a href="https://github.com/me2resh/apexyard" target="_blank" rel="noopener">github</a>
     <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog</a>
     <a href="https://github.com/me2resh/apexyard/tree/main/.claude/skills" target="_blank" rel="noopener">skill source</a>


### PR DESCRIPTION
## Summary

- **`site/_redirects` gains 2 new 200-rewrite rules** for clean URLs: `/architecture` rewrites to `/architecture.html` (and the same for `/skills`). Netlify serves the .html file content while the user-visible URL stays as the clean form. Rewrite (200) NOT redirect (301) means old bookmarks pointing at `/architecture.html` still work — backwards compat preserved.
- **Canonical / og:url / twitter:url / JSON-LD `item` URLs migrated** in `site/architecture.html` + `site/skills.html` from the .html form to the clean form. Canonical now matches the user-visible URL (the AC's "canonical should match the user-visible URL, not the served file"). Resolves the SEO audit's S14 finding from 2026-05-20.
- **Internal navigation hrefs migrated** in `site/index.html` + `site/architecture.html` + `site/skills.html` from `href="architecture.html"` → `href="/architecture"` (and same pattern for skills + index). Absolute paths so the link resolution doesn't drift if Netlify ever serves the site from a sub-path.
- **`site/sitemap.xml` updated** — the 2 page entries now point at the clean URLs (search engines see the cleaner form as canonical).
- **`site/llms.txt` + `site/llms-full.txt` updated** — the 4 LLM-discovery manifest references migrated to the clean form. Coding agents fetching pages via these URLs benefit from URL-shape consistency.

## Testing

- [x] `grep -rnE 'apexscript\.com/(architecture\|skills)\.html|href="(architecture\|skills\|index)\.html"' site/*.html site/*.md.gen site/llms.txt site/llms-full.txt site/sitemap.xml` returns no matches — all .html URL references migrated cleanly.
- [x] `bash .claude/hooks/tests/test_site_counts.sh` — PASS at 53 skills / 31 hooks / 19 roles (no count regression from this PR's URL-shape changes).
- [ ] Manual smoke (operator, post-Netlify-deploy): `curl https://yard.apexscript.com/architecture` (no .html) — should return 200 with the architecture.html content. `curl https://yard.apexscript.com/architecture.html` (legacy) — should still return 200 (backwards compat). Same pair for /skills. Not blocking — verified by the existing Netlify rewrite-rule semantics; only manual-verify if the deploy looks off.
- [ ] Manual smoke: browse the site, click `architecture` / `skills` nav, observe the URL bar shows `/architecture` (no .html).

## Glossary

| Term | Definition |
|------|------------|
| **Netlify `_redirects` 200 rewrite** | Netlify-specific syntax. `from to 200` rewrites the URL — Netlify serves the `to` file's content while the browser's URL bar shows `from`. NOT a redirect (which would force `to` into the URL bar via a 301). The 200 form is the right choice for clean-URL polish where we want both URLs to load but the user to see the cleaner one. |
| **Canonical URL** | The `<link rel="canonical" href="...">` tag in each page. Tells search engines "if this content is reachable at multiple URLs, this is the one you should index." With both `/architecture` and `/architecture.html` returning 200, the canonical disambiguates — we set it to the cleaner form so Google indexes that one. |
| **Backwards compat (old bookmarks)** | Anyone who already bookmarked `/architecture.html` keeps working. The `.html` URL still resolves directly (it's a real file). The clean URL is additive, not a replacement. |

Closes #327
Refs the 2026-05-20 SEO audit (S14 finding) — see `projects/apexyard/audits/seo-audit/` for the artefacts.