### PR TITLE
fix(#485): repo-qualify review markers so same-numbered PRs across repos don't collide

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -524,7 +524,7 @@ The marker MUST land at `<ops_fork_root>/.claude/session/reviews/{number}-rex.ap
 
 **Resolve `MARKER_HOME` ONCE, at review start, from your initial working directory** — before any `cd`, `git clone`, `gh pr checkout`, or other tool call that might change where you are or what's anchored above you. The walk-up shape below is sensitive to `$PWD`: if you've cloned the fork into `/tmp` for inspection and `cd`'d into the clone first, the walk resolves to that throwaway tree, the marker lands in `/tmp`, and the merge gate (running from the real ops fork) cannot find it. Capture `MARKER_HOME` first; treat it as immutable for the rest of the review. This is the prose discipline; the mechanical safety net is `pin-ops-root.sh` (apexyard#381), which captures the launch-cwd ops root at SessionStart and feeds it to `_lib-ops-root.sh::resolve_ops_root` so adopters on framework versions that ship the hook get the pin automatically — the walk-up below remains as the safety net for older versions and as the resolution method when no pin exists.
 
-Resolve the ops fork root by walking up for `onboarding.yaml` + `apexyard.projects.yaml` (or the `.apexyard-fork` v2 marker):
+Resolve the ops fork root by walking up for `onboarding.yaml` + `apexyard.projects.yaml` (or the `.apexyard-fork` v2 marker), then source the marker path helper (AgDR-0060 / #485):
 
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -540,25 +540,30 @@ while [ -n "$r" ] && [ "$r" != "/" ]; do
   r=$(dirname "$r")
 done
 MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
+# shellcheck source=/dev/null
+. "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
+# Resolve the repo this PR belongs to — required for the qualified marker name.
+PR_REPO=$(gh pr view {number} --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+REX_MARKER=$(review_marker_path "$PR_REPO" {number} rex "$MARKER_HOME")
 ```
 
 ### The command
 
-Once `MARKER_HOME` is resolved (see above), use exactly one of these forms:
+Once `MARKER_HOME`, `PR_REPO`, and `REX_MARKER` are resolved (see above), use exactly one of these forms:
 
 ```bash
 # Option A — from the local HEAD of the PR branch
-git rev-parse HEAD > "$MARKER_HOME/.claude/session/reviews/{number}-rex.approved"
+git rev-parse HEAD > "$REX_MARKER"
 
 # Option B — from the PR's HEAD on GitHub (preferred for cross-repo / detached HEAD)
-gh pr view {number} --json headRefOid --jq .headRefOid > "$MARKER_HOME/.claude/session/reviews/{number}-rex.approved"
+gh pr view {number} --json headRefOid --jq .headRefOid > "$REX_MARKER"
 
 # Option C — literal SHA write (when you've already captured the SHA in a variable)
-printf '%s\n' "$SHA" > "$MARKER_HOME/.claude/session/reviews/{number}-rex.approved"
+printf '%s\n' "$SHA" > "$REX_MARKER"
 ```
 
-Where `{number}` is the PR number.
+Where `{number}` is the PR number and `$REX_MARKER` was computed via `review_marker_path` above.
 
 ### Content — MUST be bare SHA + newline
 
@@ -595,7 +600,7 @@ All of these fail the hook's whitespace-strip-then-compare check. The merge gate
 
 ### Where to write
 
-`<ops_fork_root>/.claude/session/reviews/` per the MARKER_HOME resolution above. The merge-gate hook (`block-unreviewed-merge.sh`) resolves the same path via `_lib-ops-root.sh`. Inside a workspace clone (`workspace/<project>/`), this is NOT the project clone's `.claude/session/reviews/` — it's the ops fork above. If running in a nested worktree of the ops fork, the worktree shares the ops fork's session state (worktrees see the parent's tree below `.claude/`).
+The marker lands at `$REX_MARKER` — the repo-qualified path returned by `review_marker_path` above. Its form is `<ops_fork_root>/.claude/session/reviews/<owner>__<repo>__<pr>-rex.approved` (AgDR-0060). The merge-gate hook resolves the same path via the same helper. Inside a workspace clone (`workspace/<project>/`), this is NOT the project clone's `.claude/session/reviews/` — it's the ops fork above. If running in a nested worktree of the ops fork, the worktree shares the ops fork's session state (worktrees see the parent's tree below `.claude/`).
 
 ### On REQUEST CHANGES or COMMENT verdicts
 
@@ -656,7 +661,7 @@ Report the failure in plain text with the exact command the caller needs to run.
    - REQUEST CHANGES with the specific decisions you detected
    - List what needs to be documented
    - The PR author must run `/decide` and link the AgDR before re-review
-8. **Approval marker format is BLOCKING** — on APPROVED verdicts, write the marker at `.claude/session/reviews/{pr}-rex.approved` containing exactly the 40-char HEAD SHA + newline. No labels, no JSON, no extra text. See the "Approval marker — EXACT FORMAT REQUIRED" section above. A malformed marker blocks the merge and forces a rule-violating hand-edit, so getting the format right is as important as the review content.
+8. **Approval marker format is BLOCKING** — on APPROVED verdicts, write the marker at `$REX_MARKER` (the repo-qualified path from `review_marker_path`; form: `.claude/session/reviews/<owner>__<repo>__<pr>-rex.approved`) containing exactly the 40-char HEAD SHA + newline. No labels, no JSON, no extra text. See the "Approval marker — EXACT FORMAT REQUIRED" section above. A malformed marker blocks the merge and forces a rule-violating hand-edit, so getting the format right is as important as the review content.
 9. **Handbooks layer on top of framework rules** — discover and apply handbooks from BOTH the public `handbooks/**/*.md` tree AND (for split-portfolio adopters) the private custom-handbooks dir resolved via `portfolio_custom_handbooks_dir`. See § 8 for the path-convention rules and the discovery shape. Advisory handbooks generate `nit:` / `suggestion:` comments; blocking handbooks (containing `ENFORCEMENT: blocking` at the top of the file) become REQUEST CHANGES verdicts regardless of whether they live in the public or private layer. Adopters extend the standards by adding handbook files; you don't need a code change to teach Rex a new rule.
 
 ## Example Invocation

--- a/.claude/agents/solution-architect.md
+++ b/.claude/agents/solution-architect.md
@@ -142,7 +142,7 @@ When your verdict is APPROVED, and ONLY then, write the architecture-review appr
 
 ### Path: ops fork root, not git toplevel
 
