### PR TITLE
fix(#404): remove stale --pdf-output-folder flag from md-to-pdf dispatch

### DIFF
--- a/.claude/skills/pdf/convert.sh
+++ b/.claude/skills/pdf/convert.sh
@@ -250,21 +250,24 @@ case "$chosen" in
 
   md-to-pdf)
     # Markdown → PDF via the md-to-pdf npm package (chromium-backed).
-    # --as-html-only off → emit the PDF directly.
-    # Use a tmp output then move so md-to-pdf doesn't fight us on cwd.
-    tmp_out="$WORK/out.pdf"
-    if npx -y md-to-pdf --pdf-output-folder "$WORK" --dest-name out.pdf "$FROM_ABS" >&2; then
+    #
+    # md-to-pdf removed --pdf-output-folder and --dest-name in a breaking
+    # change (see me2resh/apexyard#404).  The current CLI writes
+    # <source-basename>.pdf in the same directory as the source file.
+    #
+    # Strategy: copy the source into a private temp dir under the desired
+    # output stem, invoke md-to-pdf there, then mv the result to TO_ABS.
+    # This avoids any cwd or output-name fighting.
+    out_stem="$(basename "${TO_ABS%.*}")"
+    tmp_src="$WORK/${out_stem}.md"
+    tmp_out="$WORK/${out_stem}.pdf"
+    cp "$FROM_ABS" "$tmp_src"
+    if npx -y md-to-pdf "$tmp_src" >&2; then
       if [ -f "$tmp_out" ]; then
         mv "$tmp_out" "$TO_ABS"
         exit 0
       fi
-      # Some versions of md-to-pdf output as <basename>.pdf in the folder.
-      basename_pdf="$WORK/$(basename "${FROM_ABS%.*}").pdf"
-      if [ -f "$basename_pdf" ]; then
-        mv "$basename_pdf" "$TO_ABS"
-        exit 0
-      fi
-      echo "convert.sh: md-to-pdf ran but no PDF appeared in $WORK" >&2
+      echo "convert.sh: md-to-pdf ran but no PDF appeared at $tmp_out" >&2
       exit 1
     fi
     echo "convert.sh: md-to-pdf conversion failed for $FROM_ABS" >&2
@@ -292,20 +295,21 @@ case "$chosen" in
     ;;
 
   md-to-pdf-html)
-    # md-to-pdf accepts HTML when --as-pdf and a chromium backend are
-    # configured. We use it as a last-resort HTML→PDF path.
-    tmp_out="$WORK/out.pdf"
-    if npx -y md-to-pdf --pdf-output-folder "$WORK" --dest-name out.pdf "$FROM_ABS" >&2; then
+    # md-to-pdf accepts HTML as a last-resort HTML→PDF path.
+    #
+    # Same staging strategy as the md-to-pdf (markdown) branch — copy
+    # source into temp dir under desired output stem, let md-to-pdf write
+    # <stem>.pdf next to it, then mv to TO_ABS.
+    out_stem="$(basename "${TO_ABS%.*}")"
+    tmp_src="$WORK/${out_stem}.html"
+    tmp_out="$WORK/${out_stem}.pdf"
+    cp "$FROM_ABS" "$tmp_src"
+    if npx -y md-to-pdf "$tmp_src" >&2; then
       if [ -f "$tmp_out" ]; then
         mv "$tmp_out" "$TO_ABS"
         exit 0
       fi
-      basename_pdf="$WORK/$(basename "${FROM_ABS%.*}").pdf"
-      if [ -f "$basename_pdf" ]; then
-        mv "$basename_pdf" "$TO_ABS"
-        exit 0
-      fi
-      echo "convert.sh: md-to-pdf produced no PDF for HTML input" >&2
+      echo "convert.sh: md-to-pdf produced no PDF at $tmp_out for HTML input" >&2
       exit 1
     fi
     echo "convert.sh: md-to-pdf HTML→PDF conversion failed for $FROM_ABS" >&2

