### PR TITLE
feat(#473): /launch-check --workflow — opt-in parallel + adversarially-verified audit

### DIFF
--- a/.claude/skills/launch-check/SKILL.md
+++ b/.claude/skills/launch-check/SKILL.md
@@ -2,7 +2,7 @@
 name: launch-check
 description: Production readiness audit — 10-dimension go/no-go sweep (security, a11y, compliance, analytics, SEO, GEO, perf, monitoring, docs, behaviour-quality).
 disable-model-invocation: false
-argument-hint: "[project-path] | trend [project-path]"
+argument-hint: "[project-path] | trend [project-path] | --workflow [project-path]"
 effort: high
 ---
 
@@ -12,10 +12,11 @@ Runs a 10-dimension sweep against a project and outputs a one-page verdict. Desi
 
 **Invoke from** the project's workspace directory (`cd workspace/<project>/`) or pass the path as an argument: `/launch-check workspace/my-app`.
 
-**Two modes:**
+**Three modes:**
 
-- `/launch-check [project-path]` — full audit (default). Runs all 10 dimensions, persists results to the per-project history store, and renders a "Trend (last 5 runs)" section when ≥ 2 prior runs exist.
+- `/launch-check [project-path]` — full audit (default). Runs all 10 dimensions **serially**, persists results to the per-project history store, and renders a "Trend (last 5 runs)" section when ≥ 2 prior runs exist.
 - `/launch-check trend [project-path]` — read-only trend report. Renders just the trend section from existing run files. Useful for "are we trending up?" without burning the audit cost. See § "Trend-only mode" below.
+- `/launch-check --workflow [project-path]` — **opt-in** parallel + adversarially-verified audit. Fans the 10 dimensions out concurrently (one agent each), independently verifies every FAIL/WARN finding before it lands in the verdict, then synthesizes the **same** table and persists via the **same** history store. Faster wall-clock and fewer false positives; costs more tokens (spawns ~10–20 agents). Same output, same trend continuity — see § "Workflow mode" below.
 
 ## Deep-dive companions
 
@@ -260,6 +261,95 @@ Count PASS/WARN/FAIL, apply the verdict logic, format the output table.
 Print the table exactly as shown in the "Output format" section above. Then continue to Step 6 to persist the run and render the trend section.
 
 **Do NOT auto-create tickets for the findings.** Offer: "Want me to create tickets for the blocking items?" — but let the user decide. The launch check is advisory.
+
+## Workflow mode (`--workflow`) — opt-in parallel + adversarial verify
+
+When invoked as `/launch-check --workflow [project-path]`, replace the serial Steps 3–5 with a single `Workflow` tool invocation that fans the 10 dimensions out concurrently and adversarially verifies the findings, then resume at **Step 6 (persist) unchanged**. Steps 1–2 (resolve project + detect stack) and Step 6 (persist + trend) are identical to the default path — only the *evaluation* of the 10 dimensions changes from serial to fanned-out.
+
+### Why a Workflow here (and why opt-in)
+
+The 10 dimensions are **independent and read-only** — no shared writes, no cross-dimension data dependency, no human gate. That's the canonical fan-out shape: evaluate all 10 in parallel, then have an independent skeptic try to refute each FAIL/WARN before it reaches the verdict (the false-positive killer). The trade-off is token cost — a workflow run spawns ~10–20 agents versus one serial pass — so this is **opt-in**, never the default. Rationale: AgDR-0055.
+
+**Prerequisite:** the `Workflow` tool requires explicit opt-in to multi-agent orchestration. The `--workflow` flag *is* that opt-in — when the operator passes it, author and run the workflow below. Without the flag, run the serial path and do NOT invoke `Workflow`.
+
+### The canonical workflow script
+
+Author and run this via the `Workflow` tool (adapt the project name / stack-skip set from Steps 1–2). The dimension prompts reuse the **exact PASS/WARN/FAIL criteria** from "The 9 dimensions" / row-10 below — do not invent new criteria. Auto-PASS the not-applicable dimensions per the existing rules (e.g. SEO/GEO/perf auto-PASS for a non-web project, analytics auto-PASS for a CLI/library) by passing them as already-resolved rather than spawning an agent.
+
+```javascript
+export const meta = {
+  name: 'launch-check',
+  description: 'Parallel 10-dimension production-readiness audit with adversarial verification',
+  phases: [
+    { title: 'Evaluate', detail: 'one agent per applicable dimension' },
+    { title: 'Verify', detail: 'adversarially refute each FAIL/WARN finding' },
+  ],
+}
+
+// args = { projectPath, projectName, dimensions: [{ key, label, prompt, applicable }] }
+// `prompt` carries that dimension's "What to check" + PASS/WARN/FAIL criteria verbatim
+// from this SKILL. Non-applicable dimensions are pre-resolved to PASS and skipped.
+
+const DIM_SCHEMA = {
+  type: 'object',
+  required: ['key', 'status', 'score', 'finding'],
+  properties: {
+    key:     { type: 'string' },
+    status:  { enum: ['PASS', 'WARN', 'FAIL'] },
+    score:   { type: 'integer' },            // 0-100, same scale render-trend.sh plots
+    finding: { type: 'string' },             // one-line, fits the verdict-table cell
+    evidence:{ type: 'string' },             // file:line or command output backing the status
+  },
+}
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['key', 'upheld', 'reason'],
+  properties: {
+    key:    { type: 'string' },
+    upheld: { type: 'boolean' },             // false = the skeptic refuted the WARN/FAIL
+    reason: { type: 'string' },
+  },
+}
+
+const applicable = args.dimensions.filter(d => d.applicable)
+const preResolved = args.dimensions.filter(d => !d.applicable)
+  .map(d => ({ key: d.key, status: 'PASS', score: 100, finding: 'N/A for this project type' }))
+
+// Phase 1+2 pipelined: each dimension verifies as soon as its evaluation returns,
+// rather than waiting for the slowest dimension (no barrier).
+const evaluated = await pipeline(
+  applicable,
+  d => agent(d.prompt, { label: `eval:${d.key}`, phase: 'Evaluate', schema: DIM_SCHEMA, agentType: d.agentType }),
+  (res, d) => {
+    if (!res) return null
+    if (res.status === 'PASS') return res            // nothing to refute
+    // Adversarially verify only WARN/FAIL — the findings that move the verdict.
+    return agent(
+      `Adversarially REFUTE this ${d.label} finding for ${args.projectName}: "${res.finding}" ` +
+      `(evidence: ${res.evidence || 'none'}). Default upheld=false if you cannot independently confirm it. ` +
+      `Re-check the codebase yourself.`,
+      { label: `verify:${d.key}`, phase: 'Verify', schema: VERDICT_SCHEMA },
+    ).then(v => {
+      // A refuted FAIL/WARN is downgraded to PASS (the false-positive cut).
+      if (v && v.upheld === false) return { ...res, status: 'PASS', finding: `${res.finding} (refuted on verify: ${v.reason})` }
+      return res
+    })
+  },
+)
+
+return { results: [...preResolved, ...evaluated.filter(Boolean)] }
+```
+
+### After the workflow returns
+
+1. Take `results[]` (one row per dimension, each with `status` / `score` / `finding`).
+2. Count PASS/WARN/FAIL, apply the **same verdict logic** ("Verdict logic" table above) — go / go-with-warnings / conditional-go / no-go.
+3. Print the **same verdict table** as the serial path (Step 5 "Output format").
+4. **Persist via Step 6 unchanged** — build the same superset payload (`scores{}` from each row's `score`, `findings[]` from the WARN/FAIL rows), call `audit_run_persist`, then `audit_render_trend`. The history store, schema, and `render-trend.sh` chart are identical to a serial run, so trend continuity is preserved across serial↔workflow runs.
+
+### Degrade gracefully
+
+If the `Workflow` tool is unavailable in the current Claude Code installation, say so in one line and fall back to the serial Steps 3–5. The audit must still complete — `--workflow` is an optimisation, not a hard dependency.
 
 ### Step 6: Persist the run + render the trend
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ One-line summary per skill; canonical details live in each `.claude/skills/<name
 | Skill | Purpose |
 |-------|---------|
 | `/setup` | First-run bootstrap — configure `onboarding.yaml` in 3 exchanges |
-| `/launch-check` | Production readiness audit — 10-dimension go/no-go sweep at milestone boundaries |
+| `/launch-check` | Production readiness audit — 10-dimension go/no-go sweep at milestone boundaries (opt-in `--workflow` mode fans the dimensions out in parallel + adversarially verifies findings) |
 | `/threat-model` | STRIDE threat modelling — spoofing, tampering, repudiation, disclosure, DoS, EoP |
 | `/accessibility-audit` | WCAG 2.1 AA accessibility audit — perceivable, operable, understandable, robust |
 | `/compliance-check` | GDPR + ePrivacy compliance — consent, privacy policy, data handling, user rights |

--- a/docs/agdr/AgDR-0055-launch-check-workflow-mode.md
+++ b/docs/agdr/AgDR-0055-launch-check-workflow-mode.md
@@ -1,0 +1,45 @@
+# Add an opt-in `--workflow` mode to `/launch-check` (parallel + adversarial verify)
+
+> In the context of `/launch-check` being a 10-dimension, independent, read-only production-readiness audit, facing the wish for a faster and higher-confidence milestone sweep, I decided to add an **opt-in `--workflow` mode** that authors and runs a Claude Code `Workflow` to fan the dimensions out concurrently and adversarially verify each FAIL/WARN finding before it reaches the verdict, to achieve lower wall-clock latency and fewer false positives, accepting a higher per-run token cost — which is why the mode is opt-in and the serial path stays the default.
+
+## Context
+
+`/launch-check` evaluates 10 dimensions (security, accessibility, compliance, analytics, SEO, generative-engine, performance, monitoring, docs, behaviour-quality). They are mutually independent, read-only, and have no human gate — the textbook fan-out shape. The default skill runs them serially in one agent context.
+
+Claude Code ships a `Workflow` primitive for deterministic multi-agent orchestration (parallel/pipeline fan-out, adversarial verification, synthesis). `/launch-check` is the framework's best-fit consumer: pure audit, no merges or approvals to serialize. The question was whether — and how — to wire it in without regressing the cheap default or the persisted trend history.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Leave `/launch-check` serial only** | Cheapest; zero new surface | Slow wall-clock on a 10-dimension sweep; single-context evaluation is more prone to plausible-but-wrong findings (no independent check) |
+| **Use the existing `/fan-out` skill** | Already in the framework | `/fan-out` spawns parallel agents but has no built-in adversarial-verify / synthesize / structured-output stage; we'd rebuild the verify loop by hand each time |
+| **Make `Workflow` the default for `/launch-check`** | Best output every run | Every run spawns ~10–20 agents — large token cost for a routine audit; violates the "Workflow requires explicit opt-in" norm |
+| **Opt-in `--workflow` mode (chosen)** | Faster + adversarially-verified when you want it; serial default unchanged; reuses the same persistence + trend | One more mode to document; the workflow script lives in the skill as the canonical shape |
+
+## Decision
+
+Chosen: **opt-in `--workflow` mode.**
+
+1. **Opt-in, never default.** A workflow run spawns ~10–20 agents vs one serial pass. Per the `Workflow` tool's own rule, multi-agent orchestration needs explicit opt-in — the `--workflow` flag *is* that opt-in. No flag → serial path, no `Workflow` invocation.
+
+2. **Fan-out + pipeline, not a barrier.** Each dimension is evaluated by its own agent, and each FAIL/WARN finding is adversarially verified *as soon as that dimension returns* (pipeline, no barrier) — the slowest dimension doesn't hold up the others' verification.
+
+3. **Adversarial verify is the value-add.** A second independent agent is prompted to *refute* each WARN/FAIL (default `upheld=false` if it can't independently confirm). A refuted finding is downgraded to PASS with a note. This is the false-positive cut that single-context serial evaluation can't do. PASS findings are not re-verified (nothing to refute).
+
+4. **Same output, same persistence, same trend.** The workflow synthesizes the identical verdict table + four-state verdict vocabulary, and persistence resumes at the existing Step 6 — same `_lib-audit-history.sh` (`audit_run_persist` / `audit_render_trend`), same superset JSON schema, same `render-trend.sh` chart. Trend history is continuous across serial↔workflow runs; no schema migration.
+
+5. **Graceful degrade.** If `Workflow` isn't available in the installation, the skill falls back to the serial path with a one-line notice. `--workflow` is an optimisation, not a hard dependency.
+
+## Consequences
+
+- `/launch-check` gains a third mode; frontmatter `argument-hint` + the modes list + a "Workflow mode" section (with the canonical workflow script, dimension/verdict schemas, and the after-the-workflow synthesis+persist steps) are added to the skill.
+- No new skill / hook / role / agent — the framework counts are unchanged (this is a mode added to an existing skill), so `test_site_counts.sh` is unaffected.
+- The canonical workflow script is documented in-skill so each run authors a consistent workflow (stable phases, structured output, dedupe, persist) rather than an ad-hoc one.
+- Establishes the **pattern** for wiring `Workflow` into other multi-dimension audit skills (`/threat-model`, `/accessibility-audit`, etc.) the same way if it proves useful — opt-in flag, reuse the dimension criteria, synthesize to the existing output + persistence.
+
+## Artifacts
+
+- Issue: me2resh/apexyard#473
+- Edited: `.claude/skills/launch-check/SKILL.md` (frontmatter, modes list, new "Workflow mode" section), `CLAUDE.md` (skill blurb)
+- Related: the `Workflow` tool (Claude Code harness primitive), `/fan-out` (the lighter parallel-agent skill), `_lib-audit-history.sh` + `render-trend.sh` (unchanged persistence/trend), `.claude/rules/parallel-work.md` (when to offer parallel execution).


### PR DESCRIPTION
<!-- agdr: docs/agdr/AgDR-0055-launch-check-workflow-mode.md -->

## Summary

- **Adds an opt-in `--workflow` mode to `/launch-check`** (#473). The 10 readiness dimensions are independent, read-only, and gate-free — the textbook fan-out shape — so `--workflow` authors and runs a Claude Code `Workflow` instead of the serial single-context pass.
- **Parallel evaluation + adversarial verify.** Each applicable dimension is evaluated by its own agent (reusing that dimension's existing PASS/WARN/FAIL criteria verbatim — no new criteria), and each FAIL/WARN finding is independently *refuted-or-upheld* as soon as it returns (pipeline, no barrier). A refuted finding downgrades to PASS with a note — the false-positive cut that single-context serial evaluation can't do. PASS findings aren't re-verified.
- **Same output, same persistence, same trend.** The workflow synthesizes the identical verdict table + four-state verdict vocabulary (go / go-with-warnings / conditional-go / no-go) and resumes at the existing **Step 6** — same `_lib-audit-history.sh` (`audit_run_persist` / `audit_render_trend`), same superset JSON schema, same `render-trend.sh` chart. Trend history is continuous across serial↔workflow runs; **no schema change**.
- **Opt-in by design.** A workflow run spawns ~10–20 agents vs one serial pass, and the `Workflow` primitive requires explicit opt-in — the `--workflow` flag *is* that opt-in. No flag → serial path, no `Workflow` invocation. The default behaviour is byte-for-byte unchanged.
- **Graceful degrade.** If `Workflow` isn't available in the installation, the skill says so in one line and falls back to serial. `--workflow` is an optimisation, not a hard dependency.
- **No new skill / hook / role / agent** — this is a mode added to an existing skill, so the framework counts (and `test_site_counts.sh`) are unchanged.

## Testing

- [ ] `markdownlint-cli2` (CI ruleset) — **0 errors** on the changed files (`SKILL.md`, AgDR-0055, `CLAUDE.md`). The only flags from a newer local markdownlint are MD060, a rule absent from CI's pinned version and already firing on pre-existing tables repo-wide.
- [ ] `bash .claude/hooks/tests/test_site_counts.sh` — **green** (counts unchanged: this PR adds no skill/hook/role).
- [ ] Default path unchanged — the serial Steps 3–5 and Step 6 persistence are untouched; `--workflow` only swaps the *evaluation* of the 10 dimensions for a fan-out, then rejoins Step 6.
- [ ] Canonical workflow script documented in-skill (phases, `DIM_SCHEMA` / `VERDICT_SCHEMA`, pipeline-with-adversarial-verify, after-the-workflow synthesis + persist) so each run authors a consistent workflow.

## Glossary

| Term | Definition |
|------|------------|
| **Workflow (mode)** | Opt-in `/launch-check --workflow` path that authors + runs a Claude Code `Workflow` to evaluate the 10 dimensions in parallel and adversarially verify findings. |
| **Adversarial verify** | A second independent agent prompted to *refute* a WARN/FAIL finding (default upheld=false if it can't confirm); a refuted finding downgrades to PASS. Cuts plausible-but-wrong findings. |
| **Pipeline (no barrier)** | Each dimension's finding is verified the moment that dimension returns, rather than waiting for the slowest dimension — wall-clock = slowest single chain, not sum-of-slowest-per-stage. |
| **Superset schema** | The persisted run JSON carries both the canonical audit fields and the launch-check-specific `scores{}` map, so `render-trend.sh` keeps plotting unchanged. |

Closes #473