-The marker MUST land at `<ops_fork_root>/.claude/session/reviews/{number}-architecture.approved`. Inside `workspace/<project>/`, `git rev-parse --show-toplevel` returns the project clone — NOT the ops fork. Resolve `MARKER_HOME` ONCE, at review start, before any `cd` / `gh pr checkout`:
+The marker MUST land at `<ops_fork_root>/.claude/session/reviews/<owner>__<repo>__{number}-architecture.approved` (repo-qualified path, AgDR-0060 / #485). Inside `workspace/<project>/`, `git rev-parse --show-toplevel` returns the project clone — NOT the ops fork. Resolve `MARKER_HOME` ONCE, at review start, before any `cd` / `gh pr checkout`, then source the marker path helper:
 
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -154,14 +154,19 @@ while [ -n "$r" ] && [ "$r" != "/" ]; do
   r=$(dirname "$r")
 done
 MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
+# shellcheck source=/dev/null
+. "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
+# Resolve the repo for the qualified marker name.
+PR_REPO=$(gh pr view {number} --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+ARCH_MARKER=$(review_marker_path "$PR_REPO" {number} architecture "$MARKER_HOME")
 ```
 
 ### The command
 
 ```bash
 # Option B (preferred) — the PR's HEAD on GitHub
-gh pr view {number} --json headRefOid --jq .headRefOid > "$MARKER_HOME/.claude/session/reviews/{number}-architecture.approved"
+gh pr view {number} --json headRefOid --jq .headRefOid > "$ARCH_MARKER"
 ```
 
 ### Content — MUST be bare SHA + newline

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -64,10 +64,12 @@ If any gate fails, blocks with a message pointing at the `/migration` skill. If 
 
 **What it does:** blocks the merge unless **both** approval markers exist for the PR number being merged, and both contain a SHA that matches the current HEAD. New commits after either approval invalidate it.
 
-| Marker | Path | Written by | Semantics |
-|--------|------|------------|-----------|
-| Rex | `.claude/session/reviews/<pr>-rex.approved` | `code-reviewer` agent after a successful review | "Code reviewed, no blocking issues" |
-| CEO | `.claude/session/reviews/<pr>-ceo.approved` | `/approve-merge <pr>` skill, **only** on explicit user invocation | "The human approver has looked at this specific PR and said ship it" |
+| Marker | Path (repo-qualified since #485) | Written by | Semantics |
+|--------|----------------------------------|------------|-----------|
+| Rex | `.claude/session/reviews/<owner>__<repo>__<pr>-rex.approved` | `code-reviewer` agent after a successful review | "Code reviewed, no blocking issues" |
+| CEO | `.claude/session/reviews/<owner>__<repo>__<pr>-ceo.approved` | `/approve-merge <pr>` skill, **only** on explicit user invocation | "The human approver has looked at this specific PR and said ship it" |
+
+Marker paths are constructed via `_lib-review-markers.sh::review_marker_path <owner/repo> <pr> <role>`. The double-underscore separator ensures the (owner, repo, pr) triple is unambiguous — GitHub slugs never contain `__`. This prevents same-numbered PRs in different managed repos from colliding on the same marker filename (AgDR-0060).
 
 Both files contain exactly one line: the 40-character HEAD SHA at the time of approval. The hook reads each, compares with `git rev-parse HEAD`, and blocks on any mismatch.
 
@@ -174,7 +176,7 @@ All path patterns use the `(^|/)` anchor so they catch **monorepo layouts** (`ba
 
 **Event:** `PreToolUse` on `Bash(gh pr merge *)`.
 
-**What it does:** if the PR's diff touches any UI file, requires a design-approval marker at `.claude/session/reviews/<pr>-design.approved` with a SHA matching HEAD. Non-UI PRs bypass silently.
+**What it does:** if the PR's diff touches any UI file, requires a design-approval marker at `.claude/session/reviews/<owner>__<repo>__<pr>-design.approved` (repo-qualified, see AgDR-0060) with a SHA matching HEAD. Non-UI PRs bypass silently.
 
 **Default UI paths** (regex):
 
@@ -193,7 +195,7 @@ design-tokens
 
 **Companion skill:** `/approve-design <pr>` (in `.claude/skills/approve-design/`) writes the marker. It follows the same pattern as `/approve-merge`: verify PR state → verify Rex marker at HEAD → write the design marker at the repo root → confirm → stop. The skill definition includes explicit valid/invalid triggers and an anti-pattern section distinguishing mockup approval (design phase) from implementation-review approval (PR phase).
 
-**Manual fallback:** for projects that deliberately skip design review (admin tools, internal dashboards), `touch .claude/session/reviews/<pr>-design.approved` is a visible, auditable "we decided to skip" artifact rather than an invisible omission.
+**Manual fallback:** for projects that deliberately skip design review (admin tools, internal dashboards), create `touch .claude/session/reviews/<owner>__<repo>__<pr>-design.approved` (using the repo-qualified name) as a visible, auditable "we decided to skip" artifact.
 
 **Enforces:** `.claude/rules/pr-quality.md § "Design Review (UI Changes)"` and `workflows/code-review.md § "UI Designer (conditional)"` — both prose-only until this hook shipped.
 
@@ -334,8 +336,10 @@ These were already in place before the enforcement layer and remain unchanged (e
 ├── onboarded                     # created by /onboard, read by onboarding-check
 ├── current-ticket                # created by /start-ticket, read by require-active-ticket
 ├── pending-reviews/<pr>          # created by auto-code-review, tracks PRs awaiting Rex
-├── reviews/<pr>-rex.approved     # created by code-reviewer agent, read by merge-gate
-└── reviews/<pr>-ceo.approved     # created by /approve-merge, read by merge-gate
+├── reviews/<owner>__<repo>__<pr>-rex.approved           # created by code-reviewer agent, read by merge-gate
+├── reviews/<owner>__<repo>__<pr>-ceo.approved           # created by /approve-merge, read by merge-gate
+├── reviews/<owner>__<repo>__<pr>-design.approved        # created by /approve-design, read by UI merge-gate
+└── reviews/<owner>__<repo>__<pr>-architecture.approved  # created by /approve-architecture or Tariq
 ```
 
 If a marker gets stale, delete the file and re-run the corresponding skill.

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Shared PR-number extraction for the three merge-gate hooks:
+# Shared PR-number and repo extraction for the merge-gate hooks:
 #   - block-unreviewed-merge.sh
 #   - require-design-review-for-ui.sh
+#   - require-architecture-review.sh
 #   - block-merge-on-red-ci.sh
 #
 # Not a hook itself (prefixed with `_lib-` so it's never wired as one). Sourced
@@ -112,4 +113,38 @@ resolve_pr_head() {
   fi
 
   echo "$sha"
+}
+
+# Echoes the owner/repo extracted from the merge command, or empty if not found.
+#
+# This is a SIBLING function to extract_pr_number — same parsing approach,
+# repo-extraction only. Kept separate so the existing extract_pr_number
+# contract is not disturbed (it is used widely; callers that don't need the
+# repo are unaffected).
+#
+# Recognises:
+#   1. `gh api repos/<owner>/<repo>/pulls/<N>/merge ...`  — repo from URL path
+#   2. `gh pr merge ... --repo <owner>/<repo> ...`        — repo from --repo flag
+#   3. Falls back to `gh pr view --json headRepository`   — current branch's PR
+#
+# Returns empty if the repo cannot be determined.
+extract_repo_from_command() {
+  local cmd="$1"
+  local repo=""
+
+  # 1. gh api path extraction.
+  repo=$(echo "$cmd" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' \
+    | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
+
+  # 2. --repo flag on gh pr merge.
+  if [ -z "$repo" ]; then
+    repo=$(echo "$cmd" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+  fi
+
+  # 3. Last resort: ask gh which repo the current branch's PR belongs to.
+  if [ -z "$repo" ]; then
+    repo=$(gh pr view --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+  fi
+
+  echo "$repo"
 }

--- a/.claude/hooks/_lib-review-markers.sh
+++ b/.claude/hooks/_lib-review-markers.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# _lib-review-markers.sh — single source of truth for review-marker path
+# construction.
+#
+# WHY THIS EXISTS
+# ---------------
+# Review markers (.claude/session/reviews/<qualifier>-<role>.approved) were
+# previously keyed by bare PR number, e.g. `429-rex.approved`. Because PR
+# numbers are per-repository and routinely overlap across managed repos, two
+# repos could each have a PR #429 whose markers shared the same filename —
+# a (repo, pr) collision hazard.
+#
+# This library encodes the repo in every marker path using the scheme:
+#
+#   <owner>__<repo>__<pr>-<role>.approved
+#
+# Double-underscore is the separator because GitHub owner/repo slugs use only
+# [a-zA-Z0-9._-] — they never contain `__`. Splitting on `__` reliably
+# recovers the three components. See docs/agdr/AgDR-0060-review-marker-repo-qualifier.md.
+#
+# FUNCTIONS
+# ---------
+#   review_marker_path <owner/repo> <pr> <role>
+#       Returns the absolute path to the marker file, anchored at the
+#       resolved MARKER_HOME/.claude/session/reviews/ directory. Exits with
+#       a non-zero status and an error message if required args are missing.
+#       Does NOT create the directory — callers must `mkdir -p` as needed.
+#
+#   review_markers_dir <marker_home>
+#       Returns the absolute path to the reviews directory:
+#       <marker_home>/.claude/session/reviews
+#
+# USAGE (in a hook or skill)
+# --------------------------
+#   . "$(dirname "$0")/_lib-review-markers.sh"
+#   # ... resolve MARKER_HOME as usual via _lib-ops-root.sh ...
+#   MARKER_HOME="${OPS_ROOT:-${REPO_ROOT:-.}}"
+#   REX_MARKER=$(review_marker_path "owner/repo" "$PR_NUMBER" rex)
+#
+# SOURCE GUARD
+# ------------
+# Idempotent: sourcing more than once is a no-op (standard _lib pattern).
+
+[ -n "${_LIB_REVIEW_MARKERS_SOURCED:-}" ] && return 0
+_LIB_REVIEW_MARKERS_SOURCED=1
+
+# review_markers_dir <marker_home>
+# Returns the path: <marker_home>/.claude/session/reviews
+review_markers_dir() {
+  local marker_home="${1:-.}"
+  printf '%s/.claude/session/reviews' "$marker_home"
+}
+
+# review_marker_path <owner/repo> <pr> <role> [marker_home]
+#
+# Args:
+#   owner/repo  — the fully-qualified GitHub repo (e.g. "me2resh/apexyard").
+#                 Slashes are sanitised to double-underscores in the filename.
+#   pr          — the PR number (integer)
+#   role        — the marker role: rex | ceo | design | architecture
+#   marker_home — optional; defaults to $MARKER_HOME if set, then "." as last
+#                 resort. Callers that have already resolved the ops fork root
+#                 via _lib-ops-root.sh should pass it explicitly.
+#
+# Output (stdout): the absolute marker file path.
+# Exit code: 0 on success; 1 if required args are missing (with stderr msg).
+review_marker_path() {
+  local repo="${1:-}"
+  local pr="${2:-}"
+  local role="${3:-}"
+  local marker_home="${4:-${MARKER_HOME:-.}}"
+
+  if [ -z "$repo" ] || [ -z "$pr" ] || [ -z "$role" ]; then
+    echo "_lib-review-markers.sh: review_marker_path requires <owner/repo> <pr> <role>" >&2
+    return 1
+  fi
+
+  # Sanitise: replace every '/' with '__' so the repo slug is flat-file safe.
+  local safe_repo
+  safe_repo=$(printf '%s' "$repo" | tr '/' '_' | sed 's/_/__/g; s/____/__/g')
+  # The tr+sed above can double the underscores incorrectly for repos that
+  # already use underscores. Use a single, cleaner transformation instead:
+  # replace ALL '/' with the two-char string '__'.
+  safe_repo=$(printf '%s' "$repo" | sed 's|/|__|g')
+
+  local reviews_dir
+  reviews_dir=$(review_markers_dir "$marker_home")
+
+  printf '%s/%s__%s-%s.approved' "$reviews_dir" "$safe_repo" "$pr" "$role"
+}

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -56,6 +56,8 @@ fi
 # Shared merge-shape detector + PR-number parser (see _lib-extract-pr.sh).
 # Handles `gh pr merge <N>` and `gh api repos/<owner>/<repo>/pulls/<N>/merge`.
 . "$(dirname "$0")/_lib-extract-pr.sh"
+# Repo-qualified marker path helper (#485).
+. "$(dirname "$0")/_lib-review-markers.sh"
 
 if ! is_merge_command "$COMMAND"; then
   exit 0
@@ -72,6 +74,11 @@ if [ -z "$CMD_REPO" ]; then
 fi
 
 PR_NUMBER=$(extract_pr_number "$COMMAND")
+# Also extract the repo so markers are scoped to (repo, pr) — #485.
+# CMD_REPO already parsed above; resolve via helper if blank (e.g. current-branch fallback).
+if [ -z "$CMD_REPO" ]; then
+  CMD_REPO=$(extract_repo_from_command "$COMMAND")
+fi
 
 if [ -z "$PR_NUMBER" ]; then
   echo "BLOCKED: Could not determine PR number for merge. Run from a PR branch or pass an explicit PR number." >&2
@@ -135,9 +142,10 @@ if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
   OPS_ROOT=$(resolve_ops_root "$REPO_ROOT")
 fi
 MARKER_HOME="${OPS_ROOT:-${REPO_ROOT:-.}}"
-REVIEWS_DIR="${MARKER_HOME}/.claude/session/reviews"
-REX_APPROVAL="${REVIEWS_DIR}/${PR_NUMBER}-rex.approved"
-CEO_APPROVAL="${REVIEWS_DIR}/${PR_NUMBER}-ceo.approved"
+# Repo-qualified marker paths — scoped to (CMD_REPO, PR_NUMBER) so same-numbered
+# PRs in different repos never collide. See AgDR-0060 + me2resh/apexyard#485.
+REX_APPROVAL=$(review_marker_path "${CMD_REPO:-unknown}" "$PR_NUMBER" rex "$MARKER_HOME")
+CEO_APPROVAL=$(review_marker_path "${CMD_REPO:-unknown}" "$PR_NUMBER" ceo "$MARKER_HOME")
 
 # Resolve the PR's real HEAD via GitHub, not local git (see #55). The local
 # HEAD is rarely the PR's HEAD — usually main or an unrelated feature
@@ -196,8 +204,11 @@ _INLINE_CEO_MARKER=""
 if [ ! -f "$CEO_APPROVAL" ]; then
   # Look for inline marker content in the command targeting this PR's
   # approval file. Match heredoc, printf, or echo writing to *-ceo.approved.
-  CEO_BASENAME="${PR_NUMBER}-ceo.approved"
-  if echo "$COMMAND" | grep -q "$CEO_BASENAME"; then
+  # Match both the new repo-qualified basename and the bare-number legacy form
+  # so compound commands from /approve-merge are recognised correctly. The
+  # SHA-match check below provides the safety backstop.
+  CEO_BASENAME=$(basename "$CEO_APPROVAL")
+  if echo "$COMMAND" | grep -qE "(${CEO_BASENAME}|${PR_NUMBER}-ceo\.approved)"; then
     # Extract sha=, approved_by=, skill_version= from the command string.
     _inline_sha=$(echo "$COMMAND" | grep -oE 'sha=[0-9a-f]{40}' | head -1 | cut -d= -f2)
     _inline_approved_by=$(echo "$COMMAND" | grep -oE 'approved_by=[a-z]+' | head -1 | cut -d= -f2)

--- a/.claude/hooks/require-architecture-review.sh
+++ b/.claude/hooks/require-architecture-review.sh
@@ -48,6 +48,8 @@ fi
 # Shared merge-shape detector + PR-number parser (see _lib-extract-pr.sh).
 # Handles `gh pr merge <N>` and `gh api repos/<owner>/<repo>/pulls/<N>/merge`.
 . "$(dirname "$0")/_lib-extract-pr.sh"
+# Repo-qualified marker path helper (#485).
+. "$(dirname "$0")/_lib-review-markers.sh"
 
 if ! is_merge_command "$COMMAND"; then
   exit 0
@@ -66,6 +68,11 @@ if [ -n "$CMD_REPO" ]; then
 fi
 
 PR_NUMBER=$(extract_pr_number "$COMMAND")
+# Resolve the repo for qualified marker paths (#485).
+# CMD_REPO already parsed above; fall back via helper if blank.
+if [ -z "$CMD_REPO" ]; then
+  CMD_REPO=$(extract_repo_from_command "$COMMAND")
+fi
 
 if [ -z "$PR_NUMBER" ]; then
   # Let block-unreviewed-merge.sh handle the "no PR number" error — we skip
@@ -143,8 +150,8 @@ if [ -z "$TOUCHED_DESIGN" ]; then
 fi
 
 # Design-artifact PR detected — require an architecture-review approval marker.
-# Marker lives at the ops fork root (MARKER_HOME), not the workspace clone.
-APPROVAL="${MARKER_HOME}/.claude/session/reviews/${PR_NUMBER}-architecture.approved"
+# Marker lives at the ops fork root (MARKER_HOME), repo-qualified (#485).
+APPROVAL=$(review_marker_path "${CMD_REPO:-unknown}" "$PR_NUMBER" architecture "$MARKER_HOME")
 
 if [ ! -f "$APPROVAL" ]; then
   cat >&2 <<MSG

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -47,6 +47,8 @@ fi
 # Shared merge-shape detector + PR-number parser (see _lib-extract-pr.sh).
 # Handles `gh pr merge <N>` and `gh api repos/<owner>/<repo>/pulls/<N>/merge`.
 . "$(dirname "$0")/_lib-extract-pr.sh"
+# Repo-qualified marker path helper (#485).
+. "$(dirname "$0")/_lib-review-markers.sh"
 
 if ! is_merge_command "$COMMAND"; then
   exit 0
@@ -65,6 +67,11 @@ if [ -n "$CMD_REPO" ]; then
 fi
 
 PR_NUMBER=$(extract_pr_number "$COMMAND")
+# Resolve the repo for qualified marker paths (#485).
+# CMD_REPO already parsed above; fall back via helper if blank.
+if [ -z "$CMD_REPO" ]; then
+  CMD_REPO=$(extract_repo_from_command "$COMMAND")
+fi
 
 if [ -z "$PR_NUMBER" ]; then
   # Let block-unreviewed-merge.sh handle the "no PR number" error — we skip
@@ -147,8 +154,8 @@ if [ -z "$TOUCHED_UI" ]; then
 fi
 
 # UI PR detected — require a design approval marker
-# Marker lives at the ops fork root (MARKER_HOME), not the workspace clone.
-APPROVAL="${MARKER_HOME}/.claude/session/reviews/${PR_NUMBER}-design.approved"
+# Marker lives at the ops fork root (MARKER_HOME), repo-qualified (#485).
+APPROVAL=$(review_marker_path "${CMD_REPO:-unknown}" "$PR_NUMBER" design "$MARKER_HOME")
 
 if [ ! -f "$APPROVAL" ]; then
   cat >&2 <<MSG

--- a/.claude/hooks/tests/test_block_unreviewed_merge.sh
+++ b/.claude/hooks/tests/test_block_unreviewed_merge.sh
@@ -17,13 +17,18 @@ set -u
 SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 HOOK_SRC="$SRC_ROOT/.claude/hooks/block-unreviewed-merge.sh"
 LIB_PR="$SRC_ROOT/.claude/hooks/_lib-extract-pr.sh"
+LIB_MARKERS="$SRC_ROOT/.claude/hooks/_lib-review-markers.sh"
 
-for f in "$HOOK_SRC" "$LIB_PR"; do
+for f in "$HOOK_SRC" "$LIB_PR" "$LIB_MARKERS"; do
   if [ ! -f "$f" ]; then
     echo "FAIL: required source missing: $f" >&2
     exit 1
   fi
 done
+
+# Load the marker lib so test helpers use the same path logic as the hook.
+# shellcheck source=/dev/null
+. "$LIB_MARKERS"
 
 PASS=0
 FAIL=0
@@ -46,20 +51,22 @@ make_sandbox() {
     git commit -q -m "init"
   )
   mkdir -p "$sb/.claude/hooks" "$sb/.claude/session/reviews" "$sb/bin"
-  cp "$HOOK_SRC" "$sb/.claude/hooks/block-unreviewed-merge.sh"
-  cp "$LIB_PR"   "$sb/.claude/hooks/_lib-extract-pr.sh"
+  cp "$HOOK_SRC"    "$sb/.claude/hooks/block-unreviewed-merge.sh"
+  cp "$LIB_PR"      "$sb/.claude/hooks/_lib-extract-pr.sh"
+  cp "$LIB_MARKERS" "$sb/.claude/hooks/_lib-review-markers.sh"
   chmod +x "$sb/.claude/hooks/block-unreviewed-merge.sh"
 
   # Mock `gh` so resolve_pr_head returns FIXED_SHA. The hook calls
   # `gh pr view <N> --json headRefOid -q '.headRefOid'` (or a similar
   # shape) — return the fixed SHA on stdout, no network involved.
+  # Also handles headRefName (sync-PR guard) and headRepository (repo extraction, #485).
   cat > "$sb/bin/gh" <<EOF
 #!/bin/bash
-# Minimal gh shim for test_block_unreviewed_merge. Returns FIXED_SHA for
-# any 'gh pr view ... headRefOid' call; pass-through everything else as
-# a no-op (exit 0, no stdout). Real test invocations only need pr-view.
+# Minimal gh shim for test_block_unreviewed_merge.
 case "\$*" in
-  *"pr view"*"headRefOid"*) echo "$FIXED_SHA" ;;
+  *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
+  *"pr view"*"headRefName"*)    echo "feature/GH-99-test" ;;
+  *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
   *) ;;
 esac
 exit 0
@@ -69,18 +76,28 @@ EOF
   echo "$sb"
 }
 
+# Default test repo — matches the --repo flag used in run_case().
+TEST_REPO="me2resh/apexyard"
+
 # Marker writers -------------------------------------------------------
+# All writers use review_marker_path (from _lib-review-markers.sh, sourced
+# at top) so the test markers land at the same repo-qualified paths the
+# hook will look for. The default repo matches the --repo flag in run_case().
 
 write_rex_marker() {
   # Bare SHA on line 1 — Rex's format is unchanged.
-  local sb="$1" pr="$2" sha="${3:-$FIXED_SHA}"
-  echo "$sha" > "$sb/.claude/session/reviews/${pr}-rex.approved"
+  local sb="$1" pr="$2" sha="${3:-$FIXED_SHA}" repo="${4:-$TEST_REPO}"
+  local path
+  path=$(review_marker_path "$repo" "$pr" rex "$sb")
+  echo "$sha" > "$path"
 }
 
 write_ceo_marker_structured() {
   # Valid v2 structured marker.
-  local sb="$1" pr="$2" sha="${3:-$FIXED_SHA}"
-  cat > "$sb/.claude/session/reviews/${pr}-ceo.approved" <<EOF
+  local sb="$1" pr="$2" sha="${3:-$FIXED_SHA}" repo="${4:-$TEST_REPO}"
+  local path
+  path=$(review_marker_path "$repo" "$pr" ceo "$sb")
+  cat > "$path" <<EOF
 sha=${sha}
 approved_by=user
 approved_at=2026-05-03T20:00:00Z
@@ -91,14 +108,18 @@ EOF
 
 write_ceo_marker_legacy_bare() {
   # Pre-#48 format: bare SHA, single line.
-  local sb="$1" pr="$2" sha="${3:-$FIXED_SHA}"
-  echo "$sha" > "$sb/.claude/session/reviews/${pr}-ceo.approved"
+  local sb="$1" pr="$2" sha="${3:-$FIXED_SHA}" repo="${4:-$TEST_REPO}"
+  local path
+  path=$(review_marker_path "$repo" "$pr" ceo "$sb")
+  echo "$sha" > "$path"
 }
 
 write_ceo_marker_missing_field() {
   # Has sha= and skill_version but NO approved_by.
-  local sb="$1" pr="$2"
-  cat > "$sb/.claude/session/reviews/${pr}-ceo.approved" <<EOF
+  local sb="$1" pr="$2" repo="${3:-$TEST_REPO}"
+  local path
+  path=$(review_marker_path "$repo" "$pr" ceo "$sb")
+  cat > "$path" <<EOF
 sha=${FIXED_SHA}
 skill_version=2
 EOF
@@ -106,8 +127,10 @@ EOF
 
 write_ceo_marker_wrong_approved_by() {
   # Has approved_by=robot instead of approved_by=user.
-  local sb="$1" pr="$2"
-  cat > "$sb/.claude/session/reviews/${pr}-ceo.approved" <<EOF
+  local sb="$1" pr="$2" repo="${3:-$TEST_REPO}"
+  local path
+  path=$(review_marker_path "$repo" "$pr" ceo "$sb")
+  cat > "$path" <<EOF
 sha=${FIXED_SHA}
 approved_by=robot
 skill_version=2
@@ -116,8 +139,10 @@ EOF
 
 write_ceo_marker_old_version() {
   # skill_version=1 (legacy format that should be rejected).
-  local sb="$1" pr="$2"
-  cat > "$sb/.claude/session/reviews/${pr}-ceo.approved" <<EOF
+  local sb="$1" pr="$2" repo="${3:-$TEST_REPO}"
+  local path
+  path=$(review_marker_path "$repo" "$pr" ceo "$sb")
+  cat > "$path" <<EOF
 sha=${FIXED_SHA}
 approved_by=user
 skill_version=1
@@ -132,7 +157,9 @@ run_case() {
   local input
   input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
   local got_stderr got_rc
-  got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+  # APEXYARD_OPS_DISABLE_PIN=1: force walk-up resolution so the sandbox's ops root
+  # is used, not the real session pin (avoids marker-home mismatch in CI/worktrees).
+  got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
   got_rc=$?
   rm -rf "$sb"
 
@@ -206,7 +233,7 @@ run_case "rex sha mismatch → blocks" 2 "Code-reviewer approved commit" "$sb" 2
 # 10. Non-merge command (e.g. gh pr view) → no-op exit 0
 sb=$(make_sandbox)
 input=$(jq -nc --arg c "gh pr view 209 --repo me2resh/apexyard" '{tool_name:"Bash", tool_input:{command:$c}}')
-got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
 got_rc=$?
 rm -rf "$sb"
 if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
@@ -222,7 +249,7 @@ write_rex_marker "$sb" 210
 # No CEO marker — should still block.
 input=$(jq -nc --arg c "gh api repos/me2resh/apexyard/pulls/210/merge -X PUT" \
   '{tool_name:"Bash", tool_input:{command:$c}}')
-got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
 got_rc=$?
 rm -rf "$sb"
 if [ "$got_rc" = "2" ] && echo "$got_stderr" | grep -q "no CEO approval marker"; then
@@ -235,7 +262,8 @@ fi
 # 12. Quoted approval_summary (with spaces) doesn't break the parser.
 sb=$(make_sandbox)
 write_rex_marker "$sb" 211
-cat > "$sb/.claude/session/reviews/211-ceo.approved" <<EOF
+ceo_path=$(review_marker_path "$TEST_REPO" 211 ceo "$sb")
+cat > "$ceo_path" <<EOF
 sha=${FIXED_SHA}
 approved_by=user
 approved_at=2026-05-03T20:00:00Z
@@ -253,8 +281,9 @@ run_case "structured marker with quoted multi-word summary → allows" 0 "" "$sb
 sb=$(make_sandbox)
 # Add the apexyard.projects.yaml that resolve_ops_root requires.
 : > "$sb/apexyard.projects.yaml"
-# Copy _lib-ops-root.sh into the sandbox's hook dir.
-cp "$SRC_ROOT/.claude/hooks/_lib-ops-root.sh" "$sb/.claude/hooks/_lib-ops-root.sh"
+# Copy required libs into the sandbox's hook dir.
+cp "$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"      "$sb/.claude/hooks/_lib-ops-root.sh"
+cp "$SRC_ROOT/.claude/hooks/_lib-review-markers.sh" "$sb/.claude/hooks/_lib-review-markers.sh"
 # Build a workspace clone underneath, with its own git toplevel.
 mkdir -p "$sb/workspace/demo"
 ( cd "$sb/workspace/demo" && git init -q )
@@ -262,8 +291,10 @@ mkdir -p "$sb/workspace/demo"
 write_rex_marker "$sb" 212
 write_ceo_marker_structured "$sb" 212
 # Run the hook from inside workspace/demo cwd (not the ops fork).
+# APEXYARD_OPS_DISABLE_PIN=1 forces walk-up resolution so the sandbox's
+# ops root is used, not the real session pin (mirrors test_require_architecture_review.sh).
 input=$(jq -nc --arg c "gh pr merge 212 --repo me2resh/apexyard" '{tool_name:"Bash", tool_input:{command:$c}}')
-got_stderr=$(cd "$sb/workspace/demo" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash $sb/.claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_stderr=$(cd "$sb/workspace/demo" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash $sb/.claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
 got_rc=$?
 rm -rf "$sb"
 if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
@@ -281,7 +312,7 @@ run_case_custom_cmd() {
   local input
   input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
   local got_stderr got_rc
-  got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+  got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
   got_rc=$?
   rm -rf "$sb"
   if [ "$got_rc" != "$want_rc" ]; then
@@ -351,12 +382,13 @@ make_sandbox_with_sync_branch() {
   local sb branch_name
   branch_name="${1:-sync/main-to-dev-after-v2.3.0}"
   sb=$(make_sandbox)
-  # Rewrite the gh shim to handle both headRefOid (SHA) and headRefName (branch).
+  # Rewrite the gh shim to handle headRefOid, headRefName, and headRepository.
   cat > "$sb/bin/gh" <<EOF
 #!/bin/bash
 case "\$*" in
-  *"pr view"*"headRefOid"*) echo "$FIXED_SHA" ;;
-  *"pr view"*"headRefName"*) echo "$branch_name" ;;
+  *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
+  *"pr view"*"headRefName"*)    echo "$branch_name" ;;
+  *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
   *) ;;
 esac
 exit 0
@@ -371,8 +403,9 @@ make_sandbox_non_sync() {
   cat > "$sb/bin/gh" <<EOF
 #!/bin/bash
 case "\$*" in
-  *"pr view"*"headRefOid"*) echo "$FIXED_SHA" ;;
-  *"pr view"*"headRefName"*) echo "feature/GH-99-something" ;;
+  *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
+  *"pr view"*"headRefName"*)    echo "feature/GH-99-something" ;;
+  *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
   *) ;;
 esac
 exit 0
@@ -387,7 +420,7 @@ write_rex_marker "$sb" 300
 write_ceo_marker_structured "$sb" 300
 cmd="gh pr merge 300 --repo me2resh/apexyard --squash --delete-branch"
 input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
-got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
 got_rc=$?
 rm -rf "$sb"
 if [ "$got_rc" = "2" ] && echo "$got_stderr" | grep -q "cannot be squash-merged"; then
@@ -403,7 +436,7 @@ write_rex_marker "$sb" 301
 write_ceo_marker_structured "$sb" 301
 cmd="gh pr merge 301 --repo me2resh/apexyard --merge --delete-branch"
 input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
-got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
 got_rc=$?
 rm -rf "$sb"
 if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
@@ -419,7 +452,7 @@ write_rex_marker "$sb" 302
 write_ceo_marker_structured "$sb" 302
 cmd="gh pr merge 302 --repo me2resh/apexyard --squash --delete-branch"
 input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
-got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
 got_rc=$?
 rm -rf "$sb"
 if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
@@ -436,7 +469,7 @@ write_rex_marker "$sb" 303
 write_ceo_marker_structured "$sb" 303
 cmd="gh api repos/me2resh/apexyard/pulls/303/merge -X PUT -f merge_method=squash"
 input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
-got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
 got_rc=$?
 rm -rf "$sb"
 if [ "$got_rc" = "2" ] && echo "$got_stderr" | grep -q "cannot be squash-merged"; then
@@ -452,7 +485,7 @@ write_rex_marker "$sb" 304
 write_ceo_marker_structured "$sb" 304
 cmd="gh api repos/me2resh/apexyard/pulls/304/merge -X PUT -f merge_method=merge"
 input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
-got_stderr=$(cd "$sb" && PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
 got_rc=$?
 rm -rf "$sb"
 if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
@@ -461,6 +494,83 @@ else
   echo "FAIL [sync PR + gh-api merge_method=merge → passes]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
   FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}sync-ghapi-merge-passes "
 fi
+
+# --- Cross-repo collision regression test (#485) ----------------------
+#
+# Proves that a marker for repo A's PR #N is DISTINCT from a marker for
+# repo B's PR #N — they must never collide, and one must not satisfy the
+# gate for the other.
+
+# Helper: make a sandbox whose gh shim returns a specific repo for headRepository.
+make_sandbox_for_repo() {
+  local repo="${1:-me2resh/apexyard}"
+  local sb
+  sb=$(make_sandbox)
+  cat > "$sb/bin/gh" <<EOF
+#!/bin/bash
+case "\$*" in
+  *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
+  *"pr view"*"headRefName"*)    echo "feature/test" ;;
+  *"pr view"*"headRepository"*) echo "$repo" ;;
+  *) ;;
+esac
+exit 0
+EOF
+  chmod +x "$sb/bin/gh"
+  echo "$sb"
+}
+
+# Case R1: marker for repo-A's PR #100 does NOT satisfy gate for repo-B's PR #100.
+sb=$(make_sandbox_for_repo "org-b/project-b")
+# Write markers for repo-A's PR #100 (different repo slug → different filename).
+write_rex_marker "$sb" 100 "$FIXED_SHA" "org-a/project-a"
+write_ceo_marker_structured "$sb" 100 "$FIXED_SHA" "org-a/project-a"
+# Run the gate for repo-B's PR #100 — it should be BLOCKED (markers are for the wrong repo).
+input=$(jq -nc --arg c "gh pr merge 100 --repo org-b/project-b --squash" '{tool_name:"Bash", tool_input:{command:$c}}')
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+if [ "$got_rc" = "2" ] && echo "$got_stderr" | grep -qE "no recorded code-reviewer|no CEO approval marker"; then
+  echo "PASS [cross-repo: repo-A PR#100 markers do NOT satisfy repo-B PR#100 gate (#485)]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [cross-repo: repo-A PR#100 markers must not satisfy repo-B PR#100 gate]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}cross-repo-collision-blocked "
+fi
+
+# Case R2: marker for repo-B's PR #100 DOES satisfy gate for repo-B's PR #100.
+sb=$(make_sandbox_for_repo "org-b/project-b")
+write_rex_marker "$sb" 100 "$FIXED_SHA" "org-b/project-b"
+write_ceo_marker_structured "$sb" 100 "$FIXED_SHA" "org-b/project-b"
+input=$(jq -nc --arg c "gh pr merge 100 --repo org-b/project-b --squash" '{tool_name:"Bash", tool_input:{command:$c}}')
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
+  echo "PASS [cross-repo: repo-B PR#100 markers DO satisfy repo-B PR#100 gate (#485)]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [cross-repo: correct markers must satisfy same-repo gate]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}cross-repo-same-repo-passes "
+fi
+
+# Case R3: both repo-A and repo-B have PR #100 with markers — they coexist without collision.
+sb=$(make_sandbox_for_repo "org-a/project-a")
+write_rex_marker "$sb" 100 "$FIXED_SHA" "org-a/project-a"
+write_ceo_marker_structured "$sb" 100 "$FIXED_SHA" "org-a/project-a"
+write_rex_marker "$sb" 100 "$FIXED_SHA" "org-b/project-b"
+write_ceo_marker_structured "$sb" 100 "$FIXED_SHA" "org-b/project-b"
+# Verify both marker files exist with distinct names.
+marker_a=$(review_marker_path "org-a/project-a" 100 rex "$sb")
+marker_b=$(review_marker_path "org-b/project-b" 100 rex "$sb")
+if [ "$marker_a" != "$marker_b" ] && [ -f "$marker_a" ] && [ -f "$marker_b" ]; then
+  echo "PASS [cross-repo: same PR# in two repos produces distinct, coexisting marker files (#485)]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [cross-repo: distinct markers for same PR# in two repos]: a=$marker_a b=$marker_b" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}cross-repo-distinct-files "
+fi
+rm -rf "$sb"
 
 # --- Summary ----------------------------------------------------------
 

--- a/.claude/hooks/tests/test_require_architecture_review.sh
+++ b/.claude/hooks/tests/test_require_architecture_review.sh
@@ -15,11 +15,18 @@ set -u
 
 SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 HOOK_SRC="$SRC_ROOT/.claude/hooks/require-architecture-review.sh"
+LIB_MARKERS="$SRC_ROOT/.claude/hooks/_lib-review-markers.sh"
 
-if [ ! -f "$HOOK_SRC" ]; then
-  echo "FAIL: hook missing: $HOOK_SRC" >&2
-  exit 1
-fi
+for f in "$HOOK_SRC" "$LIB_MARKERS"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: required source missing: $f" >&2
+    exit 1
+  fi
+done
+
+# Load the marker lib so test helpers use the same path logic as the hook.
+# shellcheck source=/dev/null
+. "$LIB_MARKERS"
 
 PASS=0
 FAIL=0
@@ -89,15 +96,22 @@ make_sandbox() {
   # Make it a git repo so `git rev-parse --show-toplevel` resolves to $sb.
   git -C "$sb" init -q
   git -C "$sb" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
-  mkdir -p "$sb/.claude/session/reviews"
+  mkdir -p "$sb/.claude/hooks" "$sb/.claude/session/reviews"
+  # Copy libs needed by the hook.
+  cp "$SRC_ROOT/.claude/hooks/_lib-extract-pr.sh" "$sb/.claude/hooks/_lib-extract-pr.sh"
+  cp "$SRC_ROOT/.claude/hooks/_lib-review-markers.sh" "$sb/.claude/hooks/_lib-review-markers.sh"
+  if [ -f "$SRC_ROOT/.claude/hooks/_lib-ops-root.sh" ]; then
+    cp "$SRC_ROOT/.claude/hooks/_lib-ops-root.sh" "$sb/.claude/hooks/_lib-ops-root.sh"
+  fi
   echo "$sb"
 }
 
 # Install a mock gh that answers:
-#   gh pr diff <N> ... --name-only   -> file list from $MOCK_DIFF_FILES
-#   gh pr view <N> ... headRefOid    -> $MOCK_HEAD_SHA
+#   gh pr diff <N> ... --name-only      -> file list from $MOCK_DIFF_FILES
+#   gh pr view <N> ... headRefOid       -> $MOCK_HEAD_SHA
+#   gh pr view <N> ... headRepository   -> "o/r" (from the merge command repo)
 install_mock_gh() {
-  local sb="$1" diff_files="$2" head_sha="$3"
+  local sb="$1" diff_files="$2" head_sha="$3" repo="${4:-o/r}"
   mkdir -p "$sb/bin"
   cat > "$sb/bin/gh" <<EOF
 #!/bin/bash
@@ -108,6 +122,9 @@ case "\$args" in
     ;;
   *"pr view"*headRefOid*)
     printf '%s\n' "$head_sha"
+    ;;
+  *"pr view"*headRepository*)
+    printf '%s\n' "$repo"
     ;;
   *) exit 0 ;;
 esac
@@ -140,7 +157,8 @@ echo ""
 echo "B) design-artifact PR + matching marker -> ALLOW (exit 0)"
 sb=$(make_sandbox)
 install_mock_gh "$sb" '"projects/foo/docs/technical-design-x.md"' "$SHA"
-printf '%s\n' "$SHA" > "$sb/.claude/session/reviews/77-architecture.approved"
+# Use the repo-qualified marker path (AgDR-0060/#485).
+printf '%s\n' "$SHA" > "$(review_marker_path "o/r" 77 architecture "$sb")"
 code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
 assert_eq "allows with matching marker" "0" "$code"
 rm -rf "$sb"
@@ -149,7 +167,7 @@ echo ""
 echo "B) design-artifact PR + STALE marker (SHA mismatch) -> BLOCK (exit 2)"
 sb=$(make_sandbox)
 install_mock_gh "$sb" '"projects/foo/docs/technical-design-x.md"' "$SHA"
-printf '%s\n' "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" > "$sb/.claude/session/reviews/77-architecture.approved"
+printf '%s\n' "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" > "$(review_marker_path "o/r" 77 architecture "$sb")"
 code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
 assert_eq "blocks on stale marker SHA" "2" "$code"
 rm -rf "$sb"
@@ -176,6 +194,28 @@ sb=$(make_sandbox)
 install_mock_gh "$sb" '"projects/foo/docs/technical-design-x.md"' "$SHA"
 code=$(run_gate "$sb" "gh api repos/o/r/pulls/77/merge -X PUT")
 assert_eq "blocks via gh api shape too" "2" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "C) Cross-repo collision regression (#485) — same PR# in two repos"
+
+echo ""
+echo "C) architecture marker for repo-A's PR#77 does NOT satisfy repo-B's PR#77 gate"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"projects/foo/docs/technical-design-x.md"' "$SHA" "repo-b/project-b"
+# Write marker for repo-A's PR#77 only.
+printf '%s\n' "$SHA" > "$(review_marker_path "repo-a/project-a" 77 architecture "$sb")"
+code=$(run_gate "$sb" "gh pr merge 77 --repo repo-b/project-b --squash")
+assert_eq "cross-repo: repo-A marker blocks repo-B gate (#485)" "2" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "C) architecture marker for repo-B's PR#77 DOES satisfy repo-B's PR#77 gate"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"projects/foo/docs/technical-design-x.md"' "$SHA" "repo-b/project-b"
+printf '%s\n' "$SHA" > "$(review_marker_path "repo-b/project-b" 77 architecture "$sb")"
+code=$(run_gate "$sb" "gh pr merge 77 --repo repo-b/project-b --squash")
+assert_eq "cross-repo: correct repo marker allows gate (#485)" "0" "$code"
 rm -rf "$sb"
 
 echo ""

--- a/.claude/hooks/tests/test_warn_stale_review_markers.sh
+++ b/.claude/hooks/tests/test_warn_stale_review_markers.sh
@@ -13,10 +13,19 @@
 set -u
 
 HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/warn-stale-review-markers.sh"
+LIB_MARKERS="$(cd "$(dirname "$0")/.." && pwd)/_lib-review-markers.sh"
 if [ ! -x "$HOOK_SRC" ]; then
   echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
   exit 1
 fi
+if [ ! -f "$LIB_MARKERS" ]; then
+  echo "FAIL: _lib-review-markers.sh not found at $LIB_MARKERS" >&2
+  exit 1
+fi
+
+# Load marker lib so test helpers use the same path logic as the hook.
+# shellcheck source=/dev/null
+. "$LIB_MARKERS"
 
 PASS=0
 FAIL=0
@@ -38,7 +47,8 @@ make_sandbox() {
     git commit -q -m "init"
   )
   mkdir -p "$sb/.claude/hooks" "$sb/.claude/session/reviews" "$sb/bin"
-  cp "$HOOK_SRC" "$sb/.claude/hooks/warn-stale-review-markers.sh"
+  cp "$HOOK_SRC"    "$sb/.claude/hooks/warn-stale-review-markers.sh"
+  cp "$LIB_MARKERS" "$sb/.claude/hooks/_lib-review-markers.sh"
   chmod +x "$sb/.claude/hooks/warn-stale-review-markers.sh"
   # The hook sources the shared config reader landed in apexyard#109. The
   # sandbox therefore needs both the reader and the shipped defaults so
@@ -53,6 +63,9 @@ make_sandbox() {
   fi
   echo "$sb"
 }
+
+# Default test PR repo for new-scheme marker writes.
+WARN_TEST_REPO="acme/repo"
 
 # Write a gh stub. Arguments: sandbox dir, behaviour keyword.
 #   no-pr        → all `gh pr view` calls exit 1 (no PR for branch)
@@ -86,12 +99,17 @@ case "$mode" in
     num="${num%%:*}"
     sha="${mode##*:}"
     # Route by args.
-    if [[ "$args" == *"--json number"* && "$args" != *"headRefOid"* ]]; then
+    if [[ "$args" == *"--json number"* && "$args" != *"headRefOid"* && "$args" != *"headRepository"* ]]; then
       echo "$num"
       exit 0
     fi
     if [[ "$args" == *"headRefOid"* ]]; then
       echo "$sha"
+      exit 0
+    fi
+    if [[ "$args" == *"headRepository"* ]]; then
+      # Return a test repo name for the warn-stale hook to build its glob.
+      echo "acme/repo"
       exit 0
     fi
     # Fallback: pretend success but empty.
@@ -199,9 +217,9 @@ case3() {
   local sha
   sha=$(printf 'b%.0s' {1..40})
   write_gh_stub "$sb" "pr:42:$sha"
-  # Markers record the current PR HEAD — not stale.
-  echo "$sha" > "$sb/.claude/session/reviews/42-rex.approved"
-  echo "$sha" > "$sb/.claude/session/reviews/42-ceo.approved"
+  # Markers record the current PR HEAD — not stale. Use qualified paths.
+  echo "$sha" > "$(review_marker_path "$WARN_TEST_REPO" 42 rex "$sb")"
+  echo "$sha" > "$(review_marker_path "$WARN_TEST_REPO" 42 ceo "$sb")"
   run_hook "$sb" "$(push_json_success)" "" "fresh-markers-silent"
   rm -rf "$sb"
 }
@@ -214,12 +232,16 @@ case4() {
   new_sha=$(printf 'c%.0s' {1..40})
   old_sha=$(printf 'd%.0s' {1..40})
   write_gh_stub "$sb" "pr:42:$new_sha"
-  echo "$old_sha" > "$sb/.claude/session/reviews/42-rex.approved"
+  local rex_marker
+  rex_marker=$(review_marker_path "$WARN_TEST_REPO" 42 rex "$sb")
+  echo "$old_sha" > "$rex_marker"
+  local marker_basename
+  marker_basename=$(basename "$rex_marker")
   run_hook "$sb" "$(push_json_success)" \
-    "Stale review marker: 42-rex\.approved.*was ddddddd.*now ccccccc" \
+    "Stale review marker: ${marker_basename}.*was ddddddd.*now ccccccc" \
     "stale-rex-warn"
   # Marker file should still exist (warn mode, not delete).
-  if [ ! -f "$sb/.claude/session/reviews/42-rex.approved" ]; then
+  if [ ! -f "$rex_marker" ]; then
     echo "FAIL [stale-rex-warn]: marker was deleted in warn mode" >&2
     FAIL=$((FAIL+1))
     PASS=$((PASS-1))
@@ -235,9 +257,13 @@ case5() {
   new_sha=$(printf 'e%.0s' {1..40})
   old_sha=$(printf 'f%.0s' {1..40})
   write_gh_stub "$sb" "pr:42:$new_sha"
-  echo "$old_sha" > "$sb/.claude/session/reviews/42-ceo.approved"
+  local ceo_marker
+  ceo_marker=$(review_marker_path "$WARN_TEST_REPO" 42 ceo "$sb")
+  echo "$old_sha" > "$ceo_marker"
+  local marker_basename
+  marker_basename=$(basename "$ceo_marker")
   run_hook "$sb" "$(push_json_success)" \
-    "Stale review marker: 42-ceo\.approved" \
+    "Stale review marker: ${marker_basename}" \
     "stale-ceo-warn"
   rm -rf "$sb"
 }
@@ -250,9 +276,13 @@ case6() {
   new_sha=$(printf '1%.0s' {1..40})
   old_sha=$(printf '2%.0s' {1..40})
   write_gh_stub "$sb" "pr:42:$new_sha"
-  echo "$old_sha" > "$sb/.claude/session/reviews/42-design.approved"
+  local design_marker
+  design_marker=$(review_marker_path "$WARN_TEST_REPO" 42 design "$sb")
+  echo "$old_sha" > "$design_marker"
+  local marker_basename
+  marker_basename=$(basename "$design_marker")
   run_hook "$sb" "$(push_json_success)" \
-    "Stale review marker: 42-design\.approved" \
+    "Stale review marker: ${marker_basename}" \
     "stale-design-warn"
   rm -rf "$sb"
 }
@@ -265,15 +295,19 @@ case7() {
   new_sha=$(printf '3%.0s' {1..40})
   old_sha=$(printf '4%.0s' {1..40})
   write_gh_stub "$sb" "pr:42:$new_sha"
-  echo "$old_sha" > "$sb/.claude/session/reviews/42-rex.approved"
+  local rex_marker
+  rex_marker=$(review_marker_path "$WARN_TEST_REPO" 42 rex "$sb")
+  echo "$old_sha" > "$rex_marker"
+  local marker_basename
+  marker_basename=$(basename "$rex_marker")
   # Opt in to delete mode.
   cat > "$sb/.claude/project-config.json" <<EOF
 {"review_markers": {"on_stale": "delete"}}
 EOF
   run_hook "$sb" "$(push_json_success)" \
-    "Stale review marker deleted: 42-rex\.approved" \
+    "Stale review marker deleted: ${marker_basename}" \
     "stale-rex-delete"
-  if [ -f "$sb/.claude/session/reviews/42-rex.approved" ]; then
+  if [ -f "$rex_marker" ]; then
     echo "FAIL [stale-rex-delete]: marker was NOT deleted in delete mode" >&2
     FAIL=$((FAIL+1))
     PASS=$((PASS-1))
@@ -292,14 +326,35 @@ case8() {
   # Stale marker present — but push failed, so the hook should stay silent
   # (the remote didn't move, so prior markers are still valid against the
   # remote's actual HEAD).
-  echo "$old_sha" > "$sb/.claude/session/reviews/42-rex.approved"
+  local rex_marker
+  rex_marker=$(review_marker_path "$WARN_TEST_REPO" 42 rex "$sb")
+  echo "$old_sha" > "$rex_marker"
   run_hook "$sb" "$(push_json_failure)" "" "push-failed-silent"
   # Marker must NOT have been deleted.
-  if [ ! -f "$sb/.claude/session/reviews/42-rex.approved" ]; then
+  if [ ! -f "$rex_marker" ]; then
     echo "FAIL [push-failed-silent]: marker was touched on failed push" >&2
     FAIL=$((FAIL+1))
     PASS=$((PASS-1))
   fi
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 9: cross-repo isolation (#485) --------------------
+# Stale marker for repo-other/project-other's PR#42 should NOT appear as stale
+# for acme/repo's PR#42 (different qualified prefix → different glob, no match).
+case9() {
+  local sb
+  sb=$(make_sandbox)
+  local new_sha old_sha
+  new_sha=$(printf '7%.0s' {1..40})
+  old_sha=$(printf '8%.0s' {1..40})
+  # gh stub returns PR#42 for acme/repo.
+  write_gh_stub "$sb" "pr:42:$new_sha"
+  # Write a stale marker for a DIFFERENT repo's PR#42 — should be invisible.
+  echo "$old_sha" > "$(review_marker_path "repo-other/project-other" 42 rex "$sb")"
+  # Also write a fresh marker for the correct repo — should be silent.
+  echo "$new_sha" > "$(review_marker_path "$WARN_TEST_REPO" 42 rex "$sb")"
+  run_hook "$sb" "$(push_json_success)" "" "cross-repo-isolation-silent"
   rm -rf "$sb"
 }
 
@@ -312,6 +367,7 @@ case5
 case6
 case7
 case8
+case9
 
 echo ""
 echo "==================================="

--- a/.claude/hooks/warn-stale-review-markers.sh
+++ b/.claude/hooks/warn-stale-review-markers.sh
@@ -72,25 +72,41 @@ if [ -n "$PUSH_COMBINED" ] && echo "$PUSH_COMBINED" | grep -qEi '\b(rejected|fai
   exit 0
 fi
 
+# Source the marker path helper (#485) so we can construct the right glob.
+HOOK_DIR_STALE="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "$HOOK_DIR_STALE/_lib-review-markers.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR_STALE/_lib-review-markers.sh"
+fi
+
 # -------- Resolve repo root + session/reviews dir --------
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 if [ -z "$REPO_ROOT" ]; then
   exit 0
 fi
 
-REVIEWS_DIR="${REPO_ROOT}/.claude/session/reviews"
+REVIEWS_DIR=$(review_markers_dir "$REPO_ROOT" 2>/dev/null || printf '%s/.claude/session/reviews' "$REPO_ROOT")
 if [ ! -d "$REVIEWS_DIR" ]; then
   # No reviews ever recorded — nothing can be stale.
   exit 0
 fi
 
-# -------- Resolve the PR number for the current branch --------
+# -------- Resolve the PR number and repo for the current branch --------
 # `gh pr view` with no args looks up the PR for the checked-out branch.
 # If no PR exists (early push before `gh pr create`), gh exits non-zero and
 # we exit silently — this is the expected path for most first pushes.
 PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null)
 if [ -z "$PR_NUMBER" ]; then
   exit 0
+fi
+
+# Resolve the repo so we scan only markers that belong to this PR's repo (#485).
+# `gh pr view --json headRepository` returns the repo the PR targets.
+PR_REPO=$(gh pr view "$PR_NUMBER" --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+# Fallback: derive from git remote origin if gh is offline.
+if [ -z "$PR_REPO" ]; then
+  _origin_url=$(git remote get-url origin 2>/dev/null)
+  PR_REPO=$(echo "$_origin_url" | sed -nE 's|.*[:/]([^/]+/[^/]+)(\.git)?$|\1|p')
 fi
 
 # -------- Resolve the PR's HEAD SHA --------
@@ -122,14 +138,32 @@ if [ -f "$REPO_ROOT/.claude/hooks/_lib-read-config.sh" ]; then
   fi
 fi
 
+# -------- Build the marker glob prefix for this (repo, pr) pair --------
+# New scheme: <owner>__<repo>__<pr>-*.approved  (AgDR-0060 / #485)
+# Derive the safe repo slug (same transformation as review_marker_path).
+if [ -n "$PR_REPO" ] && command -v review_marker_path >/dev/null 2>&1; then
+  _SAFE_REPO=$(printf '%s' "$PR_REPO" | sed 's|/|__|g')
+  MARKER_GLOB="${_SAFE_REPO}__${PR_NUMBER}-*.approved"
+else
+  # Fallback: scan all *-<PR_NUMBER>-*.approved or bare <PR_NUMBER>-*.approved
+  # so the hook degrades gracefully when the lib is unavailable.
+  MARKER_GLOB="*${PR_NUMBER}-*.approved"
+fi
+
 # -------- Scan the marker files for staleness --------
 # Use a for-loop with a nullglob-equivalent pattern check to handle the
 # no-match case cleanly (literal glob vs empty list).
 shopt -s nullglob 2>/dev/null
-for MARKER in "$REVIEWS_DIR"/"$PR_NUMBER"-*.approved; do
+for MARKER in "$REVIEWS_DIR"/$MARKER_GLOB; do
   [ -f "$MARKER" ] || continue
 
-  MARKER_SHA=$(tr -d '[:space:]' < "$MARKER")
+  # For the structured CEO marker (key=value format), extract the sha= field.
+  # For all other markers (bare SHA), read the whole file after stripping whitespace.
+  if grep -q '^sha=' "$MARKER" 2>/dev/null; then
+    MARKER_SHA=$(grep '^sha=' "$MARKER" | head -1 | cut -d= -f2 | tr -d '[:space:]')
+  else
+    MARKER_SHA=$(tr -d '[:space:]' < "$MARKER")
+  fi
   if [ -z "$MARKER_SHA" ]; then
     # Malformed marker (empty file) — treat as stale so it gets surfaced,
     # since the merge gate will reject it anyway.

--- a/.claude/skills/approve-architecture/SKILL.md
+++ b/.claude/skills/approve-architecture/SKILL.md
@@ -1,6 +1,6 @@
 # /approve-architecture — Record Per-PR Design-Review Approval
 
-Writes `.claude/session/reviews/<pr>-architecture.approved` with the current HEAD SHA so the `require-architecture-review.sh` merge-gate hook will let a design-artifact PR through. Without this marker, the hook blocks merges on any PR that touches a technical design, a migration AgDR, or a feature spec / PRD.
+Writes `.claude/session/reviews/<owner>__<repo>__<pr>-architecture.approved` (repo-qualified path, see AgDR-0060) with the current HEAD SHA so the `require-architecture-review.sh` merge-gate hook will let a design-artifact PR through. Without this marker, the hook blocks merges on any PR that touches a technical design, a migration AgDR, or a feature spec / PRD.
 
 This skill is the architecture-review analog of `/approve-design` (UI gate) and `/approve-merge` (CEO gate). Same pattern, different gate. The reviewer is **Tariq (the Solution Architect)**.
 
@@ -53,7 +53,7 @@ gh pr view <pr> --json state,isDraft,mergeable,headRefOid
 
 ### 4. Verify the Rex marker exists at current HEAD
 
-Architecture sign-off is a stamp on top of a Rex-approved HEAD (the design PR still gets a normal code review for its prose / diff), not parallel to it. Resolve the ops fork root (NOT git toplevel — inside `workspace/<project>/` the markers live in the ops fork above):
+Architecture sign-off is a stamp on top of a Rex-approved HEAD (the design PR still gets a normal code review for its prose / diff), not parallel to it. Resolve the ops fork root (NOT git toplevel — inside `workspace/<project>/` the markers live in the ops fork above) and source the marker path helper:
 
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -65,7 +65,10 @@ while [ -n "$r" ] && [ "$r" != "/" ]; do
   r=$(dirname "$r")
 done
 MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
-REX="$MARKER_HOME/.claude/session/reviews/<pr>-rex.approved"
+# shellcheck source=/dev/null
+. "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
+PR_REPO=$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+REX=$(review_marker_path "$PR_REPO" <pr> rex "$MARKER_HOME")
 [ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "<headRefOid from step 3>" ]
 ```
 
@@ -81,9 +84,13 @@ gh pr diff <pr> --name-only | grep -qiE '(docs/agdr/.*migration.*\.md|technical-
 
 ### 6. Write the architecture marker
 
+Use the repo-qualified path via `_lib-review-markers.sh` (already sourced in step 4):
+
 ```bash
+# (MARKER_HOME and PR_REPO already resolved in step 4 — reuse them here.)
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
-printf '%s\n' "<headRefOid>" > "$MARKER_HOME/.claude/session/reviews/<pr>-architecture.approved"
+ARCH=$(review_marker_path "$PR_REPO" <pr> architecture "$MARKER_HOME")
+printf '%s\n' "<headRefOid>" > "$ARCH"
 ```
 
 The file contains exactly one line: the 40-character HEAD SHA + newline. No labels, no JSON.
@@ -122,11 +129,11 @@ You: *invokes /approve-architecture 42*  ← CORRECT
 
 ## Relationship to other approval skills
 
-| Skill | Marker | Gate hook | Who invokes |
-|-------|--------|-----------|-------------|
-| `/approve-merge` | `<pr>-ceo.approved` | `block-unreviewed-merge.sh` | On explicit CEO per-PR merge nod |
-| `/approve-design` | `<pr>-design.approved` | `require-design-review-for-ui.sh` | On explicit designer per-PR design nod |
-| **`/approve-architecture`** | **`<pr>-architecture.approved`** | **`require-architecture-review.sh`** | On explicit architect per-PR design-review nod (or Tariq writes it on APPROVED) |
+| Skill | Marker (repo-qualified, see AgDR-0060) | Gate hook | Who invokes |
+|-------|----------------------------------------|-----------|-------------|
+| `/approve-merge` | `<owner>__<repo>__<pr>-ceo.approved` | `block-unreviewed-merge.sh` | On explicit CEO per-PR merge nod |
+| `/approve-design` | `<owner>__<repo>__<pr>-design.approved` | `require-design-review-for-ui.sh` | On explicit designer per-PR design nod |
+| **`/approve-architecture`** | **`<owner>__<repo>__<pr>-architecture.approved`** | **`require-architecture-review.sh`** | On explicit architect per-PR design-review nod (or Tariq writes it on APPROVED) |
 
 All follow the same pattern: verify PR state → verify Rex marker → write marker at ops fork root → confirm → stop. None runs `gh pr merge`.
 

--- a/.claude/skills/approve-design/SKILL.md
+++ b/.claude/skills/approve-design/SKILL.md
@@ -8,7 +8,7 @@ effort: low
 
 # /approve-design - Record Per-PR Design-Review Approval
 
-Writes `.claude/session/reviews/<pr>-design.approved` with the current HEAD SHA so the `require-design-review-for-ui.sh` merge-gate hook will let a UI PR through. Without this marker, the hook blocks merges on any PR that touches `.tsx`, `.jsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`, or `design-tokens*` files.
+Writes `.claude/session/reviews/<owner>__<repo>__<pr>-design.approved` (repo-qualified path, see AgDR-0060) with the current HEAD SHA so the `require-design-review-for-ui.sh` merge-gate hook will let a UI PR through. Without this marker, the hook blocks merges on any PR that touches `.tsx`, `.jsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`, or `design-tokens*` files.
 
 This skill is the design-review analog of `/approve-merge` (which writes the CEO marker for the merge gate). Same pattern, different gate.
 
@@ -63,11 +63,22 @@ Run `gh pr view <pr> --json state,isDraft,mergeable`. Sanity checks:
 
 ### 4. Verify the Rex marker exists at current HEAD
 
-Design review is a stamp on top of a Rex-approved HEAD, not parallel to code review. Check (using an absolute path anchored at the repo root):
+Design review is a stamp on top of a Rex-approved HEAD, not parallel to code review. Resolve the ops fork root and source the marker path helper:
 
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel)
-REX="$REPO_ROOT/.claude/session/reviews/<pr>-rex.approved"
+OPS_ROOT=""
+r="$REPO_ROOT"
+while [ -n "$r" ] && [ "$r" != "/" ]; do
+  if [ -f "$r/.apexyard-fork" ]; then OPS_ROOT="$r"; break; fi
+  if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then OPS_ROOT="$r"; break; fi
+  r=$(dirname "$r")
+done
+MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
+# shellcheck source=/dev/null
+. "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
+PR_REPO=$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+REX=$(review_marker_path "$PR_REPO" <pr> rex "$MARKER_HOME")
 [ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "$(git rev-parse HEAD)" ]
 ```
 
@@ -83,12 +94,13 @@ gh pr diff <pr> --name-only | grep -qE '\.(tsx|jsx|vue|svelte|css|scss|sass|less
 
 ### 6. Write the design marker
 
-Construct the path from the repo root (same lesson as `/approve-merge` — never use cwd-relative paths):
+Use the repo-qualified path via `_lib-review-markers.sh` (already sourced in step 4):
 
 ```bash
-REPO_ROOT=$(git rev-parse --show-toplevel)
-mkdir -p "$REPO_ROOT/.claude/session/reviews"
-git rev-parse HEAD > "$REPO_ROOT/.claude/session/reviews/<pr>-design.approved"
+# (MARKER_HOME and PR_REPO already resolved in step 4 — reuse them here.)
+mkdir -p "$MARKER_HOME/.claude/session/reviews"
+DESIGN=$(review_marker_path "$PR_REPO" <pr> design "$MARKER_HOME")
+git rev-parse HEAD > "$DESIGN"
 ```
 
 The file contains exactly one line: the 40-character HEAD SHA.
@@ -131,12 +143,12 @@ Two distinct moments. One is mockup approval (design phase). The other is implem
 
 ## Relationship to other approval skills
 
-| Skill | Marker | Gate hook | Who invokes |
-|-------|--------|-----------|-------------|
-| `/approve-merge` | `<pr>-ceo.approved` | `block-unreviewed-merge.sh` | On explicit CEO per-PR merge nod |
-| **`/approve-design`** | `<pr>-design.approved` | `require-design-review-for-ui.sh` | On explicit designer per-PR design nod |
+| Skill | Marker (repo-qualified, see AgDR-0060) | Gate hook | Who invokes |
+|-------|----------------------------------------|-----------|-------------|
+| `/approve-merge` | `<owner>__<repo>__<pr>-ceo.approved` | `block-unreviewed-merge.sh` | On explicit CEO per-PR merge nod |
+| **`/approve-design`** | `<owner>__<repo>__<pr>-design.approved` | `require-design-review-for-ui.sh` | On explicit designer per-PR design nod |
 
-Both skills follow the same pattern: verify PR state → verify Rex marker → write marker at repo root → confirm → stop. Both refuse to write on a stale Rex base. Both are invalidated by new commits. Neither runs `gh pr merge`.
+Both skills follow the same pattern: verify PR state → verify Rex marker → write marker at ops fork root → confirm → stop. Both refuse to write on a stale Rex base. Both are invalidated by new commits. Neither runs `gh pr merge`.
 
 The merge flow for a UI PR requires **three** markers before the merge-gate hooks allow through:
 

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -8,7 +8,7 @@ effort: low
 
 # /approve-merge — Record CEO Approval and Merge
 
-Writes a structured marker at `.claude/session/reviews/<pr>-ceo.approved`, then runs `gh pr merge <pr> --squash --delete-branch` in the same turn. The marker contains required key/value fields (not just a bare SHA) so a raw `echo SHA > file` from the model is mechanically rejected by `block-unreviewed-merge.sh`.
+Writes a structured marker at `.claude/session/reviews/<owner>__<repo>__<pr>-ceo.approved` (repo-qualified path, see AgDR-0060), then runs `gh pr merge <pr> --squash --delete-branch` in the same turn. The marker contains required key/value fields (not just a bare SHA) so a raw `echo SHA > file` from the model is mechanically rejected by `block-unreviewed-merge.sh`.
 
 This is the **mechanical enforcement** of the "plan-level 'go' is not merge approval" rule in `.claude/rules/pr-workflow.md`. The load-bearing semantic is "every merge needs an explicit per-PR approval", **not** "every merge needs two user messages."
 
@@ -80,13 +80,19 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 OPS_ROOT=""
 r="$REPO_ROOT"
 while [ -n "$r" ] && [ "$r" != "/" ]; do
+  if [ -f "$r/.apexyard-fork" ]; then OPS_ROOT="$r"; break; fi
   if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
     OPS_ROOT="$r"; break
   fi
   r=$(dirname "$r")
 done
 MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
-REX="$MARKER_HOME/.claude/session/reviews/<pr>-rex.approved"
+
+# Source the marker path helper — repo-qualified naming (#485, AgDR-0060).
+# shellcheck source=/dev/null
+. "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
+PR_REPO=$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+REX=$(review_marker_path "$PR_REPO" <pr> rex "$MARKER_HOME")
 [ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "<headRefOid from step 3>" ]
 ```
 
@@ -119,17 +125,18 @@ Optional fields the gate stores but doesn't validate:
 | `approved_at=<ISO>` | Audit-log timestamp. Helpful when reviewing past merges. |
 | `approval_summary=<text>` | First ≤200 chars of the user's approval message, sanitised (no shell metachars). Audit trail for "what did the user say when they approved this." |
 
-Use the **ops fork root** as the path anchor (NOT git toplevel — see #229 + #230 for the workspace-clone bug this avoids). Reuse the same MARKER_HOME computed in step 4:
+Use the **ops fork root** as the path anchor (NOT git toplevel — see #229 + #230 for the workspace-clone bug this avoids). Reuse the same MARKER_HOME and the `_lib-review-markers.sh` helper (already sourced in step 4):
 
 ```bash
-# (MARKER_HOME already resolved in step 4 — reuse it here.)
+# (MARKER_HOME and PR_REPO already resolved in step 4 — reuse them here.)
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
 ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Sanitise: drop newlines, drop shell-special chars, truncate to 200.
 summary=$(echo "<user approval message>" | tr '\n' ' ' | tr -d '"`$\\' | cut -c1-200)
 
-cat > "$MARKER_HOME/.claude/session/reviews/<pr>-ceo.approved" <<EOF
+CEO=$(review_marker_path "$PR_REPO" <pr> ceo "$MARKER_HOME")
+cat > "$CEO" <<EOF
 sha=<headRefOid>
 approved_by=user
 approved_at=${ts}
@@ -193,7 +200,7 @@ or for sync PRs:
 If the merge gate blocked, surface the exact error and tell the user how to retry:
 
 ```
-✗ Merge blocked: <reason from gate>. Marker still on disk at .claude/session/reviews/<pr>-ceo.approved — run `gh pr merge <pr> --repo <owner/repo> <strategy> --delete-branch` once the issue is fixed (no need to re-invoke /approve-merge).
+✗ Merge blocked: <reason from gate>. Marker still on disk at <CEO path from review_marker_path> — run `gh pr merge <pr> --repo <owner/repo> <strategy> --delete-branch` once the issue is fixed (no need to re-invoke /approve-merge).
 ```
 
 ### 9. Optional: post-merge child-issue closure

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -87,7 +87,7 @@ Posts a GitHub review comment with:
 - Blocking findings + handbook findings
 - Verdict: APPROVED / CHANGES REQUESTED / COMMENT
 
-On APPROVED, Tariq writes `<pr>-architecture.approved` so the `require-architecture-review.sh` gate lets the design PR merge.
+On APPROVED, Tariq writes `<owner>__<repo>__<pr>-architecture.approved` (repo-qualified, see AgDR-0060) so the `require-architecture-review.sh` gate lets the design PR merge.
 
 Invokes: Solution Architect Agent (Tariq)
 

--- a/docs/agdr/AgDR-0060-review-marker-repo-qualifier.md
+++ b/docs/agdr/AgDR-0060-review-marker-repo-qualifier.md
@@ -1,0 +1,59 @@
+# Review Marker Repo Qualifier — Scoping Markers to (repo, pr) Pairs
+
+> In the context of a multi-repo portfolio where `.claude/session/reviews/` holds approval markers keyed by bare PR number, facing a collision hazard when two different managed repos share the same PR number, I decided to encode the repo as a double-underscore-separated owner/repo prefix in the marker filename to achieve unambiguous (repo, pr) scoping, accepting a one-time re-approval cost for any markers that existed before the upgrade.
+
+## Context
+
+Review markers (`<pr>-rex.approved`, `<pr>-ceo.approved`, `<pr>-design.approved`, `<pr>-architecture.approved`) are written to `.claude/session/reviews/` and are consumed by four gate hooks: `block-unreviewed-merge.sh`, `require-design-review-for-ui.sh`, `require-architecture-review.sh`, and `warn-stale-review-markers.sh`. The markers are also written by the `/approve-merge`, `/approve-design`, `/approve-architecture`, and `/design-review` skills, plus the `code-reviewer` (Rex) and `solution-architect` (Tariq) agents.
+
+Because PR numbers are per-repository and routinely overlap across repos (every new repo starts from #1), two distinct managed repos can each have a PR #429. The bare-number scheme means `429-rex.approved` is indistinguishable at read-time regardless of which repo's PR produced it. Observed in practice: a leftover CEO marker from repo A's PR #429 sitting in `reviews/` appeared as if it belonged to repo B's freshly-opened PR #429 in a later session. The SHA-match check in the merge gate prevents a *wrong merge* from occurring (the stale marker's SHA will not match the new PR's GitHub HEAD), but the correctness/hygiene defect is real:
+
+- `warn-stale-review-markers.sh` cannot reason about which repo a marker belongs to.
+- A same-session same-PR-number scenario (two concurrent merge operations on different repos) results in one marker overwriting the other's filename with no signal to either gate.
+- Stale cross-repo markers are confusing to operators and to gate diagnostics.
+
+The fix must encode the repo in every marker filename, consistently, with a single source of truth for path construction that all readers and writers share.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **`<owner>__<repo>__<pr>-<role>.approved` (flat file, double-underscore separator)** | Flat `reviews/` directory; simple glob scan; `__` is filesystem-safe and visually distinct; sanitise `/` → `__` in owner/repo; zero ambiguity on the (repo, pr) pair | Filenames grow longer; some find/glob patterns need updating |
+| `<owner>-<repo>-<pr>-<role>.approved` (single-hyphen separator) | Shorter filenames | `owner` or `repo` slugs can themselves contain hyphens (e.g. `my-org/my-repo`) making it impossible to reliably parse back the components |
+| `<owner>/<repo>/<pr>-<role>.approved` (subdirectory per repo) | Matches GitHub's URL shape; OS-friendly tree view | Requires `mkdir -p` for each new owner/repo; glob patterns become `*/*/<pr>-*.approved`; `warn-stale-review-markers.sh` must recurse; slightly more complex |
+| Leave naming alone; rely solely on SHA mismatch as safety backstop | Zero migration cost | Does not remove the misleading-stale-marker or same-session-overwrite hazard; `warn-stale-review-markers.sh` remains unable to reason about repo; defect is explicitly called out in the bug report as major |
+
+## Decision
+
+Chosen: **`<owner>__<repo>__<pr>-<role>.approved` flat-file scheme**, because:
+
+1. The double-underscore separator is unambiguous — GitHub owner and repo slugs use only `[a-zA-Z0-9._-]`, which never includes `__`. Splitting on `__` reliably recovers the three components.
+2. The flat `reviews/` directory stays flat — no subdirectory creation required, existing glob logic (`"$REVIEWS_DIR"/"$PR_NUMBER"-*.approved`) becomes `"$REVIEWS_DIR"/"$OWNER_REPO"__"$PR_NUMBER"-*.approved`; `warn-stale-review-markers.sh` still iterates with a simple for-loop.
+3. A single shared lib (`_lib-review-markers.sh`) owns path construction; all four gate hooks and all six writers (four skills + two agents) source it. One change point for any future scheme evolution.
+
+Implementation: the `review_marker_path <owner/repo> <pr> <role>` function in `_lib-review-markers.sh` sanitises the repo string (`/` → `__`) and returns the absolute path anchored at the resolved `MARKER_HOME/.claude/session/reviews/` directory.
+
+## Backward Compatibility
+
+**New scheme only — no dual-read fallback.** Markers are session state, gitignored, and ephemeral. The SHA-match check in the gate hooks is the safety backstop that ensures a stale or unrelated marker cannot produce a wrong merge. The only cost of the hard-cutover is that any marker written under the old bare-number scheme must be re-approved (one re-invocation of the relevant skill or agent). This cost is per-session (markers don't persist across sessions in any meaningful way) and far cheaper than maintaining a dual-read path indefinitely.
+
+A dual-read fallback was considered: read new-scheme first, fall back to bare-number on miss. Rejected because:
+
+- It would silently perpetuate the collision hazard for old markers already in `reviews/`.
+- The SHA backstop means a stale old marker can't produce a wrong merge anyway, so the fallback buys convenience at the cost of false reassurance.
+- The cleanup message (`/approve-merge <pr>` or re-invoke Rex) is one turn of work, not a breaking experience.
+
+The upgrade path: any adopter who had markers in `reviews/` before the upgrade simply re-approves. The gate hooks report the exact missing file path in their BLOCKED messages, so the operator knows exactly what to re-run.
+
+## Consequences
+
+- All four gate hooks (`block-unreviewed-merge.sh`, `require-design-review-for-ui.sh`, `require-architecture-review.sh`, `warn-stale-review-markers.sh`) updated to source `_lib-review-markers.sh` and use `review_marker_path`.
+- All six writers updated: `/approve-merge`, `/approve-design`, `/approve-architecture`, `/design-review` skills; `code-reviewer` and `solution-architect` agents.
+- Tests updated to write markers at the new qualified paths. New regression test proves two repos sharing the same PR number get distinct, non-colliding markers.
+- `_lib-review-markers.sh` is a `_lib-*` file and is excluded from the hook count in `test_site_counts.sh` — no count drift.
+- `_lib-extract-pr.sh` gains a sibling `extract_repo_from_command` function (non-breaking addition; existing `extract_pr_number` contract unchanged).
+
+## Artifacts
+
+- PR: `atlas-apex:fix/GH-485-review-marker-repo-qualifier` → `me2resh/apexyard` `dev`
+- Closes me2resh/apexyard#485


### PR DESCRIPTION
## Summary

- **Introduced `_lib-review-markers.sh`** — a single source of truth for marker path construction. The function `review_marker_path <owner/repo> <pr> <role>` returns `<reviews-dir>/<owner>__<repo>__<pr>-<role>.approved`, using double-underscores as a safe separator (GitHub slugs never contain `__`). Every reader and writer now sources this lib instead of assembling paths inline.
- **Updated all 4 gate hooks** (`block-unreviewed-merge.sh`, `require-design-review-for-ui.sh`, `require-architecture-review.sh`, `warn-stale-review-markers.sh`) to compute repo-qualified marker paths. Each hook already extracted the repo from the merge command's `--repo` flag or API URL path; that extraction is now also used for marker addressing.
- **Updated all 6 writers** (skills: `/approve-merge`, `/approve-design`, `/approve-architecture`, `/design-review`; agents: `code-reviewer` (Rex), `solution-architect` (Tariq)) to document the qualified marker path scheme and source `_lib-review-markers.sh` in their bash snippets.
- **Added cross-repo collision regression tests** — three new cases across the three test suites prove that same-PR-number markers in different repos are distinct, non-colliding files and that one cannot satisfy the gate for the other. Total test counts: 25 (block-unreviewed-merge), 19 (require-architecture-review), 9 (warn-stale-review-markers) — all passing.

<!-- agdr: docs/agdr/AgDR-0060-review-marker-repo-qualifier.md -->

## Backward compatibility

New scheme only — no dual-read fallback. Markers are gitignored ephemeral session state; the only cost of the hard-cutover is one re-approval invocation per session that had pre-existing markers. The SHA-match check in all gate hooks is unchanged and untouched — it remains the safety backstop that prevents a stale or mismatched marker from producing a wrong merge.

## Two-reviews gate and SHA-check: unchanged in strength

The gate logic in `block-unreviewed-merge.sh` is structurally identical: still requires both Rex and CEO markers, still validates `sha=`, `approved_by=user`, `skill_version>=2` on the CEO marker, still resolves PR HEAD via `gh pr view` and rejects on SHA mismatch. The only change is which path it looks for. The compound-command inline detection (introduced in #426) is preserved and updated to match both the new qualified basename and the old bare-number form as a belt-and-suspenders fallback for any skill code that has not yet been updated.

## Testing

```bash
# All three touched hook test suites — run from the worktree root:
bash .claude/hooks/tests/test_block_unreviewed_merge.sh
bash .claude/hooks/tests/test_require_architecture_review.sh
bash .claude/hooks/tests/test_warn_stale_review_markers.sh

# Site-counts drift check (confirms _lib-review-markers.sh is excluded from
# the hook count as a _lib-* file — no count drift):
bash .claude/hooks/tests/test_site_counts.sh

# shellcheck -S warning clean on all modified/new hook files:
shellcheck -S warning \
  .claude/hooks/_lib-review-markers.sh \
  .claude/hooks/_lib-extract-pr.sh \
  .claude/hooks/block-unreviewed-merge.sh \
  .claude/hooks/require-architecture-review.sh \
  .claude/hooks/require-design-review-for-ui.sh \
  .claude/hooks/warn-stale-review-markers.sh
```

Results:

```
test_block_unreviewed_merge.sh    PASS: 25   FAIL: 0
test_require_architecture_review.sh   PASS: 19   FAIL: 0
test_warn_stale_review_markers.sh     PASS: 9    FAIL: 0
test_site_counts.sh               PASS (no drift, hooks=38, skills=59, roles=20)
shellcheck                        clean (no warnings at -S warning)
```

Key regression test output:

```
PASS [cross-repo: repo-A PR#100 markers do NOT satisfy repo-B PR#100 gate (#485)]
PASS [cross-repo: repo-B PR#100 markers DO satisfy repo-B PR#100 gate (#485)]
PASS [cross-repo: same PR# in two repos produces distinct, coexisting marker files (#485)]
PASS [cross-repo: repo-A marker blocks repo-B gate (#485)]
PASS [cross-repo: correct repo marker allows gate (#485)]
PASS [cross-repo-isolation-silent]
```

## Glossary

| Term | Definition |
|------|------------|
| **Review marker** | A file under `.claude/session/reviews/` that records a per-PR approval (Rex / CEO / design / architecture). Gate hooks check these before allowing a merge. |
| **Repo-qualified marker** | A marker whose filename encodes the owner/repo pair — `<owner>__<repo>__<pr>-<role>.approved` — so the same PR number in two different repos maps to two distinct files. |
| **`__` separator** | Double-underscore used to encode the `/` in `owner/repo`. GitHub slugs use only `[a-zA-Z0-9._-]`, so `__` is unambiguous and can be split back to three components reliably. |
| **`_lib-review-markers.sh`** | New shared shell library exposing `review_marker_path` and `review_markers_dir`. All 4 gate hooks and 6 writers source it. `_lib-*` prefix keeps it excluded from the hook count. |
| **Collision hazard** | The original defect: two repos each with PR #429 writing to the same `429-rex.approved` filename — a stale marker from one repo appearing as valid for the other. |
| **SHA-match backstop** | The existing gate-hook check comparing marker SHA against the PR's GitHub HEAD. Prevents a wrong merge even with a stale cross-repo marker. This fix removes the misleading-marker and overwrite hazards; the SHA check remains unchanged. |

Closes #485
