### PR TITLE
feat(#489): fire the MCP-search advisory on Read/Glob/Grep for workspace paths

### DIFF
--- a/.claude/hooks/suggest-mcp-search.sh
+++ b/.claude/hooks/suggest-mcp-search.sh
@@ -2,8 +2,15 @@
 # Advisory hook: reminds the agent to try MCP search tools (search_docs,
 # search_code) before falling back to grep+Read for codebase exploration.
 #
-# Fires on PreToolUse for Bash when the command matches grep/find patterns
-# that target framework or project paths. Non-blocking (exit 0 always).
+# Fires on PreToolUse for:
+#   - Bash: when the command matches grep/find patterns that target framework
+#     or project paths (original behaviour, unchanged).
+#   - Read/Glob/Grep: when the target path resolves inside a managed-project
+#     workspace clone (workspace/<project>/) — closes the bypass where an
+#     agent can sidestep the nudge by using native read tools instead of Bash.
+#     (#489)
+#
+# Non-blocking (exit 0 always).
 #
 # The MCP vector search returns targeted excerpts from indexed chunks,
 # saving ~3-5x tokens compared to reading full files via grep+Read.
@@ -14,68 +21,108 @@
 # invisible to the agent — the exact failure this hook exists to prevent.
 # It is also install-gated: it only nudges when the `apexyard-search` MCP
 # server is actually configured, so adopters without the premium search
-# component fall back to plain grep silently.
+# component fall back to plain grep silently. FREE ADOPTERS SEE NOTHING.
 #
-# Wired to: PreToolUse → Bash (no `if` matcher — checks command internally)
-# See: me2resh/apexyard#418 (original), #469 (additionalContext + install-gate)
+# Wired to: PreToolUse → Bash|Read|Glob|Grep (checks paths/commands internally)
+# See: me2resh/apexyard#418 (original), #469 (additionalContext + install-gate),
+#      #489 (Read/Glob/Grep workspace-path extension)
 
 set -u
 
 INPUT=$(cat)
 
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-[ "$TOOL_NAME" = "Bash" ] || exit 0
 
-COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-[ -n "$COMMAND" ] || exit 0
+# ---------------------------------------------------------------------------
+# Branch on tool type. Bash uses the original grep/find command scanner.
+# Read/Glob/Grep use a simpler workspace-path check on their input paths.
+# Any other tool exits immediately.
+# ---------------------------------------------------------------------------
 
-# --- Detect grep/find patterns that MCP could serve better ----------------
-
-is_search_command=false
-
-case "$COMMAND" in
-  grep\ -rn*|grep\ -r*|grep\ --include*|grep\ -l*)
-    is_search_command=true ;;
-  *"| grep"*)
-    is_search_command=true ;;
+case "$TOOL_NAME" in
+  Bash) ;;
+  Read|Glob|Grep) ;;
+  *) exit 0 ;;
 esac
 
-if echo "$COMMAND" | grep -qE '^find .+ -name .+\.(md|yaml|yml|ts|tsx|js|py)'; then
-  is_search_command=true
-fi
+if [ "$TOOL_NAME" = "Bash" ]; then
+  # -------------------------------------------------------------------------
+  # BASH BRANCH: original behaviour, unchanged.
+  # -------------------------------------------------------------------------
 
-$is_search_command || exit 0
+  COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+  [ -n "$COMMAND" ] || exit 0
 
-# --- Check if the search targets framework or project paths ---------------
+  # --- Detect grep/find patterns that MCP could serve better ---------------
 
-targets_framework=false
+  is_search_command=false
 
-framework_patterns=(
-  ".claude/"
-  "roles/"
-  "workflows/"
-  "templates/"
-  "docs/agdr"
-  "handbooks/"
-  "skills/"
-  "hooks/"
-  "topologies/"
-  "golden-paths/"
-)
+  case "$COMMAND" in
+    grep\ -rn*|grep\ -r*|grep\ --include*|grep\ -l*)
+      is_search_command=true ;;
+    *"| grep"*)
+      is_search_command=true ;;
+  esac
 
-for pattern in "${framework_patterns[@]}"; do
-  if echo "$COMMAND" | grep -q "$pattern"; then
-    targets_framework=true
-    break
+  if echo "$COMMAND" | grep -qE '^find .+ -name .+\.(md|yaml|yml|ts|tsx|js|py)'; then
+    is_search_command=true
   fi
-done
 
