### PR TITLE
chore(#458): whitelist sync type across branch/commit/PR validators

### DIFF
--- a/.claude/hooks/tests/test_sync_type_whitelisted.sh
+++ b/.claude/hooks/tests/test_sync_type_whitelisted.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Regression test for the `sync` conventional-commit type (#458).
+#
+# The /release-sync skill documents a `sync`-typed shape for its git
+# artifacts (branch `sync/...`, commit `sync: ...`, PR title `sync(#N): ...`).
+# Before #458, `sync` was absent from all three type whitelists
+# (branch.type_whitelist, commit.type_whitelist, pr.title_type_whitelist) and
+# from the hooks' hardcoded fallbacks, so every sync artifact was rejected by
+# the validators — making the skill's documented happy path impossible to
+# follow (surfaced during the v2.2.0 release sync, which had to retitle
+# everything to `chore`).
+#
+# This test guards both layers:
+#   - Behavioural: the branch + commit validators accept `sync`-typed input.
+#   - Static: `sync` is present in all three config whitelists AND in all
+#     three hardcoded fallback strings (so a bare checkout with no jq/config
+#     still honours it, and config/fallback don't drift).
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+BRANCH_HOOK="$SRC_ROOT/.claude/hooks/validate-branch-name.sh"
+COMMIT_HOOK="$SRC_ROOT/.claude/hooks/validate-commit-format.sh"
+PR_HOOK="$SRC_ROOT/.claude/hooks/validate-pr-create.sh"
+LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+LIB_PUSHREF="$SRC_ROOT/.claude/hooks/_lib-extract-push-ref.sh"
+DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+mark_pass() { echo "PASS [$1]"; PASS=$((PASS+1)); }
+mark_fail() { echo "FAIL [$1]: $2" >&2; FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}$1 "; }
+
+# ---------------------------------------------------------------------------
+# Behavioural sandbox: branch + commit validators against sync-typed input.
+# ---------------------------------------------------------------------------
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    : > onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+    # Local branch intentionally non-conforming so the branch hook must use
+    # the push-ref from the command, not local HEAD.
+    git checkout -q -B not-conforming-branch-name
+  )
+  mkdir -p "$sb/.claude/hooks"
+  cp "$BRANCH_HOOK" "$sb/.claude/hooks/validate-branch-name.sh"
+  cp "$COMMIT_HOOK" "$sb/.claude/hooks/validate-commit-format.sh"
+  [ -f "$LIB_CFG" ]     && cp "$LIB_CFG"     "$sb/.claude/hooks/_lib-read-config.sh"
+  [ -f "$LIB_PUSHREF" ] && cp "$LIB_PUSHREF" "$sb/.claude/hooks/_lib-extract-push-ref.sh"
+  [ -f "$DEFAULTS" ]    && cp "$DEFAULTS"    "$sb/.claude/project-config.defaults.json"
+  chmod +x "$sb/.claude/hooks/"*.sh
+  echo "$sb"
+}
+
+run_hook_case() {
+  local label="$1" hook="$2" cmd="$3" want_rc="$4"
+  local sb; sb=$(make_sandbox)
+  local input got_rc got_stderr
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  got_stderr=$(cd "$sb" && echo "$input" | bash ".claude/hooks/$hook" 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+  if [ "$got_rc" != "$want_rc" ]; then
+    mark_fail "$label" "want rc=$want_rc, got $got_rc — stderr: ${got_stderr:0:200}"
+    return
+  fi
+  mark_pass "$label"
+}
+
+# Branch: sync/ prefix is accepted (the /release-sync branch shape).
+run_hook_case "branch: sync/main-to-dev-after-v2.2.0 passes" \
+  "validate-branch-name.sh" \
+  "git push origin sync/main-to-dev-after-v2.2.0" 0
+
+# Commit: `sync:` subject is accepted.
+run_hook_case "commit: 'sync: merge main into dev' passes" \
+  "validate-commit-format.sh" \
+  "git commit -m 'sync: merge main into dev after v2.2.0 release'" 0
+
+# Commit: scoped `sync(#456):` subject is accepted.
+run_hook_case "commit: 'sync(#456): ...' passes" \
+  "validate-commit-format.sh" \
+  "git commit -m 'sync(#456): carry forward CHANGELOG.md from main'" 0
+
+# Control: an unknown type still blocks (proves we didn't open the gate).
+run_hook_case "commit: unknown type 'wibble:' still blocks" \
+  "validate-commit-format.sh" \
+  "git commit -m 'wibble: not a real type'" 2
+
+# ---------------------------------------------------------------------------
+# Static: `sync` present in all three config whitelists.
+# ---------------------------------------------------------------------------
+check_config_has_sync() {
+  local label="$1" jqpath="$2"
+  if jq -e "$jqpath | index(\"sync\")" "$DEFAULTS" >/dev/null 2>&1; then
+    mark_pass "$label"
+  else
+    mark_fail "$label" "sync missing from $jqpath in project-config.defaults.json"
+  fi
+}
+check_config_has_sync "config: branch.type_whitelist has sync"   '.branch.type_whitelist'
+check_config_has_sync "config: commit.type_whitelist has sync"   '.commit.type_whitelist'
+check_config_has_sync "config: pr.title_type_whitelist has sync" '.pr.title_type_whitelist'
+
+# ---------------------------------------------------------------------------
+# Static: `sync` present in each hook's hardcoded fallback (so a bare checkout
+# without jq/config still accepts it, and fallback doesn't drift from config).
+# ---------------------------------------------------------------------------
+check_fallback_has_sync() {
+  local label="$1" hook="$2"
+  # The fallback assignment line is `TYPES="..."` / `PR_TYPES="..."` containing
+  # the pipe-delimited literal list. Require a `|sync` (or `sync|`) token in it.
+  if grep -E '^\s*(PR_)?TYPES="[^"]*sync[^"]*"' "$hook" >/dev/null 2>&1; then
+    mark_pass "$label"
+  else
+    mark_fail "$label" "sync missing from hardcoded fallback in $(basename "$hook")"
+  fi
+}
+check_fallback_has_sync "fallback: validate-branch-name.sh has sync"   "$BRANCH_HOOK"
+check_fallback_has_sync "fallback: validate-commit-format.sh has sync" "$COMMIT_HOOK"
+check_fallback_has_sync "fallback: validate-pr-create.sh has sync"     "$PR_HOOK"
+
+# ---- Summary ------------------------------------------------------------
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -58,6 +58,15 @@ if echo "$CURRENT_BRANCH" | grep -qE '^release/v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+
   exit 0
 fi
 
+# Allow main→dev sync branches (apexyard#458, AgDR-0052). The /release-sync
+# skill prescribes `sync/main-to-dev-after-vN.N.N` as the canonical name for
+# the post-release main→dev sync PR's source branch. Like release branches,
+# these don't carry a ticket-id — the release being synced is the ticket. Same
+# narrow, intentional exception to the {type}/{TICKET}-{desc} shape.
+if echo "$CURRENT_BRANCH" | grep -qE '^sync/main-to-dev-after-v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$'; then
+  exit 0
+fi
+
 # Load the branch-type whitelist from project config.
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 # shellcheck source=./_lib-read-config.sh
@@ -68,7 +77,7 @@ if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.claude/hooks/_lib-read-config.sh" ];
 fi
 # Fallback if config unavailable (jq missing, standalone install, etc.)
 if [ -z "$TYPES" ]; then
-  TYPES="feature|fix|refactor|chore|docs|test|spike|ci|build|perf"
+  TYPES="feature|fix|refactor|chore|docs|test|spike|ci|build|perf|sync"
 fi
 
 # Load the ticket-ID regex from the tracker lib. The pattern is shape-only

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -118,7 +118,7 @@ fi
 # 3. Last-resort fallback — matches the shipped defaults (keeps this hook
 #    working in a bare checkout with no config files at all).
 if [ -z "$TYPES" ]; then
-  TYPES="feat|fix|refactor|test|docs|chore|style|perf|build|ci|revert"
+  TYPES="feat|fix|refactor|test|docs|chore|style|perf|build|ci|revert|spike|sync"
 fi
 
 TYPE_REGEX="^(${TYPES})(\([^)]+\))?!?:[[:space:]]+.+"

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -76,7 +76,7 @@ if [ -f "$HOOK_DIR/_lib-read-config.sh" ]; then
   PR_TYPES=$(config_get '.pr.title_type_whitelist[]' 2>/dev/null | paste -sd'|' -)
 fi
 if [ -z "$PR_TYPES" ]; then
-  PR_TYPES="feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert"
+  PR_TYPES="feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|release|spike|sync"
 fi
 
 TICKET_REF=""

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -56,7 +56,8 @@
       "spike",
       "ci",
       "build",
-      "perf"
+      "perf",
+      "sync"
     ]
   },
 
