### PR TITLE
fix(#433): promote /handover MCP reindex to named step + add advisory hook

### DIFF
--- a/.claude/hooks/suggest-mcp-reindex-after-clone.sh
+++ b/.claude/hooks/suggest-mcp-reindex-after-clone.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# PostToolUse hook: prompts an MCP reindex after the /handover skill clones
+# a repo into workspace/<name>/ at step 1.5-clone.
+#
+# Why this exists
+# ---------------
+# /handover SKILL.md step 1.5-clone clones the target repo immediately when a
+# URL is given (default behaviour since #417). Step 1.5-reindex tells the agent
+# to call mcp__apexyard-search__reindex(scope="project", project="<name>")
+# right after the clone so the deep-dive phases that follow (steps 2–6) can use
+# search_code / search_docs instead of falling back to grep + Read.
+#
+# In practice the reindex step is easily missed — it sits between two
+# numbered steps in a long SKILL file. This hook fires on the matching
+# git clone command and emits a one-line reminder banner, removing the
+# "I forgot the rule applied here" failure mode.
+#
+# Behaviour
+# ---------
+#   - Fires on PostToolUse Bash where the command contains `git clone … workspace/…`
+#     OR `git clone … <portfolio_workspace_dir>/…` (the helper-resolved form).
+#   - Emits a single advisory banner to stderr naming the reindex command and
+#     pointing at SKILL.md § 1.5-reindex.
+#   - Exits 0 always — advisory, non-blocking. Same shape as
+#     detect-role-trigger.sh / check-upstream-drift.sh.
+#   - Silent no-op when:
+#       * The command isn't a workspace clone
+#       * The command failed (we don't want to suggest reindex on a failed clone)
+#       * The repo doesn't ship an MCP search server (no mcp/ dir, no
+#         apexyard-search package installed) — best-effort signal, not enforced
+#
+# Banner budget: ≤ 600 chars (this hook emits ~280 chars when it fires).
+#
+# Tests at .claude/hooks/tests/test_suggest_mcp_reindex_after_clone.sh.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Bail unless this is a git clone targeting a workspace dir. We match both the
+# literal `workspace/` form (single-fork default) and any path ending in
+# `/workspace/<name>` (the helper-resolved form used in split-portfolio v2).
+#
+# Patterns recognised:
+#   git clone <url> workspace/<name>
+#   git clone <url> "workspace/<name>"
+#   git clone <url> /path/to/portfolio/workspace/<name>
+#   git clone <url> "$WORKSPACE_DIR/<name>"   ← matched literally; the shell
+#                                                 substitutes before run, so by
+#                                                 the time PostToolUse fires the
+#                                                 expanded path is in $COMMAND
+if ! echo "$COMMAND" | grep -qE '\bgit\s+clone\b.*[/"'"'"']?workspace/[^[:space:]"'"'"']+[/"'"'"']?[[:space:]]*($|2>|1>|\|)'; then
+  # Try the absolute-path workspace form
+  if ! echo "$COMMAND" | grep -qE '\bgit\s+clone\b.*/workspace/[A-Za-z0-9._-]+'; then
+    exit 0
+  fi
+fi
+
+# Skip if the prior tool call failed — no point suggesting reindex on a clone
+# that errored. PostToolUse input carries tool_response.exit_code on Bash.
+EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_response.exit_code // 0' 2>/dev/null)
+if [ "${EXIT_CODE:-0}" != "0" ]; then
+  exit 0
+fi
+
+# Extract the project name from the clone target — last path segment.
+PROJECT=$(echo "$COMMAND" | grep -oE 'workspace/[A-Za-z0-9._-]+' | head -1 | sed 's|workspace/||' | sed 's/["'"'"']//g')
+
+if [ -z "$PROJECT" ]; then
+  # Couldn't parse the project name — still emit the banner without it.
+  PROJECT="<name>"
+fi
+
+cat >&2 <<MSG
+> Repo cloned into workspace/$PROJECT/. Next step (SKILL.md § 1.5-reindex):
+    mcp__apexyard-search__reindex(scope="project", project="$PROJECT")
+  Then use search_code / search_docs for the deep-dive (steps 2-6) instead of
+  grep + Read. If the MCP server is unavailable, print one-line warning + set
+  REINDEX_STATUS=unavailable and continue.
+MSG
+
+exit 0

--- a/.claude/hooks/tests/test_suggest_mcp_reindex_after_clone.sh
+++ b/.claude/hooks/tests/test_suggest_mcp_reindex_after_clone.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Tests for suggest-mcp-reindex-after-clone.sh advisory hook
+# Run: bash .claude/hooks/tests/test_suggest_mcp_reindex_after_clone.sh
+
+set -u
+
+HOOK="$(cd "$(dirname "$0")/.." && pwd)/suggest-mcp-reindex-after-clone.sh"
+PASS=0
+FAIL=0
+
+run_hook() {
+  echo "$1" | bash "$HOOK" 2>&1
+}
+
+assert_banner_contains() {
+  local desc="$1" input="$2" needle="$3"
+  local output
+  output=$(run_hook "$input")
+  if echo "$output" | grep -qF "$needle"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc — expected banner containing '$needle', got: $output"
+  fi
+}
+
+assert_no_banner() {
+  local desc="$1" input="$2"
+  local output
+  output=$(run_hook "$input")
+  if [ -z "$output" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc — expected no output, got: $output"
+  fi
+}
+
+# --- Should fire: workspace/ clone, exit 0 ---
+
+assert_banner_contains "single-fork form — workspace/<name>" \
+  '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"git clone https://github.com/owner/example.git workspace/example"},"tool_response":{"exit_code":0}}' \
+  "Repo cloned into workspace/example/"
+
+assert_banner_contains "single-fork form — banner mentions reindex command" \
+  '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"git clone https://github.com/owner/example.git workspace/example"},"tool_response":{"exit_code":0}}' \
+  "mcp__apexyard-search__reindex"
+
+assert_banner_contains "quoted target" \
+  '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"git clone https://github.com/owner/foo.git \"workspace/foo\""},"tool_response":{"exit_code":0}}' \
+  "Repo cloned into workspace/foo/"
+
+assert_banner_contains "absolute path via portfolio helper" \
+  '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"git clone https://github.com/owner/bar.git /Users/me/portfolio/workspace/bar"},"tool_response":{"exit_code":0}}' \
+  "mcp__apexyard-search__reindex"
+
+assert_banner_contains "project name extracted from absolute path" \
+  '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"git clone https://github.com/owner/bar.git /Users/me/portfolio/workspace/bar"},"tool_response":{"exit_code":0}}' \
+  'project="bar"'
+
+# --- Should NOT fire ---
+
+assert_no_banner "clone target is NOT workspace/<name>" \
+  '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"git clone https://github.com/owner/example.git /tmp/scratch"},"tool_response":{"exit_code":0}}'
+
+assert_no_banner "not a git clone — just a grep that mentions clone" \
+  '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"git clone\" workspace/"},"tool_response":{"exit_code":0}}'
+
+assert_no_banner "no command at all" \
+  '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{}}'
+
+assert_no_banner "clone failed (exit 128)" \
+  '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"git clone https://github.com/owner/example.git workspace/example"},"tool_response":{"exit_code":128}}'
+
+assert_no_banner "clone failed (exit 1)" \
+  '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"git clone https://github.com/owner/foo.git workspace/foo"},"tool_response":{"exit_code":1}}'
+
+assert_no_banner "different tool entirely (Edit)" \
+  '{"hook_event_name":"PostToolUse","tool_name":"Edit","tool_input":{"file_path":"workspace/x/README.md"}}'
+
+# --- Summary ---
+
+echo ""
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -245,6 +245,11 @@
             "type": "command",
             "if": "Bash(git push *)",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/warn-stale-review-markers.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(git clone *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/suggest-mcp-reindex-after-clone.sh\"'"
           }
         ]
       }

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -113,13 +113,6 @@ fi
 
 In single-fork mode `WORKSPACE_DIR` resolves to `<ops-root>/workspace`; in split-portfolio v2 mode it resolves to the sibling private repo (e.g. `../<fork>-portfolio/workspace`). Don't hardcode `workspace/<name>/`.
 
