### PR TITLE
feat(#449): Rex semantic handbook supplement via MCP search_docs (additive, fail-soft)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -3,7 +3,7 @@
 name: code-reviewer
 persona_name: Rex
 description: Expert code review specialist. Reviews PRs for quality, security, and standards compliance. Use proactively after code changes or when a PR needs review.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__apexyard-search__search_docs
 disallowedTools: Write, Edit
 model: opus
 ---
@@ -240,6 +240,71 @@ fi
 
 Read each loaded handbook in full. They're flat markdown (with an optional frontmatter block on domain handbooks) — no heavy parser needed.
 
+Tag every handbook loaded in this step with `discovery_method: path-convention` so it can be cited alongside semantically-discovered ones below — see § "Handbook section in the review output" for the citation shape.
+
+#### Semantic supplement (MCP `search_docs`) — additive, fail-soft (apexyard#449)
+
+This step **supplements** the path-convention set above with handbooks that semantically match the PR's content but didn't match a path glob. It is **strictly additive** — the path-convention set is the floor and never shrinks. Adopters without MCP get path-convention only; the rest of this section is a no-op for them.
+
+Rules:
+
+1. **Skip silently if MCP is unavailable.** The `mcp__apexyard-search__search_docs` tool is declared in this agent's `tools:` line. If the tool call fails (server not running, scope not indexed, network error, or the tool isn't loaded in this Claude Code installation), catch the error, set `SEMANTIC_SUPPLEMENT_STATUS=unavailable`, and proceed with the path-convention set unchanged. Do NOT emit a user-visible warning — the supplement is opportunistic, not required. Adopters who never installed MCP must see identical Rex behaviour to before this feature shipped.
+2. **Skip silently if the index lacks handbook chunks.** A fresh MCP install that hasn't been reindexed since the framework was forked may return zero handbook results. Treat zero results as a no-op, not an error.
+3. **Query construction.** Build a single `search_docs` query that combines:
+   - The PR title (high signal — humans summarise intent here)
+   - The top 5 changed file paths by churn (`gh pr view <N> --json files --jq '.files | sort_by(.additions + .deletions) | reverse | .[0:5] | .[].path'`)
+   - Up to 5 identifier names that appear ≥ 3 times in the diff (function / class names — extract via grep on the diff body, dedupe, sort by frequency)
+
+   Concatenate as a single space-separated string. Don't fan out into N queries — one batched call.
+4. **Scope filter.** Restrict results to handbook paths: pass `scope="framework"` AND post-filter results to keep only those whose `path` starts with `handbooks/` or contains `custom-handbooks/`. The MCP server doesn't currently expose a per-glob scope filter — the post-filter is the cheapest workaround.
+5. **Top-K.** Take the top 5 chunks by score. Group by handbook path; for each unique handbook path, load the full file (same as path-convention discovery does). De-duplicate against the path-convention set — if a handbook is already loaded, skip it (don't reload).
+6. **Tag every newly-loaded handbook** with `discovery_method: semantic-search` and capture the matching chunk excerpt (truncated to 150 chars) as `semantic_match_excerpt` so the citation can show *why* it was loaded.
+
+Reference shape — minimal, fail-soft:
+
+```python
+# Pseudocode — run inside Rex's review process
+semantic_status = "unavailable"
+semantic_supplements = []
+
+try:
+    query_parts = [
+        pr_title,
+        " ".join(top_5_churn_paths),
+        " ".join(top_5_repeated_identifiers),
+    ]
+    query = " ".join(q for q in query_parts if q)
+
+    result = mcp_apexyard_search.search_docs(query=query, top_k=5)
+
+    for hit in result.results:
+        path = hit.get("path", "")
+        if not (path.startswith("handbooks/") or "custom-handbooks/" in path):
+            continue
+        if path in already_loaded_handbook_paths:
+            continue  # already discovered via path-convention; don't reload
+        semantic_supplements.append({
+            "path": path,
+            "discovery_method": "semantic-search",
+            "semantic_match_excerpt": hit.get("excerpt", "")[:150],
+        })
+
+    semantic_status = "indexed" if semantic_supplements else "no-additional-matches"
+
+except Exception:
+    # MCP server down, tool not available, index empty, network error — any of these.
+    # Silent fallback: path-convention set is unchanged. No user-visible warning.
+    semantic_status = "unavailable"
+```
+
+What this step does NOT do:
+
+- Does NOT replace the path-convention set — that set is the floor.
+- Does NOT shrink the loaded handbook set under any condition.
+- Does NOT block the review if MCP is down — Rex's review proceeds with path-convention discovery alone.
+- Does NOT emit a user-visible warning when MCP is unreachable — only verbose-logs the status for the operator who runs Rex with debug enabled.
+- Does NOT change the enforcement semantics (advisory / blocking) of any handbook — those still come from the handbook's own `ENFORCEMENT:` line. Discovery method only affects citation.
+
 #### Domain handbook frontmatter — `paths:` field
 
 Domain handbooks (`handbooks/domain/<area>/*.md`, both public and private custom layers) are the **only** bucket that supports a frontmatter block. Parse it cheaply:
@@ -397,6 +462,7 @@ For each loaded handbook (public or private custom):
    - The file:line in the diff
    - The specific rule violated (one-sentence summary)
    - The mitigation, if the handbook suggests one
+   - The handbook's `discovery_method` tag — `path-convention` (default, deterministic) or `semantic-search` (apexyard#449). For semantic-search-loaded handbooks, also include the short `semantic_match_excerpt` captured during discovery so the reader can see why this handbook was loaded for this diff. See "Handbook section in the review output" for the citation shape.
 
 #### Handbook section in the review output
 
@@ -413,9 +479,15 @@ Add a `### Handbook Findings` section to the review (between the `### Issues Fou
 
 ⚠ **TypeScript Strict Mode** — `handbooks/language/typescript/strict-mode.md`
 - `src/handlers/user.ts:42` declares `function fetchUser(id: any)` — replace with `string` or a domain value object.
+
+⚠ **Payment Idempotency** *(semantic match — discovery: semantic-search)* — `handbooks/domain/payments/idempotency-keys.md`
+- _Loaded because the PR title and `src/handlers/stripe-webhook.ts` semantically matched this handbook's index, even though no `paths:` glob in the handbook's frontmatter matched the diff._
+- `src/handlers/stripe-webhook.ts:88` retries a `charges.create` call without supplying the `Idempotency-Key` header. Add the request UUID per handbook § "What Rex flags" #2.
 ```
 
-If no handbooks loaded (e.g. the diff doesn't trigger any language handbooks and no `architecture/` or `general/` files exist), omit the section entirely.
+If no handbooks loaded (e.g. the diff doesn't trigger any language handbooks, no semantic matches above the score floor, and no `architecture/` or `general/` files exist), omit the section entirely.
+
+The `*(semantic match — discovery: semantic-search)*` annotation is required on every semantically-discovered handbook citation so the reader can see WHY a handbook fired for content that didn't match its path globs — without that visibility, semantic supplements feel non-deterministic. Path-convention citations stay un-annotated (no clutter for the dominant case).
 
 ## Process
 

--- a/handbooks/README.md
+++ b/handbooks/README.md
@@ -21,6 +21,12 @@ Rex finds handbooks by **path convention** — there is no YAML frontmatter, no 
 
 If you need a fifth bucket beyond these four, add the directory and update Rex's discovery logic in `.claude/agents/code-reviewer.md`. The path convention is open — Rex falls back to "always-load" for any directory it doesn't have specific rules for.
 
+### Semantic supplement (apexyard#449)
+
+When the MCP search server (`apexyard-search`) is installed and the framework has been reindexed, Rex **additionally** consults the vector index for handbooks that semantically match the PR's content but didn't match a path glob. This is purely additive — the path-convention table above is the floor and never shrinks. Semantically-discovered handbooks are loaded on top with the same enforcement semantics as path-discovered ones, and citations in the review output carry an explicit `*(semantic match — discovery: semantic-search)*` annotation so the reader can see why a handbook fired for a diff that didn't match its paths.
+
+Adopters who don't run MCP get path-convention discovery only — Rex's behaviour is byte-for-byte identical to pre-#449 for them, with no warning emitted. See `.claude/agents/code-reviewer.md` § 8 "Semantic supplement" for the discovery shape and fail-soft semantics.
+
 ## File format
 
 Flat markdown. No YAML frontmatter required. Rex reads the file as prose during review and applies the rules conversationally.


### PR DESCRIPTION
## Summary

- **Adds a new step in Rex's §8 (Adopter Handbooks)** — after path-convention discovery, Rex queries `mcp__apexyard-search__search_docs` for handbooks whose content semantically matches the PR's title + top-churn paths + repeated identifiers, loads any matches not already in the path-convention set, and tags them `discovery_method: semantic-search` so citations can show *why* the handbook fired.
- **Strictly additive — path-convention set is the floor** — every handbook Rex loaded before this change still loads. The new step can only ADD handbooks, never remove or shrink the set. Rex's existing capabilities are unchanged.
- **Fail-soft for MCP-less adopters** — if MCP is unreachable, the server is down, the index has no handbook chunks, or the tool isn't loaded in the Claude Code installation, the supplement is a silent no-op. No user-visible warning. Adopters who never installed MCP get byte-for-byte identical Rex behaviour to pre-#449.
- **Explicit attribution prevents "Rex is non-deterministic" complaint** — semantically-discovered citations carry an inline `*(semantic match — discovery: semantic-search)*` tag plus the matching chunk excerpt, so the reader can see exactly why a handbook fired for a diff that didn't match its path globs.

## Why this matters

Today's situation:

- ✅ `apexyard-search` MCP indexer indexes `handbooks/**/*.md` and `custom-handbooks/**/*.md` (`indexer.py` `FRAMEWORK_GLOBS` line 24 + `PORTFOLIO_GLOBS` line 33). The vector index has them.
- ❌ No consumer queries the index for them. Rex's tools list was `Read, Grep, Glob, Bash` — no MCP. Discovery was path-convention only (always-load `architecture/` + `general/`, diff-glob match for `language/<lang>/` and `domain/<area>/`). Semantically-related handbooks that don't share path globs with the diff never load.

Concrete miss this PR closes: a Stripe-webhook PR can now surface `handbooks/domain/payments/idempotency-keys.md` even if the handbook's `paths:` frontmatter doesn't include `src/handlers/stripe-webhook.ts` — the semantic match catches what the path glob misses.

Phase 2 (planning skills consulting MCP for handbooks during `/feature`, `/plan-initiative`, `/tech-vision`) is intentionally deferred per #449's design notes — measure Rex's Phase 1 recall first to decide if Phase 2 is worth shipping.

## What I did NOT change

- Path-convention discovery: untouched. Same `find` + `python3 match_handbooks.py` shape, same always-load buckets, same diff-glob matching, same domain-handbook frontmatter parser.
- Enforcement semantics: untouched. Advisory / blocking still comes from the handbook's own `ENFORCEMENT:` line. Discovery method only affects how the citation is written.
- Per-handbook precedence: untouched. Adopter still resolves overlap in prose inside the custom handbook.
- Backend / Frontend Engineer agents: untouched. They don't query MCP. Separate ticket if measurement shows they should.
- `/feature`, `/plan-initiative`, `/tech-vision` skills: untouched (Phase 2 deferral).

## Testing

- [ ] `bash .claude/agents/tests/test_agent_wrap_shape.sh` — PASS (19/19 roles still pass; code-reviewer.md frontmatter still well-formed)
- [ ] Manual: `grep ^tools: .claude/agents/code-reviewer.md` — confirms `mcp__apexyard-search__search_docs` is in the list
- [ ] Manual: open a PR in an adopter fork WITHOUT MCP installed → Rex's behaviour unchanged, no `search_docs` invocation in the log, no warning
- [ ] Manual: open the same PR in an adopter fork WITH MCP installed → Rex calls `search_docs`, supplement runs, any matches show the `*(semantic match — discovery: semantic-search)*` annotation in the review output
- [ ] Manual: tear MCP server down mid-review → Rex catches the error, sets `SEMANTIC_SUPPLEMENT_STATUS=unavailable`, finishes the review with path-convention findings only, no user-visible warning

## Backwards compatibility

- **Adopters without MCP**: zero behaviour change. The `tools:` line adds a tool they don't have; Claude Code drops unrecognised tools silently. Rex never calls the unavailable tool.
- **Adopters with MCP but no handbook chunks indexed**: zero behaviour change. The `search_docs` call returns empty; supplement is a no-op.
- **Adopters with MCP and indexed handbooks**: Rex's existing findings are unchanged; the review may gain additional handbook citations explicitly tagged as semantic matches. Adopters can spot-check each annotation and refine handbook content if a semantic match feels off.
- **No schema changes** to handbooks themselves. No new frontmatter fields, no new authoring conventions.

## Out of scope (deferred)

- **Phase 2**: extending the semantic supplement to `/feature`, `/plan-initiative`, `/tech-vision`, `/write-spec`. Per #449, ship Phase 1 first, measure recall, then decide.
- **Tuning the query construction**: today's query is `PR title + top-5 churn paths + top-5 repeated identifiers`. If recall is poor, that's iteration on the same step — separate change.
- **MCP scope filter at the server**: today we post-filter results to keep only those whose path starts with `handbooks/` or contains `custom-handbooks/`. A native scope filter would be cleaner but requires a server change — separate ticket.
- **Custom embedder tuning** for handbook content: keep the existing embedder; tune later if measured recall is poor.

Closes #449

## Glossary

| Term | Definition |
|------|------------|
| **Path-convention discovery** | Rex's existing handbook discovery: always-load `architecture/` + `general/`, diff-glob match for `language/<lang>/` and `domain/<area>/`. Deterministic, predictable, ignores semantic relevance. The floor. |
| **Semantic supplement** | The new step added in this PR: query MCP's vector index with `PR title + top-churn paths + repeated identifiers`, load any matching handbooks not already in the path-convention set. Additive, fail-soft, opt-in via MCP installation. |
| **`discovery_method` tag** | Per-handbook annotation captured during discovery — `path-convention` (default, un-cited in output) or `semantic-search` (cited inline with the matching excerpt). Lets the review reader audit WHY a handbook fired. |
| **Fail-soft** | When MCP is unreachable / unavailable / empty, the supplement returns no results and Rex proceeds with path-convention discovery only. No error, no user-visible warning, no degraded review. |
