### PR TITLE
fix(#426): merge hook handles compound marker-write + merge commands

### DIFF
--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -142,8 +142,31 @@ MSG
 fi
 
 # --- CEO marker check ---
+# If the marker file doesn't exist on disk, check whether the COMMAND
+# itself will create it (compound command: `cat > marker && gh pr merge`).
+# PreToolUse hooks fire BEFORE execution, so in a compound command the
+# marker write hasn't happened yet. We validate the inline content
+# in-memory and let the command through if it's valid. See #426.
+_INLINE_CEO_MARKER=""
 if [ ! -f "$CEO_APPROVAL" ]; then
-  cat >&2 <<MSG
+  # Look for inline marker content in the command targeting this PR's
+  # approval file. Match heredoc, printf, or echo writing to *-ceo.approved.
+  CEO_BASENAME="${PR_NUMBER}-ceo.approved"
+  if echo "$COMMAND" | grep -q "$CEO_BASENAME"; then
+    # Extract sha=, approved_by=, skill_version= from the command string.
+    _inline_sha=$(echo "$COMMAND" | grep -oE 'sha=[0-9a-f]{40}' | head -1 | cut -d= -f2)
+    _inline_approved_by=$(echo "$COMMAND" | grep -oE 'approved_by=[a-z]+' | head -1 | cut -d= -f2)
+    _inline_skill_version=$(echo "$COMMAND" | grep -oE 'skill_version=[0-9]+' | head -1 | cut -d= -f2)
+    if [ -n "$_inline_sha" ] && [ "$_inline_approved_by" = "user" ] && \
+       [ -n "$_inline_skill_version" ] && [ "$_inline_skill_version" -ge 2 ] 2>/dev/null; then
+      _INLINE_CEO_MARKER="valid"
+      CEO_SHA="$_inline_sha"
+      CEO_APPROVED_BY="$_inline_approved_by"
+      CEO_SKILL_VERSION="$_inline_skill_version"
+    fi
+  fi
+  if [ "$_INLINE_CEO_MARKER" != "valid" ]; then
+    cat >&2 <<MSG
 BLOCKED: PR #${PR_NUMBER} has Rex approval but no CEO approval marker.
 
 Plan-level "go" / "continue" / "ship it" does NOT authorize a merge. Each
@@ -164,29 +187,31 @@ To unblock:
 NEVER create this marker yourself from an umbrella "go" on a plan.
 EVER. This is the exact failure this hook exists to prevent.
 MSG
-  exit 2
+    exit 2
+  fi
 fi
 
-# Parse the structured CEO marker. Required fields (#48):
-#   sha=<40-char hex>
-#   approved_by=user
-#   skill_version=<N>  with N >= 2
-#
-# Bare-SHA legacy markers (single line, no `=`) fail the parse and are
-# rejected with a clear "stale format" message pointing at /approve-merge.
-ceo_field() {
-  # Extract value of `<key>=` from the marker, stripping surrounding quotes.
-  # Reads only the first matching line so a malformed marker with duplicates
-  # still produces a deterministic answer.
-  grep -E "^${1}=" "$CEO_APPROVAL" 2>/dev/null \
-    | head -1 \
-    | sed -E "s/^${1}=//" \
-    | sed -E 's/^"(.*)"$/\1/'
-}
+# Parse the structured CEO marker — from file unless already extracted
+# from inline command content (compound-command path, see #426 above).
+if [ "$_INLINE_CEO_MARKER" != "valid" ]; then
+  # Required fields (#48):
+  #   sha=<40-char hex>
+  #   approved_by=user
+  #   skill_version=<N>  with N >= 2
+  #
+  # Bare-SHA legacy markers (single line, no `=`) fail the parse and are
+  # rejected with a clear "stale format" message pointing at /approve-merge.
+  ceo_field() {
+    grep -E "^${1}=" "$CEO_APPROVAL" 2>/dev/null \
+      | head -1 \
+      | sed -E "s/^${1}=//" \
+      | sed -E 's/^"(.*)"$/\1/'
+  }
 
-CEO_SHA=$(ceo_field sha)
-CEO_APPROVED_BY=$(ceo_field approved_by)
-CEO_SKILL_VERSION=$(ceo_field skill_version)
+  CEO_SHA=$(ceo_field sha)
+  CEO_APPROVED_BY=$(ceo_field approved_by)
+  CEO_SKILL_VERSION=$(ceo_field skill_version)
+fi
 
 # Reject the bare-SHA legacy format. A marker with no `sha=` line is either
 # a pre-#132 plain-SHA file or something the model fabricated via raw echo

--- a/.claude/hooks/tests/test_block_unreviewed_merge.sh
+++ b/.claude/hooks/tests/test_block_unreviewed_merge.sh
@@ -273,6 +273,70 @@ else
   FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}workspace-clone-resolves-up "
 fi
 