-After a successful clone, trigger an MCP reindex immediately so `search_code` returns results during the deep-dive phases that follow. The reindex is best-effort — skip silently if the MCP server is not available.
-
-```
-# Best-effort reindex — don't block the handover on MCP availability
-mcp__apexyard-search__reindex(scope="project", project="<name>")
-```
-
 #### On clone failure
 
 If the clone fails (private repo without credentials, network error, repo moved): report the exit code, point at `gh auth login` or a manual `git clone <repo-url> "$WORKSPACE_DIR/<name>"` as the recovery, and continue with the local-path fallback. Do **not** retry or invent an alternative URL. The operator picks up from there.
@@ -133,6 +126,28 @@ CLONE_STATUS="cloned"   # or "preserved" | "declined" | "failed: <reason>"
 ```
 
 All subsequent reads in steps 2–6 use `$WORKSPACE_DIR/<name>/` as the repo root whenever `$CLONE_STATUS` is `cloned` or `preserved`. When `$CLONE_STATUS` is `declined` or `failed`, fall back to GitHub API reads via `gh api` / `gh -R <owner/name> …` (degraded but functional).
+
+### 1.5-reindex. Reindex the cloned repo in MCP (default: always attempt)
+
+After a successful clone (`$CLONE_STATUS=cloned`), trigger an MCP reindex so `search_code` and `search_docs` return results during the deep-dive phases that follow (steps 2–6). Without this step those queries return empty against the just-cloned repo, and the agent silently falls back to `find` + `cat` + `Bash` — defeating the token-cost benefit of cloning early.
+
+```
+mcp__apexyard-search__reindex(scope="project", project="<name>")
+```
+
+**On MCP unavailable:** the call will error. Catch the error, print a single-line warning, set the marker, and continue. **Do not skip silently** — silent skips are indistinguishable between "server down" and "agent forgot the step", and the second failure mode is what this step exists to prevent.
+
+```
+⚠ MCP reindex unavailable — falling back to grep + Read for steps 2–6
+```
+
+```bash
+REINDEX_STATUS="indexed"   # or "unavailable" | "skipped" (when $CLONE_STATUS != cloned)
+```
+
+When `$REINDEX_STATUS="indexed"`, prefer `search_code` and `search_docs` over `grep` + `Read` for the assessment reads in steps 2–6 (per the MCP-search-first rule). When `unavailable` or `skipped`, fall back to `grep` + `Read` without further apology.
+
+A `PostToolUse` hook (`suggest-mcp-reindex-after-clone.sh`) fires after the clone command and emits a one-line reminder of this step. Same advisory shape as `detect-role-trigger.sh` — exit 0, non-blocking, removes the "I forgot the rule applied here" failure mode.
 
 ### 1.5. Pick a topology (default: skip / custom)
 

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -542,7 +542,7 @@ a:hover { color: var(--accent); }
 
   <rect x="394" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
   <text x="410" y="252" font-size="14" font-weight="700" fill="#1E3A5F">[~] Hooks</text>
-  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 35 shell gates</text>
+  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 36 shell gates</text>
   <text x="410" y="295" font-size="11" fill="#4A6FA5">Merge gate · ticket-first · secrets · …</text>
 
   <rect x="704" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>

--- a/site/architecture.md.gen
+++ b/site/architecture.md.gen
@@ -25,7 +25,7 @@ Fork apexyard once and treat the fork as your ops repo. Add an entry to `apexyar
 Declares what's true and what's enforced:
 
 - **Registry** (`apexyard.projects.yaml`) — lists every managed project