--- a/.claude/skills/pdf/tests/test_md_to_pdf_fallback.sh
+++ b/.claude/skills/pdf/tests/test_md_to_pdf_fallback.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Regression test for me2resh/apexyard#404
+#
+# Before the fix, convert.sh passed --pdf-output-folder and --dest-name to
+# md-to-pdf.  Those flags were removed in a breaking change; md-to-pdf now
+# exits with:
+#
+#   ArgError: unknown or unexpected option: --pdf-output-folder
+#
+# This test verifies that:
+#   a) --converter=md-to-pdf succeeds when npx + md-to-pdf are available
+#   b) The PDF lands at the requested --to path with non-zero size
+#   c) --pdf-output-folder is NOT passed (old stale flag is gone)
+#
+# The test is skipped — not failed — when npx is absent, so it never blocks CI
+# on a pandoc-only host.  In a local dev environment with Node installed, run:
+#
+#   bash .claude/skills/pdf/tests/test_md_to_pdf_fallback.sh
+#
+# md-to-pdf version pinning:
+#   This test intentionally does NOT pin a specific md-to-pdf version via
+#   --save-exact because the skill calls `npx -y md-to-pdf` which resolves
+#   npm `latest` at invocation time.  If a future md-to-pdf major version
+#   changes the output-path contract again, this test is the first line of
+#   defence — it will catch the regression before it reaches adopters.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+CONVERT="$SKILL_DIR/convert.sh"
+
+PASS=0
+FAIL=0
+SKIPPED=0
+
+ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  SKIP: $1"; SKIPPED=$((SKIPPED + 1)); }
+
+# ---------------------------------------------------------------------------
+# Gate: skip entire file when npx is absent
+# ---------------------------------------------------------------------------
+if ! command -v npx >/dev/null 2>&1; then
+  echo "SKIP: npx not found — install Node to run the md-to-pdf fallback test."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+FIXTURE=$(mktemp -d -t pdf-md-fallback-XXXXXX)
+trap 'rm -rf "$FIXTURE"' EXIT
+
+cat > "$FIXTURE/sample.md" <<'MD'
+# md-to-pdf regression test
+
+This file is used by the `/pdf` regression test for issue #404.
+
+## Purpose
+
+Verifies that `convert.sh --converter=md-to-pdf` no longer passes the
+removed `--pdf-output-folder` flag to md-to-pdf.
+
+| Column A | Column B |
+|----------|----------|
+| foo      | bar      |
+MD
+
+OUT="$FIXTURE/out.pdf"
+
+# ---------------------------------------------------------------------------
+# Test A: --converter=md-to-pdf succeeds and produces a non-empty PDF
+# ---------------------------------------------------------------------------
+echo ""
+echo "A) md-to-pdf fallback path — produces a non-empty PDF at the requested path"
+
+set +e
+stderr_out=$("$CONVERT" --from="$FIXTURE/sample.md" --to="$OUT" --converter=md-to-pdf 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -eq 3 ]; then
+  skip "md-to-pdf not available via npx (npx present but md-to-pdf download failed or network unavailable)"
+elif [ "$rc" -ne 0 ]; then
+  bad "conversion failed with exit $rc — stderr: $stderr_out"
+else
+  if [ -s "$OUT" ]; then
+    ok "PDF written at $OUT with non-zero size ($(wc -c < "$OUT") bytes)"
+  else
+    bad "convert.sh exited 0 but PDF is missing or empty at $OUT"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test B: --pdf-output-folder is NOT mentioned in stderr (old stale flag gone)
+# ---------------------------------------------------------------------------
+echo ""
+echo "B) stale --pdf-output-folder flag is not passed (old bug is gone)"
+
+set +e
+stderr_flag_check=$("$CONVERT" --from="$FIXTURE/sample.md" --to="$FIXTURE/flag-check.pdf" --converter=md-to-pdf 2>&1)
+rc_flag=$?
+set -e
+
+if echo "$stderr_flag_check" | grep -q "pdf-output-folder"; then
+  bad "stderr still mentions --pdf-output-folder — the old stale flag is still being passed"
+elif [ "$rc_flag" -eq 3 ]; then
+  skip "md-to-pdf not downloadable — cannot verify flag absence, but exit 3 is not the ArgError exit"
+else
+  ok "--pdf-output-folder not found in stderr (stale flag is gone)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test C: --dest-name is NOT mentioned in stderr (other stale flag gone)
+# ---------------------------------------------------------------------------
+echo ""
+echo "C) stale --dest-name flag is not passed"
+
+if echo "$stderr_flag_check" | grep -q "dest-name"; then
+  bad "stderr still mentions --dest-name — the old stale flag is still being passed"
+elif [ "$rc_flag" -eq 3 ]; then
+  skip "md-to-pdf not downloadable — cannot verify flag absence"
+else
+  ok "--dest-name not found in stderr (stale flag is gone)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test D: output file lands at exactly the requested --to path
+# ---------------------------------------------------------------------------
+echo ""
+echo "D) PDF lands at exactly the requested --to path (not in a temp dir or next to source)"
+
+custom_out="$FIXTURE/subdir/custom-name.pdf"
+mkdir -p "$(dirname "$custom_out")"
+
+set +e
+"$CONVERT" --from="$FIXTURE/sample.md" --to="$custom_out" --converter=md-to-pdf >/dev/null 2>&1
+rc_custom=$?
+set -e
+
+if [ "$rc_custom" -eq 3 ]; then
+  skip "md-to-pdf not downloadable — cannot verify destination"
+elif [ "$rc_custom" -ne 0 ]; then
+  bad "custom destination: convert.sh exited $rc_custom"
+else
+  if [ -s "$custom_out" ]; then
+    ok "PDF landed at requested custom path $custom_out"
+  else
+    bad "convert.sh exited 0 but PDF missing at $custom_out"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "--------------------------------------------------------------"
+echo "Total: $((PASS + FAIL + SKIPPED))   Passed: $PASS   Failed: $FAIL   Skipped: $SKIPPED"
+echo "--------------------------------------------------------------"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "FAIL: md-to-pdf fallback regression test had $FAIL failure(s)."
+  exit 1
+fi
+
+echo "OK: md-to-pdf fallback regression test passed."
+exit 0


