### PR TITLE
release(#395): v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to ApexYard are documented here.
 
+## [2.0.1] — 2026-05-24
+
+### Mobile UX hotfix for the v2.0.0 marketing site
+
+Patch-only release fixing 7 mobile UX regressions surfaced after v2.0.0 shipped. No framework changes — site-only.
+
+### Fixed
+
+- `fix(#393)` **Main-page nav restored on mobile** — `architecture`, `skills`, and `how it works` links were hidden by the `<700px` collapse rule on all 4 site pages. Added `class="always"` so they stay visible. Mobile readers can move between sections again.
+- `fix(#393)` **Eyebrow row wraps cleanly** — the "Copy as Markdown for AI" button no longer crowds the pill+subtitle row at narrow widths. Drops to its own line below the eyebrow on mobile.
+- `fix(#393)` **Duplicated lead text hidden from sighted users on `/how-it-works`** — the `#ai-lead` block (added in v2.0.0 to satisfy `/geo-audit` G12) is now visually-hidden via clip+position trick. AI crawlers and screen readers still consume it; sighted users no longer see the same prose twice.
+- `fix(#393)` **Homepage hero polish** — "Built by me2resh" moved from between tagline and subhead to below the CTAs; version line dimmed further (14px→13px, opacity 0.7→0.55); hero inline link shortened and `white-space:nowrap` so it doesn't wrap mid-phrase.
+- `fix(#393)` **Subtitles trimmed on `/architecture` and `/skills`** so they don't wrap awkwardly on mobile.
+
+### Compatibility
+
+No breaking changes. No framework code touched. Adopters see no changes to hooks, skills, rules, agents, templates, or workflows — only `site/` files were modified.
+
 ## [2.0.0] — 2026-05-24
 
 ### Six new skills, agent runtime overhaul, marketing site repositioned

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -248,6 +248,10 @@ a:hover { color: var(--accent); }
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin-bottom: 0.65rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.65rem;
 }
 .page-header__eyebrow .pill {
   border: 1px solid var(--accent);
@@ -255,7 +259,12 @@ a:hover { color: var(--accent); }
   padding: 0.2rem 0.6rem;
   font-size: 11px;
   letter-spacing: 0.06em;
-  margin-right: 0.5rem;
+}
+@media (max-width: 700px) {
+  /* On mobile, drop the copy-for-ai button to a new line below the pill + subtitle so it
+     doesn't compete with the page-header rhythm. Inline margin-left:auto already pushes it
+     right on desktop. */
+  .page-header__eyebrow .copy-for-ai { margin-left: 0; flex-basis: 100%; }
 }
 .page-header h1 {
   font-family: var(--mono);
@@ -440,10 +449,10 @@ a:hover { color: var(--accent); }
       <span class="titlebar__path">~/<a href="/"><b>apexyard</b></a> <span class="dim">· architecture</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
-      <a href="/how-it-works">how it works</a>
+      <a href="/how-it-works" class="always">how it works</a>
       <a href="/#quickstart" class="is-cta always">quickstart</a>
       <a href="/architecture" class="is-current always">architecture</a>
-      <a href="/skills">skills</a>
+      <a href="/skills" class="always">skills</a>
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>
       <a href="https://github.com/me2resh/apexyard" class="is-cta" target="_blank" rel="noopener">github →</a>
     </nav>
@@ -456,7 +465,7 @@ a:hover { color: var(--accent); }
     <div class="page-header__inner">
       <div class="page-header__eyebrow">
         <span class="pill">apexyard / architecture</span>
-        <span>one fork, five layers, optional sibling repo</span>
+        <span>5 layers, optional sibling repo</span>
         <button class="copy-for-ai" data-md-url="/architecture.md" type="button" style="margin-left:auto;font-size:0.75rem;padding:0.25rem 0.6rem;border:1px solid currentColor;border-radius:4px;background:transparent;color:inherit;cursor:pointer;font-family:inherit;">Copy as Markdown for AI</button>
       </div>
       <h1>Architecture</h1>

--- a/site/how-it-works.html
+++ b/site/how-it-works.html
@@ -236,6 +236,10 @@ a:hover { color: var(--accent); }
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin-bottom: 0.65rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.65rem;
 }
 .page-header__eyebrow .pill {
   border: 1px solid var(--accent);
@@ -243,7 +247,29 @@ a:hover { color: var(--accent); }
   padding: 0.2rem 0.6rem;
   font-size: 11px;
   letter-spacing: 0.06em;
-  margin-right: 0.5rem;
+}
+@media (max-width: 700px) {
+  /* On mobile, drop the copy-for-ai button to a new line below the pill + subtitle so it
+     doesn't compete with the page-header rhythm. Inline margin-left:auto already pushes it
+     right on desktop. */
+  .page-header__eyebrow .copy-for-ai { margin-left: 0; flex-basis: 100%; }
+}
+
+/* GEO-content block visually hidden from sighted users but kept in the DOM for AI
+   crawlers + screen readers. The block exists to satisfy /geo-audit G12 (first-500-tokens
+   structured lead — what-is / what-can / needed-to-start). On this page (how-it-works) the
+   block visibly duplicates the tagline ("a walkthrough of one realistic day"), so we drop
+   it from the human render but preserve the markup for citation grounding. Per #393 finding #4. */
+.ai-lead-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 .page-header h1 {
   font-family: var(--mono);
@@ -501,8 +527,8 @@ main { background: var(--paper); }
     <nav class="titlebar__right" aria-label="Primary">
       <a href="/how-it-works" class="is-current always">how it works</a>
       <a href="/#quickstart" class="is-cta always">quickstart</a>
-      <a href="/architecture">architecture</a>
-      <a href="/skills">skills</a>
+      <a href="/architecture" class="always">architecture</a>
+      <a href="/skills" class="always">skills</a>
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>
       <a href="https://github.com/me2resh/apexyard" class="is-cta" target="_blank" rel="noopener">github →</a>
     </nav>
@@ -522,7 +548,7 @@ main { background: var(--paper); }
       <p class="tagline">
         A walkthrough of one realistic day using ApexYard, written for someone who isn't an engineer. No terminal output, no jargon. By the end you'll know exactly what using the tool feels like.
       </p>
-      <p class="tagline" id="ai-lead">
+      <p class="tagline ai-lead-hidden" id="ai-lead" aria-hidden="false">
         <strong>What is it?</strong> ApexYard is a walkthrough of one realistic day: open your inbox, work on a change while the framework auto-reviews, approve a contractor's PR, run a launch-readiness check, ship by evening.
         <strong>What can it do?</strong> Adds review, guardrails, and process around every change you make with Claude Code — so the work that ships is the work a real engineering team would have shipped.
         <strong>What's needed to start?</strong> Fork apexyard, run <code>/setup</code>, register your projects. The page below is a narrative; see <a href="/#quickstart" class="uline">quickstart</a> for the install steps.

--- a/site/index.html
+++ b/site/index.html
@@ -322,6 +322,12 @@ a:hover { color: var(--accent); }
   letter-spacing: 0.06em;
   font-size: 11px;
 }