-- **Hooks** (`.claude/hooks/`) — 35 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
+- **Hooks** (`.claude/hooks/`) — 36 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
 - **Rules** (`.claude/rules/`) — 11 modular self-discipline guides
 - **Onboarding** (`onboarding.yaml`) — company name, mission, team, tech stack
 

--- a/site/index.md.gen
+++ b/site/index.md.gen
@@ -75,7 +75,7 @@ The reviewer changes based on what you're working on. Touching auth code? A secu
 
 Want to adopt a project you've inherited? `/handover`. Want to capture an idea before it evaporates? `/idea`. Want to know what's waiting on you across every product? `/inbox`. Want a launch-readiness check before customers see it? `/launch-check`. 54 of these in total — each one is a focused workflow with safety rails.
 
-### Guardrails that stop bad code from shipping · 35 hooks
+### Guardrails that stop bad code from shipping · 36 hooks
 
 Every edit needs a real ticket behind it. Every database change needs a rollback plan. Every merge needs a real review. Secrets in code get caught before they're committed. Mechanically enforced — 32 small scripts that fire at the right moments.
 

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -3,7 +3,7 @@
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and
 > one place for all your products, built on top of Claude Code. 55 skills,
-> 35 hooks, 19 role definitions. Open source, plain markdown and shell, no SaaS,
+> 36 hooks, 19 role definitions. Open source, plain markdown and shell, no SaaS,
 > no lock-in.
 
 This file is the LLM/agent-friendly concatenation of the apexyard marketing