+# --- Compound command tests (#426) ------------------------------------
+
+# Helper: run with a custom command string (not just `gh pr merge <N>`)
+run_case_custom_cmd() {
+  local label="$1" want_rc="$2" want_stderr_regex="$3" sb="$4" cmd="$5"
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:300})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# Case: compound command with valid inline marker + merge → should PASS
+sb=$(make_sandbox)
+write_rex_marker "$sb" 42
+cmd="cat > $sb/.claude/session/reviews/42-ceo.approved <<EOF
+sha=${FIXED_SHA}
+approved_by=user
+approved_at=2026-05-27T12:00:00Z
+skill_version=2
+approval_summary=test
+EOF
+gh pr merge 42 --repo me2resh/apexyard --squash"
+run_case_custom_cmd "compound-valid-inline-marker" 0 "" "$sb" "$cmd"
+
+# Case: compound command with WRONG SHA in inline marker → should BLOCK
+sb=$(make_sandbox)
+write_rex_marker "$sb" 42
+cmd="cat > $sb/.claude/session/reviews/42-ceo.approved <<EOF
+sha=${WRONG_SHA}
+approved_by=user
+skill_version=2
+EOF
+gh pr merge 42 --repo me2resh/apexyard --squash"
+run_case_custom_cmd "compound-wrong-sha-inline" 2 "CEO approved commit" "$sb" "$cmd"
+
+# Case: compound command with missing approved_by in inline → should BLOCK
+sb=$(make_sandbox)
+write_rex_marker "$sb" 42
+cmd="printf 'sha=${FIXED_SHA}\nskill_version=2\n' > $sb/.claude/session/reviews/42-ceo.approved && gh pr merge 42 --repo me2resh/apexyard --squash"
+run_case_custom_cmd "compound-missing-approved-by" 2 "no CEO approval marker" "$sb" "$cmd"
+
+# Case: compound command with skill_version=1 in inline → should BLOCK
+sb=$(make_sandbox)
+write_rex_marker "$sb" 42
+cmd="cat > $sb/.claude/session/reviews/42-ceo.approved <<EOF
+sha=${FIXED_SHA}
+approved_by=user
+skill_version=1
+EOF
+gh pr merge 42 --repo me2resh/apexyard --squash"
+run_case_custom_cmd "compound-old-skill-version" 2 "no CEO approval marker" "$sb" "$cmd"
+
 # --- Summary ----------------------------------------------------------
 
 echo ""

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -70,12 +70,14 @@ Clear the marker on completion (Step "Post-Handover Checklist" below). If the sk
 ### Bootstrap scope — what IS and IS NOT exempt
 
 The bootstrap exemption covers ONLY these writes:
+
 - `apexyard.projects.yaml` — registry append (step 7)
 - `projects/<name>/` — assessment, architecture stub, README (steps 5, 6)
 - `.claude/session/active-bootstrap` — the marker itself (step 0)
 - Topology instantiation files (step 5.5, if a topology is picked)
 
 It does NOT cover:
+
 - Palette changes, UI work, or any other user request made during the session
 - Creating or pushing new repositories
 - Commits to branches without a ticket

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -542,7 +542,7 @@ a:hover { color: var(--accent); }
 
   <rect x="394" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
   <text x="410" y="252" font-size="14" font-weight="700" fill="#1E3A5F">[~] Hooks</text>
-  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 34 shell gates</text>
+  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 35 shell gates</text>
   <text x="410" y="295" font-size="11" fill="#4A6FA5">Merge gate · ticket-first · secrets · …</text>
 
   <rect x="704" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -542,7 +542,7 @@ a:hover { color: var(--accent); }
 
   <rect x="394" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
   <text x="410" y="252" font-size="14" font-weight="700" fill="#1E3A5F">[~] Hooks</text>
-  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 32 shell gates</text>
+  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 34 shell gates</text>
   <text x="410" y="295" font-size="11" fill="#4A6FA5">Merge gate · ticket-first · secrets · …</text>
 
   <rect x="704" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>

