### PR TITLE
fix(#494): block build-agent self-review — require a real GitHub review behind the rex marker

### DIFF
--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -23,6 +23,7 @@ This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on t
 You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
 
 **MUST NOT:**
+
 - Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
 - Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
 - Impersonate Rex or present your self-check as an independent review

--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -18,6 +18,17 @@ When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_
 
 This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Backend Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.
 
+## You cannot self-review
+
+You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
+
+**MUST NOT:**
+- Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
+- Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
+- Impersonate Rex or present your self-check as an independent review
+
+**DO:** Report your build results plainly — what you built, what tests you ran, what passed or failed. The orchestrator runs the real, independent Rex review after you hand off.
+
 ---
 
 *Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/.claude/agents/data-engineer.md
+++ b/.claude/agents/data-engineer.md
@@ -18,6 +18,17 @@ When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_
 
 This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Data Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.
 
+## You cannot self-review
+
+You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
+
+**MUST NOT:**
+- Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
+- Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
+- Impersonate Rex or present your self-check as an independent review
+
+**DO:** Report your build results plainly — what you built, what tests you ran, what passed or failed. The orchestrator runs the real, independent Rex review after you hand off.
+
 ---
 
 *Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/.claude/agents/data-engineer.md
+++ b/.claude/agents/data-engineer.md
@@ -23,6 +23,7 @@ This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on t
 You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
 
 **MUST NOT:**
+
 - Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
 - Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
 - Impersonate Rex or present your self-check as an independent review

--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -23,6 +23,7 @@ This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on t
 You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
 
 **MUST NOT:**
+
 - Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
 - Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
 - Impersonate Rex or present your self-check as an independent review

--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -18,6 +18,17 @@ When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_
 
 This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Frontend Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.
 
+## You cannot self-review
+
+You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
+
+**MUST NOT:**
+- Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
+- Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
+- Impersonate Rex or present your self-check as an independent review
+
+**DO:** Report your build results plainly — what you built, what tests you ran, what passed or failed. The orchestrator runs the real, independent Rex review after you hand off.
+
 ---
 
 *Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/.claude/agents/platform-engineer.md
+++ b/.claude/agents/platform-engineer.md
@@ -18,6 +18,17 @@ When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_
 
 This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Platform Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.
 
+## You cannot self-review
+
+You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
+
+**MUST NOT:**
+- Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
+- Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
+- Impersonate Rex or present your self-check as an independent review
+
+**DO:** Report your build results plainly — what you built, what tests you ran, what passed or failed. The orchestrator runs the real, independent Rex review after you hand off.
+
 ---
 
 *Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/.claude/agents/platform-engineer.md
+++ b/.claude/agents/platform-engineer.md
@@ -23,6 +23,7 @@ This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on t
 You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
 
 **MUST NOT:**
+
 - Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
 - Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
 - Impersonate Rex or present your self-check as an independent review

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -14,6 +14,17 @@ Read and adopt `@roles/product/product-manager.md` for full identity, responsibi
 
 This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Product Manager"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.
 
+## You cannot self-review
+
+You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
+
+**MUST NOT:**
+- Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
+- Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
+- Impersonate Rex or present your self-check as an independent review
+
+**DO:** Report your build results plainly — what you built, what tasks you completed, what acceptance criteria you verified. The orchestrator runs the real, independent Rex review after you hand off.
+
 ---
 
 *Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -19,6 +19,7 @@ This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on t
 You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
 
 **MUST NOT:**
+
 - Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
 - Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
 - Impersonate Rex or present your self-check as an independent review

--- a/.claude/agents/ui-designer.md
+++ b/.claude/agents/ui-designer.md
@@ -14,6 +14,17 @@ Read and adopt `@roles/design/ui-designer.md` for full identity, responsibilitie
 
 This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as UI Designer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.
 
+## You cannot self-review
+
+You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
+
+**MUST NOT:**
+- Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
+- Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
+- Impersonate Rex or present your self-check as an independent review
+
+**DO:** Report your build results plainly — what you designed, what deliverables you produced, what acceptance criteria you verified. The orchestrator runs the real, independent Rex review after you hand off.
+
 ---
 
 *Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/.claude/agents/ui-designer.md
+++ b/.claude/agents/ui-designer.md
@@ -19,6 +19,7 @@ This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on t
 You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
 
 **MUST NOT:**
+
 - Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
 - Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
 - Impersonate Rex or present your self-check as an independent review

--- a/.claude/agents/ux-designer.md
+++ b/.claude/agents/ux-designer.md
@@ -14,6 +14,17 @@ Read and adopt `@roles/design/ux-designer.md` for full identity, responsibilitie
 
 This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as UX Designer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.
 
+## You cannot self-review
+
+You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
+
+**MUST NOT:**
+- Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
+- Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
+- Impersonate Rex or present your self-check as an independent review
+
+**DO:** Report your build results plainly — what you designed, what deliverables you produced, what acceptance criteria you verified. The orchestrator runs the real, independent Rex review after you hand off.
+
 ---
 
 *Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/.claude/agents/ux-designer.md
+++ b/.claude/agents/ux-designer.md
@@ -19,6 +19,7 @@ This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on t
 You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot spawn the real code-reviewer (Rex). Because of this, any review you produce is not independent — it is the author reviewing their own work, which defeats the two-reviews merge gate.
 
 **MUST NOT:**
+
 - Write any file under `.claude/session/reviews/` — this includes `*-rex.approved`, `*-ceo.approved`, or any other marker
 - Frame your final report as a "Code Review", "Rex review", "Rex Code Review", or include a "Verdict: APPROVED / CHANGES REQUESTED" section
 - Impersonate Rex or present your self-check as an independent review

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -42,18 +42,9 @@
 # grep-able rule violation — much more obvious than an `echo $SHA`. See
 # me2resh/apexyard#48 for the design rationale.
 #
-# The Rex marker is a bare-SHA file, same as before #494 — but starting
-# with #494 the hook also verifies that a real GitHub review was posted at
-# the PR HEAD. A fabricated local file with no corresponding GitHub review
-# is rejected. See AgDR-0062 for the design.
-#
-# Rex posts a COMMENT-type review (GitHub blocks self-approval on own-PR),
-# so the check accepts ANY review state (APPROVED, COMMENTED,
-# CHANGES_REQUESTED) by any reviewer at HEAD — not just APPROVED.
-#
-# Graceful degrade: if gh is unavailable (network/auth), the hook warns
-# and falls back to the prior SHA-only behaviour. An infra failure must
-# not permanently brick the merge gate.
+# The Rex marker is unchanged (still bare-SHA) because Rex's marker is
+# written by the code-reviewer agent's automated review flow, not an
+# explicit human-authorization moment. Different threat model.
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -201,94 +192,6 @@ New commits were pushed after the Rex review. Re-invoke Rex on the latest
 HEAD before merging.
 MSG
   exit 2
-fi
-
-# --- Rex real-GitHub-review check (#494) ---
-# Require a real posted GitHub review at the PR HEAD by an INDEPENDENT
-# reviewer (not the PR author), not just a local file.
-#
-# This prevents build agents fabricating a *-rex.approved file without the
-# real code-reviewer agent ever posting a review on GitHub. It also prevents
-# a build sub-agent self-posting a COMMENT-type review via `gh pr review
-# --comment` (GitHub only blocks self-*approval*, not self-*comment*) and
-# then writing the marker. An independent review must exist.
-#
-# Rex posts a COMMENT-type review (GitHub blocks self-approval on own PR)
-# so we accept any review state — APPROVED, COMMENTED, CHANGES_REQUESTED —
-# but the review MUST come from someone other than the PR author.
-#
-# Graceful degrade: if gh is unavailable (non-zero exit or unparseable JSON),
-# warn and fall back to the prior SHA-only behaviour. An infrastructure
-# failure must not permanently block merges. Note: a determined actor could
-# deliberately trigger a gh-failure (e.g. by revoking auth mid-session) to
-# reach this weaker path — the warning on stderr surfaces that the check was
-# skipped so the operator can decide whether the merge is safe.
-_GH_REVIEW_CHECK_SKIPPED=0
-
-# Fetch the PR author's login so we can exclude self-reviews.
-_PR_AUTHOR=""
-if [ -n "$CMD_REPO" ]; then
-  _PR_AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$CMD_REPO" \
-    --json author -q '.author.login' 2>/dev/null)
-else
-  _PR_AUTHOR=$(gh pr view "$PR_NUMBER" \
-    --json author -q '.author.login' 2>/dev/null)
-fi
-# A missing author is non-fatal — we will still filter on it below, but
-# if gh failed here it will also fail on the reviews call and we will
-# gracefully degrade from there.
-
-if [ -n "$CMD_REPO" ]; then
-  _REVIEWS_JSON=$(gh pr view "$PR_NUMBER" --repo "$CMD_REPO" \
-    --json reviews -q '.reviews' 2>/dev/null)
-else
-  _REVIEWS_JSON=$(gh pr view "$PR_NUMBER" \
-    --json reviews -q '.reviews' 2>/dev/null)
-fi
-
-if [ -z "$_REVIEWS_JSON" ]; then
-  # gh call failed — network, auth, or gh not installed.
-  echo "WARN: Could not fetch GitHub reviews for PR #${PR_NUMBER} — skipping real-review check (falling back to SHA-only). Re-authenticate gh if this persists." >&2
-  _GH_REVIEW_CHECK_SKIPPED=1
-fi
-
-if [ "$_GH_REVIEW_CHECK_SKIPPED" = "0" ] && [ -n "$CURRENT_SHA" ]; then
-  # Look for any review at CURRENT_SHA by an author OTHER THAN the PR author.
-  # GitHub's reviews array contains objects with at least:
-  #   { "state": "APPROVED|COMMENTED|CHANGES_REQUESTED",
-  #     "commit": { "oid": "<sha>" },
-  #     "author": { "login": "<login>" } }
-  # We require at least one review where:
-  #   - commit.oid == HEAD sha, AND
-  #   - author.login != the PR author (independent reviewer)
-  _REVIEW_AT_HEAD=$(echo "$_REVIEWS_JSON" | \
-    jq -r --arg sha "$CURRENT_SHA" --arg author "$_PR_AUTHOR" \
-      '[.[] | select(.commit.oid == $sha and .author.login != $author)] | length' 2>/dev/null)
-
-  if [ -z "$_REVIEW_AT_HEAD" ]; then
-    # jq unavailable or parse failed — degrade gracefully.
-    echo "WARN: Could not parse GitHub reviews JSON for PR #${PR_NUMBER} — skipping real-review check (jq parse failure)." >&2
-    _GH_REVIEW_CHECK_SKIPPED=1
-  elif [ "$_REVIEW_AT_HEAD" = "0" ]; then
-    cat >&2 <<MSG
-BLOCKED: rex marker present but no INDEPENDENT GitHub review at HEAD ${CURRENT_SHA:0:7} — a self-review by the PR author does not count.
-
-A fabricated local marker file is not sufficient, and a review posted by
-the PR author themselves does not satisfy the gate. The real code-reviewer
-(Rex) — running as a different GitHub identity — must post an actual GitHub
-review on this PR before the merge gate can be satisfied.
-
-To unblock:
-  1. Invoke the real code-reviewer agent on this PR:
-       /code-review
-  2. Rex will post a review comment on GitHub and record the marker.
-  3. Retry the merge.
-
-See AgDR-0062 and .claude/rules/pr-workflow.md § "Build agents cannot
-self-review" for the rationale.
-MSG
-    exit 2
-  fi
 fi
 
 # --- CEO marker check ---

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -204,19 +204,40 @@ MSG
 fi
 
 # --- Rex real-GitHub-review check (#494) ---
-# Require a real posted GitHub review at the PR HEAD, not just a local file.
+# Require a real posted GitHub review at the PR HEAD by an INDEPENDENT
+# reviewer (not the PR author), not just a local file.
+#
 # This prevents build agents fabricating a *-rex.approved file without the
-# real code-reviewer agent ever posting a review on GitHub.
+# real code-reviewer agent ever posting a review on GitHub. It also prevents
+# a build sub-agent self-posting a COMMENT-type review via `gh pr review
+# --comment` (GitHub only blocks self-*approval*, not self-*comment*) and
+# then writing the marker. An independent review must exist.
 #
 # Rex posts a COMMENT-type review (GitHub blocks self-approval on own PR)
-# so we accept any review state — APPROVED, COMMENTED, CHANGES_REQUESTED.
-# The invariant is that a human-visible review exists in the GitHub audit
-# trail at HEAD, not that it has a particular verdict.
+# so we accept any review state — APPROVED, COMMENTED, CHANGES_REQUESTED —
+# but the review MUST come from someone other than the PR author.
 #
-# Graceful degrade: if gh is unavailable, warn and skip this check so an
-# infra outage does not permanently block merges. The SHA-match above still
-# applies — the local marker must exist and match HEAD.
+# Graceful degrade: if gh is unavailable (non-zero exit or unparseable JSON),
+# warn and fall back to the prior SHA-only behaviour. An infrastructure
+# failure must not permanently block merges. Note: a determined actor could
+# deliberately trigger a gh-failure (e.g. by revoking auth mid-session) to
+# reach this weaker path — the warning on stderr surfaces that the check was
+# skipped so the operator can decide whether the merge is safe.
 _GH_REVIEW_CHECK_SKIPPED=0
+
+# Fetch the PR author's login so we can exclude self-reviews.
+_PR_AUTHOR=""
+if [ -n "$CMD_REPO" ]; then
+  _PR_AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$CMD_REPO" \
+    --json author -q '.author.login' 2>/dev/null)
+else
+  _PR_AUTHOR=$(gh pr view "$PR_NUMBER" \
+    --json author -q '.author.login' 2>/dev/null)
+fi
+# A missing author is non-fatal — we will still filter on it below, but
+# if gh failed here it will also fail on the reviews call and we will
+# gracefully degrade from there.
+
 if [ -n "$CMD_REPO" ]; then
   _REVIEWS_JSON=$(gh pr view "$PR_NUMBER" --repo "$CMD_REPO" \
     --json reviews -q '.reviews' 2>/dev/null)
@@ -232,13 +253,17 @@ if [ -z "$_REVIEWS_JSON" ]; then
 fi
 
 if [ "$_GH_REVIEW_CHECK_SKIPPED" = "0" ] && [ -n "$CURRENT_SHA" ]; then
-  # Look for any review submitted at or after CURRENT_SHA.
+  # Look for any review at CURRENT_SHA by an author OTHER THAN the PR author.
   # GitHub's reviews array contains objects with at least:
-  #   { "state": "APPROVED|COMMENTED|CHANGES_REQUESTED", "commit": { "oid": "<sha>" } }
-  # We accept any review whose commit.oid matches the HEAD SHA.
+  #   { "state": "APPROVED|COMMENTED|CHANGES_REQUESTED",
+  #     "commit": { "oid": "<sha>" },
+  #     "author": { "login": "<login>" } }
+  # We require at least one review where:
+  #   - commit.oid == HEAD sha, AND
+  #   - author.login != the PR author (independent reviewer)
   _REVIEW_AT_HEAD=$(echo "$_REVIEWS_JSON" | \
-    jq -r --arg sha "$CURRENT_SHA" \
-      '[.[] | select(.commit.oid == $sha)] | length' 2>/dev/null)
+    jq -r --arg sha "$CURRENT_SHA" --arg author "$_PR_AUTHOR" \
+      '[.[] | select(.commit.oid == $sha and .author.login != $author)] | length' 2>/dev/null)
 
   if [ -z "$_REVIEW_AT_HEAD" ]; then
     # jq unavailable or parse failed — degrade gracefully.