@@ -244,7 +244,7 @@ each owned by different parts of the framework:
    for the framework.
 2. **Capability layer** — the runnable spec: `.claude/skills/` (55
    slash commands), `.claude/agents/` (23 sub-agents incl. Rex), and
-   `.claude/hooks/` (35 mechanical enforcement scripts).
+   `.claude/hooks/` (36 mechanical enforcement scripts).
 3. **Framework defaults layer** — `.claude/project-config.defaults.json`
    ships the framework's opinions; adopters override per-repo in
    `.claude/project-config.json` (shallow merge).

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -3,7 +3,7 @@
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and one
 > place for all your products, built on top of Claude Code. 55 skills,
-> 35 hooks, 19 role definitions. Open source, plain markdown and shell,
+> 36 hooks, 19 role definitions. Open source, plain markdown and shell,
 > no SaaS, no lock-in.
 
 ## Pages
@@ -54,7 +54,7 @@
   across the portfolio in ~1 second.
 - **55 slash commands** grouped by outcome: keep quality high, move work
   forward, see everything at once, onboard new code, run things.
-- **35 shell hooks** mechanically enforce the rules — ticket-first, migration
+- **36 shell hooks** mechanically enforce the rules — ticket-first, migration
   gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR-title
   validation, upstream-drift banner, leak protection.
 - **19 role definitions** across 5 departments (Engineering, Product, Design,

--- a/site/skill.md
+++ b/site/skill.md
@@ -43,7 +43,7 @@ what you're trying to do:
 - **Run things** (`/update`, `/split-portfolio`, `/release`, `/debug`,
   `/pdf`, `/fan-out`)
 
-35 shell hooks enforce SDLC rules mechanically — ticket-first, migration
+36 shell hooks enforce SDLC rules mechanically — ticket-first, migration
 gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR
 title validation, decision-record-required-for-architecture, upstream-drift
 banner, leak protection. 19 role definitions activate on triggers (label,


### PR DESCRIPTION
## Summary

- **Promotes the post-clone MCP reindex from prose comment to named sub-step `1.5-reindex`** — putting it structurally on the same footing as `1.5-clone` above and `1.5` (topology) below so the agent's eye doesn't pass over it during execution
- **Replaces "skip silently" language with explicit non-silent failure semantics** — emit a one-line warning, set `REINDEX_STATUS=unavailable`, continue. Silent skips are indistinguishable between "server down" and "agent forgot" — the second is the failure mode this PR exists to prevent
- **Adds an advisory PostToolUse hook** (`suggest-mcp-reindex-after-clone.sh`) that fires after the matching `git clone … workspace/<name>` and emits a one-line reminder. Exit 0 always, non-blocking — same shape as `detect-role-trigger.sh` and `check-upstream-drift.sh`
- **Wires the hook in `.claude/settings.json`** under PostToolUse Bash with `if: "Bash(git clone *)"`
- **11-case test suite** under `.claude/hooks/tests/` — 5 should-fire cases (workspace clones, quoted paths, absolute paths via portfolio helper, banner content, project-name extraction) + 6 should-not (non-workspace targets, failed clones with exit code != 0, wrong tool, empty input). All 11 pass

## Why this matters

The /handover skill clones the target repo into `workspace/<name>/` at step 1.5-clone (default behaviour since #417). The whole point is that subsequent reads in steps 2–6 use the local clone via `search_code` / `search_docs` and the MCP index — described as "3-15× cheaper per query" than `grep` + `Read`. That savings is conditional on the MCP index actually containing the cloned repo, which requires the reindex call.

Before this PR the reindex was a prose comment inside the bash block, framed as "best-effort — skip silently if the MCP server is not available." In practice that phrase reads as permission to skip *unconditionally*. The reindex got skipped even when the server was running, all deep-dive reads ran against an empty index, and the savings vanished.

Two changes together fix it: structural promotion (so the step is harder to miss in the SKILL.md), and an advisory hook (so even if it IS missed, the operator gets a visible reminder right after the clone command).

## Testing

- [ ] `bash .claude/hooks/tests/test_suggest_mcp_reindex_after_clone.sh` — 11 PASS, 0 FAIL
- [ ] `jq empty .claude/settings.json` — valid JSON
- [ ] Visual: render `.claude/skills/handover/SKILL.md` and confirm the new `1.5-reindex` section sits between `1.5-clone` and `1.5` (topology) with the warning + status-marker example blocks
- [ ] Manual repro path: run `/handover <url>` against a URL, observe step 1.5-clone clone, observe the hook banner emitted after the clone, observe step 1.5-reindex triggering the MCP reindex tool call
- [ ] On MCP unavailable: confirm the one-line warning prints and `$REINDEX_STATUS=unavailable` is set; subsequent steps fall back to `grep` + `Read` without further apology

## Backwards compatibility

- No new dependencies (the hook is pure bash + jq, already required)
- Hook silently no-ops on non-workspace clones, failed clones, and non-`Bash` tool calls — adopters who don't use `/handover` see no change
- The SKILL.md edit removes one prose comment block and adds one numbered sub-step; existing operators who already do the reindex by habit are unaffected (the new step formalises what they were already doing)

Closes #433.

## Glossary

| Term | Definition |
|------|------------|
| 1.5-clone | Step in `/handover` SKILL.md (added in #417) that clones the target repo into `workspace/<name>/` immediately when a Git URL is given. Default behaviour; cheapest moment to clone before any reads. |
| 1.5-reindex | New step added by this PR — call `mcp__apexyard-search__reindex(scope="project", project="<name>")` after a successful clone so `search_code` / `search_docs` return results during the deep-dive phases (steps 2–6) that follow. |
| `REINDEX_STATUS` | New marker variable set by step 1.5-reindex: `"indexed"` on success, `"unavailable"` when the MCP server can't be reached, `"skipped"` when `CLONE_STATUS` isn't `"cloned"`. Steps 2–6 read it to decide between MCP search and `grep` + `Read`. |
| Advisory hook | Non-blocking PostToolUse hook that emits a banner to stderr and exits 0. Same pattern as `detect-role-trigger.sh` / `check-upstream-drift.sh` — removes the "I forgot the rule applied here" failure mode without changing tool behaviour. |
| PostToolUse | Claude Code hook event that fires after a tool call completes. Carries the tool input AND the response (exit code, output) — lets the hook condition on whether the operation succeeded before suggesting follow-ups. |