+@media (max-width: 700px) {
+  /* Drop the copy-for-ai button to its own line on mobile so the pill + subtitle row
+     stays as a single coherent group. Inline margin-left:auto already pushes it right
+     on desktop. */
+  .hero__eyebrow .copy-for-ai { margin-left: 0; flex-basis: 100%; }
+}
 
 .hero__title {
   font-family: var(--mono);
@@ -1536,10 +1542,10 @@ a:hover { color: var(--accent); }
       <span class="titlebar__path">~/<b>apexyard</b></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
-      <a href="/how-it-works">how it works</a>
+      <a href="/how-it-works" class="always">how it works</a>
       <a href="#quickstart" class="is-cta always">quickstart</a>
-      <a href="/architecture">architecture</a>
-      <a href="/skills">skills</a>
+      <a href="/architecture" class="always">architecture</a>
+      <a href="/skills" class="always">skills</a>
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>
       <a href="https://github.com/me2resh/apexyard" class="is-cta" target="_blank" rel="noopener">github →</a>
     </nav>
@@ -1562,8 +1568,8 @@ a:hover { color: var(--accent); }
 
     <h1 class="hero__title rise rise-2">apexyard</h1>
 
-    <p class="hero__version rise rise-2" style="margin:-0.5em 0 0.5em;font-size:14px;opacity:0.7;letter-spacing:0.05em;">
-      <a href="https://github.com/me2resh/apexyard/releases/tag/v2.0.0" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v2.0.0</a>
+    <p class="hero__version rise rise-2" style="margin:-0.5em 0 0.5em;font-size:13px;opacity:0.55;letter-spacing:0.05em;">
+      <a href="https://github.com/me2resh/apexyard/releases/tag/v2.0.1" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v2.0.1</a>
       &nbsp;·&nbsp;
       <a href="https://github.com/me2resh/apexyard/blob/main/CHANGELOG.md" style="color:inherit;text-decoration:underline;text-underline-offset:3px;" target="_blank" rel="noopener">changelog</a>
     </p>
@@ -1572,12 +1578,8 @@ a:hover { color: var(--accent); }
       Ship AI-built software like a real engineering team — without hiring one.
     </p>
 
-    <p class="hero__builtby rise rise-3">
-      Built by <a href="https://me2resh.com" target="_blank" rel="noopener">me2resh</a>
-    </p>
-
     <p class="hero__sub rise rise-3" id="ai-lead">
-      ApexYard adds the reviews, guardrails, and process behind every change you make with Claude Code. Catch the mistakes before your customers do — automatically, without checking every commit yourself. <a href="/how-it-works" class="uline">See what a day with it looks like →</a>
+      ApexYard adds the reviews, guardrails, and process behind every change you make with Claude Code. Catch the mistakes before your customers do — automatically, without checking every commit yourself. <a href="/how-it-works" class="uline" style="white-space:nowrap;">See a day with it →</a>
     </p>
 
     <div class="hero__cta rise rise-4">
@@ -1585,6 +1587,10 @@ a:hover { color: var(--accent); }
       <span class="cta__sep" aria-hidden="true">·</span>
       <a href="https://github.com/me2resh/apexyard" class="cta cta--ghost" target="_blank" rel="noopener">⑂ Fork on GitHub ↗</a>
     </div>
+
+    <p class="hero__builtby rise rise-4">
+      Built by <a href="https://me2resh.com" target="_blank" rel="noopener">me2resh</a>
+    </p>
 
   </div>
 </section>

--- a/site/skills.html
+++ b/site/skills.html
@@ -224,6 +224,10 @@ a:hover { color: var(--accent); }
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin-bottom: 0.65rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.65rem;
 }
 .page-header__eyebrow .pill {
   border: 1px solid var(--accent);
@@ -231,7 +235,12 @@ a:hover { color: var(--accent); }
   padding: 0.2rem 0.6rem;
   font-size: 11px;
   letter-spacing: 0.06em;
-  margin-right: 0.5rem;
+}
+@media (max-width: 700px) {
+  /* On mobile, drop the copy-for-ai button to a new line below the pill + subtitle so it
+     doesn't compete with the page-header rhythm. Inline margin-left:auto already pushes it
+     right on desktop. */
+  .page-header__eyebrow .copy-for-ai { margin-left: 0; flex-basis: 100%; }
 }
 .page-header h1 {
   font-family: var(--mono);
@@ -435,9 +444,9 @@ main {
       <span class="titlebar__path">~/<a href="/"><b>apexyard</b></a> <span class="dim">· skills</span></span>
     </div>
     <nav class="titlebar__right" aria-label="Primary">
-      <a href="/how-it-works">how it works</a>
+      <a href="/how-it-works" class="always">how it works</a>
       <a href="/#quickstart" class="is-cta always">quickstart</a>
-      <a href="/architecture">architecture</a>
+      <a href="/architecture" class="always">architecture</a>
       <a href="/skills" class="is-current always">skills</a>
       <a href="https://github.com/me2resh/apexyard/releases" target="_blank" rel="noopener">changelog →</a>
       <a href="https://github.com/me2resh/apexyard" class="is-cta" target="_blank" rel="noopener">github →</a>
@@ -451,7 +460,7 @@ main {
     <div class="page-header__inner">
       <div class="page-header__eyebrow">
         <span class="pill">apexyard / skills</span>
-        <span>53 active slash commands — grouped by what you're trying to do</span>
+        <span>53 active slash commands, grouped by outcome</span>
         <button class="copy-for-ai" data-md-url="/skills.md" type="button" style="margin-left:auto;font-size:0.75rem;padding:0.25rem 0.6rem;border:1px solid currentColor;border-radius:4px;background:transparent;color:inherit;cursor:pointer;font-family:inherit;">Copy as Markdown for AI</button>
       </div>
       <h1>Skills</h1>


### PR DESCRIPTION
<!-- multi-close: approved -->
<!-- agdr: not-applicable -->

## v2.0.1 — 2026-05-24

PATCH release. Mobile UX hotfix for the v2.0.0 marketing site. No framework code touched — site-only.

This PR will tag `v2.0.1` on `main` after merge.

### Fixed

- `fix(#393)` **Main-page nav restored on mobile** — `architecture`, `skills`, and `how it works` links were hidden by the `<700px` collapse rule on all 4 site pages. Added `class="always"` so they stay visible. Mobile readers can move between sections again.
- `fix(#393)` **Eyebrow row wraps cleanly** — the "Copy as Markdown for AI" button no longer crowds the pill+subtitle row at narrow widths. Drops to its own line below the eyebrow on mobile.
- `fix(#393)` **Duplicated lead text hidden from sighted users on `/how-it-works`** — the `#ai-lead` block (added in v2.0.0 to satisfy `/geo-audit` G12) is now visually-hidden via clip+position trick. AI crawlers and screen readers still consume it; sighted users no longer see the same prose twice.
- `fix(#393)` **Homepage hero polish** — "Built by me2resh" moved from between tagline and subhead to below the CTAs; version line dimmed further (14px→13px, opacity 0.7→0.55, also bumped to v2.0.1); hero inline link shortened to "See a day with it →" + `white-space:nowrap` so it doesn't wrap mid-phrase.
- `fix(#393)` **Subtitles trimmed on `/architecture` and `/skills`** so they don't wrap awkwardly on mobile.

### Compatibility

No breaking changes. No framework code touched. Adopters see no changes to hooks, skills, rules, agents, templates, or workflows — only `site/` files were modified.

### Release strategy

Branched `release/v2.0.1` from `upstream/main` (NOT from dev) to sidestep the v1.4→v2.0 squash divergence carried on dev. Cherry-picked the squashed #394 fix (`0b51465`) onto the release branch and bumped the site version link to `v2.0.1` while resolving the (trivial) conflict on the version pill.

The main→dev sync is a known follow-up — same shape as the v2.0.0 release; will be folded into the next release cut or done as a standalone sync PR.

## AgDR note

`<!-- agdr: not-applicable -->` marker present at the top: release PRs are pure version-cuts with no architectural decisions (the underlying #393 fix was already shipped as a cosmetic CSS+HTML hotfix to dev with the same skip marker on PR #394).

## Testing

- [x] Cherry-pick clean against main baseline (one trivial conflict in the version pill, resolved to keep #394's polish + bump to v2.0.1)
- [x] CHANGELOG appended above `[2.0.0]` with parallel structure
- [x] `git log upstream/main..HEAD` shows exactly 2 commits (cherry-picked fix + CHANGELOG)
- [x] Site version link updated `v2.0.0` → `v2.0.1` (will resolve to a real tag after merge)
- [ ] Netlify deploy preview surfaces from the PR — visual mobile check of all 4 pages at <700px
- [ ] After merge: `v2.0.1` tag pushed to `upstream/main`
- [ ] After merge: GitHub Release created with CHANGELOG section
- [ ] After merge: drift banner on adopters' forks fires on next session

## Glossary

| Term | Definition |
|------|------------|
| PATCH bump | Semver third-position increment (X.Y.**Z**+1). Applied when only `fix:` commits are included since the last tag — no new features, no breaking changes. |
| Release-cut branch model | apexyard's framework-only flow: daily PRs land on `dev`; `main` only receives release PRs from `dev` (tagged with semver). Adopted in AgDR-0007. |
| dev/main squash divergence | When a release PR is squash-merged to main, the resulting commit has a different SHA than the equivalent dev history. dev still carries the unsquashed commits unless a sync-back PR is filed. v1.2.0, v1.3.0, and v2.0.0 all created this gap. |
| Cherry-pick | `git cherry-pick <sha>` — replay a single commit's diff onto the current branch. Used here so the v2.0.1 release contains exactly the #394 fix and nothing else. |
| `<!-- multi-close: approved -->` | Bypass marker for the single-`Closes`-per-PR hook. Release PRs legitimately close many tickets at once and are the canonical use case for the marker. |
| `<!-- agdr: not-applicable -->` | Bypass marker for the require-AgDR-for-arch-PR hook. Used when a PR has no architectural decisions to record (pure release-cuts, cosmetic fixes). |

Closes #395
Closes #393