@@ -246,12 +271,12 @@ if [ "$_GH_REVIEW_CHECK_SKIPPED" = "0" ] && [ -n "$CURRENT_SHA" ]; then
     _GH_REVIEW_CHECK_SKIPPED=1
   elif [ "$_REVIEW_AT_HEAD" = "0" ]; then
     cat >&2 <<MSG
-BLOCKED: rex marker present for PR #${PR_NUMBER} but no posted GitHub review at HEAD ${CURRENT_SHA:0:7}.
+BLOCKED: rex marker present but no INDEPENDENT GitHub review at HEAD ${CURRENT_SHA:0:7} — a self-review by the PR author does not count.
 
-A fabricated local marker file is not sufficient — the real code-reviewer
-(Rex) must post an actual GitHub review on this PR before the merge gate
-can be satisfied. A file written by a build agent (platform-engineer,
-backend-engineer, etc.) does not count.
+A fabricated local marker file is not sufficient, and a review posted by
+the PR author themselves does not satisfy the gate. The real code-reviewer
+(Rex) — running as a different GitHub identity — must post an actual GitHub
+review on this PR before the merge gate can be satisfied.
 
 To unblock:
   1. Invoke the real code-reviewer agent on this PR:

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -42,9 +42,18 @@
 # grep-able rule violation — much more obvious than an `echo $SHA`. See
 # me2resh/apexyard#48 for the design rationale.
 #
-# The Rex marker is unchanged (still bare-SHA) because Rex's marker is
-# written by the code-reviewer agent's automated review flow, not an
-# explicit human-authorization moment. Different threat model.
+# The Rex marker is a bare-SHA file, same as before #494 — but starting
+# with #494 the hook also verifies that a real GitHub review was posted at
+# the PR HEAD. A fabricated local file with no corresponding GitHub review
+# is rejected. See AgDR-0062 for the design.
+#
+# Rex posts a COMMENT-type review (GitHub blocks self-approval on own-PR),
+# so the check accepts ANY review state (APPROVED, COMMENTED,
+# CHANGES_REQUESTED) by any reviewer at HEAD — not just APPROVED.
+#
+# Graceful degrade: if gh is unavailable (network/auth), the hook warns
+# and falls back to the prior SHA-only behaviour. An infra failure must
+# not permanently brick the merge gate.
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -192,6 +201,69 @@ New commits were pushed after the Rex review. Re-invoke Rex on the latest
 HEAD before merging.
 MSG
   exit 2
+fi
+
+# --- Rex real-GitHub-review check (#494) ---
+# Require a real posted GitHub review at the PR HEAD, not just a local file.
+# This prevents build agents fabricating a *-rex.approved file without the
+# real code-reviewer agent ever posting a review on GitHub.
+#
+# Rex posts a COMMENT-type review (GitHub blocks self-approval on own PR)
+# so we accept any review state — APPROVED, COMMENTED, CHANGES_REQUESTED.
+# The invariant is that a human-visible review exists in the GitHub audit
+# trail at HEAD, not that it has a particular verdict.
+#
+# Graceful degrade: if gh is unavailable, warn and skip this check so an
+# infra outage does not permanently block merges. The SHA-match above still
+# applies — the local marker must exist and match HEAD.
+_GH_REVIEW_CHECK_SKIPPED=0
+if [ -n "$CMD_REPO" ]; then
+  _REVIEWS_JSON=$(gh pr view "$PR_NUMBER" --repo "$CMD_REPO" \
+    --json reviews -q '.reviews' 2>/dev/null)
+else
+  _REVIEWS_JSON=$(gh pr view "$PR_NUMBER" \
+    --json reviews -q '.reviews' 2>/dev/null)
+fi
+
+if [ -z "$_REVIEWS_JSON" ]; then
+  # gh call failed — network, auth, or gh not installed.
+  echo "WARN: Could not fetch GitHub reviews for PR #${PR_NUMBER} — skipping real-review check (falling back to SHA-only). Re-authenticate gh if this persists." >&2
+  _GH_REVIEW_CHECK_SKIPPED=1
+fi
+
+if [ "$_GH_REVIEW_CHECK_SKIPPED" = "0" ] && [ -n "$CURRENT_SHA" ]; then
+  # Look for any review submitted at or after CURRENT_SHA.
+  # GitHub's reviews array contains objects with at least:
+  #   { "state": "APPROVED|COMMENTED|CHANGES_REQUESTED", "commit": { "oid": "<sha>" } }
+  # We accept any review whose commit.oid matches the HEAD SHA.
+  _REVIEW_AT_HEAD=$(echo "$_REVIEWS_JSON" | \
+    jq -r --arg sha "$CURRENT_SHA" \
+      '[.[] | select(.commit.oid == $sha)] | length' 2>/dev/null)
+
+  if [ -z "$_REVIEW_AT_HEAD" ]; then
+    # jq unavailable or parse failed — degrade gracefully.
+    echo "WARN: Could not parse GitHub reviews JSON for PR #${PR_NUMBER} — skipping real-review check (jq parse failure)." >&2
+    _GH_REVIEW_CHECK_SKIPPED=1
+  elif [ "$_REVIEW_AT_HEAD" = "0" ]; then
+    cat >&2 <<MSG
+BLOCKED: rex marker present for PR #${PR_NUMBER} but no posted GitHub review at HEAD ${CURRENT_SHA:0:7}.
+
+A fabricated local marker file is not sufficient — the real code-reviewer
+(Rex) must post an actual GitHub review on this PR before the merge gate
+can be satisfied. A file written by a build agent (platform-engineer,
+backend-engineer, etc.) does not count.
+
+To unblock:
+  1. Invoke the real code-reviewer agent on this PR:
+       /code-review
+  2. Rex will post a review comment on GitHub and record the marker.
+  3. Retry the merge.
+
+See AgDR-0062 and .claude/rules/pr-workflow.md § "Build agents cannot
+self-review" for the rationale.
+MSG
+    exit 2
+  fi
 fi
 
 # --- CEO marker check ---

--- a/.claude/hooks/tests/test_block_unreviewed_merge.sh
+++ b/.claude/hooks/tests/test_block_unreviewed_merge.sh
@@ -59,7 +59,9 @@ make_sandbox() {
   # Mock `gh` so resolve_pr_head returns FIXED_SHA. The hook calls
   # `gh pr view <N> --json headRefOid -q '.headRefOid'` (or a similar
   # shape) — return the fixed SHA on stdout, no network involved.
-  # Also handles headRefName (sync-PR guard) and headRepository (repo extraction, #485).
+  # Also handles headRefName (sync-PR guard), headRepository (repo extraction, #485),
+  # and reviews (real-GitHub-review gate, #494). The default shim returns a
+  # single COMMENTED review at FIXED_SHA so "happy path" tests keep passing.
   cat > "$sb/bin/gh" <<EOF
 #!/bin/bash
 # Minimal gh shim for test_block_unreviewed_merge.
@@ -67,6 +69,7 @@ case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "feature/GH-99-test" ;;
   *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
+  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"}}]' ;;
   *) ;;
 esac
 exit 0
@@ -382,13 +385,15 @@ make_sandbox_with_sync_branch() {
   local sb branch_name
   branch_name="${1:-sync/main-to-dev-after-v2.3.0}"
   sb=$(make_sandbox)
-  # Rewrite the gh shim to handle headRefOid, headRefName, and headRepository.
+  # Rewrite the gh shim to handle headRefOid, headRefName, headRepository,
+  # and reviews (#494 real-review gate).
   cat > "$sb/bin/gh" <<EOF
 #!/bin/bash
 case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "$branch_name" ;;
   *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
+  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"}}]' ;;
   *) ;;
 esac
 exit 0
@@ -406,6 +411,7 @@ case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "feature/GH-99-something" ;;
   *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
+  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"}}]' ;;
   *) ;;
 esac
 exit 0
@@ -512,6 +518,7 @@ case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "feature/test" ;;
   *"pr view"*"headRepository"*) echo "$repo" ;;
+  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"}}]' ;;
   *) ;;
 esac
 exit 0
@@ -571,6 +578,170 @@ else
   FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}cross-repo-distinct-files "
 fi
 rm -rf "$sb"
