### PR TITLE
chore(GH-454): sync ops fork with upstream apexyard dev

### DIFF
--- a/.apexyard-fork
+++ b/.apexyard-fork
@@ -1,0 +1,1 @@
+# This file marks the directory as an ApexYard ops fork (split-portfolio v2).

--- a/onboarding.yaml
+++ b/onboarding.yaml
@@ -19,20 +19,16 @@
 # across the registry. Per-project docs live in projects/<name>/, and live
 # working copies (optional) live in workspace/<name>/.
 #
-# Built for CTOs, engineering leads, and Chief-of-Staff roles managing a
-# portfolio of 2+ repos. If you have exactly one repo, you can still fork
-# apexyard and register a single project — the skills work the same way.
-#
 # See docs/setup.md for the full guide.
 
 # -----------------------------------------------------------------------------
 # Company Information
 # -----------------------------------------------------------------------------
 company:
-  name: "Your Company Name"
-  mission: "What you're building and why"
-  vision: "Where you're headed long-term"
-  website: "https://yourcompany.com"
+  name: "ZAVA"
+  mission: ""
+  vision: ""
+  website: ""
 
   # Core values that guide decision-making
   values:
@@ -42,123 +38,87 @@ company:
 
   # What kind of software you build
   products:
-    - name: "Main Product"
-      description: "Brief description of what it does"
-      type: "web-app"  # web-app, mobile-app, api, cli, library, saas
+    - name: "Main Platform"
+      description: "Healthtech platform with EHR integration (Smile CDR), serverless AWS backend, and Vue frontend"
+      type: "saas"
 
 # -----------------------------------------------------------------------------
 # Team Structure
 # -----------------------------------------------------------------------------
-# List your team members and their roles.
-# Roles should match filenames in roles/ (e.g., "tech-lead" -> roles/engineering/tech-lead.md)
-#
-# Available roles:
-#   Engineering: head-of-engineering, tech-lead, backend-engineer, frontend-engineer,
-#                qa-engineer, platform-engineer, sre
-#   Product:     head-of-product, product-manager, product-analyst
-#   Design:      head-of-design, ui-designer, ux-designer
-#   Security:    head-of-security, security-auditor, penetration-tester
-#   Data:        head-of-data, data-analyst, data-engineer
-#
 team:
-  - name: "Team Lead"
-    role: "tech-lead"
+  - name: "Ahmed"
+    role: "head-of-engineering"
     department: "engineering"
-
-  - name: "Developer 1"
-    role: "backend-engineer"
-    department: "engineering"
-
-  - name: "Developer 2"
-    role: "frontend-engineer"
-    department: "engineering"
-
-  # Uncomment and add more team members as needed:
-  # - name: "PM"
-  #   role: "product-manager"
-  #   department: "product"
-  #
-  # - name: "Designer"
-  #   role: "ux-designer"
-  #   department: "design"
+    responsibilities:
+      - "Platform"
+      - "Security"
+      - "Architecture"
+    title: "Director of Platform & Architecture"
 
 # -----------------------------------------------------------------------------
 # Tech Stack
 # -----------------------------------------------------------------------------
-# Define your technology choices. This helps Claude Code give relevant advice.
-#
 tech_stack:
-  language: "TypeScript"          # Primary language
-  runtime: "Node.js"              # Runtime environment
-  framework: "React"              # Frontend framework (React, Vue, Svelte, etc.)
-  backend: "Express"              # Backend framework (Express, Fastify, NestJS, etc.)
-  database: "PostgreSQL"          # Primary database
-  hosting: "AWS"                  # Cloud provider (AWS, GCP, Azure, Vercel, etc.)
-  ci_cd: "GitHub Actions"         # CI/CD platform
-  testing: "Vitest"               # Test framework
-  e2e_testing: "Playwright"       # E2E test framework
+  language: "TypeScript"           # Primary language (SAM lambdas + NestJS BFF)
+  runtime: "Node.js"
+  framework: "Vue"                 # Frontend framework
+  backend: "NestJS"                # BFF pattern — ALB + Nginx on 2 Fargate containers
+  database: "MySQL"                # Legacy monolith DB
+  hosting: "AWS"
+  cdn: "Cloudflare"
+  ci_cd: "GitHub Actions"
+  testing: "Vitest"
+  e2e_testing: "Playwright"
+  iac: "AWS SAM"                   # Serverless infrastructure
 
