### PR TITLE
fix(#370): hook wrappers silent no-op outside an apexyard fork

### DIFF
--- a/.claude/hooks/tests/test_settings_wrappers_silent_noop.sh
+++ b/.claude/hooks/tests/test_settings_wrappers_silent_noop.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Settings.json hook-wrapper invariants — protects against the #370 regression
+# where wrappers crashed with "No such file or directory" when Claude Code
+# was launched outside an apexyard ancestry.
+#
+# Bug shape: every wrapper has a walk-up loop terminating with `done;exec
+# "$r/.claude/hooks/<name>.sh"`. When `$r` walks all the way to `/`, the
+# exec lands on `/.claude/hooks/<name>.sh` — which doesn't exist. Result:
+# one "Failed with non-blocking status code" message per wrapper, per
+# tool call, flooding the UI.
+#
+# Fix shape: insert an anchor-found guard between `done;` and `exec`:
+#   done;[ -f "$r/.apexyard-fork" ] || [ -f "$r/onboarding.yaml" ] || exit 0;exec ...
+# When the anchor isn't found, the wrapper silently exits 0 — which is
+# the correct behaviour outside an ops fork.
+#
+# This test enforces:
+#   1. Every wrapper has the anchor-found guard (no unguarded `done;exec`)
+#   2. A representative wrapper invoked from /tmp (no apexyard ancestry)
+#      exits 0 with no stderr output
+#   3. The same wrapper invoked from the ops fork exits 0 (negative
+#      control — confirms the guard doesn't accidentally block in-fork
+#      invocations)
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SETTINGS="$ROOT/.claude/settings.json"
+
+[ -f "$SETTINGS" ] || { echo "FAIL: settings.json not at $SETTINGS" >&2; exit 1; }
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+PASS=0
+FAIL=0
+FAILED=""
+
+mark_pass() { green "  ok   $1"; PASS=$((PASS+1)); }
+mark_fail() {
+  red "  FAIL $1: $2" >&2
+  FAIL=$((FAIL+1))
+  FAILED="$FAILED $1"
+}
+
+echo "== Settings.json hook-wrapper invariants (#370 regression guard)"
+
+# --- Invariant 1: every wrapper has the anchor-found guard --------------------
+# Count wrappers (each `r=$PWD` line is one wrapper) vs guards present.
+total=$(grep -cF 'r=$PWD' "$SETTINGS")
+guarded=$(grep -cF '|| exit 0;exec' "$SETTINGS")
+unguarded=$(grep -cF 'done;exec' "$SETTINGS")
+
+if [ "$total" = "0" ]; then
+  mark_fail "wrapper count" "expected ≥1 wrapper matching the r=\$PWD shape; found 0 — settings.json may have drifted"
+fi
+
+if [ "$guarded" = "$total" ] && [ "$unguarded" = "0" ]; then
+  mark_pass "all $total wrappers have the anchor-found guard (no unguarded done;exec)"
+else
+  mark_fail "wrapper guards" "total=$total guarded=$guarded unguarded=$unguarded — every wrapper must have '|| exit 0;exec' (#370 regression)"
+fi
+
+# --- Invariant 2: wrapper invoked outside the fork exits 0 silently ----------
+# Extract the canonical wrapper shape + substitute a real hook name
+WRAPPER='r=$PWD;while [ ! -f "$r/.apexyard-fork" ] && [ ! -f "$r/onboarding.yaml" ] && [ -n "$r" ] && [ "$r" != / ];do r=${r%/*};done;[ -f "$r/.apexyard-fork" ] || [ -f "$r/onboarding.yaml" ] || exit 0;exec "$r/.claude/hooks/detect-role-trigger.sh"'
+
+OUT=$(mktemp)
+ERR=$(mktemp)
+(
+  cd /tmp
+  echo '' | bash -c "$WRAPPER" >"$OUT" 2>"$ERR"
+)
+rc=$?
+
+if [ "$rc" = "0" ] && [ ! -s "$ERR" ]; then
+  mark_pass "wrapper invoked from /tmp (no fork ancestry) exits 0 with empty stderr"
+else
+  mark_fail "outside-fork silent no-op" "rc=$rc stderr=[$(cat "$ERR")]"
+fi
+rm -f "$OUT" "$ERR"
+
+# --- Invariant 3: wrapper invoked INSIDE the fork still works (negative control)
+# The guard must not block legitimate in-fork invocations. Use a path that
+# WON'T trigger any role-trigger banner so we get a clean exit-0 baseline.
+OUT=$(mktemp)
+ERR=$(mktemp)
+(
+  cd "$ROOT"
+  echo '{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"src/utils/format.ts"}}' \
+    | bash -c "$WRAPPER" >"$OUT" 2>"$ERR"
+)
+rc=$?
+
+if [ "$rc" = "0" ] && [ ! -s "$ERR" ]; then
+  mark_pass "wrapper invoked from inside the fork still exits 0 silently on non-trigger path"
+else
+  mark_fail "inside-fork still works" "rc=$rc stderr=[$(cat "$ERR")]"
+fi
+rm -f "$OUT" "$ERR"
+
+# --- Summary ---
+echo
+echo "===== test_settings_wrappers_silent_noop.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED"
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_settings_wrappers_silent_noop.sh
+++ b/.claude/hooks/tests/test_settings_wrappers_silent_noop.sh
@@ -68,7 +68,7 @@ WRAPPER='r=$PWD;while [ ! -f "$r/.apexyard-fork" ] && [ ! -f "$r/onboarding.yaml
 OUT=$(mktemp)
 ERR=$(mktemp)
 (
-  cd /tmp
+  cd /tmp || exit 1
   echo '' | bash -c "$WRAPPER" >"$OUT" 2>"$ERR"
 )
 rc=$?
@@ -86,7 +86,7 @@ rm -f "$OUT" "$ERR"
 OUT=$(mktemp)
 ERR=$(mktemp)
 (
-  cd "$ROOT"
+  cd "$ROOT" || exit 1
   echo '{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"src/utils/format.ts"}}' \
     | bash -c "$WRAPPER" >"$OUT" 2>"$ERR"
 )

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,35 +6,35 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/onboarding-check.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/onboarding-check.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-upstream-drift.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/check-upstream-drift.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-jq-installed.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/check-jq-installed.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-portfolio-config.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/check-portfolio-config.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/clear-bootstrap-marker.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/clear-bootstrap-marker.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/clear-issue-skill-marker.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/clear-issue-skill-marker.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/link-custom-skills.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/link-custom-skills.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/apply-agent-routing.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/apply-agent-routing.sh\"'"
           }
         ]
       }
