### PR TITLE
fix(#399): site/ — GA4 + consent banner on all 4 pages

### DIFF
--- a/site/architecture.html
+++ b/site/architecture.html
@@ -19,8 +19,8 @@
 <link rel="alternate" type="text/markdown" href="/architecture.md">
 
 <!-- LLM consumers: payload size hints (token estimate = chars / 4). #333 item C. -->
-<meta name="llm:token-count" content="8864">
-<meta name="llm:doc-length" content="35458 chars">
+<meta name="llm:token-count" content="10201">
+<meta name="llm:doc-length" content="40807 chars">
 
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="ApexYard">

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -432,7 +432,80 @@ a:hover { color: var(--accent); }
 }
 .page-footer a { color: var(--ink-soft); border-bottom: 1px dotted currentColor; padding-bottom: 1px; }
 .page-footer a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* begin: consent-css — keep in sync across all site/*.html pages (#399) */
+.consent {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--paper);
+  border-top: 1px solid var(--ink);
+  z-index: 100;
+  font-size: 12px;
+  padding: 1rem var(--gutter);
+}
+.consent[hidden] { display: none; }
+.consent__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.consent__msg {
+  flex: 1;
+  min-width: 260px;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+.consent__msg a { color: var(--accent); }
+.consent__actions { display: flex; gap: 0.5rem; }
+.consent__btn {
+  font: inherit;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.consent__btn:hover { border-color: var(--ink); }
+.consent__btn--accept {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.consent__btn--accept:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+/* end: consent-css */
 </style>
+<!-- begin: gtag — keep in sync across all site/*.html pages (#399) -->
+<!-- Google tag (gtag.js) with Consent Mode v2 - analytics_storage defaults to denied
+     until the consent banner below records an explicit choice. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G3EMR3CB02"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    'ad_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'analytics_storage': 'denied'
+  });
+  try {
+    if (localStorage.getItem('ay-consent') === 'granted') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+  } catch (e) {}
+  gtag('js', new Date());
+  gtag('config', 'G-G3EMR3CB02');
+</script>
+<!-- end: gtag -->
 </head>
 <body>
 
@@ -778,6 +851,59 @@ a:hover { color: var(--accent); }
     <div class="page-footer__meta">© 2026 <a href="https://me2resh.com" target="_blank" rel="noopener">me2resh</a> · ApexYard · open source · plain markdown · zero dependencies</div>
   </div>
 </footer>
+
+<!-- begin: consent — keep in sync across all site/*.html pages (#399) -->
+<!-- ============================================================
+     COOKIE CONSENT BANNER
+     Hidden if a prior choice is stored. On Accept, updates gtag
+     Consent Mode to grant analytics_storage.
+     ============================================================ -->
+<div id="consent" class="consent" role="region" aria-label="Cookie consent" hidden>
+  <div class="consent__inner">
+    <p class="consent__msg">
+      This site uses Google Analytics to count visits. No ads, no cross-site tracking.
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy</a>.
+    </p>
+    <div class="consent__actions">
+      <button type="button" class="consent__btn" data-consent="denied">Decline</button>
+      <button type="button" class="consent__btn consent__btn--accept" data-consent="granted">Accept</button>
+    </div>
+  </div>
+</div>
+<script>
+(function () {
+  var KEY = 'ay-consent';
+  var el = document.getElementById('consent');
+  if (!el) return;
+  var stored = null;
+  try { stored = localStorage.getItem(KEY); } catch (e) {}
+  if (stored !== 'granted' && stored !== 'denied') {
+    el.hidden = false;
+  }
+  function record(choice) {
+    if (el.hidden) return;
+    try { localStorage.setItem(KEY, choice); } catch (e) {}
+    if (choice === 'granted' && typeof gtag === 'function') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+    el.hidden = true;
+  }
+  el.addEventListener('click', function (e) {
+    var btn = e.target.closest('[data-consent]');
+    if (!btn) return;
+    record(btn.getAttribute('data-consent'));
+  });
+  // Escape dismisses the banner as "denied" - keyboard users without
+  // a mouse shouldn't be stuck with a fixed-bottom banner they can't
+  // dismiss. "Denied" is the non-consenting default per Consent Mode v2.
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !el.hidden) {
+      record('denied');
+    }
+  });
+})();
+</script>
+<!-- end: consent -->
 
 <script src="/copy-for-ai.js" defer></script>
 </body>

--- a/site/how-it-works.html
+++ b/site/how-it-works.html
@@ -18,8 +18,8 @@
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
 <!-- LLM consumers: payload size hints (token estimate = chars / 4). -->
-<meta name="llm:token-count" content="6572">
-<meta name="llm:doc-length" content="26291 chars">
+<meta name="llm:token-count" content="8065">
+<meta name="llm:doc-length" content="32263 chars">
 
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="ApexYard">

--- a/site/how-it-works.html
+++ b/site/how-it-works.html
@@ -508,7 +508,80 @@ main { background: var(--paper); }
 }
 .page-footer a { color: var(--ink-soft); border-bottom: 1px dotted currentColor; padding-bottom: 1px; }
 .page-footer a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* begin: consent-css — keep in sync across all site/*.html pages (#399) */
+.consent {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--paper);
+  border-top: 1px solid var(--ink);
+  z-index: 100;
+  font-size: 12px;
+  padding: 1rem var(--gutter);
+}
+.consent[hidden] { display: none; }
+.consent__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.consent__msg {
+  flex: 1;
+  min-width: 260px;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+.consent__msg a { color: var(--accent); }
+.consent__actions { display: flex; gap: 0.5rem; }
+.consent__btn {
+  font: inherit;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.consent__btn:hover { border-color: var(--ink); }
+.consent__btn--accept {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.consent__btn--accept:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+/* end: consent-css */
 </style>
+<!-- begin: gtag — keep in sync across all site/*.html pages (#399) -->
+<!-- Google tag (gtag.js) with Consent Mode v2 - analytics_storage defaults to denied
+     until the consent banner below records an explicit choice. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G3EMR3CB02"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    'ad_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'analytics_storage': 'denied'
+  });
+  try {
+    if (localStorage.getItem('ay-consent') === 'granted') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+  } catch (e) {}
+  gtag('js', new Date());
+  gtag('config', 'G-G3EMR3CB02');
+</script>
+<!-- end: gtag -->
 </head>
 <body>
 
@@ -745,6 +818,59 @@ main { background: var(--paper); }
     <div class="page-footer__meta">© 2026 <a href="https://me2resh.com" target="_blank" rel="noopener">me2resh</a> · ApexYard · open source · plain markdown · zero dependencies</div>
   </div>
 </footer>
+
+<!-- begin: consent — keep in sync across all site/*.html pages (#399) -->
+<!-- ============================================================
+     COOKIE CONSENT BANNER
+     Hidden if a prior choice is stored. On Accept, updates gtag
+     Consent Mode to grant analytics_storage.
+     ============================================================ -->
+<div id="consent" class="consent" role="region" aria-label="Cookie consent" hidden>
+  <div class="consent__inner">
+    <p class="consent__msg">
+      This site uses Google Analytics to count visits. No ads, no cross-site tracking.
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy</a>.
+    </p>
+    <div class="consent__actions">
+      <button type="button" class="consent__btn" data-consent="denied">Decline</button>
+      <button type="button" class="consent__btn consent__btn--accept" data-consent="granted">Accept</button>
+    </div>
+  </div>
+</div>
+<script>
+(function () {
+  var KEY = 'ay-consent';
+  var el = document.getElementById('consent');
+  if (!el) return;
+  var stored = null;
+  try { stored = localStorage.getItem(KEY); } catch (e) {}
+  if (stored !== 'granted' && stored !== 'denied') {
+    el.hidden = false;
+  }
+  function record(choice) {
+    if (el.hidden) return;
+    try { localStorage.setItem(KEY, choice); } catch (e) {}
+    if (choice === 'granted' && typeof gtag === 'function') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+    el.hidden = true;
+  }
+  el.addEventListener('click', function (e) {
+    var btn = e.target.closest('[data-consent]');
+    if (!btn) return;
+    record(btn.getAttribute('data-consent'));
+  });
+  // Escape dismisses the banner as "denied" - keyboard users without
+  // a mouse shouldn't be stuck with a fixed-bottom banner they can't
+  // dismiss. "Denied" is the non-consenting default per Consent Mode v2.
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !el.hidden) {
+      record('denied');
+    }
+  });
+})();
+</script>
+<!-- end: consent -->
 
 <script src="/copy-for-ai.js" defer></script>
 </body>

--- a/site/index.html
+++ b/site/index.html
@@ -1454,6 +1454,7 @@ a:hover { color: var(--accent); }
    Gates Google Analytics (Consent Mode v2) for GDPR/ePrivacy.
    ============================================================ */
 
+/* begin: consent-css — keep in sync across all site/*.html pages (#399) */
 .consent {
   position: fixed;
   bottom: 0;
@@ -1502,8 +1503,10 @@ a:hover { color: var(--accent); }
   background: var(--accent);
   border-color: var(--accent);
 }
+/* end: consent-css */
 </style>
 
+<!-- begin: gtag — keep in sync across all site/*.html pages (#399) -->
 <!-- Google tag (gtag.js) with Consent Mode v2 - analytics_storage defaults to denied
      until the consent banner below records an explicit choice. -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-G3EMR3CB02"></script>
@@ -1522,8 +1525,9 @@ a:hover { color: var(--accent); }
     }
   } catch (e) {}
   gtag('js', new Date());
-  gtag('config', 'G-G3EMR3CB02', { 'anonymize_ip': true });
+  gtag('config', 'G-G3EMR3CB02');
 </script>
+<!-- end: gtag -->
 </head>
 <body>
 <a href="#main" class="skip">Skip to content</a>
@@ -2511,6 +2515,7 @@ confirm it skips the missing column before you ship."</span></pre>
 })();
 </script>
 
+<!-- begin: consent — keep in sync across all site/*.html pages (#399) -->
 <!-- ============================================================
      COOKIE CONSENT BANNER
      Hidden if a prior choice is stored. On Accept, updates gtag
@@ -2561,6 +2566,7 @@ confirm it skips the missing column before you ship."</span></pre>
   });
 })();
 </script>
+<!-- end: consent -->
 
 <script src="/copy-for-ai.js" defer></script>
 </body>

--- a/site/index.html
+++ b/site/index.html
@@ -19,8 +19,8 @@
 <link rel="alternate" type="text/markdown" href="/index.md">
 
 <!-- LLM consumers: payload size hints (token estimate = chars / 4). #333 item C. -->
-<meta name="llm:token-count" content="23189">
-<meta name="llm:doc-length" content="92757 chars">
+<meta name="llm:token-count" content="23697">
+<meta name="llm:doc-length" content="94791 chars">
 
 <!-- Open Graph -->
 <meta property="og:type" content="website">

--- a/site/skills.html
+++ b/site/skills.html
@@ -427,7 +427,80 @@ main {
 }
 .page-footer a { color: var(--ink-soft); border-bottom: 1px dotted currentColor; padding-bottom: 1px; }
 .page-footer a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* begin: consent-css — keep in sync across all site/*.html pages (#399) */
+.consent {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--paper);
+  border-top: 1px solid var(--ink);
+  z-index: 100;
+  font-size: 12px;
+  padding: 1rem var(--gutter);
+}
+.consent[hidden] { display: none; }
+.consent__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.consent__msg {
+  flex: 1;
+  min-width: 260px;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+.consent__msg a { color: var(--accent); }
+.consent__actions { display: flex; gap: 0.5rem; }
+.consent__btn {
+  font: inherit;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.consent__btn:hover { border-color: var(--ink); }
+.consent__btn--accept {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.consent__btn--accept:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+/* end: consent-css */
 </style>
+<!-- begin: gtag — keep in sync across all site/*.html pages (#399) -->
+<!-- Google tag (gtag.js) with Consent Mode v2 - analytics_storage defaults to denied
+     until the consent banner below records an explicit choice. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G3EMR3CB02"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    'ad_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'analytics_storage': 'denied'
+  });
+  try {
+    if (localStorage.getItem('ay-consent') === 'granted') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+  } catch (e) {}
+  gtag('js', new Date());
+  gtag('config', 'G-G3EMR3CB02');
+</script>
+<!-- end: gtag -->
 </head>
 <body>
 
@@ -953,6 +1026,59 @@ main {
     <div class="page-footer__meta">© 2026 <a href="https://me2resh.com" target="_blank" rel="noopener">me2resh</a> · ApexYard · open source · plain markdown · zero dependencies</div>
   </div>
 </footer>
+
+<!-- begin: consent — keep in sync across all site/*.html pages (#399) -->
+<!-- ============================================================
+     COOKIE CONSENT BANNER
+     Hidden if a prior choice is stored. On Accept, updates gtag
+     Consent Mode to grant analytics_storage.
+     ============================================================ -->
+<div id="consent" class="consent" role="region" aria-label="Cookie consent" hidden>
+  <div class="consent__inner">
+    <p class="consent__msg">
+      This site uses Google Analytics to count visits. No ads, no cross-site tracking.
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy</a>.
+    </p>
+    <div class="consent__actions">
+      <button type="button" class="consent__btn" data-consent="denied">Decline</button>
+      <button type="button" class="consent__btn consent__btn--accept" data-consent="granted">Accept</button>
+    </div>
+  </div>
+</div>
+<script>
+(function () {
+  var KEY = 'ay-consent';
+  var el = document.getElementById('consent');
+  if (!el) return;
+  var stored = null;
+  try { stored = localStorage.getItem(KEY); } catch (e) {}
+  if (stored !== 'granted' && stored !== 'denied') {
+    el.hidden = false;
+  }
+  function record(choice) {
+    if (el.hidden) return;
+    try { localStorage.setItem(KEY, choice); } catch (e) {}
+    if (choice === 'granted' && typeof gtag === 'function') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+    el.hidden = true;
+  }
+  el.addEventListener('click', function (e) {
+    var btn = e.target.closest('[data-consent]');
+    if (!btn) return;
+    record(btn.getAttribute('data-consent'));
+  });
+  // Escape dismisses the banner as "denied" - keyboard users without
+  // a mouse shouldn't be stuck with a fixed-bottom banner they can't
+  // dismiss. "Denied" is the non-consenting default per Consent Mode v2.
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !el.hidden) {
+      record('denied');
+    }
+  });
+})();
+</script>
+<!-- end: consent -->
 
 <script src="/copy-for-ai.js" defer></script>
 </body>

--- a/site/skills.html
+++ b/site/skills.html
@@ -19,8 +19,8 @@
 <link rel="alternate" type="text/markdown" href="/skills.md">
 
 <!-- LLM consumers: payload size hints (token estimate = chars / 4). #333 item C. -->
-<meta name="llm:token-count" content="10658">
-<meta name="llm:doc-length" content="42632 chars">
+<meta name="llm:token-count" content="11920">
+<meta name="llm:doc-length" content="47681 chars">
 
 <meta property="og:title" content="ApexYard Skills — 53 active slash commands for Claude Code">
 <meta property="og:description" content="53 active slash commands available in any apexyard-managed project. Run any of these in a Claude Code session inside your fork.">


### PR DESCRIPTION
<!-- private-refs: allow -->
<!-- ^ allow: `apexscript` token in `yard.apexscript.com` is the framework's
     own marketing domain, not a private managed-project name. -->
<!-- agdr: not-applicable -->

## Summary

- **GA4 now fires on all 4 site pages** — `gtag.js` + Consent Mode v2 default block copied verbatim from `index.html` into `how-it-works.html`, `architecture.html`, and `skills.html`. Pre-fix, only `/` was tracked; any visit landing directly on the 3 other pages (Twitter/LinkedIn shares from the v2.0 launch, search results, LLM citations from `llms.txt` which explicitly lists all 4) was invisible to GA4 and — worse — got no consent UI at all (a GDPR gap, not just a measurement gap).
- **Cookie consent banner now present on all 4 pages** with the same Accept/Decline/Escape flow and `localStorage.ay-consent` persistence. A user who lands on `/how-it-works` first now gets the consent choice on that page, and the choice is honoured site-wide on subsequent navigation (same localStorage key).
- **Markers added for future sync** — every copy/paste'd block is wrapped in `<!-- begin: gtag -->` / `<!-- end: gtag -->`, `<!-- begin: consent -->` / `<!-- end: consent -->`, and `/* begin: consent-css */` / `/* end: consent-css */`. Static-HTML site has no build step, so a shared partial doesn't exist; the markers make it greppable when the GA4 ID, Consent Mode config, or banner copy needs to change in one place.
- **Dead-config cleanup** — removed `'anonymize_ip': true` from `gtag('config', ...)`. This was a Universal Analytics flag that truncated the last octet of the IP; in GA4 all IPs are auto-anonymized by default and the parameter is a no-op. Removing it kills dead config without changing behaviour.

## Testing

- [x] Coverage check shows parity across all 4 pages:
  ```
  site/index.html:        gtag-refs=6  google-refs=1  consent-banner=1  consent-css=1  begin-markers=3
  site/how-it-works.html: gtag-refs=6  google-refs=1  consent-banner=1  consent-css=1  begin-markers=3
  site/architecture.html: gtag-refs=6  google-refs=1  consent-banner=1  consent-css=1  begin-markers=3
  site/skills.html:       gtag-refs=6  google-refs=1  consent-banner=1  consent-css=1  begin-markers=3
  ```
- [x] `grep anonymize_ip site/*.html` returns 0 hits across the board (dead config removed)
- [x] No framework code changed — `git diff --name-only origin/main..HEAD` returns exactly 4 site files; no scope leak into hooks / skills / rules / agents
- [x] CSP allowlist already covers GA4 endpoints (`script-src 'self' 'unsafe-inline' https://www.googletagmanager.com` + `img-src ... https://www.google-analytics.com` + `connect-src ... https://analytics.google.com`); no CSP changes needed
- [ ] Post-merge Netlify deploy preview will surface from this PR — visual check on each of the 4 pages that consent banner renders correctly and Accept flow grants `analytics_storage`
- [ ] Post-deploy: GA4 Realtime should show traffic on `/how-it-works`, `/architecture`, `/skills` (currently flat-zero on those paths)

## AgDR note

`<!-- agdr: not-applicable -->` marker present at the top: this PR is a pure HTML/CSS/JS copy-paste with no architectural decisions, no library choices, no new dependencies. The framework's existing Consent Mode v2 implementation is being applied to additional pages, not changed.

## Leak-protection skip note

`<!-- private-refs: allow -->` marker present at the top: the body legitimately references `yard.apexscript.com`, the framework's own public marketing domain. The leak-protection hook trips on the `apexscript` token because of name-collision with a registered project (a recurring false-positive — same exception as the v2.0.0 launch PRs).

## Out of scope (deliberately deferred)

- **Apexyard-owned privacy policy page.** The consent banner currently links to `policies.google.com/privacy` (Google's policy). For full GDPR compliance the site should host its own privacy policy explaining what data the framework's marketing site collects, who it shares with, and how to request deletion. Separate ticket — out of scope for an analytics-coverage fix.
- **Self-hosted analytics (Plausible, Umami, etc.).** GA4 is what's wired; swapping is a separate strategic call.
- **Auto-sync linter** that fails CI when the marker-bounded blocks drift across pages. Worth considering once we have a second class of cross-page block; YAGNI for one block right now.

## Glossary

| Term | Definition |
|------|------------|
| GA4 | Google Analytics 4 — Google's current analytics product. Identified by measurement ID `G-G3EMR3CB02` for this site. |
| Consent Mode v2 | Google's framework for declaring user-consent state (`denied` / `granted`) before any tracking fires. Required for sites serving EU traffic post-DMA. |
| `analytics_storage` | The Consent Mode v2 axis controlling whether GA4 may set cookies and send events. Default `denied`; flipped to `granted` after the user clicks Accept. |
| `anonymize_ip: true` | A Universal Analytics flag that truncated the last octet of the visitor's IP. **No-op in GA4** (all IPs are auto-anonymized by default). Removed in this PR to kill dead config. |
| `localStorage.ay-consent` | Per-domain persistence of the user's consent choice (`granted` / `denied`). One key for the whole site, so a choice made on one page is honoured on all subsequent navigation. |
| begin/end markers | HTML comment / CSS comment pairs (`<!-- begin: gtag --> ... <!-- end: gtag -->` etc.) wrapping each cross-page block. Greppable anchors for future sync edits — no build step to do it automatically. |
| Cherry-pick release path | Branch off `upstream/main` (NOT dev), commit the fix, PR to main. Avoids the v1.4→v2.0 squash divergence on dev. Same pattern as the v2.0.1 mobile UX fix (PR #396). |

Closes #399
