### PR TITLE
fix(#469): suggest-mcp-search surfaces to the agent + install-gates

### DIFF
--- a/.claude/hooks/suggest-mcp-search.sh
+++ b/.claude/hooks/suggest-mcp-search.sh
@@ -8,8 +8,16 @@
 # The MCP vector search returns targeted excerpts from indexed chunks,
 # saving ~3-5x tokens compared to reading full files via grep+Read.
 #
+# IMPORTANT (#469): the advisory is emitted as `hookSpecificOutput.additional
+# Context` JSON on STDOUT (exit 0), NOT stderr. Claude Code does not inject
+# exit-0 stderr into the model's context, so the old stderr banner was
+# invisible to the agent — the exact failure this hook exists to prevent.
+# It is also install-gated: it only nudges when the `apexyard-search` MCP
+# server is actually configured, so adopters without the premium search
+# component fall back to plain grep silently.
+#
 # Wired to: PreToolUse → Bash (no `if` matcher — checks command internally)
-# See: me2resh/apexyard#418
+# See: me2resh/apexyard#418 (original), #469 (additionalContext + install-gate)
 
 set -u
 
@@ -69,18 +77,35 @@ fi
 
 $targets_framework || exit 0
 
-# --- Emit advisory banner ------------------------------------------------
+# --- Install-gate: only nudge if apexyard-search is actually configured -----
+# Resolve the ops fork from this hook's own location, and also honour
+# $APEXYARD_PORTFOLIO_ROOT (split-portfolio mode keeps .mcp.json beside the
+# portfolio). If apexyard-search isn't configured in any candidate .mcp.json,
+# stay silent — the adopter doesn't have the premium search component, so the
+# nudge would be noise. (#469)
 
-cat >&2 <<'BANNER'
+ops_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)"
 
-💡 MCP search available — consider using it before grep+Read:
+mcp_has_search=false
+for mcp_json in "$ops_root/.mcp.json" "${APEXYARD_PORTFOLIO_ROOT:-}/.mcp.json"; do
+  [ -n "$mcp_json" ] && [ -f "$mcp_json" ] || continue
+  if grep -q 'apexyard-search' "$mcp_json" 2>/dev/null; then
+    mcp_has_search=true
+    break
+  fi
+done
 
-  • search_docs  — framework docs (skills, roles, handbooks, AgDRs, workflows)
-  • search_code  — managed project codebases (workspace clones)
+$mcp_has_search || exit 0
 
-MCP returns targeted excerpts and saves ~3-5x tokens vs reading full files.
-Load with: ToolSearch("select:mcp__apexyard-search__search_docs,mcp__apexyard-search__search_code")
+# --- Emit advisory as additionalContext on stdout (non-blocking) -----------
 
-BANNER
+ADVISORY="apexyard-search MCP is available — prefer mcp__apexyard-search__search_code (managed-project codebases) / search_docs (framework docs) over grep+Read for this search. Semantic, returns targeted excerpts, ~3-5x fewer tokens. Fall back to grep only if MCP returns nothing. Load via ToolSearch(\"select:mcp__apexyard-search__search_code,mcp__apexyard-search__search_docs\")."
+
+jq -n --arg t "$ADVISORY" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    additionalContext: $t
+  }
+}'
 
 exit 0

--- a/.claude/hooks/tests/test_suggest_mcp_search.sh
+++ b/.claude/hooks/tests/test_suggest_mcp_search.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
-# Tests for suggest-mcp-search.sh advisory hook
+# Tests for suggest-mcp-search.sh advisory hook (#418, #469).
 # Run: bash .claude/hooks/tests/test_suggest_mcp_search.sh
+#
+# #469: the hook now (a) emits its advisory as hookSpecificOutput.additional
+# Context JSON on STDOUT (exit 0, non-blocking) so the model actually reads it,
+# and (b) is install-gated — it only fires when `apexyard-search` is configured
+# in a resolvable .mcp.json. These tests inject the gate via a temp
+# $APEXYARD_PORTFOLIO_ROOT/.mcp.json fixture.
 
 set -u
 
