### PR TITLE
feat(#418): enforce MCP search-first pattern

### DIFF
--- a/.claude/hooks/remind-mcp-tools.sh
+++ b/.claude/hooks/remind-mcp-tools.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# SessionStart hook: reminds the agent to load MCP search tools at the
+# start of every session. The tools are deferred (require ToolSearch to
+# load schemas), which creates friction that causes agents to default to
+# grep+Read instead.
+#
+# This banner is the cheapest possible fix for the deferred-tool friction
+# problem — it puts the load command in the agent's context at session
+# start so it doesn't have to remember to do it.
+#
+# Silent when: no MCP config exists (no .mcp.json at ops root or portfolio
+# root — the MCP tools aren't set up, so reminding is pointless).
+#
+# See: me2resh/apexyard#418
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$REPO_ROOT" ] || exit 0
+
+# Check if MCP is configured — look for .mcp.json in the repo root or
+# the ops root (portfolio walkers may land us in a different root)
+mcp_configured=false
+r="$REPO_ROOT"
+while [ -n "$r" ] && [ "$r" != "/" ]; do
+  if [ -f "$r/.mcp.json" ]; then
+    mcp_configured=true
+    break
+  fi
+  r=$(dirname "$r")
+done
+
+$mcp_configured || exit 0
+
+cat >&2 <<'BANNER'
+
+📎 MCP search tools available (apexyard-search). Load before your first lookup:
+   ToolSearch("select:mcp__apexyard-search__search_docs,mcp__apexyard-search__search_code,mcp__apexyard-search__reindex")
+
+   Use search_docs for framework questions, search_code for project code.
+   Fall back to grep+Read only when MCP results don't answer the question.
+
+BANNER
+
+exit 0

--- a/.claude/hooks/suggest-mcp-search.sh
+++ b/.claude/hooks/suggest-mcp-search.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Advisory hook: reminds the agent to try MCP search tools (search_docs,
+# search_code) before falling back to grep+Read for codebase exploration.
+#
+# Fires on PreToolUse for Bash when the command matches grep/find patterns
+# that target framework or project paths. Non-blocking (exit 0 always).
+#
+# The MCP vector search returns targeted excerpts from indexed chunks,
+# saving ~3-5x tokens compared to reading full files via grep+Read.
+#
+# Wired to: PreToolUse → Bash (no `if` matcher — checks command internally)
+# See: me2resh/apexyard#418
+
+set -u
+
+INPUT=$(cat)
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -n "$COMMAND" ] || exit 0
+
+# --- Detect grep/find patterns that MCP could serve better ----------------
+
+is_search_command=false
+
+case "$COMMAND" in
+  grep\ -r*|grep\ -rn*|grep\ --include*|grep\ -l*)
+    is_search_command=true ;;
+  *"| grep"*)
+    is_search_command=true ;;
+esac
+
+if echo "$COMMAND" | grep -qE '^find .+ -name .+\.(md|yaml|yml|ts|tsx|js|py)'; then
+  is_search_command=true
+fi
+
+$is_search_command || exit 0
+
+# --- Check if the search targets framework or project paths ---------------
+
+targets_framework=false
+
+framework_patterns=(
+  ".claude/"
+  "roles/"
+  "workflows/"
+  "templates/"
+  "docs/agdr"
+  "handbooks/"
+  "skills/"
+  "hooks/"
+  "topologies/"
+  "golden-paths/"
+)
+
+for pattern in "${framework_patterns[@]}"; do
+  if echo "$COMMAND" | grep -q "$pattern"; then
+    targets_framework=true
+    break
+  fi
+done
+
+# Also check for workspace/ or projects/ (managed project code)
+if echo "$COMMAND" | grep -qE '(workspace/|projects/)'; then
+  targets_framework=true
+fi
+
+$targets_framework || exit 0
+
+# --- Emit advisory banner ------------------------------------------------
+
+cat >&2 <<'BANNER'
+
+💡 MCP search available — consider using it before grep+Read:
+
+  • search_docs  — framework docs (skills, roles, handbooks, AgDRs, workflows)
+  • search_code  — managed project codebases (workspace clones)
+
+MCP returns targeted excerpts and saves ~3-5x tokens vs reading full files.
+Load with: ToolSearch("select:mcp__apexyard-search__search_docs,mcp__apexyard-search__search_code")
+
+BANNER
+
+exit 0

--- a/.claude/hooks/suggest-mcp-search.sh
+++ b/.claude/hooks/suggest-mcp-search.sh
@@ -26,7 +26,7 @@ COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/nul
 is_search_command=false
 
 case "$COMMAND" in