-  # Additional tools (uncomment what you use):
-  # orm: "Prisma"
-  # state_management: "Zustand"
-  # styling: "Tailwind CSS"
-  # api_style: "REST"             # REST, GraphQL, gRPC
-  # iac: "Terraform"              # Infrastructure as Code tool
-  # monitoring: "Datadog"
-  # error_tracking: "Sentry"
+  # Additional services
+  ehr: "Smile CDR"                 # EHR system
+  legacy: "PHP + MySQL monolith"
+  bff_pattern: "ALB + Nginx on Fargate (2 containers, NestJS)"
 
 # -----------------------------------------------------------------------------
 # Project Management
 # -----------------------------------------------------------------------------
 project_management:
-  tool: "GitHub Issues"           # GitHub Issues, Linear, Jira, etc.
-  sprint_duration: "1 week"       # Sprint/cycle length
-  branching_strategy: "feature-branch"  # feature-branch, gitflow, trunk-based
-
-  # Ticket ID prefix (used in branch names and PR titles)
-  # Examples: "GH" for GitHub Issues (#42), "PROJ" for Jira (PROJ-42)
-  ticket_prefix: "GH"
+  tool: "Jira"
+  instance: "zavamed.atlassian.net"
+  sprint_duration: ""              # Kanban — no fixed sprints
+  branching_strategy: "feature-branch"
+  ticket_prefix: "PLAT"
 
 # -----------------------------------------------------------------------------
 # Quality Standards
 # -----------------------------------------------------------------------------
 quality:
-  # Minimum test coverage percentage
   test_coverage_target: 80
 
-  # Required approvals before merge
   required_reviews: 1
 
-  # Enforce these checks before merge
   required_checks:
     - lint
     - typecheck
     - test
     - build
+    - sam validate --lint
 
-  # Code review style
-  review_style: "thorough"        # thorough, lightweight, pair-programming
+  review_style: "thorough"
 
 # -----------------------------------------------------------------------------
 # Workflows
 # -----------------------------------------------------------------------------
-# Enable or disable workflow stages.
-# Set to false to skip stages that don't apply to your team.
-#
 workflows:
-  require_prd: true               # Require PRD before development
-  require_technical_design: true   # Require tech design before coding
-  require_qa_signoff: true         # Require QA verification before Done
-  require_security_review: false   # Require security review before launch
-  use_feature_flags: false         # Use feature flags for rollouts
-  use_agent_decision_records: true # Track AI agent decisions
+  require_prd: true
+  require_technical_design: true
+  require_qa_signoff: true
+  require_security_review: true    # Ahmed leads security
+  require_design_review: true      # Vue frontend
+  use_feature_flags: false
+  use_agent_decision_records: true
 
 # -----------------------------------------------------------------------------
 # Communication
 # -----------------------------------------------------------------------------
-# Where your team communicates (helps Claude know where to suggest updates)
-#
 communication:
-  primary: "Slack"                # Slack, Discord, Teams, etc.
-  documentation: "GitHub Wiki"    # GitHub Wiki, Notion, Confluence, etc.
-  design: "Figma"                 # Figma, Sketch, code-first, etc.
+  primary: "Slack"
+  documentation: "GitHub Wiki"
+  design: "Figma"


### PR DESCRIPTION
## Summary

- Sync 9 upstream commits from me2resh/apexyard dev — includes all fixes filed this session
- MCP reindex promoted to named step 1.5-reindex in /handover + advisory PostToolUse hook added (#433)
- onboarding.yaml now resolved via portfolio paths helper in split-portfolio mode (#434)
- Ollama/LiteLLM agent routing: reachability check, model-pulled check, ANTHROPIC_BASE_URL wiring (#438)
- SessionStart warning when Ollama routing config is present but proxy is unreachable (#442)
- split-portfolio v2 silent fallback fixes for workspace_dir and projects/ (#373)
- Rex code-reviewer enhanced with MCP search_docs semantic supplement (#450)
- /release-sync carries forward CHANGELOG.md from main to dev (#451)
- /dfd write block inline helper fix (#443)

## Testing

- Merged cleanly — no conflicts
- Bootstrap marker cleared

## Glossary

| Term | Definition |
|------|------------|
| upstream/dev | Pre-release branch of the apexyard framework |
| split-portfolio v2 | Mode where private portfolio lives in a sibling repo separate from the public ops fork |
| Ollama | Local LLM inference runtime; routed through a LiteLLM proxy for Claude Code agent use |

Closes #454