### PR TITLE
fix(#475): make code-reading sub-agents MCP-first

### DIFF
--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -2,13 +2,17 @@
 name: backend-engineer
 description: Implements domain logic, APIs, and infrastructure following clean architecture principles. Activates during the Build phase on backend code (domain / application / infrastructure layers), API work, or database schema changes.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Karim
 ---
 
 # Karim — Backend Engineer
 
 Read and adopt `@roles/engineering/backend-engineer.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## MCP-first code search
+
+When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_code` (and `search_docs` for docs) over `grep` + `Read`** — it's semantic, returns targeted excerpts, and costs ~3–5× fewer tokens. Fall back to `grep`/`Read` only when an MCP query returns nothing relevant (e.g. the project isn't indexed). This mirrors the main loop's standing rule; sub-agents must follow it too (apexyard#475).
 
 ## Activation context
 

--- a/.claude/agents/data-engineer.md
+++ b/.claude/agents/data-engineer.md
@@ -2,13 +2,17 @@
 name: data-engineer
 description: Builds ETL pipelines, designs data models, owns data-quality work, and manages warehouse schema changes. Activates on ETL / data-modelling / warehouse-schema / data-quality work — pipeline implementation, often in-flow with Backend Engineer handoff.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Anwar
 ---
 
 # Anwar — Data Engineer
 
 Read and adopt `@roles/data/data-engineer.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## MCP-first code search
+
+When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_code` (and `search_docs` for docs) over `grep` + `Read`** — it's semantic, returns targeted excerpts, and costs ~3–5× fewer tokens. Fall back to `grep`/`Read` only when an MCP query returns nothing relevant (e.g. the project isn't indexed). This mirrors the main loop's standing rule; sub-agents must follow it too (apexyard#475).
 
 ## Activation context
 

--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -2,13 +2,17 @@
 name: frontend-engineer
 description: Builds user interfaces following the design system — accessible, performant, and delightful. Activates during the Build phase on UI code, component work, design-system integration, or accessibility review.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Yasmin
 ---
 
 # Yasmin — Frontend Engineer
 
 Read and adopt `@roles/engineering/frontend-engineer.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## MCP-first code search
+
+When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_code` (and `search_docs` for docs) over `grep` + `Read`** — it's semantic, returns targeted excerpts, and costs ~3–5× fewer tokens. Fall back to `grep`/`Read` only when an MCP query returns nothing relevant (e.g. the project isn't indexed). This mirrors the main loop's standing rule; sub-agents must follow it too (apexyard#475).
 
 ## Activation context
 

--- a/.claude/agents/platform-engineer.md
+++ b/.claude/agents/platform-engineer.md
@@ -2,13 +2,17 @@
 name: platform-engineer
 description: Builds and maintains infrastructure, CI/CD pipelines, and developer tooling — the platform that lets engineers ship fast and safely. Activates on CI/CD pipeline changes, developer tooling, infrastructure-as-code work, or golden-path templates.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Adel
 ---
 
 # Adel — Platform Engineer
 
 Read and adopt `@roles/engineering/platform-engineer.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## MCP-first code search
+
+When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_code` (and `search_docs` for docs) over `grep` + `Read`** — it's semantic, returns targeted excerpts, and costs ~3–5× fewer tokens. Fall back to `grep`/`Read` only when an MCP query returns nothing relevant (e.g. the project isn't indexed). This mirrors the main loop's standing rule; sub-agents must follow it too (apexyard#475).
 
 ## Activation context
 

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -2,7 +2,7 @@
 name: qa-engineer
 description: Verifies acceptance criteria on merged PRs, triages bugs, runs regression checks, and signs off tickets before they move to Done. Activates when a ticket enters the QA state after merge. Read-only by design — QA verifies, doesn't ship.
 model: haiku
-allowed-tools: Bash, Read, Grep, Glob
+allowed-tools: Bash, Read, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Salim
 ---
 
