### PR TITLE
fix(#381): pin ops-root via CLAUDE_CODE_SESSION_ID SessionStart hook

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -450,13 +450,18 @@ When your verdict is APPROVED, and ONLY then, write the approval marker file so 
 
 The marker MUST land at `<ops_fork_root>/.claude/session/reviews/{number}-rex.approved`. Inside `workspace/<project>/`, `git rev-parse --show-toplevel` returns the project clone — NOT the ops fork. Writing to a relative `.claude/session/reviews/` path from inside a workspace clone puts the marker where the merge-gate hook can't see it (the bug fix in me2resh/apexyard#229 + #230 aligned the merge gate with this path; this section is the agent-side counterpart).
 
-Resolve the ops fork root by walking up for `onboarding.yaml` + `apexyard.projects.yaml`:
+**Resolve `MARKER_HOME` ONCE, at review start, from your initial working directory** — before any `cd`, `git clone`, `gh pr checkout`, or other tool call that might change where you are or what's anchored above you. The walk-up shape below is sensitive to `$PWD`: if you've cloned the fork into `/tmp` for inspection and `cd`'d into the clone first, the walk resolves to that throwaway tree, the marker lands in `/tmp`, and the merge gate (running from the real ops fork) cannot find it. Capture `MARKER_HOME` first; treat it as immutable for the rest of the review. This is the prose discipline; the mechanical safety net is `pin-ops-root.sh` (apexyard#381), which captures the launch-cwd ops root at SessionStart and feeds it to `_lib-ops-root.sh::resolve_ops_root` so adopters on framework versions that ship the hook get the pin automatically — the walk-up below remains as the safety net for older versions and as the resolution method when no pin exists.
+
+Resolve the ops fork root by walking up for `onboarding.yaml` + `apexyard.projects.yaml` (or the `.apexyard-fork` v2 marker):
 
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel)
 OPS_ROOT=""
 r="$REPO_ROOT"
 while [ -n "$r" ] && [ "$r" != "/" ]; do
+  if [ -f "$r/.apexyard-fork" ]; then
+    OPS_ROOT="$r"; break
+  fi
   if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
     OPS_ROOT="$r"; break
   fi

--- a/.claude/hooks/_lib-ops-root.sh
+++ b/.claude/hooks/_lib-ops-root.sh
@@ -25,20 +25,66 @@
 # also benefit from the marker (set by `/setup`) but the legacy walk
 # remains a fallback for un-migrated forks.
 #
+# -----------------------------------------------------------------------
+# PIN-FIRST, WALK-UP-FALLBACK RESOLUTION (apexyard#381)
+# -----------------------------------------------------------------------
+#
+# The walk-up alone has a sharp edge: if a hook runs from a cwd inside
+# an UNRELATED ops-fork-shaped directory tree, the walk resolves to
+# THAT tree, not the operator's real ops fork. The motivating incident:
+# the code-reviewer sub-agent (Rex) was reviewing a PR by cloning the
+# fork into /tmp and `cd`ing into the clone before resolving
+# MARKER_HOME. A /tmp ops-fork clone satisfies the anchor conditions,
+# so the walk resolved to the throwaway clone; the <pr>-rex.approved
+# marker landed in /tmp instead of the real ops fork, and the merge
+# gate (running from the real ops fork) couldn't find it.
+#
+# Mitigation: a SessionStart hook (`pin-ops-root.sh`) captures the
+# launch-cwd ops root and writes it to
+# `${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-<SESSION_ID>`.
+# `resolve_ops_root` consults the pin BEFORE walking up. Stale pins
+# self-heal because the pinned path is re-validated against the anchor
+# conditions; a pin pointing at a dir that no longer satisfies the
+# anchors is ignored and the walk-up runs.
+#
+# Escape hatches:
+#   - APEXYARD_OPS_DISABLE_PIN=1     → ignore the pin, use walk-up only
+#   - APEXYARD_OPS_PIN_DIR=<dir>     → override the pin directory
+#   - CLAUDE_CODE_SESSION_ID unset   → no pin lookup, walk-up only
+#
+# Spaced-path safety: the pin file is written by `pin-ops-root.sh` with
+# `printf '%s\n' "$path"` and read here with `IFS= read -r` so paths
+# containing spaces survive the round-trip intact.
+#
+# No-regression guarantee: if the pin is absent for any reason (no
+# session id, no pin dir, stale pin, escape hatch set), resolution
+# falls back to `resolve_ops_root_walk` — the pure walk-up that was
+# this lib's only behaviour before #381. Worst case is no improvement,
+# never worse.
+#
 # Functions:
 #   resolve_ops_root [start_dir]
-#       Walks up from start_dir (default: $PWD) toward / looking for a
-#       directory that satisfies either anchor condition.
+#       Pin-first (when available + valid), then walk up from start_dir
+#       (default: $PWD) toward / looking for a directory that satisfies
+#       either anchor condition.
 #       Echoes the path on success; echoes nothing and returns 0 on miss
 #       (caller is expected to fall back to start_dir or a sensible
 #       default).
