### PR TITLE
fix(#461): fix --body parser truncation in require-agdr-for-arch-pr.sh

### DIFF
--- a/.claude/hooks/require-agdr-for-arch-pr.sh
+++ b/.claude/hooks/require-agdr-for-arch-pr.sh
@@ -51,17 +51,53 @@ fi
 extract_flag_value() {
   # $1 = flag regex (e.g. --title | -t). Matches:
   #   --title "value with spaces"
-  #   --title 'value'
+  #   --title 'value with spaces'
   #   --title value
+  #
+  # The original sed form used `[^"]*` which truncated at the first embedded
+  # double-quote inside the body value — false-blocking PRs whose body contained
+  # a `"` before the AgDR reference (me2resh/apexyard#461). The fix mirrors the
+  # already-corrected extractor in block-private-refs-in-public-repos.sh
+  # (me2resh/apexyard#227): awk with a greedy `(.*)` match anchored on the next
+  # recognised flag boundary (whitespace + `--<letter>`) or end-of-string. This
+  # captures the full quoted span, including any embedded quotes, without
+  # bleeding past the start of the next flag.
   local flag_re="$1"
   local cmd="$2"
-  local v
-  v=$(echo "$cmd" | sed -nE "s/.*(${flag_re})[[:space:]]+\"([^\"]*)\".*/\2/p" | head -1)
-  if [ -n "$v" ]; then echo "$v"; return; fi
-  v=$(echo "$cmd" | sed -nE "s/.*(${flag_re})[[:space:]]+'([^']*)'.*/\2/p" | head -1)
-  if [ -n "$v" ]; then echo "$v"; return; fi
-  v=$(echo "$cmd" | sed -nE "s/.*(${flag_re})[[:space:]]+([^[:space:]]+).*/\2/p" | head -1)
-  echo "$v"
+  printf '%s' "$cmd" | awk -v FLAG_RE="$flag_re" -v SQ="'" '
+    { buf = (NR == 1 ? $0 : buf "\n" $0) }
+    END {
+      s = buf
+      # Double-quoted value: greedy `(.*)` anchored on next flag or EOS.
+      re = "(" FLAG_RE ")[[:space:]]+\"(.*)\"([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^(" FLAG_RE ")[[:space:]]+\"", "", chunk)
+        sub("\"([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
+        sub("\"[[:space:]]*$", "", chunk)
+        print chunk
+        exit
+      }
+      # Single-quoted value: same greedy + anchor treatment.
+      re = "(" FLAG_RE ")[[:space:]]+" SQ "(.*)" SQ "([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^(" FLAG_RE ")[[:space:]]+" SQ, "", chunk)
+        sub(SQ "([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
+        sub(SQ "[[:space:]]*$", "", chunk)
+        print chunk
+        exit
+      }
+      # Unquoted value: single token, embedded quotes irrelevant.
+      re = "(" FLAG_RE ")[[:space:]]+[^[:space:]]+"
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^(" FLAG_RE ")[[:space:]]+", "", chunk)
+        print chunk
+        exit
+      }
+    }
+  '
 }
 
 TITLE=$(extract_flag_value '--title|-t' "$COMMAND")

--- a/.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
+++ b/.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
@@ -282,6 +282,41 @@ run_case "spike active-ticket marker (arch change, non-spike branch + title) →
   "gh pr create --base main --title 'feat(#180): tweak domain' --body 'no AgDR'"
 
 # ---------------------------------------------------------------------------