@@ -45,15 +45,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-migration-ticket.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/require-migration-ticket.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
           }
         ]
       },
@@ -63,144 +63,144 @@
           {
             "type": "command",
             "if": "Bash(git add *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-git-add-all.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-git-add-all.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-main-push.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-main-push.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-branch-name.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/validate-branch-name.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/check-secrets.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/check-secrets.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/verify-commit-refs.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/verify-commit-refs.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-commit-format.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/validate-commit-format.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-agdr-for-arch-changes.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/require-agdr-for-arch-changes.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/pre-push-gate.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/pre-push-gate.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-agent-routing-drift.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-agent-routing-drift.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-agent-routing-drift.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-agent-routing-drift.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-skill-for-issue-create.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/require-skill-for-issue-create.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh issue create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/suggest-ticket-template.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/suggest-ticket-template.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh issue create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-issue-structure.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/validate-issue-structure.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh issue create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/validate-pr-create.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/validate-pr-create.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-agdr-for-arch-pr.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/require-agdr-for-arch-pr.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh issue comment *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr comment *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh api *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr merge *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-unreviewed-merge.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-unreviewed-merge.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh api *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-unreviewed-merge.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-unreviewed-merge.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr merge *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh api *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh pr merge *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh api *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-migration-ticket.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/require-migration-ticket.sh\"'"
           },
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh issue edit *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
           }
         ]
       }
