### PR TITLE
fix(#442): warn at SessionStart when Ollama routing is INACTIVE; promote shell-profile step in docs

### DIFF
--- a/.claude/hooks/apply-agent-routing.sh
+++ b/.claude/hooks/apply-agent-routing.sh
@@ -538,6 +538,26 @@ if [ "$REACHABLE_COUNT" -ge 1 ]; then
     : > "$SESSION_ENV"
   fi
   printf 'ANTHROPIC_BASE_URL=%s\n' "$FIRST_EP" >> "$SESSION_ENV"
+
+  # -----------------------------------------------------------------------------
+  # Routing-active check — see me2resh/apexyard#442.
+  # __session__.env is written above, but Claude Code's process env was set
+  # when Claude was launched — SessionStart hooks run in child shells and
+  # can't mutate the parent. So unless the adopter sources __session__.env
+  # in their shell profile BEFORE launching Claude Code, the routing won't
+  # actually take effect even though the banner reports overrides applied.
+  # Detect the mismatch and warn explicitly so the adopter sees the gap
+  # at SessionStart rather than discovering it via "why is my proxy log
+  # empty?" later.
+  # -----------------------------------------------------------------------------
+  if [ -z "${ANTHROPIC_BASE_URL:-}" ] || [ "${ANTHROPIC_BASE_URL:-}" != "$FIRST_EP" ]; then
+    cat >&2 <<EOF
+⚠ agent-routing: ANTHROPIC_BASE_URL=$FIRST_EP was written to $SESSION_ENV but is NOT set in this Claude session's process env. Routing is INACTIVE — every agent call still hits the Anthropic API. To activate, add this line to your shell profile (~/.zshrc / ~/.bashrc) and relaunch Claude Code from a fresh terminal:
+    [ -f "$SESSION_ENV" ] && . "$SESSION_ENV" && export ANTHROPIC_BASE_URL
+See docs/local-model-setup.md § "Before you start" and me2resh/apexyard#442.
+EOF
+    warnings=$((warnings + 1))
+  fi
 fi
 
 # Clean up local-routing scratch files.

--- a/.claude/hooks/tests/test_agent_routing_sync_and_drift.sh
+++ b/.claude/hooks/tests/test_agent_routing_sync_and_drift.sh
@@ -538,7 +538,11 @@ agents:
     endpoint: http://localhost:4000
 YAML
 
-banner_output=$(cd "$SB" && PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+# Case 9 simulates the happy path where the adopter has done the shell-profile
+# step from docs/local-model-setup.md — ANTHROPIC_BASE_URL is already set in
+# the process env so the new routing-active check (me2resh/apexyard#442)
+# does NOT fire.
+banner_output=$(cd "$SB" && ANTHROPIC_BASE_URL=http://localhost:4000 PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
 after_tm=$(read_model_line "$SB/.claude/agents/ticket-manager.md")
 session_env="$SB/.claude/session/agent-env/__session__.env"
 agent_env="$SB/.claude/session/agent-env/ticket-manager.env"
@@ -551,7 +555,7 @@ if [ "$after_tm" = "ollama/qwen2.5-coder:14b" ] \
    && [ "$session_set" = "1" ] \
    && [ "$agent_set" = "1" ] \
    && echo "$banner_output" | grep -qE 'applied 1 agent-routing override.*1 Ollama, 0 warning'; then
-  mark_pass "case 9: Ollama agent with reachable proxy + pulled model (full apply, session + per-agent env, no warnings)"
+  mark_pass "case 9: Ollama agent with reachable proxy + pulled model (full apply, session + per-agent env, no warnings; ANTHROPIC_BASE_URL preset)"
 else
   mark_fail "case 9: Ollama agent reachable + pulled" "model=$after_tm session=$session_set agent=$agent_set banner=[$banner_output]"
 fi
@@ -619,7 +623,9 @@ agents:
     endpoint: http://localhost:4000
 YAML
 
-banner_output=$(cd "$SB" && PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+# Case 11 — ANTHROPIC_BASE_URL preset (happy-path shell), so the only warning
+# should be the model-not-pulled hint, not the routing-active check.
+banner_output=$(cd "$SB" && ANTHROPIC_BASE_URL=http://localhost:4000 PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
 session_env="$SB/.claude/session/agent-env/__session__.env"
 session_set=0
 [ -f "$session_env" ] && grep -q '^ANTHROPIC_BASE_URL=http://localhost:4000$' "$session_env" && session_set=1
@@ -628,7 +634,7 @@ if echo "$banner_output" | grep -qE 'model qwen2\.5-coder:14b not in local Ollam
    && echo "$banner_output" | grep -qE 'ollama pull qwen2\.5-coder:14b' \
    && [ "$session_set" = "1" ] \
    && echo "$banner_output" | grep -qE 'applied 1 agent-routing override.*1 Ollama, 1 warning'; then
-  mark_pass "case 11: Ollama agent with reachable proxy + missing model (override applies, pull-hint emitted)"
+  mark_pass "case 11: Ollama agent with reachable proxy + missing model (override applies, pull-hint emitted; ANTHROPIC_BASE_URL preset)"
 else
   mark_fail "case 11: Ollama model-not-pulled" "session=$session_set banner=[$banner_output]"
 fi
@@ -657,7 +663,8 @@ agents:
     endpoint: http://localhost:4000
 YAML
 
-banner_output=$(cd "$SB" && PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+# Case 12 — ANTHROPIC_BASE_URL preset (happy-path shell).
+banner_output=$(cd "$SB" && ANTHROPIC_BASE_URL=http://localhost:4000 PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
 session_env="$SB/.claude/session/agent-env/__session__.env"
 session_lines=0
 [ -f "$session_env" ] && session_lines=$(wc -l < "$session_env" | tr -d ' ')
@@ -667,7 +674,7 @@ if [ -f "$session_env" ] \
    && [ "$session_lines" = "1" ] \
    && ! echo "$banner_output" | grep -qE 'multiple endpoints' \
    && echo "$banner_output" | grep -qE 'applied 2 agent-routing override.*2 Ollama'; then
-  mark_pass "case 12: two agents same endpoint (single __session__.env, no multi-endpoint warning)"
+  mark_pass "case 12: two agents same endpoint (single __session__.env, no multi-endpoint warning; ANTHROPIC_BASE_URL preset)"
 else
   mark_fail "case 12: same endpoint" "session_lines=$session_lines banner=[$banner_output]"
 fi
@@ -698,7 +705,12 @@ agents:
     endpoint: http://localhost:4001
 YAML
 
-banner_output=$(cd "$SB" && PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+# Case 13 — ANTHROPIC_BASE_URL preset matching EITHER endpoint (whichever
+# wins as first-declared). Both 4000 and 4001 are reachable per the mock;
+# the iteration order picks one. We just need to keep the routing-active
+# warning silent, so set the env to match either possibility — the parser's
+# determinism is tested by checking the resulting session env content below.
+banner_output=$(cd "$SB" && ANTHROPIC_BASE_URL=http://localhost:4000 PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
 session_env="$SB/.claude/session/agent-env/__session__.env"
 session_set=0
 # Order of writes from $AGENT_ENDPOINTS depends on the iteration order of
@@ -712,6 +724,47 @@ if [ "$session_set" = "1" ] \
   mark_pass "case 13: two agents different endpoints (first wins, multi-endpoint warning emitted)"
 else
   mark_fail "case 13: different endpoints" "session_set=$session_set banner=[$banner_output]"
+fi
+unset APEXYARD_MOCK_CURL_DIR
+rm -rf "$SB"
+
+# ===========================================================================
+# CASE 14 — Ollama agent with reachable proxy + pulled model BUT the parent
+# shell didn't preset ANTHROPIC_BASE_URL. me2resh/apexyard#442: the routing
+# is INACTIVE because Claude Code's process env doesn't have the var.
+# Expect: __session__.env still written (next-session prep); banner reports
+# "1 Ollama, 1 warning(s)" naming the routing-INACTIVE gap and the exact
+# shell-profile line to add.
+# ===========================================================================
+SB=$(make_fork)
+MOCK_BIN=$(make_mock_curl "$SB")
+APEXYARD_MOCK_CURL_DIR=$(mktemp -d)
+export APEXYARD_MOCK_CURL_DIR
+printf '200\n[]\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_4000_v1_models"
+printf '200\n{"models":[{"name":"qwen2.5-coder:14b"}]}\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_4000_api_tags"
+
+cat > "$SB/agent-routing.yaml" <<'YAML'
+version: 1
+agents:
+  ticket-manager:
+    model: ollama/qwen2.5-coder:14b
+    endpoint: http://localhost:4000
+YAML
+
+# Deliberately NOT setting ANTHROPIC_BASE_URL — simulates the adopter who
+# enabled Example C but never did the shell-profile step.
+banner_output=$(cd "$SB" && unset ANTHROPIC_BASE_URL; PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true)
+session_env="$SB/.claude/session/agent-env/__session__.env"
+session_set=0
+[ -f "$session_env" ] && grep -q '^ANTHROPIC_BASE_URL=http://localhost:4000$' "$session_env" && session_set=1
+
+if [ "$session_set" = "1" ] \
+   && echo "$banner_output" | grep -qiE 'routing is INACTIVE' \
+   && echo "$banner_output" | grep -qF "$session_env" \
+   && echo "$banner_output" | grep -qE 'applied 1 agent-routing override.*1 Ollama, 1 warning'; then
+  mark_pass "case 14 (#442): Ollama routing INACTIVE when ANTHROPIC_BASE_URL not preset (session env written, warning names the gap)"
+else
+  mark_fail "case 14 (#442): routing-inactive warning" "session=$session_set banner=[$banner_output]"
 fi
 unset APEXYARD_MOCK_CURL_DIR
 rm -rf "$SB"

--- a/docs/local-model-setup.md
+++ b/docs/local-model-setup.md
@@ -6,6 +6,25 @@ This is **opt-in**. The default `agent-routing.yaml` shape is empty; absence of 
 
 > **Read this first:** [Spike #195 — local-model routing measurement + recommendation](spikes/local-model-routing.md). The TL;DR is *"NO-GO as designed, partial GO for synthesis-style sub-tasks; not for everything."* This guide ships the routing mechanism #438 asks for, but the spike's conclusions about tool-call reliability, cold-start latency, and "no silent fallback" all still apply.
 
+## Before you start — the one manual step
+
+`ANTHROPIC_BASE_URL` is set in your shell **before** Claude Code launches. SessionStart hooks (which is where `apply-agent-routing.sh` runs) execute in child shells and **cannot** change Claude's process env. So even after the SessionStart banner reports `applied N agent-routing override(s)`, the routing is INACTIVE until you do this:
+
+```bash
+# Add ONE of these to ~/.zshrc, ~/.bashrc, or your equivalent shell profile.
+# The session-env file is written by apply-agent-routing.sh on each
+# SessionStart and contains the resolved ANTHROPIC_BASE_URL for the
+# first-declared reachable endpoint in agent-routing.yaml.
+
+ops_root="${APEXYARD_OPS_ROOT:-$HOME/projects/apexyard}"   # or your fork's path
+session_env="${ops_root}/.claude/session/agent-env/__session__.env"
+[ -f "$session_env" ] && . "$session_env" && export ANTHROPIC_BASE_URL
+```
+
+Open a fresh terminal and launch Claude Code from it. On every SessionStart, the apply hook checks whether `$ANTHROPIC_BASE_URL` in the current process matches what `__session__.env` says it should be — if not, the banner now emits a one-line `⚠ routing INACTIVE` warning naming the gap. No silent failure.
+
+If you'd rather not edit your shell profile, the alternative is to `export ANTHROPIC_BASE_URL=http://localhost:4000` manually in every terminal before `claude`. That works too; it's just the same step done by hand each time.
+
 ## 1. Install Ollama
 
 | OS | One-liner |


### PR DESCRIPTION
## Summary

- **Adds a routing-active visibility check** in `apply-agent-routing.sh` — after writing `__session__.env`, compare the resolved endpoint to `$ANTHROPIC_BASE_URL` in the current process; on mismatch emit a one-line warning naming the gap and the exact remediation. Folds into the existing `[N Ollama, K warning(s)]` banner.
- **Promotes the shell-profile step to a "Before you start" callout** at the top of `docs/local-model-setup.md` (was buried at step 5). Explains why SessionStart hooks can't propagate env vars into Claude's process and shows the exact one-liner to add.
- **14/14 tests pass** (4 existing cases updated to preset `ANTHROPIC_BASE_URL`, 1 new case 14 specifically asserts the routing-inactive warning).

## Why this matters

#440 shipped the apply-agent-routing.sh extension that writes `__session__.env` with `ANTHROPIC_BASE_URL=<endpoint>`. The SessionStart banner reports `applied 1 agent-routing override(s) [1 Ollama, 0 warning(s)]`. **But Claude Code's process env was set at launch time** — SessionStart hooks run in child shells and cannot mutate the parent. Unless the adopter sources `__session__.env` in their shell profile **before** launching Claude Code, the routing is INACTIVE and every agent call still hits the Anthropic API.

The buried-at-step-5 doc made this easy to skim past on first install. The optimistic banner reinforced the illusion that everything worked.

After this PR, the banner reports `[1 Ollama, 1 warning(s)]` with explicit text naming the gap, the file path, the shell-profile line to add, and the relaunch requirement.

## Testing

- [ ] `bash .claude/hooks/tests/test_agent_routing_sync_and_drift.sh` — 14/14 PASS
- [ ] `bash -n .claude/hooks/apply-agent-routing.sh` — syntax OK
- [ ] **Manual happy-path**: source `__session__.env` in `~/.zshrc`, relaunch Claude, observe `[1 Ollama, 0 warning(s)]` and `$ANTHROPIC_BASE_URL` set in the process
- [ ] **Manual gap-path**: skip the shell-profile step, relaunch Claude, observe `[1 Ollama, 1 warning(s)]` with the routing-INACTIVE warning quoting the exact path
- [ ] **Recovery**: add the shell-profile line, open a fresh terminal, relaunch — warning clears

## Backwards compatibility

- Adopters who have the shell-profile step in place: zero behaviour change (warning is silent on match).
- Adopters who declared an `endpoint:` but skipped the shell-profile step: now get a clear warning instead of silent failure. This is the intended fix.
- Adopters with no `endpoint:` declaration: zero behaviour change (check only runs when a reachable endpoint exists).

## Out of scope (deferred)

- Modifying `.zshrc` / `.bashrc` directly from the hook — too invasive.
- A wrapper script (`apexyard-launch`) that sets env then `exec`s Claude — bigger UX change, separate ticket if desired.
- Per-agent env scoping (still gated on upstream Claude Code surfacing per-agent invocation env).

Closes #442.

## Glossary

| Term | Definition |
|------|------------|
| **Routing-active check** | New SessionStart-time check in `apply-agent-routing.sh` that compares the resolved endpoint to `$ANTHROPIC_BASE_URL` in the current process. Fires a warning when they differ. |
| **`__session__.env`** | File written by `apply-agent-routing.sh` at `.claude/session/agent-env/__session__.env` containing `ANTHROPIC_BASE_URL=<endpoint>`. Must be sourced from the adopter's shell profile to take effect. |
| **Shell-profile step** | The manual one-liner the adopter adds to `~/.zshrc` / `~/.bashrc` to source `__session__.env` on shell start. Required for routing to actually activate (Claude Code can't read this file by itself). |
| **Routing INACTIVE** | The state where the override has been "applied" (model rewritten, env file written) but Claude Code's process env doesn't have `ANTHROPIC_BASE_URL` set — so every agent call still hits the Anthropic API. The warning this PR adds catches exactly this state. |