--- a/site/architecture.md.gen
+++ b/site/architecture.md.gen
@@ -25,7 +25,7 @@ Fork apexyard once and treat the fork as your ops repo. Add an entry to `apexyar
 Declares what's true and what's enforced:
 
 - **Registry** (`apexyard.projects.yaml`) — lists every managed project
-- **Hooks** (`.claude/hooks/`) — 32 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
+- **Hooks** (`.claude/hooks/`) — 34 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
 - **Rules** (`.claude/rules/`) — 11 modular self-discipline guides
 - **Onboarding** (`onboarding.yaml`) — company name, mission, team, tech stack
 

--- a/site/architecture.md.gen
+++ b/site/architecture.md.gen
@@ -25,7 +25,7 @@ Fork apexyard once and treat the fork as your ops repo. Add an entry to `apexyar
 Declares what's true and what's enforced:
 
 - **Registry** (`apexyard.projects.yaml`) — lists every managed project
-- **Hooks** (`.claude/hooks/`) — 34 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
+- **Hooks** (`.claude/hooks/`) — 35 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
 - **Rules** (`.claude/rules/`) — 11 modular self-discipline guides
 - **Onboarding** (`onboarding.yaml`) — company name, mission, team, tech stack
 

--- a/site/index.md.gen
+++ b/site/index.md.gen
@@ -75,7 +75,7 @@ The reviewer changes based on what you're working on. Touching auth code? A secu
 
 Want to adopt a project you've inherited? `/handover`. Want to capture an idea before it evaporates? `/idea`. Want to know what's waiting on you across every product? `/inbox`. Want a launch-readiness check before customers see it? `/launch-check`. 54 of these in total — each one is a focused workflow with safety rails.
 
-### Guardrails that stop bad code from shipping · 32 hooks
+### Guardrails that stop bad code from shipping · 34 hooks
 
 Every edit needs a real ticket behind it. Every database change needs a rollback plan. Every merge needs a real review. Secrets in code get caught before they're committed. Mechanically enforced — 32 small scripts that fire at the right moments.
 

--- a/site/index.md.gen
+++ b/site/index.md.gen
@@ -75,7 +75,7 @@ The reviewer changes based on what you're working on. Touching auth code? A secu
 
 Want to adopt a project you've inherited? `/handover`. Want to capture an idea before it evaporates? `/idea`. Want to know what's waiting on you across every product? `/inbox`. Want a launch-readiness check before customers see it? `/launch-check`. 54 of these in total — each one is a focused workflow with safety rails.
 
-### Guardrails that stop bad code from shipping · 34 hooks
+### Guardrails that stop bad code from shipping · 35 hooks
 
 Every edit needs a real ticket behind it. Every database change needs a rollback plan. Every merge needs a real review. Secrets in code get caught before they're committed. Mechanically enforced — 32 small scripts that fire at the right moments.
 

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -3,7 +3,7 @@
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and
 > one place for all your products, built on top of Claude Code. 55 skills,
-> 34 hooks, 19 role definitions. Open source, plain markdown and shell, no SaaS,
+> 35 hooks, 19 role definitions. Open source, plain markdown and shell, no SaaS,
 > no lock-in.
 
 This file is the LLM/agent-friendly concatenation of the apexyard marketing
@@ -244,7 +244,7 @@ each owned by different parts of the framework:
    for the framework.
 2. **Capability layer** — the runnable spec: `.claude/skills/` (55
    slash commands), `.claude/agents/` (23 sub-agents incl. Rex), and
-   `.claude/hooks/` (34 mechanical enforcement scripts).
+   `.claude/hooks/` (35 mechanical enforcement scripts).
 3. **Framework defaults layer** — `.claude/project-config.defaults.json`
    ships the framework's opinions; adopters override per-repo in
    `.claude/project-config.json` (shallow merge).

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -3,7 +3,7 @@
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and
 > one place for all your products, built on top of Claude Code. 55 skills,
-> 32 hooks, 19 role definitions. Open source, plain markdown and shell, no SaaS,
+> 34 hooks, 19 role definitions. Open source, plain markdown and shell, no SaaS,
 > no lock-in.
 
 This file is the LLM/agent-friendly concatenation of the apexyard marketing