@@ -11,6 +11,10 @@ persona_name: Salim
 Read and adopt `@roles/engineering/qa-engineer.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
 
 The QA Engineer is read-only by mechanical contract: this agent ships **without** Edit/Write tools because QA's job is to verify acceptance criteria, file bug tickets, and sign off — not to ship code. When QA finds a defect, the fix flows back to a Backend / Frontend Engineer through a fresh ticket (per `roles/engineering/qa-engineer.md` § "If QA Finds Issues" and `workflows/sdlc.md` § "Phase 5: QA Verification").
+
+## MCP-first code search
+
+When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_code` (and `search_docs` for docs) over `grep` + `Read`** — it's semantic, returns targeted excerpts, and costs ~3–5× fewer tokens. Fall back to `grep`/`Read` only when an MCP query returns nothing relevant (e.g. the project isn't indexed). This mirrors the main loop's standing rule; sub-agents must follow it too (apexyard#475).
 
 ## Activation context
 

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -3,7 +3,7 @@
 name: security-reviewer
 persona_name: Hakim
 description: Security Auditor — runs OWASP / threat-model / SAST analysis on PR diffs and provides remediation guidance. Auto-activates on PRs touching auth, crypto, secrets, user data, APIs, or third-party integrations; explicit invocation via /security-review. Canonical role at @roles/security/security-auditor.md.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 disallowedTools: Write, Edit
 model: opus
 ---
@@ -15,6 +15,10 @@ Read and adopt `@roles/security/security-auditor.md` for full identity, responsi
 ## Consolidation note (Wave 2 PR 3 — #347)
 
 This agent file previously ran as `Hatim` (utility agent, narrow PR-review scope, `model: inherit`). Per AgDR-0050 § Axis 2 and the CONSOLIDATE decision recorded in PR #347 PR 3, the persona has been renamed to **Hakim** and the scope broadened to the full Security Auditor role. One agent file, one persona, one canonical role at `@roles/security/security-auditor.md`. The `security-reviewer.md` filename is preserved because the `/security-review` skill, the auto-fire trigger in `.claude/rules/role-triggers.md`, and the `auto-code-review.sh` hook all reference it.
+
+## MCP-first code search
+
+When reading a managed-project codebase during a review, **prefer `mcp__apexyard-search__search_code` (and `search_docs` for docs) over `grep` + `Read`** — it's semantic, returns targeted excerpts, and costs ~3–5× fewer tokens. Fall back to `grep`/`Read` only when an MCP query returns nothing relevant (e.g. the project isn't indexed). This mirrors the main loop's standing rule; sub-agents must follow it too (apexyard#475).
 
 ## ⛔ Operational HARD STOP — MANDATORY ACTION
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -2,13 +2,17 @@
 name: tech-lead
 description: Bridges architecture and implementation — authors technical designs, leads code reviews, mentors engineers, and owns technical quality for a domain. Activates on technical design, planning phase, code review approval gate, or task breakdown.
 model: opus
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Hisham
 ---
 
 # Hisham — Tech Lead
 
 Read and adopt `@roles/engineering/tech-lead.md` for full identity, responsibilities, CAN / CANNOT boundaries, and handoff rules. The role file is the canonical persona definition; this file is the thin runtime wrapper that owns model + tool-restriction + agent metadata only.
+
+## MCP-first code search
+
+When reading a managed-project codebase (e.g. authoring a technical design against an existing service), **prefer `mcp__apexyard-search__search_code` (and `search_docs` for docs) over `grep` + `Read`** — it's semantic, returns targeted excerpts, and costs ~3–5× fewer tokens. Fall back to `grep`/`Read` only when an MCP query returns nothing relevant (e.g. the project isn't indexed). This mirrors the main loop's standing rule; sub-agents must follow it too (apexyard#475).
 
 ## Activation context
 

