### PR TITLE
chore(ITH-210): sync ops fork with upstream apexyard v1.2.0→v2.2.0

### DIFF
--- a/.claude/project-config.json
+++ b/.claude/project-config.json
@@ -1,0 +1,10 @@
+{
+  "portfolio": {
+    "registry": "../apexyard-portfolio/apexyard.projects.yaml",
+    "projects_dir": "../apexyard-portfolio/projects",
+    "ideas_backlog": "../apexyard-portfolio/projects/ideas-backlog.md"
+  },
+  "tracker": {
+    "kind": "none"
+  }
+}


### PR DESCRIPTION
<!-- agdr: not-applicable -->

## Summary
- **Syncs 3 major releases (v1.3.0 → v2.0.0 → v2.1.0 → v2.2.0)** from upstream me2resh/apexyard — 456 files, bringing new agents, hooks, skills, tracker lib (`_lib-tracker.sh` with native Jira/Linear/Asana support), ops-root resolution, and spike-workflow primitives
- **Clean fast-forward merge** — no conflicts; local main had no diverging commits ahead of upstream

## Commits pulled in

- `3584059` release(#452): v2.2.0 (#453)
- `fb861f4` release(#408): v2.1.0 (#409)
- `eb41cfe` chore(#401): CHANGELOG v2.0.2 + site version pill bump (#402)
- `b29b266` fix(#399): site/ — GA4 + consent banner on all 4 pages (#400)
- `189f86a` release(#395): v2.0.1 (#396)
- `d1c2115` release(#391): v2.0.0 (#392)
- `15516a8` release(#278): v1.3.0 (#279)

## Testing
- Merged cleanly (fast-forward, zero conflicts)
- Local main untouched until this PR merges

## Glossary
| Term | Definition |
|------|------------|
| ops fork | This fork of me2resh/apexyard used as the Chief-of-Staff ops repo |
| upstream sync | Routine pull of new framework commits from me2resh/apexyard into the fork |
| fast-forward merge | Git merge where the local branch had no diverging commits — upstream commits are replayed directly, no merge commit needed |

Closes ITH-210