@@ -244,7 +244,7 @@ each owned by different parts of the framework:
    for the framework.
 2. **Capability layer** — the runnable spec: `.claude/skills/` (55
    slash commands), `.claude/agents/` (23 sub-agents incl. Rex), and
-   `.claude/hooks/` (32 mechanical enforcement scripts).
+   `.claude/hooks/` (34 mechanical enforcement scripts).
 3. **Framework defaults layer** — `.claude/project-config.defaults.json`
    ships the framework's opinions; adopters override per-repo in
    `.claude/project-config.json` (shallow merge).

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -3,7 +3,7 @@
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and one
 > place for all your products, built on top of Claude Code. 55 skills,
-> 32 hooks, 19 role definitions. Open source, plain markdown and shell,
+> 34 hooks, 19 role definitions. Open source, plain markdown and shell,
 > no SaaS, no lock-in.
 
 ## Pages
@@ -54,7 +54,7 @@
   across the portfolio in ~1 second.
 - **55 slash commands** grouped by outcome: keep quality high, move work
   forward, see everything at once, onboard new code, run things.
-- **32 shell hooks** mechanically enforce the rules — ticket-first, migration
+- **34 shell hooks** mechanically enforce the rules — ticket-first, migration
   gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR-title
   validation, upstream-drift banner, leak protection.
 - **19 role definitions** across 5 departments (Engineering, Product, Design,

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -3,7 +3,7 @@
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and one
 > place for all your products, built on top of Claude Code. 55 skills,
-> 34 hooks, 19 role definitions. Open source, plain markdown and shell,
+> 35 hooks, 19 role definitions. Open source, plain markdown and shell,
 > no SaaS, no lock-in.
 
 ## Pages
@@ -54,7 +54,7 @@
   across the portfolio in ~1 second.
 - **55 slash commands** grouped by outcome: keep quality high, move work
   forward, see everything at once, onboard new code, run things.
-- **34 shell hooks** mechanically enforce the rules — ticket-first, migration
+- **35 shell hooks** mechanically enforce the rules — ticket-first, migration
   gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR-title
   validation, upstream-drift banner, leak protection.
 - **19 role definitions** across 5 departments (Engineering, Product, Design,

--- a/site/skill.md
+++ b/site/skill.md
@@ -43,7 +43,7 @@ what you're trying to do:
 - **Run things** (`/update`, `/split-portfolio`, `/release`, `/debug`,
   `/pdf`, `/fan-out`)
 
-32 shell hooks enforce SDLC rules mechanically — ticket-first, migration
+34 shell hooks enforce SDLC rules mechanically — ticket-first, migration
 gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR
 title validation, decision-record-required-for-architecture, upstream-drift
 banner, leak protection. 19 role definitions activate on triggers (label,

--- a/site/skill.md
+++ b/site/skill.md
@@ -43,7 +43,7 @@ what you're trying to do:
 - **Run things** (`/update`, `/split-portfolio`, `/release`, `/debug`,
   `/pdf`, `/fan-out`)
 
-34 shell hooks enforce SDLC rules mechanically — ticket-first, migration
+35 shell hooks enforce SDLC rules mechanically — ticket-first, migration
 gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR
 title validation, decision-record-required-for-architecture, upstream-drift
 banner, leak protection. 19 role definitions activate on triggers (label,


### PR DESCRIPTION
## Summary

- **Inline marker validation** — when the CEO marker file doesn't exist on disk but the command string contains a write to `*-ceo.approved` with valid structured content (sha + approved_by=user + skill_version>=2), the hook validates in-memory and lets the command through. The actual file write executes before the merge in the compound command.
- **File-based path unchanged** — standalone `gh pr merge` with a pre-existing marker works exactly as before.
- **4 new test cases** — valid inline marker (passes), wrong SHA inline (blocks), missing approved_by inline (blocks), old skill_version inline (blocks). Total: 17/17 pass.

## Testing

`bash .claude/hooks/tests/test_block_unreviewed_merge.sh` — 17 pass, 0 fail

## Glossary

| Term | Definition |
|------|------------|
| Compound command | A single Bash tool call containing multiple commands chained with `&&` — e.g. `cat > marker && gh pr merge` |
| PreToolUse | Hook event that fires before the tool executes — the marker written by `cat` doesn't exist on disk when the hook runs |
| Inline marker | Structured CEO approval content extracted from the command string and validated in-memory, without requiring the file to exist |

Refs #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)