@@ -8,79 +14,94 @@ HOOK="$(cd "$(dirname "$0")/.." && pwd)/suggest-mcp-search.sh"
 PASS=0
 FAIL=0
 
+# --- Fixtures: a portfolio root WITH apexyard-search, and one WITHOUT --------
+MCP_DIR=$(mktemp -d)
+printf '%s' '{"mcpServers":{"apexyard-search":{"command":"apexyard-search"}}}' > "$MCP_DIR/.mcp.json"
+
+NO_MCP_DIR=$(mktemp -d)
+printf '%s' '{"mcpServers":{"some-other-server":{}}}' > "$NO_MCP_DIR/.mcp.json"
+
+cleanup() { rm -rf "$MCP_DIR" "$NO_MCP_DIR"; }
+trap cleanup EXIT
+
+# run_hook <input-json> <portfolio_root>  → prints the hook's stdout
 run_hook() {
-  echo "$1" | bash "$HOOK" 2>&1
+  echo "$1" | APEXYARD_PORTFOLIO_ROOT="$2" bash "$HOOK"
 }
 
-assert_banner() {
+# assert the hook emitted a well-formed additionalContext advisory on stdout
+assert_advisory() {
   local desc="$1" input="$2"
-  local output
-  output=$(run_hook "$input")
-  if echo "$output" | grep -q "MCP search available"; then
+  local out
+  out=$(run_hook "$input" "$MCP_DIR")
+  if echo "$out" | jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"
+        and (.hookSpecificOutput.additionalContext | test("search_code"))' >/dev/null 2>&1; then
     PASS=$((PASS + 1))
   else
     FAIL=$((FAIL + 1))
-    echo "FAIL: $desc — expected banner, got: $output"
+    echo "FAIL: $desc — expected additionalContext JSON, got: $out"
   fi
 }
 
-assert_no_banner() {
-  local desc="$1" input="$2"
-  local output
-  output=$(run_hook "$input")
-  if [ -z "$output" ]; then
+# assert the hook stayed silent (no output) under the given portfolio root
+assert_silent() {
+  local desc="$1" input="$2" portfolio="$3"
+  local out
+  out=$(run_hook "$input" "$portfolio")
+  if [ -z "$out" ]; then
     PASS=$((PASS + 1))
   else
     FAIL=$((FAIL + 1))
-    echo "FAIL: $desc — expected no output, got: $output"
+    echo "FAIL: $desc — expected silence, got: $out"
   fi
 }
 
-# --- Should fire (grep on framework paths) ---
+# --- Gate OPEN (apexyard-search configured) + a workspace/framework search ---
 
-assert_banner "grep -r on roles/" \
+assert_advisory "grep -r on roles/" \
   '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"activation\" roles/"}}'
 
-assert_banner "grep -rn on .claude/hooks/" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -rn \"require-active\" .claude/hooks/"}}'
+assert_advisory "grep -rn on workspace/<proj>" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -rn \"export\" workspace/example-app/src/"}}'
 
-assert_banner "grep on workflows/" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"SDLC\" workflows/"}}'
-
-assert_banner "grep on docs/agdr" \
+assert_advisory "grep on docs/agdr" \
   '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"migration\" docs/agdr/"}}'
 
-assert_banner "grep on handbooks/" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -l \"blocking\" handbooks/"}}'
-
-assert_banner "grep on workspace/" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -rn \"export\" workspace/yumyum/backend/src/"}}'
-
-assert_banner "find on templates/" \
+assert_advisory "find on templates/" \
   '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"find templates/ -name \"*.md\""}}'
 
-assert_banner "piped grep on skills/" \
+assert_advisory "piped grep on skills/" \
   '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"cat skills/debug/SKILL.md | grep hypothesis"}}'
 