-# Also check for workspace/ or projects/ (managed project code)
-if echo "$COMMAND" | grep -qE '(workspace/|projects/)'; then
-  targets_framework=true
+  $is_search_command || exit 0
+
+  # --- Check if the search targets framework or project paths ---------------
+
+  targets_framework=false
+
+  framework_patterns=(
+    ".claude/"
+    "roles/"
+    "workflows/"
+    "templates/"
+    "docs/agdr"
+    "handbooks/"
+    "skills/"
+    "hooks/"
+    "topologies/"
+    "golden-paths/"
+  )
+
+  for pattern in "${framework_patterns[@]}"; do
+    if echo "$COMMAND" | grep -q "$pattern"; then
+      targets_framework=true
+      break
+    fi
+  done
+
+  # Also check for workspace/ or projects/ (managed project code)
+  if echo "$COMMAND" | grep -qE '(workspace/|projects/)'; then
+    targets_framework=true
+  fi
+
+  $targets_framework || exit 0
+
+else
+  # -------------------------------------------------------------------------
+  # READ / GLOB / GREP BRANCH (#489): fire when the target path is inside a
+  # managed-project workspace clone (workspace/<project>/).
+  #
+  # Field layout per Claude Code tool_input schema:
+  #   Read  → .tool_input.file_path
+  #   Glob  → .tool_input.path  (directory to glob in; pattern in .tool_input.pattern)
+  #   Grep  → .tool_input.path  (directory to search in; pattern in .tool_input.pattern)
+  # We use file_path // path to cover all three shapes in one jq query.
+  # -------------------------------------------------------------------------
+
+  TARGET_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+  [ -n "$TARGET_PATH" ] || exit 0
+
+  # Only proceed when the path is inside a workspace clone.
+  case "$TARGET_PATH" in
+    *workspace/*) ;;
+    *) exit 0 ;;
+  esac
+
 fi
-
-$targets_framework || exit 0
 
 # --- Install-gate: only nudge if apexyard-search is actually configured -----
 # Resolve the ops fork from this hook's own location, and also honour

--- a/.claude/hooks/tests/test_suggest_mcp_search.sh
+++ b/.claude/hooks/tests/test_suggest_mcp_search.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Tests for suggest-mcp-search.sh advisory hook (#418, #469).
+# Tests for suggest-mcp-search.sh advisory hook (#418, #469, #489).
 # Run: bash .claude/hooks/tests/test_suggest_mcp_search.sh
 #
 # #469: the hook now (a) emits its advisory as hookSpecificOutput.additional
@@ -7,6 +7,10 @@
 # and (b) is install-gated — it only fires when `apexyard-search` is configured
 # in a resolvable .mcp.json. These tests inject the gate via a temp
 # $APEXYARD_PORTFOLIO_ROOT/.mcp.json fixture.
+#
+# #489: the hook also fires on Read/Glob/Grep when the target path is inside
+# a managed-project workspace clone (workspace/<project>/). The install-gate
+# applies equally — free adopters without apexyard-search see nothing.
 
 set -u
 
@@ -95,11 +99,58 @@ assert_silent "non-search command (ls)" \
 assert_silent "search but not a framework/workspace path" \
   '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"TODO\" src/"}}' "$MCP_DIR"
 
-assert_silent "non-Bash tool" \
+assert_silent "Bash: non-grep command (ls)" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"ls workspace/"}}' "$MCP_DIR"
+
+assert_silent "Bash: non-grep bash command (npm)" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"npm test"}}' "$MCP_DIR"
+
+# --- Read / Glob / Grep: fire on workspace/ paths (gate OPEN) ---------------
+
+assert_advisory "Read on workspace/<proj> path" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"workspace/example-app/src/index.ts"}}'
+
+assert_advisory "Glob on workspace/<proj> path" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Glob","tool_input":{"path":"workspace/example-app/src/","pattern":"**/*.ts"}}'
+
+assert_advisory "Grep on workspace/<proj> path" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Grep","tool_input":{"path":"workspace/example-app/","pattern":"export"}}'
+
+# --- Read / Glob / Grep: gate CLOSED (free adopter) → silent ----------------
+
+assert_silent "Read: gate closed (no apexyard-search)" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"workspace/example-app/src/index.ts"}}' \
+  "$NO_MCP_DIR"
+
+assert_silent "Glob: gate closed (no apexyard-search)" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Glob","tool_input":{"path":"workspace/example-app/src/","pattern":"**/*.ts"}}' \
+  "$NO_MCP_DIR"
+
+assert_silent "Grep: gate closed (no apexyard-search)" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Grep","tool_input":{"path":"workspace/example-app/","pattern":"export"}}' \
+  "$NO_MCP_DIR"
+
+# --- Read / Glob / Grep: paths OUTSIDE workspace/ → silent even gate open ---
+
+assert_silent "Read: path outside workspace/ (framework file)" \
   '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"roles/engineering/tech-lead.md"}}' "$MCP_DIR"
 
-assert_silent "non-grep bash command (npm)" \
-  '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"npm test"}}' "$MCP_DIR"
+assert_silent "Read: path outside workspace/ (src/)" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"src/something.ts"}}' "$MCP_DIR"
+
+assert_silent "Glob: path outside workspace/" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Glob","tool_input":{"path":"src/","pattern":"**/*.ts"}}' "$MCP_DIR"
+
+assert_silent "Grep: path outside workspace/" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Grep","tool_input":{"path":"src/","pattern":"export"}}' "$MCP_DIR"
+
+# --- Other tool types → always silent --------------------------------------
+
+assert_silent "Write tool: not triggered" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"workspace/example-app/src/foo.ts","content":"x"}}' "$MCP_DIR"
+
+assert_silent "Edit tool: not triggered" \
+  '{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"workspace/example-app/src/foo.ts","old_string":"x","new_string":"y"}}' "$MCP_DIR"
 
 # --- Report ----------------------------------------------------------------
 echo ""

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -66,6 +66,15 @@
         ]
       },
       {
+        "matcher": "Read|Glob|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/suggest-mcp-search.sh\"'"
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {


### PR DESCRIPTION
## Summary

- **Closes the Read/Glob/Grep bypass** — the `suggest-mcp-search` advisory previously only fired on `Bash` tool calls. An agent could sidestep the nudge entirely by reaching for `Read`, `Glob`, or `Grep` against a workspace-clone path, which never triggered the banner. This PR extends the hook to cover all three tools when the target path is inside `workspace/<project>/`.
- **Workspace-scoped, not blanket** — the new Read/Glob/Grep branch only fires when the resolved path contains `workspace/`. Framework file reads (e.g. `Read roles/engineering/tech-lead.md`) are untouched and stay silent, preserving the original behaviour's intent that the nudge only applies to managed-project code lookups.
- **Install-gate fully preserved for all tools** — the load-bearing `apexyard-search` check in `.mcp.json` applies equally to the new Read/Glob/Grep branch. Free adopters who don't have the premium `apexyard-search` MCP configured will see **nothing** from this hook regardless of which tool they use. This was an explicit requirement and is verified by three dedicated test cases (one per tool in the no-MCP fixture).
- **settings.json wired** — a new `Read|Glob|Grep` PreToolUse matcher block invokes the same ops-root-resolving hook wrapper already used by the Bash entry.

## Testing

```bash
# All 23 cases pass, 0 failures
bash .claude/hooks/tests/test_suggest_mcp_search.sh

# Hook count unchanged (edited existing file, did not add one)
bash .claude/hooks/tests/test_site_counts.sh

# shellcheck clean
shellcheck .claude/hooks/suggest-mcp-search.sh
```

Test coverage added (#489 cases):
- Read/Glob/Grep on `workspace/<project>/...` path WITH apexyard-search configured → advisory fires
- Read/Glob/Grep on `workspace/<project>/...` path WITHOUT apexyard-search (free adopter) → silent
- Read/Glob/Grep on paths OUTSIDE `workspace/` (framework files, `src/`, etc.) → silent
- Write/Edit tools on workspace paths → silent (only Bash/Read/Glob/Grep are in scope)
- All original Bash cases unchanged and passing

## Glossary

| Term | Definition |
|------|------------|
| advisory hook | A `PreToolUse` hook that emits guidance as `hookSpecificOutput.additionalContext` JSON on stdout and always exits 0 — never blocks the tool call |
| install-gate | The `.mcp.json` check that ensures the hook stays silent for free adopters who don't have the `apexyard-search` premium MCP configured |
| workspace clone | A local working copy of a registered managed project, living under `workspace/<name>/` in the ops repo |
| MCP-first | The framework guideline to prefer `apexyard-search` semantic search over `grep`/`Read` for managed-project code lookups (~3–5× fewer tokens) |

Closes #489
