### PR TITLE
feat(#480): /handover checklist-first doc selection + template pick

### DIFF
--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: handover
 description: Onboard an external repo via a structured handover assessment + harnessability scoring across 5 codebase dimensions.
-argument-hint: "<project name> [path or url] [--topology <name>]"
+argument-hint: "<project name> [path or url] [--topology <name>] [--all | --interactive]"
 allowed-tools: Bash, Read, Grep, Glob, Write
 ---
 
@@ -50,18 +50,35 @@ The Path resolution section's example sources the helper *once* for documentatio
 /handover legacy-billing-api ../legacy-billing-api
 /handover marketing-site https://github.com/some-org/marketing-site
 /handover marketing-site --topology typescript-nextjs
+/handover legacy-billing-api --all          # non-interactive: generate the full default set
+/handover legacy-billing-api --interactive  # explicit opt-in to the checklist (same as default)
 ```
 
 The `--topology <name>` flag pre-selects a topology bundle and skips the interactive pick in step 1.5. Available v1 topologies: `typescript-nextjs`, `python-fastapi`, `go-data-pipeline`. See [`topologies/README.md`](../../../topologies/README.md) and AgDR-0048.
 
+### Document-set flags (`--all` vs `--interactive`) — default is the checklist
+
+By default the skill presents a **document selection checklist** (step 5.6) after the assessment is computed, so the operator opts in to exactly the artefacts they want and picks the template for each template-backed doc. Two flags override the prompt:
+
+| Flag | Behaviour |
+|------|-----------|
+| `--all` | **Non-interactive.** Generate the full default set with no checklist and the conventional template for each template-backed doc — byte-for-byte the pre-checklist behaviour. Use this for scripted / unattended runs or when you just want everything. |
+| `--interactive` (default) | Present the checklist + per-doc template pick. Equivalent to passing no flag. The flag exists so the default is nameable in scripts and docs. |
+
+Default is `--interactive` because a handover rarely needs every artefact, and the wrong template choice on a template-backed doc is annoying to undo by hand. `--all` is the explicit escape that preserves today's muscle memory — existing invocations that pass neither flag now see the checklist; pass `--all` to keep the old no-prompt flow. The handover assessment + harnessability score are **always** generated regardless of flag — they are the skill's core output, not optional artefacts.
+
 ## Output location
 
-The skill writes two files under `projects/<name>/`:
+The skill always writes the handover assessment; the rest of the artefacts are **selected via the step 5.6 checklist** (or generated in full with `--all`):
 
 ```
-projects/<name>/handover-assessment.md         ← always (re)written
-projects/<name>/architecture/container.md      ← only if missing — stub L2 C4 diagram
+projects/<name>/handover-assessment.md         ← always (re)written (assessment + harnessability)
+projects/<name>/architecture/container.md      ← if selected + missing — stub L2 C4 diagram (default-ticked)
+projects/<name>/architecture/context.md        ← if selected + missing — stub L1 C4 diagram
+projects/<name>/architecture/sequence-<flow>.md ← if selected + a clear flow exists
 ```
+
+Richer artefacts the operator can select but which are owned by dedicated skills — DFD (`/dfd`), Feature Inventory (`/extract-features`), user-journey HTML (`/journey`), Architecture Vision (`/tech-vision`) — are **handed off** rather than generated inline (see step 5.6).
 
 The folder lives in the ops repo (your fork of apexyard), alongside the rest of `projects/`.
 
@@ -86,7 +103,7 @@ Clear the marker on completion (Step "Post-Handover Checklist" below). If the sk
 The bootstrap exemption covers ONLY these writes:
 
 - `apexyard.projects.yaml` — registry append (step 7)
-- `projects/<name>/` — assessment, architecture stub, README (steps 5, 6)
+- `projects/<name>/` — assessment, architecture stubs (container / context / sequence), README (steps 5, 6, 6.1)
 - `.claude/session/active-bootstrap` — the marker itself (step 0)
 - Topology instantiation files (step 5.5, if a topology is picked)
 
@@ -613,7 +630,133 @@ If the workspace clone doesn't exist yet (operator hasn't cloned), defer the pip
 TOPOLOGY_INSTANTIATED="$PICKED_TOPOLOGY@$TOPOLOGY_VERSION"
 ```
 
-### 6. Write the L2 container diagram stub (if missing)
+### 5.6. Document selection (checklist) — opt in to what gets generated
+
+By this point the **computed core** is done: the handover assessment (step 5) and the harnessability score (step 4.5) are written regardless of any selection. This step decides which of the *additional* generatable artefacts to produce, and — for each template-backed one — which template to render it from.
+
+**Skip condition (`--all`)**: if the operator passed `--all` on the invocation, skip the checklist entirely. Generate the full default set (every row marked "default ✓" in the catalogue below) using each doc's conventional template. Note `document selection: --all (full set)` in the step 10 summary and continue to step 6. This is the byte-for-byte pre-checklist behaviour — existing scripted invocations keep working by adding `--all`.
+
+Otherwise (default, or explicit `--interactive`): present the checklist.
+
+#### Two kinds of output
+
+The catalogue distinguishes two classes — keep them visually distinct in the prompt so the operator knows which ones offer a template pick:
+
+- **Computed / toggle-only** — derived from the repo scan; there is no template to choose, only whether to emit. (Example: the L2 container diagram is *assembled* from detected signals, but it still renders **through** the `architecture/c4-container.md` template — so it's template-backed, see below. The handover assessment itself is pure-computed and is always on, never shown as a toggle.)
+- **Template-backed / choose-a-template** — rendered from a file in the template library. For these the operator gets a second sub-prompt to pick which resolved template to use (framework default vs an adopter `custom-templates/**` override, plus any sibling templates that fit the slot).
+
+#### The catalogue
+
+Present this as a numbered checklist. The "default" column marks what `--all` (and the pre-ticked checklist) would generate. Toggle-only rows have no template pick; template-backed rows do.
+
+| # | Artefact | Kind | Template (resolved via `portfolio_resolve_template`) | Default | Generated by |
+|---|----------|------|------------------------------------------------------|---------|--------------|
+| 1 | L2 container diagram (`architecture/container.md`) | template-backed | `architecture/c4-container.md` | ✓ (if signals + not already present) | step 6 |
+| 2 | L1 context diagram (`architecture/context.md`) | template-backed | `architecture/c4-context.md` | — | step 6.1 (`/c4` context pass) |
+| 3 | Data Flow Diagram (`architecture/dfd.md`) | template-backed | `architecture/dfd.md` | — | hand off to `/dfd <name>` |
+| 4 | Feature Inventory (`feature-inventory.md`) | computed (six-axis scan) | — | — | hand off to `/extract-features <name>` |
+| 5 | User-journey preview (`journeys/<flow>.html`) | computed (HTML, from flows) | — | — | hand off to `/journey <name>` |
+| 6 | Architecture Vision draft (`architecture/vision.md`) | template-backed | `architecture/vision.md` | — | hand off to `/tech-vision <name>` |
+| 7 | Sequence diagram (`architecture/sequence-<flow>.md`) | template-backed | `architecture/sequence.md` | — | step 6.1 (sequence pass) |
+
+> The handover assessment + harnessability score are NOT in this catalogue — they are always written (step 5 / 4.5). The catalogue is only the *optional* surface.
+
+Render the prompt like this (pre-tick the default rows; the operator toggles):
+
+```
+Document selection for <name>. The handover assessment + harnessability score are
+always written. Pick which additional docs to generate (default-ticked shown with [x]):
+
+  [x] 1. L2 container diagram          (template-backed → c4-container)
+  [ ] 2. L1 context diagram            (template-backed → c4-context)
+  [ ] 3. Data Flow Diagram             (template-backed → dfd)
+  [ ] 4. Feature Inventory             (computed — six-axis scan)
+  [ ] 5. User-journey preview          (computed — HTML)
+  [ ] 6. Architecture Vision draft     (template-backed → vision)
+  [ ] 7. Sequence diagram              (template-backed → sequence)
+
+Reply with: 'default' (keep ticks as-is), 'all', 'none',
+a comma-list of numbers to GENERATE (e.g. '1,3,4'),
+or toggles like '+2 -1' to adjust the defaults.
+```
+
+Accept:
+
+- `default` or empty — generate exactly the pre-ticked rows
+- `all` — generate every catalogue row (same set as `--all`)
+- `none` — generate nothing optional (assessment + harnessability only)
+- A comma-list (`1,3,4`) — generate exactly those rows
+- Toggle shorthand (`+2 -1`) — start from the defaults, add `+N`, remove `-N`
+
+If the response is ambiguous, ask **one** clarification; on a second ambiguous answer, fall back to `default`.
+
+#### Per-doc template pick (template-backed rows only)
+
+For each **template-backed** row the operator selected, run a template-pick sub-step before generation. Toggle-only / computed rows skip this entirely (there is nothing to pick).
+
+Resolve the candidate templates with the portfolio helper so adopter overrides surface alongside the framework default:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+
+# Conventional template for this slot (e.g. architecture/c4-container.md).
+default_tpl=$(portfolio_resolve_template architecture/c4-container.md)
+
+# Adopter override candidate (only listed when it actually exists — resolve()
+# already prefers it, so equality means there's only one real candidate).
+registry=$(portfolio_registry)
+custom_dir="$(dirname "$registry")/custom-templates"
+```
+
+Present the candidates, defaulting to the conventional one:
+
+```
+Template for the L2 container diagram:
+
+  [1] c4-container.md            (framework default — templates/architecture/)
+  [2] c4-container.md            (adopter override — custom-templates/architecture/)   ← only shown if it exists
+  [3] Other library template     (pick any file under templates/architecture/ or custom-templates/architecture/)
+
+[1/2/3 — default 1]
+```
+
+Rules for the pick:
+
+- **List the override only when it exists.** `portfolio_resolve_template` already returns the override path when present, so when the custom file is absent, candidate `[2]` is omitted and `[1]` is the sole conventional pick — don't fabricate a second row.
+- **Default is always the conventional template** for that slot (candidate `[1]`, or the override if `portfolio_resolve_template` returned it — i.e. the path the helper would pick unprompted). Pressing enter / empty input takes the default. This keeps `--all` and "default" runs byte-stable.
+- **`[3] Other`** lets the operator point at any sibling template (e.g. render the container slot from a custom `c4-container-microservices.md` they keep in `custom-templates/architecture/`). Glob `templates/architecture/*.md` + `custom-templates/architecture/*.md`, list them, let the operator choose. If they pick a path that doesn't exist, re-prompt once, then fall back to the default.
+- Record the chosen absolute path in a per-doc variable (e.g. `$CONTAINER_TEMPLATE`) and pass it to the generating step instead of re-resolving. Step 6's "Assembling the file" block reads `$CONTAINER_TEMPLATE` when set, falling back to `portfolio_resolve_template architecture/c4-container.md` when the checklist was skipped (`--all`) or the variable is unset.
+
+#### Hand-offs vs in-skill generation
+
+Rows 1, 2, 7 are generated **in this skill** (steps 6 / 6.1). Rows 3–6 are richer artefacts owned by dedicated skills — for those, the checklist records the selection and, after the summary (step 10), the skill **offers to hand off** to the matching skill rather than reimplementing it:
+
+```
+You selected: Data Flow Diagram, Feature Inventory.
+Run the owning skills now against the cloned repo?
+
+  /dfd <name>               — Data Flow Diagram
+  /extract-features <name>  — Feature Inventory
+
+[y to run in sequence / n to skip — default n]
+```
+
+This mirrors step 8's follow-up-skill offer (security/code review) — the checklist never reimplements `/dfd`, `/extract-features`, `/journey`, or `/tech-vision`; it routes to them. On `n`, note the selected-but-deferred docs in the summary so the operator can run them later.
+
+#### Record the selection for the summary
+
+```bash
+# Examples — set per the operator's picks
+SELECTED_DOCS="container,dfd,feature-inventory"
+CONTAINER_TEMPLATE="$default_tpl"   # absolute path chosen in the per-doc pick
+```
+
+The step 10 summary reports both the generated set and the deferred (handed-off) set.
+
+### 6. Write the L2 container diagram stub (if selected and missing)
+
+**Selection condition**: generate this file only when row 1 (L2 container diagram) was selected in step 5.6 — i.e. the operator kept it ticked, passed `--all`, or named it in the comma-list. If row 1 was de-selected, skip this step and note `architecture/container.md: skipped (deselected)` in the summary.
 
 **Skip condition**: if `projects/<name>/architecture/container.md` already exists, skip this entire step and note it in the final summary (`architecture/container.md: preserved`). Never overwrite.
 
@@ -734,10 +877,12 @@ Resolve the C4 container template via the portfolio helper so adopter overrides 
 ```bash
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
-container_template=$(portfolio_resolve_template architecture/c4-container.md)
+# Prefer the template chosen in step 5.6's per-doc pick; fall back to the
+# conventional resolution when the checklist was skipped (--all) or unset.
+container_template="${CONTAINER_TEMPLATE:-$(portfolio_resolve_template architecture/c4-container.md)}"
 ```
 
-Single-fork adopters (no `portfolio` block) and adopters with no override fall straight through to `templates/architecture/c4-container.md` (the template shipped in #50). Adopters who want a customised C4 shape drop their version at `<private_repo>/custom-templates/architecture/c4-container.md`. See `templates/README.md` for the path-mirroring convention.
+Single-fork adopters (no `portfolio` block) and adopters with no override fall straight through to `templates/architecture/c4-container.md` (the template shipped in #50). Adopters who want a customised C4 shape drop their version at `<private_repo>/custom-templates/architecture/c4-container.md`. See `templates/README.md` for the path-mirroring convention. When the operator picked a non-conventional template in step 5.6 (the `[3] Other` option), `$CONTAINER_TEMPLATE` carries that choice and is used verbatim here.
 
 Start from the resolved template. Replace:
 
@@ -773,6 +918,28 @@ Create `projects/<name>/architecture/` if missing.
 #### If there's nothing meaningful to draw
 
 If after scanning you find zero signals (no `package.json`, no `pyproject.toml`, no Dockerfile, no known framework, no DB), skip the file and note in the summary: `architecture/container.md: skipped (no container signals detected — add manually from the C4 container template — resolve via portfolio_resolve_template architecture/c4-container.md — when ready)`. Better to write nothing than fabricate a wrong diagram.
+
+### 6.1. Write the L1 context + sequence diagram stubs (if selected)
+
+These are the other two **in-skill** template-backed docs from the step 5.6 catalogue (rows 2 and 7). Generate each only when it was selected; otherwise skip silently.
+
+**Row 2 — L1 context diagram** (`projects/<name>/architecture/context.md`): render from the template chosen in the per-doc pick (`$CONTEXT_TEMPLATE`, falling back to `portfolio_resolve_template architecture/c4-context.md`). Populate the system box with the project name and the `System_Ext` actors from the externals detected in step 6's external-systems scan (auth / payments / email / storage / LLM). Same "auto-generated — refine me" note + never-overwrite rule as the container stub.
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+context_template="${CONTEXT_TEMPLATE:-$(portfolio_resolve_template architecture/c4-context.md)}"
+```
+
+**Row 7 — sequence diagram** (`projects/<name>/architecture/sequence-<flow>.md`): only meaningful when a clear request flow surfaced during the read (e.g. an auth handshake or a primary API path). Render from `$SEQUENCE_TEMPLATE` (fallback `portfolio_resolve_template architecture/sequence.md`). If no obvious flow exists, skip and note `sequence: skipped (no clear flow detected)` — don't fabricate one.
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+sequence_template="${SEQUENCE_TEMPLATE:-$(portfolio_resolve_template architecture/sequence.md)}"
+```
+
+Both follow the architecture-stub conventions: write once, never overwrite (preserve on re-handover), and prepend the machine-drafted note. The richer rows (3–6: DFD, Feature Inventory, journey, vision) are **not** generated here — they hand off to `/dfd`, `/extract-features`, `/journey`, `/tech-vision` per step 5.6's hand-off offer.
 
 ### 7. Append to the portfolio registry
 
@@ -1032,7 +1199,8 @@ If the project is healthy (recent commits, active PRs/issues), skip the prompt e
 
 ```
 Handover assessment written: projects/{name}/handover-assessment.md
-Architecture stub:           projects/{name}/architecture/container.md ({written | preserved | skipped})
+Document selection:          {"checklist — generated: {list}; deferred (handed off): {list}" | "--all (full set)" | "none (assessment only)"}
+Architecture stub:           projects/{name}/architecture/container.md ({written | preserved | skipped | skipped (deselected)})
 Topology bundle:             {"<name>@<version> instantiated (handbooks + AgDR draft + CI pipelines)" | "declined" | "skipped (no pick)" | "pipelines pending — workspace not cloned"}
 Registry updated:            apexyard.projects.yaml ({added | skipped})
 Next-step tickets filed:     {N filed of M offered | none offered (zero risks) | declined (skipped all) | skipped (registry not appended)}
@@ -1075,6 +1243,8 @@ Filed follow-up tickets:
 16. **The routing heuristic is the default, not the law** — step 7.5's auto-route from next-step shape to `/feature` / `/task` / `/bug` is a sensible default. The operator can override per item (`1 as feature` / `3 as bug`). When in doubt, default to `/task` — handover-derived next-steps are almost never user-facing capabilities (`/feature` shape) and rarely strictly broken behaviour (`/bug` shape).
 17. **Source-link every filed ticket back to the assessment** — each ticket dispatched in step 7.5 carries a `_Source: handover deep-dive on YYYY-MM-DD — see projects/<name>/handover-assessment.md_` footer. Without that link, the assessment's context (risks, harnessability score, build status) is invisible to anyone working the ticket later, and the recommendation traceability rot is exactly the failure mode this step exists to prevent.
 18. **Re-runs surface deltas, not redundancy** — the filed-marker presence on each next-step entry is the source of truth for "already done". On re-handover, step 5's regeneration of `## Next Steps` MUST preserve any `~~strikethrough~~ → Filed as [#N](url)` markers from prior runs (don't blow away the operator's filing history). Step 7.5 then prompts only on the entries that lack a `Filed as` link, so the operator never re-sees what they've already filed. If every entry already carries a `Filed as` link, the whole step skips (see § Skip conditions). Byte-equivalence of the section text is NOT the test — only the per-entry marker presence is.
+19. **Document selection is a checklist, not a fixed pipeline** — step 5.6 presents the generatable artefacts as an opt-in checklist (default-ticked: the L2 container diagram). The handover assessment + harnessability score are ALWAYS written and never appear in the checklist — they are the skill's core output. `--all` is the non-interactive escape that generates the full default set with conventional templates (byte-for-byte the pre-checklist behaviour); `--interactive` (the default) presents the checklist. Distinguish computed/toggle-only rows (no template to pick) from template-backed rows (per-doc template pick).
+20. **Per-doc template pick defaults to the conventional template** — for each selected template-backed doc, list the resolved candidates (framework `templates/**` + adopter `custom-templates/**` via `portfolio_resolve_template`) and default to the conventional one (candidate `[1]`, i.e. the path `portfolio_resolve_template` would pick unprompted). Empty input takes the default, keeping `--all` and "default" runs byte-stable. Only list the adopter override candidate when it actually exists. Never reimplement a dedicated skill's artefact — DFD / Feature Inventory / journey / vision hand off to `/dfd` / `/extract-features` / `/journey` / `/tech-vision`.
 
 ## When to use this
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ One-line summary per skill; canonical details live in each `.claude/skills/<name
 | `/codify-rule` | Turn a review comment that caught a Rex-miss into a draft handbook entry |
 | `/investigation` | Create an investigation ticket + live-doc for sustained root-cause work |
 | `/idea` | Capture a new product idea to the shared backlog |
-| `/handover` | Onboard an external repo + score harnessability across 5 codebase dimensions + offer to file Next Steps as tracker tickets |
+| `/handover` | Onboard an external repo + score harnessability across 5 codebase dimensions + checklist-pick which docs to generate (per-doc template choice; `--all` for the full non-interactive set) + offer to file Next Steps as tracker tickets |
 | `/onboard` | Deprecated alias — redirects to `/setup` or `/handover` |
 | `/extract-features` | Six-axis Feature Inventory (routes / models / jobs / tests / UI / docs) for rewrites |
 | `/feature-diagram` | Per-feature Mermaid flowchart of routes / models / jobs / screens involved |

--- a/docs/agdr/AgDR-0057-handover-checklist-selection.md
+++ b/docs/agdr/AgDR-0057-handover-checklist-selection.md
@@ -1,0 +1,52 @@
+# `/handover` — checklist-first document selection + per-doc template pick
+
+> In the context of `/handover` always generating a fixed set of artefacts (handover assessment + an L2 container stub) with no operator say in what gets produced or which template backs it, facing operators who want only a subset of the docs and who keep adopter template overrides they can't reach from the skill, I decided to add an opt-in **document-selection checklist** (step 5.6) plus a **per-doc template pick** that reuses the existing `portfolio_resolve_template` resolution, defaulting the skill to interactive-with-`--all`-escape, to achieve operator control over the generated set without re-litigating template plumbing, accepting that existing no-flag invocations now see a prompt (mitigated by the `--all` escape that restores the old no-prompt flow byte-for-byte).
+
+## Context
+
+`/handover` adopts an external repo: it clones, reads the surface area, scores harnessability, writes a handover assessment, and stubs an L2 C4 container diagram. The document-generation surface was **fixed** — the operator could not say "skip the container diagram" or "also draft a context diagram", and template-backed docs always rendered from the conventional framework template even when the adopter kept an override at `custom-templates/architecture/`.
+
+Two gaps:
+
+1. **No selection.** A pure-backend handover doesn't need a container diagram; a UI-heavy one might want a journey preview and a DFD. The fixed pipeline forced a one-size output.
+2. **No template choice.** The skill already resolves templates via `portfolio_resolve_template` (framework `templates/**` → adopter `custom-templates/**` override), but that resolution was invisible and unprompted — the operator couldn't pick a non-conventional sibling template (e.g. a `c4-container-microservices.md` variant).
+
+The framework already has the UX prior art for an opt-in, per-item interactive flow: `/tickets-batch` and `/plan-initiative` both run a checklist / per-item micro-interview with `all` / `none` / comma-list shorthands.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Leave the fixed pipeline** | Zero new surface; no prompt latency | Operators keep getting docs they don't want and can't reach their template overrides |
+| **Always interactive (no `--all`)** | Simplest mental model | Breaks scripted / unattended runs; no way to reproduce today's output non-interactively |
+| **`--all` default, `--interactive` opt-in** | Existing muscle memory totally unbroken (no-flag = today's behaviour) | The valuable feature (the checklist) is off by default and gets rediscovered rarely; weaker realisation of the issue's intent |
+| **Interactive default, `--all` escape (chosen)** | Realises the issue's recommended shape; the checklist is the thing operators see; `--all` cleanly restores the old flow | No-flag invocations now see one prompt (with a sensible default + the `--all` escape) |
+| **A new `/handover-docs` skill** | Clean separation | Splits one logical flow across two skills; the doc set depends on the just-computed assessment, so it belongs inline |
+
+## Decision
+
+Chosen: **interactive-by-default checklist with an `--all` non-interactive escape, plus a per-doc template pick that reuses `portfolio_resolve_template`.**
+
+1. **Checklist after the computed core (step 5.6).** The handover assessment + harnessability score are always written — they are the skill's reason to exist and never appear in the checklist. The checklist gates only the *optional* artefacts (container / context / sequence diagrams, DFD, Feature Inventory, journey, vision). Default-ticked: the L2 container diagram, matching today's default output.
+
+2. **`--all` is the escape, not the default.** Per the issue's "recommend interactive-with-`--all`-escape", interactive is the default. `--all` generates the full default set with conventional templates and no prompt — byte-for-byte the pre-checklist behaviour — so any scripted invocation stays reproducible by adding one flag. `--interactive` names the default for scripts/docs. The behaviour change for existing no-flag callers is a single prompt with a sensible default and an explicit escape; this is the acceptable cost of making the feature discoverable.
+
+3. **Computed/toggle-only vs template-backed is an explicit distinction.** Toggle-only rows (Feature Inventory, journey) have no template to choose — only whether to emit. Template-backed rows (container, context, DFD, vision, sequence) get a second sub-prompt to pick the template.
+
+4. **Per-doc template pick reuses the existing mechanism.** No new resolution code. For each selected template-backed doc, the candidates come from `portfolio_resolve_template <slot>` (framework default + adopter `custom-templates/**` override). The default is always the conventional template — the path the helper would pick unprompted — so empty input keeps `--all` and "default" runs byte-stable. The adopter override is listed only when it exists; an `Other` option globs sibling templates for non-conventional variants.
+
+5. **Hand off, don't reimplement.** Rows owned by dedicated skills (DFD → `/dfd`, Feature Inventory → `/extract-features`, journey → `/journey`, vision → `/tech-vision`) are recorded in the selection and offered as a hand-off after the summary, mirroring step 8's follow-up-skill offer. Only the in-skill C4 stubs (container, context, sequence) are generated inline.
+
+## Consequences
+
+- Existing no-flag `/handover` runs now show a one-line document-selection prompt with the L2 container diagram pre-ticked; pressing enter/`default` reproduces close to today's output. `--all` restores the exact old no-prompt flow.
+- Operators can now reach their `custom-templates/**` overrides per doc, and pick non-conventional sibling templates, without touching skill plumbing.
+- No new skill, hook, or role — site counts (57 skills / 37 hooks / 20 roles) are unchanged. The change is confined to `.claude/skills/handover/SKILL.md`, the CLAUDE.md one-liner, and this AgDR.
+- The bootstrap exemption scope was widened to cover the new `architecture/context.md` and `architecture/sequence-<flow>.md` writes (same `projects/<name>/` class already exempt).
+- Re-handover preservation extends to the new stubs: like the container stub, context/sequence are written once and never overwritten.
+
+## Artifacts
+
+- `.claude/skills/handover/SKILL.md` — step 5.6 (checklist + per-doc template pick), step 6.1 (in-skill context/sequence stubs), Usage flags, Output-location + summary updates, Rules 19–20
+- `CLAUDE.md` — `/handover` one-line description
+- Closes me2resh/apexyard#480


### PR DESCRIPTION
## Summary

- **Checklist-first document selection (new step 5.6)** — after `/handover` computes the assessment + harnessability score, it now presents a numbered catalogue of the *optional* artefacts (L2/L1 C4 diagrams, DFD, Feature Inventory, journey, vision, sequence) and lets the operator pick which to generate via `default` / `all` / `none` / a comma-list / `+N -N` toggles. Previously the doc set was fixed, so a pure-backend handover still got a container diagram and a UI-heavy one couldn't request a journey or DFD. The handover assessment + harnessability score are always written and never appear in the checklist — they are the skill's core output.
- **Per-doc template pick** — for each selected *template-backed* doc the operator now chooses the template, with candidates resolved through the **existing** `portfolio_resolve_template` mechanism (framework `templates/**` + adopter `custom-templates/**` override) and an `Other` option for sibling variants. The default is always the conventional template — the path the helper would pick unprompted — so `--all` and "default" runs stay byte-stable. This exposes adopter overrides that were previously unreachable from the skill, without any new resolution code.
- **Computed vs template-backed distinction made explicit** — toggle-only/computed rows (Feature Inventory, journey) offer no template pick; template-backed rows do. The prompt labels each so the operator knows which ones ask a follow-up question.
- **Interactive-by-default with an `--all` escape** — the checklist is the default (`--interactive` names it for scripts); `--all` generates the full default set with conventional templates and no prompt, byte-for-byte the pre-checklist flow. This realises the issue's recommended shape while keeping scripted runs reproducible by adding one flag. Documented in Usage + `argument-hint`.
- **In-skill stubs + hand-offs** — step 6.1 generates the L1 context + sequence stubs inline when selected; richer artefacts (DFD/inventory/journey/vision) hand off to their owning skills (`/dfd`, `/extract-features`, `/journey`, `/tech-vision`) rather than being reimplemented, mirroring step 8's follow-up offer.
- **Supporting wiring** — `CONTAINER_TEMPLATE`/`CONTEXT_TEMPLATE`/`SEQUENCE_TEMPLATE` thread the per-doc pick into the generation steps; bootstrap-exemption scope widened to the new stubs; Rules 19–20 added; Output-location + step 10 summary updated; `/handover` one-liner in `CLAUDE.md` refreshed (skill/hook/role counts unchanged).

## Testing

1. `bash .claude/hooks/tests/test_site_counts.sh` → PASS (57 skills / 37 hooks / 20 roles — unchanged; no new skill/hook/role added).
2. `npx --no-install markdownlint-cli2 --config .markdownlint.json .claude/skills/handover/SKILL.md docs/agdr/AgDR-0057-*.md CLAUDE.md` → only MD060 (table-pipe-spacing) findings, which are not in CI's pinned `markdownlint-cli2-action@v16` linter; no MD022/MD032/MD040-class errors.
3. Read-through consistency: `--all` skip-path, the template-pick fallback (`${CONTAINER_TEMPLATE:-$(portfolio_resolve_template …)}`), and the selection-condition guards in steps 6 / 6.1 all reference variables set in step 5.6. No executable tests exist for a skill doc — verification is lint + site-counts + internal consistency.

## Glossary

| Term | Definition |
|------|------------|
| Template-backed doc | An artefact rendered from a file in the template library (`templates/**` or an adopter `custom-templates/**` override), as opposed to a computed/toggle-only output assembled from the repo scan |
| `portfolio_resolve_template` | Existing helper in `_lib-portfolio-paths.sh` that resolves a template path with adopter-override semantics (custom override first, framework default second) |
| Computed / toggle-only output | An artefact derived from the repo scan with no template to choose — the operator only decides whether to emit it (e.g. the Feature Inventory) |
| `--all` | Non-interactive flag that generates the full default doc set with conventional templates, reproducing the pre-checklist behaviour byte-for-byte |
| Hand-off | Recording a doc selection and offering to run the owning skill (`/dfd`, `/extract-features`, `/journey`, `/tech-vision`) instead of reimplementing its output inline |
| Bootstrap exemption | The `require-active-ticket.sh` carve-out that lets `/handover` write `projects/<name>/` files before a tracker ticket exists |

<!-- agdr: docs/agdr/AgDR-0057-handover-checklist-selection.md -->

Closes #480
