### PR TITLE
fix(#374): grep -c double-output in code-quality.yml golden-path

### DIFF
--- a/golden-paths/pipelines/code-quality.yml
+++ b/golden-paths/pipelines/code-quality.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           npm run typecheck 2>&1 | tee typecheck-output.txt || true
 
-          ERRORS=$(grep -c "error TS" typecheck-output.txt || echo "0")
+          ERRORS=$(grep -c "error TS" typecheck-output.txt || true)
           echo "errors=$ERRORS" >> $GITHUB_OUTPUT
 
           if [ "$ERRORS" -gt 0 ]; then
@@ -72,7 +72,7 @@ jobs:
         run: |
           npx prettier --check "**/*.{ts,tsx,js,jsx,json,md}" 2>&1 | tee format-output.txt || true
 
-          UNFORMATTED=$(grep -c "would be reformatted" format-output.txt || echo "0")
+          UNFORMATTED=$(grep -c "would be reformatted" format-output.txt || true)
           echo "unformatted=$UNFORMATTED" >> $GITHUB_OUTPUT
 
       # Run tests
@@ -82,7 +82,7 @@ jobs:
           npm run test 2>&1 | tee test-output.txt || true
 
           if grep -q "Tests:.*failed" test-output.txt; then
-            FAILED=$(grep "Tests:" test-output.txt | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' || echo "0")
+            FAILED=$(grep "Tests:" test-output.txt | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' || true)
             echo "failed=$FAILED" >> $GITHUB_OUTPUT
             echo "::error::$FAILED tests failed"
           else


### PR DESCRIPTION
## Summary
- Replaces `|| echo "0"` with `|| true` in three `grep -c` lines in `golden-paths/pipelines/code-quality.yml`
- Fixes red CI on adopter projects with a clean repo (zero TS errors, zero unformatted files)

## Why
`grep -c` always emits its count on stdout (including `0` on no matches) AND exits 1 when there are no matches. The previous `|| echo "0"` clause appended a SECOND `0`, producing `"0\n0"` in the captured variable. That two-line value broke:

- `[ "$VAR" -gt 0 ]` → `integer expression expected`
- GITHUB_OUTPUT writer → `Invalid format '0'`, `Unable to process file command 'output'`

`|| true` suppresses grep's non-zero exit without polluting stdout — grep's own `0` is the value we want.

## Affected steps
- TypeScript Check (line 46)
- Format Check (line 75)
- Run Tests (line 85)

## Testing
1. Copy the updated `golden-paths/pipelines/code-quality.yml` into a repo's `.github/workflows/`
2. Push a commit on a clean state (zero TS errors, zero unformatted files, zero failing tests)
3. Observe TypeScript Check, Format Check, and Run Tests steps all pass (previously they failed with `integer expression expected` / `Invalid format '0'`)
4. Introduce one TS error / unformatted file / failing test and re-run — the count is detected correctly and the appropriate `::error::` annotation fires

Verified end-to-end on an adopter repo's CI run prior to filing.

Closes #374

## Glossary
| Term | Definition |
|------|------------|
| golden-path | A reusable CI/CD workflow shipped by apexyard for adopters to copy into their `.github/workflows/`. |
| GITHUB_OUTPUT | Per-step output file GitHub Actions reads to expose values to downstream steps via `${{ steps.<id>.outputs.<key> }}`. |
