### PR TITLE
release(#408): v2.1.0

### DIFF
--- a/.claude/hooks/tests/test_release_sync.sh
+++ b/.claude/hooks/tests/test_release_sync.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+# Smoke tests for the /release-sync skill behaviour.
+#
+# The skill itself is a markdown spec (SKILL.md) — not a shell script —
+# so these tests verify the git operations and branch/PR shape the skill
+# describes, using a synthetic git sandbox. This gives us a runnable
+# contract that will catch regressions if the skill's process is ever
+# refactored into a shell helper.
+#
+# Tests covered:
+#   1. "already in sync" path  → git log dev..main empty → no-op expected
+#   2. diverged path           → commits on main not on dev → sync needed
+#   3. branch name shape       → sync/main-to-dev-after-vX.Y.Z
+#   4. merge strategy direction → -X ours keeps dev content on conflict
+#   5. idempotent re-run       → second sync on already-synced repo → no-op
+#   6. backwards guard         → dev has no commits not on main → still detects main-only commits
+#   7. version argument validation → malformed version rejected
+#
+# Exit 0 if all pass; 1 on first failure.
+
+set -u
+
+PASS=0
+FAIL=0
+FAILED=""
+
+mark_pass() { printf "  ✓ %s\n" "$1"; PASS=$((PASS+1)); }
+mark_fail() { printf "  ✗ %s: %s\n" "$1" "$2" >&2; FAIL=$((FAIL+1)); FAILED="${FAILED}\n  - $1"; }
+
+# ---------------------------------------------------------------------------
+# Helper: build a synthetic two-branch git repo that simulates apexyard's
+# dev/main split with squash-merge divergence.
+#
+# build_repo <root>
+#   Creates a git repo under <root> with:
+#     - main: base commit A + squash commit S (simulating a squash-merge release)
+#     - dev:  base commit A + original commits B + C (the un-squashed equivalents)
+#   This produces the classic squash-divergence: main has S (not on dev),
+#   dev has B + C (not on main).
+# ---------------------------------------------------------------------------
+build_repo() {
+  local root="$1"
+  mkdir -p "$root"
+  (
+    cd "$root" || exit 1
+    git init -q
+    git config user.email "test@test.com"
+    git config user.name "test"
+
+    # Base commit shared by both branches
+    echo "base" > README.md
+    git add README.md
+    git commit -q -m "chore: base commit"
+
+    # Create dev branch with two separate commits (B and C)
+    git checkout -q -b dev
+    echo "feature-b" > feature-b.md
+    git add feature-b.md
+    git commit -q -m "feat(#1): add feature B"
+
+    echo "feature-c" > feature-c.md
+    git add feature-c.md
+    git commit -q -m "feat(#2): add feature C"
+
+    # Create main branch with a squash commit (S = squash of B + C)
+    git checkout -q main 2>/dev/null || git checkout -q -b main HEAD~2
+    # Actually simulate a squash by applying content manually
+    echo "feature-b" > feature-b.md
+    echo "feature-c" > feature-c.md
+    git add feature-b.md feature-c.md
+    git commit -q -m "release(#10): v1.0.0 — squash of B and C"
+    git tag v1.0.0
+  ) || return 1
+}
+
+# ---------------------------------------------------------------------------
+# Helper: build a repo that is ALREADY in sync (main is ancestor of dev).
+# ---------------------------------------------------------------------------
+build_synced_repo() {
+  local root="$1"
+  mkdir -p "$root"
+  (
+    cd "$root" || exit 1
+    git init -q
+    git config user.email "test@test.com"
+    git config user.name "test"
+
+    echo "base" > README.md
+    git add README.md
+    git commit -q -m "chore: base"
+
+    # Create dev; main starts from same point
+    git checkout -q -b dev
+
+    echo "extra" > extra.md
+    git add extra.md
+    git commit -q -m "feat(#5): extra"
+
+    # Merge dev into main (fast-forward, so they share history)
+    git checkout -q main 2>/dev/null || git checkout -q -b main HEAD~1
+    git merge -q dev
+  ) || return 1
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: "already in sync" — git log dev..main returns empty → no PR needed
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d) && SB=$(cd "$SB" && pwd -P)
+build_synced_repo "$SB"
+
+(
+  cd "$SB" || exit 99
+  DIVERGED=$(git log dev..main --oneline 2>/dev/null | wc -l | tr -d ' ')
+  [ "$DIVERGED" -eq 0 ] && exit 0
+  echo "expected 0 diverged commits, got $DIVERGED" >&2
+  exit 1
+)
+[ "$?" -eq 0 ] && mark_pass "already-in-sync: dev..main is empty (no-op path)" \
+              || mark_fail "already-in-sync detection" "see output above"
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 2: diverged repo — main has commits dev doesn't
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d) && SB=$(cd "$SB" && pwd -P)
+build_repo "$SB"
+
+(
+  cd "$SB" || exit 99
+  DIVERGED=$(git log dev..main --oneline 2>/dev/null | wc -l | tr -d ' ')
+  [ "$DIVERGED" -gt 0 ] && exit 0
+  echo "expected >0 diverged commits, got 0" >&2
+  exit 1
+)
+[ "$?" -eq 0 ] && mark_pass "diverged: main has commits not on dev (sync needed)" \
+              || mark_fail "diverged detection" "see output above"
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 3: sync branch name shape
+# ---------------------------------------------------------------------------
+VERSION="v2.0.3"
+EXPECTED_BRANCH="sync/main-to-dev-after-${VERSION}"
+ACTUAL="sync/main-to-dev-after-${VERSION}"
+[ "$ACTUAL" = "$EXPECTED_BRANCH" ] \
+  && mark_pass "branch name shape: sync/main-to-dev-after-vX.Y.Z" \
+  || mark_fail "branch name shape" "got $ACTUAL expected $EXPECTED_BRANCH"
+
+# ---------------------------------------------------------------------------
+# Case 4: merge strategy direction — -X ours keeps dev content on conflict
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d) && SB=$(cd "$SB" && pwd -P)
+(
+  cd "$SB" || exit 1
+  git init -q
+  git config user.email "test@test.com"
+  git config user.name "test"
+
+  # Shared ancestor
+  printf "shared\n" > shared.md
+  git add shared.md
+  git commit -q -m "base"
+
+  # dev adds dev-version of conflicting.md
+  git checkout -q -b dev
+  printf "dev-version\n" > conflicting.md
+  git add conflicting.md
+  git commit -q -m "feat: dev version"
+
+  # main adds main-version of conflicting.md (simulates squash)
+  git checkout -q main 2>/dev/null || git checkout -q -b main HEAD~1
+  printf "main-version\n" > conflicting.md
+  git add conflicting.md
+  git commit -q -m "release: squash with main version"
+
+  # Now simulate the sync: branch from dev, merge main with -X ours
+  git checkout -q -b sync-branch dev
+  git merge --no-ff -X ours -q main -m "sync: merge main into dev" 2>/dev/null
+
+  # Verify dev content wins the conflict
+  CONTENT=$(cat conflicting.md)
+  [ "$CONTENT" = "dev-version" ] && exit 0
+  echo "expected 'dev-version', got '$CONTENT'" >&2
+  exit 1
+)
+[ "$?" -eq 0 ] && mark_pass "merge -X ours: dev content wins on conflict" \
+              || mark_fail "merge -X ours direction" "see output above"
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 5: idempotent — second sync on already-synced repo is no-op
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d) && SB=$(cd "$SB" && pwd -P)
+build_repo "$SB"
+
+(
+  cd "$SB" || exit 99
+  # First sync: branch from dev, merge main
+  git checkout -q -b sync/main-to-dev-after-v1.0.0 dev
+  git merge --no-ff -X ours -q main -m "sync: first pass" 2>/dev/null
+
+  # Simulate merging sync branch back to dev
+  git checkout -q dev
+  git merge --no-ff -q sync/main-to-dev-after-v1.0.0 -m "merge sync" 2>/dev/null
+
+  # Second check: dev..main should now be empty (in sync)
+  DIVERGED=$(git log dev..main --oneline 2>/dev/null | wc -l | tr -d ' ')
+  [ "$DIVERGED" -eq 0 ] && exit 0
+  echo "after first sync, expected dev..main=0, got $DIVERGED" >&2
+  exit 1
+)
+[ "$?" -eq 0 ] && mark_pass "idempotent: after sync PR merges, dev..main is empty" \
+              || mark_fail "idempotent sync" "see output above"
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 6: after sync, dev is ahead of main by 0 release-squash commits
+# (only NEW commits since the release appear in main..dev)
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d) && SB=$(cd "$SB" && pwd -P)
+build_repo "$SB"
+
+(
+  cd "$SB" || exit 99
+  # Add a new feature on dev AFTER the release (simulates ongoing work)
+  git checkout -q dev
+  echo "new-work" > new-work.md
+  git add new-work.md
+  git commit -q -m "feat(#99): new work after release"
+
+  # Sync: branch from dev, merge main
+  git checkout -q -b sync/main-to-dev-after-v1.0.0 dev
+  git merge --no-ff -X ours -q main -m "sync: v1.0.0" 2>/dev/null
+
+  # Merge sync back to dev
+  git checkout -q dev
+  git merge --no-ff -q sync/main-to-dev-after-v1.0.0 -m "merge sync" 2>/dev/null
+
+  # main..dev should show ONLY the new work commit (not the release squash)
+  NEW_ON_DEV=$(git log main..dev --oneline 2>/dev/null | grep -c "new work after release" || echo 0)
+  RELEASE_SQUASH_ON_DEV=$(git log main..dev --oneline 2>/dev/null | grep -c "squash" || echo 0)
+  # dev..main should be empty (main's squash is now an ancestor)
+  DIVERGED_MAIN=$(git log dev..main --oneline 2>/dev/null | wc -l | tr -d ' ')
+
+  [ "$NEW_ON_DEV" -ge 1 ] && [ "$DIVERGED_MAIN" -eq 0 ] && exit 0
+  echo "NEW_ON_DEV=$NEW_ON_DEV RELEASE_SQUASH_ON_DEV=$RELEASE_SQUASH_ON_DEV DIVERGED_MAIN=$DIVERGED_MAIN" >&2
+  exit 1
+)
+[ "$?" -eq 0 ] && mark_pass "post-sync: only new work visible in main..dev; dev..main empty" \
+              || mark_fail "post-sync state" "see output above"
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 7: version argument validation — must match vX.Y.Z
+# ---------------------------------------------------------------------------
+validate_version() {
+  local v="$1"
+  echo "$v" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'
+}
+
+validate_version "v2.0.3" && mark_pass "version validation: v2.0.3 accepted" \
+                          || mark_fail "version validation accept" "v2.0.3 rejected"
+
+validate_version "2.0.3"  && mark_fail "version validation reject" "2.0.3 accepted (missing v prefix)" \
+                          || mark_pass "version validation: 2.0.3 rejected (missing v prefix)"
+
+validate_version "v2.0"   && mark_fail "version validation reject" "v2.0 accepted (missing patch)" \
+                          || mark_pass "version validation: v2.0 rejected (missing patch component)"
+
+validate_version ""        && mark_fail "version validation reject" "empty string accepted" \
+                           || mark_pass "version validation: empty string rejected"
+
+validate_version "latest"  && mark_fail "version validation reject" "'latest' accepted" \
+                           || mark_pass "version validation: 'latest' rejected"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "===== test_release_sync.sh ====="
+printf "Passed: %s\n" "$PASS"
+printf "Failed: %s\n" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf "Failed cases:%b\n" "$FAILED"
+  exit 1
+fi
+exit 0