-# --- Should NOT fire ---
+# --- Non-blocking: the advisory is valid JSON (jq parses) -------------------
+adv_out=$(run_hook '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -rn x workspace/p/"}}' "$MCP_DIR")
+if echo "$adv_out" | jq -e . >/dev/null 2>&1; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1)); echo "FAIL: advisory output must be valid JSON, got: $adv_out"
+fi
 
-assert_no_banner "grep on non-framework path" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"TODO\" src/"}}'
+# --- Gate CLOSED (apexyard-search NOT configured) → silent even on a match ---
 
-assert_no_banner "non-Bash tool" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"roles/engineering/tech-lead.md"}}'
+assert_silent "gate closed: no apexyard-search in .mcp.json" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -rn \"export\" workspace/example-app/src/"}}' \
+  "$NO_MCP_DIR"
 
-assert_no_banner "non-grep bash command" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"npm test"}}'
+# --- Should NOT fire even with the gate open --------------------------------
 
-assert_no_banner "git command" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git log --oneline -5"}}'
+assert_silent "non-search command (ls)" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"ls workspace/"}}' "$MCP_DIR"
 
-assert_no_banner "grep on random dir" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"error\" /var/log/"}}'
+assert_silent "search but not a framework/workspace path" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"TODO\" src/"}}' "$MCP_DIR"
 
-# --- Results ---
+assert_silent "non-Bash tool" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"roles/engineering/tech-lead.md"}}' "$MCP_DIR"
 
+assert_silent "non-grep bash command (npm)" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"npm test"}}' "$MCP_DIR"
+
+# --- Report ----------------------------------------------------------------
 echo ""
-echo "Results: $PASS passed, $FAIL failed"
-[ "$FAIL" -eq 0 ] && exit 0 || exit 1
+echo "suggest-mcp-search: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
<!-- agdr: not-applicable -->
<!-- Bug fix to an existing advisory hook — output channel + gating; no architecture decision. -->

## Summary

- **Fixes the `suggest-mcp-search` advisory never reaching the agent (#469).** The hook (from #418) wrote its `💡 MCP search available` banner to **stderr with `exit 0`** — which Claude Code does **not** inject into the model's context. So the hook fired correctly but the nudge was **invisible to the agent**, which is the exact failure it exists to prevent (confirmed against the hooks contract: only exit-2 stderr reaches the model, and exit 2 blocks the tool — wrong for an advisory).
- **Now emits `hookSpecificOutput.additionalContext` JSON on stdout** (exit 0, non-blocking) — a system reminder the model reads on the next turn, without blocking the Bash call.
- **Install-gated.** It only nudges when `apexyard-search` is configured in a resolvable `.mcp.json` (ops root via the hook's own path, or `$APEXYARD_PORTFOLIO_ROOT`). Adopters without the premium search component get **silent fallback to plain grep** — no nag.
- Detection logic (grep/find targeting framework or `workspace/`/`projects/` paths) is unchanged.

## Testing

- [ ] `bash .claude/hooks/tests/test_suggest_mcp_search.sh` — **11 passed**. The suite was rewritten to inject the gate via a temp `$APEXYARD_PORTFOLIO_ROOT/.mcp.json` fixture and asserts: additionalContext JSON emitted when gated-on; **silence when `apexyard-search` isn't configured**; silence on non-search commands, non-framework paths, and non-Bash tools; output is valid JSON.
- [ ] Example paths in the test genericized (no private project names committed to the public repo).

## Glossary

| Term | Definition |
|------|------------|
| **additionalContext** | The `hookSpecificOutput` field a PreToolUse hook prints to stdout (exit 0) to inject a non-blocking advisory the model reads. |
| **Install-gate** | Emitting the MCP nudge only when the `apexyard-search` MCP server is actually configured in `.mcp.json`. |

Closes #469