### PR DESCRIPTION
## Summary

- **Removed stale `--pdf-output-folder` and `--dest-name` flags from `convert.sh`** — md-to-pdf removed both flags in a breaking API change; every invocation of the md-to-pdf fallback path was aborting with `ArgError: unknown or unexpected option: --pdf-output-folder`, meaning `/pdf` was entirely broken for the majority of adopters who don't have pandoc installed (common on macOS where pandoc pulls in LaTeX dependencies)
- **New dispatch strategy: stage-in-temp-dir** — source is copied into a private `$WORK` dir under the desired output stem, `npx -y md-to-pdf <tmp>.md` is invoked there (md-to-pdf writes `<stem>.pdf` next to the source by default), then the result is `mv`'d to the requested `TO_ABS`; this is compatible with the current md-to-pdf API and avoids any cwd or output-name collisions
- **Same fix applied to `md-to-pdf-html` branch** — the HTML → PDF fallback path had identical stale flags and is fixed with the same staging pattern
- **Regression test added** at `.claude/skills/pdf/tests/test_md_to_pdf_fallback.sh` — covers 4 cases: successful conversion, absence of `--pdf-output-folder`, absence of `--dest-name`, and custom output path landing at exactly the requested `--to` path; all 4 pass locally against npm `latest`

## Testing

```bash
# Run the new regression test
bash .claude/skills/pdf/tests/test_md_to_pdf_fallback.sh

# Run the existing smoke test (should still pass)
bash .claude/skills/pdf/tests/smoke.sh

# Manual end-to-end repro from the issue (requires Node, no pandoc needed)
echo '# Test' > /tmp/test.md
.claude/skills/pdf/convert.sh --from=/tmp/test.md --to=/tmp/test.pdf --converter=md-to-pdf
# Expected: exit 0, /tmp/test.pdf written with non-zero size
```

Closes #404

---

## Glossary

| Term | Definition |
|------|------------|
| `md-to-pdf` | npm package that converts markdown/HTML to PDF using headless Chromium (Puppeteer). Used by `/pdf` as the no-pandoc fallback. |
| `--pdf-output-folder` | Flag removed from md-to-pdf in a breaking API change; `convert.sh` was still passing it, causing an `ArgError` on every invocation of the fallback path. |
| `--dest-name` | Companion stale flag — also removed from md-to-pdf; used alongside `--pdf-output-folder` to name the output file. Removed in the same fix. |
| `stage-in-temp-dir strategy` | The replacement approach: copy source into `$WORK/<desired-stem>.md`, run `npx md-to-pdf` there, then `mv` `$WORK/<desired-stem>.pdf` to the requested output path. Relies on md-to-pdf's default behaviour of writing `<source-basename>.pdf` next to the source. |
| `graceful degrade` | The pattern `/pdf` uses: try each converter in order, fall through on missing-dep; only exit non-zero if NO converter is installed. The stale flags were causing the md-to-pdf branch to error (exit 1) instead of degrade (exit 3). |