+# Regression: embedded-quote truncation bug (apexyard#461).
+#
+# The original sed extractor used `[^"]*` which stopped at the first embedded
+# double-quote inside --body, false-blocking PRs where quoted text appeared
+# before the AgDR reference or the skip marker.
+#
+# These cases exercise the three required sub-scenarios from the ticket ACs:
+#   (A) AgDR reference follows an embedded quote → hook PASSES.
+#   (B) Skip marker follows an embedded quote     → hook PASSES with warn.
+#   (C) Embedded quote, but NO AgDR reference     → hook still BLOCKS
+#       (true-negative: verifying we haven't over-corrected the gate).
+#
+# All three use the c1_base/c1_feat arch-change fixture so the hook's
+# arch-detection fires and the body-check is actually reached.
+# ---------------------------------------------------------------------------
+
+# (A) AgDR reference comes after embedded quote text → PASS.
+DIR=$(setup_repo c1_base c1_feat)
+run_case "embedded quote before AgDR ref → PASS (no false-block) [#461-A]" \
+  "$DIR" 0 "" \
+  "gh pr create --base main --title 'feat(#1): tweak domain' --body 'Summary: uses \"greedy\" matching. See AgDR-0007-tweak-domain for rationale.'"
+
+# (B) Skip marker follows an embedded quote → PASS with skip-marker warning.
+DIR=$(setup_repo c1_base c1_feat)
+run_case "embedded quote before skip marker → PASS with skip warning [#461-B]" \
+  "$DIR" 0 "agdr: not-applicable marker present" \
+  "gh pr create --base main --title 'refactor(#2): move domain' --body 'Uses \"pure\" rename. <!-- agdr: not-applicable -->'"
+
+# (C) Embedded quote, but genuinely NO AgDR reference and NO skip marker → still BLOCK.
+DIR=$(setup_repo c1_base c1_feat)
+run_case "embedded quote, no AgDR ref at all → still BLOCKS (true-negative) [#461-C]" \
+  "$DIR" 2 "no AgDR reference" \
+  "gh pr create --base main --title 'feat(#3): tweak domain' --body 'Uses \"greedy\" matching but forgot to add the decision record.'"
+
+# ---------------------------------------------------------------------------
 # Result
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Fixed false-block on PRs with quoted body text** — `extract_flag_value()` in `require-agdr-for-arch-pr.sh` used `sed … "[^"]*" …` which truncated the extracted body at the first embedded double-quote, causing the hook to never see an AgDR reference or skip marker that appeared after any quoted text in the PR body. Replaced with the greedy `awk` extractor already used by `block-private-refs-in-public-repos.sh` (#227) and `validate-issue-structure.sh`, which anchors on the next flag boundary rather than the first internal `"`.
- **Three regression tests added** — covering the three ACs from #461: (A) AgDR reference after embedded quote passes, (B) skip marker after embedded quote passes with warning, (C) missing AgDR with embedded quote still blocks (true-negative confirms the gate is not over-corrected).
- **Sibling hook audit complete** — `block-private-refs-in-public-repos.sh` and `validate-issue-structure.sh` already carry the fixed `awk` form; `validate-pr-create.sh`, `require-migration-ticket.sh`, `require-active-ticket.sh`, and `verify-commit-refs.sh` do not own a `--body` extractor and are unaffected.

## Testing

1. Run `.claude/hooks/tests/test_require_agdr_for_arch_pr.sh` — all existing cases pass, three new `[#461-A/B/C]` cases pass.
2. Verify true-negative: a body with an embedded `"` but no AgDR reference still exits 2 ("no AgDR reference").
3. Verify `--body-file` path is unchanged — hook reads the file directly, bypasses the extractor, unaffected by this fix.

Refs #461

---

## Glossary

| Term | Definition |
|------|------------|
| `extract_flag_value()` | Shell function that parses a named flag value (e.g. `--body "..."`) out of a raw `gh pr create` command string passed via JSON to the hook. |
| `[^"]*` (sed form) | Non-greedy character class that matches any char except `"` — stops at the first embedded quote inside the body, truncating everything after it. |
| Greedy awk extractor | The replacement: uses `awk` with `(.*)` (greedy) plus a flag-boundary anchor (`[[:space:]]+--[a-zA-Z]` or EOS) to match the full body span to its closing quote, not to the first internal `"`. |
| Flag-boundary anchor | The end condition `([[:space:]]+--[a-zA-Z]|[[:space:]]*$)` that tells the greedy match where the flag's quoted value ends — at the next `--flag` or end-of-string. |
| False block | The hook rejecting a PR that actually satisfies the rule — here, an AgDR reference present but hidden behind the truncation. |
| `--body-file` path | `gh pr create --body-file <path>` — the hook reads the file directly and is not affected by the extractor bug; recommended for bodies with rich Markdown. |
