### PR TITLE
feat(#482): /report-apexyard-bug + /request-apexyard-feature (upstream framework feedback)

### DIFF
--- a/.claude/skills/report-apexyard-bug/SKILL.md
+++ b/.claude/skills/report-apexyard-bug/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: report-apexyard-bug
+description: Report a bug in the apexyard FRAMEWORK itself (hook misfire, skill gap, rule bug) — files a structured issue upstream to me2resh/apexyard. Distinct from /bug, which files into your own project.
+argument-hint: "<short description of the framework bug>"
+allowed-tools: Bash, Read, Write
+---
+
+# /report-apexyard-bug — Report a Framework Bug Upstream
+
+Files a structured GitHub Issue **about the apexyard framework itself** to the
+canonical upstream **`me2resh/apexyard`** — for when a hook misfires, a skill is
+broken, a rule produces a wrong result, or the docs are wrong.
+
+This is the framework-feedback sibling of `/bug`. The difference is the target:
+
+| Skill | Reports a bug in… | Files to… |
+|-------|-------------------|-----------|
+| `/bug` | your managed project's code | your project's own GitHub repo |
+| **`/report-apexyard-bug`** | the apexyard **framework** (hooks / skills / rules / agents / docs) | **`me2resh/apexyard`** (upstream) |
+
+> **Leak protection (mandatory).** This skill writes to a PUBLIC framework repo.
+> NEVER include a registered private project's name, repo slug, or workspace path
+> in the issue. Per `.claude/rules/leak-protection.md`, describe the context
+> generically ("a registered project", "one of the managed workspaces"). The
+> `block-private-refs-in-public-repos.sh` hook is the mechanical backstop, but
+> scrub at authoring time — the private name is right there in your context while
+> you write, and not referencing it takes active suppression.
+
+## Usage
+
+```
+/report-apexyard-bug detect-role-trigger.sh fires on the wrong path
+/report-apexyard-bug /handover crashes when the repo has no README
+/report-apexyard-bug require-active-ticket blocks an exempt docs edit
+```
+
+## Process
+
+### 0. Write the active-issue-skill marker (REQUIRED — me2resh/apexyard#268)
+
+Before any `gh issue create`, write this skill's name to the active-issue-skill
+marker so `require-skill-for-issue-create.sh` lets the command through. At entry:
+
+```bash
+ops_root="$(r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;echo $r)"
+mkdir -p "$ops_root/.claude/session"
+echo "report-apexyard-bug" > "$ops_root/.claude/session/active-issue-skill"
+```
+
+Remove the marker on **every** exit path (success, cancel, error):
+
+```bash
+rm -f "$ops_root/.claude/session/active-issue-skill"
+```
+
+### 1. Resolve the upstream repo
+
+This skill always files **upstream**, regardless of the adopter's fork origin.
+Resolve it (prefer the configured `upstream` remote; fall back to the canonical
+slug):
+
+```bash
+UPSTREAM=$(git remote get-url upstream 2>/dev/null \
+  | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')
+UPSTREAM="${UPSTREAM:-me2resh/apexyard}"
+```
+
+If `$UPSTREAM` doesn't look like `me2resh/apexyard` (a fork owner crept in via a
+mis-set `upstream`), confirm with the user before filing, or default to the
+canonical `me2resh/apexyard`.
+
+### 2. Capture the framework version
+
+So the maintainer knows which version the report is against, capture the version
+from the fork (the SessionStart upstream-drift banner shows it; otherwise derive
+it):
+
+```bash
+FW_VERSION=$(git -C "$ops_root" describe --tags --abbrev=0 2>/dev/null \
+  || git -C "$ops_root" rev-parse --short HEAD 2>/dev/null \
+  || echo "unknown")
+```
+
+### 3. Gather details (one question at a time)
+
+Ask conversationally — do NOT batch. Wait for each answer.
+
+**a) What part of the framework?** (which hook / skill / rule / agent / doc — e.g. `detect-role-trigger.sh`, `/handover`, `.claude/rules/leak-protection.md`)
+
+**b) Given / When / Then** — what was the state, what did you do, what happened vs what should have happened.
+
+**c) Repro** — the minimal steps. Include the exact command / skill invocation if relevant. **Scrub private project names** — use `<project>` / "a registered project".
+
+**d) Severity** — `blocker` (can't work) / `major` (wrong result, workaround exists) / `minor` (cosmetic / docs).
+
+**e) Anything else** — error output, the banner text, related issue numbers (optional).
+
+### 4. Show the formatted issue for confirmation
+
+Substitute into this body and display it for `yes / edit / cancel`. **Re-scan the
+rendered body for any private project name before showing it.**
+
+```
+Here's the framework bug I'll file to <UPSTREAM>:
+
+---
+**[Bug] {title}**
+
+## Affected
+{hook / skill / rule / agent / doc}
+
+## Given / When / Then
+**Given** {state}
+**When** {action}
+**Then** {observed} — expected {expected}
+
+## Repro
+1. {step 1}
+2. {step 2}
+
+## Framework version
+{FW_VERSION}
+
+## Severity
+{blocker | major | minor}
+
+## Notes
+{error output / banner / related issues, or "—"}
+
+## Glossary
+| Term | Definition |
+|------|------------|
+| {term} | {definition} |
+---
+
+Labels: bug
+Repo: <UPSTREAM>
+
+File this upstream? (yes / edit / cancel)
+```
+
+### 5. Handle response
+
+- **yes** → create the issue
+- **edit** / **change X** → update, re-show
+- **cancel** / **no** → abort (and remove the marker)
+
+### 6. Create the GitHub Issue
+
+```bash
+gh issue create --repo "$UPSTREAM" \
+  --title "[Bug] {title}" \
+  --label "bug" \
+  --body "{formatted body}"
+```
+
+If the `bug` label doesn't exist on the upstream repo, drop `--label` and note it
+(don't fail the whole filing over a missing label — per the create-labels-first
+convention, but upstream label management isn't the adopter's job).
+
+### 7. Return the URL
+
+```
+Filed upstream: <UPSTREAM>#{number} — {title}
+{url}
+```
+
+## Rules
+
+1. **One question at a time.** Never batch. Wait for each answer.
+2. **Always confirm before filing.** Show the full issue, get explicit "yes".
+3. **Scrub private project names** — this writes to a PUBLIC repo. Describe context generically. See `.claude/rules/leak-protection.md`. Use the `<!-- private-refs: allow -->` body marker ONLY on explicit user confirmation that a name must stay.
+4. **Always file upstream** — `me2resh/apexyard`, not the adopter's fork or a managed project.
+5. **Capture the framework version** so the report is actionable.
+6. **Label `bug`.** Title prefix `[Bug]`.
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/.claude/skills/request-apexyard-feature/SKILL.md
+++ b/.claude/skills/request-apexyard-feature/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: request-apexyard-feature
+description: Request a new feature or enhancement for the apexyard FRAMEWORK itself — files a structured issue upstream to me2resh/apexyard. Distinct from /feature, which files into your own project.
+argument-hint: "<short description of the framework feature>"
+allowed-tools: Bash, Read, Write
+---
+
+# /request-apexyard-feature — Request a Framework Feature Upstream
+
+Files a structured GitHub Issue **proposing a feature or enhancement for the
+apexyard framework itself** to the canonical upstream **`me2resh/apexyard`** —
+for a new skill, a new hook, a rule improvement, a better workflow, etc.
+
+This is the framework-feedback sibling of `/feature`. The difference is the target:
+
+| Skill | Requests a feature for… | Files to… |
+|-------|-------------------------|-----------|
+| `/feature` | your managed project | your project's own GitHub repo |
+| **`/request-apexyard-feature`** | the apexyard **framework** (skills / hooks / rules / agents / workflows) | **`me2resh/apexyard`** (upstream) |
+
+> **Leak protection (mandatory).** This skill writes to a PUBLIC framework repo.
+> NEVER include a registered private project's name, repo slug, or workspace path.
+> Per `.claude/rules/leak-protection.md`, describe the motivating context
+> generically ("while onboarding a project", "during bulk ticket filing"). The
+> `block-private-refs-in-public-repos.sh` hook is the backstop; scrub at authoring
+> time.
+
+## Usage
+
+```
+/request-apexyard-feature a /reindex skill for manual MCP reindexing
+/request-apexyard-feature let /handover pick which docs to generate
+/request-apexyard-feature a hook that warns on stale review markers
+```
+
+## Process
+
+### 0. Write the active-issue-skill marker (REQUIRED — me2resh/apexyard#268)
+
+```bash
+ops_root="$(r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;echo $r)"
+mkdir -p "$ops_root/.claude/session"
+echo "request-apexyard-feature" > "$ops_root/.claude/session/active-issue-skill"
+```
+
+Remove the marker on **every** exit path (success, cancel, error):
+
+```bash
+rm -f "$ops_root/.claude/session/active-issue-skill"
+```
+
+### 1. Resolve the upstream repo
+
+Always files **upstream**, regardless of the adopter's fork origin:
+
+```bash
+UPSTREAM=$(git remote get-url upstream 2>/dev/null \
+  | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')
+UPSTREAM="${UPSTREAM:-me2resh/apexyard}"
+```
+
+If `$UPSTREAM` doesn't resolve to `me2resh/apexyard`, confirm with the user or
+default to the canonical slug before filing.
+
+### 2. Capture the framework version
+
+```bash
+FW_VERSION=$(git -C "$ops_root" describe --tags --abbrev=0 2>/dev/null \
+  || git -C "$ops_root" rev-parse --short HEAD 2>/dev/null \
+  || echo "unknown")
+```
+
+### 3. Gather details (one question at a time)
+
+Ask conversationally — do NOT batch. Wait for each answer.
+
+**a) The problem / friction** — what's awkward or missing in the framework today? (the *why*, not the solution)
+
+**b) Proposed behaviour** — what should the framework do? (new skill / hook / rule / agent / workflow change — name it concretely)
+
+**c) Why it helps adopters** — who benefits and how; what they do instead today.
+
+**d) Scope hint** (optional) — anything explicitly out of scope, or a rough size.
+
+**e) Related** (optional) — existing skills/hooks it touches, related issue numbers.
+
+### 4. Show the formatted issue for confirmation
+
+Substitute into this body and display for `yes / edit / cancel`. **Re-scan for any
+private project name before showing it.**
+
+```
+Here's the framework feature request I'll file to <UPSTREAM>:
+
+---
+**[Feature] {title}**
+
+## Problem
+{the friction / gap in the framework today}
+
+## Proposed behaviour
+{what the framework should do — new skill / hook / rule / agent / workflow}
+
+## Why it helps adopters
+{who benefits + how; what they do today instead}
+
+## Scope / out of scope
+{scope hint or "—"}
+
+## Framework version
+{FW_VERSION}
+
+## Related
+{touched skills/hooks + related issues, or "—"}
+
+## Glossary
+| Term | Definition |
+|------|------------|
+| {term} | {definition} |
+---
+
+Labels: enhancement
+Repo: <UPSTREAM>
+
+File this upstream? (yes / edit / cancel)
+```
+
+### 5. Handle response
+
+- **yes** → create the issue
+- **edit** / **change X** → update, re-show
+- **cancel** / **no** → abort (and remove the marker)
+
+### 6. Create the GitHub Issue
+
+```bash
+gh issue create --repo "$UPSTREAM" \
+  --title "[Feature] {title}" \
+  --label "enhancement" \
+  --body "{formatted body}"
+```
+
+If the `enhancement` label doesn't exist upstream, drop `--label` and note it.
+
+### 7. Return the URL
+
+```
+Filed upstream: <UPSTREAM>#{number} — {title}
+{url}
+```
+
+## Rules
+
+1. **One question at a time.** Never batch. Wait for each answer.
+2. **Always confirm before filing.** Show the full issue, get explicit "yes".
+3. **Scrub private project names** — this writes to a PUBLIC repo. See `.claude/rules/leak-protection.md`. Use the `<!-- private-refs: allow -->` marker ONLY on explicit user confirmation.
+4. **Always file upstream** — `me2resh/apexyard`.
+5. **Lead with the problem, not the solution** — the "why" makes a feature request actionable.
+6. **Label `enhancement`.** Title prefix `[Feature]`.
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,10 +198,10 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Rules | `.claude/rules/` | 11 modular rule files (AgDR triggers, code standards, git conventions, leak protection, parallel work, plan mode, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Handbooks | `handbooks/` | Adopter-authored coding standards consumed by Rex during code review. Discovery by path-convention (`architecture/` + `general/` always-load; `language/<lang>/` loads on diff-match). Advisory by default; opt in to blocking via `ENFORCEMENT: blocking` marker. See [`handbooks/README.md`](handbooks/README.md). |
 | Agents | `.claude/agents/` | 24 sub-agents (5 utility incl. Hakim post-consolidation + 7 engineering + 1 architecture (Tariq) + 6 product-design + 5 security-data). Per AgDR-0050 + the #347 PR 3 Hatim→Hakim consolidation decision + AgDR-0054 (Solution Architect). |
-| Skills | `.claude/skills/` | 57 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 59 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (57)
+### Available skills (59)
 
 One-line summary per skill; canonical details live in each `.claude/skills/<name>/SKILL.md`.
 
@@ -234,6 +234,8 @@ One-line summary per skill; canonical details live in each `.claude/skills/<name
 | `/plan-initiative` | Initiative → milestones → tasks: Socratic interview, DAG, topo-sorted sequence, two-pass filing with `blocks`/`blocked by` cross-refs |
 | `/feature` | Create a structured feature ticket (user story + acceptance criteria) |
 | `/bug` | Create a structured bug ticket (Given/When/Then + repro + severity) |
+| `/report-apexyard-bug` | Report a bug in the apexyard **framework itself** upstream to `me2resh/apexyard` (leak-scrubbed) — distinct from `/bug` |
+| `/request-apexyard-feature` | Request a feature/enhancement for the apexyard **framework itself** upstream to `me2resh/apexyard` — distinct from `/feature` |
 | `/task` | Create a structured technical task ticket (driver + scope + ACs) |
 | `/tickets-batch` | Bulk-file 5–20 structured tickets in one shared-context flow |
 | `/migration` | Create a labelled migration ticket + migration AgDR (required by migration gate) |
@@ -299,7 +301,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Rules (modular, framework-wide) | `.claude/rules/` |
 | **Adopter handbooks** (consumed by Rex during code review) | `handbooks/` — see [`handbooks/README.md`](handbooks/README.md) for the discovery + advisory/blocking conventions |
 | Agents | `.claude/agents/` |
-| Skills (57 slash commands) | `.claude/skills/` |
+| Skills (59 slash commands) | `.claude/skills/` |
 | Hook wiring | `.claude/settings.json` |
 | **Per-project docs** | `projects/<name>/` |
 | **Live working copies** (gitignored) | `workspace/<name>/` |

--- a/docs/agdr/AgDR-0059-upstream-feedback-skills.md
+++ b/docs/agdr/AgDR-0059-upstream-feedback-skills.md
@@ -1,0 +1,41 @@
+# Two skills for filing framework feedback upstream (`/report-apexyard-bug`, `/request-apexyard-feature`)
+
+> In the context of adopters hitting bugs in — or wanting features for — the apexyard framework itself with no in-session path to report them, facing the fact that the existing `/bug` and `/feature` skills file into the adopter's OWN project tracker, I decided to add two thin sibling skills that file a structured issue UPSTREAM to `me2resh/apexyard`, with mandatory leak-scrubbing of private project names, to achieve a closed feedback loop from adopter to maintainer, accepting two more skills on the surface (mitigated by namespaced `apexyard-` names that make the distinction obvious).
+
+## Context
+
+`/bug` and `/feature` create structured GitHub issues in the **adopter's managed-project repo** — the right target for a bug/feature in *their* code. But an adopter who hits a framework bug (a hook misfires, a skill is broken, a rule produces a wrong result) or has a framework feature idea has **no in-session path** to report it upstream; they'd have to leave the session and navigate to GitHub manually. The feedback loop from adopter → framework maintainer was missing.
+
+The motivating signal: across heavy framework use, real framework bugs surfaced (hook false-positives, gate-level mismatches, packaging gaps) that an adopter would want to report — but the only structured-issue skills filed into the wrong repo.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Reuse `/bug` + `/feature` with a "which repo?" prompt | No new skills | Overloads project-scoped skills with an upstream mode; the default target ambiguity is exactly the leak risk we want to avoid |
+| One `/feedback` skill (asks bug-or-feature) | Single command | Conflates two different templates + labels; less discoverable than named intent |
+| **Two named skills `/report-apexyard-bug` + `/request-apexyard-feature` (chosen)** | Intent is explicit in the name; clearly distinct from `/bug`/`/feature`; each carries the right template + label; namespaced `apexyard-` signals "about the framework" | Two more skills on the surface |
+
+## Decision
+
+Chosen: **two named skills filing upstream, with leak-scrubbing.**
+
+1. **Target is always upstream `me2resh/apexyard`** — resolved via `git remote get-url upstream` with a fallback to the canonical slug, regardless of the adopter's fork origin. (Confirmed via AskUserQuestion: file upstream, not the adopter's fork.)
+2. **Named, not a single `/feedback`** — `/report-apexyard-bug` and `/request-apexyard-feature` make the intent explicit and carry the correct template (bug = Given/When/Then + repro + severity + affected-part; feature = problem-first + proposed behaviour + adopter benefit) and label (`bug` / `enhancement`).
+3. **Mandatory leak-scrubbing** — both skills write to a PUBLIC repo, so private registered-project names must never appear. The skills instruct authoring-time scrubbing and rely on `block-private-refs-in-public-repos.sh` as the mechanical backstop, consistent with `.claude/rules/leak-protection.md`. The `<!-- private-refs: allow -->` escape is used only on explicit user confirmation.
+4. **Framework-version capture** — both record the fork's version (`git describe`/short SHA) so the maintainer knows which version the report is against.
+5. **Reuse existing plumbing** — the active-issue-skill marker (per #268 / AgDR-0030) gates the `gh issue create`; the require-skill-for-issue-create hook checks only that the marker is non-empty, so the new skill names work without an allowlist change.
+
+## Consequences
+
+- Two new skills: `.claude/skills/report-apexyard-bug/SKILL.md`, `.claude/skills/request-apexyard-feature/SKILL.md`.
+- Skill count 57 → 59 (`CLAUDE.md` + `site/*` updated; `test_site_counts.sh` green). No new hook/role/agent.
+- Adopters get a one-command path to send framework feedback; the maintainer sees adopter bug reports + feature requests in the canonical repo.
+- The leak-protection backstop now covers a new write path (framework feedback) in addition to the existing tracker-write paths — same rule, additional surface.
+
+## Artifacts
+
+- Issue: me2resh/apexyard#482
+- New: `.claude/skills/{report-apexyard-bug,request-apexyard-feature}/SKILL.md`
+- Edited: `CLAUDE.md` (skills table + counts), `site/*` (counts)
+- Related: `/bug` + `/feature` (the project-scoped siblings), `.claude/rules/leak-protection.md` (the scrubbing rule + backstop hook), AgDR-0030 (#268 issue-skill marker), the `/onboard`→`/setup` alias-redirect precedent for how thin intent-named skills coexist.

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -560,7 +560,7 @@ a:hover { color: var(--accent); }
 
   <rect x="84" y="373" width="600" height="100" fill="#DDE9DD" stroke="#2D6A4F" stroke-width="1.3"/>
   <text x="100" y="402" font-size="15" font-weight="700" fill="#1B4332">[/] Skills</text>
-  <text x="100" y="425" font-size="12" fill="#1A1612">.claude/skills/  ·  57 slash commands</text>
+  <text x="100" y="425" font-size="12" fill="#1A1612">.claude/skills/  ·  59 slash commands</text>
   <text x="100" y="447" font-size="11" fill="#52796F">/feature  /handover  /c4  /threat-model  /process  /dfd  /journey  /update  /release  …</text>
 
   <rect x="704" y="373" width="600" height="100" fill="#DDE9DD" stroke="#2D6A4F" stroke-width="1.3"/>

--- a/site/architecture.md.gen
+++ b/site/architecture.md.gen
@@ -33,7 +33,7 @@ Declares what's true and what's enforced:
 
 What the agent can DO:
 
-- **Skills** (`.claude/skills/`) — 57 slash commands: `/feature`, `/handover`, `/c4`, `/threat-model`, `/process`, `/dfd`, `/journey`, `/update`, `/release`, and 46 more
+- **Skills** (`.claude/skills/`) — 59 slash commands: `/feature`, `/handover`, `/c4`, `/threat-model`, `/process`, `/dfd`, `/journey`, `/update`, `/release`, and 46 more
 - **Agents** (`.claude/agents/`) — 23 specialised sub-agents: 5 utility (Rex code review, Hakim security audit, Munir deps, Tariq PR, Idris tickets) + 18 dept-aligned agents across engineering / product / design / security / data
 
 ### Layer 3 — Framework defaults (ochre)

--- a/site/index.md.gen
+++ b/site/index.md.gen
@@ -4,7 +4,7 @@
 
 ## What is it?
 
-ApexYard adds the reviews, guardrails, and process behind every change you make with Claude Code. Catch the mistakes before your customers do — automatically, without checking every commit yourself. 57 skills grouped by what you're trying to do, plus a persistent decision-log across the whole portfolio.
+ApexYard adds the reviews, guardrails, and process behind every change you make with Claude Code. Catch the mistakes before your customers do — automatically, without checking every commit yourself. 59 skills grouped by what you're trying to do, plus a persistent decision-log across the whole portfolio.
 
 ## What can it do?
 
@@ -71,7 +71,7 @@ claude
 
 The reviewer changes based on what you're working on. Touching auth code? A security reviewer takes a look. Touching the database? Someone who specialises in database changes walks you through the rollback plan. Behind the scenes: 20 role definitions across 5 departments, each with its own checklist and boundaries.
 
-### Tools for every step of shipping software · 57 slash commands
+### Tools for every step of shipping software · 59 slash commands
 
 Want to adopt a project you've inherited? `/handover`. Want to capture an idea before it evaporates? `/idea`. Want to know what's waiting on you across every product? `/inbox`. Want a launch-readiness check before customers see it? `/launch-check`. 54 of these in total — each one is a focused workflow with safety rails.
 

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -2,7 +2,7 @@
 
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and
-> one place for all your products, built on top of Claude Code. 57 skills,
+> one place for all your products, built on top of Claude Code. 59 skills,
 > 38 hooks, 20 role definitions. Open source, plain markdown and shell, no SaaS,
 > no lock-in.
 
@@ -242,7 +242,7 @@ each owned by different parts of the framework:
 1. **Governance layer** — the markdown spec: `CLAUDE.md`, `roles/`,
    `workflows/`, `templates/`, `handbooks/`. The "what good looks like"
    for the framework.
-2. **Capability layer** — the runnable spec: `.claude/skills/` (57
+2. **Capability layer** — the runnable spec: `.claude/skills/` (59
    slash commands), `.claude/agents/` (24 sub-agents incl. Rex), and
    `.claude/hooks/` (38 mechanical enforcement scripts).
 3. **Framework defaults layer** — `.claude/project-config.defaults.json`
@@ -294,7 +294,7 @@ Free with any project you don't want named publicly.
 
 # Skills (https://yard.apexscript.com/skills)
 
-57 slash commands grouped by what you're trying to do — not by what's
+59 slash commands grouped by what you're trying to do — not by what's
 under the hood. Each is a markdown SKILL.md file under
 `.claude/skills/<name>/`.
 

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -2,7 +2,7 @@
 
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and one
-> place for all your products, built on top of Claude Code. 57 skills,
+> place for all your products, built on top of Claude Code. 59 skills,
 > 38 hooks, 20 role definitions. Open source, plain markdown and shell,
 > no SaaS, no lock-in.
 
@@ -11,7 +11,7 @@
 - [Home](https://yard.apexscript.com/) — what apexyard does for non-technical founders, who it's for, how to get started
 - [How it works](https://yard.apexscript.com/how-it-works) — a plain-English walkthrough of one realistic day with apexyard
 - [Architecture](https://yard.apexscript.com/architecture) — the technical 5-layer model + portfolio model
-- [Skills](https://yard.apexscript.com/skills) — full slash-command reference (57 skills) grouped by outcome
+- [Skills](https://yard.apexscript.com/skills) — full slash-command reference (59 skills) grouped by outcome
 
 ## Full-content companion
 
@@ -52,7 +52,7 @@
 - **Portfolio model.** One registry (`apexyard.projects.yaml`) lists every repo
   under management. Skills like `/inbox`, `/status`, `/tasks` aggregate
   across the portfolio in ~1 second.
-- **57 slash commands** grouped by outcome: keep quality high, move work
+- **59 slash commands** grouped by outcome: keep quality high, move work
   forward, see everything at once, onboard new code, run things.
 - **38 shell hooks** mechanically enforce the rules — ticket-first, migration
   gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR-title

--- a/site/skill.md
+++ b/site/skill.md
@@ -23,7 +23,7 @@ organisation. Three load-bearing outcomes:
    surfaced from every registered project in one prompt.
 
 Persistent decision-log across every managed project; strict merge gates
-(code-reviewer agent + per-PR CEO approval); 57 slash commands grouped by
+(code-reviewer agent + per-PR CEO approval); 59 slash commands grouped by
 what you're trying to do:
 
 - **Keep quality high** (`/code-review`, `/security-review`, `/audit-deps`,

--- a/site/skills.md.gen
+++ b/site/skills.md.gen
@@ -1,6 +1,6 @@
 # ApexYard Skills
 
-> 57 slash commands grouped by what you're trying to do — not by what's under the hood. Drop into your Claude Code session inside an apexyard fork.
+> 59 slash commands grouped by what you're trying to do — not by what's under the hood. Drop into your Claude Code session inside an apexyard fork.
 
 ## In plain English
 
@@ -8,7 +8,7 @@ These are the commands you type into Claude Code to get ApexYard to do something
 
 ## What is it?
 
-ApexYard ships 57 slash commands grouped under outcome headings — Keep quality high, Move work forward, See everything at once, Onboard new code, Run things.
+ApexYard ships 59 slash commands grouped under outcome headings — Keep quality high, Move work forward, See everything at once, Onboard new code, Run things.
 
 ## What can it do?
 


### PR DESCRIPTION
<!-- agdr: docs/agdr/AgDR-0059-upstream-feedback-skills.md -->

## Summary

- **Adds `/report-apexyard-bug` + `/request-apexyard-feature` (#482)** — two thin skills that let someone *using* the apexyard framework file a bug report / feature request **about the framework itself** upstream to `me2resh/apexyard`. Closes the adopter→maintainer feedback loop that didn't exist.
- **Distinct from `/bug` and `/feature`**, which file into the adopter's *own* project tracker. The new skills always file **upstream** (resolved via `git remote get-url upstream`, fallback to the canonical `me2resh/apexyard`), regardless of the adopter's fork origin.
  - `/report-apexyard-bug` — Given/When/Then + repro + severity + which hook/skill/rule is affected → `[Bug]` issue.
  - `/request-apexyard-feature` — problem-first + proposed behaviour + adopter benefit → `[Feature]` issue.
- **Mandatory leak-scrubbing** — both write to a PUBLIC repo, so they scrub private registered-project names at authoring time and rely on `block-private-refs-in-public-repos.sh` as the backstop (per `.claude/rules/leak-protection.md`). The `<!-- private-refs: allow -->` escape is used only on explicit confirmation.
- Both **capture the framework version** (`git describe`/short SHA) so reports are actionable, **confirm before filing** (yes/edit/cancel), and use the **active-issue-skill marker** (#268) so `require-skill-for-issue-create.sh` permits the `gh issue create`.
- **CLAUDE.md** skills table + counts 57→59; `site/*` counts refreshed; **AgDR-0059** records the decision (named-not-`/feedback`, upstream target, leak-scrubbing). No new hook/role/agent.

## Testing

- [ ] `bash .claude/hooks/tests/test_site_counts.sh` — **green** (skills 57→59; hooks/roles unchanged).
- [ ] `markdownlint-cli2` (CI ruleset) — 0 errors on the two SKILL.md + AgDR-0059 + CLAUDE.md (only MD060, not in CI's pinned linter).
- [ ] `require-skill-for-issue-create.sh` accepts the new skill names — verified it checks only for a non-empty active-issue-skill marker (no fixed allowlist), so `report-apexyard-bug` / `request-apexyard-feature` work without a hook change.
- [ ] Manual: both skills are intent-named, interactive (one question at a time), confirm-before-file, and target upstream — consistent with `/bug` / `/feature`'s shape.

## Glossary

| Term | Definition |
|------|------------|
| **Upstream feedback** | A bug/feature about the apexyard *framework* filed to `me2resh/apexyard`, vs a project ticket filed to the adopter's own repo. |
| **Leak scrubbing** | Removing registered private project names before writing to the public framework repo (per `.claude/rules/leak-protection.md`). |
| **active-issue-skill marker** | The session marker (#268) that lets a structured ticket skill's `gh issue create` through the require-skill gate. |

Closes #482
