### PR TITLE
fix(#373): catch split-portfolio v2 silent fallbacks for workspace_dir and projects/

### DIFF
--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -375,6 +375,34 @@ portfolio_validate() {
   # would be noisy on fresh forks before /setup runs.
   local root
   root=$(_portfolio_root)
+
+  # Partial split-portfolio v2 detection — see me2resh/apexyard#373.
+  # The registry and projects_dir are the v1 keys that turn a fork into a
+  # split-portfolio v2 setup when overridden to sibling paths. If either is
+  # sibling-pointing but workspace_dir falls back to the in-fork default,
+  # the asymmetry is silent — clones accumulate in the public fork while
+  # docs land in the sibling. Surface the gap so SessionStart catches it.
+  # (onboarding gets its own validation below; it doesn't trigger this
+  # check because adopters legitimately centralise company config without
+  # going split-portfolio v2.)
+  local root_real wd_real
+  root_real=$(cd "$root" 2>/dev/null && pwd -P) || root_real="$root"
+  wd_real=$(cd "$workspace_dir" 2>/dev/null && pwd -P) || wd_real="$workspace_dir"
+
+  _outside_fork() {
+    case "$1" in
+      "$root_real"|"$root_real"/*) return 1 ;;
+    esac
+    return 0
+  }
+
+  if _outside_fork "$registry" || _outside_fork "$projects_dir"; then
+    if ! _outside_fork "$wd_real"; then
+      echo "broken: partial split-portfolio v2 config — registry/projects_dir point at a sibling repo but workspace_dir falls back to the in-fork default; set .portfolio.workspace_dir in .claude/project-config.json to the sibling path (e.g. \"../<fork>-portfolio/workspace\"). See me2resh/apexyard#373."
+      return 1
+    fi
+  fi
+
   case "$onboarding" in
     "$root"/*|"$root")
       # In-fork path — leave it to onboarding-check.sh.

--- a/.claude/hooks/tests/test_portfolio_paths.sh
+++ b/.claude/hooks/tests/test_portfolio_paths.sh
@@ -145,10 +145,53 @@ projects: []
 YAML
 mkdir -p "$SB/../portfolio_test_$$/proj"
 touch "$SB/../portfolio_test_$$/proj/ideas.md"
+mkdir -p "$SB/../portfolio_test_$$/workspace"
 
 # Resolve the actual sibling path (mktemp may use a different real path on macOS).
 SIB=$(cd "$SB/../portfolio_test_$$" && pwd)
 
+# Complete split-portfolio v2 config — registry/projects_dir/ideas_backlog AND
+# workspace_dir all pointing at the sibling repo. The partial-v2 detector
+# added in me2resh/apexyard#373 fires only when workspace_dir falls back to
+# the in-fork default while the other keys are sibling-pointing, so this
+# fixture must include workspace_dir to test the "validate OK" path.
+cat > "$SB/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "registry": "$SIB/apex.yaml",
+    "projects_dir": "$SIB/proj",
+    "ideas_backlog": "$SIB/proj/ideas.md",
+    "workspace_dir": "$SIB/workspace"
+  }
+}
+JSON
+
+run_case "override: absolute registry path wins" "$SB" '
+r=$(portfolio_registry)
+expected="'"$SIB"'/apex.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "override: validate is OK against complete sibling-dir paths" "$SB" '
+if portfolio_validate >/dev/null 2>&1; then exit 0; else echo "validate failed: $(portfolio_validate)"; exit 1; fi
+'
+rm -rf "$SB" "$SIB"
+
+# ---------------------------------------------------------------------------
+# Case 2b: partial split-portfolio v2 — registry / projects_dir point at a
+# sibling repo but workspace_dir falls back to the in-fork default.
+# This is the silent-fallback Bug 1 from me2resh/apexyard#373. validate()
+# must surface it as broken so the SessionStart banner fires.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+mkdir -p "$SB/../portfolio_partial_$$/proj"
+touch "$SB/../portfolio_partial_$$/proj/ideas.md"
+cat > "$SB/../portfolio_partial_$$/apex.yaml" <<'YAML'
+version: 1
+projects: []
+YAML
+SIB=$(cd "$SB/../portfolio_partial_$$" && pwd)
+
+# DELIBERATELY OMIT workspace_dir — this is the bug fixture.
 cat > "$SB/.claude/project-config.json" <<JSON
 {
   "portfolio": {
@@ -159,13 +202,18 @@ cat > "$SB/.claude/project-config.json" <<JSON
 }
 JSON
 
-run_case "override: absolute registry path wins" "$SB" '
-r=$(portfolio_registry)
-expected="'"$SIB"'/apex.yaml"
-if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
-'
-run_case "override: validate is OK against sibling-dir paths" "$SB" '
-if portfolio_validate >/dev/null 2>&1; then exit 0; else echo "validate failed: $(portfolio_validate)"; exit 1; fi
+run_case "v2 (#373): partial config — workspace_dir missing while registry is sibling → broken" "$SB" '
+out=$(portfolio_validate 2>&1)
+rc=$?
+case "$out" in
+  *"partial split-portfolio v2 config"*)
+    [ "$rc" -ne 0 ] && exit 0
+    echo "rc was 0 even though partial-v2 message printed: $out"
+    exit 1
+    ;;
+esac
+echo "expected partial-v2 message, got rc=$rc out=$out"
+exit 1
 '
 rm -rf "$SB" "$SIB"
 

--- a/.claude/skills/dfd/SKILL.md
+++ b/.claude/skills/dfd/SKILL.md
@@ -167,10 +167,10 @@ bash .claude/skills/dfd/discover.sh "$target_dir" "$scope_hint"   > "$discovery_
 bash .claude/skills/dfd/classify.sh "$target_dir"                 > "$classifications_yaml"
 
 bash .claude/skills/dfd/generate-mermaid.sh "$PROJECT" "$discovery_yaml" "$classifications_yaml" \
-  > "projects/${PROJECT}/architecture/dfd.md"
+  > "${projects_dir}/${PROJECT}/architecture/dfd.md"
 
 # Persist the source-of-truth combined report for re-run diffs
-cat "$discovery_yaml" "$classifications_yaml" > "projects/${PROJECT}/architecture/dfd-source.yaml"
+cat "$discovery_yaml" "$classifications_yaml" > "${projects_dir}/${PROJECT}/architecture/dfd-source.yaml"
 ```
 
 The generator replaces placeholders in the template skeleton with real actors / processes / stores / flows from the in-memory model. Every cross-boundary arrow MUST carry a payload label.
@@ -182,7 +182,7 @@ Build a JSON document with the in-memory model and pipe through `generate-dragon
 ```bash
 echo "$model_json" \
   | bash .claude/skills/dfd/generate-dragon.sh \
-  > "projects/${PROJECT}/architecture/dfd.json"
+  > "${projects_dir}/${PROJECT}/architecture/dfd.json"
 ```
 
 `generate-dragon.sh` is a **pure function over the in-memory model** — `/threat-model --format=dragon` (#255) will import the same serialiser when it lands. If `#255` ships first with the serialiser inside `/threat-model`, switch this skill to import from there during code review.

--- a/.claude/skills/extract-features/SKILL.md
+++ b/.claude/skills/extract-features/SKILL.md
@@ -36,6 +36,8 @@ projects_dir=$(portfolio_projects_dir)
 
 Defaults match today's single-fork layout (`./projects`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir}` keys in `.claude/project-config.json` — the helper resolves whichever mode they're in. See `docs/multi-project.md`.
 
+**Write targets** (see me2resh/apexyard#373): paths documented as `projects/<name>/X` in this skill are canonical adopter-facing forms — implement them in bash as `"${projects_dir}/<name>/X"`. Never construct from `"${PWD}/projects/..."`, `"$(git rev-parse --show-toplevel)/projects/..."`, or a literal `./projects/...` — those break in split-portfolio v2 mode where `projects_dir` resolves to a sibling repo.
+
 ## Usage
 
 ```

--- a/.claude/skills/feature-diagram/SKILL.md
+++ b/.claude/skills/feature-diagram/SKILL.md
@@ -33,6 +33,8 @@ projects_dir=$(portfolio_projects_dir)
 
 Defaults match today's single-fork layout (`./projects`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir}` keys in `.claude/project-config.json` — the helper resolves whichever mode they're in. See `docs/multi-project.md`.
 
+**Write targets** (see me2resh/apexyard#373): paths documented as `projects/<name>/X` in this skill are canonical adopter-facing forms — implement them in bash as `"${projects_dir}/<name>/X"`. Never construct from `"${PWD}/projects/..."`, `"$(git rev-parse --show-toplevel)/projects/..."`, or a literal `./projects/...` — those break in split-portfolio v2 mode where `projects_dir` resolves to a sibling repo.
+
 ## Usage
 
 ```

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -24,10 +24,13 @@ Read the registry path via `portfolio_registry`, the per-project docs dir via `p
 ```bash
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+projects_dir=$(portfolio_projects_dir)
 registry=$(portfolio_registry)
 ```
 
 Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
+**Write targets** (see me2resh/apexyard#373): paths documented as `projects/<name>/X` in this skill are canonical adopter-facing forms — implement them in bash as `"${projects_dir}/<name>/X"`. Never construct from `"${PWD}/projects/..."`, `"$(git rev-parse --show-toplevel)/projects/..."`, or a literal `./projects/...` — those break in split-portfolio v2 mode where `projects_dir` resolves to a sibling repo.
 
 ## Usage
 

--- a/.claude/skills/journey/SKILL.md
+++ b/.claude/skills/journey/SKILL.md
@@ -38,6 +38,8 @@ projects_dir=$(portfolio_projects_dir)
 
 Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir}` keys in `.claude/project-config.json`. Don't hardcode literal `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
 
+**Write targets** (see me2resh/apexyard#373): paths documented as `projects/<name>/X` in this skill are canonical adopter-facing forms — implement them in bash as `"${projects_dir}/<name>/X"`. Never construct from `"${PWD}/projects/..."`, `"$(git rev-parse --show-toplevel)/projects/..."`, or a literal `./projects/...` — those break in split-portfolio v2 mode where `projects_dir` resolves to a sibling repo.
+
 ## Usage
 
 ```

--- a/.claude/skills/plan-initiative/SKILL.md
+++ b/.claude/skills/plan-initiative/SKILL.md
@@ -33,6 +33,8 @@ projects_dir=$(portfolio_projects_dir)
 
 Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `projects/` paths — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
 
+**Write targets** (see me2resh/apexyard#373): paths documented as `projects/<name>/X` in this skill are canonical adopter-facing forms — implement them in bash as `"${projects_dir}/<name>/X"`. Never construct from `"${PWD}/projects/..."`, `"$(git rev-parse --show-toplevel)/projects/..."`, or a literal `./projects/...` — those break in split-portfolio v2 mode where `projects_dir` resolves to a sibling repo.
+
 ## Usage
 
 ```

--- a/.claude/skills/process/SKILL.md
+++ b/.claude/skills/process/SKILL.md
@@ -38,6 +38,8 @@ workspace_dir=$(portfolio_workspace_dir)
 
 Defaults match the single-fork layout. Split-portfolio v2 adopters get the resolved sibling-repo paths transparently. Do not hardcode `apexyard.projects.yaml` or `projects/` literals — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
 
+**Write targets** (see me2resh/apexyard#373): paths documented as `projects/<name>/X` in this skill are canonical adopter-facing forms — implement them in bash as `"${projects_dir}/<name>/X"`. Never construct from `"${PWD}/projects/..."`, `"$(git rev-parse --show-toplevel)/projects/..."`, or a literal `./projects/...` — those break in split-portfolio v2 mode where `projects_dir` resolves to a sibling repo.
+
 ## Usage
 
 ```

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -16,10 +16,13 @@ Read the registry path via `portfolio_registry`, the per-project docs dir via `p
 ```bash
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+projects_dir=$(portfolio_projects_dir)
 registry=$(portfolio_registry)
 ```
 
 Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
+**Write targets** (see me2resh/apexyard#373): paths documented as `projects/<name>/X` in this skill are canonical adopter-facing forms — implement them in bash as `"${projects_dir}/<name>/X"`. Never construct from `"${PWD}/projects/..."`, `"$(git rev-parse --show-toplevel)/projects/..."`, or a literal `./projects/...` — those break in split-portfolio v2 mode where `projects_dir` resolves to a sibling repo.
 
 ## Activated role
 

--- a/.claude/skills/stakeholder-update/SKILL.md
+++ b/.claude/skills/stakeholder-update/SKILL.md
@@ -16,10 +16,13 @@ Read the registry path via `portfolio_registry`, the per-project docs dir via `p
 ```bash
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+projects_dir=$(portfolio_projects_dir)
 registry=$(portfolio_registry)
 ```
 
 Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
+**Write targets** (see me2resh/apexyard#373): paths documented as `projects/<name>/X` in this skill are canonical adopter-facing forms — implement them in bash as `"${projects_dir}/<name>/X"`. Never construct from `"${PWD}/projects/..."`, `"$(git rev-parse --show-toplevel)/projects/..."`, or a literal `./projects/...` — those break in split-portfolio v2 mode where `projects_dir` resolves to a sibling repo.
 
 ## Usage
 

--- a/.claude/skills/tech-vision/SKILL.md
+++ b/.claude/skills/tech-vision/SKILL.md
@@ -35,6 +35,8 @@ template=$(portfolio_resolve_template architecture/vision.md)
 
 Defaults match today's single-fork layout (`./projects`, `./templates/architecture/vision.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir}` keys in `.claude/project-config.json` and may drop a custom template at `<private_repo>/custom-templates/architecture/vision.md` — the helper resolves whichever mode they're in. See `docs/multi-project.md` and `templates/README.md` (custom-templates layer).
 
+**Write targets** (see me2resh/apexyard#373): paths documented as `projects/<name>/X` in this skill are canonical adopter-facing forms — implement them in bash as `"${projects_dir}/<name>/X"`. Never construct from `"${PWD}/projects/..."`, `"$(git rev-parse --show-toplevel)/projects/..."`, or a literal `./projects/...` — those break in split-portfolio v2 mode where `projects_dir` resolves to a sibling repo.
+
 ## Usage
 
 ```


### PR DESCRIPTION
## Summary

- **Adds partial-v2 detection to `portfolio_validate()`** — when `portfolio.registry` or `portfolio.projects_dir` resolves outside the ops-fork root (sibling-pointing) but `portfolio.workspace_dir` falls back to the in-fork default, the validator now returns 1 with a structured error and the SessionStart banner fires. Closes the silent-fallback Bug 1 from #373.
- **Fixes `/dfd` SKILL.md's executable bash block** — the three writes at lines 169–185 used literal `projects/${PROJECT}/architecture/...` paths. Switched to `${projects_dir}/${PROJECT}/architecture/...` so split-portfolio v2 adopters get their DFDs written into the sibling repo. Closes Bug 2's only code-shaped offender.
- **Adds an explicit "Write targets" rule** to the Path resolution section of the 9 prompt-based skills (extract-features, feature-diagram, handover, journey, plan-initiative, process, roadmap, stakeholder-update, tech-vision). Stops Claude from constructing `${PWD}/projects/...` or `./projects/...` when the SKILL.md documents the canonical adopter-facing form.
- **39/39 portfolio-paths tests pass** (38 prior + 1 new partial-v2 case). Updated one existing test fixture that was asserting the now-obsolete "partial sibling config validates OK" behaviour.

## Why this matters

Before this PR, an adopter with this `.claude/project-config.json`:

```json
{
  "portfolio": {
    "registry": "../sibling/apexyard.projects.yaml",
    "projects_dir": "../sibling/projects"
  }
}
```

would get NO warning that `workspace_dir` was missing. Every subsequent `/handover` clone landed in the public ops-fork's `workspace/` instead of the configured sibling. Same shape for `/dfd` (Bug 2's literal write): in split-portfolio v2 mode, DFDs were written to `<ops-root>/projects/<name>/architecture/dfd.md` instead of `<sibling>/projects/<name>/architecture/dfd.md`. Two divergent copies of project docs ended up in two repos with no banner, no error.

The validator change is the load-bearing fix — it catches the broader bug at SessionStart so adopters notice within seconds of starting Claude Code, not weeks of accumulated drift. The skill changes prevent regressions of the same shape in the most documented surfaces.

## Testing

- [ ] `bash .claude/hooks/tests/test_portfolio_paths.sh` → 39 PASS, 0 FAIL
- [ ] `bash .claude/hooks/tests/test_site_counts.sh` → clean (no new hook, no count refresh needed)
- [ ] `bash -n .claude/hooks/_lib-portfolio-paths.sh` → syntax OK
- [ ] **Manual repro of Bug 1**: in a sandbox fork with only `portfolio.registry` set to a sibling path, run `bash .claude/hooks/check-portfolio-config.sh < /dev/null`. Expected banner: `broken: partial split-portfolio v2 config — registry/projects_dir point at a sibling repo but workspace_dir falls back to the in-fork default; set .portfolio.workspace_dir in .claude/project-config.json to the sibling path …`
- [ ] **Negative test**: complete v2 config with all four sibling keys → silent banner
- [ ] **Negative test**: single-fork mode (no `portfolio` block) → silent banner
- [ ] **Manual repro of Bug 2**: run `/dfd <project>` in a split-portfolio v2 setup. Output files land in `${sibling}/projects/<project>/architecture/`, NOT in `${ops-root}/projects/<project>/architecture/`.

## Backwards compatibility

- **Single-fork adopters**: zero behaviour change. The new check only fires when registry OR projects_dir is sibling-pointing.
- **Complete v2 adopters** (all four `portfolio.{registry, projects_dir, workspace_dir, onboarding}` keys explicit): zero behaviour change. The new check skips when workspace_dir is sibling-pointing.
- **Partial v2 adopters**: THIS IS THE BUG SHAPE — they now get a banner and a one-line fix instruction. The previous silent behaviour was the bug.
- **Skill docs**: documentation-only additions. No bash that was previously executed differently. The `${projects_dir}` form was already used by half the SKILL.md examples; this just unifies the rest.

## Scope (deliberately tight)

In scope (closes #373):
- `portfolio_validate()` extension for partial-v2 detection
- `/dfd` SKILL.md's three literal-path bash writes
- 9 prompt-based skills' explicit "Write targets" rule
- 1 new test case, 1 existing test fixture updated

Out of scope:
- **The 11 audit skills** (accessibility-audit, analytics-audit, compliance-check, docs-audit, geo-audit, launch-check, monitoring-audit, performance-audit, security-review, seo-audit, threat-model). They delegate to `_lib-audit-history.sh` which already resolves through `portfolio_projects_dir`. Their literal `projects/<name>/audits/...` strings in SKILL.md are descriptive prose, not bash. Touching them adds churn without fixing a bug.
- **Auto-defaulting `workspace_dir` to a sibling path when registry is sibling**. Rejected — would silently move the writable target without the adopter noticing, exactly the failure mode this PR exists to prevent. If adopters ask, file a separate ticket with explicit opt-in design.
- **A separate `check-partial-v2-config.sh` hook**. The check belongs in `portfolio_validate()` where every existing validator already lives.

Closes #373.

## Glossary

| Term | Definition |
|------|------------|
| **Split-portfolio v2** | Two-repo mode (public framework fork + private sibling) introduced by `/split-portfolio`. `portfolio.{registry, projects_dir, workspace_dir, onboarding}` keys in `.claude/project-config.json` route reads + writes to the sibling. |
| **Partial v2 config** | The bug shape this PR catches: some `portfolio.*` keys point at the sibling while others fall back to in-fork defaults. Specifically: `registry` OR `projects_dir` is sibling but `workspace_dir` is the in-fork default → silent fallback for workspace clones. |
| **In-fork default** | The string value that `portfolio_<x>()` returns when no override is set: `./apexyard.projects.yaml` / `./projects` / `./workspace` / `./onboarding.yaml`. Resolves against the ops-fork root. |
| **Helper-resolved write** | Bash construction like `"${projects_dir}/<name>/X"` where `projects_dir` comes from `portfolio_projects_dir`. Routes to whichever filesystem path the resolver returns (single-fork in-fork OR split-portfolio sibling). |
| **Audit skill** | The 11 audit/review skills that delegate writes to `_lib-audit-history.sh`. NOT touched by this PR because the lib already resolves through `portfolio_projects_dir` correctly. |