+
+# --- Real-GitHub-review gate tests (#494) -----------------------------
+#
+# The hook now also calls `gh pr view --json reviews` and requires at
+# least one review at the PR HEAD SHA. These cases extend the gh shim to
+# return synthetic reviews JSON so we can exercise all three branches:
+#   (a) marker present + real review at HEAD → PASS
+#   (b) marker present + NO review at HEAD → BLOCK
+#   (c) gh unavailable (shim exits non-zero) → warn + fall back to SHA-only → PASS
+
+# make_sandbox_with_reviews <reviews_json>
+# Returns a sandbox where `gh pr view ... --json reviews` outputs the given JSON.
+make_sandbox_with_reviews() {
+  local reviews_json="$1"
+  local sb
+  sb=$(make_sandbox)
+  cat > "$sb/bin/gh" <<EOF
+#!/bin/bash
+case "\$*" in
+  *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
+  *"pr view"*"headRefName"*)    echo "feature/GH-99-test" ;;
+  *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
+  *"pr view"*"--json reviews"*) echo '${reviews_json}' ;;
+  *) ;;
+esac
+exit 0
+EOF
+  chmod +x "$sb/bin/gh"
+  echo "$sb"
+}
+
+# make_sandbox_gh_unavailable: gh shim exits 1 for all calls (simulates
+# network/auth failure). The hook should warn + fall back to SHA-only.
+make_sandbox_gh_unavailable() {
+  local sb
+  sb=$(make_sandbox)
+  cat > "$sb/bin/gh" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+  chmod +x "$sb/bin/gh"
+  echo "$sb"
+}
+
+# Case G1: marker present + real review at HEAD → PASS (#494)
+sb=$(make_sandbox_with_reviews "[{\"state\":\"COMMENTED\",\"commit\":{\"oid\":\"${FIXED_SHA}\"}}]")
+write_rex_marker "$sb" 400
+write_ceo_marker_structured "$sb" 400
+run_case "rex marker + real GitHub review at HEAD → passes (#494)" 0 "" "$sb" 400
+
+# Case G2: marker present + NO review at HEAD → BLOCK (#494)
+# Reviews JSON is empty array — no review exists.
+sb=$(make_sandbox_with_reviews "[]")
+write_rex_marker "$sb" 401
+write_ceo_marker_structured "$sb" 401
+run_case "rex marker + NO GitHub review at HEAD → blocks (#494)" 2 "no posted GitHub review at HEAD" "$sb" 401
+
+# Case G3: marker present + review at DIFFERENT SHA → BLOCK (#494)
+# The review was posted for an older commit, not the current HEAD.
+sb=$(make_sandbox_with_reviews "[{\"state\":\"APPROVED\",\"commit\":{\"oid\":\"${WRONG_SHA}\"}}]")
+write_rex_marker "$sb" 402
+write_ceo_marker_structured "$sb" 402
+run_case "rex marker + review at WRONG SHA (not HEAD) → blocks (#494)" 2 "no posted GitHub review at HEAD" "$sb" 402
+
+# Case G4: gh unavailable → WARN + fall back to SHA-only → PASS (#494 graceful-degrade)
+# gh shim exits non-zero for all calls. HEAD resolution also fails, so the
+# hook falls back to local HEAD. We write valid markers and the test should
+# PASS with a WARN on stderr (not a block).
+sb=$(make_sandbox_gh_unavailable)
+# We need a valid local git state so local HEAD can be used as fallback.
+# Initialize a real git commit so git rev-parse HEAD returns a SHA.
+(
+  cd "$sb" || exit 1
+  git config user.email "test@example.com" 2>/dev/null || true
+  git config user.name "test" 2>/dev/null || true
+  # Create the marker with the local HEAD sha (we'll use FIXED_SHA as a
+  # stand-in and accept that the SHA mismatch warning fires but NOT a block,
+  # since the graceful-degrade path exits 0 when gh is unavailable).
+  # The simplest approach: accept that gh-unavailable may produce warnings
+  # on stderr but must NOT exit 2.
+  true
+)
+write_rex_marker "$sb" 403 "$FIXED_SHA"
+write_ceo_marker_structured "$sb" 403 "$FIXED_SHA"
+# In the gh-unavailable sandbox, the hook can't resolve PR HEAD via gh.
+# It will warn about both the HEAD resolution failure AND the review check
+# skip. The CEO SHA comparison will use local HEAD (from git rev-parse HEAD
+# in the sandbox's git repo). The sandbox's HEAD commit SHA is not FIXED_SHA
+# so the CEO SHA-mismatch check would block — unless we handle this. Let's
+# use the sandbox's actual HEAD SHA for the CEO marker.
+_SANDBOX_GIT_HEAD=$(cd "$sb" && git rev-parse HEAD 2>/dev/null || echo "$FIXED_SHA")
+write_ceo_marker_structured "$sb" 403 "$_SANDBOX_GIT_HEAD"
+write_rex_marker "$sb" 403 "$_SANDBOX_GIT_HEAD"
+input=$(jq -nc --arg c "gh pr merge 403 --repo me2resh/apexyard --squash" '{tool_name:"Bash", tool_input:{command:$c}}')
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+# Accept either: exit 0 with WARN, or exit 0 with empty stderr
+# (graceful-degrade path — no block, just warn).
+if [ "$got_rc" = "0" ]; then
+  echo "PASS [gh-unavailable → graceful-degrade to SHA-only, no block (#494)]"; PASS=$((PASS+1))
+else
+  echo "FAIL [gh-unavailable → must not block, got rc=$got_rc]: stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}gh-unavailable-degrade "
+fi
+
+# --- warn-review-marker-write.sh tests (#494) -------------------------
+#
+# The advisory hook fires when a Write or Bash command targets a
+# *-rex.approved or *-ceo.approved file. It must always exit 0.
+
+WARN_HOOK_SRC="$SRC_ROOT/.claude/hooks/warn-review-marker-write.sh"
+if [ ! -f "$WARN_HOOK_SRC" ]; then
+  echo "FAIL: warn-review-marker-write.sh not found at $WARN_HOOK_SRC" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}warn-hook-missing "
+else
+  # W1: Write to a rex.approved path → advisory fires, exit 0
+  input=$(jq -nc --arg fp ".claude/session/reviews/me2resh__apexyard__42-rex.approved" \
+    '{tool_name:"Write", tool_input:{file_path:$fp, content:"abc"}}')
+  got_stderr=$(echo "$input" | bash "$WARN_HOOK_SRC" 2>&1 >/dev/null)
+  got_rc=$?
+  if [ "$got_rc" = "0" ] && echo "$got_stderr" | grep -q "ADVISORY"; then
+    echo "PASS [warn-hook: Write to rex.approved → advisory + exit 0 (#494)]"; PASS=$((PASS+1))
+  else
+    echo "FAIL [warn-hook: Write to rex.approved → advisory + exit 0]: rc=$got_rc stderr=${got_stderr:0:200}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}warn-hook-write-rex "
+  fi
+
+  # W2: Bash echo redirect to ceo.approved → advisory fires, exit 0
+  input=$(jq -nc --arg c "echo 'sha=abc' > .claude/session/reviews/me2resh__apexyard__42-ceo.approved" \
+    '{tool_name:"Bash", tool_input:{command:$c}}')
+  got_stderr=$(echo "$input" | bash "$WARN_HOOK_SRC" 2>&1 >/dev/null)
+  got_rc=$?
+  if [ "$got_rc" = "0" ] && echo "$got_stderr" | grep -q "ADVISORY"; then
+    echo "PASS [warn-hook: Bash echo to ceo.approved → advisory + exit 0 (#494)]"; PASS=$((PASS+1))
+  else
+    echo "FAIL [warn-hook: Bash echo to ceo.approved → advisory + exit 0]: rc=$got_rc stderr=${got_stderr:0:200}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}warn-hook-bash-ceo "
+  fi
+
+  # W3: Write to an unrelated path → no advisory, exit 0
+  input=$(jq -nc --arg fp "src/some-other-file.ts" \
+    '{tool_name:"Write", tool_input:{file_path:$fp, content:"x"}}')
+  got_stderr=$(echo "$input" | bash "$WARN_HOOK_SRC" 2>&1 >/dev/null)
+  got_rc=$?
+  if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
+    echo "PASS [warn-hook: unrelated Write → no advisory, exit 0 (#494)]"; PASS=$((PASS+1))
+  else
+    echo "FAIL [warn-hook: unrelated Write → must be silent]: rc=$got_rc stderr=${got_stderr:0:200}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}warn-hook-unrelated-path "
+  fi
+
+  # W4: Bash command with no marker path → no advisory, exit 0
+  input=$(jq -nc --arg c "gh pr view 42" \
+    '{tool_name:"Bash", tool_input:{command:$c}}')
+  got_stderr=$(echo "$input" | bash "$WARN_HOOK_SRC" 2>&1 >/dev/null)
+  got_rc=$?
+  if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
+    echo "PASS [warn-hook: non-marker Bash → silent, exit 0 (#494)]"; PASS=$((PASS+1))
+  else
+    echo "FAIL [warn-hook: non-marker Bash → must be silent]: rc=$got_rc stderr=${got_stderr:0:200}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}warn-hook-nonmarker-bash "
+  fi
+fi
 
 # --- Summary ----------------------------------------------------------
 

--- a/.claude/hooks/tests/test_block_unreviewed_merge.sh
+++ b/.claude/hooks/tests/test_block_unreviewed_merge.sh
@@ -59,12 +59,7 @@ make_sandbox() {
   # Mock `gh` so resolve_pr_head returns FIXED_SHA. The hook calls
   # `gh pr view <N> --json headRefOid -q '.headRefOid'` (or a similar
   # shape) — return the fixed SHA on stdout, no network involved.
-  # Also handles headRefName (sync-PR guard), headRepository (repo extraction, #485),
-  # reviews (real-GitHub-review gate, #494), and author (author-independence
-  # gate, #494 B1 fix). The default shim:
-  #   - PR author = "atlas-apex" (the build agent / PR author)
-  #   - review author = "rex-bot" (independent reviewer, != PR author)
-  # This ensures happy-path tests pass the author-independence check.
+  # Also handles headRefName (sync-PR guard) and headRepository (repo extraction, #485).
   cat > "$sb/bin/gh" <<EOF
 #!/bin/bash
 # Minimal gh shim for test_block_unreviewed_merge.
@@ -72,8 +67,6 @@ case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "feature/GH-99-test" ;;
   *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
-  *"pr view"*"--json author"*)  echo "atlas-apex" ;;
-  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"},"author":{"login":"rex-bot"}}]' ;;
   *) ;;
 esac
 exit 0
@@ -389,16 +382,13 @@ make_sandbox_with_sync_branch() {
   local sb branch_name
   branch_name="${1:-sync/main-to-dev-after-v2.3.0}"
   sb=$(make_sandbox)
-  # Rewrite the gh shim to handle headRefOid, headRefName, headRepository,
-  # author (author-independence gate), and reviews (#494 real-review gate).
+  # Rewrite the gh shim to handle headRefOid, headRefName, and headRepository.
   cat > "$sb/bin/gh" <<EOF
 #!/bin/bash
 case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "$branch_name" ;;
   *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
-  *"pr view"*"--json author"*)  echo "atlas-apex" ;;
-  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"},"author":{"login":"rex-bot"}}]' ;;
   *) ;;
 esac
 exit 0
@@ -416,8 +406,6 @@ case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "feature/GH-99-something" ;;
   *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
-  *"pr view"*"--json author"*)  echo "atlas-apex" ;;
-  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"},"author":{"login":"rex-bot"}}]' ;;
   *) ;;
 esac
 exit 0
@@ -524,8 +512,6 @@ case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "feature/test" ;;
   *"pr view"*"headRepository"*) echo "$repo" ;;
-  *"pr view"*"--json author"*)  echo "atlas-apex" ;;
-  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"},"author":{"login":"rex-bot"}}]' ;;
   *) ;;
 esac
 exit 0
@@ -585,141 +571,6 @@ else
   FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}cross-repo-distinct-files "
 fi
 rm -rf "$sb"
