### PR TITLE
chore(#491): bump marketing-site framework version to 2.2.0

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -51,10 +51,10 @@
   "url": "https://yard.apexscript.com/",
   "description": "Ship AI-built software like a real engineering team. Automatic code review, launch-readiness checks, one inbox for every product — on Claude Code.",
   "license": "https://opensource.org/licenses/MIT",
-  "softwareVersion": "1.3.0",
+  "softwareVersion": "2.2.0",
   "downloadUrl": "https://github.com/me2resh/apexyard",
   "datePublished": "2026-04-09",
-  "dateModified": "2026-05-24",
+  "dateModified": "2026-05-29",
   "copyrightYear": "2026",
   "copyrightHolder": {
     "@type": "Person",
@@ -1565,7 +1565,7 @@ a:hover { color: var(--accent); }
   <div class="hero__inner">
 
     <div class="hero__eyebrow rise rise-1">
-      <span class="pill">apexyard v1.1</span>
+      <span class="pill">apexyard v2.2</span>
       <span>open source · built for founders shipping with AI</span>
       <button class="copy-for-ai" data-md-url="/index.md" type="button" style="margin-left:auto;font-size:0.75rem;padding:0.25rem 0.6rem;border:1px solid currentColor;border-radius:4px;background:transparent;color:inherit;cursor:pointer;font-family:inherit;">Copy as Markdown for AI</button>
     </div>
@@ -1573,7 +1573,7 @@ a:hover { color: var(--accent); }
     <h1 class="hero__title rise rise-2">apexyard</h1>
 
     <p class="hero__version rise rise-2" style="margin:-0.5em 0 0.5em;font-size:13px;opacity:0.55;letter-spacing:0.05em;">
-      <a href="https://github.com/me2resh/apexyard/releases/tag/v1.1.0" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v1.1.0</a>
+      <a href="https://github.com/me2resh/apexyard/releases/tag/v2.2.0" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v2.2.0</a>
       &nbsp;·&nbsp;
       <a href="https://github.com/me2resh/apexyard/blob/main/CHANGELOG.md" style="color:inherit;text-decoration:underline;text-underline-offset:3px;" target="_blank" rel="noopener">changelog</a>
     </p>
@@ -1692,8 +1692,8 @@ a:hover { color: var(--accent); }
       <span>PRs reviewed &amp; merged · last 90 days</span>
     </div>
     <div class="hero__metric">
-      <strong>7</strong>
-      <span>Production releases shipped (v0.1 → v1.3)</span>
+      <strong>12</strong>
+      <span>Production releases shipped (v0.1 → v2.2)</span>
     </div>
     <div class="hero__metric">
       <strong>29</strong>


### PR DESCRIPTION
## Summary

- **Fixes the stale framework version on the public marketing site** (`site/index.html`, served at yard.apexscript.com). The CEO spotted the JSON-LD advertising `1.3.0` while the framework is at `2.2.0`; the hero also still read `apexyard v1.1` / linked the `v1.1.0` release. The labels had drifted ~5 release cycles because `/release` doesn't bump the site.
- **JSON-LD** — `softwareVersion` `1.3.0 → 2.2.0`; `dateModified` `2026-05-24 → 2026-05-29` (the v2.2.0 release date) so the structured data is internally coherent.
- **Hero** — pill `apexyard v1.1 → v2.2`; version link text + `releases/tag/` href `v1.1.0 → v2.2.0` (tag verified to exist).
- **Releases metric** — `7 → 12` and range `(v0.1 → v1.3) → (v0.1 → v2.2)`; 12 matches the CHANGELOG release-entry count (`0.1.0 … 2.2.0`).
- **Historical strings left untouched** — the `## [1.3.0]` CHANGELOG entry, `v1.2.0-to-v1.3.0.sh` migration-script names, and AgDR examples are correct history, not drift.

Follow-up (out of scope): make `/release` update the site version strings so this can't drift again — noted on the ticket.

## Testing

- `bash .claude/hooks/tests/test_site_counts.sh` → PASS (skills/hooks/roles counts unchanged; per-page payload-size meta within 5%).
- `gh release view v2.2.0` confirms the hero link target resolves (link-check safe).
- Visual: only the five version strings changed (see diff) — no layout/content drift.

## Glossary

| Term | Definition |
|------|------------|
| JSON-LD `softwareVersion` | Schema.org structured-data field search engines read for the app's advertised version |
| Release-cut drift | Version labels going stale because the release flow updates the tag but not the site's hard-coded strings |

Closes #491
