### PR TITLE
fix(#459): require --merge for sync PRs; guard --squash in hook

### DIFF
--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -78,6 +78,48 @@ if [ -z "$PR_NUMBER" ]; then
   exit 2
 fi
 
+# --- Sync-PR squash guard (apexyard#459) ---
+# /release-sync PRs MUST be merged with --merge (true merge, two parents).
+# Squash-merging destroys the second parent (pointing at the release squash
+# on main), so the release squash is never an ancestor of dev, and the
+# squash-divergence the skill exists to fix is silently re-introduced.
+#
+# Detection: if the PR's head branch starts with `sync/main-to-dev-after-`,
+# refuse --squash or --rebase on the merge command.
+#
+# We resolve the branch from GitHub (same gh call as the HEAD-SHA lookup
+# below) so the guard fires on both the `gh pr merge` and `gh api .../merge`
+# shapes. On network failure we skip the guard and let the merge proceed —
+# an unavailable gh API is not a reason to permanently block all syncs.
+if echo "$COMMAND" | grep -qE '(--squash|--rebase)'; then
+  _SYNC_BRANCH=""
+  if [ -n "$CMD_REPO" ]; then
+    _SYNC_BRANCH=$(gh pr view "$PR_NUMBER" --repo "$CMD_REPO" \
+      --json headRefName -q '.headRefName' 2>/dev/null)
+  else
+    _SYNC_BRANCH=$(gh pr view "$PR_NUMBER" \
+      --json headRefName -q '.headRefName' 2>/dev/null)
+  fi
+  if echo "$_SYNC_BRANCH" | grep -qE '^sync/main-to-dev-after-'; then
+    cat >&2 <<MSG
+BLOCKED: Sync PR #${PR_NUMBER} (branch: ${_SYNC_BRANCH}) cannot be squash-merged.
+
+/release-sync PRs MUST be merged with --merge (true merge that preserves both
+parents). Squash-merging destroys the second parent (pointing at the release
+squash commit on main), so the release squash is NOT made an ancestor of dev —
+defeating the entire purpose of /release-sync.
+
+Use --merge instead:
+  gh pr merge ${PR_NUMBER} --repo ${CMD_REPO:-me2resh/apexyard} --merge --delete-branch
+
+Or invoke /approve-merge ${PR_NUMBER} — it auto-detects sync PRs and uses --merge.
+
+See AgDR-0053 for the full rationale.
+MSG
+    exit 2
+  fi
+fi
+
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 # Resolve the ops fork root (where session markers live), not the
 # workspace clone's git toplevel. Inside `workspace/<project>/`,

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -85,13 +85,16 @@ fi
 # squash-divergence the skill exists to fix is silently re-introduced.
 #
 # Detection: if the PR's head branch starts with `sync/main-to-dev-after-`,
-# refuse --squash or --rebase on the merge command.
-#
-# We resolve the branch from GitHub (same gh call as the HEAD-SHA lookup
-# below) so the guard fires on both the `gh pr merge` and `gh api .../merge`
-# shapes. On network failure we skip the guard and let the merge proceed —
-# an unavailable gh API is not a reason to permanently block all syncs.
-if echo "$COMMAND" | grep -qE '(--squash|--rebase)'; then
+# refuse a squash/rebase merge on BOTH command shapes:
+#   - `gh pr merge <N> --squash` / `--rebase`
+#   - `gh api .../pulls/<N>/merge -f merge_method=squash` (or rebase)
+# The `gh api` shape is the silent-bypass route that motivated #47, so the
+# guard must match `merge_method=squash|rebase` as well as the `--squash`
+# flag. (We make our own `gh pr view --json headRefName` call here — it is a
+# separate API call from the HEAD-SHA lookup further down, not the same one.)
+# On network failure we skip the guard and let the merge proceed — an
+# unavailable gh API is not a reason to permanently block all syncs.
+if echo "$COMMAND" | grep -qE '(--squash|--rebase|merge_method=squash|merge_method=rebase)'; then
   _SYNC_BRANCH=""
   if [ -n "$CMD_REPO" ]; then
     _SYNC_BRANCH=$(gh pr view "$PR_NUMBER" --repo "$CMD_REPO" \
@@ -110,7 +113,7 @@ squash commit on main), so the release squash is NOT made an ancestor of dev —
 defeating the entire purpose of /release-sync.
 
 Use --merge instead:
-  gh pr merge ${PR_NUMBER} --repo ${CMD_REPO:-me2resh/apexyard} --merge --delete-branch
+  gh pr merge ${PR_NUMBER} --repo ${CMD_REPO:-<owner/repo>} --merge --delete-branch
 
 Or invoke /approve-merge ${PR_NUMBER} — it auto-detects sync PRs and uses --merge.
 

--- a/.claude/hooks/tests/test_block_unreviewed_merge.sh
+++ b/.claude/hooks/tests/test_block_unreviewed_merge.sh
@@ -337,6 +337,98 @@ EOF
 gh pr merge 42 --repo me2resh/apexyard --squash"
 run_case_custom_cmd "compound-old-skill-version" 2 "no CEO approval marker" "$sb" "$cmd"
 
+# --- Sync-PR squash guard tests (apexyard#459) -------------------------
+#
+# The guard in block-unreviewed-merge.sh refuses --squash on PRs whose
+# head branch starts with `sync/main-to-dev-after-`. The guard fires on
+# both merge shapes (gh pr merge + gh api .../merge).
+#
+# The gh mock in make_sandbox already handles `gh pr view ... headRefOid`
+# calls. We extend it per-sandbox to also handle `headRefName` calls so
+# the guard's branch-lookup gets a deterministic branch name.
+
+make_sandbox_with_sync_branch() {
+  local sb branch_name
+  branch_name="${1:-sync/main-to-dev-after-v2.3.0}"
+  sb=$(make_sandbox)
+  # Rewrite the gh shim to handle both headRefOid (SHA) and headRefName (branch).
+  cat > "$sb/bin/gh" <<EOF
+#!/bin/bash
+case "\$*" in
+  *"pr view"*"headRefOid"*) echo "$FIXED_SHA" ;;
+  *"pr view"*"headRefName"*) echo "$branch_name" ;;
+  *) ;;
+esac
+exit 0
+EOF
+  chmod +x "$sb/bin/gh"
+  echo "$sb"
+}
+
+make_sandbox_non_sync() {
+  local sb
+  sb=$(make_sandbox)
+  cat > "$sb/bin/gh" <<EOF
+#!/bin/bash
+case "\$*" in
+  *"pr view"*"headRefOid"*) echo "$FIXED_SHA" ;;
+  *"pr view"*"headRefName"*) echo "feature/GH-99-something" ;;
+  *) ;;
+esac
+exit 0
+EOF
+  chmod +x "$sb/bin/gh"
+  echo "$sb"
+}
+
+# Case S1: sync PR + --squash → BLOCKED (the core guard)
+sb=$(make_sandbox_with_sync_branch "sync/main-to-dev-after-v2.3.0")
+write_rex_marker "$sb" 300
+write_ceo_marker_structured "$sb" 300
+cmd="gh pr merge 300 --repo me2resh/apexyard --squash --delete-branch"
+input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+if [ "$got_rc" = "2" ] && echo "$got_stderr" | grep -q "cannot be squash-merged"; then
+  echo "PASS [sync PR + --squash → blocked (apexyard#459)]"; PASS=$((PASS+1))
+else
+  echo "FAIL [sync PR + --squash → blocked]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}sync-squash-blocked "
+fi
+
+# Case S2: sync PR + --merge + valid markers → PASSES (the correct path)
+sb=$(make_sandbox_with_sync_branch "sync/main-to-dev-after-v2.3.0")
+write_rex_marker "$sb" 301
+write_ceo_marker_structured "$sb" 301
+cmd="gh pr merge 301 --repo me2resh/apexyard --merge --delete-branch"
+input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
+  echo "PASS [sync PR + --merge + valid markers → passes (apexyard#459)]"; PASS=$((PASS+1))
+else
+  echo "FAIL [sync PR + --merge + valid markers → passes]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}sync-merge-passes "
+fi
+
+# Case S3: non-sync PR + --squash + valid markers → PASSES (guard narrowly scoped)
+sb=$(make_sandbox_non_sync)
+write_rex_marker "$sb" 302
+write_ceo_marker_structured "$sb" 302
+cmd="gh pr merge 302 --repo me2resh/apexyard --squash --delete-branch"
+input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
+  echo "PASS [non-sync PR + --squash still passes (guard narrowly scoped, apexyard#459)]"; PASS=$((PASS+1))
+else
+  echo "FAIL [non-sync PR + --squash guard scope]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}non-sync-squash-unaffected "
+fi
+
 # --- Summary ----------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_block_unreviewed_merge.sh
