### PR TITLE
feat(#448): /release-sync carry forward CHANGELOG.md from main to dev

### DIFF
--- a/.claude/hooks/tests/test_release_sync.sh
+++ b/.claude/hooks/tests/test_release_sync.sh
@@ -274,6 +274,161 @@ validate_version "latest"  && mark_fail "version validation reject" "'latest' ac
                            || mark_pass "version validation: 'latest' rejected"
 
 # ---------------------------------------------------------------------------
+# Helper: build a sync branch already in the post-state we want to test
+# step 5b against. The contract of step 5b is:
+#
+#   "If CHANGELOG.md on the sync branch differs from main's CHANGELOG.md,
+#    replace it with main's and commit as a separate atomic commit."
+#
+# How that drift came about isn't part of the contract — multiple mechanics
+# can produce it (a prior `/release-sync` run that didn't carry forward,
+# a manual main edit between releases, divergence from a hand-written
+# CHANGELOG bump on dev that doesn't match main, etc). The test sets up
+# the drift state directly so the carry-forward step is exercised against
+# the condition it's documented to handle, not against one specific path
+# that led there. See apexyard#448 for the design notes.
+#
+# build_sync_branch_with_changelog_drift <root>
+#   Creates a repo with:
+#     - main: CHANGELOG with v2.1.0 + v2.0.0 + v1.0.0 entries
+#     - sync branch: CHANGELOG stuck at v1.0.0 (the drift), plus an
+#       unrelated code commit on top (so step 5b's commit lands above it
+#       and we can assert "only CHANGELOG.md touched in step 5b's commit").
+# ---------------------------------------------------------------------------
+build_sync_branch_with_changelog_drift() {
+  local root="$1"
+  mkdir -p "$root"
+  (
+    cd "$root" || exit 1
+    git init -q
+    git config user.email "test@test.com"
+    git config user.name "test"
+
+    # Base commit: shared CHANGELOG with only v1.0.0.
+    printf '%s\n' "# Changelog" "" "## [1.0.0] — 2026-01-01" "" "- initial release" > CHANGELOG.md
+    echo "base" > README.md
+    git add CHANGELOG.md README.md
+    git commit -q -m "chore: base commit"
+
+    # main branch: advance CHANGELOG with v2.0.0 then v2.1.0 entries.
+    git checkout -q -b main
+    printf '%s\n' "# Changelog" "" \
+      "## [2.1.0] — 2026-05-24" "" "- latest release" "" \
+      "## [2.0.0] — 2026-05-24" "" "- previous release" "" \
+      "## [1.0.0] — 2026-01-01" "" "- initial release" > CHANGELOG.md
+    git add CHANGELOG.md
+    git commit -q -m "chore: advance CHANGELOG to v2.1.0"
+    git tag v2.1.0
+
+    # Sync branch: simulate the post-step-5 state where the sync branch's
+    # CHANGELOG drifted from main's. We branch from base (so CHANGELOG is
+    # still at v1.0.0), then add an unrelated code commit on top so step
+    # 5b's commit lands above it.
+    git checkout -q -b "sync/main-to-dev-after-v2.1.0" main~1
+    echo "feature-b" > feature-b.md
+    git add feature-b.md
+    git commit -q -m "feat(#1): add feature B"
+  ) || return 1
+}
+
+# Run step 5b's carry-forward logic against the current working tree. The
+# function returns 0 if a carry-forward commit was created, 1 if no commit
+# was needed (idempotent path). Echoes the new commit SHA on stdout when
+# a commit is created. Mirrors the SKILL.md bash exactly so the test is
+# verifying the prescribed contract, not a re-implementation.
+run_carry_forward() {
+  if ! git diff --quiet main -- CHANGELOG.md; then
+    git checkout main -- CHANGELOG.md
+    if ! git diff --quiet --cached -- CHANGELOG.md \
+        || ! git diff --quiet -- CHANGELOG.md; then
+      git add CHANGELOG.md
+      git commit -q -m "sync: carry forward CHANGELOG.md from main after vX.Y.Z release
+
+Refs #448"
+      git rev-parse HEAD
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Case 8 (apexyard#448): CHANGELOG drift → carry-forward creates a commit
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d) && SB=$(cd "$SB" && pwd -P)
+build_sync_branch_with_changelog_drift "$SB"
+(
+  cd "$SB" || exit 99
+  # Pre-condition: sync branch's CHANGELOG drifts from main's.
+  if git diff --quiet main -- CHANGELOG.md; then
+    echo "pre-condition failed: sync branch CHANGELOG already matches main" >&2
+    exit 1
+  fi
+  # Run the carry-forward (step 5b).
+  CF_SHA=$(run_carry_forward) || { echo "carry-forward returned no-op when drift existed" >&2; exit 1; }
+  # Post-condition: CHANGELOG now matches main exactly.
+  if ! git diff --quiet main -- CHANGELOG.md; then
+    echo "post-condition failed: CHANGELOG still drifts from main after carry-forward" >&2
+    exit 1
+  fi
+  # Post-condition: the carry-forward commit IS the most-recent commit that touched CHANGELOG.
+  if [ "$(git log -1 --format=%H -- CHANGELOG.md)" != "$CF_SHA" ]; then
+    echo "post-condition failed: carry-forward SHA is not the last CHANGELOG-touching commit" >&2
+    exit 1
+  fi
+  exit 0
+)
+[ "$?" -eq 0 ] && mark_pass "carry-forward (apexyard#448): creates a commit when CHANGELOG drifted from main" \
+              || mark_fail "carry-forward drift case" "see output above"
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 9 (apexyard#448): idempotent — no commit when CHANGELOG already matches
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d) && SB=$(cd "$SB" && pwd -P)
+build_sync_branch_with_changelog_drift "$SB"
+(
+  cd "$SB" || exit 99
+  # First run: should create a commit (drift exists).
+  run_carry_forward > /dev/null || { echo "first run unexpectedly no-op" >&2; exit 1; }
+  COMMITS_AFTER_FIRST=$(git rev-list HEAD | wc -l | tr -d ' ')
+  # Second run: should be a no-op (CHANGELOG now matches main).
+  if run_carry_forward > /dev/null; then
+    echo "second run unexpectedly created a commit (idempotency broken)" >&2
+    exit 1
+  fi
+  COMMITS_AFTER_SECOND=$(git rev-list HEAD | wc -l | tr -d ' ')
+  if [ "$COMMITS_AFTER_FIRST" != "$COMMITS_AFTER_SECOND" ]; then
+    echo "commit count changed on idempotent re-run: $COMMITS_AFTER_FIRST → $COMMITS_AFTER_SECOND" >&2
+    exit 1
+  fi
+  exit 0
+)
+[ "$?" -eq 0 ] && mark_pass "carry-forward (apexyard#448): idempotent — second run is no-op" \
+              || mark_fail "carry-forward idempotency" "see output above"
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 10 (apexyard#448): carry-forward only touches CHANGELOG.md
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d) && SB=$(cd "$SB" && pwd -P)
+build_sync_branch_with_changelog_drift "$SB"
+(
+  cd "$SB" || exit 99
+  CF_SHA=$(run_carry_forward) || { echo "carry-forward unexpectedly no-op" >&2; exit 1; }
+  # The commit's name-only diff must be CHANGELOG.md and nothing else.
+  TOUCHED=$(git show --name-only --format="" "$CF_SHA" | grep -v '^$')
+  if [ "$TOUCHED" != "CHANGELOG.md" ]; then
+    echo "carry-forward touched files other than CHANGELOG.md: '$TOUCHED'" >&2
+    exit 1
+  fi
+  exit 0
+)
+[ "$?" -eq 0 ] && mark_pass "carry-forward (apexyard#448): touches only CHANGELOG.md" \
+              || mark_fail "carry-forward scope" "see output above"
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo

--- a/.claude/skills/release-sync/SKILL.md
+++ b/.claude/skills/release-sync/SKILL.md
@@ -86,6 +86,52 @@ Dev already has the un-squashed versions of all content in the squash commit. An
 
 **Important:** `-X ours` resolves conflicts automatically. It does NOT mean we wholesale replace main's content. Git will only apply this strategy to the conflict regions, not to content that differs cleanly. The merge will preserve any genuine new content introduced in the release commit that wasn't already in dev.
 
+### 5b. Carry forward `CHANGELOG.md` from main (apexyard#448)
+
+The `-X ours` strategy is correct for *code* — dev already has the un-squashed equivalents and should win on every conflict. But `CHANGELOG.md` is the one file where the opposite is true: every release writes new entries on `main`, and `dev` should track those entries forward. Without this step the release-notes history accumulates only on `main`, and the next `/release` run prepends a new entry on a stale `dev` CHANGELOG and the squash-merge silently truncates the prior releases on `main` (see apexyard#446 / #447 for the symptom this caused for v2.2.0).
+
+After the `-X ours` merge above, **check whether `CHANGELOG.md` on the sync branch differs from `upstream/main`'s copy. If yes, replace it with main's copy and commit it as a separate atomic commit on top of the merge.**
+
+```bash
+# Compare the sync branch's CHANGELOG to main's. Use --quiet so the exit
+# code is the load-bearing signal: 0 = same, 1 = different.
+if ! git diff --quiet upstream/main -- CHANGELOG.md; then
+  echo "Carrying forward CHANGELOG.md from main..."
+  git checkout upstream/main -- CHANGELOG.md
+  # Re-check: did the checkout actually change anything in the working tree?
+  if ! git diff --quiet --cached -- CHANGELOG.md \
+      || ! git diff --quiet -- CHANGELOG.md; then
+    git add CHANGELOG.md
+    git commit -m "sync: carry forward CHANGELOG.md from main after <version> release
+
+The -X ours merge above kept dev's CHANGELOG.md, which lacks the entries
+written on main during the <version> release flow. This commit restores
+main's CHANGELOG so dev tracks the full release history forward.
+
+Without this step the next /release run would prepend the new version
+entry on a stale dev CHANGELOG, and the squash-merge to main would silently
+truncate the prior releases — the exact pre-v2.2.0 regression captured in
+apexyard#446 and root-caused in apexyard#448.
+
+Refs #448"
+  fi
+fi
+```
+
+**Path-specific by design (v1).** This step is hardcoded to `CHANGELOG.md` — the one file the release flow writes on `main`. Generalising to other "main-leads" files is deferred until a second one shows up (and would warrant the YAML config knob mentioned in #448 § "Design Notes").
+
+**Why a separate commit rather than amending the merge.** The carry-forward is a deliberate, audit-trail-visible step. Leaving it as its own commit makes the operation reviewable in the sync PR (Rex sees two commits and can sanity-check each); amending would hide the carry-forward inside the merge commit and obscure the audit trail.
+
+**Idempotent.** Re-running `/release-sync` on an already-synced repo finds `git diff --quiet upstream/main -- CHANGELOG.md` returns 0, the `if` block is skipped, and no commit is created. The existing "already in sync" guard in step 2 still catches the all-empty case; this guard handles the narrower "code is synced but CHANGELOG drifted in a prior unfixed run" case.
+
+**What this step does NOT do.**
+
+- Does **not** touch any file other than `CHANGELOG.md`.
+- Does **not** modify `main`'s tree — only updates the sync branch's `CHANGELOG.md` to match.
+- Does **not** rewrite history — the carry-forward is a fresh commit on top of the merge commit.
+- Does **not** run if `main`'s `CHANGELOG.md` equals dev's (post-merge) — the `if` guard skips the entire block.
+- Does **not** preserve in-flight `CHANGELOG.md` edits on `dev`. Under the release-cut model `dev` does NOT add CHANGELOG entries between releases — only `/release` writes there — so this is the expected steady-state. If an adopter has hand-edited `CHANGELOG.md` on `dev`, the carry-forward overwrites those edits. The right shape for that case is to land the edits via the `/release` skill (or a chore PR) before invoking `/release-sync`.
+
 ### 6. Push and open the PR
 
 ```bash
@@ -109,6 +155,9 @@ gh pr create \
 - **Merge strategy: `-X ours`** — dev wins on every conflict because dev already
   carries the un-squashed equivalents of all content in the squash commit; the
   strategy is semantically safe and correct in this direction
+- **`CHANGELOG.md` is carried forward separately** — `-X ours` would drop the release-notes
+  entries written on main, so a second commit on top of the merge restores `main`'s
+  `CHANGELOG.md` verbatim. Path-specific, audit-trail-visible, idempotent. See apexyard#448.
 - **No functional changes** — this is a bookkeeping merge that reconciles SHA
   divergence introduced by the squash-merge release flow; no logic is added or removed
 
@@ -129,9 +178,10 @@ See [#403](https://github.com/me2resh/apexyard/issues/403) for full root-cause a
 
 1. After merging, verify: `git log upstream/dev..upstream/main --oneline` returns empty
 2. Verify: `git log upstream/main..upstream/dev --oneline` shows only commits newer than <version>
-3. Open a test release PR from dev → main — confirm only new work appears in the diff
+3. Verify CHANGELOG is in sync: `diff <(git show upstream/main:CHANGELOG.md) <(git show upstream/dev:CHANGELOG.md)` returns empty (apexyard#448)
+4. Open a test release PR from dev → main — confirm only new work appears in the diff and the next `/release` v<next-version> prepends cleanly on top of <version>
 
-Refs #403
+Refs #403, #448
 
 ---
 
@@ -142,6 +192,7 @@ Refs #403
 | Squash divergence | When a release PR is squash-merged to main, the resulting commit has a different SHA than the equivalent dev history, so dev still carries the un-squashed commits as "unsynced" |
 | `-X ours` | Git merge strategy option that resolves conflicts in favour of "our" side — when on a dev-based branch merging main, "ours" = dev, which is correct because dev already has the un-squashed equivalents |
 | `sync/main-to-dev-after-<version>` | Short-lived branch used to carry the merge commit from main into dev; deleted after the PR merges |
+| CHANGELOG carry-forward | Path-specific step 5b that restores `main`'s `CHANGELOG.md` on the sync branch after the `-X ours` merge would otherwise drop the release-notes entries written on `main`. Atomic separate commit, idempotent re-run. See apexyard#448. |
 ```
 
 ### 7. Stop at PR creation
@@ -167,6 +218,8 @@ After merge: git log upstream/dev..upstream/main should return empty.
 | Merge produces zero diff (all conflicts resolved to identical content) | Proceed — the merge commit itself is the artefact, even if the tree is identical to dev HEAD |
 | Skill invoked on a managed project | Exit 1 with error "release-sync is framework-only" |
 | Version not provided | Exit 1 with usage hint |
+| Code is synced but `CHANGELOG.md` drifted (prior unfixed `/release-sync` run, manual main edit, etc.) | Step 2's `git log dev..main` may be empty yet step 5b's `git diff upstream/main -- CHANGELOG.md` is not. In that case create the sync branch from `upstream/dev`, skip the `-X ours` merge in step 5 (nothing to merge), run only step 5b's carry-forward commit, and open the PR with the body trimmed to the CHANGELOG-only summary. The PR is still useful — it surfaces the drift to a reviewer rather than letting the next `/release` silently truncate history. |
+| Dev has in-flight edits to `CHANGELOG.md` between releases (unusual) | Carry-forward overwrites them. This is a recognised trade-off — under the release-cut model `dev` only receives CHANGELOG edits via `/release`. If you genuinely need a between-release CHANGELOG edit, land it via a chore PR before running `/release-sync` so the file is identical on `main` and `dev` by the time this skill runs. |
 
 ## Rules
 


### PR DESCRIPTION
## Summary

- **Adds step 5b "Carry forward CHANGELOG.md from main"** to the `/release-sync` skill — between the existing `-X ours` merge and the push/PR. Path-specific (only `CHANGELOG.md`), atomic separate commit on top of the merge, audit-trail-visible to the sync PR reviewer, idempotent via `git diff --quiet upstream/main -- CHANGELOG.md` guard.
- **Closes the apexyard#446 / #447 root cause** — the existing `-X ours` strategy was dropping the release-notes additions written on `main`. Five releases of drift (v1.3.0 → v2.1.0) accumulated and had to be content-resynced manually pre-v2.2.0. After this lands, dev's `CHANGELOG.md` stays in sync without a chore PR each cycle.
- **3 new tests** in `test_release_sync.sh` cover the carry-forward contract: drift produces a commit; idempotent re-runs are no-ops; only `CHANGELOG.md` is touched. **14/14 tests now pass** (11 original + 3 new).

## Why this matters

Today's `/release-sync` is:

1. branch from `upstream/dev` → `sync/main-to-dev-after-vN.N.N`
2. `git merge --no-ff -X ours upstream/main` (dev wins on conflict)
3. push + open PR

The `-X ours` is correct for *code* — dev already has the un-squashed equivalents of everything in the squash commit. But for `CHANGELOG.md`, the opposite is true: every release writes new entries on `main`, and dev should track those entries forward. Without the carry-forward step, the release-notes history accumulates only on `main`, dev's CHANGELOG goes stale, and the next `/release` prepends a new entry on a stale `dev` CHANGELOG — the squash to `main` then silently truncates the prior releases. This was the exact pre-v2.2.0 regression captured in #446 (chore content fix) and root-caused in #448 (this PR).

## What this PR does NOT do

- **Does not generalise to other files.** Only `CHANGELOG.md` is carried forward in v1. If a second main-leads file shows up later, that's a separate ticket (and a candidate for a YAML config knob).
- **Does not migrate to a custom merge driver.** Option 2 in #448's design notes would apply outside `/release-sync` too; over-engineered for one file.
- **Does not amend the merge commit.** A separate atomic commit on top keeps the carry-forward visible in the sync PR's commit list — reviewable, revertable, and honest about what happened.
- **Does not preserve in-flight `CHANGELOG.md` edits on dev.** Under the release-cut model dev doesn't receive between-release CHANGELOG edits; this is a recognised trade-off named explicitly in the new Edge Cases row.

## Testing

- [ ] `bash .claude/hooks/tests/test_release_sync.sh` — 14/14 PASS (11 original + 3 new for carry-forward)
- [ ] Visual: read `.claude/skills/release-sync/SKILL.md` § "Step 5b" — bash block matches what `run_carry_forward()` in the test file mirrors
- [ ] Manual: run `/release-sync` against a sandbox where dev's `CHANGELOG.md` differs from main's → verify a single atomic commit lands above the merge commit and only `CHANGELOG.md` is in its diff
- [ ] Manual: re-run on an already-synced repo → no second carry-forward commit (idempotent)

## Backwards compatibility

- **Existing `/release-sync` PRs**: unaffected. The path-specific step only fires when `git diff --quiet upstream/main -- CHANGELOG.md` reports a difference. Adopters who already keep CHANGELOG in sync see a no-op.
- **Adopters without `CHANGELOG.md`**: `git diff --quiet upstream/main -- CHANGELOG.md` returns 0 (no diff for a non-existent file), the `if` block is skipped, no commit created.
- **No new dependencies, no new config keys, no schema changes.**

## Out of scope (intentional)

- Generalising to other "main-leads" files (`docs/*`, etc).
- Auto-enabling the carry-forward via a `.claude/project-config.json` knob — keep the v1 hardcoded.
- A pre-merge check that bails out if `CHANGELOG.md` on dev has uncommitted between-release edits — adopters who want this should land the edits via `/release` or a chore PR first; documented as an Edge Cases row instead.

Closes #448

## Glossary

| Term | Definition |
|------|------------|
| **Release-cut model** | Apexyard's gitflow-lite: daily PRs merge to `dev`; `main` only receives release PRs from `dev`. See AgDR-0007. |
| **`-X ours`** | Git merge strategy that resolves conflicts by keeping the receiving (dev) branch's side. Correct for code in `/release-sync` (dev already has un-squashed equivalents); wrong for CHANGELOG (main has authoritative release-notes additions). |
| **CHANGELOG carry-forward** | New step 5b in this PR: after the `-X ours` merge, restore `main`'s `CHANGELOG.md` on the sync branch via a separate atomic commit. Idempotent, path-specific, audit-trail-visible. |
| **Main-leads file** | A file where `main`'s version is authoritative and `dev` should follow forward. `CHANGELOG.md` is the only one today. If a second appears later, that's the moment to revisit the YAML config approach. |