--- a/docs/agdr/AgDR-0056-subagent-mcp-first.md
+++ b/docs/agdr/AgDR-0056-subagent-mcp-first.md
@@ -1,0 +1,44 @@
+# Make sub-agents MCP-first (prompt-level, mirroring the main-loop rule)
+
+> In the context of the "use MCP search before grep" rule only reaching the main agent loop, facing a confirmed case where the `tech-lead` sub-agent read a managed-project codebase entirely via `grep`/`Read` (zero `search_code` calls in `activity.jsonl`), I decided to make the code-reading sub-agents MCP-first at the prompt + tools level — add `mcp__apexyard-search__search_code` + `search_docs` to their `tools`/`allowed-tools` and a short "MCP-first" instruction block to each agent body — rather than try to extend the `suggest-mcp-search.sh` hook into sub-agent contexts, to achieve consistent MCP-first behaviour across delegated work, accepting that this is self-discipline (prompt-level) rather than mechanical enforcement.
+
+## Context
+
+The portfolio rule "prefer `mcp__apexyard-search__search_code` / `search_docs` over `grep` + `Read`" is enforced on the **main loop** two ways: the `suggest-mcp-search.sh` PreToolUse advisory hook (fires on the main agent's Bash/grep calls and injects a `hookSpecificOutput.additionalContext` nudge), and operator feedback memory. Neither reaches a spawned sub-agent: the hook observes the *main* agent's tool calls, and a sub-agent runs its own loop with its own (separately-declared) tools.
+
+Observed 2026-06-01 (this is the originating incident): the `tech-lead` sub-agent authored a curios-dog Cognito migration design by reading the Terraform + DynamoDB code via `grep`/`Read`. The MCP `activity.jsonl` showed **zero** `search_code` entries for that run. The design came out correct, but via the more expensive path the rule exists to avoid. Filed as me2resh/apexyard#475.
+
+Two contributing facts:
+
+1. The engineering/data agent definitions carried `search_docs` at most (most carried neither `search_code` nor `search_docs` in their `tools`/`allowed-tools` line), so the tool wasn't even available to them.
+2. Their agent prompts had no MCP-first instruction.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Extend `suggest-mcp-search.sh` to fire inside sub-agent contexts** | Mechanical (not self-discipline) | The hook observes the *invoking* loop's tool calls; sub-agent tool calls aren't surfaced to the parent hook in a way the current PreToolUse plumbing can intercept. Would need harness-level changes we don't control. High effort, uncertain feasibility. |
+| **Prompt-level MCP-first in each agent + add the tools (chosen)** | Simple, additive, immediately effective; reuses the proven `solution-architect` agent shape (which already does this); no harness changes | Self-discipline, not mechanically enforced — a sub-agent *could* still grep. Matches how the main-loop rule degrades, so no worse than today's primary mechanism. |
+| **Do nothing (rely on the per-call prompt to say "prefer search_code")** | Zero change | The originating incident shows an ad-hoc per-spawn instruction isn't reliable; the discipline belongs in the agent definition, not in each caller's prompt. |
+
+## Decision
+
+Chosen: **prompt-level MCP-first, baked into the agent definitions.**
+
+1. **Add the MCP search tools** (`mcp__apexyard-search__search_code` + `search_docs`) to the `tools` / `allowed-tools` line of every code-reading sub-agent: `tech-lead`, `backend-engineer`, `frontend-engineer`, `data-engineer`, `platform-engineer`, `qa-engineer`, `security-reviewer`. (The `code-reviewer` already had `search_docs`; the new `solution-architect` already has both + the instruction — it's the reference implementation.)
+2. **Add a short `## MCP-first code search` block** to each agent body: prefer `search_code`/`search_docs` over `grep`+`Read`; fall back to grep only when MCP returns nothing (e.g. project not indexed). One consistent paragraph across all seven.
+3. **Do NOT attempt to extend the hook** into sub-agent contexts for now — the hook plumbing can't see a sub-agent's tool calls, and the prompt-level lever matches how the main-loop rule already works (advisory + self-discipline). Recorded here so a future maintainer doesn't re-investigate the hook route assuming it's a quick win.
+
+## Consequences
+
+- The seven code-reading agents now have `search_code`/`search_docs` available and an explicit MCP-first instruction. A spawned agent reviewing/authoring against a managed project should now produce `search_code` entries in `activity.jsonl` (verifiable).
+- Fallback to grep when MCP returns nothing is preserved — no hard dependency on MCP (adopters without it see unchanged behaviour).
+- This is self-discipline, not a gate. If a future need for *mechanical* enforcement arises, it requires harness-level work (sub-agent tool-call interception) that's out of scope here.
+- No framework-count change (agent count unchanged — these are edits to existing agents), so `test_site_counts.sh` is unaffected.
+
+## Artifacts
+
+- Issue: me2resh/apexyard#475
+- Edited: `.claude/agents/{tech-lead,backend-engineer,frontend-engineer,data-engineer,platform-engineer,qa-engineer,security-reviewer}.md` (tools line + MCP-first block)
+- Reference implementation: `.claude/agents/solution-architect.md` (#472 — already MCP-first)
+- Related: `suggest-mcp-search.sh` (#418, #469/#470 — the main-loop hook), the "use MCP before grep" operator feedback rule, AgDR-0050 (agent runtime / tools conventions).


### PR DESCRIPTION
<!-- agdr: docs/agdr/AgDR-0056-subagent-mcp-first.md -->

## Summary

- **Makes the 7 code-reading sub-agents MCP-first (#475).** The standing "use MCP search before grep" rule only reached the **main loop** — via `suggest-mcp-search.sh` (which observes the main agent's Bash calls) + operator feedback memory. A spawned sub-agent runs its own loop with its own tools, so neither lever reached it. Confirmed 2026-06-01: the `tech-lead` sub-agent authored a curios-dog migration design entirely via `grep`/`Read` — **zero `search_code` calls** in `activity.jsonl`.
- **Adds the MCP search tools** (`mcp__apexyard-search__search_code` + `search_docs`) to the `tools`/`allowed-tools` line of `tech-lead`, `backend-engineer`, `frontend-engineer`, `data-engineer`, `platform-engineer`, `qa-engineer`, `security-reviewer`. (`code-reviewer` already had `search_docs`; `solution-architect` already had both + the instruction — it's the reference implementation.)
- **Adds a consistent `## MCP-first code search` block** to each agent body: prefer `search_code`/`search_docs` over `grep`+`Read`; fall back to grep only when MCP returns nothing (e.g. project not indexed). Graceful degradation preserved — adopters without MCP see unchanged behaviour.
- **AgDR-0056** records the decision and **why the hook route was rejected for now**: extending `suggest-mcp-search.sh` into sub-agent contexts needs harness-level tool-call interception the current PreToolUse plumbing can't do. Prompt-level (self-discipline) matches how the main-loop rule already works.
- **No model-line changes** — the unrelated local sonnet→opus overrides on backend/frontend-engineer were explicitly excluded (restored to `dev` before editing); the diff is tools-line + MCP-block only.

## Testing

- [ ] `markdownlint-cli2` (CI ruleset) — **0 errors** on the 7 agents + AgDR-0056 (only MD060 from a newer-than-CI local linter, already firing repo-wide on pre-existing tables).
- [ ] Diff verified to contain **no `model:` line changes** (contamination check) — only `allowed-tools`/`tools` additions + the MCP-first prose block.
- [ ] No agent-count change (edits to existing agents) → `test_site_counts.sh` unaffected.
- [ ] Manual follow-up to verify behaviour: a spawned agent reviewing a managed project should now emit `search_code` entries in `activity.jsonl` (companion staleness gap noted below).

## Note — companion gap (separate follow-up)

This PR fixes whether sub-agents *use* MCP. It does **not** address index *staleness* — nothing reindexes a workspace clone after `git pull`/merge, so `search_code` can return `not_indexed` or stale results even once agents prefer it. Filing a separate ticket for a post-pull reindex trigger; the two are companions (no point being MCP-first against a stale index).

## Glossary

| Term | Definition |
|------|------------|
| **MCP-first** | Prefer `mcp__apexyard-search__search_code` / `search_docs` over `grep` + `Read`, falling back to grep only when MCP returns nothing. |
| **Sub-agent inheritance** | Whether a behaviour enforced on the main agent loop carries into agents spawned via the Agent tool — it does not for tool-call-observing hooks, which is the gap this closes at the prompt level. |
| **activity.jsonl** | The apexyard-search MCP server's query log; zero `search_code` entries for a code-reading run is the symptom this fixes. |

Closes #475