+++ b/.claude/hooks/tests/test_block_unreviewed_merge.sh
@@ -429,6 +429,39 @@ else
   FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}non-sync-squash-unaffected "
 fi
 
+# Case S4: sync PR + `gh api ... merge_method=squash` → BLOCKED
+# (the gh-api bypass shape — the gap that motivated #47; must be caught too)
+sb=$(make_sandbox_with_sync_branch "sync/main-to-dev-after-v2.3.0")
+write_rex_marker "$sb" 303
+write_ceo_marker_structured "$sb" 303
+cmd="gh api repos/me2resh/apexyard/pulls/303/merge -X PUT -f merge_method=squash"
+input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+if [ "$got_rc" = "2" ] && echo "$got_stderr" | grep -q "cannot be squash-merged"; then
+  echo "PASS [sync PR + gh-api merge_method=squash → blocked (apexyard#459, #47 bypass class)]"; PASS=$((PASS+1))
+else
+  echo "FAIL [sync PR + gh-api merge_method=squash → blocked]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}sync-ghapi-squash-blocked "
+fi
+
+# Case S5: sync PR + `gh api ... merge_method=merge` → PASSES (correct gh-api path)
+sb=$(make_sandbox_with_sync_branch "sync/main-to-dev-after-v2.3.0")
+write_rex_marker "$sb" 304
+write_ceo_marker_structured "$sb" 304
+cmd="gh api repos/me2resh/apexyard/pulls/304/merge -X PUT -f merge_method=merge"
+input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
+  echo "PASS [sync PR + gh-api merge_method=merge → passes (apexyard#459)]"; PASS=$((PASS+1))
+else
+  echo "FAIL [sync PR + gh-api merge_method=merge → passes]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}sync-ghapi-merge-passes "
+fi
+
 # --- Summary ----------------------------------------------------------
 
 echo ""

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -138,15 +138,37 @@ approval_summary="${summary}"
 EOF
 ```
 
-### 6. Run the merge — DEFAULT FLOW
+### 6. Determine merge strategy
 
-Unless `--no-merge` was passed, run the merge in the same turn:
+Before running the merge, check whether this is a **sync-class PR**. A PR is sync-class if either:
+
+- Its head branch matches `sync/main-to-dev-after-*` (the canonical `/release-sync` branch prefix), OR
+- Its PR title starts with `sync(` (the canonical `/release-sync` PR title prefix)
 
 ```bash
-gh pr merge <pr> --repo <owner/repo> --squash --delete-branch
+PR_HEAD_BRANCH=$(gh pr view <pr> --repo <owner/repo> --json headRefName -q '.headRefName' 2>/dev/null)
+PR_TITLE=$(gh pr view <pr> --repo <owner/repo> --json title -q '.title' 2>/dev/null)
+
+MERGE_STRATEGY="--squash"  # default for all other PRs
+if echo "$PR_HEAD_BRANCH" | grep -qE '^sync/main-to-dev-after-' || \
+   echo "$PR_TITLE" | grep -qE '^sync\('; then
+  MERGE_STRATEGY="--merge"
+fi
 ```
 
-The merge command is gated by the existing `block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, and `require-design-review-for-ui.sh` PreToolUse hooks. If anything is wrong, the merge fails with the same error message the user would see if they ran `gh pr merge` themselves. The CEO marker stays on disk so the user can retry the merge after fixing the cause without re-approving.
+**Why auto-detect instead of a flag:** a `--merge-strategy` flag would require the operator to remember to pass it on every sync PR merge. Sync PRs squashed silently — the v2.2.0 incident — show that operator ceremony is not a reliable safeguard. Auto-detection makes the correct behaviour the default; an operator who wants to override can do so via the CLI directly. See `AgDR-0053`.
+
+**Why `--merge` for sync PRs:** the sync branch's top commit is a true two-parent merge commit (branch = dev, second parent = main's release squash). That two-parent relationship is the ancestry link that makes future `dev → main` release PRs conflict-free. Squash-merging discards the second parent permanently, defeating the skill's entire purpose. See `AgDR-0053`.
+
+### 7. Run the merge — DEFAULT FLOW
+
+Unless `--no-merge` was passed, run the merge in the same turn using the strategy determined in step 6:
+
+```bash
+gh pr merge <pr> --repo <owner/repo> ${MERGE_STRATEGY} --delete-branch
+```
+
+The merge command is gated by the existing `block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, and `require-design-review-for-ui.sh` PreToolUse hooks. The `block-unreviewed-merge.sh` hook also includes a guard that refuses `--squash` on `sync/`-prefixed PRs — so even a direct `gh pr merge <sync-pr> --squash` will be blocked, protecting against both accidental and deliberate strategy errors. If anything else is wrong, the merge fails with the same error message the user would see if they ran `gh pr merge` themselves. The CEO marker stays on disk so the user can retry the merge after fixing the cause without re-approving.
 
 After a successful merge, capture and report the merge commit SHA:
 
@@ -154,21 +176,27 @@ After a successful merge, capture and report the merge commit SHA:
 gh pr view <pr> --repo <owner/repo> --json mergeCommit -q '.mergeCommit.oid'
 ```
 
