### PR TITLE
fix(#419): bootstrap exemption scope guard

### DIFF
--- a/.claude/hooks/tests/test_warn_bootstrap_scope.sh
+++ b/.claude/hooks/tests/test_warn_bootstrap_scope.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/warn-bootstrap-scope.sh — verifies the
+# advisory banner fires exactly when the bootstrap marker is active AND the
+# commit message does not reference handover output.
+#
+# Test layout (6+ cases):
+#
+#   1. Bootstrap marker exists + non-bootstrap commit message  → should WARN
+#   2. Bootstrap marker exists + "handover" commit message     → should NOT warn
+#   3. Bootstrap marker exists + "registry" commit message     → should NOT warn
+#   4. No bootstrap marker + any commit message                → should NOT warn
+#   5. Bootstrap marker exists + "assessment" commit message   → should NOT warn
+#   6. Non-Bash tool name                                      → should NOT fire
+#   7. Bootstrap marker + "architecture" commit message        → should NOT warn
+#   8. Bootstrap marker + "topology" commit message            → should NOT warn
+#   9. Bootstrap marker + non-git command                      → should NOT fire
+#  10. Bootstrap marker exists + non-bootstrap commit (double- → should WARN
+#      quoted -m)
+#
+# Each case pipes a synthetic hook payload into the script and asserts:
+#   - exit code is 0 (advisory only — never blocks)
+#   - stderr matches the expected banner (or is silent when no trigger applies)
+#
+# Test style matches the existing tests/*.sh — bash + jq + grep, no external
+# test framework.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK="$SRC_ROOT/.claude/hooks/warn-bootstrap-scope.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook is not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED=""
+
+# Helpers -----------------------------------------------------------------------
+
+# Temporary directory for the fake bootstrap marker.
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+# Path the hook will look for: .claude/session/active-bootstrap under
+# the fake git root.  We create a minimal git repo structure so that
+# `git rev-parse --show-toplevel` resolves to $TMPDIR_WORK.
+FAKE_ROOT="$TMPDIR_WORK/repo"
+mkdir -p "$FAKE_ROOT/.git" "$FAKE_ROOT/.claude/session"
+git -C "$FAKE_ROOT" init -q 2>/dev/null || true
+
+# On macOS /tmp is a symlink to /private/var/... — canonicalise so that
+# the path written to MARKER matches what `git rev-parse --show-toplevel`
+# returns from inside the directory.
+if command -v realpath >/dev/null 2>&1; then
+  FAKE_ROOT=$(realpath "$FAKE_ROOT")
+elif command -v python3 >/dev/null 2>&1; then
+  FAKE_ROOT=$(python3 -c "import os; print(os.path.realpath('$FAKE_ROOT'))")
+else
+  # Fallback: cd into the dir and capture the physical pwd.
+  FAKE_ROOT=$(cd -P "$FAKE_ROOT" && pwd)
+fi
+
+MARKER="$FAKE_ROOT/.claude/session/active-bootstrap"
+
+set_marker() {
+  printf '%s' "handover" > "$MARKER"
+}
+
+clear_marker() {
+  rm -f "$MARKER"
+}
+
+# run_case <label> <expected_rc> <expect_banner:yes|no> <json_input>
+#
+# Runs the hook with the given JSON input (piped via stdin).
+# The hook must be called with GIT_DIR and PWD set so that
+# `git rev-parse --show-toplevel` returns FAKE_ROOT — achieved by
+# invoking via `bash -c "cd $FAKE_ROOT && exec $HOOK"` with stdin piped.
+run_case() {
+  local label="$1" want_rc="$2" expect_banner="$3" input="$4"
+  local got_stderr got_rc
+
+  got_stderr=$(printf '%s' "$input" | bash -c "cd '$FAKE_ROOT' && exec '$HOOK'" 2>&1 >/dev/null)
+  got_rc=$?
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:200})" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "; return
+  fi
+
+  if [ "$expect_banner" = "yes" ]; then
+    if printf '%s' "$got_stderr" | grep -q "Bootstrap exemption is active"; then
+      echo "PASS [$label] — banner emitted"
+      PASS=$((PASS+1)); return
+    fi
+    echo "FAIL [$label]: expected advisory banner, got: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "; return
+  fi
+
+  # expect_banner = no
+  if [ -z "$got_stderr" ]; then
+    echo "PASS [$label] — silent"
+    PASS=$((PASS+1)); return
+  fi
+  echo "FAIL [$label]: expected silent, got: $got_stderr" >&2
+  FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+}
+
+# --- 1. Bootstrap marker + non-bootstrap commit message → should WARN ---------
+
+set_marker
+in=$(jq -nc \
+  --arg c "git commit -m 'style: update palette colours to match brand'" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "marker + non-bootstrap commit → warns" 0 "yes" "$in"
+
+# --- 2. Bootstrap marker + handover commit message → should NOT warn ----------
+
+set_marker
+in=$(jq -nc \
+  --arg c "git commit -m 'chore: add handover assessment for legacy-billing-api'" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "marker + handover commit → silent" 0 "no" "$in"
+
+# --- 3. Bootstrap marker + registry commit message → should NOT warn ----------
+
+set_marker
+in=$(jq -nc \
+  --arg c "git commit -m 'chore: append legacy-billing-api to registry'" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "marker + registry commit → silent" 0 "no" "$in"
+
+# --- 4. No bootstrap marker + any commit message → should NOT warn ------------
+
+clear_marker
+in=$(jq -nc \
+  --arg c "git commit -m 'style: update palette colours to match brand'" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "no marker + non-bootstrap commit → silent" 0 "no" "$in"
+
+# --- 5. Bootstrap marker + assessment commit message → should NOT warn --------
+
+set_marker
+in=$(jq -nc \
+  --arg c "git commit -m 'chore: write handover assessment for marketing-site'" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "marker + assessment commit → silent" 0 "no" "$in"
+
+# --- 6. Non-Bash tool → should NOT fire at all --------------------------------
+
+set_marker
+in=$(jq -nc \
+  --arg cmd "git commit -m 'style: update palette'" \
+  '{tool_name:"Edit", tool_input:{file_path:"src/index.ts"}}')
+run_case "non-Bash tool → silent" 0 "no" "$in"
+
+# --- 7. Bootstrap marker + architecture commit → should NOT warn --------------
+
+set_marker
+in=$(jq -nc \
+  --arg c "git commit -m 'chore: add architecture container stub for billing-api'" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "marker + architecture commit → silent" 0 "no" "$in"
+
+# --- 8. Bootstrap marker + topology commit → should NOT warn ------------------
+
+set_marker
+in=$(jq -nc \
+  --arg c "git commit -m 'chore: instantiate typescript-nextjs topology for marketing-site'" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "marker + topology commit → silent" 0 "no" "$in"
+
+# --- 9. Bootstrap marker + non-git command → should NOT fire ------------------
+
+set_marker
+in=$(jq -nc \
+  --arg c "npm run build" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "marker + non-git command → silent" 0 "no" "$in"
+
+# --- 10. Bootstrap marker + non-bootstrap commit (double-quoted -m) → warn ----
+
+set_marker
+in=$(jq -nc \
+  --arg c 'git commit -m "feat: add dark mode toggle to settings page"' \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "marker + non-bootstrap double-quoted commit → warns" 0 "yes" "$in"
+
+# --- Non-blocking guarantee ---------------------------------------------------
+# Even when the hook fires, exit code is 0 — the underlying tool call proceeds.
+
+set_marker
+in=$(jq -nc \
+  --arg c "git commit -m 'style: unrelated change'" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+got_rc=$(printf '%s' "$in" | bash -c "cd '$FAKE_ROOT' && exec '$HOOK'" >/dev/null 2>&1; echo $?)
+if [ "$got_rc" = "0" ]; then
+  echo "PASS [non-blocking: hook exits 0 even when banner fires]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [non-blocking: expected rc=0, got $got_rc]" >&2
+  FAIL=$((FAIL+1)); FAILED="${FAILED}non-blocking "
+fi
+
+# --- Summary ------------------------------------------------------------------
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/warn-bootstrap-scope.sh
+++ b/.claude/hooks/warn-bootstrap-scope.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# PreToolUse advisory hook on `git commit`: fires when the bootstrap
+# exemption marker is active (.claude/session/active-bootstrap) but the
+# commit message does NOT reference expected handover outputs.
+#
+# The bootstrap exemption is intentionally narrow — it covers only the
+# registry, assessment, architecture stub, README, and topology files
+# written by /handover, /setup, /update, and /split-portfolio. If the
+# agent commits something unrelated while the marker is set, that is
+# scope-creep and warrants an advisory warning.
+#
+# Resolution: .claude/rules/workflow-gates.md § Bootstrap-skill exemption
+# and .claude/skills/handover/SKILL.md § "Bootstrap scope".
+#
+# This hook is ADVISORY ONLY — exit 0 in every path. It never blocks.
+# Shape mirrors check-upstream-drift.sh and detect-role-trigger.sh.
+
+set -u
+
+INPUT=$(cat)
+
+# Only act on Bash tool calls.
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Only inspect git commit commands.
+if ! printf '%s' "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
+  exit 0
+fi
+
+# Only warn when the bootstrap marker is active.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+MARKER="$REPO_ROOT/.claude/session/active-bootstrap"
+if [ ! -f "$MARKER" ]; then
+  exit 0
+fi
+
+# Extract commit message from -m or -F flags (same pattern as
+# validate-commit-format.sh). If the message cannot be extracted (e.g.
+# heredoc substitution, interactive commit), exit 0 — we can't check.
+COMMAND_FLAT=$(printf '%s' "$COMMAND" | tr '\n' ' ')
+MSG=""
+MSG=$(printf '%s' "$COMMAND_FLAT" | sed -nE "s/.*-m[[:space:]]+'([^']*)'.*/\1/p" | head -1)
+if [ -z "$MSG" ]; then
+  MSG=$(printf '%s' "$COMMAND_FLAT" | sed -nE 's/.*-m[[:space:]]+"([^"]*)".*/\1/p' | head -1)
+fi
+if [ -z "$MSG" ]; then
+  MSG_FILE=$(printf '%s' "$COMMAND_FLAT" | sed -nE 's/.*(-F|--file)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
+  if [ -n "$MSG_FILE" ] && [ -f "$MSG_FILE" ]; then
+    MSG=$(cat "$MSG_FILE")
+  fi
+fi
+
+if [ -z "$MSG" ]; then
+  # Can't read the message (heredoc / interactive) — advisory can't run.
+  exit 0
+fi
+
+# Check whether the commit message contains keywords that belong to
+# the expected set of handover outputs. Case-insensitive grep.
+#
+# Bootstrap-related keywords are intentionally specific to avoid false
+# positives on common verbs like "update" or "setup":
+#
+#   handover-assessment, handover       — /handover skill output
+#   apexyard.projects.yaml, registry    — registry append (step 7)
+#   architecture/container, architecture stub — C4 diagram stub
+#   topology                            — topology bundle instantiation
+#   /setup, /update, /split-portfolio   — other bootstrap skills
+#   projects/<path>                     — ops-repo projects/ dir writes
+#   active-bootstrap                    — the marker file itself
+if printf '%s' "$MSG" | grep -qiE \
+  'handover|apexyard\.projects\.yaml|registry|architecture.?(stub|container)|topology|/setup|/update|split.?portfolio|projects/|active-bootstrap'; then
+  # Commit looks related to bootstrap work — no warning.
+  exit 0
+fi
+
+# The marker is active but the commit message doesn't reference any known
+# bootstrap output. Emit an advisory banner.
+cat >&2 <<'BANNER'
+⚠ Bootstrap exemption is active but this commit doesn't reference handover output.
+  If this work is unrelated to the handover, run /start-ticket first.
+BANNER
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -115,6 +115,11 @@
           },
           {
             "type": "command",
+            "if": "Bash(git commit *)",
+            "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/warn-bootstrap-scope.sh\"'"
+          },
+          {
+            "type": "command",
             "if": "Bash(git push *)",
             "command": "bash -c 'r=$PWD;while [ ! -f \"$r/.apexyard-fork\" ] && [ ! -f \"$r/onboarding.yaml\" ] && [ -n \"$r\" ] && [ \"$r\" != / ];do r=${r%/*};done;[ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ] || exit 0;exec \"$r/.claude/hooks/block-agent-routing-drift.sh\"'"
           },

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -67,6 +67,21 @@ mkdir -p .claude/session && echo "handover" > .claude/session/active-bootstrap
 
 Clear the marker on completion (Step "Post-Handover Checklist" below). If the skill is interrupted, the SessionStart hook `clear-bootstrap-marker.sh` clears it at the start of the next session. See AgDR-0011 + me2resh/apexyard#150.
 
+### Bootstrap scope — what IS and IS NOT exempt
+
+The bootstrap exemption covers ONLY these writes:
+- `apexyard.projects.yaml` — registry append (step 7)
+- `projects/<name>/` — assessment, architecture stub, README (steps 5, 6)
+- `.claude/session/active-bootstrap` — the marker itself (step 0)
+- Topology instantiation files (step 5.5, if a topology is picked)
+
+It does NOT cover:
+- Palette changes, UI work, or any other user request made during the session
+- Creating or pushing new repositories
+- Commits to branches without a ticket
+
+If the user requests work outside the handover's scope mid-session, tell them: "That's outside the handover's bootstrap exemption — let me /start-ticket first." Then follow the normal SDLC: ticket → branch → PR → review.
+
 ### 1. Locate the target repo
 
 If a path is given, use it. If a URL is given, prompt the user to clone it into `workspace/<name>/` first (don't clone automatically — that's a side-effect with cost). If nothing is given, ask:


### PR DESCRIPTION
## Summary

- **Explicit scope section in /handover SKILL.md** — enumerates exactly which writes the bootstrap exemption covers (registry, assessment, architecture stub, topology) and explicitly states what is NOT exempt (palette changes, UI work, unrelated commits). Includes the redirect message agents should use when asked for out-of-scope work.
- **Advisory hook `warn-bootstrap-scope.sh`** — fires on `git commit` when the bootstrap marker is active but the commit message doesn't reference handover output. Emits a non-blocking banner reminding the agent to `/start-ticket` first. 11 test cases, all passing.

## Testing

1. `bash .claude/hooks/tests/test_warn_bootstrap_scope.sh` — 11 cases pass
2. During a /handover session, committing registry/assessment changes → no warning
3. During a /handover session, committing unrelated changes → advisory banner fires
4. Outside bootstrap (no marker) → no warning on any commit

## Glossary

| Term | Definition |
|------|------------|
| Bootstrap exemption | A mechanism that allows specific skills (/handover, /setup, /update, /split-portfolio) to write files without an active ticket, since they run before any tracker is configured |
| Scope creep | The failure mode where the agent extends the bootstrap exemption to cover ALL work in a session, not just the exempt skill's writes |

Refs #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)