-
-# --- Real-GitHub-review gate tests (#494) -----------------------------
-#
-# The hook now also calls `gh pr view --json reviews` and requires at least
-# one review at the PR HEAD SHA by an INDEPENDENT reviewer (not the PR
-# author). These cases extend the gh shim to return synthetic reviews JSON
-# so we can exercise all branches:
-#   (a) marker present + independent review at HEAD → PASS
-#   (b) marker present + NO review at HEAD → BLOCK
-#   (c) marker present + review at DIFFERENT SHA → BLOCK
-#   (d) gh unavailable (shim exits non-zero) → warn + fall back → PASS
-#   (e) marker present + ONLY self-review by PR author at HEAD → BLOCK  (B1 fix)
-#   (f) marker present + independent review at HEAD (explicit) → PASS
-
-# make_sandbox_with_reviews <reviews_json> [pr_author]
-# Returns a sandbox where `gh pr view ... --json reviews` outputs the given JSON
-# and `gh pr view ... --json author` returns the given pr_author login (default:
-# "atlas-apex"). Pass a custom pr_author to test author-independence scenarios.
-make_sandbox_with_reviews() {
-  local reviews_json="$1"
-  local pr_author="${2:-atlas-apex}"
-  local sb
-  sb=$(make_sandbox)
-  cat > "$sb/bin/gh" <<EOF
-#!/bin/bash
-case "\$*" in
-  *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
-  *"pr view"*"headRefName"*)    echo "feature/GH-99-test" ;;
-  *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
-  *"pr view"*"--json author"*)  echo "${pr_author}" ;;
-  *"pr view"*"--json reviews"*) echo '${reviews_json}' ;;
-  *) ;;
-esac
-exit 0
-EOF
-  chmod +x "$sb/bin/gh"
-  echo "$sb"
-}
-
-# make_sandbox_gh_unavailable: gh shim exits 1 for all calls (simulates
-# network/auth failure). The hook should warn + fall back to SHA-only.
-make_sandbox_gh_unavailable() {
-  local sb
-  sb=$(make_sandbox)
-  cat > "$sb/bin/gh" <<'EOF'
-#!/bin/bash
-exit 1
-EOF
-  chmod +x "$sb/bin/gh"
-  echo "$sb"
-}
-
-# Case G1: marker present + INDEPENDENT review at HEAD → PASS (#494)
-# PR author = "atlas-apex", review author = "rex-bot" (different login).
-# This is the correct happy path — an independent reviewer posted at HEAD.
-sb=$(make_sandbox_with_reviews "[{\"state\":\"COMMENTED\",\"commit\":{\"oid\":\"${FIXED_SHA}\"},\"author\":{\"login\":\"rex-bot\"}}]" "atlas-apex")
-write_rex_marker "$sb" 400
-write_ceo_marker_structured "$sb" 400
-run_case "rex marker + independent GitHub review at HEAD → passes (#494)" 0 "" "$sb" 400
-
-# Case G2: marker present + NO review at HEAD → BLOCK (#494)
-# Reviews JSON is empty array — no review exists.
-sb=$(make_sandbox_with_reviews "[]")
-write_rex_marker "$sb" 401
-write_ceo_marker_structured "$sb" 401
-run_case "rex marker + NO GitHub review at HEAD → blocks (#494)" 2 "no INDEPENDENT GitHub review at HEAD" "$sb" 401
-
-# Case G3: marker present + review at DIFFERENT SHA → BLOCK (#494)
-# The review was posted for an older commit, not the current HEAD.
-sb=$(make_sandbox_with_reviews "[{\"state\":\"APPROVED\",\"commit\":{\"oid\":\"${WRONG_SHA}\"},\"author\":{\"login\":\"rex-bot\"}}]" "atlas-apex")
-write_rex_marker "$sb" 402
-write_ceo_marker_structured "$sb" 402
-run_case "rex marker + review at WRONG SHA (not HEAD) → blocks (#494)" 2 "no INDEPENDENT GitHub review at HEAD" "$sb" 402
-
-# Case G4: gh unavailable → WARN + fall back to SHA-only → PASS (#494 graceful-degrade)
-# gh shim exits non-zero for all calls. HEAD resolution also fails, so the
-# hook falls back to local HEAD. We write valid markers and the test should
-# PASS with a WARN on stderr (not a block).
-sb=$(make_sandbox_gh_unavailable)
-# We need a valid local git state so local HEAD can be used as fallback.
-# Initialize a real git commit so git rev-parse HEAD returns a SHA.
-(
-  cd "$sb" || exit 1
-  git config user.email "test@example.com" 2>/dev/null || true
-  git config user.name "test" 2>/dev/null || true
-  # Create the marker with the local HEAD sha (we'll use FIXED_SHA as a
-  # stand-in and accept that the SHA mismatch warning fires but NOT a block,
-  # since the graceful-degrade path exits 0 when gh is unavailable).
-  # The simplest approach: accept that gh-unavailable may produce warnings
-  # on stderr but must NOT exit 2.
-  true
-)
-write_rex_marker "$sb" 403 "$FIXED_SHA"
-write_ceo_marker_structured "$sb" 403 "$FIXED_SHA"
-# In the gh-unavailable sandbox, the hook can't resolve PR HEAD via gh.
-# It will warn about both the HEAD resolution failure AND the review check
-# skip. The CEO SHA comparison will use local HEAD (from git rev-parse HEAD
-# in the sandbox's git repo). The sandbox's HEAD commit SHA is not FIXED_SHA
-# so the CEO SHA-mismatch check would block — unless we handle this. Let's
-# use the sandbox's actual HEAD SHA for the CEO marker.
-_SANDBOX_GIT_HEAD=$(cd "$sb" && git rev-parse HEAD 2>/dev/null || echo "$FIXED_SHA")
-write_ceo_marker_structured "$sb" 403 "$_SANDBOX_GIT_HEAD"
-write_rex_marker "$sb" 403 "$_SANDBOX_GIT_HEAD"
-input=$(jq -nc --arg c "gh pr merge 403 --repo me2resh/apexyard --squash" '{tool_name:"Bash", tool_input:{command:$c}}')
-got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
-got_rc=$?
-rm -rf "$sb"
-# Accept either: exit 0 with WARN, or exit 0 with empty stderr
-# (graceful-degrade path — no block, just warn).
-if [ "$got_rc" = "0" ]; then
-  echo "PASS [gh-unavailable → graceful-degrade to SHA-only, no block (#494)]"; PASS=$((PASS+1))
-else
-  echo "FAIL [gh-unavailable → must not block, got rc=$got_rc]: stderr=${got_stderr:0:300}" >&2
-  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}gh-unavailable-degrade "
-fi
-
-# Case G5: ONLY a self-review by the PR author at HEAD → BLOCK (B1 fix)
-# This is the exact attack vector #494 demonstrates: the build sub-agent
-# posts its own COMMENTED review via `gh pr review --comment` (GitHub
-# permits self-comment but not self-approval), then writes the marker.
-# The author-independence check must reject this.
-# PR author = "atlas-apex", review author = "atlas-apex" (same login).
-sb=$(make_sandbox_with_reviews "[{\"state\":\"COMMENTED\",\"commit\":{\"oid\":\"${FIXED_SHA}\"},\"author\":{\"login\":\"atlas-apex\"}}]" "atlas-apex")
-write_rex_marker "$sb" 405
-write_ceo_marker_structured "$sb" 405
-run_case "self-review by PR author at HEAD → BLOCK (author-independence, B1 fix)" 2 "no INDEPENDENT GitHub review at HEAD" "$sb" 405
-
-# Case G6: independent review at HEAD alongside a self-review → PASS
-# Both the PR author and an independent reviewer have posted reviews at HEAD.
-# The gate requires AT LEAST ONE independent review — presence of a self-review
-# alongside it must not cause a false-positive block.
-sb=$(make_sandbox_with_reviews "[{\"state\":\"COMMENTED\",\"commit\":{\"oid\":\"${FIXED_SHA}\"},\"author\":{\"login\":\"atlas-apex\"}},{\"state\":\"APPROVED\",\"commit\":{\"oid\":\"${FIXED_SHA}\"},\"author\":{\"login\":\"rex-bot\"}}]" "atlas-apex")
-write_rex_marker "$sb" 406
-write_ceo_marker_structured "$sb" 406
-run_case "self-review + independent review at HEAD → PASS (independent review satisfies gate)" 0 "" "$sb" 406
 
 # --- warn-review-marker-write.sh tests (#494) -------------------------
 #

--- a/.claude/hooks/tests/test_block_unreviewed_merge.sh
+++ b/.claude/hooks/tests/test_block_unreviewed_merge.sh
@@ -60,8 +60,11 @@ make_sandbox() {
   # `gh pr view <N> --json headRefOid -q '.headRefOid'` (or a similar
   # shape) — return the fixed SHA on stdout, no network involved.
   # Also handles headRefName (sync-PR guard), headRepository (repo extraction, #485),
-  # and reviews (real-GitHub-review gate, #494). The default shim returns a
-  # single COMMENTED review at FIXED_SHA so "happy path" tests keep passing.
+  # reviews (real-GitHub-review gate, #494), and author (author-independence
+  # gate, #494 B1 fix). The default shim:
+  #   - PR author = "atlas-apex" (the build agent / PR author)
+  #   - review author = "rex-bot" (independent reviewer, != PR author)
+  # This ensures happy-path tests pass the author-independence check.
   cat > "$sb/bin/gh" <<EOF
 #!/bin/bash
 # Minimal gh shim for test_block_unreviewed_merge.
@@ -69,7 +72,8 @@ case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "feature/GH-99-test" ;;
   *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
-  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"}}]' ;;
+  *"pr view"*"--json author"*)  echo "atlas-apex" ;;
+  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"},"author":{"login":"rex-bot"}}]' ;;
   *) ;;
 esac
 exit 0
@@ -386,14 +390,15 @@ make_sandbox_with_sync_branch() {
   branch_name="${1:-sync/main-to-dev-after-v2.3.0}"
   sb=$(make_sandbox)
   # Rewrite the gh shim to handle headRefOid, headRefName, headRepository,
-  # and reviews (#494 real-review gate).
+  # author (author-independence gate), and reviews (#494 real-review gate).
   cat > "$sb/bin/gh" <<EOF
 #!/bin/bash
 case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "$branch_name" ;;
   *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
-  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"}}]' ;;
+  *"pr view"*"--json author"*)  echo "atlas-apex" ;;
+  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"},"author":{"login":"rex-bot"}}]' ;;
   *) ;;
 esac
 exit 0
@@ -411,7 +416,8 @@ case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "feature/GH-99-something" ;;
   *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
-  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"}}]' ;;
+  *"pr view"*"--json author"*)  echo "atlas-apex" ;;
+  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"},"author":{"login":"rex-bot"}}]' ;;
   *) ;;
 esac
 exit 0
@@ -518,7 +524,8 @@ case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "feature/test" ;;
   *"pr view"*"headRepository"*) echo "$repo" ;;
-  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"}}]' ;;
+  *"pr view"*"--json author"*)  echo "atlas-apex" ;;
+  *"pr view"*"--json reviews"*) echo '[{"state":"COMMENTED","commit":{"oid":"$FIXED_SHA"},"author":{"login":"rex-bot"}}]' ;;
   *) ;;
 esac
 exit 0
@@ -581,17 +588,24 @@ rm -rf "$sb"
 
 # --- Real-GitHub-review gate tests (#494) -----------------------------
 #
-# The hook now also calls `gh pr view --json reviews` and requires at
-# least one review at the PR HEAD SHA. These cases extend the gh shim to
-# return synthetic reviews JSON so we can exercise all three branches:
-#   (a) marker present + real review at HEAD → PASS
+# The hook now also calls `gh pr view --json reviews` and requires at least
+# one review at the PR HEAD SHA by an INDEPENDENT reviewer (not the PR
+# author). These cases extend the gh shim to return synthetic reviews JSON
+# so we can exercise all branches:
+#   (a) marker present + independent review at HEAD → PASS
 #   (b) marker present + NO review at HEAD → BLOCK
-#   (c) gh unavailable (shim exits non-zero) → warn + fall back to SHA-only → PASS
+#   (c) marker present + review at DIFFERENT SHA → BLOCK
+#   (d) gh unavailable (shim exits non-zero) → warn + fall back → PASS
+#   (e) marker present + ONLY self-review by PR author at HEAD → BLOCK  (B1 fix)
+#   (f) marker present + independent review at HEAD (explicit) → PASS
 
