### PR TITLE
docs(#410): add clean-code handbooks for Rex (naming, functions, structure)

### DIFF
--- a/handbooks/general/clean-code-functions.md
+++ b/handbooks/general/clean-code-functions.md
@@ -1,0 +1,115 @@
+# Handbook: Clean Code — Functions
+
+**Scope:** all PRs (handbook lives under `general/` — Rex always loads it).
+**Enforcement:** advisory.
+
+## The rule
+
+### Single Responsibility
+
+Every function must do **one thing**. If you need "and" to describe what a function does, it does too much.
+
+```ts
+// Bad: two responsibilities — validation AND persistence
+function saveUser(user: User) {
+  if (!user.email.includes('@')) throw new Error('Invalid email')
+  if (!user.name) throw new Error('Name required')
+  db.insert('users', user)
+  sendWelcomeEmail(user.email)
+}
+
+// Good: each function has one job
+function validateUser(user: User): void {
+  if (!user.email.includes('@')) throw new Error('Invalid email')
+  if (!user.name) throw new Error('Name required')
+}
+
+function persistUser(user: User): void {
+  db.insert('users', user)
+}
+
+function onboardUser(user: User): void {
+  validateUser(user)
+  persistUser(user)
+  sendWelcomeEmail(user.email)
+}
+```
+
+### Size
+
+- Functions should fit in one screen (~20–30 lines). If they don't, extract sub-functions.
+- Avoid deeply nested conditionals (>2 levels). Use early returns (guard clauses) to flatten nesting.
+
+```ts
+// Bad: 3 levels of nesting
+function processOrder(order: Order) {
+  if (order) {
+    if (order.items.length > 0) {
+      if (order.isPaid) {
+        fulfillOrder(order)
+      }
+    }
+  }
+}
+
+// Good: guard clauses
+function processOrder(order: Order) {
+  if (!order) return
+  if (order.items.length === 0) return
+  if (!order.isPaid) return
+  fulfillOrder(order)
+}
+```
+
+### Arguments
+
+- Prefer **≤ 3 parameters**. More than 3 is a signal the function is doing too much, or that a parameter object is warranted.
+- Use a named options object when parameters exceed 3 or when their order is non-obvious.
+- Use rest parameters (`...args`) for genuinely variadic functions.
+
+```ts
+// Bad: 5 positional args — order is easy to mix up
+function createInvoice(studentId, amount, dueDate, currency, notes) { ... }
+
+// Good: named options object
+function createInvoice({ studentId, amount, dueDate, currency, notes }: InvoiceOptions) { ... }
+```
+
+### Reusability
+
+- Extract repeated logic into a shared function the moment it appears a second time.
+- Never hardcode values that change between contexts — accept them as parameters or import from a single constants file.
+- Functions that handle a class of inputs are more valuable than functions that handle one specific case.
+
+### Consistent Style
+
+Apply the same function declaration style within a module. If you use arrow functions for service methods, use them throughout. Mixing `function foo()` and `const foo = () =>` in the same file without a clear rule is noise.
+
+## Why
+
+Small, single-purpose functions are the unit of reuse. They are independently testable, independently readable, and independently replaceable. A function that does three things can only be tested as a bundle of three things — a bug anywhere forces you to understand all three before you can fix one.
+
+Guard clauses eliminate the "Christmas tree" nesting pattern that forces readers to track indentation depth as a proxy for logic depth.
+
+## What Rex flags
+
+1. **Functions longer than ~40 lines** without an obvious structural reason (e.g. a long but flat switch/case).
+2. **Nesting depth > 2** — three or more levels of `if`/`for`/`try` nested inside each other.
+3. **Functions with > 3 positional parameters** not wrapped in an options object.
+4. **Duplicated logic blocks** — the same 3+ line sequence appearing in two or more places without extraction.
+5. **Functions described with "and" in a comment** — a clear signal of double responsibility.
+6. **Hardcoded values** (magic numbers, magic strings) that should be constants or parameters.
+
+## Sample findings
+
+> **Function size** — `processEnrollment()` is 78 lines and handles validation, fee calculation, section assignment, and notification. Extract each concern into its own function (`validateEnrollmentRequest`, `calculateEnrollmentFee`, `assignStudentToSection`, `notifyEnrollmentSuccess`) and have `processEnrollment` orchestrate them.
+
+> **Nesting depth** — Three levels of `if` nesting inside `handleAttendance()` makes the happy path hard to follow. Flatten with guard clauses: return early on each invalid condition and keep the main logic at the top level.
+
+> **Hardcoded value** — `if (absences > 10)` on line 34 is a magic number. Extract to a named constant: `const MAX_ALLOWED_ABSENCES = 10`.
+
+## What's NOT a violation
+
+- A function that is long because it contains a flat, exhaustive `switch` statement or lookup table — length here is data, not complexity.
+- A small utility lambda (1–3 lines) defined inline at the call site when it is used exactly once and extracting it would create more indirection than clarity.
+- Two functions that share similar structure but operate on genuinely different data shapes — not every similarity is duplication.

--- a/handbooks/general/clean-code-naming.md
+++ b/handbooks/general/clean-code-naming.md
@@ -1,0 +1,54 @@
+# Handbook: Clean Code — Naming
+
+**Scope:** all PRs (handbook lives under `general/` — Rex always loads it).
+**Enforcement:** advisory.
+
+## The rule
+
+Names are the primary communication layer of code. Every identifier — variable, function, class, module, file — must answer "what is this?" without requiring the reader to trace execution.
+
+| Identifier type | Rule | Good | Bad |
+|---|---|---|---|
+| Variable | Noun describing the data it holds | `discountAmount`, `activeUsers` | `x`, `d`, `temp`, `data` |
+| Boolean variable | `is/has/can/should` prefix | `isActive`, `hasPermission`, `canRetry` | `active`, `flag`, `check` |
+| Function | Verb + noun describing the action and subject | `calculateTotalWithTax`, `fetchUserById` | `ab`, `doStuff`, `process` |
+| Class | PascalCase noun for the concept it models | `InvoiceRepository`, `StudentEnrollment` | `Mgr`, `Handler`, `Util` |
+| Constant | SCREAMING_SNAKE_CASE for true constants | `MAX_RETRY_COUNT`, `DEFAULT_PAGE_SIZE` | `n`, `val`, `MAGIC_123` |
+| Event handler | `handle` + event | `handleSubmit`, `handlePaymentFailed` | `click`, `onEvent`, `fn` |
+
+**Single-letter names** are only acceptable for:
+- Loop counters: `i`, `j`, `k`
+- Well-understood math conventions in a clearly scoped block: `x`, `y` in a coordinate transform
+
+**Abbreviations**: only use them if they are universally understood in the domain (`id`, `url`, `api`, `db`). Never invent abbreviations (`usrCnt`, `invItm`, `pmtAmt`).
+
+**Case consistency**: pick one convention per identifier class and apply it uniformly across the entire file and module. Never mix `camelCase` and `snake_case` for the same kind of identifier in the same module.
+
+## Why
+
+Descriptive names eliminate the need to hold mental state while reading. When a reader sees `discountAmount` they know what it is, where it comes from, and roughly what values it takes. When they see `d` they must trace backwards. The cognitive load compounds — a function with 4 single-letter variables forces the reader to maintain a private symbol table in working memory throughout.
+
+## What Rex flags
+
+1. **Single-letter or two-letter variable names** outside of loop counters and math conventions (e.g. `let x = getUser()`, `const d = new Date()`).
+2. **Meaningless generic names** — `data`, `result`, `temp`, `value`, `item`, `obj`, `info`, `stuff`, `thing`.
+3. **Negated booleans** — `notActive`, `isNotValid`. Prefer `isInactive`, `isInvalid`.
+4. **Function names with no verb** — `userData()`, `total()`, `list()`.
+5. **Inconsistent casing** — a module using both `camelCase` and `snake_case` for variables of the same kind.
+6. **Invented abbreviations** — `usrCnt`, `invItm`, `pmtAmt`.
+
+## Sample findings
+
+> **Naming** — `const d = await getUser(userId)` uses a single-letter variable. Rename to `user` so the reader doesn't need to scroll up to know what `d` represents.
+
+> **Naming** — `function data()` has no verb. Rename to describe the action: `fetchDashboardData()`, `loadStudentData()`, etc.
+
+> **Naming** — `isNotVerified` is a negated boolean. Prefer `isUnverified` so the positive case reads naturally: `if (isUnverified)` instead of `if (isNotVerified)`.
+
+## What's NOT a violation
+
+- `i`, `j`, `k` as loop indices.
+- `e` as an event parameter in a short, immediately-used handler: `btn.addEventListener('click', e => e.preventDefault())`.
+- `id`, `url`, `api`, `db`, `dto` — domain-standard abbreviations whose meaning is unambiguous.
+- Short lambda parameters when the function is a one-liner and the type is clear from context: `users.filter(u => u.isActive)`.
+- File names that are intentionally terse by convention: `index.ts`, `types.ts`, `utils.ts`.

--- a/handbooks/general/clean-code-structure.md
+++ b/handbooks/general/clean-code-structure.md
@@ -1,0 +1,126 @@
+# Handbook: Clean Code — Structure, Comments & Data
+
+**Scope:** all PRs (handbook lives under `general/` — Rex always loads it).
+**Enforcement:** advisory.
+
+## The rule
+
+### Comments — explain WHY, never WHAT
+
+Code already shows WHAT it does. Comments exist for the WHY — the non-obvious constraint, the business rule, the workaround, the gotcha.
+
+```ts
+// Bad: restates the code
+// increment the counter
+counter++
+
+// Bad: explains WHAT, which the code already shows
+// filter active users from the list
+const activeUsers = users.filter(u => u.isActive)
+
+// Good: explains WHY — the rule that isn't obvious from the code
+// students on academic probation are excluded from the honour roll
+// even if their current GPA qualifies them (policy: Board resolution 2024-03)
+const eligibleStudents = students.filter(s => !s.isOnProbation && s.gpa >= HONOUR_ROLL_GPA)
+```
+
+**Comment density**: a file where every other line has a comment is under-expressed in code, not well-documented. If you feel the need to explain WHAT, improve the name instead.
+
+**Inline documentation** (JSDoc / TSDoc): required on public API surfaces — exported functions, service methods, and types consumed outside the module. Not required on internal helpers.
+
+### Single Source of Truth
+
+Configuration, thresholds, feature flags, and shared constants must live in **one place**. Duplication means divergence.
+
+```ts
+// Bad: the same value in two places
+// invoiceService.ts
+if (amount > 10000) requireManagerApproval()
+
+// paymentService.ts
+if (totalCharge > 10000) flagForReview()   // <-- will drift
+
+// Good: one source
+// constants/finance.ts
+export const MANAGER_APPROVAL_THRESHOLD = 10_000
+
+// invoiceService.ts + paymentService.ts both import from constants/finance.ts
+```
+
+### Data Exposure — expose only what is needed
+
+Avoid passing entire objects when only a few fields are required. Use destructuring to make the dependency explicit. Hiding internal state protects the caller from implementation details and narrows the surface for bugs.
+
+```ts
+// Bad: passes the whole session object; callee depends on an invisible contract
+function renderUserMenu(session: Session) {
+  return `Hello, ${session.user.profile.displayName}`
+}
+
+// Good: callee only needs the name
+function renderUserMenu({ displayName }: { displayName: string }) {
+  return `Hello, ${displayName}`
+}
+```
+
+### Folder / Module Structure
+
+Organise by **feature**, not by file type.
+
+```
+// Bad: file-type organisation — forces cross-folder jumps for every feature
+/components/StudentCard.tsx
+/components/InvoiceCard.tsx
+/services/studentService.ts
+/services/invoiceService.ts
+
+// Good: feature organisation — everything for a feature is co-located
+/students/StudentCard.tsx
+/students/studentService.ts
+/invoices/InvoiceCard.tsx
+/invoices/invoiceService.ts
+```
+
+Each module/folder should have a clear, bounded responsibility. If you cannot describe a module's purpose in one sentence without using "and", split it.
+
+### Formatting Consistency
+
+- Indentation, spacing, quote style, and semicolons are enforced by the project formatter (Prettier / ESLint). Run the formatter before committing — do not hand-format.
+- Keep operator spacing consistent: `a + b`, not `a+b`.
+- One blank line between logical sections within a function; two blank lines between top-level declarations.
+
+## Why
+
+**Comments**: stale comments that contradict the code are worse than no comments. Keeping them to the WHY ensures they remain accurate even when the code around them changes.
+
+**Single source of truth**: every duplication is a future inconsistency. When a threshold changes in one place but not another, the bug is invisible until it hits production.
+
+**Data exposure**: a function that depends on a whole object is implicitly coupled to every field of that object. Narrowing to only what's needed makes the dependency graph visible and reduces the blast radius of refactors.
+
+**Feature-based structure**: when a developer works on the Student feature, they should be able to stay in one folder. File-type structure forces constant context-switching across the tree.
+
+## What Rex flags
+
+1. **WHAT comments** — comments that explain what the code does rather than why it does it (`// loop through users`, `// return the result`).
+2. **Commented-out code** — dead code left as comments. Delete it; git history preserves it.
+3. **Duplicated constants or thresholds** — the same magic number or string literal appearing in more than one file without a shared source.
+4. **Whole-object parameter passing** when only 1–2 fields are used inside the function.
+5. **Cross-module imports that break feature boundaries** — a finance module importing directly from an internal SIS helper instead of a shared interface.
+6. **TODO comments older than one sprint** without a linked ticket — either create a ticket or remove the comment.
+
+## Sample findings
+
+> **Comment quality** — `// loop through students and calculate average` on line 45 describes WHAT the code does. The code already shows that. Remove the comment or replace it with WHY: e.g. `// weighted average required because elective subjects carry half the credit value`.
+
+> **Commented-out code** — Lines 67–74 are commented out. If this code is no longer needed, delete it — git history preserves it. If it's needed conditionally, extract it behind a flag or a separate function.
+
+> **Single source of truth** — The value `30` (representing the maximum absence threshold) appears on lines 12, 89, and 134 in three different files. Extract to `constants/attendance.ts` as `MAX_ABSENCES_BEFORE_ALERT = 30` and import from there.
+
+> **Data exposure** — `generateReport(enrollment: Enrollment)` uses only `enrollment.studentId` and `enrollment.termId` inside the function body. Change the signature to `generateReport({ studentId, termId }: Pick<Enrollment, 'studentId' | 'termId'>)` to make the dependency explicit.
+
+## What's NOT a violation
+
+- Section-header comments in long files to aid navigation (`// --- Validation ---`, `// --- Persistence ---`) when the file cannot be reasonably split further.
+- TODOs tied to a real open ticket: `// TODO(#234): replace with batch API when endpoint is ready`.
+- JSDoc on exported public API functions — always welcome, never excessive.
+- Commented-out code in a PR that explicitly removes the feature and keeps the comment temporarily as context during review — remove before merge.


### PR DESCRIPTION
## Summary
- Add three advisory Rex-consumed handbooks distilled from the FreeCodeCamp "How to Write Clean Code" article
- `handbooks/general/clean-code-naming.md` — identifier naming rules, boolean prefixes, case consistency, banned abbreviations
- `handbooks/general/clean-code-functions.md` — SRP, guard clauses, ≤3 args, reusability, duplication extraction
- `handbooks/general/clean-code-structure.md` — WHY-only comments, single source of truth, minimal data exposure, feature-based folders

## Testing
- [ ] All three files present under `handbooks/general/`
- [ ] Each follows the standard handbook format (rule / why / what Rex flags / sample findings / not a violation)
- [ ] All three carry `Enforcement: advisory`
- [ ] Rex loads them on every PR review (`general/` is always-loaded per `handbooks/README.md`)
- [ ] No framework code changed — handbook additions only

Closes #410

---

## Glossary
| Term | Definition |
|------|------------|
| Rex | The Code Reviewer agent that performs automated first-pass PR review |
| Handbook | A markdown file under `handbooks/` that Rex consults during review |
| Advisory enforcement | Rex surfaces findings as suggestions; the PR can still merge if other gates pass |
| SRP | Single Responsibility Principle — every function/class should have one reason to change |
| Guard clause | An early return at the top of a function that handles the edge case, flattening nesting |

🤖 Generated with [Claude Code](https://claude.com/claude-code)