-  grep\ -r*|grep\ -rn*|grep\ --include*|grep\ -l*)
+  grep\ -rn*|grep\ -r*|grep\ --include*|grep\ -l*)
     is_search_command=true ;;
   *"| grep"*)
     is_search_command=true ;;

--- a/.claude/hooks/tests/test_suggest_mcp_search.sh
+++ b/.claude/hooks/tests/test_suggest_mcp_search.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Tests for suggest-mcp-search.sh advisory hook
+# Run: bash .claude/hooks/tests/test_suggest_mcp_search.sh
+
+set -u
+
+HOOK="$(cd "$(dirname "$0")/.." && pwd)/suggest-mcp-search.sh"
+PASS=0
+FAIL=0
+
+run_hook() {
+  echo "$1" | bash "$HOOK" 2>&1
+}
+
+assert_banner() {
+  local desc="$1" input="$2"
+  local output
+  output=$(run_hook "$input")
+  if echo "$output" | grep -q "MCP search available"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc — expected banner, got: $output"
+  fi
+}
+
+assert_no_banner() {
+  local desc="$1" input="$2"
+  local output
+  output=$(run_hook "$input")
+  if [ -z "$output" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc — expected no output, got: $output"
+  fi
+}
+
+# --- Should fire (grep on framework paths) ---
+
+assert_banner "grep -r on roles/" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"activation\" roles/"}}'
+
+assert_banner "grep -rn on .claude/hooks/" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -rn \"require-active\" .claude/hooks/"}}'
+
+assert_banner "grep on workflows/" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"SDLC\" workflows/"}}'
+
+assert_banner "grep on docs/agdr" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"migration\" docs/agdr/"}}'
+
+assert_banner "grep on handbooks/" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -l \"blocking\" handbooks/"}}'
+
+assert_banner "grep on workspace/" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -rn \"export\" workspace/yumyum/backend/src/"}}'
+
+assert_banner "find on templates/" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"find templates/ -name \"*.md\""}}'
+
+assert_banner "piped grep on skills/" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"cat skills/debug/SKILL.md | grep hypothesis"}}'
+
+# --- Should NOT fire ---
+
+assert_no_banner "grep on non-framework path" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"TODO\" src/"}}'
+
+assert_no_banner "non-Bash tool" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"roles/engineering/tech-lead.md"}}'
+
+assert_no_banner "non-grep bash command" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"npm test"}}'
+
+assert_no_banner "git command" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git log --oneline -5"}}'
+
+assert_no_banner "grep on random dir" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"error\" /var/log/"}}'
+
+# --- Results ---
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,10 @@
           {
             "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/apply-agent-routing.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/remind-mcp-tools.sh\"'"
           }
         ]
       }
@@ -200,6 +204,10 @@
           {
             "type": "command",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/suggest-mcp-search.sh\"'"
           },
           {
             "type": "command",


### PR DESCRIPTION
## Summary

- **Advisory hook `suggest-mcp-search.sh`** — fires on `PreToolUse` for `Bash` when `grep -r`/`find` targets framework or project paths (roles/, workflows/, handbooks/, .claude/, workspace/, etc.). Emits a non-blocking banner reminding the agent to try MCP `search_docs`/`search_code` first, saving ~3-5x tokens per lookup.
- **Session-start hook `remind-mcp-tools.sh`** — emits the `ToolSearch` load command at session start so MCP tools are in context from the beginning, removing deferred-tool friction that was the primary root cause of underuse.
- **Wired both hooks** in `.claude/settings.json` — SessionStart for the reminder, PreToolUse Bash for the advisory.

## Testing

1. `bash .claude/hooks/tests/test_suggest_mcp_search.sh` — 13 cases (8 should-fire, 5 should-not), all pass
2. Start a new session → MCP reminder banner appears with ToolSearch command
3. Run `grep -r "activation" roles/` → advisory banner fires
4. Run `npm test` → no banner (non-framework path)

## Glossary

| Term | Definition |
|------|------------|
| MCP | Model Context Protocol — the protocol Claude Code uses to communicate with external tool servers like the apexyard-search vector index |
| Deferred tool | A tool whose schema isn't loaded at session start; requires a `ToolSearch` call to activate, creating friction vs always-available tools like `grep` |
| Advisory hook | A hook that emits guidance (exit 0 always) but never blocks the underlying tool call — same shape as `detect-role-trigger.sh` |

Refs #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)