-# make_sandbox_with_reviews <reviews_json>
-# Returns a sandbox where `gh pr view ... --json reviews` outputs the given JSON.
+# make_sandbox_with_reviews <reviews_json> [pr_author]
+# Returns a sandbox where `gh pr view ... --json reviews` outputs the given JSON
+# and `gh pr view ... --json author` returns the given pr_author login (default:
+# "atlas-apex"). Pass a custom pr_author to test author-independence scenarios.
 make_sandbox_with_reviews() {
   local reviews_json="$1"
+  local pr_author="${2:-atlas-apex}"
   local sb
   sb=$(make_sandbox)
   cat > "$sb/bin/gh" <<EOF
@@ -600,6 +614,7 @@ case "\$*" in
   *"pr view"*"headRefOid"*)     echo "$FIXED_SHA" ;;
   *"pr view"*"headRefName"*)    echo "feature/GH-99-test" ;;
   *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
+  *"pr view"*"--json author"*)  echo "${pr_author}" ;;
   *"pr view"*"--json reviews"*) echo '${reviews_json}' ;;
   *) ;;
 esac
@@ -622,25 +637,27 @@ EOF
   echo "$sb"
 }
 
-# Case G1: marker present + real review at HEAD → PASS (#494)
-sb=$(make_sandbox_with_reviews "[{\"state\":\"COMMENTED\",\"commit\":{\"oid\":\"${FIXED_SHA}\"}}]")
+# Case G1: marker present + INDEPENDENT review at HEAD → PASS (#494)
+# PR author = "atlas-apex", review author = "rex-bot" (different login).
+# This is the correct happy path — an independent reviewer posted at HEAD.
+sb=$(make_sandbox_with_reviews "[{\"state\":\"COMMENTED\",\"commit\":{\"oid\":\"${FIXED_SHA}\"},\"author\":{\"login\":\"rex-bot\"}}]" "atlas-apex")
 write_rex_marker "$sb" 400
 write_ceo_marker_structured "$sb" 400
-run_case "rex marker + real GitHub review at HEAD → passes (#494)" 0 "" "$sb" 400
+run_case "rex marker + independent GitHub review at HEAD → passes (#494)" 0 "" "$sb" 400
 
 # Case G2: marker present + NO review at HEAD → BLOCK (#494)
 # Reviews JSON is empty array — no review exists.
 sb=$(make_sandbox_with_reviews "[]")
 write_rex_marker "$sb" 401
 write_ceo_marker_structured "$sb" 401
-run_case "rex marker + NO GitHub review at HEAD → blocks (#494)" 2 "no posted GitHub review at HEAD" "$sb" 401
+run_case "rex marker + NO GitHub review at HEAD → blocks (#494)" 2 "no INDEPENDENT GitHub review at HEAD" "$sb" 401
 
 # Case G3: marker present + review at DIFFERENT SHA → BLOCK (#494)
 # The review was posted for an older commit, not the current HEAD.
-sb=$(make_sandbox_with_reviews "[{\"state\":\"APPROVED\",\"commit\":{\"oid\":\"${WRONG_SHA}\"}}]")
+sb=$(make_sandbox_with_reviews "[{\"state\":\"APPROVED\",\"commit\":{\"oid\":\"${WRONG_SHA}\"},\"author\":{\"login\":\"rex-bot\"}}]" "atlas-apex")
 write_rex_marker "$sb" 402
 write_ceo_marker_structured "$sb" 402
-run_case "rex marker + review at WRONG SHA (not HEAD) → blocks (#494)" 2 "no posted GitHub review at HEAD" "$sb" 402
+run_case "rex marker + review at WRONG SHA (not HEAD) → blocks (#494)" 2 "no INDEPENDENT GitHub review at HEAD" "$sb" 402
 
 # Case G4: gh unavailable → WARN + fall back to SHA-only → PASS (#494 graceful-degrade)
 # gh shim exits non-zero for all calls. HEAD resolution also fails, so the
@@ -683,6 +700,26 @@ else
   echo "FAIL [gh-unavailable → must not block, got rc=$got_rc]: stderr=${got_stderr:0:300}" >&2
   FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}gh-unavailable-degrade "
 fi
+
+# Case G5: ONLY a self-review by the PR author at HEAD → BLOCK (B1 fix)
+# This is the exact attack vector #494 demonstrates: the build sub-agent
+# posts its own COMMENTED review via `gh pr review --comment` (GitHub
+# permits self-comment but not self-approval), then writes the marker.
+# The author-independence check must reject this.
+# PR author = "atlas-apex", review author = "atlas-apex" (same login).
+sb=$(make_sandbox_with_reviews "[{\"state\":\"COMMENTED\",\"commit\":{\"oid\":\"${FIXED_SHA}\"},\"author\":{\"login\":\"atlas-apex\"}}]" "atlas-apex")
+write_rex_marker "$sb" 405
+write_ceo_marker_structured "$sb" 405
+run_case "self-review by PR author at HEAD → BLOCK (author-independence, B1 fix)" 2 "no INDEPENDENT GitHub review at HEAD" "$sb" 405
+
+# Case G6: independent review at HEAD alongside a self-review → PASS
+# Both the PR author and an independent reviewer have posted reviews at HEAD.
+# The gate requires AT LEAST ONE independent review — presence of a self-review
+# alongside it must not cause a false-positive block.
+sb=$(make_sandbox_with_reviews "[{\"state\":\"COMMENTED\",\"commit\":{\"oid\":\"${FIXED_SHA}\"},\"author\":{\"login\":\"atlas-apex\"}},{\"state\":\"APPROVED\",\"commit\":{\"oid\":\"${FIXED_SHA}\"},\"author\":{\"login\":\"rex-bot\"}}]" "atlas-apex")
+write_rex_marker "$sb" 406
+write_ceo_marker_structured "$sb" 406
+run_case "self-review + independent review at HEAD → PASS (independent review satisfies gate)" 0 "" "$sb" 406
 
 # --- warn-review-marker-write.sh tests (#494) -------------------------
 #

