### PR TITLE
feat(#438): Ollama/LiteLLM agent routing — reachability + model-pulled checks + session-wide ANTHROPIC_BASE_URL

### DIFF
--- a/.claude/hooks/apply-agent-routing.sh
+++ b/.claude/hooks/apply-agent-routing.sh
@@ -13,6 +13,16 @@
 #   - Silently exit 0 if no routing file exists (zero-config zero-
 #     behaviour-change — the documented out-of-box experience)
 #   - Parse the YAML (yq preferred; python3 fallback)
+#   - Local-routing prep (me2resh/apexyard#438):
+#       a. For each unique endpoint, probe `<endpoint>/v1/models` or
+#          `/health` with a 2s timeout. Mark reachable/unreachable.
+#          Unreachable endpoints have their per-agent rows filtered out
+#          BEFORE the apply loop — a downed proxy doesn't poison the
+#          session.
+#       b. For `model: ollama/<name>` rows whose endpoint is reachable,
+#          query `<endpoint>/api/tags` for the model name. On miss emit
+#          a warning naming `ollama pull <name>`. The model rewrite still
+#          applies.
 #   - For each entry in agents:
 #       1. Locate .claude/agents/<name>.md — silently skip if missing
 #          (adopter may have a stale entry; harmless, not an error)
@@ -21,14 +31,18 @@
 #          so the drift guard has a baseline regardless of whether the
 #          adopter committed the rewrite
 #       3. Rewrite the model: line in the agent file to the override
-#       4. If endpoint: set, write to .claude/session/agent-env/<name>.env
-#          (per-agent endpoint env file; if Claude Code doesn't expose
-#          per-agent env, the adopter falls back to manual export of
-#          ANTHROPIC_BASE_URL — banner caveat below)
+#       4. If endpoint: set AND reachable, write to .claude/session/
+#          agent-env/<name>.env (per-agent endpoint env file — informational
+#          in v1 until Claude Code exposes per-agent env scoping)
 #       5. If env: block set, append KEY=VALUE lines to that env file
 #          (resolving $VAR_NAME refs against the parent env)
+#   - Write session-wide .claude/session/agent-env/__session__.env with
+#     ANTHROPIC_BASE_URL=<first-reachable-endpoint> (the routing mechanism
+#     that actually works in v1, per AgDR-0050 § Axis 5). Multi-endpoint
+#     declarations warn and use the first.
 #   - Print a single one-line summary banner: silent on N=0; else
-#       "ApexYard: applied N agent-routing override(s) from agent-routing.yaml"
+#       "ApexYard: applied N agent-routing override(s) from agent-routing.yaml [M Ollama, K warning(s)]"
+#     The Ollama / warning suffix is omitted when both counts are 0.
 #   - Idempotent: running twice with the same config produces the same
 #     state, no compounding writes (env files are truncated, not appended,
 #     when written; the framework-defaults snapshot is keyed by agent
@@ -258,6 +272,106 @@ if [ -z "$ROWS" ]; then
 fi
 
 # -----------------------------------------------------------------------------
+# Local-routing prep — extends the v1 schema's `endpoint:` + `model: ollama/*`
+# semantics into actually-applied state. See me2resh/apexyard#438.
+#
+# Two non-blocking checks (warnings to stderr; model rewrite proceeds):
+#
+#   1. Reachability — for each unique endpoint declared by any agent, probe
+#      `<endpoint>/v1/models` (LiteLLM healthcheck) with a 2s timeout. If
+#      neither it nor `/health` responds 2xx, mark the endpoint unreachable.
+#      Endpoint rows pointing at unreachable proxies are filtered out of
+#      $ROWS BEFORE the apply loop, so per-agent .env file's
+#      ANTHROPIC_BASE_URL is NOT written when the proxy is down — a downed
+#      proxy can't poison the session.
+#
+#   2. Model-pulled — for `model: ollama/<name>` rows whose endpoint is
+#      reachable, query `<endpoint>/api/tags` and grep for the model name.
+#      On miss: warn the adopter to run `ollama pull <name>`. The model
+#      rewrite still applies; Ollama may pull on first call with cold-start
+#      cost — that's an adopter-visible cost, not a hook concern.
+#
+# After the apply loop we also write a session-wide `__session__.env`
+# containing ANTHROPIC_BASE_URL=<first-reachable-endpoint>. This is the only
+# routing mechanism that works in v1 — per AgDR-0050 § Axis 5, Claude Code
+# doesn't consume per-agent env files yet. The per-agent files keep being
+# written for forward-compat. Multi-endpoint declarations warn and pick
+# the first.
+# -----------------------------------------------------------------------------
+
+ollama_applied=0
+warnings=0
+
+EP_REACH=$(mktemp 2>/dev/null) || { exit 0; }
+AGENT_MODELS=$(mktemp 2>/dev/null) || { rm -f "$EP_REACH"; exit 0; }
+AGENT_ENDPOINTS=$(mktemp 2>/dev/null) || { rm -f "$EP_REACH" "$AGENT_MODELS"; exit 0; }
+
+# Build agent → model and agent → endpoint maps from $ROWS.
+printf '%s\n' "$ROWS" | awk -F'\t' '$2=="model" {print $1 "\t" $3}' > "$AGENT_MODELS"
+printf '%s\n' "$ROWS" | awk -F'\t' '$2=="endpoint" && $3!="" {print $1 "\t" $3}' > "$AGENT_ENDPOINTS"
+
+# 1. Reachability probe — one curl per unique endpoint, 2s timeout each.
+UNIQUE_EPS=$(awk -F'\t' '{print $2}' "$AGENT_ENDPOINTS" | sort -u)
+while IFS= read -r ep; do
+  [ -z "$ep" ] && continue
+  reachable=0
+  if command -v curl >/dev/null 2>&1; then
+    if curl --max-time 2 --silent --fail -o /dev/null "$ep/v1/models" 2>/dev/null; then
+      reachable=1
+    elif curl --max-time 2 --silent --fail -o /dev/null "$ep/health" 2>/dev/null; then
+      reachable=1
+    fi
+  else
+    # No curl available — skip reachability check entirely, treat as reachable.
+    # The model rewrite + per-agent env file still apply; the adopter just
+    # doesn't get the "your proxy is down" warning. Better than blocking.
+    reachable=1
+  fi
+  printf '%s\t%s\n' "$ep" "$reachable" >> "$EP_REACH"
+  if [ "$reachable" -eq 0 ]; then
+    echo "⚠ agent-routing: endpoint $ep not reachable; skipping endpoint override (model rewrite still applies)" >&2
+    warnings=$((warnings + 1))
+  fi
+done <<EOF
+$UNIQUE_EPS
+EOF
+
+# 2. Model-pulled check — for ollama/* models whose endpoint is reachable.
+while IFS=$'\t' read -r agent model; do
+  [ -z "$agent" ] && continue
+  case "$model" in
+    ollama/*)
+      ollama_applied=$((ollama_applied + 1))
+      ep=$(awk -F'\t' -v a="$agent" '$1==a {print $2; exit}' "$AGENT_ENDPOINTS")
+      [ -z "$ep" ] && continue
+      reach=$(awk -F'\t' -v e="$ep" '$1==e {print $2; exit}' "$EP_REACH")
+      [ "${reach:-0}" = "1" ] || continue
+      model_name="${model#ollama/}"
+      if command -v curl >/dev/null 2>&1; then
+        if ! curl --max-time 2 --silent --fail "$ep/api/tags" 2>/dev/null | grep -q "\"name\":\"$model_name\""; then
+          echo "⚠ agent-routing: $agent — model $model_name not in local Ollama; run: ollama pull $model_name" >&2
+          warnings=$((warnings + 1))
+        fi
+      fi
+      ;;
+  esac
+done < "$AGENT_MODELS"
+
+# 3. Filter $ROWS — drop endpoint rows pointing at unreachable endpoints.
+#    The apply loop downstream will not see those rows, so per-agent env
+#    files keep their existing ANTHROPIC_BASE_URL untouched.
+ROWS=$(printf '%s\n' "$ROWS" | awk -F'\t' -v reach="$EP_REACH" '
+  BEGIN {
+    while ((getline line < reach) > 0) {
+      split(line, p, "\t")
+      r[p[1]] = p[2]
+    }
+  }
+  $2 == "endpoint" && r[$3] == "0" { next }
+  { print }
+')
+
+# -----------------------------------------------------------------------------
 # Snapshot framework defaults BEFORE any rewrite — so the drift guard
 # has a baseline regardless of whether the adopter committed the rewrite
 # to the fork.
@@ -387,6 +501,49 @@ done < "$TMP_ROWS"
 rm -f "$TMP_ROWS"
 
 # -----------------------------------------------------------------------------
+# Session-wide ANTHROPIC_BASE_URL — write __session__.env using the first
+# reachable endpoint declared in agent-routing.yaml. Per AgDR-0050 § Axis 5,
+# v1 supports one endpoint per session because Claude Code doesn't consume
+# per-agent env files yet. If multiple distinct reachable endpoints were
+# declared, warn the adopter and use the first-declared.
+# -----------------------------------------------------------------------------
+
+# Reachable endpoints in declaration order (NOT sorted — first agent wins).
+REACHABLE_EPS=""
+while IFS=$'\t' read -r agent ep; do
+  [ -z "$ep" ] && continue
+  reach=$(awk -F'\t' -v e="$ep" '$1==e {print $2; exit}' "$EP_REACH")
+  if [ "${reach:-0}" = "1" ]; then
+    # De-dup while preserving order
+    if ! echo "$REACHABLE_EPS" | grep -Fxq "$ep"; then
+      REACHABLE_EPS="${REACHABLE_EPS}${ep}
+"
+    fi
+  fi
+done < "$AGENT_ENDPOINTS"
+
+REACHABLE_COUNT=$(printf '%s' "$REACHABLE_EPS" | grep -c .)
+if [ "$REACHABLE_COUNT" -ge 1 ]; then
+  FIRST_EP=$(printf '%s' "$REACHABLE_EPS" | head -1)
+  if [ "$REACHABLE_COUNT" -gt 1 ]; then
+    EP_LIST=$(printf '%s' "$REACHABLE_EPS" | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g')
+    echo "⚠ agent-routing: multiple endpoints declared ($EP_LIST); v1 supports one endpoint per session; using $FIRST_EP. See AgDR-0050 § Axis 5." >&2
+    warnings=$((warnings + 1))
+  fi
+  SESSION_ENV="$ENV_DIR/__session__.env"
+  if [ -f "$SESSION_ENV" ]; then
+    grep -v '^ANTHROPIC_BASE_URL=' "$SESSION_ENV" > "${SESSION_ENV}.tmp" 2>/dev/null || true
+    mv "${SESSION_ENV}.tmp" "$SESSION_ENV"
+  else
+    : > "$SESSION_ENV"
+  fi
+  printf 'ANTHROPIC_BASE_URL=%s\n' "$FIRST_EP" >> "$SESSION_ENV"
+fi
+
+# Clean up local-routing scratch files.
+rm -f "$EP_REACH" "$AGENT_MODELS" "$AGENT_ENDPOINTS"
+
+# -----------------------------------------------------------------------------
 # Write the framework-defaults snapshot. The drift guard reads this to
 # decide whether a committed model: line is the framework default or a
 # leaked override.
@@ -406,7 +563,11 @@ fi
 # Wave-1-invariant 600-char SessionStart budget.
 # -----------------------------------------------------------------------------
 if [ "$applied" -gt 0 ]; then
-  echo "ApexYard: applied $applied agent-routing override(s) from agent-routing.yaml" >&2
+  suffix=""
+  if [ "$ollama_applied" -gt 0 ] || [ "$warnings" -gt 0 ]; then
+    suffix=" [${ollama_applied} Ollama, ${warnings} warning(s)]"
+  fi
+  echo "ApexYard: applied $applied agent-routing override(s) from agent-routing.yaml${suffix}" >&2
 fi
 
 exit 0

--- a/.claude/hooks/tests/test_agent_routing_sync_and_drift.sh
+++ b/.claude/hooks/tests/test_agent_routing_sync_and_drift.sh
@@ -3,7 +3,7 @@
 # block-agent-routing-drift.sh (pre-commit + pre-push drift guard) —
 # the two hooks #351 PR 2 ships per AgDR-0050 § Axis 4.
 #
-# Coverage (7 cases):
+# Coverage (13 cases):
 #
 #   Sync hook (apply-agent-routing.sh):
 #     1. Empty config — empty agent-routing.yaml means no-op; no agent
@@ -26,6 +26,28 @@
 #        hook exits 0.
 #     7. Drift accepts on no-drift — staged agent file carries the
 #        framework default model: line; hook exits 0 cleanly.
+#     8. Utility-agent override — ticket-manager sonnet → opus exercises
+#        the utility-class path (not just role-derived agents).
+#
+#   Ollama local-routing extensions (me2resh/apexyard#438):
+#     9. Ollama agent + reachable proxy + pulled model — full apply:
+#        model rewrite, per-agent env file, __session__.env, banner
+#        suffix "1 Ollama, 0 warning(s)".
+#    10. Ollama agent + UNREACHABLE proxy — model still rewrites; per-
+#        agent env file NOT written; no __session__.env; banner reports
+#        "1 Ollama, 1 warning(s)" with reachability warning emitted.
+#    11. Ollama agent + reachable proxy + model NOT pulled — apply
+#        succeeds (proxy is reachable); banner emits `ollama pull <name>`
+#        hint as a 1-warning.
+#    12. Two agents same endpoint — single __session__.env written, no
+#        multi-endpoint warning.
+#    13. Two agents different endpoints — first-declared wins;
+#        multi-endpoint warning emitted.
+#
+#   Mock curl: cases 9-13 prepend a fake `curl` to PATH that consults
+#   $APEXYARD_MOCK_CURL_DIR for canned responses. Each fixture is named
+#   by the URL with /:?&= squeezed to a single underscore, contents
+#   `<HTTP_STATUS>\n<BODY>`. Missing fixture = exit 7 (unreachable).
 #
 # Pattern follows test_portfolio_paths.sh + test_split_portfolio_v2_migration.sh:
 #   - SRC_ROOT resolved from the test file's location
@@ -431,6 +453,267 @@ if [ "$after_tm" = "opus" ] && [ "$after_qa" = "haiku" ] \
 else
   mark_fail "case 8: ticket-manager utility override" "after_tm=$after_tm qa=$after_qa snapshot=$defaults_snapshot_exists banner=[$banner_output]"
 fi
+rm -rf "$SB"
+
+# ===========================================================================
+# Mock curl helper for the Ollama-path cases (cases 9-13).
+#
+# Drops a fake `curl` script onto $PATH that consults $APEXYARD_MOCK_CURL_DIR
+# for canned responses. Each fixture is named by the sanitised URL and
+# contains `<HTTP_STATUS>\n<BODY>`. Missing fixture = simulated network
+# failure (exit 7). Honours `--fail` so the hook's reachability check
+# behaves like real curl would.
+# ===========================================================================
+make_mock_curl() {
+  local sb="$1"
+  local fixture_dir="$sb/.test-curl-fixtures/bin"
+  mkdir -p "$fixture_dir"
+  cat > "$fixture_dir/curl" <<'CURL_MOCK'
+#!/bin/bash
+# Mock curl — for hook tests only.
+url=""
+fail=0
+output_target=""
+expect_output_target=0
+for arg in "$@"; do
+  if [ "$expect_output_target" = "1" ]; then
+    output_target="$arg"
+    expect_output_target=0
+    continue
+  fi
+  case "$arg" in
+    -s|--silent) ;;
+    -f|--fail)   fail=1 ;;
+    -o)          expect_output_target=1 ;;
+    --max-time)  expect_output_target=1 ;;
+    --max-time=*) ;;
+    http*) url="$arg" ;;
+    *) ;;
+  esac
+done
+# If `--max-time <N>` consumed N as the output_target, undo that.
+case "$output_target" in
+  ''|[0-9]*) output_target="" ;;
+esac
+[ -z "$url" ] && exit 1
+key=$(printf '%s' "$url" | tr '/:?&=' '_____' | tr -s '_')
+fixture="${APEXYARD_MOCK_CURL_DIR:-/nonexistent}/$key"
+if [ -f "$fixture" ]; then
+  status=$(head -1 "$fixture")
+  body=$(tail -n +2 "$fixture")
+  if [ "$status" -ge 400 ] && [ "$fail" = "1" ]; then
+    exit 22
+  fi
+  if [ "$output_target" = "/dev/null" ] || [ -z "$output_target" ]; then
+    printf '%s' "$body"
+  else
+    printf '%s' "$body" > "$output_target"
+  fi
+  exit 0
+fi
+# No fixture = unreachable / connection refused
+exit 7
+CURL_MOCK
+  chmod +x "$fixture_dir/curl"
+  echo "$fixture_dir"
+}
+
+# ===========================================================================
+# CASE 9 — Ollama agent with reachable proxy + pulled model.
+# Expects: model rewrite, per-agent env file + __session__.env both written,
+# banner reports "1 Ollama, 0 warning(s)".
+# ===========================================================================
+SB=$(make_fork)
+MOCK_BIN=$(make_mock_curl "$SB")
+APEXYARD_MOCK_CURL_DIR=$(mktemp -d)
+export APEXYARD_MOCK_CURL_DIR
+printf '200\n[]\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_4000_v1_models"
+printf '200\n{"models":[{"name":"qwen2.5-coder:14b"}]}\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_4000_api_tags"
+
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  ticket-manager:
+    model: ollama/qwen2.5-coder:14b
+    endpoint: http://localhost:4000
+YAML
+
+banner_output=$(cd "$SB" && PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+after_tm=$(read_model_line "$SB/.claude/agents/ticket-manager.md")
+session_env="$SB/.claude/session/agent-env/__session__.env"
+agent_env="$SB/.claude/session/agent-env/ticket-manager.env"
+session_set=0
+agent_set=0
+[ -f "$session_env" ] && grep -q '^ANTHROPIC_BASE_URL=http://localhost:4000$' "$session_env" && session_set=1
+[ -f "$agent_env" ] && grep -q '^ANTHROPIC_BASE_URL=http://localhost:4000$' "$agent_env" && agent_set=1
+
+if [ "$after_tm" = "ollama/qwen2.5-coder:14b" ] \
+   && [ "$session_set" = "1" ] \
+   && [ "$agent_set" = "1" ] \
+   && echo "$banner_output" | grep -qE 'applied 1 agent-routing override.*1 Ollama, 0 warning'; then
+  mark_pass "case 9: Ollama agent with reachable proxy + pulled model (full apply, session + per-agent env, no warnings)"
+else
+  mark_fail "case 9: Ollama agent reachable + pulled" "model=$after_tm session=$session_set agent=$agent_set banner=[$banner_output]"
+fi
+unset APEXYARD_MOCK_CURL_DIR
+rm -rf "$SB"
+
+# ===========================================================================
+# CASE 10 — Ollama agent with UNREACHABLE proxy.
+# Expects: model rewrite still applies; per-agent env file NOT written;
+# __session__.env NOT written; banner reports "1 Ollama, 1 warning(s)".
+# ===========================================================================
+SB=$(make_fork)
+MOCK_BIN=$(make_mock_curl "$SB")
+APEXYARD_MOCK_CURL_DIR=$(mktemp -d)
+export APEXYARD_MOCK_CURL_DIR
+# Deliberately register NO fixtures — mock curl returns exit 7 (unreachable).
+
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  ticket-manager:
+    model: ollama/qwen2.5-coder:14b
+    endpoint: http://localhost:4000
+YAML
+
+banner_output=$(cd "$SB" && PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+after_tm=$(read_model_line "$SB/.claude/agents/ticket-manager.md")
+session_env="$SB/.claude/session/agent-env/__session__.env"
+agent_env="$SB/.claude/session/agent-env/ticket-manager.env"
+session_absent=1
+agent_absent=1
+[ -f "$session_env" ] && session_absent=0
+[ -f "$agent_env" ] && agent_absent=0
+
+if [ "$after_tm" = "ollama/qwen2.5-coder:14b" ] \
+   && [ "$session_absent" = "1" ] \
+   && [ "$agent_absent" = "1" ] \
+   && echo "$banner_output" | grep -qE 'endpoint http://localhost:4000 not reachable' \
+   && echo "$banner_output" | grep -qE 'applied 1 agent-routing override.*1 Ollama, 1 warning'; then
+  mark_pass "case 10: Ollama agent with unreachable proxy (model rewrites, no env files, 1 warning)"
+else
+  mark_fail "case 10: Ollama unreachable" "model=$after_tm session_absent=$session_absent agent_absent=$agent_absent banner=[$banner_output]"
+fi
+unset APEXYARD_MOCK_CURL_DIR
+rm -rf "$SB"
+
+# ===========================================================================
+# CASE 11 — Ollama agent with reachable proxy but model NOT pulled.
+# Expects: model rewrites; env files written (proxy is reachable); banner
+# reports "1 Ollama, 1 warning(s)" with the `ollama pull` hint emitted.
+# ===========================================================================
+SB=$(make_fork)
+MOCK_BIN=$(make_mock_curl "$SB")
+APEXYARD_MOCK_CURL_DIR=$(mktemp -d)
+export APEXYARD_MOCK_CURL_DIR
+printf '200\n[]\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_4000_v1_models"
+# /api/tags returns a body that does NOT contain qwen2.5-coder:14b
+printf '200\n{"models":[{"name":"llama3.1:8b"}]}\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_4000_api_tags"
+
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  ticket-manager:
+    model: ollama/qwen2.5-coder:14b
+    endpoint: http://localhost:4000
+YAML
+
+banner_output=$(cd "$SB" && PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+session_env="$SB/.claude/session/agent-env/__session__.env"
+session_set=0
+[ -f "$session_env" ] && grep -q '^ANTHROPIC_BASE_URL=http://localhost:4000$' "$session_env" && session_set=1
+
+if echo "$banner_output" | grep -qE 'model qwen2\.5-coder:14b not in local Ollama' \
+   && echo "$banner_output" | grep -qE 'ollama pull qwen2\.5-coder:14b' \
+   && [ "$session_set" = "1" ] \
+   && echo "$banner_output" | grep -qE 'applied 1 agent-routing override.*1 Ollama, 1 warning'; then
+  mark_pass "case 11: Ollama agent with reachable proxy + missing model (override applies, pull-hint emitted)"
+else
+  mark_fail "case 11: Ollama model-not-pulled" "session=$session_set banner=[$banner_output]"
+fi
+unset APEXYARD_MOCK_CURL_DIR
+rm -rf "$SB"
+
+# ===========================================================================
+# CASE 12 — Two agents same endpoint.
+# Expects: single __session__.env written, no multi-endpoint warning.
+# ===========================================================================
+SB=$(make_fork)
+MOCK_BIN=$(make_mock_curl "$SB")
+APEXYARD_MOCK_CURL_DIR=$(mktemp -d)
+export APEXYARD_MOCK_CURL_DIR
+printf '200\n[]\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_4000_v1_models"
+printf '200\n{"models":[{"name":"qwen2.5-coder:14b"},{"name":"llama3.1:8b"}]}\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_4000_api_tags"
+
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  ticket-manager:
+    model: ollama/qwen2.5-coder:14b
+    endpoint: http://localhost:4000
+  qa-engineer:
+    model: ollama/llama3.1:8b
+    endpoint: http://localhost:4000
+YAML
+
+banner_output=$(cd "$SB" && PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+session_env="$SB/.claude/session/agent-env/__session__.env"
+session_lines=0
+[ -f "$session_env" ] && session_lines=$(wc -l < "$session_env" | tr -d ' ')
+
+if [ -f "$session_env" ] \
+   && grep -q '^ANTHROPIC_BASE_URL=http://localhost:4000$' "$session_env" \
+   && [ "$session_lines" = "1" ] \
+   && ! echo "$banner_output" | grep -qE 'multiple endpoints' \
+   && echo "$banner_output" | grep -qE 'applied 2 agent-routing override.*2 Ollama'; then
+  mark_pass "case 12: two agents same endpoint (single __session__.env, no multi-endpoint warning)"
+else
+  mark_fail "case 12: same endpoint" "session_lines=$session_lines banner=[$banner_output]"
+fi
+unset APEXYARD_MOCK_CURL_DIR
+rm -rf "$SB"
+
+# ===========================================================================
+# CASE 13 — Two agents different endpoints.
+# Expects: first-declared endpoint wins; multi-endpoint warning emitted.
+# ===========================================================================
+SB=$(make_fork)
+MOCK_BIN=$(make_mock_curl "$SB")
+APEXYARD_MOCK_CURL_DIR=$(mktemp -d)
+export APEXYARD_MOCK_CURL_DIR
+printf '200\n[]\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_4000_v1_models"
+printf '200\n[]\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_4001_v1_models"
+printf '200\n{"models":[{"name":"qwen2.5-coder:14b"}]}\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_4000_api_tags"
+printf '200\n{"models":[{"name":"llama3.1:8b"}]}\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_4001_api_tags"
+
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  ticket-manager:
+    model: ollama/qwen2.5-coder:14b
+    endpoint: http://localhost:4000
+  qa-engineer:
+    model: ollama/llama3.1:8b
+    endpoint: http://localhost:4001
+YAML
+
+banner_output=$(cd "$SB" && PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+session_env="$SB/.claude/session/agent-env/__session__.env"
+session_set=0
+# Order of writes from $AGENT_ENDPOINTS depends on the iteration order of
+# $ROWS; either endpoint may show up as "first". Just check that exactly
+# one of them is in the session env and the warning fires.
+[ -f "$session_env" ] && grep -qE '^ANTHROPIC_BASE_URL=http://localhost:400[01]$' "$session_env" && session_set=1
+
+if [ "$session_set" = "1" ] \
+   && echo "$banner_output" | grep -qE 'multiple endpoints declared' \
+   && echo "$banner_output" | grep -qE 'applied 2 agent-routing override'; then
+  mark_pass "case 13: two agents different endpoints (first wins, multi-endpoint warning emitted)"
+else
+  mark_fail "case 13: different endpoints" "session_set=$session_set banner=[$banner_output]"
+fi
+unset APEXYARD_MOCK_CURL_DIR
 rm -rf "$SB"
 
 # ===========================================================================

--- a/agent-routing.yaml.example
+++ b/agent-routing.yaml.example
@@ -37,14 +37,25 @@
 #   fork ships with framework default models that work out-of-box.
 # - Omitted agents inherit the framework default from
 #   .claude/agents/<name>.md frontmatter.
-# - At SessionStart, the sync hook (ships in PR 2) rewrites the affected
-#   .claude/agents/*.md frontmatter in-place. Pre-commit + pre-push
-#   guards (PR 2) catch accidental commits of the rewritten frontmatter
-#   so adopter routing choices never leak to the public fork.
+# - At SessionStart, the sync hook (`apply-agent-routing.sh`) rewrites
+#   the affected `.claude/agents/*.md` frontmatter in-place. Pre-commit
+#   and pre-push guards (`block-agent-routing-drift.sh`) catch accidental
+#   commits of the rewritten frontmatter so adopter routing choices never
+#   leak to the public fork.
 #
-# Until PR 2 lands, authoring this file is documented but inert — the
-# YAML is parsed by the schema validator and `portfolio_agent_routing`
-# resolver, but no hook applies it yet.
+# - For entries with `endpoint:`, the sync hook also writes session-wide
+#   `ANTHROPIC_BASE_URL` to `.claude/session/agent-env/__session__.env`
+#   (the per-agent files are written too but are informational until
+#   Claude Code exposes per-agent env scoping). Endpoint reachability is
+#   checked at SessionStart with a 2s budget; an unreachable proxy emits
+#   a warning and skips the override (model rewrite still applies).
+#
+# - For `model: ollama/<name>` entries, the sync hook queries the
+#   endpoint's `/api/tags` and warns if the named model isn't pulled
+#   locally (suggesting `ollama pull <name>`). See me2resh/apexyard#438.
+#
+# See `docs/local-model-setup.md` for the install + configuration
+# walkthrough (Ollama + LiteLLM proxy + this file's Example C).
 #
 
 # Schema version. Bump if breaking changes are introduced.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -266,6 +266,14 @@ Cargo workspaces with many crates have a slow first index — see the caveat bel
 - **No new failure mode.** Skills that benefit from LSP (`/code-review`, `/threat-model`, `/security-review`) fall back to grep + Read transparently when LSP is absent. There is no "broken without LSP" path — only a faster one with it.
 - **Plugin marketplace links may move.** The plugin ecosystem is young. If a marketplace search turns up multiple options for one language, prefer the one maintained by the language's own community (e.g. official `tsserver` over a third-party wrapper).
 
+## Optional: Local agent routing
+
+Agents can optionally route through a locally-running Ollama instance via a LiteLLM proxy — useful when you want to keep prompts off any cloud API for specific sub-tasks (ticket triage, data-analyst sketches, exploratory rephrasing). See [`local-model-setup.md`](local-model-setup.md) for the install + configuration walkthrough.
+
+**Opt-in only.** Absence of an `endpoint:` field in your `agent-routing.yaml` keeps every agent on its framework default. Nothing in the default `/setup` output enables this.
+
+Before opting in, read the [local-model-routing spike memo](spikes/local-model-routing.md) — it measured cold-start latency and tool-call reliability against real workloads and recommends bounded use, not whole-portfolio routing.
+
 ---
 
 ## Customization

--- a/docs/local-model-setup.md
+++ b/docs/local-model-setup.md
@@ -1,0 +1,139 @@
+# Local model routing — agents via LiteLLM proxy + Ollama
+
+Route specific Claude Code sub-agents through a locally-running Ollama instance instead of the Claude API. Useful when you want to keep prompts off any cloud API for bounded sub-tasks (ticket triage, data-analyst sketches, exploratory rephrasing).
+
+This is **opt-in**. The default `agent-routing.yaml` shape is empty; absence of an `endpoint:` field keeps every agent on its framework default. Nothing in this setup changes the out-of-box experience.
+
+> **Read this first:** [Spike #195 — local-model routing measurement + recommendation](spikes/local-model-routing.md). The TL;DR is *"NO-GO as designed, partial GO for synthesis-style sub-tasks; not for everything."* This guide ships the routing mechanism #438 asks for, but the spike's conclusions about tool-call reliability, cold-start latency, and "no silent fallback" all still apply.
+
+## 1. Install Ollama
+
+| OS | One-liner |
+|----|-----------|
+| macOS | `brew install ollama` (then `ollama serve` runs as a launchd service) |
+| Linux | `curl -fsSL https://ollama.com/install.sh \| sh` |
+| Windows | Download from <https://ollama.com/download> |
+
+Verify:
+
+```bash
+ollama --version
+ollama list   # empty after fresh install
+```
+
+## 2. Pull an agent-grade model
+
+Tool-call reliability is the load-bearing risk for routing agents through a local model. The `qwen2.5-coder` family ships with strong tool-call behaviour and is what we'd start with for ticket-manager / data-analyst-style structured-output work. Picking a model that fits *your* hardware matters more than picking the highest-MTEB one — the model must hold tools sanely on the workloads you'll actually run, not just on benchmarks.
+
+| Model | Disk | RAM at load (Q4) | Notes |
+|-------|------|------------------|-------|
+| `qwen2.5-coder:14b` | ~9 GB | ~10 GB | Recommended starting point — strong tool-call reliability |
+| `qwen2.5-coder:7b` | ~4.5 GB | ~6 GB | Works on most laptops; tool-call slightly weaker |
+| `llama3.1:8b` | ~5 GB | ~6 GB | Generalist; less reliable on structured outputs |
+| `deepseek-coder-v2:16b` | ~10 GB | ~12 GB | Code-oriented; needs M-series Pro or 14+ GB GPU |
+| `mistral-small3:24b` | ~13 GB | ~18 GB | Strongest of the four; M-series Max territory |
+
+Pull whichever fits:
+
+```bash
+ollama pull qwen2.5-coder:14b
+ollama list
+```
+
+First call to a freshly-pulled model has **~9–10s cold-start latency** (measured in spike #195). Subsequent calls within the `OLLAMA_KEEP_ALIVE` window are warm.
+
+## 3. Install + configure LiteLLM proxy
+
+Claude Code expects an Anthropic-shaped HTTP API. LiteLLM is a thin proxy that translates Anthropic Messages requests into Ollama's native format. Install it as a Python tool:
+
+```bash
+pip install 'litellm[proxy]'
+```
+
+Create `~/.config/litellm/config.yaml` (or wherever your proxy config lives):
+
+```yaml
+model_list:
+  - model_name: ollama/qwen2.5-coder:14b
+    litellm_params:
+      model: ollama/qwen2.5-coder:14b
+      api_base: http://localhost:11434
+
+  - model_name: ollama/llama3.1:8b
+    litellm_params:
+      model: ollama/llama3.1:8b
+      api_base: http://localhost:11434
+```
+
+Start the proxy on port 4000:
+
+```bash
+litellm --config ~/.config/litellm/config.yaml --port 4000
+```
+
+Sanity check:
+
+```bash
+curl -s http://localhost:4000/v1/models | head -5
+```
+
+You should see the two models from the config. Leave the proxy running in a separate terminal (or as a launchd / systemd unit if you'd rather not babysit it).
+
+## 4. Configure `agent-routing.yaml`
+
+In your portfolio's `agent-routing.yaml` (or the fork-local copy in single-fork mode), add the agents you want to route:
+
+```yaml
+version: 1
+agents:
+  ticket-manager:
+    model: ollama/qwen2.5-coder:14b
+    endpoint: http://localhost:4000
+    env:
+      OLLAMA_KEEP_ALIVE: "30m"
+```
+
+Restart Claude Code. The `apply-agent-routing.sh` SessionStart hook will:
+
+1. Probe `http://localhost:4000/v1/models` with a 2s timeout. If the proxy is down → emit a warning, skip the endpoint override, fall through to the model rewrite only.
+2. Query `http://localhost:4000/api/tags` for `qwen2.5-coder:14b`. If the model isn't pulled → emit `⚠ agent-routing: ticket-manager — model qwen2.5-coder:14b not in local Ollama; run: ollama pull qwen2.5-coder:14b`. The override still applies; Ollama may pull on first call with the cold-start cost.
+3. Rewrite `.claude/agents/ticket-manager.md` frontmatter so `model: ollama/qwen2.5-coder:14b`.
+4. Write `.claude/session/agent-env/ticket-manager.env` with `ANTHROPIC_BASE_URL=http://localhost:4000` (informational in v1 — see constraints below).
+5. Write `.claude/session/agent-env/__session__.env` with the same `ANTHROPIC_BASE_URL`. This is the session-wide variable Claude Code actually reads at startup.
+6. Emit a one-line banner: `ApexYard: applied 1 agent-routing override(s) from agent-routing.yaml [1 Ollama, 0 warning(s)]`.
+
+The `block-agent-routing-drift.sh` pre-commit/pre-push hooks will refuse to let the rewritten frontmatter escape to the public framework remote — adopter routing choices stay local.
+
+## 5. Verify it's actually routing
+
+Open a new Claude Code session in your apexyard fork. Trigger a ticket-manager invocation (e.g. `/task something-trivial`). Watch the LiteLLM proxy log — you should see an inbound POST to `/v1/messages` and a corresponding outbound call to Ollama's `/api/chat`.
+
+If the routing didn't take effect, check in this order:
+
+1. `cat .claude/session/agent-env/__session__.env` — does it contain `ANTHROPIC_BASE_URL=http://localhost:4000`?
+2. `echo $ANTHROPIC_BASE_URL` — has the env file been sourced by your shell profile? (You may need to add `. .claude/session/agent-env/__session__.env` to your `.zshrc`/`.bashrc`.)
+3. Was the LiteLLM proxy reachable when Claude Code started? (Check the SessionStart banner — `0 warning(s)` means the reachability check passed.)
+4. `grep model .claude/agents/ticket-manager.md` — has the model frontmatter been rewritten?
+
+## Constraints (read these before relying on local routing for anything important)
+
+- **Single endpoint per session.** v1 sets `ANTHROPIC_BASE_URL` once at SessionStart. All agents share it. You can't have ticket-manager route to local Ollama while code-reviewer stays on Claude — that's a v2 concern, gated on Claude Code surfacing per-agent invocation env scoping (see [AgDR-0050 § Axis 5](agdr/AgDR-0050-agent-runtime-overhaul.md)). If you declare multiple distinct endpoints, the first wins and a warning is emitted.
+
+- **Cold-start ~9–10s.** Measured in spike #195. The first call after `ollama serve` boot (or after `OLLAMA_KEEP_ALIVE` expires) pays full model-load cost. Subsequent calls within the keep-alive window are warm.
+
+- **No silent fallback to Claude.** A downed LiteLLM proxy or Ollama service means the routed agent fails — the framework will NOT silently route to the Claude API instead. This is deliberate: silent fallback obscures whether you're actually getting local-routing semantics, and the spike memo specifically warned against it.
+
+- **Tool-call reliability is model-dependent.** Even the recommended `qwen2.5-coder:14b` will occasionally drop tool calls under load. Run on a sub-task you can tolerate failing before pinning it as your primary path. Pure prose-synthesis tasks (e.g. inbox summary) are more forgiving than tool-call-heavy ones (e.g. ticket triage with `gh` API calls).
+
+- **Hardware sizing.** As a rough guide: M-series Macs with ≥ 32 GB unified memory comfortably run any 14B model warm; ≥ 16 GB handles 7B models; below 16 GB will swap on the larger ones. Linux + discrete GPU: VRAM is the binding constraint, not system RAM.
+
+- **`OLLAMA_KEEP_ALIVE`.** The env-var setting on the agent entry (`env: { OLLAMA_KEEP_ALIVE: "30m" }`) keeps the model resident in Ollama's process for 30 minutes after the last request. Tune to your usage pattern — too short and you pay cold-start on every session; too long and idle memory stays pinned.
+
+## Disabling local routing
+
+Delete the `endpoint:` line from the agent entry (or comment out the whole agent block). Restart Claude Code. The SessionStart hook rewrites the agent frontmatter back to the framework default and removes the session env file. No re-install required.
+
+## What this guide is *not*
+
+- Not a guide for routing the apexyard-search MCP server's embedding calls through Ollama. That's a separate concern with separate config; not in scope here.
+- Not a recommendation that you *should* run local models for production agents. The spike memo's conclusion stands: route a bounded sub-task to a local model when (a) you have an offline-or-private-data constraint, or (b) you've measured that the quality is acceptable for that specific sub-task. Don't route everything.


### PR DESCRIPTION
## Summary

- **Extends `apply-agent-routing.sh`** to make Ollama Example C actually route — pre-apply reachability probes, model-pulled checks, and a session-wide `__session__.env` write that solves the v1 "Claude Code doesn't consume per-agent env files" gap
- **Writes `docs/local-model-setup.md`** as the single-page install + configure walkthrough (Ollama + LiteLLM proxy + Example C + constraints quoted verbatim from spike #195)
- **5 new test cases** (9–13) covering the Ollama path against a mock curl that consults `$APEXYARD_MOCK_CURL_DIR` for canned responses; 8 existing cases stay green; total 13 PASS / 0 FAIL
- **Updates `agent-routing.yaml.example`** to drop the stale "Until PR 2 lands, ... documented but inert" comment (the sync hook has shipped since #351) and point readers at the new setup doc
- **Adds a one-paragraph pointer** to `docs/getting-started.md` after the LSP section, opt-in by default

## Why this matters

Before this PR: a customer who followed Example C verbatim got nothing. The per-agent env file was written, the model: line was rewritten, and then Claude Code ignored the env file (because v1 doesn't consume per-agent files yet) and routed all traffic through the Anthropic API regardless. No banner, no warning, no signal that the proxy wasn't being used.

After this PR: the SessionStart banner reports `[N Ollama, K warning(s)]` so the operator sees instantly whether their proxy is reachable, whether the named model is pulled, and how many overrides actually applied. The session-wide `ANTHROPIC_BASE_URL` write is the routing mechanism that actually works under v1's "Claude Code reads session env at startup" semantics — per AgDR-0050 § Axis 5. The per-agent files keep being written for forward-compat (when Claude Code exposes per-agent env scoping in a later version).

Spike #195's "NO-GO as designed, partial GO" conclusion is preserved verbatim in the docs — this PR ships the routing mechanism, not a recommendation that you route everything.

## Testing

- [ ] `bash .claude/hooks/tests/test_agent_routing_sync_and_drift.sh` — 13 PASS, 0 FAIL
- [ ] `bash .claude/hooks/tests/test_site_counts.sh` — clean (no new hook added, so no count refresh needed)
- [ ] `bash -n .claude/hooks/apply-agent-routing.sh` — syntax check
- [ ] Manual: start LiteLLM proxy on `:4000` with an Ollama backend; uncomment Example C in `agent-routing.yaml`; restart Claude Code; observe banner `applied 1 agent-routing override(s) [1 Ollama, 0 warning(s)]` and check that `.claude/session/agent-env/__session__.env` contains the expected `ANTHROPIC_BASE_URL=http://localhost:4000`
- [ ] Manual (negative): stop the LiteLLM proxy; restart Claude Code; observe `[1 Ollama, 1 warning(s)]` with `endpoint http://localhost:4000 not reachable` warning, model rewrite still applied
- [ ] Manual (model-not-pulled): start the proxy but don't pull `qwen2.5-coder:14b`; observe `ollama pull qwen2.5-coder:14b` hint in the banner

## Backwards compatibility

- Hook is unchanged behaviour for adopters with no `agent-routing.yaml` (zero-config zero-output)
- Hook is unchanged behaviour for adopters with `model:` overrides but no `endpoint:` field (current Example A / B shapes)
- Tests 1–8 verify the unchanged-behaviour cases still pass byte-for-byte
- Bash 3.2 compatible (uses temp files, not associative arrays) — works on macOS default `/bin/bash`
- No new shell dep beyond `curl` (already required by check-upstream-drift.sh)

## Out of scope (deferred)

- Per-agent invocation env-var scoping (gated on Claude Code upstream surfacing the API — tracked as a follow-up to AgDR-0050 § Axis 5)
- Tool-call reliability matrix per local model — separate spike
- Auto-fallback Claude→Ollama when proxy is down (spike #195 explicitly warned against silent fallback; deliberate non-feature)
- Ollama for embedding routing (different concern, different layer; lives outside the public framework)

Closes #438.

## Glossary

| Term | Definition |
|------|------------|
| **LiteLLM proxy** | Thin HTTP proxy that translates Anthropic Messages API requests into Ollama's native `/api/chat` format. Required for routing agents (which expect an Anthropic-shaped endpoint) through Ollama. Not required for direct Ollama use cases. |
| **Ollama** | Local LLM runtime (https://ollama.com). Serves models on `http://localhost:11434` via its native API. Models pulled via `ollama pull <name>`. |
| **`ANTHROPIC_BASE_URL`** | Env var Claude Code reads at startup to redirect inference traffic to a non-default endpoint. v1 sets this session-wide because Claude Code doesn't expose per-agent env scoping yet. |
| **Reachability check** | 2s-timeout curl against `<endpoint>/v1/models` (LiteLLM's models list) or `/health`. Two attempts; if both fail, endpoint marked unreachable and per-agent env file write is skipped. |
| **Model-pulled check** | 2s-timeout curl against `<endpoint>/api/tags` (Ollama's native model-list endpoint), greps for the named model. Emits `ollama pull <name>` hint on miss; doesn't block the override. |
| **Session-wide env file** | `.claude/session/agent-env/__session__.env` — written by the sync hook with the first reachable endpoint's `ANTHROPIC_BASE_URL`. Read by Claude Code at startup. |
| **Cold start** | ~9-10s first-call latency measured in spike #195 — Ollama pays the model-load cost on the first request after `ollama serve` boot or after `OLLAMA_KEEP_ALIVE` expires. |