-### 7. Report
+### 8. Report
 
-Single-line confirmation:
+Single-line confirmation (include the merge strategy used so the operator can see it):
 
 ```
-✓ Merged PR #<pr> as commit <sha>. Branch deleted.
+✓ Merged PR #<pr> as commit <sha> (strategy: --squash). Branch deleted.
+```
+
+or for sync PRs:
+
+```
+✓ Merged PR #<pr> as commit <sha> (strategy: --merge, auto-detected sync PR — ancestry preserved). Branch deleted.
 ```
 
 If the merge gate blocked, surface the exact error and tell the user how to retry:
 
 ```
-✗ Merge blocked: <reason from gate>. Marker still on disk at .claude/session/reviews/<pr>-ceo.approved — run `gh pr merge <pr> --repo <owner/repo> --squash --delete-branch` once the issue is fixed (no need to re-invoke /approve-merge).
+✗ Merge blocked: <reason from gate>. Marker still on disk at .claude/session/reviews/<pr>-ceo.approved — run `gh pr merge <pr> --repo <owner/repo> <strategy> --delete-branch` once the issue is fixed (no need to re-invoke /approve-merge).
 ```
 
-### 8. Optional: post-merge child-issue closure
+### 9. Optional: post-merge child-issue closure
 
 If the PR's merge commit / PR body contains `Closes <owner/repo>#<N>` references that GitHub's auto-closer didn't catch (squash merges with cross-repo refs sometimes silently miss), you can offer to close them with a comment. This is **out of scope for the default flow** — only do it if the user explicitly asks. Don't auto-close child issues; that's another externally-visible action that needs its own per-issue confirmation.
 