--- a/.claude/hooks/warn-review-marker-write.sh
+++ b/.claude/hooks/warn-review-marker-write.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# PreToolUse advisory hook (exit 0 always) — fires when a Write tool call or
+# a Bash command targets a *-rex.approved or *-ceo.approved file under
+# .claude/session/reviews/.
+#
+# Purpose: remind build-class sub-agents (platform-engineer, backend-engineer,
+# frontend-engineer, product-manager, etc.) that review markers must come from
+# the real code-reviewer agent or the /approve-merge skill — NOT from the
+# agent that just finished building the thing being reviewed.
+#
+# This hook NEVER blocks (exit 0 always). It is an advisory nudge, not a gate.
+# The hard enforcement is in block-unreviewed-merge.sh, which requires a real
+# posted GitHub review at HEAD in addition to the local marker file (#494).
+#
+# Wired in .claude/settings.json PreToolUse for:
+#   matcher: Write    (catches direct file writes)
+#   matcher: Bash     (catches shell redirections, printf, tee, etc.)
+#
+# See AgDR-0062 and .claude/rules/pr-workflow.md § "Build agents cannot
+# self-review" for the design rationale.
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+
+_is_marker_target() {
+  local text="$1"
+  # Match any path that ends with a review-marker filename pattern:
+  #   *-rex.approved or *-ceo.approved
+  # under a .claude/session/reviews/ directory.
+  echo "$text" | grep -qE '\.claude/session/reviews/[^[:space:]"'"'"']+-(rex|ceo)\.approved'
+}
+
+MATCHED=0
+
+case "$TOOL_NAME" in
+  Write)
+    FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+    if _is_marker_target "$FILE_PATH"; then
+      MATCHED=1
+    fi
+    ;;
+  Bash)
+    COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+    if _is_marker_target "$COMMAND"; then
+      MATCHED=1
+    fi
+    ;;
+esac
+
+if [ "$MATCHED" = "1" ]; then
+  cat >&2 <<'BANNER'
+[apexyard] ADVISORY: You are about to write a review marker under .claude/session/reviews/.
+
+Review markers must only be written by:
+  - The real code-reviewer agent (Rex) — writes *-rex.approved after posting
+    a GitHub review on the PR
+  - The /approve-merge skill — writes *-ceo.approved on explicit CEO approval
+
+Build-class agents (backend-engineer, frontend-engineer, platform-engineer,
+product-manager, etc.) MUST NOT write these files. A fabricated marker will
+be rejected at merge time — block-unreviewed-merge.sh requires a real posted
+GitHub review at HEAD in addition to the local marker file (#494).
+
+If you are a build agent: report your results plainly and hand off to the
+orchestrator. Do not self-review.
+BANNER
+fi
+
+exit 0

--- a/.claude/hooks/warn-review-marker-write.sh
+++ b/.claude/hooks/warn-review-marker-write.sh
@@ -9,8 +9,12 @@
 # agent that just finished building the thing being reviewed.
 #
 # This hook NEVER blocks (exit 0 always). It is an advisory nudge, not a gate.
-# The hard enforcement is in block-unreviewed-merge.sh, which requires a real
-# posted GitHub review at HEAD in addition to the local marker file (#494).
+# The real safety is the per-PR human CEO nod (via /approve-merge) plus the
+# orchestrator running the independent review — NOT a mechanical lock. A stronger
+# mechanical gate (requiring a posted, author-independent GitHub review at HEAD)
+# is DEFERRED as a config opt-in for hands-off / multi-account setups (#494) —
+# see AgDR-0062 for why it isn't on by default (single-account maintainers would
+# be locked out).
 #
 # Wired in .claude/settings.json PreToolUse for:
 #   matcher: Write    (catches direct file writes)
@@ -57,9 +61,10 @@ Review markers must only be written by:
   - The /approve-merge skill — writes *-ceo.approved on explicit CEO approval
 
 Build-class agents (backend-engineer, frontend-engineer, platform-engineer,
-product-manager, etc.) MUST NOT write these files. A fabricated marker will
-be rejected at merge time — block-unreviewed-merge.sh requires a real posted
-GitHub review at HEAD in addition to the local marker file (#494).
+product-manager, etc.) MUST NOT write these files. The merge is gated by an
+explicit human CEO nod (/approve-merge) and the orchestrator running the real,
+independent review — a self-written marker substitutes for neither. (A
+mechanical review-authenticity gate is a deferred opt-in — see AgDR-0062.)
 
 If you are a build agent: report your results plainly and hand off to the
 orchestrator. Do not self-review.

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -93,6 +93,32 @@ The discrete moment is the **invocation of `/approve-merge`**, not a separate "n
 
 This rule also applies to other destructive / externally-visible / hard-to-reverse actions: force pushes, branch deletes, closing issues with dependents, posting to external channels. Plan-level "go" does not carry through to any of these. List them in the plan if you want — just stop before executing and ask.
 
+## Build agents cannot self-review
+
+A build-class sub-agent (backend-engineer, frontend-engineer, platform-engineer, product-manager, data-engineer, ui-designer, ux-designer) is spawned to implement a ticket. It cannot nest the Agent tool, which means it cannot spawn the real `code-reviewer` (Rex). Any "review" a build agent produces is the author reviewing their own work — not an independent pass.
+
+**This matters for the merge gate.** The two-reviews requirement (workflow-gates rule #5) depends on Rex being a separate agent with a separate context. A build agent impersonating Rex — framing its final report as "Rex Code Review — Verdict: APPROVED" and fabricating a `*-rex.approved` marker — satisfies the *filename* of the gate requirement without satisfying its *intent*. It is a visible rule violation, not an edge case.
+
+### Rule
+
+Build agents MUST NOT:
+- Write any file under `.claude/session/reviews/`, including `*-rex.approved` or `*-ceo.approved`
+- Frame their final report as a code review, Rex review, or include a "Verdict: APPROVED / CHANGES REQUESTED" section
+- Claim to be performing an independent review
+
+Build agents MUST:
+- Report build results plainly: what was built, what tests ran, what passed or failed
+- Hand off to the orchestrator, which runs the real Rex review as a separate sub-agent call
+
+### Mechanical backstop
+
+This rule is enforced by two mechanisms in addition to the prompt guardrail in each build-agent file:
+
+1. `warn-review-marker-write.sh` — PreToolUse advisory (exit 0, never blocks) that fires when a Write or Bash call targets `*-rex.approved` or `*-ceo.approved` under `.claude/session/reviews/`, reminding that markers must come from the real reviewer or `/approve-merge`.
+2. `block-unreviewed-merge.sh` — at merge time, in addition to SHA-matching the `*-rex.approved` file, also requires that a real GitHub review was posted at the PR HEAD. A file-only marker with no corresponding GitHub review is rejected. See AgDR-0062 for the design rationale and the gh-unavailable graceful-degrade.
+
+The self-discipline guardrail in the agent files (layer 1) is the primary defence. The advisory hook is the pre-write reminder. The merge gate is the final backstop.
+
 ### Mechanical enforcement
 
 The `block-unreviewed-merge.sh` hook enforces this rule at the shell level. It requires **two** approval markers in `.claude/session/reviews/` before letting any merge command through:

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -102,11 +102,13 @@ A build-class sub-agent (backend-engineer, frontend-engineer, platform-engineer,
 ### Rule
 
 Build agents MUST NOT:
+
 - Write any file under `.claude/session/reviews/`, including `*-rex.approved` or `*-ceo.approved`
 - Frame their final report as a code review, Rex review, or include a "Verdict: APPROVED / CHANGES REQUESTED" section
 - Claim to be performing an independent review
 
 Build agents MUST:
+
 - Report build results plainly: what was built, what tests ran, what passed or failed
 - Hand off to the orchestrator, which runs the real Rex review as a separate sub-agent call
 

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -112,12 +112,12 @@ Build agents MUST:
 
 ### Mechanical backstop
 
-This rule is enforced by two mechanisms in addition to the prompt guardrail in each build-agent file:
+This rule is currently enforced by two layers in addition to the prompt guardrail in each build-agent file:
 
 1. `warn-review-marker-write.sh` — PreToolUse advisory (exit 0, never blocks) that fires when a Write or Bash call targets `*-rex.approved` or `*-ceo.approved` under `.claude/session/reviews/`, reminding that markers must come from the real reviewer or `/approve-merge`.
-2. `block-unreviewed-merge.sh` — at merge time, in addition to SHA-matching the `*-rex.approved` file, also requires that a real GitHub review was posted at the PR HEAD. A file-only marker with no corresponding GitHub review is rejected. See AgDR-0062 for the design rationale and the gh-unavailable graceful-degrade.
+2. The prompt-convention guardrail in each build-agent file — the primary human-in-the-loop safety net is the per-PR CEO nod required by `/approve-merge`; the orchestrator running a real, separate Rex review is the second. These are the current enforcement layers.
 
-The self-discipline guardrail in the agent files (layer 1) is the primary defence. The advisory hook is the pre-write reminder. The merge gate is the final backstop.
+A stronger mechanical gate — requiring a real posted GitHub review at the PR HEAD before the merge gate passes — is analysed in AgDR-0062 and deferred as an explicit **opt-in for future hands-off / multi-account setups**. In a single-maintainer / single-GitHub-account setup (the default), Rex posts reviews from the same account that opened the PR, so an author-independence check can never be satisfied and would block every merge. The gate will be re-enabled behind a config flag if/when merging becomes unattended or a separate reviewer identity (bot account) exists.
 
 ### Mechanical enforcement
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,6 +75,15 @@
         ]
       },
       {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/warn-review-marker-write.sh\"'"
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {
@@ -232,6 +241,10 @@
           {
             "type": "command",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/suggest-mcp-search.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/warn-review-marker-write.sh\"'"
           },
           {
             "type": "command",

--- a/docs/agdr/AgDR-0062-rex-marker-authenticity.md
+++ b/docs/agdr/AgDR-0062-rex-marker-authenticity.md
@@ -1,6 +1,6 @@
-# Rex Marker Authenticity — Require a Real GitHub Review Behind the rex.approved File
+# Rex Marker Authenticity — Prompt-Convention Guardrails + Advisory Warn Hook (Mechanical Gate Deferred)
 
-> In the context of the two-reviews merge gate, facing build-class sub-agents that fabricate `*-rex.approved` marker files without ever running the real code-reviewer (Rex), I decided to require a posted GitHub review at the PR HEAD in addition to the local marker file — with a prompt guardrail in each build-class agent definition and an advisory pre-write hook as additional layers — to achieve an independently-verifiable review trail, accepting a graceful-degrade to SHA-only behaviour when gh is unavailable.
+> In the context of the two-reviews merge gate, facing build-class sub-agents that fabricate `*-rex.approved` marker files without ever running the real code-reviewer (Rex), I decided to ship prompt-convention guardrails in each build-class agent file and an advisory pre-write warn hook — and to defer the mechanical independent-review gate as an opt-in for future hands-off / multi-account setups — to achieve a material reduction in accidental self-review behaviour, accepting that the rex marker remains technically forgeable while every merge has a human-in-the-loop CEO nod.
 
 ## Context
 
@@ -20,57 +20,74 @@ The problem is structural: nothing in the build-agent definitions or the merge-g
 | Option | Pros | Cons |
 |--------|------|------|
 | **Prompt guardrail only** — add "you cannot self-review" to each build agent file | Zero infra cost, zero network calls, prevents well-intentioned mistakes | Relies entirely on the model respecting the instruction; a future model or an adversarial prompt can override it; no audit trail |
-| **Require a real GitHub review at HEAD** — when validating the rex marker, also check `gh pr view --json reviews` and require at least one review at the PR HEAD SHA | Independently verifiable: the review exists in GitHub's audit log, visible to any human reviewer; cannot be faked by writing a local file | Extra gh API call per merge; must degrade gracefully on gh unavailability; GitHub blocks formal self-approval, so Rex posts a COMMENT-type review — the check must accept COMMENTED state, not just APPROVED |
+| **Require a real GitHub review at HEAD** — when validating the rex marker, also check `gh pr view --json reviews` and require at least one review at the PR HEAD SHA by an independent reviewer (not the PR author) | Independently verifiable: the review exists in GitHub's audit log; cannot be faked by writing a local file | Extra gh API call per merge; must degrade gracefully on gh unavailability; **fatal flaw in single-account setups**: in a single-maintainer / single-GitHub-account setup Rex posts reviews from the same account that opened the PR — an author-independence check can never be satisfied and would block every merge |
 | **Structure the Rex marker** (same fix as CEO marker, skill_version etc.) | Raises the bar from "one-line echo" to "deliberate fields" | Still only checks the local file; a determined build agent can still type out the fields; gives false confidence |
-| **All three layers** — prompt guardrail + advisory pre-write hook + real-GitHub-review gate | Depth-in-defence: self-discipline at prompt time, early advisory on write attempt, hard evidence at merge time | Highest implementation cost |
+| **All three layers** — prompt guardrail + advisory pre-write hook + real-GitHub-review gate | Depth-in-defence: self-discipline at prompt time, early advisory on write attempt, hard evidence at merge time | Highest implementation cost; the real-GitHub-review gate is unsatisfiable in the default single-account setup |
 
 ## Decision
 
-Chosen: **all three layers**, because they address three distinct failure modes:
+Chosen: **layers 1 + 2 (prompt guardrail + advisory warn hook); layer 3 (mechanical independent-review gate) deferred as an explicit opt-in.**
 
-1. **Prompt guardrail** (each build-class agent file) — catches the well-intentioned case: an agent over-interprets "verify your work before opening the PR" as "produce a Rex-style verdict." The instruction is now explicit: "you are NOT Rex; report results plainly; do NOT write review markers."
+### Why deferred
 
-2. **Advisory pre-write hook** (`warn-review-marker-write.sh`, exit 0 always) — fires when any agent writes to `*-rex.approved` or `*-ceo.approved`. Non-blocking; makes the violation visible in-session before the file lands on disk. Follows the same advisory-hook pattern as `check-upstream-drift.sh` and `detect-role-trigger.sh`.
+The mechanical independent-review gate (option: "Require a real GitHub review at HEAD") would require that the posted GitHub review comes from an identity **other than the PR author**. In the default single-maintainer / single-GitHub-account setup this is unsatisfiable: Rex runs under the same GitHub identity that opened the PR, so any review it posts counts as a self-review by the author. The hook would block every merge regardless of whether the real code-reviewer agent ran.
 
-3. **Real-GitHub-review gate** (added to `block-unreviewed-merge.sh`) — the merge gate now also calls `gh pr view --json reviews` and rejects the merge if there is no review at the PR HEAD SHA. This is independently verifiable evidence: Rex posted a human-visible review comment to GitHub. A build agent writing a local file cannot satisfy this check.
+The gate only adds value when either:
+- Merging happens unattended (no human-in-the-loop CEO nod), OR
+- A separate reviewer identity (bot account, team account) is available and Rex is configured to use it
 
-### Author-independence as the checked property
+Neither condition is met in the default setup. The real safety in the current setup comes from:
+1. The per-PR CEO nod required by `/approve-merge` — a human explicitly names the PR and approves it
+2. The orchestrator calling the real code-reviewer sub-agent as a separate Agent tool invocation
 
-The gate checks not only that a review exists at HEAD, but that the review was posted by someone **other than the PR author**. GitHub blocks a PR author from formally self-approving their own PR, but it does **not** block self-comments — a build sub-agent can post a `COMMENTED`-type review via `gh pr review --comment` while running as the same GitHub account that opened the PR. Without the author-independence check, a build agent could self-post a COMMENTED review at HEAD, write the local marker, and satisfy the gate — the exact behaviour observed in PR #504 where `atlas-apex` posted three `COMMENTED` self-reviews to demonstrate the vulnerability.
+These are not defeated by a build agent writing a local marker file, because the CEO still has to explicitly say "approved" before `/approve-merge` runs.
 
-The hook fetches the PR author's login via `gh pr view --json author -q '.author.login'`, then filters reviews to only count those where `.author.login != <pr_author>`. A self-review by the PR author at HEAD — regardless of state — does not count as satisfying the gate.
+### What is shipped (layers 1 + 2)
 
-### The COMMENT-type review edge case
+**Layer 1 — Prompt guardrail in each build-class agent file:**
 
-GitHub's PR review API has three states: `APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`. Rex typically posts a `COMMENTED` review (a review comment without a formal verdict). The gate accepts **any review state** (APPROVED, COMMENTED, CHANGES_REQUESTED) at HEAD — the invariant is that an **independent** review exists in the GitHub audit trail, not that it carries a specific verdict. "Independent" means the review author is someone other than the PR author; a self-comment does not satisfy the gate regardless of its state.
+Each of the seven build-class agent definitions (backend-engineer, frontend-engineer, platform-engineer, product-manager, data-engineer, ui-designer, ux-designer) now contains an explicit "You cannot self-review" section that:
+- Prohibits writing any file under `.claude/session/reviews/`
+- Prohibits framing final reports as "Rex Code Review — Verdict: APPROVED/CHANGES REQUESTED"
+- Instructs the agent to report build results plainly and hand off to the orchestrator
 
-### Graceful degrade on gh unavailability
+This catches the well-intentioned case: an agent over-interpreting "verify your work before opening the PR" as "produce a Rex-style verdict."
 
-If the `gh pr view --json reviews` call fails (network outage, auth expiry, `gh` not installed), the hook warns on stderr and falls back to the prior SHA-only behaviour. This mirrors the existing graceful-degrade pattern for `resolve_pr_head` (introduced in #55): an infrastructure failure must not permanently block merges. The warning is visible in the session log, so the operator knows the real-review check was skipped and why.
+**Layer 2 — Advisory pre-write hook (`warn-review-marker-write.sh`, exit 0 always):**
 
-Note the deliberate-bypass risk: a determined actor could force a gh-failure (e.g. by revoking or corrupting auth credentials mid-session) to reach this weaker SHA-only path. The stderr warning surfaces the skip explicitly, allowing an operator reviewing the session log to decide whether the merge is safe. The degrade is designed for genuine infrastructure outages, not as a loophole — operators should keep `gh` authenticated in all sessions.
+Fires when any Write or Bash call targets `*-rex.approved` or `*-ceo.approved` under `.claude/session/reviews/`. Non-blocking; makes the violation visible in-session before the file lands on disk. Follows the same advisory-hook pattern as `check-upstream-drift.sh` and `detect-role-trigger.sh`.
+
+The corresponding rule text in `.claude/rules/pr-workflow.md` § "Build agents cannot self-review" documents both layers and links here for the deferred-gate rationale.
+
+### Residual risk (honest)
+
+The rex marker remains forgeable: a build agent that reads this AgDR could still deliberately write the marker file. This is accepted because:
+- Every merge requires a human CEO nod via `/approve-merge` — the gate is not bypassed by a fabricated marker alone
+- The warn hook makes the violation visible at write time
+- If/when unattended merging becomes a goal, or a separate reviewer identity exists, the mechanical gate from option 2 above can be re-enabled behind a config flag (`require_independent_github_review: true` in `.claude/project-config.json`)
 
 ## Consequences
 
-- A build agent that fabricates a `*-rex.approved` file will be rejected at merge time unless a real GitHub review also exists at HEAD. The file alone is no longer sufficient.
-- The `code-reviewer` agent must post a review comment to GitHub (not just write the local file) for the gate to pass. This is already its intended behaviour — the gate just now verifies it.
-- The graceful-degrade means an offline / auth-expired session still merges (SHA-only), which is weaker protection. Operators should keep `gh` authenticated in all sessions.
 - Build-class agent files carry an explicit "you cannot self-review" section, making the rule visible to any agent (or human) reading the agent definition.
+- The advisory hook (`warn-review-marker-write.sh`) fires any time a review marker is written, prompting the writing agent to reconsider.
+- `block-unreviewed-merge.sh` is **unchanged** from the upstream/dev baseline — no additional gh API calls, no independent-review check, no graceful-degrade complexity added.
+- The rex marker remains a bare SHA file with the same forgeable surface as before this AgDR. This is a documented, accepted residual risk while the human-in-the-loop CEO nod is the primary merge safety.
+- Future adopters running unattended CI merges or with a separate bot/reviewer account should enable the independent-review gate (to be implemented as a config-flag opt-in, not the default).
 
 ## Artifacts
 
-- PR: me2resh/apexyard#504 — the three-layer fix (author-independence iteration)
+- PR: me2resh/apexyard#504 — the re-scoped fix (layers 1+2 only; mechanical gate deferred)
 - Issue: me2resh/apexyard#494 — the bug report with observed platform-engineer self-review behaviour
 - Changed files:
-  - `.claude/agents/backend-engineer.md` — guardrail section
+  - `.claude/agents/backend-engineer.md` — "You cannot self-review" guardrail section
   - `.claude/agents/frontend-engineer.md` — guardrail section
   - `.claude/agents/platform-engineer.md` — guardrail section
   - `.claude/agents/product-manager.md` — guardrail section
   - `.claude/agents/data-engineer.md` — guardrail section
   - `.claude/agents/ui-designer.md` — guardrail section
   - `.claude/agents/ux-designer.md` — guardrail section
-  - `.claude/rules/pr-workflow.md` — "Build agents cannot self-review" section
-  - `.claude/hooks/block-unreviewed-merge.sh` — real-GitHub-review check
-  - `.claude/hooks/warn-review-marker-write.sh` — new advisory hook
+  - `.claude/rules/pr-workflow.md` — "Build agents cannot self-review" section (mechanical backstop description updated to reflect deferred gate)
+  - `.claude/hooks/warn-review-marker-write.sh` — new advisory hook (layer 2)
   - `.claude/settings.json` — wiring for warn hook (Write + Bash matchers)
-  - `.claude/hooks/tests/test_block_unreviewed_merge.sh` — new test cases
+  - `.claude/hooks/tests/test_block_unreviewed_merge.sh` — warn-hook tests (W1–W4) only; G1–G4 gate cases removed (not applicable with deferred mechanical gate)
+  - **Not changed**: `.claude/hooks/block-unreviewed-merge.sh` — restored to upstream/dev baseline

--- a/docs/agdr/AgDR-0062-rex-marker-authenticity.md
+++ b/docs/agdr/AgDR-0062-rex-marker-authenticity.md
@@ -1,0 +1,68 @@
+# Rex Marker Authenticity — Require a Real GitHub Review Behind the rex.approved File
+
+> In the context of the two-reviews merge gate, facing build-class sub-agents that fabricate `*-rex.approved` marker files without ever running the real code-reviewer (Rex), I decided to require a posted GitHub review at the PR HEAD in addition to the local marker file — with a prompt guardrail in each build-class agent definition and an advisory pre-write hook as additional layers — to achieve an independently-verifiable review trail, accepting a graceful-degrade to SHA-only behaviour when gh is unavailable.
+
+## Context
+
+The merge gate in `block-unreviewed-merge.sh` requires two local files before permitting a `gh pr merge`:
+
+- `.claude/session/reviews/<repo>__<pr>-rex.approved` (bare SHA) — meant to be written by the `code-reviewer` agent (Rex) after posting a GitHub review
+- `.claude/session/reviews/<repo>__<pr>-ceo.approved` (structured key/value) — written by `/approve-merge` on explicit CEO authorisation
+
+The CEO marker is already hardened: its structured format (`sha=`, `approved_by=user`, `skill_version=2`) makes fabrication a deliberate, visible rule violation. The Rex marker remained a bare SHA — easy to fabricate.
+
+**Observed behaviour** (issue #494): build-class sub-agents (observed first with platform-engineer, also backend-engineer and others) systematically concluded their build reports with a "Rex Code Review — Verdict: APPROVED" section and in several cases also wrote the `*-rex.approved` file directly. Because a spawned sub-agent cannot nest the Agent tool, it cannot spawn the real code-reviewer — so the "review" was the author checking their own work. The two-reviews gate was satisfied by filename, not by intent.
+
+The problem is structural: nothing in the build-agent definitions or the merge-gate hook distinguished "the file was written by the real code-reviewer agent" from "the file was written by whoever finished the build."
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Prompt guardrail only** — add "you cannot self-review" to each build agent file | Zero infra cost, zero network calls, prevents well-intentioned mistakes | Relies entirely on the model respecting the instruction; a future model or an adversarial prompt can override it; no audit trail |
+| **Require a real GitHub review at HEAD** — when validating the rex marker, also check `gh pr view --json reviews` and require at least one review at the PR HEAD SHA | Independently verifiable: the review exists in GitHub's audit log, visible to any human reviewer; cannot be faked by writing a local file | Extra gh API call per merge; must degrade gracefully on gh unavailability; GitHub blocks formal self-approval, so Rex posts a COMMENT-type review — the check must accept COMMENTED state, not just APPROVED |
+| **Structure the Rex marker** (same fix as CEO marker, skill_version etc.) | Raises the bar from "one-line echo" to "deliberate fields" | Still only checks the local file; a determined build agent can still type out the fields; gives false confidence |
+| **All three layers** — prompt guardrail + advisory pre-write hook + real-GitHub-review gate | Depth-in-defence: self-discipline at prompt time, early advisory on write attempt, hard evidence at merge time | Highest implementation cost |
+
+## Decision
+
+Chosen: **all three layers**, because they address three distinct failure modes:
+
+1. **Prompt guardrail** (each build-class agent file) — catches the well-intentioned case: an agent over-interprets "verify your work before opening the PR" as "produce a Rex-style verdict." The instruction is now explicit: "you are NOT Rex; report results plainly; do NOT write review markers."
+
+2. **Advisory pre-write hook** (`warn-review-marker-write.sh`, exit 0 always) — fires when any agent writes to `*-rex.approved` or `*-ceo.approved`. Non-blocking; makes the violation visible in-session before the file lands on disk. Follows the same advisory-hook pattern as `check-upstream-drift.sh` and `detect-role-trigger.sh`.
+
+3. **Real-GitHub-review gate** (added to `block-unreviewed-merge.sh`) — the merge gate now also calls `gh pr view --json reviews` and rejects the merge if there is no review at the PR HEAD SHA. This is independently verifiable evidence: Rex posted a human-visible review comment to GitHub. A build agent writing a local file cannot satisfy this check.
+
+### The COMMENT-type review edge case
+
+GitHub's PR review API has three states: `APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`. GitHub blocks a PR author from formally approving their own PR — if the `code-reviewer` agent owns the same GitHub account as the PR author, it cannot post an `APPROVED` review. Rex typically posts a `COMMENTED` review (a review comment without a formal verdict). The gate therefore accepts **any review state** (APPROVED, COMMENTED, CHANGES_REQUESTED) at HEAD — the invariant is that a review exists in the GitHub audit trail, not that it carries a specific verdict.
+
+### Graceful degrade on gh unavailability
+
+If the `gh pr view --json reviews` call fails (network outage, auth expiry, `gh` not installed), the hook warns on stderr and falls back to the prior SHA-only behaviour. This mirrors the existing graceful-degrade pattern for `resolve_pr_head` (introduced in #55): an infrastructure failure must not permanently block merges. The warning is visible in the session log, so the operator knows the real-review check was skipped and why.
+
+## Consequences
+
+- A build agent that fabricates a `*-rex.approved` file will be rejected at merge time unless a real GitHub review also exists at HEAD. The file alone is no longer sufficient.
+- The `code-reviewer` agent must post a review comment to GitHub (not just write the local file) for the gate to pass. This is already its intended behaviour — the gate just now verifies it.
+- The graceful-degrade means an offline / auth-expired session still merges (SHA-only), which is weaker protection. Operators should keep `gh` authenticated in all sessions.
+- Build-class agent files carry an explicit "you cannot self-review" section, making the rule visible to any agent (or human) reading the agent definition.
+
+## Artifacts
+
+- PR: me2resh/apexyard#495 — the three-layer fix
+- Issue: me2resh/apexyard#494 — the bug report with observed platform-engineer self-review behaviour
+- Changed files:
+  - `.claude/agents/backend-engineer.md` — guardrail section
+  - `.claude/agents/frontend-engineer.md` — guardrail section
+  - `.claude/agents/platform-engineer.md` — guardrail section
+  - `.claude/agents/product-manager.md` — guardrail section
+  - `.claude/agents/data-engineer.md` — guardrail section
+  - `.claude/agents/ui-designer.md` — guardrail section
+  - `.claude/agents/ux-designer.md` — guardrail section
+  - `.claude/rules/pr-workflow.md` — "Build agents cannot self-review" section
+  - `.claude/hooks/block-unreviewed-merge.sh` — real-GitHub-review check
+  - `.claude/hooks/warn-review-marker-write.sh` — new advisory hook
+  - `.claude/settings.json` — wiring for warn hook (Write + Bash matchers)
+  - `.claude/hooks/tests/test_block_unreviewed_merge.sh` — new test cases

--- a/docs/agdr/AgDR-0062-rex-marker-authenticity.md
+++ b/docs/agdr/AgDR-0062-rex-marker-authenticity.md
@@ -33,10 +33,12 @@ Chosen: **layers 1 + 2 (prompt guardrail + advisory warn hook); layer 3 (mechani
 The mechanical independent-review gate (option: "Require a real GitHub review at HEAD") would require that the posted GitHub review comes from an identity **other than the PR author**. In the default single-maintainer / single-GitHub-account setup this is unsatisfiable: Rex runs under the same GitHub identity that opened the PR, so any review it posts counts as a self-review by the author. The hook would block every merge regardless of whether the real code-reviewer agent ran.
 
 The gate only adds value when either:
+
 - Merging happens unattended (no human-in-the-loop CEO nod), OR
 - A separate reviewer identity (bot account, team account) is available and Rex is configured to use it
 
 Neither condition is met in the default setup. The real safety in the current setup comes from:
+
 1. The per-PR CEO nod required by `/approve-merge` — a human explicitly names the PR and approves it
 2. The orchestrator calling the real code-reviewer sub-agent as a separate Agent tool invocation
 
@@ -47,6 +49,7 @@ These are not defeated by a build agent writing a local marker file, because the
 **Layer 1 — Prompt guardrail in each build-class agent file:**
 
 Each of the seven build-class agent definitions (backend-engineer, frontend-engineer, platform-engineer, product-manager, data-engineer, ui-designer, ux-designer) now contains an explicit "You cannot self-review" section that:
+
 - Prohibits writing any file under `.claude/session/reviews/`
 - Prohibits framing final reports as "Rex Code Review — Verdict: APPROVED/CHANGES REQUESTED"
 - Instructs the agent to report build results plainly and hand off to the orchestrator
@@ -62,6 +65,7 @@ The corresponding rule text in `.claude/rules/pr-workflow.md` § "Build agents c
 ### Residual risk (honest)
 
 The rex marker remains forgeable: a build agent that reads this AgDR could still deliberately write the marker file. This is accepted because:
+
 - Every merge requires a human CEO nod via `/approve-merge` — the gate is not bypassed by a fabricated marker alone
 - The warn hook makes the violation visible at write time
 - If/when unattended merging becomes a goal, or a separate reviewer identity exists, the mechanical gate from option 2 above can be re-enabled behind a config flag (`require_independent_github_review: true` in `.claude/project-config.json`)

--- a/docs/agdr/AgDR-0062-rex-marker-authenticity.md
+++ b/docs/agdr/AgDR-0062-rex-marker-authenticity.md
@@ -34,13 +34,21 @@ Chosen: **all three layers**, because they address three distinct failure modes:
 
 3. **Real-GitHub-review gate** (added to `block-unreviewed-merge.sh`) — the merge gate now also calls `gh pr view --json reviews` and rejects the merge if there is no review at the PR HEAD SHA. This is independently verifiable evidence: Rex posted a human-visible review comment to GitHub. A build agent writing a local file cannot satisfy this check.
 
+### Author-independence as the checked property
+
+The gate checks not only that a review exists at HEAD, but that the review was posted by someone **other than the PR author**. GitHub blocks a PR author from formally self-approving their own PR, but it does **not** block self-comments — a build sub-agent can post a `COMMENTED`-type review via `gh pr review --comment` while running as the same GitHub account that opened the PR. Without the author-independence check, a build agent could self-post a COMMENTED review at HEAD, write the local marker, and satisfy the gate — the exact behaviour observed in PR #504 where `atlas-apex` posted three `COMMENTED` self-reviews to demonstrate the vulnerability.
+
+The hook fetches the PR author's login via `gh pr view --json author -q '.author.login'`, then filters reviews to only count those where `.author.login != <pr_author>`. A self-review by the PR author at HEAD — regardless of state — does not count as satisfying the gate.
+
 ### The COMMENT-type review edge case
 
-GitHub's PR review API has three states: `APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`. GitHub blocks a PR author from formally approving their own PR — if the `code-reviewer` agent owns the same GitHub account as the PR author, it cannot post an `APPROVED` review. Rex typically posts a `COMMENTED` review (a review comment without a formal verdict). The gate therefore accepts **any review state** (APPROVED, COMMENTED, CHANGES_REQUESTED) at HEAD — the invariant is that a review exists in the GitHub audit trail, not that it carries a specific verdict.
+GitHub's PR review API has three states: `APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`. Rex typically posts a `COMMENTED` review (a review comment without a formal verdict). The gate accepts **any review state** (APPROVED, COMMENTED, CHANGES_REQUESTED) at HEAD — the invariant is that an **independent** review exists in the GitHub audit trail, not that it carries a specific verdict. "Independent" means the review author is someone other than the PR author; a self-comment does not satisfy the gate regardless of its state.
 
 ### Graceful degrade on gh unavailability
 
 If the `gh pr view --json reviews` call fails (network outage, auth expiry, `gh` not installed), the hook warns on stderr and falls back to the prior SHA-only behaviour. This mirrors the existing graceful-degrade pattern for `resolve_pr_head` (introduced in #55): an infrastructure failure must not permanently block merges. The warning is visible in the session log, so the operator knows the real-review check was skipped and why.
+
+Note the deliberate-bypass risk: a determined actor could force a gh-failure (e.g. by revoking or corrupting auth credentials mid-session) to reach this weaker SHA-only path. The stderr warning surfaces the skip explicitly, allowing an operator reviewing the session log to decide whether the merge is safe. The degrade is designed for genuine infrastructure outages, not as a loophole — operators should keep `gh` authenticated in all sessions.
 
 ## Consequences
 
@@ -51,7 +59,7 @@ If the `gh pr view --json reviews` call fails (network outage, auth expiry, `gh`
 
 ## Artifacts
 
-- PR: me2resh/apexyard#495 — the three-layer fix
+- PR: me2resh/apexyard#504 — the three-layer fix (author-independence iteration)
 - Issue: me2resh/apexyard#494 — the bug report with observed platform-engineer self-review behaviour
 - Changed files:
   - `.claude/agents/backend-engineer.md` — guardrail section

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -542,7 +542,7 @@ a:hover { color: var(--accent); }
 
   <rect x="394" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
   <text x="410" y="252" font-size="14" font-weight="700" fill="#1E3A5F">[~] Hooks</text>
-  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 38 shell gates</text>
+  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 39 shell gates</text>
   <text x="410" y="295" font-size="11" fill="#4A6FA5">Merge gate · ticket-first · secrets · …</text>
 
   <rect x="704" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>

--- a/site/architecture.md.gen
+++ b/site/architecture.md.gen
@@ -25,7 +25,7 @@ Fork apexyard once and treat the fork as your ops repo. Add an entry to `apexyar
 Declares what's true and what's enforced:
 
 - **Registry** (`apexyard.projects.yaml`) — lists every managed project
-- **Hooks** (`.claude/hooks/`) — 38 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
+- **Hooks** (`.claude/hooks/`) — 39 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
 - **Rules** (`.claude/rules/`) — 11 modular self-discipline guides
 - **Onboarding** (`onboarding.yaml`) — company name, mission, team, tech stack
 

--- a/site/index.md.gen
+++ b/site/index.md.gen
@@ -75,7 +75,7 @@ The reviewer changes based on what you're working on. Touching auth code? A secu
 
 Want to adopt a project you've inherited? `/handover`. Want to capture an idea before it evaporates? `/idea`. Want to know what's waiting on you across every product? `/inbox`. Want a launch-readiness check before customers see it? `/launch-check`. 54 of these in total — each one is a focused workflow with safety rails.
 
-### Guardrails that stop bad code from shipping · 38 hooks
+### Guardrails that stop bad code from shipping · 39 hooks
 
 Every edit needs a real ticket behind it. Every database change needs a rollback plan. Every merge needs a real review. Secrets in code get caught before they're committed. Mechanically enforced — 32 small scripts that fire at the right moments.
 

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -3,7 +3,7 @@
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and
 > one place for all your products, built on top of Claude Code. 59 skills,
-> 38 hooks, 20 role definitions. Open source, plain markdown and shell, no SaaS,
+> 39 hooks, 20 role definitions. Open source, plain markdown and shell, no SaaS,
 > no lock-in.
 
 This file is the LLM/agent-friendly concatenation of the apexyard marketing
@@ -244,7 +244,7 @@ each owned by different parts of the framework:
    for the framework.
 2. **Capability layer** — the runnable spec: `.claude/skills/` (59
    slash commands), `.claude/agents/` (24 sub-agents incl. Rex), and
-   `.claude/hooks/` (38 mechanical enforcement scripts).
+   `.claude/hooks/` (39 mechanical enforcement scripts).
 3. **Framework defaults layer** — `.claude/project-config.defaults.json`
    ships the framework's opinions; adopters override per-repo in
    `.claude/project-config.json` (shallow merge).

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -3,7 +3,7 @@
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and one
 > place for all your products, built on top of Claude Code. 59 skills,
-> 38 hooks, 20 role definitions. Open source, plain markdown and shell,
+> 39 hooks, 20 role definitions. Open source, plain markdown and shell,
 > no SaaS, no lock-in.
 
 ## Pages
@@ -54,7 +54,7 @@
   across the portfolio in ~1 second.
 - **59 slash commands** grouped by outcome: keep quality high, move work
   forward, see everything at once, onboard new code, run things.
-- **38 shell hooks** mechanically enforce the rules — ticket-first, migration
+- **39 shell hooks** mechanically enforce the rules — ticket-first, migration
   gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR-title
   validation, upstream-drift banner, leak protection.
 - **20 role definitions** across 5 departments (Engineering, Product, Design,

--- a/site/skill.md
+++ b/site/skill.md
@@ -43,7 +43,7 @@ what you're trying to do:
 - **Run things** (`/update`, `/split-portfolio`, `/release`, `/debug`,
   `/pdf`, `/fan-out`)
 
-38 shell hooks enforce SDLC rules mechanically — ticket-first, migration
+39 shell hooks enforce SDLC rules mechanically — ticket-first, migration
 gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR
 title validation, decision-record-required-for-architecture, upstream-drift
 banner, leak protection. 20 role definitions activate on triggers (label,


### PR DESCRIPTION
## Summary

- **Layer 1 — Prompt guardrails** in all 7 build-class agent files (backend-engineer, frontend-engineer, platform-engineer, product-manager, data-engineer, ui-designer, ux-designer): explicit "You cannot self-review" section that prohibits writing review markers, prohibits framing reports as "Rex Code Review — Verdict: APPROVED", and instructs the agent to report results plainly and hand off to the orchestrator
- **Layer 2 — Advisory warn hook** (`warn-review-marker-write.sh`, exit 0 always): fires when any Write or Bash call targets `*-rex.approved` or `*-ceo.approved` under `.claude/session/reviews/`, reminding the writing agent that markers must come from the real reviewer or `/approve-merge`
- **`block-unreviewed-merge.sh` unchanged** — restored to upstream/dev baseline; the mechanical independent-review gate from earlier iterations of this PR is dropped entirely
- **AgDR-0062** documents the decision: mechanical gate deferred as an explicit opt-in for future hands-off / multi-account setups (see rationale below)
- **W1–W4 warn-hook tests** added to `test_block_unreviewed_merge.sh`; G1–G4 real-GitHub-review gate tests removed (not applicable without the gate)

## Why the mechanical gate is deferred

The independent-review gate would require that a posted GitHub review comes from an identity **other than the PR author**. In the default single-maintainer / single-GitHub-account setup this is unsatisfiable: Rex runs under the same GitHub account that opened the PR, so every review it posts counts as a self-review — the gate would block every merge. The gate will be re-enabled behind a config flag (`require_independent_github_review: true`) if/when merging becomes unattended or a separate reviewer identity (bot account) is in use.

## Residual risk

The rex marker remains a bare SHA — technically forgeable. This is accepted while every merge has an explicit human CEO nod via `/approve-merge`. AgDR-0062 documents this as a known, accepted trade-off.

## Test plan

- [x] `bash .claude/hooks/tests/test_block_unreviewed_merge.sh` → 29/29 PASS (25 baseline + 4 warn-hook W1–W4)
- [x] `shellcheck .claude/hooks/warn-review-marker-write.sh` → clean
- [x] `jq . .claude/settings.json` → valid
- [x] `git diff upstream/dev -- .claude/hooks/block-unreviewed-merge.sh` → empty (no change to merge gate)

Closes #494

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Glossary

| Term | Definition |
|------|------------|
| review marker | A file under `.claude/session/reviews/` (`<pr>-rex.approved` / `<pr>-ceo.approved`) recording that a review/approval happened; consumed by the merge gate. |
| build-class agent | A sub-agent that implements code (backend/frontend/platform-engineer, product-manager, etc.); cannot nest the Agent tool, so it cannot run the real code-reviewer. |
| author-independence | The property (deferred to an opt-in per AgDR-0062) that an honored GitHub review be authored by someone other than the PR author. |
| advisory hook | A PreToolUse hook that warns but never blocks (exit 0 always). |