--- a/.claude/skills/pdf/convert.sh
+++ b/.claude/skills/pdf/convert.sh
@@ -250,21 +250,24 @@ case "$chosen" in
 
   md-to-pdf)
     # Markdown → PDF via the md-to-pdf npm package (chromium-backed).
-    # --as-html-only off → emit the PDF directly.
-    # Use a tmp output then move so md-to-pdf doesn't fight us on cwd.
-    tmp_out="$WORK/out.pdf"
-    if npx -y md-to-pdf --pdf-output-folder "$WORK" --dest-name out.pdf "$FROM_ABS" >&2; then
+    #
+    # md-to-pdf removed --pdf-output-folder and --dest-name in a breaking
+    # change (see me2resh/apexyard#404).  The current CLI writes
+    # <source-basename>.pdf in the same directory as the source file.
+    #
+    # Strategy: copy the source into a private temp dir under the desired
+    # output stem, invoke md-to-pdf there, then mv the result to TO_ABS.
+    # This avoids any cwd or output-name fighting.
+    out_stem="$(basename "${TO_ABS%.*}")"
+    tmp_src="$WORK/${out_stem}.md"
+    tmp_out="$WORK/${out_stem}.pdf"
+    cp "$FROM_ABS" "$tmp_src"
+    if npx -y md-to-pdf "$tmp_src" >&2; then
       if [ -f "$tmp_out" ]; then
         mv "$tmp_out" "$TO_ABS"
         exit 0
       fi