@@ -73,7 +74,8 @@
       "build",
       "ci",
       "revert",
-      "spike"
+      "spike",
+      "sync"
     ]
   },
 
@@ -91,7 +93,8 @@
       "chore",
       "revert",
       "release",
-      "spike"
+      "spike",
+      "sync"
     ],
     "required_sections": [
       "Testing",

--- a/.claude/skills/release-sync/SKILL.md
+++ b/.claude/skills/release-sync/SKILL.md
@@ -59,6 +59,8 @@ git checkout -b sync/main-to-dev-after-<version> upstream/dev
 
 The branch is based on `upstream/dev` (NOT `upstream/main`). This is intentional — we're merging main INTO dev, not branching from main.
 
+> **`sync` is a whitelisted type** (apexyard#458). The `sync/` branch prefix, the `sync:` commit subject, and the `sync(#N):` PR title are all accepted by the branch / commit / PR-title validators. The branch name `sync/main-to-dev-after-vN.N.N` is also exempt from the `{type}/{TICKET-ID}-{desc}` ticket-id requirement (same narrow exception as `release/vN.N.N`) — the release being synced is the ticket. The PR title still references a live OPEN ticket via `sync(#N):` (use the release-cut ticket or a dedicated sync ticket), since `validate-pr-create.sh` checks ticket existence independent of the type.
+
 ### 5. Merge main with `-X ours`
 
 ```bash


### PR DESCRIPTION
## Summary

- **Whitelists the `sync` conventional-commit type** across all three validators (branch / commit / PR-title) so the `/release-sync` skill's documented shape — `sync/` branch, `sync:` commit, `sync(#N):` PR title — actually passes the gates. Before this, `sync` was absent from every whitelist, so the v2.2.0 release sync had to retitle every artifact to `chore` (the merge commit only slipped through because `git merge -m` bypasses the commit-format hook).
- **Aligns the three hardcoded fallback strings with their config lists.** Each gains `sync`; while there, fixed pre-existing drift — the commit fallback was missing `spike`, the PR fallback was missing `release`+`spike`. A bare checkout (no jq/config) now honours the same types the config declares, so config and fallback can't silently diverge.
- **Exempts `sync/main-to-dev-after-vN.N.N` branches from the ticket-id requirement** — the same narrow exception `release/vN.N.N` already has. These branches don't carry a ticket id because the release being synced is the ticket. The PR title still references a live OPEN ticket via `sync(#N):` (validate-pr-create checks ticket existence independent of the type).
- **New regression test** (`test_sync_type_whitelisted.sh`, 10 cases): behavioural acceptance of `sync`-typed branch + commit input, a control case proving an unknown type still blocks, and static assertions that `sync` is present in all three config whitelists AND all three hardcoded fallbacks.

## Why

Surfaced while running `/release-sync v2.2.0` (the first real exercise of the skill end-to-end against production state). The skill's SKILL.md prescribes a `sync`-typed shape, but the framework's own validators rejected it — a self-inconsistency where the documented happy path was impossible to follow. This closes the gap so the next release sync runs as written.

Root-cause ticket: #458. (Sibling ticket #459 tracks a separate `/release-sync` issue — `--squash` defeating ancestry closure — not addressed here.)

## Testing

- [ ] `bash .claude/hooks/tests/test_sync_type_whitelisted.sh` — 10/10 pass
- [ ] `bash .claude/hooks/tests/test_validate_branch_name_pushref.sh` — 15/15 (no regression)
- [ ] `bash .claude/hooks/tests/test_validate_commit_format_heredoc.sh` — 9/9 (no regression)
- [ ] `bash .claude/hooks/tests/test_validate_pr_create_head.sh` — 8/8 (no regression)
- [ ] `bash .claude/hooks/tests/test_validate_pr_create_upstream.sh` — 7/7 (no regression)
- [ ] Manual: a `sync/main-to-dev-after-v2.2.0` branch, a `sync: ...` commit, and a `sync(#N): ...` PR title all pass their validators; an unknown type still blocks

## Glossary

| Term | Definition |
|------|------------|
| **`sync` type** | The conventional-commit-adjacent type used by `/release-sync` for its main→dev sync artifacts. Now whitelisted alongside `feat`/`fix`/`release`/etc. |
| **Type whitelist** | The allowed type prefixes, declared in `.claude/project-config.defaults.json` (`branch.type_whitelist`, `commit.type_whitelist`, `pr.title_type_whitelist`) and enforced by the branch / commit / PR-title validators. |
| **Hardcoded fallback** | The literal type list each validator uses when config/jq is unavailable (bare checkout). Must stay aligned with the config list or a bare checkout diverges. |
| **Ticket-id exemption** | The narrow exception (already enjoyed by `release/vN.N.N`) where a branch may skip the `{type}/{TICKET-ID}-{desc}` shape. Extended to `sync/main-to-dev-after-vN.N.N`. |

Refs #458
