### PR TITLE
fix(#434): route CLAUDE.md SETUP step 1 onboarding.yaml through portfolio helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,16 @@ You are the **Chief of Staff** running a portfolio of projects inside apexyard. 
 
 ## SETUP
 
-1. Read `onboarding.yaml` for company-specific configuration
+1. Read `onboarding.yaml` for company-specific configuration. Resolve the path via the portfolio paths helper so split-portfolio v2 adopters read the sibling repo's copy instead of the (template-default) one in the fork:
+
+   ```bash
+   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+   onboarding=$(portfolio_onboarding_path)
+   # Read "$onboarding" with the Read tool
+   ```
+
+   In single-fork mode this still resolves to `<ops-root>/onboarding.yaml` — same file you'd reach without the helper. The indirection only matters in split-portfolio mode but costs nothing to apply unconditionally.
+
 2. Read `apexyard.projects.yaml` — the portfolio registry listing every repo under management
 3. Understand the team structure and roles
 4. Apply the workflows and standards defined in this stack


### PR DESCRIPTION
## Summary

- **Routes CLAUDE.md SETUP step 1 through `portfolio_onboarding_path`** — the resolver already exists in `_lib-portfolio-paths.sh` (since #242), but the session-start instruction kept telling agents to "Read `onboarding.yaml`" verbatim. In split-portfolio v2 mode that resolves against the fork root (template defaults) instead of the sibling (fully-configured). One adopter-visible doc tweak; zero code change.

## Why this matters

Every session starts with the SETUP block. If step 1 picks up template defaults — `"Your Company Name"`, `tool: "GitHub Issues"`, `ticket_prefix: "GH"` — every downstream role activation, ticket creation, and PR workflow operates on wrong company / tracker config. In single-fork mode this never fires (one repo, one onboarding.yaml). In split-portfolio v2 mode the silently-wrong-defaults bug bites every session.

The helper has been right for ~3 releases; only the instruction lagged.

## Testing

- [ ] In single-fork mode: `portfolio_onboarding_path` returns `<ops-root>/onboarding.yaml` (unchanged behaviour)
- [ ] In split-portfolio v2 mode: returns `<sibling>/onboarding.yaml` (the adopter's filled-in copy)
- [ ] Visual check: CLAUDE.md SETUP § renders the bash snippet correctly in GitHub's markdown preview
- [ ] No diff in `.claude/hooks/_lib-portfolio-paths.sh` or `.claude/hooks/tests/` — the helper logic itself isn't touched, only the instruction that drives Claude to use it

Closes #434.

## Glossary

| Term | Definition |
|------|------------|
| `portfolio_onboarding_path` | Resolver in `_lib-portfolio-paths.sh` that returns the onboarding.yaml path: `<ops-root>/onboarding.yaml` in single-fork mode, `<sibling>/onboarding.yaml` in split-portfolio v2 mode. Sibling pattern to `portfolio_registry` / `portfolio_projects_dir` / `portfolio_workspace_dir`. |
| Split-portfolio v2 | The two-repo mode (public framework fork + private sibling) introduced by the `/split-portfolio` skill, where adopter-private configuration lives in the sibling and the fork remains shareable. |
| Single-fork mode | The original out-of-box mode where one fork holds both framework and adopter config. `portfolio_*_path` helpers resolve to the fork in this mode. |