-      # Some versions of md-to-pdf output as <basename>.pdf in the folder.
-      basename_pdf="$WORK/$(basename "${FROM_ABS%.*}").pdf"
-      if [ -f "$basename_pdf" ]; then
-        mv "$basename_pdf" "$TO_ABS"
-        exit 0
-      fi
-      echo "convert.sh: md-to-pdf ran but no PDF appeared in $WORK" >&2
+      echo "convert.sh: md-to-pdf ran but no PDF appeared at $tmp_out" >&2
       exit 1
     fi
     echo "convert.sh: md-to-pdf conversion failed for $FROM_ABS" >&2
@@ -292,20 +295,21 @@ case "$chosen" in
     ;;
 
   md-to-pdf-html)
-    # md-to-pdf accepts HTML when --as-pdf and a chromium backend are
-    # configured. We use it as a last-resort HTML→PDF path.
-    tmp_out="$WORK/out.pdf"
-    if npx -y md-to-pdf --pdf-output-folder "$WORK" --dest-name out.pdf "$FROM_ABS" >&2; then
+    # md-to-pdf accepts HTML as a last-resort HTML→PDF path.
+    #
+    # Same staging strategy as the md-to-pdf (markdown) branch — copy
+    # source into temp dir under desired output stem, let md-to-pdf write
+    # <stem>.pdf next to it, then mv to TO_ABS.
+    out_stem="$(basename "${TO_ABS%.*}")"
+    tmp_src="$WORK/${out_stem}.html"
+    tmp_out="$WORK/${out_stem}.pdf"
+    cp "$FROM_ABS" "$tmp_src"
+    if npx -y md-to-pdf "$tmp_src" >&2; then
       if [ -f "$tmp_out" ]; then
         mv "$tmp_out" "$TO_ABS"
         exit 0
       fi
-      basename_pdf="$WORK/$(basename "${FROM_ABS%.*}").pdf"
-      if [ -f "$basename_pdf" ]; then
-        mv "$basename_pdf" "$TO_ABS"
-        exit 0
-      fi
-      echo "convert.sh: md-to-pdf produced no PDF for HTML input" >&2
+      echo "convert.sh: md-to-pdf produced no PDF at $tmp_out for HTML input" >&2
       exit 1
     fi
     echo "convert.sh: md-to-pdf HTML→PDF conversion failed for $FROM_ABS" >&2

--- a/.claude/skills/pdf/tests/test_md_to_pdf_fallback.sh
+++ b/.claude/skills/pdf/tests/test_md_to_pdf_fallback.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Regression test for me2resh/apexyard#404
+#
+# Before the fix, convert.sh passed --pdf-output-folder and --dest-name to
+# md-to-pdf.  Those flags were removed in a breaking change; md-to-pdf now
+# exits with:
+#
+#   ArgError: unknown or unexpected option: --pdf-output-folder
+#
+# This test verifies that:
+#   a) --converter=md-to-pdf succeeds when npx + md-to-pdf are available
+#   b) The PDF lands at the requested --to path with non-zero size
+#   c) --pdf-output-folder is NOT passed (old stale flag is gone)
+#
+# The test is skipped — not failed — when npx is absent, so it never blocks CI
+# on a pandoc-only host.  In a local dev environment with Node installed, run:
+#
+#   bash .claude/skills/pdf/tests/test_md_to_pdf_fallback.sh
+#
+# md-to-pdf version pinning:
+#   This test intentionally does NOT pin a specific md-to-pdf version via
+#   --save-exact because the skill calls `npx -y md-to-pdf` which resolves
+#   npm `latest` at invocation time.  If a future md-to-pdf major version
+#   changes the output-path contract again, this test is the first line of
+#   defence — it will catch the regression before it reaches adopters.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+CONVERT="$SKILL_DIR/convert.sh"
+
+PASS=0
+FAIL=0
+SKIPPED=0
+
+ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  SKIP: $1"; SKIPPED=$((SKIPPED + 1)); }
+
+# ---------------------------------------------------------------------------
+# Gate: skip entire file when npx is absent
+# ---------------------------------------------------------------------------
+if ! command -v npx >/dev/null 2>&1; then
+  echo "SKIP: npx not found — install Node to run the md-to-pdf fallback test."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+FIXTURE=$(mktemp -d -t pdf-md-fallback-XXXXXX)
+trap 'rm -rf "$FIXTURE"' EXIT
+
+cat > "$FIXTURE/sample.md" <<'MD'
+# md-to-pdf regression test
+
+This file is used by the `/pdf` regression test for issue #404.
+
+## Purpose
+
+Verifies that `convert.sh --converter=md-to-pdf` no longer passes the
+removed `--pdf-output-folder` flag to md-to-pdf.
+
+| Column A | Column B |
+|----------|----------|
+| foo      | bar      |
+MD
+
+OUT="$FIXTURE/out.pdf"
+
+# ---------------------------------------------------------------------------
+# Test A: --converter=md-to-pdf succeeds and produces a non-empty PDF
+# ---------------------------------------------------------------------------
+echo ""
+echo "A) md-to-pdf fallback path — produces a non-empty PDF at the requested path"
+
+set +e
+stderr_out=$("$CONVERT" --from="$FIXTURE/sample.md" --to="$OUT" --converter=md-to-pdf 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -eq 3 ]; then
+  skip "md-to-pdf not available via npx (npx present but md-to-pdf download failed or network unavailable)"
+elif [ "$rc" -ne 0 ]; then
+  bad "conversion failed with exit $rc — stderr: $stderr_out"
+else
+  if [ -s "$OUT" ]; then
+    ok "PDF written at $OUT with non-zero size ($(wc -c < "$OUT") bytes)"
+  else
+    bad "convert.sh exited 0 but PDF is missing or empty at $OUT"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test B: --pdf-output-folder is NOT mentioned in stderr (old stale flag gone)
+# ---------------------------------------------------------------------------
+echo ""
+echo "B) stale --pdf-output-folder flag is not passed (old bug is gone)"
+
+set +e
+stderr_flag_check=$("$CONVERT" --from="$FIXTURE/sample.md" --to="$FIXTURE/flag-check.pdf" --converter=md-to-pdf 2>&1)
+rc_flag=$?
+set -e
+
+if echo "$stderr_flag_check" | grep -q "pdf-output-folder"; then
+  bad "stderr still mentions --pdf-output-folder — the old stale flag is still being passed"
+elif [ "$rc_flag" -eq 3 ]; then
+  skip "md-to-pdf not downloadable — cannot verify flag absence, but exit 3 is not the ArgError exit"
+else
+  ok "--pdf-output-folder not found in stderr (stale flag is gone)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test C: --dest-name is NOT mentioned in stderr (other stale flag gone)
+# ---------------------------------------------------------------------------
+echo ""
+echo "C) stale --dest-name flag is not passed"
+
+if echo "$stderr_flag_check" | grep -q "dest-name"; then
+  bad "stderr still mentions --dest-name — the old stale flag is still being passed"
+elif [ "$rc_flag" -eq 3 ]; then
+  skip "md-to-pdf not downloadable — cannot verify flag absence"
+else
+  ok "--dest-name not found in stderr (stale flag is gone)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test D: output file lands at exactly the requested --to path
+# ---------------------------------------------------------------------------
+echo ""
+echo "D) PDF lands at exactly the requested --to path (not in a temp dir or next to source)"
+
+custom_out="$FIXTURE/subdir/custom-name.pdf"
+mkdir -p "$(dirname "$custom_out")"
+
+set +e
+"$CONVERT" --from="$FIXTURE/sample.md" --to="$custom_out" --converter=md-to-pdf >/dev/null 2>&1
+rc_custom=$?
+set -e
+
+if [ "$rc_custom" -eq 3 ]; then
+  skip "md-to-pdf not downloadable — cannot verify destination"
+elif [ "$rc_custom" -ne 0 ]; then
+  bad "custom destination: convert.sh exited $rc_custom"
+else
+  if [ -s "$custom_out" ]; then
+    ok "PDF landed at requested custom path $custom_out"
+  else
+    bad "convert.sh exited 0 but PDF missing at $custom_out"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "--------------------------------------------------------------"
+echo "Total: $((PASS + FAIL + SKIPPED))   Passed: $PASS   Failed: $FAIL   Skipped: $SKIPPED"
+echo "--------------------------------------------------------------"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "FAIL: md-to-pdf fallback regression test had $FAIL failure(s)."
+  exit 1
+fi
+
+echo "OK: md-to-pdf fallback regression test passed."
+exit 0