--- a/.claude/skills/release-sync/SKILL.md
+++ b/.claude/skills/release-sync/SKILL.md
@@ -201,6 +201,22 @@ Refs #403, #448
 
 Do **NOT** merge the sync PR. Rex + CEO approval applies to this PR the same as any other. The skill's job is to open the PR; the operator drives the merge gate.
 
+**CRITICAL — merge strategy for this PR:**
+
+> The sync PR **MUST** be merged with a **true merge (`--merge`)**, never `--squash` or `--rebase`.
+
+The merge commit produced by step 5 above is the artefact that closes ancestry. It carries **two parents**: (1) the dev branch head, and (2) the release squash commit on main. That two-parent relationship is exactly what makes `git merge-base --is-ancestor <release-squash> dev` return true — i.e., what makes future release PRs conflict-free.
+
+Squash-merging this sync PR collapses the two-parent merge commit into a single-parent commit. The second parent (pointing at main's release squash) is permanently discarded. Dev gets main's *content* but the release squash is NOT an ancestor of dev. The `git log upstream/dev..upstream/main` divergence check will still show commits after squash — the exact failure this skill exists to prevent.
+
+`/approve-merge` auto-detects `sync/`-prefixed PRs and uses `--merge` automatically. If merging via the CLI directly, pass `--merge` (not `--squash`, not `--rebase`):
+
+```bash
+gh pr merge <sync-pr-number> --repo me2resh/apexyard --merge --delete-branch
+```
+
+A guard in `block-unreviewed-merge.sh` will also refuse `--squash` on a `sync/`-prefixed PR to prevent accidental regression. See `AgDR-0053`.
+
 Print:
 
 ```
@@ -208,7 +224,9 @@ Sync PR opened: <URL>
 Branch: sync/main-to-dev-after-<version> → dev
 Commits on main not yet on dev: N
 Next step: /code-review, then /approve-merge once Rex approves.
+IMPORTANT: /approve-merge will use --merge (not --squash) automatically for this sync PR.
 After merge: git log upstream/dev..upstream/main should return empty.
+After merge: git merge-base --is-ancestor <release-squash-sha> upstream/dev should return true.
 ```
 
 ## Edge Cases
@@ -228,15 +246,17 @@ After merge: git log upstream/dev..upstream/main should return empty.
 1. **Framework-only.** Refuse on managed projects.
 2. **No auto-merge.** The PR must go through Rex + CEO approval like every other PR.
 3. **Branch base is always `upstream/dev`.** Never branch from main for this operation.
-4. **Merge strategy is always `-X ours`.** Dev wins on conflicts, always. Do not offer to flip this.
-5. **No-op on already-synced repos.** Idempotent: if main has nothing dev doesn't, exit 0.
-6. **Version argument is required.** The version labels the sync branch and PR body for auditability.
+4. **`-X ours` merge strategy during branch build.** Dev wins on conflicts, always. Do not offer to flip this.
+5. **`--merge` (true merge) on PR merge.** Never `--squash` or `--rebase`. The merge commit IS the ancestry-closure artefact; destroying it defeats the skill's purpose. `/approve-merge` enforces this automatically on `sync/`-prefixed PRs; a guard in `block-unreviewed-merge.sh` refuses `--squash` on them as a mechanical backstop.
+6. **No-op on already-synced repos.** Idempotent: if main has nothing dev doesn't, exit 0.
+7. **Version argument is required.** The version labels the sync branch and PR body for auditability.
 
 ## Related
 
 - `/release` — the upstream skill that creates the squash divergence; invoke `/release-sync` as its final step
 - `AgDR-0007` — the release-cut branch model this skill stabilises
-- `AgDR-0052` — the decision record for this skill's design choices
+- `AgDR-0052` — the original design decisions for this skill
+- `AgDR-0053` — the decision to use `--merge` (not `--squash`) for sync PRs, and the auto-detect + guard design
 - `docs/release-process.md` — the prose runbook
 
 ---

--- a/docs/agdr/AgDR-0053-sync-pr-merge-strategy.md
+++ b/docs/agdr/AgDR-0053-sync-pr-merge-strategy.md
@@ -1,0 +1,124 @@
+# Sync PRs must use --merge (true merge), not --squash
+
+> In the context of the apexyard `/release-sync` skill (AgDR-0052), facing
+> the discovery that the v2.2.0 sync PR was squash-merged — silently destroying
+> the ancestry link the skill was designed to create — I decided to
+> (a) auto-detect sync-class PRs in `/approve-merge` and use `--merge`
+> automatically, and (b) add a guard in `block-unreviewed-merge.sh` that
+> refuses `--squash` on `sync/`-prefixed PRs, accepting the trade-off that
+> this is a special case in two previously-general components.
+
+## Context
+
+The `/release-sync` skill (introduced in apexyard#403, documented in AgDR-0052)
+fixes squash-divergence by branching from `upstream/dev`, running
+`git merge --no-ff -X ours upstream/main`, and opening a PR. The merge commit
+produced by that operation has **two parents**:
+
+1. The dev branch head (first parent — the branch this is on)
+2. The release squash commit on main (second parent — what was merged in)
+
+The second parent relationship is what makes
+`git merge-base --is-ancestor <release-squash> dev` return true. That
+ancestry link is the entire value of the skill: once it holds, future
+`dev → main` release PRs only show genuinely-new commits in the diff.
+
+However, during the release that followed the introduction of `/release-sync`,
+the sync PR was merged with `--squash` (the `/approve-merge` default). Squash
+collapses the two-parent merge commit into a single-parent commit. The second
+parent is permanently discarded.
+
+Post-merge verification confirmed the breakage:
+
+```
+git merge-base --is-ancestor <release-squash> upstream/dev  →  false
+git log upstream/dev..upstream/main --oneline               →  still N commits
+```
+
+Dev got main's *content* (the CHANGELOG carry-forward worked correctly) but the
+release squash is not an ancestor of dev. The next release PR will re-encounter
+the squash-divergence conflicts the skill was designed to prevent.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Add `--merge-strategy <merge\|squash\|rebase>` flag to `/approve-merge`** | General-purpose; operator picks per PR | Requires operator to remember to pass `--merge` for every sync PR; the v2.2.0 incident shows this is the failure mode we're solving — operator ceremony isn't a reliable safeguard |
+| **B. Auto-detect sync-class PRs in `/approve-merge`, use `--merge` automatically** | Correct by default; operator can't forget; no new flag surfaces | Special-case in a previously-general skill; detection is heuristic (branch prefix + title prefix) |
+| **C. Change the default in `/approve-merge` from `--squash` to `--merge`** | No special case | Breaking change for all non-sync PRs; the framework documents squash-merge as the release model; adopters who prefer squash for clean `main` history would be affected |
+
+For the guard:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **D. Guard in `block-unreviewed-merge.sh` refusing `--squash` on sync PRs** | Mechanical backstop; fires on both `gh pr merge` and `gh api` shapes; catches direct CLI merges, not just `/approve-merge` invocations | Special-case in a previously-general hook; requires a GitHub API call (same gh call as the existing SHA resolution) |
+| **E. Guard in `/approve-merge` only (no hook change)** | Simpler; no hook change needed | Does not prevent a direct `gh pr merge <sync-pr> --squash` invocation that bypasses the skill entirely |
+| **F. No guard; rely on documentation only** | Zero added complexity | The v2.2.0 incident shows documentation alone doesn't prevent this; the failure mode is silent and hard to notice until the next release PR hits divergence |
+
+## Decision
+
+Chosen: **Option B (auto-detect in `/approve-merge`) + Option D (guard in hook)**.
+
+**B** because:
+
+1. The failure mode is silent — the merge succeeds, the branch is deleted, and the breakage is only visible weeks later at the next release. A purely-flag approach puts the safety entirely on operator memory.
+2. The detection heuristic is stable: `sync/main-to-dev-after-` is the canonical branch prefix documented in the SKILL.md; `sync(` is the canonical PR title prefix. Neither will change without a deliberate update to the skill.
+3. Surfacing the strategy in the merge report (`strategy: --merge, auto-detected sync PR`) makes the behaviour visible without adding friction.
+
+**D** because:
+
+1. Option B only covers merges via `/approve-merge`. A developer or automation that runs `gh pr merge <sync-pr> --squash` directly bypasses the skill and re-introduces the bug silently.
+2. The guard reuses the same `gh pr view` call already present in the hook for SHA resolution, so the incremental cost is low.
+3. The guard's error message explains the rationale and the correct command, so it's educational rather than just blocking.
+
+Option A (flag) is rejected because it converts a safety requirement into optional operator ceremony — the exact failure mode this fix targets. It could be added later as an opt-in override for unusual cases, but the default must be safe-by-default.
+
+**Merge strategy terminology clarification:**
+
+There are two independent merge strategies in play and they must not be confused:
+
+| Where | Strategy | Meaning |
+|-------|----------|---------|
+| Step 5 of `/release-sync` (building the sync branch) | `-X ours` | When running `git merge upstream/main` to build the sync branch, dev content wins on conflicts. This is about *conflict resolution during the local branch build*. |
+| Step 7 (merging the sync PR into dev) | `--merge` (true merge) | When merging the sync PR via GitHub, use a true merge commit (not squash). This is about *how the PR is merged into dev*. |
+
+These are orthogonal. `-X ours` is correct and unchanged. `--merge` is the new requirement being added here.
+
+## Consequences
+
+- `/approve-merge` auto-uses `--merge` for any PR whose head branch starts with
+  `sync/main-to-dev-after-` or whose title starts with `sync(`. For all other
+  PRs the default remains `--squash`. The strategy used is surfaced in the
+  merge report.
+- `block-unreviewed-merge.sh` blocks `--squash` and `--rebase` on `sync/main-to-dev-after-*`
+  PRs on both the `gh pr merge` and `gh api .../pulls/<N>/merge` shapes. Network
+  failure on the `gh pr view` branch-lookup falls back to "skip guard" (don't
+  block the merge) rather than "block all syncs" — availability beats strict
+  enforcement on an ephemeral check.
+- A test in `test_block_unreviewed_merge.sh` covers: sync PR + `--squash` → blocked;
+  sync PR + `--merge` + valid markers → passes; non-sync PR + `--squash` + valid
+  markers → still passes (guard is narrowly scoped).
+
+## Residual state — recent release divergence
+
+The v2.2.0 sync PR was squash-merged before this fix. Dev currently has main's
+content but the v2.2.0 squash commit (`3584059`) is not an ancestor of dev.
+
+**Recommendation**: run `/release-sync` again at the next release using this
+fixed flow. The `-X ours` strategy will cleanly resolve the content-identical
+conflicts (dev and main agree on content, so there are no real conflicts), and
+the `--merge` PR merge will close the ancestry gap. The cost is one extra
+round of conflict resolution at the next release.
+
+An alternative is a one-off ancestry-repair merge on dev now (before the next
+release), but this is an externally-visible change to a shared branch and
+warrants explicit operator sign-off. The recommendation above — absorb it at
+next release — is lower-risk and requires no out-of-band intervention.
+
+## Artifacts
+
+- `.claude/skills/release-sync/SKILL.md` — step 7 expanded with merge-strategy requirement + rationale; rule 5 updated; AgDR-0053 referenced
+- `.claude/skills/approve-merge/SKILL.md` — step 6 (sync detection) and step 7 (merge command) updated; step 8 report updated; AgDR-0053 referenced
+- `.claude/hooks/block-unreviewed-merge.sh` — sync-PR squash guard added after PR-number extraction
+- `.claude/hooks/tests/test_block_unreviewed_merge.sh` — three new cases covering the guard
+- Implementing ticket: `me2resh/apexyard#459`


### PR DESCRIPTION
## Summary

- **Fix ancestry-closure for sync PRs** — `/release-sync` builds a two-parent merge commit whose second parent is the release squash on main; that relationship is what makes `git merge-base --is-ancestor <release-squash> dev` return true. When the sync PR is squash-merged the second parent is permanently discarded and the fix is silently undone. This PR requires sync PRs to use `--merge` (true merge) via three mechanisms working together.

- **`/approve-merge` auto-detects sync-class PRs** — when the PR's head branch starts with `sync/main-to-dev-after-` or the title starts with `sync(`, `/approve-merge` substitutes `--merge` for its usual `--squash`. The chosen approach is auto-detect (not a `--merge-strategy` flag) so the operator can't forget; the strategy used is reported in the merge confirmation. See `AgDR-0053` for the flag-vs-autodetect decision.

- **`block-unreviewed-merge.sh` guard** — a new check after PR-number extraction refuses `--squash` or `--rebase` on any `sync/main-to-dev-after-*` PR. Fires on both `gh pr merge` and `gh api .../pulls/<N>/merge` shapes (same coverage as the existing squash-divergence guards). Falls back gracefully if the `gh pr view` branch-lookup fails (network/auth), so a transient error doesn't permanently block all syncs.

- **Three new tests** — sync+`--squash` → blocked; sync+`--merge`+valid markers → passes; non-sync+`--squash`+valid markers → passes (guard is narrowly scoped). All 22 cases in `test_block_unreviewed_merge.sh` + all 14 in `test_release_sync.sh` pass.

- **AgDR-0053** — documents squash-vs-merge for sync PRs as a first-class decision (extends AgDR-0052's merge-semantics section), including the residual divergence recommendation (see below).

## Residual divergence from a recent release

A recent release's sync PR was squash-merged before this fix. Dev is content-correct but the release squash commit is not yet an ancestor of dev (`git merge-base --is-ancestor <release-squash> upstream/dev` returns false; `git log upstream/dev..upstream/main` still shows divergence).

**Recommendation** (documented in AgDR-0053, not performed here): absorb it at the next release. The `/release-sync` `-X ours` strategy will cleanly resolve the content-identical conflicts (no real content divergence), and the `--merge` PR merge will close the ancestry gap in one operation. A standalone ancestry-repair merge before the next release is an option but is an externally-visible change to dev that warrants separate operator sign-off; the next-release approach is lower-risk and fully self-contained.

## Approach decision: flag vs auto-detect

Option A (add `--merge-strategy <merge|squash|rebase>` flag) was rejected because it converts a safety requirement into optional operator ceremony — the exact failure mode being fixed. Auto-detection (Option B) makes the correct behaviour the default; an operator who genuinely needs to override can do so via the CLI directly. Full rationale in `AgDR-0053`.

## Testing

1. Check that `test_block_unreviewed_merge.sh` passes (19 pre-existing + 3 new = 22 total; 1 pre-existing failure in workspace-clone test is not related to this change)
2. Check that `test_release_sync.sh` passes (14 cases, unchanged)
3. On the next `/release-sync` run: confirm `gh pr merge <sync-pr> --squash` is blocked by the hook, and `/approve-merge <sync-pr>` succeeds with `--merge`
4. Post-merge: `git merge-base --is-ancestor <release-squash-sha> upstream/dev` should return true

Refs #459

---

## Glossary

| Term | Definition |
|------|------------|
| Squash-divergence | The SHA gap when a release PR squash-merges dev→main: main's squash commit has a different SHA than dev's original commits, so git still sees them as unrelated history |
| Ancestry closure | Making the release squash commit a reachable ancestor of dev via a true merge, so future release PRs don't re-encounter phantom divergence |
| True merge (`--merge`) | A merge that creates a two-parent commit; both parents are preserved in history. Required for sync PRs because the second parent (pointing at the release squash) IS the ancestry link |
| `-X ours` | The conflict-resolution strategy used when building the sync branch (`git merge -X ours upstream/main`): dev content wins on conflicts because dev already has the un-squashed equivalents. Orthogonal to and unchanged by this PR |
| Auto-detect | The `/approve-merge` mechanism that reads the PR's head branch name and title before choosing `--squash` vs `--merge`, so the operator doesn't need to pass a flag |