+#
+#   resolve_ops_root_walk [start_dir]
+#       Pure walk-up — never consults the pin. Used by `pin-ops-root.sh`
+#       itself (to avoid a self-referential lookup at pin-write time)
+#       and by any caller that explicitly wants pinless resolution.
 #
 # Sourced by hooks; never executed directly.
 
 [ -n "${_LIB_OPS_ROOT_SOURCED:-}" ] && return 0
 _LIB_OPS_ROOT_SOURCED=1
 
-resolve_ops_root() {
+# Pure walk-up. Recognises BOTH the v2 .apexyard-fork marker AND the
+# legacy v1 (onboarding.yaml + apexyard.projects.yaml) pair. Never
+# touches the pin.
+resolve_ops_root_walk() {
   local start="${1:-$PWD}"
   local r="$start"
   while [ -n "$r" ] && [ "$r" != "/" ]; do
@@ -57,4 +103,49 @@ resolve_ops_root() {
     r=$(dirname "$r")
   done
   return 0
+}
+
+# Validate that a candidate path satisfies one of the ops-root anchor
+# conditions. Returns 0 if valid, 1 otherwise. Used to re-check a
+# pinned path before trusting it.
+_ops_root_anchor_valid() {
+  local r="$1"
+  [ -n "$r" ] || return 1
+  [ -d "$r" ] || return 1
+  if [ -f "$r/.apexyard-fork" ]; then
+    return 0
+  fi
+  if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# Pin-first resolver. Tries the pin file (when available + valid),
+# falls back to walk-up. See header for the full strategy.
+resolve_ops_root() {
+  local start="${1:-$PWD}"
+
+  # Pin check — only when the session id is available and the escape
+  # hatch isn't set. Any failure here silently falls through to walk-up.
+  if [ -z "${APEXYARD_OPS_DISABLE_PIN:-}" ] && [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+    local pin_dir="${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}"
+    local pin_file="$pin_dir/ops-root-${CLAUDE_CODE_SESSION_ID}"
+    if [ -f "$pin_file" ]; then
+      local pinned=""
+      # Read one line preserving spaces. IFS= so leading/trailing
+      # whitespace inside the path survives; -r so backslashes are
+      # literal. The single read is the whole file; we ignore any
+      # subsequent lines (defensive against future format expansion).
+      IFS= read -r pinned < "$pin_file" || pinned=""
+      if [ -n "$pinned" ] && _ops_root_anchor_valid "$pinned"; then
+        printf '%s' "$pinned"
+        return 0
+      fi
+      # Pin present but stale (path no longer satisfies anchors).
+      # Fall through to walk-up — self-healing.
+    fi
+  fi
+
+  resolve_ops_root_walk "$start"
 }

--- a/.claude/hooks/pin-ops-root.sh
+++ b/.claude/hooks/pin-ops-root.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# SessionStart hook: pin the ops-fork root for this session.
+#
+# Background: hooks and sub-agents that need to write or read
+# framework session state (`.claude/session/*`) resolve the ops-fork
+# root via `_lib-ops-root.sh::resolve_ops_root`. Pre-#381 that function
+# only had a walk-up implementation — it climbed from `$PWD` looking
+# for the `.apexyard-fork` v2 marker or the legacy
+# `onboarding.yaml` + `apexyard.projects.yaml` v1 pair.
+#
+# The walk-up has a sharp edge: if a hook runs from a cwd that happens
+# to sit inside an UNRELATED ops-fork-shaped tree (e.g. a /tmp clone of
+# the fork made for PR review), the walk resolves to that throwaway
+# tree rather than the operator's real fork. The motivating incident:
+# the `code-reviewer` sub-agent (Rex) cloned a fork into /tmp for
+# review purposes, then `cd`'d into the clone before resolving
+# MARKER_HOME. The clone satisfies the anchor conditions, so Rex
+# resolved MARKER_HOME to /tmp; the `<pr>-rex.approved` marker landed
+# there; the merge gate (running from the real ops fork) couldn't see
+# it. Operators had to mirror the marker locally as a workaround.
+#
+# This hook closes that gap by capturing the launch-cwd ops root at
+# session start — BEFORE any sub-agent or skill has had a chance to
+# `cd` somewhere unrelated — and writing it to a per-session pin file:
+#
+#   ${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-<SESSION_ID>
+#
+# `resolve_ops_root` then consults the pin BEFORE walking up. Stale
+# pins self-heal because the pinned path is re-validated against the
+# anchor conditions on read.
+#
+# Silent no-ops:
+#   - CLAUDE_CODE_SESSION_ID unset                    → exit 0 (no pin)
+#   - walk-up from $PWD fails to find an ops root     → exit 0 (no pin)
+#   - pin already exists with the same path           → exit 0 (no-op)
+#
+# Idempotent: re-invoking the hook on the same session overwrites the
+# pin with the same value (or refreshes it if the operator
+# legitimately switched ops forks mid-session — rare).
+#
+# Spaced-path safety: the path is written with `printf '%s\n' "$path"`
+# so the corresponding `IFS= read -r` in `_lib-ops-root.sh` reads it
+# back intact. No `tr -d '[:space:]'` shenanigans here or there.
+
+set -u
+
+# Locate the lib relative to this script. The settings.json wrapper
+# walks up to the ops fork before exec'ing us, so $0 is always at
+# .claude/hooks/pin-ops-root.sh inside the ops fork.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$HOOK_DIR/_lib-ops-root.sh"
+
+# Defensive: if the lib is missing the hook can't do anything useful.
+# Silent exit (no banner) — same shape as the rest of the SessionStart
+# chain.
+if [ ! -f "$LIB" ]; then
+  exit 0
+fi
+
+# Source the lib to get resolve_ops_root_walk. Use the WALK variant
+# (not resolve_ops_root) to avoid self-referential pin lookup at
+# pin-write time.
+# shellcheck source=/dev/null
+. "$LIB"
+
+# No session id → no per-session pin to write. Common in scripted /
+# CI contexts; the walk-up fallback handles those just fine.
+if [ -z "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+  exit 0
+fi
+
+# Resolve ops root from the launch cwd via the pure walk-up.
+ops_root="$(resolve_ops_root_walk "$PWD")"
+if [ -z "$ops_root" ]; then
+  # No anchor found upward from $PWD. The current session isn't in an
+  # ops-fork-shaped tree at launch time, so there's nothing to pin.
+  exit 0
+fi
+
+pin_dir="${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}"
+pin_file="$pin_dir/ops-root-${CLAUDE_CODE_SESSION_ID}"
+
+# Create the pin directory if missing. mkdir -p is idempotent.
+mkdir -p "$pin_dir" 2>/dev/null || exit 0
+
+# Write the pin. printf '%s\n' preserves spaces in the path; the
+# matching `IFS= read -r` in _lib-ops-root.sh reads it back intact.
+printf '%s\n' "$ops_root" > "$pin_file" 2>/dev/null || exit 0
+
+exit 0

--- a/.claude/hooks/tests/test_resolve_ops_root_pin.sh
+++ b/.claude/hooks/tests/test_resolve_ops_root_pin.sh
@@ -1,0 +1,310 @@
+#!/bin/bash
+# Smoke tests for the pin-first / walk-up-fallback behaviour added to
+# .claude/hooks/_lib-ops-root.sh in apexyard#381, plus a tiny
+# functional check on .claude/hooks/pin-ops-root.sh itself.
+#
+# Each case:
+#   - builds an isolated sandbox under $TMPDIR with a synthetic
+#     ops-fork layout (v1 or v2 anchors)
+#   - optionally writes a pin file under a per-case APEXYARD_OPS_PIN_DIR
+#   - sources the lib (or invokes the SessionStart hook)
+#   - exports CLAUDE_CODE_SESSION_ID to drive the pin lookup
+#   - asserts the returned path / pin-file contents
+#
+# Cases covered:
+#   1. Pin hit (pin exists, cwd outside ops root) → returns pinned path
+#   2. Stale pin (pin points at dir with no anchors) → falls back to walk-up
+#   3. APEXYARD_OPS_DISABLE_PIN=1 → pin ignored, walk-up used
+#   4. resolve_ops_root_walk direct call → ignores pin entirely
+#   5. Spaced path in pin (/tmp/test space/ops) → read back intact
+#   6. CLAUDE_CODE_SESSION_ID unset → falls back to walk-up
+#   7. pin-ops-root.sh writes the pin file from launch cwd
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+LIB="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
+HOOK="$SRC_ROOT/.claude/hooks/pin-ops-root.sh"
+
+if [ ! -f "$LIB" ]; then
+  echo "FAIL: lib not found at $LIB" >&2
+  exit 1
+fi
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: hook not found at $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+mark_pass() { echo "  ✓ $1"; return 0; }
+mark_fail() { echo "  ✗ $1: $2" >&2; return 1; }
+
+run_case() {
+  local fn="$1"
+  if "$fn"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES $fn"
+  fi
+}
+
+# Legacy v1 sandbox: onboarding.yaml + apexyard.projects.yaml.
+build_v1_sandbox() {
+  local sb="$1"
+  mkdir -p "$sb/workspace/demo/.git"
+  : > "$sb/onboarding.yaml"
+  : > "$sb/apexyard.projects.yaml"
+}
+
+# v2 sandbox: .apexyard-fork marker.
+build_v2_sandbox() {
+  local sb="$1"
+  mkdir -p "$sb/workspace/demo/.git"
+  : > "$sb/.apexyard-fork"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: pin hit — pin exists, cwd outside ops root, returns pinned path
+# ---------------------------------------------------------------------------
+case_1() {
+  local case_name="pin hit: returns pinned path even when cwd is outside ops root"
+  local sb pin_dir cwd_outside
+  sb=$(mktemp -d)
+  pin_dir=$(mktemp -d)
+  cwd_outside=$(mktemp -d)
+  build_v1_sandbox "$sb"
+
+  # Write the pin.
+  printf '%s\n' "$sb" > "$pin_dir/ops-root-testsess1"
+
+  (
+    export CLAUDE_CODE_SESSION_ID="testsess1"
+    export APEXYARD_OPS_PIN_DIR="$pin_dir"
+    unset APEXYARD_OPS_DISABLE_PIN
+    # shellcheck source=/dev/null
+    . "$LIB"
+    out=$(cd "$cwd_outside" && resolve_ops_root)
+    [ "$out" = "$sb" ] || { mark_fail "$case_name" "expected '$sb', got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: stale pin — pin points at dir with no anchors → walk-up fallback
+# ---------------------------------------------------------------------------
+case_2() {
+  local case_name="stale pin: falls back to walk-up when pinned path has no anchors"
+  local sb pin_dir stale_dir
+  sb=$(mktemp -d)
+  pin_dir=$(mktemp -d)
+  stale_dir=$(mktemp -d)   # no anchors
+  build_v1_sandbox "$sb"
+
+  # Pin points at a dir that doesn't satisfy anchor conditions.
+  printf '%s\n' "$stale_dir" > "$pin_dir/ops-root-testsess2"
+
+  (
+    export CLAUDE_CODE_SESSION_ID="testsess2"
+    export APEXYARD_OPS_PIN_DIR="$pin_dir"
+    unset APEXYARD_OPS_DISABLE_PIN
+    # shellcheck source=/dev/null
+    . "$LIB"
+    # cwd inside the real ops fork — walk-up should find $sb.
+    out=$(cd "$sb/workspace/demo" && resolve_ops_root)
+    [ "$out" = "$sb" ] \
+      || { mark_fail "$case_name" "expected walk-up to '$sb', got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: APEXYARD_OPS_DISABLE_PIN=1 → pin ignored, walk-up used
+# ---------------------------------------------------------------------------
+case_3() {
+  local case_name="escape hatch: APEXYARD_OPS_DISABLE_PIN=1 forces walk-up"
+  local sb1 sb2 pin_dir
+  sb1=$(mktemp -d)
+  sb2=$(mktemp -d)
+  pin_dir=$(mktemp -d)
+  build_v1_sandbox "$sb1"
+  build_v1_sandbox "$sb2"
+
+  # Pin points at sb1, cwd inside sb2 — without the escape hatch we'd
+  # see sb1; WITH it we should see sb2 from the walk-up.
+  printf '%s\n' "$sb1" > "$pin_dir/ops-root-testsess3"
+
+  (
+    export CLAUDE_CODE_SESSION_ID="testsess3"
+    export APEXYARD_OPS_PIN_DIR="$pin_dir"
+    export APEXYARD_OPS_DISABLE_PIN=1
+    # shellcheck source=/dev/null
+    . "$LIB"
+    out=$(cd "$sb2/workspace/demo" && resolve_ops_root)
+    [ "$out" = "$sb2" ] \
+      || { mark_fail "$case_name" "expected walk-up to '$sb2' (escape hatch on), got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: resolve_ops_root_walk direct call → ignores pin entirely
+# ---------------------------------------------------------------------------
+case_4() {
+  local case_name="resolve_ops_root_walk ignores pin even when set"
+  local sb1 sb2 pin_dir
+  sb1=$(mktemp -d)
+  sb2=$(mktemp -d)
+  pin_dir=$(mktemp -d)
+  build_v1_sandbox "$sb1"
+  build_v1_sandbox "$sb2"
+
+  # Pin says sb1; walk from sb2 should still return sb2.
+  printf '%s\n' "$sb1" > "$pin_dir/ops-root-testsess4"
+
+  (
+    export CLAUDE_CODE_SESSION_ID="testsess4"
+    export APEXYARD_OPS_PIN_DIR="$pin_dir"
+    unset APEXYARD_OPS_DISABLE_PIN
+    # shellcheck source=/dev/null
+    . "$LIB"
+    out=$(cd "$sb2/workspace/demo" && resolve_ops_root_walk)
+    [ "$out" = "$sb2" ] \
+      || { mark_fail "$case_name" "expected walk-up to '$sb2', got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: spaced path in pin → read back intact
+# ---------------------------------------------------------------------------
+case_5() {
+  local case_name="spaced path: pin file round-trips through IFS= read -r intact"
+  local base pin_dir cwd_outside sb_name sb
+  base=$(mktemp -d)
+  sb_name="test space/ops fork"
+  sb="$base/$sb_name"
+  mkdir -p "$sb"
+  build_v1_sandbox "$sb"
+  pin_dir=$(mktemp -d)
+  cwd_outside=$(mktemp -d)
+
+  printf '%s\n' "$sb" > "$pin_dir/ops-root-testsess5"
+
+  (
+    export CLAUDE_CODE_SESSION_ID="testsess5"
+    export APEXYARD_OPS_PIN_DIR="$pin_dir"
+    unset APEXYARD_OPS_DISABLE_PIN
+    # shellcheck source=/dev/null
+    . "$LIB"
+    out=$(cd "$cwd_outside" && resolve_ops_root)
+    [ "$out" = "$sb" ] \
+      || { mark_fail "$case_name" "expected '$sb' (with spaces), got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 6: CLAUDE_CODE_SESSION_ID unset → walk-up only (pin ignored)
+# ---------------------------------------------------------------------------
+case_6() {
+  local case_name="no session id: pin lookup skipped, walk-up used"
+  local sb1 sb2 pin_dir
+  sb1=$(mktemp -d)
+  sb2=$(mktemp -d)
+  pin_dir=$(mktemp -d)
+  build_v1_sandbox "$sb1"
+  build_v1_sandbox "$sb2"
+
+  # A "default" pin shape that could match if anything tried to read it
+  # without the session id.
+  printf '%s\n' "$sb1" > "$pin_dir/ops-root-"
+
+  (
+    unset CLAUDE_CODE_SESSION_ID
+    export APEXYARD_OPS_PIN_DIR="$pin_dir"
+    unset APEXYARD_OPS_DISABLE_PIN
+    # shellcheck source=/dev/null
+    . "$LIB"
+    out=$(cd "$sb2/workspace/demo" && resolve_ops_root)
+    [ "$out" = "$sb2" ] \
+      || { mark_fail "$case_name" "expected walk-up to '$sb2' (no session id), got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 7: pin-ops-root.sh writes the pin file from launch cwd
+# ---------------------------------------------------------------------------
+case_7() {
+  local case_name="pin-ops-root.sh: SessionStart hook writes pin file"
+  local sb pin_dir
+  sb=$(mktemp -d)
+  pin_dir=$(mktemp -d)
+  build_v2_sandbox "$sb"
+
+  local sess="testsess7-$$"
+  (
+    export CLAUDE_CODE_SESSION_ID="$sess"
+    export APEXYARD_OPS_PIN_DIR="$pin_dir"
+    # Run the hook from inside the ops fork. The hook resolves $PWD via
+    # walk-up and writes the pin.
+    cd "$sb/workspace/demo" || exit 1
+    bash "$HOOK" >/dev/null 2>&1
+  )
+
+  local pin_file="$pin_dir/ops-root-$sess"
+  if [ ! -f "$pin_file" ]; then
+    mark_fail "$case_name" "pin file not created at '$pin_file'"
+    return
+  fi
+
+  local pinned=""
+  IFS= read -r pinned < "$pin_file" || pinned=""
+  [ "$pinned" = "$sb" ] \
+    || { mark_fail "$case_name" "expected pin contents '$sb', got '$pinned'"; return; }
+  mark_pass "$case_name"
+}
+
+# ---------------------------------------------------------------------------
+# Case 8: pin-ops-root.sh is a silent no-op when CLAUDE_CODE_SESSION_ID unset
+# ---------------------------------------------------------------------------
+case_8() {
+  local case_name="pin-ops-root.sh: no-op when CLAUDE_CODE_SESSION_ID is unset"
+  local sb pin_dir
+  sb=$(mktemp -d)
+  pin_dir=$(mktemp -d)
+  build_v2_sandbox "$sb"
+
+  (
+    unset CLAUDE_CODE_SESSION_ID
+    export APEXYARD_OPS_PIN_DIR="$pin_dir"
+    cd "$sb" || exit 1
+    bash "$HOOK" >/dev/null 2>&1
+  )
+
+  # Pin dir should still be empty (no file created).
+  local count
+  count=$(find "$pin_dir" -mindepth 1 -maxdepth 1 -type f 2>/dev/null | wc -l)
+  [ "$count" -eq 0 ] \
+    || { mark_fail "$case_name" "expected no pin files in '$pin_dir', found $count"; return; }
+  mark_pass "$case_name"
+}
+
+echo "Running pin-first resolve_ops_root tests..."
+for fn in case_1 case_2 case_3 case_4 case_5 case_6 case_7 case_8; do
+  run_case "$fn"
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/pin-ops-root.sh\"'"
+          },
+          {
+            "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/onboarding-check.sh\"'"
           },
           {

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -447,7 +447,7 @@ a:hover { color: var(--accent); }
 
   <rect x="394" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
   <text x="410" y="252" font-size="14" font-weight="700" fill="#1E3A5F">[~] Hooks</text>
-  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 31 shell gates</text>
+  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 32 shell gates</text>
   <text x="410" y="295" font-size="11" fill="#4A6FA5">Merge gate · ticket-first · secrets · …</text>
 
   <rect x="704" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>

--- a/site/architecture.md.gen
+++ b/site/architecture.md.gen
@@ -21,7 +21,7 @@ Fork apexyard once and treat the fork as your ops repo. Add an entry to `apexyar
 Declares what's true and what's enforced:
 
 - **Registry** (`apexyard.projects.yaml`) — lists every managed project
-- **Hooks** (`.claude/hooks/`) — 31 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
+- **Hooks** (`.claude/hooks/`) — 32 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
 - **Rules** (`.claude/rules/`) — 11 modular self-discipline guides
 - **Onboarding** (`onboarding.yaml`) — company name, mission, team, tech stack
 

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>ApexYard — multi-project SDLC framework for Claude Code</title>
-<meta name="description" content="Multi-project ops-repo framework for Claude Code. One fork governs every project — 54 skills, 31 hooks, 19 roles, one inbox. MIT, plain markdown and shell.">
+<meta name="description" content="Multi-project ops-repo framework for Claude Code. One fork governs every project — 54 skills, 32 hooks, 19 roles, one inbox. MIT, plain markdown and shell.">
 <link rel="canonical" href="https://yard.apexscript.com/">
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
@@ -20,7 +20,7 @@
 <meta property="og:site_name" content="ApexYard">
 <meta property="og:url" content="https://yard.apexscript.com/">
 <meta property="og:title" content="ApexYard — multi-project SDLC framework for Claude Code">
-<meta property="og:description" content="Multi-project ops-repo framework for Claude Code. One fork governs every project — 54 skills, 31 hooks, 19 roles, one inbox. MIT, plain markdown and shell.">
+<meta property="og:description" content="Multi-project ops-repo framework for Claude Code. One fork governs every project — 54 skills, 32 hooks, 19 roles, one inbox. MIT, plain markdown and shell.">
 <meta property="og:image" content="https://yard.apexscript.com/og/index.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -29,7 +29,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:url" content="https://yard.apexscript.com/">
 <meta name="twitter:title" content="ApexYard — multi-project SDLC framework for Claude Code">
-<meta name="twitter:description" content="ApexYard is a multi-project ops-repo framework for Claude Code. One fork governs every project — 54 skills, 31 hooks, 19 roles, one inbox.">
+<meta name="twitter:description" content="ApexYard is a multi-project ops-repo framework for Claude Code. One fork governs every project — 54 skills, 32 hooks, 19 roles, one inbox.">
 <meta name="twitter:image" content="https://yard.apexscript.com/og/index.png">
 
 <!-- Structured data: SoftwareApplication, Organization, WebSite -->
@@ -42,7 +42,7 @@
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
   "url": "https://yard.apexscript.com/",
-  "description": "Multi-project ops-repo framework for Claude Code. One fork governs every project — 54 skills, 31 hooks, 19 roles, one inbox.",
+  "description": "Multi-project ops-repo framework for Claude Code. One fork governs every project — 54 skills, 32 hooks, 19 roles, one inbox.",
   "license": "https://opensource.org/licenses/MIT",
   "softwareVersion": "1.1.0",
   "downloadUrl": "https://github.com/me2resh/apexyard",
@@ -1447,7 +1447,7 @@ footer.foot {
     <p class="hero__sub rise rise-3" id="ai-lead">
       <strong>What is it?</strong> ApexYard is a multi-project ops-repo framework for Claude Code. One fork governs every project under management with strict merge gates, persistent AgDR memory, and 53 audit-and-decision skills.
       <strong>What can it do?</strong> Activate the right role on each ticket, run mechanical merge gates as shell hooks (not PDFs), aggregate every project's PRs, issues, and CI into one inbox, persist architectural decisions as AgDRs across the portfolio.
-      <strong>What's needed to start?</strong> Fork <code>github.com/me2resh/apexyard</code>, clone it, run <code>/setup</code>, register your projects. 19 roles, 54 skills, 31 mechanical gates, one inbox across the whole portfolio. Claude Code is the default driver; the rules, hooks, agents, and skills are plain markdown and shell — swap the AI, keep the forge.
+      <strong>What's needed to start?</strong> Fork <code>github.com/me2resh/apexyard</code>, clone it, run <code>/setup</code>, register your projects. 19 roles, 54 skills, 32 mechanical gates, one inbox across the whole portfolio. Claude Code is the default driver; the rules, hooks, agents, and skills are plain markdown and shell — swap the AI, keep the forge.
     </p>
 
     <div class="hero__cta rise rise-4">
@@ -1765,7 +1765,7 @@ confirm it skips the missing column before merge."</span></pre>
     </article>
 
     <article class="layer">
-      <div class="layer__num">hooks · 31 shell scripts</div>
+      <div class="layer__num">hooks · 32 shell scripts</div>
       <h3 class="layer__title">Rules that fire themselves</h3>
       <p class="layer__desc">
         Ticket-first on every edit. Migration gate on schema paths. Two-marker merge (Rex + CEO), SHA-bound, invalidates on every commit. Red CI block. Secrets scanner. Design-review gate on UI PRs. Upstream-drift banner at session start.

--- a/site/index.md.gen
+++ b/site/index.md.gen
@@ -1,6 +1,6 @@
 # ApexYard
 
-> Multi-project ops-repo framework for Claude Code. One fork governs every project — 54 skills, 31 hooks, 19 roles, one inbox. MIT, plain markdown and shell.
+> Multi-project ops-repo framework for Claude Code. One fork governs every project — 54 skills, 32 hooks, 19 roles, one inbox. MIT, plain markdown and shell.
 
 ## What is it?
 
@@ -9,7 +9,7 @@ ApexYard is a multi-project ops-repo framework for Claude Code. One fork governs
 ## What can it do?
 
 - Activate the right role on each ticket (19 roles across 5 departments)
-- Run mechanical merge gates as shell hooks (not PDFs) — 31 hooks block PRs that bypass code review, CEO approval, design review, secrets scanning, AgDR-required architecture changes, and migration tickets
+- Run mechanical merge gates as shell hooks (not PDFs) — 32 hooks block PRs that bypass code review, CEO approval, design review, secrets scanning, AgDR-required architecture changes, and migration tickets
 - Aggregate every project's PRs, issues, and CI into one inbox via `/inbox`, `/status`, `/tasks`
 - Persist architectural decisions as AgDRs across the portfolio so prior decisions resurface in seconds via `/agdr search`
 - Generate C4 L1 + L2 diagrams, BPMN process flows, DFDs with trust boundaries, and structured product specs
@@ -55,7 +55,7 @@ PR touches auth → Security Auditor activates. Ticket hits QA → QA Engineer. 
 
 `/handover` adopts a project. `/idea` captures a concept. `/inbox`, `/status`, `/tasks` triage the portfolio. `/decide` records a technical call as an AgDR. `/launch-check` runs a 10-dimension readiness audit. `/c4` generates L1 + L2 architecture diagrams from a codebase.
 
-### Hooks · 31 shell scripts
+### Hooks · 32 shell scripts
 
 Ticket-first on every edit. Migration gate on schema paths. Two-marker merge (Rex + CEO), SHA-bound, invalidates on every commit. Red CI block. Secrets scanner. Design-review gate on UI PRs. Upstream-drift banner at session start.
 

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -2,7 +2,7 @@
 
 > ApexYard is a multi-project ops repo framework for Claude Code that governs
 > a portfolio of repos under one fork — strict SDLC, persistent AgDR memory,
-> 54 skills, 31 hooks, 19 role definitions. MIT, plain markdown and shell,
+> 54 skills, 32 hooks, 19 role definitions. MIT, plain markdown and shell,
 > no SaaS, no lock-in.
 
 This file is the LLM/agent-friendly concatenation of the apexyard marketing
@@ -89,7 +89,7 @@ the current codebase.
 
 ### Rules that fire themselves
 
-31 shell hooks mechanically enforce the SDLC: ticket-first (Edit/Write/
+32 shell hooks mechanically enforce the SDLC: ticket-first (Edit/Write/
 Bash), migration-ticket-first, auto code review, merge gates (Rex + CEO
 + design review), red-CI block, commit format, AgDR for architecture
 changes, branch / PR-title validation, secrets scanning, upstream-drift
@@ -130,7 +130,7 @@ each owned by different parts of the framework:
    for the framework.
 2. **Capability layer** — the runnable spec: `.claude/skills/` (54
    slash commands), `.claude/agents/` (23 sub-agents incl. Rex), and
-   `.claude/hooks/` (31 mechanical enforcement scripts).
+   `.claude/hooks/` (32 mechanical enforcement scripts).
 3. **Framework defaults layer** — `.claude/project-config.defaults.json`
    ships the framework's opinions; adopters override per-repo in
    `.claude/project-config.json` (shallow merge).

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,7 +1,7 @@
 # ApexYard
 
 > ApexYard is a multi-project ops repo framework for Claude Code that governs
-> a portfolio of repos under one fork — 54 skills, 31 hooks, 19 role definitions,
+> a portfolio of repos under one fork — 54 skills, 32 hooks, 19 role definitions,
 > strict SDLC gates, persistent AgDR memory. MIT, plain markdown and shell,
 > no SaaS, no lock-in.
 
@@ -36,7 +36,7 @@
 - **54 slash commands** across audits, tickets, architecture, decisions,
   portfolio aggregation, and framework ops. Each is a markdown SKILL.md file
   under `.claude/skills/<name>/`.
-- **31 shell hooks** mechanically enforce SDLC rules — ticket-first, migration
+- **32 shell hooks** mechanically enforce SDLC rules — ticket-first, migration
   gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR-title
   validation, upstream-drift banner, leak protection.
 - **19 role definitions** across 5 departments (Engineering, Product, Design,

--- a/site/skill.md
+++ b/site/skill.md
@@ -32,7 +32,7 @@ across 6 buckets:
   `/split-portfolio`, `/fan-out`, `/start-ticket`, `/approve-merge`,
   `/approve-design`)
 
-31 shell hooks enforce SDLC rules mechanically — ticket-first, migration
+32 shell hooks enforce SDLC rules mechanically — ticket-first, migration
 gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR
 title validation, AgDR-required-for-architecture, upstream-drift banner,
 leak protection. 19 role definitions activate on triggers (label, diff


### PR DESCRIPTION
## Summary

- **Pin the ops-fork root at SessionStart** — a new SessionStart hook (`pin-ops-root.sh`) captures the launch-cwd ops root and writes it to `${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-<SESSION_ID>` so later resolution can use it. The motivating incident: the `code-reviewer` agent (Rex) clones the fork into `/tmp` for inspection, `cd`s into the clone, then walks up looking for ops-fork anchors — the throwaway clone satisfies the anchors, so the `<pr>-rex.approved` marker landed in `/tmp` and the merge gate (running from the real ops fork) couldn't find it. Hit twice in one session per the bug report; adopters were mirroring the marker locally as a workaround.
- **Refactor `_lib-ops-root.sh` to pin-first, walk-up-fallback** — `resolve_ops_root` now consults the pin (when `CLAUDE_CODE_SESSION_ID` is set and the escape hatch is off), re-validates the pinned path against the anchor conditions so stale pins self-heal, and falls back to the new `resolve_ops_root_walk` function (the pure walk-up, extracted unchanged from the previous implementation). No-regression guarantee: when the pin is absent for any reason, behaviour matches the previous lib exactly.
- **Add the agent-side prose discipline** — `.claude/agents/code-reviewer.md` now tells Rex to resolve `MARKER_HOME` ONCE at review start, before any `cd` / `git clone` / `gh pr checkout`. The walk-up code block remains as the resolution method and now also recognises the v2 `.apexyard-fork` marker (it was checking only the legacy v1 pair). This is the prose layer; the SessionStart pin is the mechanical safety net.
- **Spaced-path safe** — the pin file is written with `printf '%s\n' "$path"` and read with `IFS= read -r`, so paths containing spaces survive the round-trip intact. Regression test covers `/tmp/test space/ops fork`.
- **Escape hatches surfaced explicitly** — `APEXYARD_OPS_DISABLE_PIN=1` forces walk-up; `APEXYARD_OPS_PIN_DIR=<dir>` overrides the pin directory; unsetting `CLAUDE_CODE_SESSION_ID` skips the pin lookup. All documented in the lib header.

## Testing

- [x] New tests at `.claude/hooks/tests/test_resolve_ops_root_pin.sh` — 8/8 PASS covering pin hit, stale pin, escape hatch, walk-only function, spaced path, no session id, hook write, hook no-op
- [x] Existing `.claude/hooks/tests/test_ops_root.sh` — 8/8 PASS (no regression on the original walk-up behaviour)
- [x] All other tests touching `_lib-ops-root.sh` PASS: `test_agent_routing_sync_and_drift.sh` (8/8), `test_block_unreviewed_merge.sh` (13/13), `test_check_jq_installed.sh` (5/5), `test_link_custom_skills.sh` (7/7), `test_require_skill_for_issue_create.sh` (18/18), `test_subpack_extraction.sh` (PASS), `test_split_portfolio_v2_migration.sh` (25/25), `test_workspace_tracker_resolution.sh` (7/7)
- [x] `jq . .claude/settings.json` — valid JSON
- [x] `bash -n` syntax check passes on all three modified `.sh` files
- [ ] `shellcheck -S warning` — could not run (shellcheck not installed on the spawn machine; flagging for parent to run)

Closes #381

## Glossary

| Term | Definition |
|------|------------|
| ops fork root | The directory holding the operator's apexyard fork — identified by either the v2 `.apexyard-fork` marker or the legacy v1 pair `onboarding.yaml` + `apexyard.projects.yaml`. Framework session state lives at `<ops_fork_root>/.claude/session/`. |
| `MARKER_HOME` | The path the `code-reviewer` agent (Rex) writes its `<pr>-rex.approved` approval marker to. Must equal the ops fork root, not the project clone or a `/tmp` inspection clone, or the merge gate cannot see the marker. |
| pin file | A small text file at `${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-<SESSION_ID>` containing the ops-fork-root path captured at SessionStart. Written by `pin-ops-root.sh`; read by `resolve_ops_root` before falling back to walk-up. |
| `CLAUDE_CODE_SESSION_ID` | The per-session identifier Claude Code exports to hooks. Used here as the pin-file key so concurrent sessions on the same machine don't clobber each other's pins. |
| stale pin | A pin file whose path no longer satisfies the ops-fork anchor conditions (e.g. the dir was deleted or the marker file removed). `resolve_ops_root` detects this on re-validation and falls through to the walk-up — the pin self-heals on the next SessionStart. |
| escape hatch | An environment variable that disables the pin lookup. `APEXYARD_OPS_DISABLE_PIN=1` makes `resolve_ops_root` behave exactly like the pre-#381 walk-up-only implementation, useful for debugging or for adopters who hit an unexpected interaction. |