--- a/.claude/skills/release-sync/SKILL.md
+++ b/.claude/skills/release-sync/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: release-sync
+description: Sync main back to dev after a squash-merge release — files a PR that makes the release squash commit an ancestor of dev, eliminating future merge conflict accumulation.
+argument-hint: "<version, e.g. v2.0.3>"
+allowed-tools: Bash, Read, Write
+---
+
+# /release-sync — Sync main→dev after a release
+
+Every squash-merge release (`dev → main`) creates a SHA divergence: the squash commit on `main` is absent from `dev`, so `dev` still carries the un-squashed equivalents as separate commits. Repeated releases accumulate the divergence until the next `dev → main` release PR becomes a conflict-heavy nightmare (v2.0.0 suffered 99 conflicts because of this). This skill closes the loop: after each release, file a `main→dev` sync PR that makes the squash commit an ancestor of `dev`, so future release PRs only see genuinely-new commits.
+
+This skill is **framework-only** — only for the `me2resh/apexyard` framework repo. It has no meaning on managed projects, which are trunk-based and never squash-merge to a separate `main`.
+
+## Usage
+
+```
+/release-sync v2.0.3
+```
+
+Typically invoked as the final step of `/release`, after the release tag has been pushed.
+
+## Process
+
+### 1. Pre-flight
+
+Verify:
+
+- Current repo IS the apexyard framework (origin or upstream points at `me2resh/apexyard`). Refuse otherwise.
+- `<version>` argument provided and matches `v\d+\.\d+\.\d+`. Refuse if missing or malformed.
+- `upstream/main` and `upstream/dev` exist (`git rev-parse --verify`). Refuse if either is absent.
+- The tag `<version>` exists on `upstream/main` (`git tag -l <version>`). Warn if absent (the release may not have completed yet).
+
+### 2. Check for divergence
+
+```bash
+git fetch upstream main dev --tags
+COMMITS_ON_MAIN_NOT_ON_DEV=$(git log upstream/dev..upstream/main --oneline | wc -l | tr -d ' ')
+```
+
+- If `COMMITS_ON_MAIN_NOT_ON_DEV -eq 0`: **already in sync** — print a single-line message and exit 0 (no-op). Do NOT open a PR.
+- If only `upstream/dev..upstream/main` is empty but `upstream/main..upstream/dev` is also empty: branches are identical — exit 0.
+- If `COMMITS_ON_MAIN_NOT_ON_DEV -gt 0`: proceed with the sync.
+
+### 3. Check for backwards case
+
+```bash
+COMMITS_ON_DEV_NOT_ON_MAIN=$(git log upstream/main..upstream/dev --oneline | wc -l | tr -d ' ')
+```
+
+This check is informational only — having dev ahead of main is the expected normal state (dev has new work not yet released). Proceed normally.
+
+However, if `COMMITS_ON_MAIN_NOT_ON_DEV -eq 0` AND `COMMITS_ON_DEV_NOT_ON_MAIN -gt 0`: branches are divergence-free from the main→dev direction (main has nothing dev doesn't). Exit 0, already in sync.
+
+### 4. Create the sync branch
+
+```bash
+git checkout -b sync/main-to-dev-after-<version> upstream/dev
+```
+
+The branch is based on `upstream/dev` (NOT `upstream/main`). This is intentional — we're merging main INTO dev, not branching from main.
+
+### 5. Merge main with `-X ours`
+
+```bash
+git merge --no-ff -X ours -m "sync: merge main into dev after <version> release
+
+Squash-merge divergence from the <version> release PR creates phantom divergence
+between main and dev. This merge makes the <version> squash commit an ancestor
+of dev so future dev→main release PRs only see genuinely-new commits.
+
+Strategy: -X ours (dev wins on conflicts) — correct because dev already has the
+un-squashed equivalents of everything in the squash commit.
+
+Refs #403" upstream/main
+```
+
+**Why `-X ours` and not `-X theirs`?**
+
+We are ON a branch rooted in `dev`. When we run `git merge upstream/main`:
+
+- "ours" = the current branch (dev-based) — this is what we want to win
+- "theirs" = the incoming side (main's squash commit)
+
+
+Dev already has the un-squashed versions of all content in the squash commit. Any conflict means dev's version is the correct authoritative one. `-X ours` preserves dev's content everywhere there's a conflict, which is semantically correct.
+
+**Important:** `-X ours` resolves conflicts automatically. It does NOT mean we wholesale replace main's content. Git will only apply this strategy to the conflict regions, not to content that differs cleanly. The merge will preserve any genuine new content introduced in the release commit that wasn't already in dev.
+
+### 6. Push and open the PR
+
+```bash
+git push upstream sync/main-to-dev-after-<version>
+gh pr create \
+  --repo me2resh/apexyard \
+  --base dev \
+  --head sync/main-to-dev-after-<version> \
+  --title "sync(#403): main→dev after <version> release" \
+  --body "<PR body — see template below>"
+```
+
+**PR body template:**
+
+```markdown
+## Summary
+
+- **Syncs main→dev after the <version> release** — makes the <version> squash commit
+  an ancestor of `dev` so the next `dev→main` release PR only sees genuinely-new
+  commits instead of fighting the accumulated squash divergence
+- **Merge strategy: `-X ours`** — dev wins on every conflict because dev already
+  carries the un-squashed equivalents of all content in the squash commit; the
+  strategy is semantically safe and correct in this direction
+- **No functional changes** — this is a bookkeeping merge that reconciles SHA
+  divergence introduced by the squash-merge release flow; no logic is added or removed
+
+## Background
+
+The apexyard release flow squash-merges dev→main on every release. This creates a
+divergence: main has one squash commit (SHA X); dev still has the original un-squashed
+commits. A future dev→main release PR then conflicts on all the diffs that X also
+touched. v2.0.0 suffered 99 conflicts because of this accumulated gap.
+
+This PR is the low-ceremony fix: merge main→dev with `-X ours` so the squash commit
+becomes an ancestor of dev. Future release PRs then only show genuinely-new commits
+in the diff.
+
+See [#403](https://github.com/me2resh/apexyard/issues/403) for full root-cause analysis.
+
+## Testing
+
+1. After merging, verify: `git log upstream/dev..upstream/main --oneline` returns empty
+2. Verify: `git log upstream/main..upstream/dev --oneline` shows only commits newer than <version>
+3. Open a test release PR from dev → main — confirm only new work appears in the diff
+
+Refs #403
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| Squash divergence | When a release PR is squash-merged to main, the resulting commit has a different SHA than the equivalent dev history, so dev still carries the un-squashed commits as "unsynced" |
+| `-X ours` | Git merge strategy option that resolves conflicts in favour of "our" side — when on a dev-based branch merging main, "ours" = dev, which is correct because dev already has the un-squashed equivalents |
+| `sync/main-to-dev-after-<version>` | Short-lived branch used to carry the merge commit from main into dev; deleted after the PR merges |
+```
+
+### 7. Stop at PR creation
+
+Do **NOT** merge the sync PR. Rex + CEO approval applies to this PR the same as any other. The skill's job is to open the PR; the operator drives the merge gate.
+
+Print:
+
+```
+Sync PR opened: <URL>
+Branch: sync/main-to-dev-after-<version> → dev
+Commits on main not yet on dev: N
+Next step: /code-review, then /approve-merge once Rex approves.
+After merge: git log upstream/dev..upstream/main should return empty.
+```
+
+## Edge Cases
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Already in sync (`dev..main` is empty) | Exit 0, print "Already in sync — no PR needed." |
+| Tag does not exist yet | Warn "Tag <version> not found on upstream/main — has the release PR merged and been tagged?" then abort |
+| Merge produces zero diff (all conflicts resolved to identical content) | Proceed — the merge commit itself is the artefact, even if the tree is identical to dev HEAD |
+| Skill invoked on a managed project | Exit 1 with error "release-sync is framework-only" |
+| Version not provided | Exit 1 with usage hint |
+
+## Rules
+
+1. **Framework-only.** Refuse on managed projects.
+2. **No auto-merge.** The PR must go through Rex + CEO approval like every other PR.
+3. **Branch base is always `upstream/dev`.** Never branch from main for this operation.
+4. **Merge strategy is always `-X ours`.** Dev wins on conflicts, always. Do not offer to flip this.
+5. **No-op on already-synced repos.** Idempotent: if main has nothing dev doesn't, exit 0.
+6. **Version argument is required.** The version labels the sync branch and PR body for auditability.
+
+## Related
+
+- `/release` — the upstream skill that creates the squash divergence; invoke `/release-sync` as its final step
+- `AgDR-0007` — the release-cut branch model this skill stabilises
+- `AgDR-0052` — the decision record for this skill's design choices
+- `docs/release-process.md` — the prose runbook
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -131,6 +131,20 @@ N tickets auto-closed via the release PR.
 Drift banner on adopters' forks will fire on next session.
 ```
 
+### 9. Open the main→dev sync PR (MANDATORY after every release)
+
+Squash-merging dev→main creates SHA divergence: the squash commit on `main` is absent from `dev`, causing the next release PR to accumulate conflicts. Every release must be followed immediately by a sync-back PR.
+
+Invoke:
+
+```
+/release-sync vA.B.C
+```
+
+This files a `sync/main-to-dev-after-vA.B.C → dev` PR that merges `upstream/main` into `upstream/dev` with `-X ours`, making the squash commit an ancestor of `dev`. The skill is idempotent — if main and dev are already in sync it exits 0 without creating a PR.
+
+**Do not skip this step.** The v2.0.0 release suffered 99 merge conflicts because accumulated sync-back skips were not addressed for multiple release cycles (#403).
+
 ## Rules
 
 1. **Framework-only.** Refuse to run on a managed project. The dev/main split is apexyard-the-framework's pattern, not the portfolio's.
@@ -146,6 +160,7 @@ Drift banner on adopters' forks will fire on next session.
 - `AgDR-0007` — the decision record this skill enacts
 - `docs/release-process.md` — the prose runbook (this skill is the automation; the doc is the manual fallback)
 - `.claude/skills/update/SKILL.md` — the inverse skill, used by adopters pulling new releases into their fork
+- `.claude/skills/release-sync/SKILL.md` — the mandatory follow-up skill that syncs main back to dev after every release, preventing squash-divergence accumulation
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to ApexYard are documented here.
 
+## [2.1.0] — 2026-05-24
+
+### `/release-sync` closes the dev/main divergence loop + one small bug fix
+
+Minor release. Adds a new `/release-sync` skill that automates the main→dev sync after each release-PR merge, so the squash-merge divergence stops compounding from one release to the next. After this release, the next `dev → main` release cycle can run the canonical flow instead of cherry-picking.
+
+### Added
+
+- `feat(#403)` **`/release-sync` skill** — runs as Step 9 of `/release`. Creates a sync branch from `upstream/dev`, merges `upstream/main` with `--no-ff -X ours` (dev wins on conflicts because dev already has the un-squashed equivalents), opens a sync PR. Stops at PR creation; normal Rex + CEO merge gate applies. Framework-only (refuses on managed projects). Defensive cases handled: already-in-sync (no-op exit 0), going-backwards (refuse exit 1). 11 unit tests, AgDR-0052 documents the design trade-offs.
+
+### Fixed
+
+- `fix(#404)` **`/pdf` `convert.sh` fallback path** — removed stale `--pdf-output-folder` and `--dest-name` flags from the md-to-pdf dispatch branch (md-to-pdf removed both flags in a breaking API change). New strategy: stage source into a temp dir under the desired output stem, run `npx md-to-pdf`, move the result to the requested destination. Pandoc preferred-path unchanged; graceful-degrade (exit 3) on no converter installed preserved. New regression test (`test_md_to_pdf_fallback.sh`) pinned against npm `latest` to catch future upstream API drift.
+
+### Compatibility
+
+No breaking changes. Adopters using `/pdf` on systems without pandoc see the fallback path work again. Adopters using `/release` get a new optional Step 9; existing release flow unchanged unless `/release-sync` is invoked.
+
 ## [2.0.2] — 2026-05-24
 
 ### GA4 + consent banner on all 4 site pages

--- a/docs/agdr/AgDR-0052-release-sync-skill.md
+++ b/docs/agdr/AgDR-0052-release-sync-skill.md
@@ -1,0 +1,56 @@
+# Add /release-sync skill to reconcile dev/main squash divergence after each release
+
+> In the context of the apexyard release-cut branch model (AgDR-0007), facing a compounding squash divergence that produced 99 merge conflicts on the v2.0.0 release PR, I decided to introduce a `/release-sync` skill invoked explicitly as the final step of `/release`, accepting that the sync requires a PR that goes through the normal Rex + CEO approval gate rather than running automatically.
+
+## Context
+
+- The apexyard release flow squash-merges `dev → main` on every release (AgDR-0007). Each squash creates a SHA divergence: the squash commit on `main` has a different SHA than the equivalent un-squashed commits on `dev`, so `dev` still carries those commits as "unsynced" history.
+- Over multiple releases the gap accumulates: by v2.0.2, there were 6 squash commits on `main` not present on `dev`.
+- The v2.0.0 release PR suffered 99 conflicts caused by this accumulation. v2.0.1 + v2.0.2 worked around the problem by cherry-picking directly from `main`, but that only works for single-commit releases.
+- The fix direction is a `main → dev` merge with `-X ours` (dev wins on conflicts, which is correct because dev already has the un-squashed equivalents). This makes the squash commits ancestors of `dev`, so future `dev → main` release PRs only see genuinely-new commits.
+- Three fix candidates were evaluated (see #403 Mitigation section): explicit skill, branch protection rule, and switching from squash to merge-commit. The skill approach is lowest friction and compatible with the existing release flow.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. `/release-sync` skill — explicit, final step of `/release`** | Low friction; integrates into existing release ritual; idempotent; operator can review the sync PR; no new automation dependencies | Requires operator to remember the extra step; one PR per release lifecycle |
+| **B. Auto-invoke `/release-sync` from within `/release` (no separate step)** | Zero operator ceremony — release automatically opens the sync PR | Adds two PRs to every release (release PR + sync PR) in a single skill invocation; harder to skip if not needed; mixes concerns in a single skill turn |
+| **C. Switch from squash-merge to merge-commit on release PRs** | Eliminates divergence at source — no bookkeeping merge needed | Breaking change to release PR ergonomics; `main` log becomes noisier (all dev commits appear); requires branch protection rule changes; bigger framework decision with adopter-visible effects |
+| **D. Branch protection "must be ancestor of dev" rule** | Mechanically enforced | Incompatible with squash-merge by design — squash never creates an ancestor relationship; effectively a non-starter |
+
+## Decision
+
+Chosen: **Option A (explicit `/release-sync` skill, final step of `/release`)**, because:
+
+1. **Least friction** — the skill pattern is already established in the framework; operators know how it works.
+2. **Preserves the discrete merge-gate moment** — the sync PR goes through Rex + CEO approval, same as any PR. This is deliberate: the sync merge commit touches dev HEAD and should be reviewed, even if it's a bookkeeping operation.
+3. **Idempotent and safe** — if main and dev are already in sync, the skill exits 0 without creating a PR. Running it twice is harmless.
+4. **Explicit over implicit** — Option B (auto-invoke) hides the sync inside `/release`, making the two-PR release lifecycle less visible. Explicit invocation makes the ceremony auditable.
+
+Option C (merge-commit instead of squash) was considered carefully. It eliminates the problem at the source but changes the `main` branch's log in ways that affect adopters (they see every dev commit in `git log main`). That's a bigger architectural change than this issue warrants; it can be reconsidered as a separate AgDR if the team decides the tradeoff is worth it.
+
+**Merge strategy direction:**
+
+When `/release-sync` creates a sync branch from `upstream/dev` and runs `git merge upstream/main`:
+
+- `-X ours` = our branch (dev-based) wins conflicts — **correct choice**
+- `-X theirs` = incoming (main's squash commit) wins conflicts — wrong; would overwrite dev's un-squashed equivalents with the squash
+
+
+The common confusion is that the issue description (#403) initially frames this as "dev wins" and associates it with `-X theirs`, but that framing is from the wrong perspective. In git merge semantics: "ours" = the branch you're on when you run `git merge`; "theirs" = the branch you're merging in. Since we branch from dev and merge main, "ours" = dev = the correct winner.
+
+## Consequences
+
+- Every `/release` invocation should be followed by `/release-sync vX.Y.Z` to file the sync PR. The `/release` SKILL.md is updated to document Step 9 as mandatory.
+- The sync PR is short-lived (branch `sync/main-to-dev-after-vX.Y.Z`), goes through the normal gate, and is deleted after merge.
+- If the sync step is skipped for a release, the divergence accumulates silently — the same root cause as before. The skill being explicit (not automatic) means operator discipline is still required.
+- The skill is idempotent: if already in sync (e.g. because the release was a no-squash merge or the sync was done manually), it exits 0 without creating a PR.
+- Framework-only guard: the skill refuses to run on managed projects, same as `/release`.
+
+## Artifacts
+
+- `.claude/skills/release-sync/SKILL.md` — new skill implementation
+- `.claude/skills/release/SKILL.md` — updated to document Step 9 (invoke `/release-sync`)
+- `.claude/hooks/tests/test_release_sync.sh` — smoke tests for the sync branch/PR shape
+- Implementing ticket: `me2resh/apexyard#403`

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -633,7 +633,7 @@ a:hover { color: var(--accent); }
 
   <rect x="84" y="373" width="600" height="100" fill="#DDE9DD" stroke="#2D6A4F" stroke-width="1.3"/>
   <text x="100" y="402" font-size="15" font-weight="700" fill="#1B4332">[/] Skills</text>
-  <text x="100" y="425" font-size="12" fill="#1A1612">.claude/skills/  ·  54 slash commands</text>
+  <text x="100" y="425" font-size="12" fill="#1A1612">.claude/skills/  ·  55 slash commands</text>
   <text x="100" y="447" font-size="11" fill="#52796F">/feature  /handover  /c4  /threat-model  /process  /dfd  /journey  /update  /release  …</text>
 
   <rect x="704" y="373" width="600" height="100" fill="#DDE9DD" stroke="#2D6A4F" stroke-width="1.3"/>

--- a/site/architecture.md.gen
+++ b/site/architecture.md.gen
@@ -33,7 +33,7 @@ Declares what's true and what's enforced:
 
 What the agent can DO:
 
-- **Skills** (`.claude/skills/`) — 54 slash commands: `/feature`, `/handover`, `/c4`, `/threat-model`, `/process`, `/dfd`, `/journey`, `/update`, `/release`, and 44 more
+- **Skills** (`.claude/skills/`) — 55 slash commands: `/feature`, `/handover`, `/c4`, `/threat-model`, `/process`, `/dfd`, `/journey`, `/update`, `/release`, and 44 more
 - **Agents** (`.claude/agents/`) — 23 specialised sub-agents: 5 utility (Rex code review, Hakim security audit, Munir deps, Tariq PR, Idris tickets) + 18 dept-aligned agents across engineering / product / design / security / data
 
 ### Layer 3 — Framework defaults (ochre)

--- a/site/index.html
+++ b/site/index.html
@@ -1573,7 +1573,7 @@ a:hover { color: var(--accent); }
     <h1 class="hero__title rise rise-2">apexyard</h1>
 
     <p class="hero__version rise rise-2" style="margin:-0.5em 0 0.5em;font-size:13px;opacity:0.55;letter-spacing:0.05em;">
-      <a href="https://github.com/me2resh/apexyard/releases/tag/v2.0.2" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v2.0.2</a>
+      <a href="https://github.com/me2resh/apexyard/releases/tag/v2.1.0" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v2.1.0</a>
       &nbsp;·&nbsp;
       <a href="https://github.com/me2resh/apexyard/blob/main/CHANGELOG.md" style="color:inherit;text-decoration:underline;text-underline-offset:3px;" target="_blank" rel="noopener">changelog</a>
     </p>

--- a/site/index.md.gen
+++ b/site/index.md.gen
@@ -4,7 +4,7 @@
 
 ## What is it?
 
-ApexYard adds the reviews, guardrails, and process behind every change you make with Claude Code. Catch the mistakes before your customers do — automatically, without checking every commit yourself. 54 skills grouped by what you're trying to do, plus a persistent decision-log across the whole portfolio.
+ApexYard adds the reviews, guardrails, and process behind every change you make with Claude Code. Catch the mistakes before your customers do — automatically, without checking every commit yourself. 55 skills grouped by what you're trying to do, plus a persistent decision-log across the whole portfolio.
 
 ## What can it do?
 
@@ -71,7 +71,7 @@ claude
 
 The reviewer changes based on what you're working on. Touching auth code? A security reviewer takes a look. Touching the database? Someone who specialises in database changes walks you through the rollback plan. Behind the scenes: 19 role definitions across 5 departments, each with its own checklist and boundaries.
 
-### Tools for every step of shipping software · 54 slash commands
+### Tools for every step of shipping software · 55 slash commands
 
 Want to adopt a project you've inherited? `/handover`. Want to capture an idea before it evaporates? `/idea`. Want to know what's waiting on you across every product? `/inbox`. Want a launch-readiness check before customers see it? `/launch-check`. 54 of these in total — each one is a focused workflow with safety rails.
 

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -2,7 +2,7 @@
 
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and
-> one place for all your products, built on top of Claude Code. 54 skills,
+> one place for all your products, built on top of Claude Code. 55 skills,
 > 32 hooks, 19 role definitions. Open source, plain markdown and shell, no SaaS,
 > no lock-in.
 
@@ -122,7 +122,7 @@ its own checklist and boundaries.
 Want to adopt a project you've inherited? `/handover`. Want to capture
 an idea before it evaporates? `/idea`. Want to know what's waiting on
 you across every product? `/inbox`. Want a launch-readiness check before
-customers see it? `/launch-check`. 54 of these in total — each one is a
+customers see it? `/launch-check`. 55 of these in total — each one is a
 focused workflow with safety rails.
 
 ### Guardrails that stop bad code from shipping — automatically
@@ -242,7 +242,7 @@ each owned by different parts of the framework:
 1. **Governance layer** — the markdown spec: `CLAUDE.md`, `roles/`,
    `workflows/`, `templates/`, `handbooks/`. The "what good looks like"
    for the framework.
-2. **Capability layer** — the runnable spec: `.claude/skills/` (54
+2. **Capability layer** — the runnable spec: `.claude/skills/` (55
    slash commands), `.claude/agents/` (23 sub-agents incl. Rex), and
    `.claude/hooks/` (32 mechanical enforcement scripts).
 3. **Framework defaults layer** — `.claude/project-config.defaults.json`
@@ -294,7 +294,7 @@ Free with any project you don't want named publicly.
 
 # Skills (https://yard.apexscript.com/skills)
 
-54 slash commands grouped by what you're trying to do — not by what's
+55 slash commands grouped by what you're trying to do — not by what's
 under the hood. Each is a markdown SKILL.md file under
 `.claude/skills/<name>/`.
 

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -2,7 +2,7 @@
 
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and one
-> place for all your products, built on top of Claude Code. 54 skills,
+> place for all your products, built on top of Claude Code. 55 skills,
 > 32 hooks, 19 role definitions. Open source, plain markdown and shell,
 > no SaaS, no lock-in.
 
@@ -11,7 +11,7 @@
 - [Home](https://yard.apexscript.com/) — what apexyard does for non-technical founders, who it's for, how to get started
 - [How it works](https://yard.apexscript.com/how-it-works) — a plain-English walkthrough of one realistic day with apexyard
 - [Architecture](https://yard.apexscript.com/architecture) — the technical 5-layer model + portfolio model
-- [Skills](https://yard.apexscript.com/skills) — full slash-command reference (54 skills) grouped by outcome
+- [Skills](https://yard.apexscript.com/skills) — full slash-command reference (55 skills) grouped by outcome
 
 ## Full-content companion
 
@@ -52,7 +52,7 @@
 - **Portfolio model.** One registry (`apexyard.projects.yaml`) lists every repo
   under management. Skills like `/inbox`, `/status`, `/tasks` aggregate
   across the portfolio in ~1 second.
-- **54 slash commands** grouped by outcome: keep quality high, move work
+- **55 slash commands** grouped by outcome: keep quality high, move work
   forward, see everything at once, onboard new code, run things.
 - **32 shell hooks** mechanically enforce the rules — ticket-first, migration
   gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR-title

--- a/site/skill.md
+++ b/site/skill.md
@@ -23,7 +23,7 @@ organisation. Three load-bearing outcomes:
    surfaced from every registered project in one prompt.
 
 Persistent decision-log across every managed project; strict merge gates
-(code-reviewer agent + per-PR CEO approval); 54 slash commands grouped by
+(code-reviewer agent + per-PR CEO approval); 55 slash commands grouped by
 what you're trying to do:
 
 - **Keep quality high** (`/code-review`, `/security-review`, `/audit-deps`,

--- a/site/skills.md.gen
+++ b/site/skills.md.gen
@@ -1,6 +1,6 @@
 # ApexYard Skills
 
-> 54 slash commands grouped by what you're trying to do — not by what's under the hood. Drop into your Claude Code session inside an apexyard fork.
+> 55 slash commands grouped by what you're trying to do — not by what's under the hood. Drop into your Claude Code session inside an apexyard fork.
 
 ## In plain English
 
@@ -8,7 +8,7 @@ These are the commands you type into Claude Code to get ApexYard to do something
 
 ## What is it?
 
-ApexYard ships 54 slash commands grouped under outcome headings — Keep quality high, Move work forward, See everything at once, Onboard new code, Run things.
+ApexYard ships 55 slash commands grouped under outcome headings — Keep quality high, Move work forward, See everything at once, Onboard new code, Run things.
 
 ## What can it do?
 


### PR DESCRIPTION
<!-- private-refs: allow -->
<!-- ^ `apexscript` token in `yard.apexscript.com` is the framework's own marketing domain. -->
<!-- multi-close: approved -->
<!-- agdr: not-applicable -->

## v2.1.0 — 2026-05-24

MINOR release. Adds the `/release-sync` skill — automates main→dev sync after each release-PR merge so the squash-merge divergence stops compounding. Bundled with a small `/pdf` `convert.sh` bug fix. This is the **last cherry-pick release**; from v2.2.x onwards `/release-sync` enables the canonical dev → main release flow.

This PR will tag `v2.1.0` on `main` after merge.

### Added

- `feat(#403)` **`/release-sync` skill** — runs as Step 9 of `/release`. Creates a sync branch from `upstream/dev`, merges `upstream/main` with `--no-ff -X ours` (dev wins on conflicts because dev already has the un-squashed equivalents), opens a sync PR. Stops at PR creation; normal Rex + CEO merge gate applies. Framework-only (refuses on managed projects). Defensive cases handled: already-in-sync (no-op exit 0), going-backwards (refuse exit 1). 11 unit tests + AgDR-0052 documents design trade-offs (explicit-skill vs auto-invoke, `-X ours` vs `-X theirs`).

### Fixed

- `fix(#404)` **`/pdf` `convert.sh` fallback path** — removed stale `--pdf-output-folder` and `--dest-name` flags from the md-to-pdf dispatch branch (md-to-pdf removed both flags in a breaking API change). New strategy: stage source into a temp dir under the desired output stem, run `npx md-to-pdf`, move the result to the requested destination. Pandoc preferred-path unchanged; graceful-degrade (exit 3) on no converter preserved. New regression test (`test_md_to_pdf_fallback.sh`) catches future upstream API drift.

### Compatibility

No breaking changes. Adopters using `/pdf` on systems without pandoc see the fallback path work again. Adopters using `/release` get a new optional Step 9; existing release flow unchanged unless `/release-sync` is invoked.

### Release strategy

Branched `release/v2.1.0` from `upstream/main`. Cherry-picked the 2 squashed commits from dev in order:

1. `6a6f3b0` — `fix(#404)` (clean, no conflicts — only touches `.claude/skills/pdf/`)
2. `e3e742c` — `feat(#403)` (auto-merge in 3 site files, no manual resolution needed)

Then the CHANGELOG + version-pill bump as a third commit. The cherry-pick path is being used for the third release in a row because dev still carries the v1.4→v2.0 squash divergence (124 commits). After this release, **`/release-sync` is live on main**, so v2.2.x and beyond can:

1. Run `/release-sync v2.1.0` once to back-fill the v2.1.0 squash into dev
2. Then start using the canonical dev → main release flow

A separate task should kick off the historical sync for v1.2.0, v1.3.0, v2.0.0 squashes that never made it back to dev (the `/release-sync` skill handles N=1 at a time; can be looped).

## Skip markers

- `<!-- private-refs: allow -->` — `yard.apexscript.com` (framework's marketing domain) recurring false-positive on `apexscript` token. Same exception used by every v2.x.x release PR.
- `<!-- multi-close: approved -->` — defensive habit for release PRs. Single `Closes` line here (#408); #403 + #404 already auto-closed on PR #405 + #406 merges to dev.
- `<!-- agdr: not-applicable -->` — release PRs are pure version-cuts. Underlying feature (#403) shipped with AgDR-0052 in its own PR.

## Testing

- [x] `bash .claude/hooks/tests/test_site_counts.sh` — PASS (55 skills now actual; site copy updated to match via the #406 cherry-pick)
- [x] `git log upstream/main..HEAD` shows exactly 3 commits (2 cherry-picks + CHANGELOG/version bump)
- [x] `find .claude/skills -maxdepth 1 -type d | wc -l` returns 55 (was 54 on v2.0.2; +1 for `/release-sync`)
- [x] CHANGELOG `## [2.1.0]` section structured parallel to `## [2.0.2]` directly below
- [x] Site version link updated `v2.0.2` → `v2.1.0`
- [ ] Netlify deploy preview surfaces from this PR — visual mobile check
- [ ] After merge: `v2.1.0` tag pushed to `upstream/main`
- [ ] After merge: GitHub Release created with CHANGELOG section
- [ ] After merge: drift banner on adopters' forks fires on next session

## Glossary

| Term | Definition |
|------|------------|
| MINOR bump | Semver second-position increment (X.**Y**+1.0). Triggered by `feat:` commits — new functionality, no breaking changes. |
| Cherry-pick release path | Branch off `upstream/main`, pick specific dev commits, PR back to main. Used here because dev carries 124 commits of v1.4→v2.0 squash divergence that would conflict on a normal release. v2.1.0 is the LAST cherry-pick release — `/release-sync` ships in this PR. |
| `/release-sync` | New skill (Step 9 of `/release`). Branches from `upstream/dev`, merges `upstream/main` with `--no-ff -X ours`, opens a sync PR. Makes the release squash commit an ancestor of dev so future dev→main releases don't re-conflict. |
| `-X ours` vs `-X theirs` | Git merge strategy options. "ours" = the branch you're ON when running `merge`. Since `/release-sync` branches from dev and merges in main, "ours" = dev = correct winner (dev has the unsquashed equivalents). AgDR-0052 details the semantic. |
| Squash divergence | Each squash-merge to main creates a commit with a different SHA than the equivalent unsquashed history on dev. dev still carries the unsquashed commits unless synced back. The `/release-sync` skill prevents future accumulation. |

Closes #408