@@ -210,7 +210,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/detect-role-trigger.sh\"'"
           }
         ]
       }
@@ -222,12 +222,12 @@
           {
             "type": "command",
             "if": "Bash(gh pr create *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/auto-code-review.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/auto-code-review.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;exec \"$r/.claude/hooks/warn-stale-review-markers.sh\"'"
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/warn-stale-review-markers.sh\"'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- **Fixes the UI-flooding "No such file or directory" error** that every `.claude/settings.json` hook wrapper produced on every tool call when Claude Code was launched outside an apexyard ancestry (e.g. `/tmp`, a bare project clone, any unrelated repo). Root cause: the walk-up loop correctly stops at `/` when no anchor file is found, but the wrapper unconditionally `exec`s `$r/.claude/hooks/<name>.sh` — which lands on `/.claude/hooks/<name>.sh` (doesn't exist). One error per wrapper, per tool call → unusable terminal.
- **Inserts an anchor-found guard between `done;` and `exec`** in all 43 wrappers: `done;[ -f "$r/.apexyard-fork" ] || [ -f "$r/onboarding.yaml" ] || exit 0;exec ...`. When neither anchor is found, the wrapper silently exits 0 — the correct behaviour outside an ops fork (hooks are framework-internal and shouldn't fire on unrelated repos).
- **Single uniform transform** applied via a python JSON-safe text substitution: 43 OLD → 43 NEW, JSON re-validated post-edit. Zero unguarded `done;exec` patterns remain in `.claude/settings.json`.
- **New regression test `test_settings_wrappers_silent_noop.sh`** locks in three invariants: every wrapper has the guard (catches future-added wrapper without the guard), wrapper invoked from `/tmp` exits 0 silently (empirical bug-fix confirmation), wrapper invoked from inside the fork on a non-trigger path still exits 0 (negative control proving the guard doesn't accidentally block legitimate invocations).

## Testing

- [x] `bash .claude/hooks/tests/test_settings_wrappers_silent_noop.sh` — PASS at 3/3.
- [x] Manual reproduction: `(cd /tmp && bash -c '<wrapper>')` — exits 0 with empty stderr (was: `bash: /.claude/hooks/<name>.sh: No such file or directory`).
- [x] In-fork invocation still works: PreToolUse Edit hook on a non-security-sensitive path → exits 0 silently as before.
- [x] All existing hooks tests still PASS (no regression in the rest of the test suite — the fix is in the wrapper, not in any hook's body).

## Glossary

| Term | Definition |
|------|------------|
| **Hook wrapper** | The `bash -c '...'` invocation in `.claude/settings.json` that wraps each `.claude/hooks/<name>.sh` call. Pre-#370 shape: walk up from `$PWD` to find an ops-fork anchor, then exec the hook at the resolved path. Post-#370 shape: same walk-up, but if no anchor is found, silently exit 0 instead of attempting to exec at `/`. |
| **Anchor file** | One of `.apexyard-fork` (v2 marker) or `onboarding.yaml` (v1 legacy). The wrapper resolves the ops-fork root by walking up the directory tree looking for either. Per AgDR-0021 § B + AgDR-0041 § "Decision" point 2 — wrappers accept either form. |
| **Silent no-op outside the fork** | The corrected behaviour. Adopter runs Claude Code in `/tmp` or a bare clone, the framework's hooks don't fire (correct — they're framework-internal), and the operator's terminal stays clean. Previously: noise flood per tool call. |
| **Walk-up loop termination at `/`** | Bash idiom: `while ... && [ "$r" != / ]; do r=${r%/*}; done`. When no anchor is found, `$r` arrives at `/`. The fix's `|| exit 0` short-circuits the subsequent exec when `$r == /` (no anchor found at root). |

Closes #370