### PR TITLE
perf(#372): drop @docs/multi-project.md auto-import from CLAUDE.md

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -30,6 +30,8 @@ Re-running `/setup` on an already-configured fork shows the current config and a
 
 ## Process
 
+> **Tip for the agent driving setup**: `docs/multi-project.md` is the canonical reference for portfolio modes, v1→v2 migration, custom-templates path-mirroring, the FAQ, and trade-offs. As of #372 it is **not** auto-imported into the session context (the 70k-char file was loading ~18k tokens into every session, even for adopters who never re-run setup). The steps below are self-contained for the mechanical setup. If a first-timer asks a question mid-setup that this SKILL doesn't answer directly, `Read docs/multi-project.md` on demand rather than guessing.
+
 ### Step −1: Pre-flight — refuse if `jq` is missing (REQUIRED)
 
 `/setup` (and every framework hook that reads `.claude/project-config.json` overrides) depends on `jq`. Without it, override reads silently fall back to defaults — the adopter's `.ui_paths`, `.tracker.*`, `.migration_paths`, etc. have zero effect and there's no error to debug. Refuse to proceed until jq is on PATH so the operator never sees the silently-degraded state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ ApexYard governs a portfolio of repos as one organisation. The repo this `CLAUDE
 
 Skills like `/projects`, `/inbox`, `/status`, `/tasks`, and `/stakeholder-update` aggregate across the registry. Even if you only have one repo to govern, you still fork apexyard and register that single repo — the skills work the same way, and future projects plug into the same registry.
 
-Full setup guide: @docs/multi-project.md
+Full setup guide: `docs/multi-project.md` (read on demand — large; not auto-imported)
 
 ---
 


### PR DESCRIPTION
## Summary

- **Removed the 70.7k-char auto-import on CLAUDE.md:20** — `@docs/multi-project.md` was loaded into every Claude Code session context (~18k tokens), tripping the "Large file will impact performance" warning and forcing earlier compaction. The file is setup / migration documentation, not daily-ops reference — none of the everyday portfolio skills (`/projects`, `/inbox`, `/status`, `/tasks`) read it.
- **Added on-demand-Read tip to `/setup` Process section** — belt-and-suspenders mitigation so the agent driving a first-time setup knows to `Read docs/multi-project.md` if a niche question (e.g. custom-templates path-mirroring, v1→v2 migration semantics) surfaces mid-flow. Tip lives above Step −1 so it applies to BOTH single-fork and split-portfolio paths.
- **Discoverability preserved**: the file is still listed in the Quick Reference table at `CLAUDE.md:297` (`| Full setup guide | docs/multi-project.md |`), still cited by 32 `SKILL.md` files as a textual "see also" pointer, and still Read on demand by the skills that genuinely need it (`/setup`, `/handover`, `/update`, `/split-portfolio`).
- **Annotation added on line 20** — `(read on demand — large; not auto-imported)` makes the intent visible so a future contributor doesn't "fix" the missing `@` thinking it was an oversight.

## Testing

- [x] `git diff` shows two surgical edits: one line in `CLAUDE.md`, two lines in `.claude/skills/setup/SKILL.md`
- [x] Markdownlint posture unchanged on both files: 36 pre-existing MD060 errors on CLAUDE.md before/after; 24 pre-existing MD060 errors on `.claude/skills/setup/SKILL.md` before/after — neutral diff
- [x] Grepped for `@docs/multi-project` across the tracked tree: only matches are stale snapshots under `.claude/worktrees/` (gitignored, unaffected)
- [x] Quick Reference table line at `CLAUDE.md:297` unchanged
- [x] No skill or hook depends on the `@`-import path — all 32 references in skill docs are textual `docs/multi-project.md` mentions, designed for on-demand Read
- [x] `/setup` SKILL.md is 615 lines and fully self-contained for the mechanical bootstrap — the tip handles the niche-question edge case explicitly

## Scope decision

Scoped the on-demand-Read tip to `/setup` only. The other bootstrap-class skills (`/handover`, `/update`, `/split-portfolio`) serve adopters who already configured their fork once and have more accumulated context — the risk profile is lower. Keeping this PR focused on what the issue asked for plus the first-time-setup mitigation.

## Glossary

| Term | Definition |
|------|------------|
| `@` auto-import | A Claude Code CLAUDE.md convention where a path prefixed with `@` is loaded into the session context automatically at session start. Counts against the context window for every session. |
| On-demand Read | The Read tool fetches the file only when a skill / agent actually needs it — zero cost on sessions that don't touch it. |
| Bootstrap-class skills | Skills (`/setup`, `/handover`, `/update`, `/split-portfolio`) that run before any portfolio is configured. Exempt from the active-ticket gate per `.claude/rules/workflow-gates.md`. |
| MD060 | Markdownlint rule for table column style consistency. Pre-existing errors on both touched files predate this change. |
| Context compaction | When the conversation grows past a threshold, Claude Code summarises earlier turns to fit the model's context window. Larger auto-imports trigger compaction sooner. |

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)