### PR TITLE
fix(#493): release site-version bump + correct issue-filing version on dev + tracker shape-only fallback

### DIFF
--- a/.claude/hooks/tests/test_site_counts.sh
+++ b/.claude/hooks/tests/test_site_counts.sh
@@ -214,6 +214,40 @@ if [ "$DRIFT" -gt 0 ]; then
   exit 1
 fi
 
+# --- Advertised version vs CHANGELOG (#493) ----------------------------------
+# The marketing site (site/index.html) hard-codes the framework version in its
+# JSON-LD `softwareVersion`. /release now bumps it as part of the release cut
+# (step 3.5 of .claude/skills/release/SKILL.md). This guard asserts the site's
+# advertised version still equals the top-most release entry in CHANGELOG.md, so
+# a future cut that bumps the CHANGELOG without bumping the site (or vice-versa)
+# fails CI instead of drifting silently across release cycles. Wired into CI via
+# the same .github/workflows/site-counts-check.yml that runs this whole test.
+echo
+echo "Advertised site version vs CHANGELOG (drift guard):"
+# CHANGELOG: the top-most `## [X.Y.Z]` heading is the canonical current version.
+CHANGELOG_VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md 2>/dev/null \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+# site/index.html: JSON-LD `softwareVersion` (bare X.Y.Z, no `v` prefix).
+SITE_VERSION=$(grep -oE '"softwareVersion"[[:space:]]*:[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' site/index.html 2>/dev/null \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+if [ -z "$CHANGELOG_VERSION" ]; then
+  echo "FAIL: could not parse the top '## [X.Y.Z]' release entry from CHANGELOG.md"
+  exit 1
+fi
+if [ -z "$SITE_VERSION" ]; then
+  echo "FAIL: could not parse JSON-LD softwareVersion from site/index.html"
+  exit 1
+fi
+if [ "$SITE_VERSION" != "$CHANGELOG_VERSION" ]; then
+  echo "FAIL: site/index.html softwareVersion=$SITE_VERSION but CHANGELOG.md top entry is $CHANGELOG_VERSION"
+  echo "      The marketing site's advertised version drifted from the release line."
+  echo "      Fix: bump site/index.html (softwareVersion + the other version strings"
+  echo "      per .claude/skills/release/SKILL.md step 3.5) to match CHANGELOG.md."
+  exit 1
+fi
+echo "  ok   site softwareVersion=$SITE_VERSION matches CHANGELOG top entry $CHANGELOG_VERSION"
+
 # --- LLM payload-size meta tags (#333 item C) ---
 # Each main marketing page carries <meta name="llm:token-count" content="N">
 # and <meta name="llm:doc-length" content="M chars">. The token estimate is

--- a/.claude/hooks/tests/test_tracker_aware_hooks.sh
+++ b/.claude/hooks/tests/test_tracker_aware_hooks.sh
@@ -273,9 +273,16 @@ else
   record_fail "linear: closed-state (Done) → blocked"
 fi
 
-# Linear: missing ticket (linear exits 1) — should block.
+# Linear: tracker CLI returns empty (linear exits 1). Under #501 this is
+# treated as "not queryable here" — indistinguishable from an absent /
+# unauthenticated CLI — so the hook falls back to shape-only and PASSES
+# (exit 0) rather than blocking. Prior to #501 this blocked (exit 2); the
+# behaviour was reversed because blocking made it impossible to open a PR
+# referencing a real, valid non-GitHub ticket when the CLI isn't reachable.
+# (Closed-state Linear tickets still block — see the "Done" case above — and
+# gh fabricated #N still blocks — see Case 12.)
 install_mock "$SB" linear 'exit 1'
-cmd='gh pr create --title "feat(LIN-99): missing" --body "
+cmd='gh pr create --title "feat(LIN-99): unqueryable" --body "
 ## Testing
 x
 
@@ -284,10 +291,10 @@ x
 |------|------------|
 | LIN | Linear |
 " --head feature/LIN-99-test'
-if run_pr_hook "$SB" "$cmd" 2; then
-  record_pass "linear: missing ticket → blocked"
+if run_pr_hook "$SB" "$cmd" 0; then
+  record_pass "linear: tracker CLI returns empty → shape-only PASS (#501; was block pre-#501)"
 else
-  record_fail "linear: missing ticket → blocked"
+  record_fail "linear: tracker CLI returns empty → shape-only PASS (#501; was block pre-#501)"
 fi
 rm -rf "$SB"
 
@@ -601,6 +608,127 @@ if [ "$rc" -ne 0 ]; then
   record_pass "lib: tracker_view (none) exits non-zero (existence-check disabled)"
 else
   record_fail "lib: tracker_view (none) exits non-zero (existence-check disabled)" "got rc=$rc"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 10 (#501): non-gh tracker, CLI absent / returns empty → shape-only
+# fallback. The existence check can't run (no working CLI), so a well-formed
+# key in a valid PR title must PASS (not block) — blocking would make it
+# impossible to open a PR referencing a real non-GitHub ticket.
+# =============================================================================
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{
+  "tracker": {
+    "kind": "linear",
+    "view_command": "linear issue view {id} --json",
+    "id_pattern": "^[A-Z]+-[0-9]+$"
+  }
+}
+JSON
+# Mock linear CLI that always fails (CLI absent / unauthenticated / not
+# queryable from this environment) — tracker_view returns empty.
+install_mock "$SB" linear 'exit 1'
+cmd='gh pr create --title "feat(LIN-77): real linear ticket" --body "
+## Testing
+x
+
+## Glossary
+| Term | Definition |
+|------|------------|
+| LIN | Linear |
+" --head feature/LIN-77-test'
+if run_pr_hook "$SB" "$cmd" 0; then
+  record_pass "#501 pr-create: non-gh tracker not queryable → shape-only PASS (no block)"
+else
+  record_fail "#501 pr-create: non-gh tracker not queryable → shape-only PASS (no block)"
+fi
+
+# Same mode — verify-commit-refs.sh must also fall back to shape-only and PASS
+# on a #N ref it cannot verify against the (absent) non-gh tracker.
+cmd='git commit -m "feat: wire LIN-77
+
+Closes #77
+"'
+if run_commit_hook "$SB" "$cmd" 0; then
+  record_pass "#501 commit-refs: non-gh tracker not queryable → shape-only PASS (no block)"
+else
+  record_fail "#501 commit-refs: non-gh tracker not queryable → shape-only PASS (no block)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 11 (#501): an ill-formed PR title still fails the shape check even
+# under a non-gh tracker. Shape-only fallback must NOT become a blanket pass —
+# the title regex (type(TICKET): …) still gates malformed titles.
+# =============================================================================
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{
+  "tracker": {
+    "kind": "linear",
+    "view_command": "linear issue view {id} --json",
+    "id_pattern": "^[A-Z]+-[0-9]+$"
+  }
+}
+JSON
+install_mock "$SB" linear 'exit 1'
+# Malformed title: no ticket ref in the type(TICKET): shape → must block (exit 2).
+cmd='gh pr create --title "feat: missing ticket parens" --body "
+## Testing
+x
+
+## Glossary
+| Term | Definition |
+|------|------------|
+| x | x |
+" --head feature/LIN-1-test'
+if run_pr_hook "$SB" "$cmd" 2; then
+  record_pass "#501 pr-create: ill-formed title still fails shape check under non-gh tracker"
+else
+  record_fail "#501 pr-create: ill-formed title still fails shape check under non-gh tracker"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 12 (#501): gh behaviour is UNCHANGED — a fabricated #N under the default
+# gh tracker still BLOCKS (exit 2). The shape-only fallback is strictly non-gh;
+# the GitHub-issue existence check must remain hard for tracker.kind == gh.
+# =============================================================================
+SB=$(make_fork)
+# Default config (no project-config.json) → tracker.kind = gh. Mock gh returns
+# nothing (issue doesn't exist).
+install_mock "$SB" gh '
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  exit 1
+fi
+exit 0
+'
+cmd='gh pr create --title "feat(#88888): missing gh ticket" --body "
+## Testing
+x
+
+## Glossary
+| Term | Definition |
+|------|------------|
+| x | x |
+" --head feature/GH-1-test'
+if run_pr_hook "$SB" "$cmd" 2; then
+  record_pass "#501 pr-create: gh tracker fabricated #N still BLOCKS (gh behaviour unchanged)"
+else
+  record_fail "#501 pr-create: gh tracker fabricated #N still BLOCKS (gh behaviour unchanged)"
+fi
+
+# verify-commit-refs.sh under gh: fabricated #N still blocks.
+cmd='git commit -m "feat: thing
+
+Closes #88888
+"'
+if run_commit_hook "$SB" "$cmd" 2; then
+  record_pass "#501 commit-refs: gh tracker fabricated #N still BLOCKS (gh behaviour unchanged)"
+else
+  record_fail "#501 commit-refs: gh tracker fabricated #N still BLOCKS (gh behaviour unchanged)"
 fi
 rm -rf "$SB"
 

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -249,7 +249,18 @@ if [ -n "$TICKET_REF" ]; then
         MATCHED_REPO="$UPSTREAM_REPO"
       fi
     fi
-    if [ -z "$ISSUE_JSON" ]; then
+    if [ -z "$ISSUE_JSON" ] && [ "$TRACKER_KIND" != "gh" ]; then
+      # Non-gh tracker (Linear / Jira / Asana / custom) returned nothing — the
+      # tracker CLI is absent, unauthenticated, or not queryable from this
+      # environment (#501). Do NOT block: the title already passed the shape
+      # check against tracker_id_pattern, which is all we can assert without a
+      # working CLI. Blocking here would make it impossible to open a PR that
+      # references a real, valid non-GitHub ticket. Hard existence enforcement
+      # is retained ONLY for tracker.kind == gh (the block below).
+      echo "WARN: validate-pr-create.sh: tracker '${TRACKER_KIND}' not queryable here — ${TICKET_REF} accepted on shape only (no existence check)." >&2
+      ISSUE_JSON=""
+      TICKET_NUM=""
+    elif [ -z "$ISSUE_JSON" ]; then
       # Name both trackers in the error when an upstream fallback was tried,
       # so the operator sees exactly where the lookup was attempted.
       if [ -n "$UPSTREAM_REPO" ]; then

--- a/.claude/hooks/verify-commit-refs.sh
+++ b/.claude/hooks/verify-commit-refs.sh
@@ -206,6 +206,7 @@ fi
 # "every PR needs its own OPEN ticket".
 MISSING=""
 CLOSED=""
+SHAPE_ONLY=""
 for REF in $REFS; do
   NUM=$(echo "$REF" | tr -d '#')
   # Dispatch via the tracker lib. For non-gh kinds `--repo` may be a no-op.
@@ -213,6 +214,16 @@ for REF in $REFS; do
   # Short-circuit: only consult upstream when the primary tracker missed.
   if [ -z "$ISSUE_JSON" ] && [ -n "$UPSTREAM_REPO" ]; then
     ISSUE_JSON=$(tracker_view "$NUM" "$UPSTREAM_REPO" 2>/dev/null)
+  fi
+  if [ -z "$ISSUE_JSON" ] && [ "$TRACKER_KIND" != "gh" ]; then
+    # Non-gh tracker (Linear / Jira / Asana / custom) returned nothing — the
+    # tracker CLI is absent, unauthenticated, or not queryable from this
+    # environment (#501). Do NOT block: the ref already passed the well-formed
+    # shape extraction above, which is all we can assert without a working CLI.
+    # Hard existence enforcement (adding to MISSING → exit 2) is retained ONLY
+    # for tracker.kind == gh.
+    SHAPE_ONLY="${SHAPE_ONLY}${REF} "
+    continue
   fi
   if [ -z "$ISSUE_JSON" ]; then
     MISSING="${MISSING}${REF} "
@@ -253,6 +264,10 @@ If the reference is truly informational (cross-repo link that can't be verified
 with \`gh issue view\`), write it as a plain URL instead of #N notation.
 MSG
   exit 2
+fi
+
+if [ -n "$SHAPE_ONLY" ]; then
+  echo "WARN: verify-commit-refs.sh: tracker '${TRACKER_KIND}' not queryable here — ${SHAPE_ONLY}accepted on shape only (no existence check). See #501." >&2
 fi
 
 if [ -n "$CLOSED" ]; then

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -76,6 +76,49 @@ Run `git log <prev-tag>..upstream/dev --pretty=format:'%h %s'` and group by conv
 
 Show the draft and let the user edit interactively before opening the PR.
 
+### 3.5. Bump the marketing-site version strings (`site/index.html`)
+
+The marketing site hard-codes the framework version in several places. `/release`
+bumps the git tag + CHANGELOG but historically did NOT touch these, so they
+drifted across ~5 release cycles before anyone noticed (#491 / #493). Update them
+**in the same commit that lands the CHANGELOG entry**, driven by the version being
+cut (`vX.Y.Z`, with `X.Y.Z` the bare semver and `X.Y` the major.minor) and the
+release date (`YYYY-MM-DD`):
+
+| Location in `site/index.html` | What to set | Approx. line |
+|------|------|------|
+| JSON-LD `softwareVersion` | `X.Y.Z` (no `v` prefix — matches CHANGELOG `## [X.Y.Z]`) | ~L54 |
+| JSON-LD `dateModified` | release date `YYYY-MM-DD` | ~L57 |
+| Hero pill `apexyard vX.Y` | `apexyard vX.Y` | ~L1568 |
+| Hero version link **text** | `vX.Y.Z` | ~L1576 |
+| Hero version link **href** | `…/releases/tag/vX.Y.Z` | ~L1576 |
+| Releases-shipped metric **count** | number of `## [` release entries in `CHANGELOG.md` | ~L1696 |
+| Releases-shipped metric **range** | `(v0.1 → vX.Y)` | ~L1696 |
+
+Derive every value from the version being cut — do not hand-pick. Suggested
+computation:
+
+```bash
+VER="${VERSION#v}"                       # 2.2.0  (strip leading v if present)
+MAJOR_MINOR="${VER%.*}"                   # 2.2
+RELEASE_DATE=$(date +%F)                  # YYYY-MM-DD (or the CHANGELOG entry's date)
+RELEASE_COUNT=$(grep -cE '^## \[[0-9]' "$ops_root/CHANGELOG.md")  # count of release entries
+```
+
+**Leave historical version strings untouched** — CHANGELOG entries, migration-script
+filenames (e.g. `migrate-v1-to-v2.ts`), and AgDR examples that quote an old version
+are history, not the current-version advertisement. Only the seven locations above
+move with each cut.
+
+Show the resulting `site/index.html` diff alongside the CHANGELOG diff in the
+dry-run / preview so the operator sees both before the PR opens.
+
+> **Durable guard:** `test_site_counts.sh` asserts `site/index.html`'s JSON-LD
+> `softwareVersion` equals the top-most `## [X.Y.Z]` entry in `CHANGELOG.md`, and
+> the CI workflow `site-counts-check.yml` runs it on every PR. If you bump the
+> CHANGELOG without bumping the site (or vice-versa), CI goes red — the drift can
+> no longer accumulate silently.
+
 ### 4. Open the release PR
 
 Branch from `dev`: `release/vA.B.C`. Push to `upstream`. Open PR:

--- a/.claude/skills/report-apexyard-bug/SKILL.md
+++ b/.claude/skills/report-apexyard-bug/SKILL.md
@@ -73,12 +73,29 @@ canonical `me2resh/apexyard`.
 
 So the maintainer knows which version the report is against, capture the version
 from the fork (the SessionStart upstream-drift banner shows it; otherwise derive
-it):
+it).
+
+**Do NOT use `git describe --tags --abbrev=0`.** Under the release-cut branch
+model, release tags (`vX.Y.Z`) are created on `main` and are NOT ancestors of
+`dev`, so `git describe` from a `dev` checkout reports a stale version (observed:
+`v1.1.0` when the line is actually `v2.2.0`) — every issue filed from `dev` would
+be mislabeled (#503). Derive from `CHANGELOG.md` instead, which `/release-sync`
+carries `main → dev`, so it is always current on `dev`:
 
 ```bash
-FW_VERSION=$(git -C "$ops_root" describe --tags --abbrev=0 2>/dev/null \
-  || git -C "$ops_root" rev-parse --short HEAD 2>/dev/null \
-  || echo "unknown")
+# Primary: top-most `## [X.Y.Z]` heading in CHANGELOG.md (carried main→dev by
+# /release-sync, so always the canonical current version on dev).
+FW_VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$ops_root/CHANGELOG.md" 2>/dev/null \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+if [ -n "$FW_VERSION" ]; then
+  FW_VERSION="v$FW_VERSION"          # keep the `v` prefix the field renders today
+else
+  # Fallbacks: highest semver tag across ALL refs (catches main-only release
+  # tags via -v:refname sort) → short HEAD → literal "unknown".
+  FW_VERSION=$(git -C "$ops_root" tag --sort=-v:refname 2>/dev/null | head -1)
+  [ -z "$FW_VERSION" ] && FW_VERSION=$(git -C "$ops_root" rev-parse --short HEAD 2>/dev/null)
+  [ -z "$FW_VERSION" ] && FW_VERSION="unknown"
+fi
 ```
 
 ### 3. Gather details (one question at a time)

--- a/.claude/skills/request-apexyard-feature/SKILL.md
+++ b/.claude/skills/request-apexyard-feature/SKILL.md
@@ -64,10 +64,27 @@ default to the canonical slug before filing.
 
 ### 2. Capture the framework version
 
+**Do NOT use `git describe --tags --abbrev=0`.** Under the release-cut branch
+model, release tags (`vX.Y.Z`) are created on `main` and are NOT ancestors of
+`dev`, so `git describe` from a `dev` checkout reports a stale version (observed:
+`v1.1.0` when the line is actually `v2.2.0`) — every issue filed from `dev` would
+be mislabeled (#503). Derive from `CHANGELOG.md` instead, which `/release-sync`
+carries `main → dev`, so it is always current on `dev`:
+
 ```bash
-FW_VERSION=$(git -C "$ops_root" describe --tags --abbrev=0 2>/dev/null \
-  || git -C "$ops_root" rev-parse --short HEAD 2>/dev/null \
-  || echo "unknown")
+# Primary: top-most `## [X.Y.Z]` heading in CHANGELOG.md (carried main→dev by
+# /release-sync, so always the canonical current version on dev).
+FW_VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$ops_root/CHANGELOG.md" 2>/dev/null \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+if [ -n "$FW_VERSION" ]; then
+  FW_VERSION="v$FW_VERSION"          # keep the `v` prefix the field renders today
+else
+  # Fallbacks: highest semver tag across ALL refs (catches main-only release
+  # tags via -v:refname sort) → short HEAD → literal "unknown".
+  FW_VERSION=$(git -C "$ops_root" tag --sort=-v:refname 2>/dev/null | head -1)
+  [ -z "$FW_VERSION" ] && FW_VERSION=$(git -C "$ops_root" rev-parse --short HEAD 2>/dev/null)
+  [ -z "$FW_VERSION" ] && FW_VERSION="unknown"
+fi
 ```
 
 ### 3. Gather details (one question at a time)


### PR DESCRIPTION
<!-- multi-close: approved -->

Three independent framework fixes batched on one branch (all touch `.claude/` paths only).

## Summary

- **#493 — `/release` auto-bumps the marketing-site version strings + a durable drift guard.** The release flow bumped the git tag and CHANGELOG but never touched `site/index.html`'s hard-coded version, so the site advertised a stale version that drifted across ~5 release cycles before anyone noticed (#491). A new **step 3.5** in `.claude/skills/release/SKILL.md` updates all seven version locations (JSON-LD `softwareVersion` + `dateModified`, hero pill `apexyard vX.Y`, hero version link text + `releases/tag/vX.Y.Z` href, releases-shipped count + `(v0.1 → vX.Y)` range) — derived from the version being cut, not hand-edited — and explicitly leaves historical strings (CHANGELOG entries, migration filenames, AgDR examples) untouched. `test_site_counts.sh` now asserts the site's `softwareVersion` equals the top `## [X.Y.Z]` CHANGELOG entry, so any future cut that bumps one without the other fails CI instead of drifting silently. The existing `site-counts-check.yml` workflow already runs this test, so no workflow change is needed.
- **#503 — issue-filing skills capture the correct version on `dev`.** Under the release-cut model, release tags live on `main` and are not ancestors of `dev`, so `git describe --tags --abbrev=0` from a `dev` checkout returned a stale version (`v1.1.0` when the line was actually `v2.2.0`), mislabeling every issue filed from `dev`. Both `report-apexyard-bug` and `request-apexyard-feature` now derive the version from the top `## [X.Y.Z]` in `CHANGELOG.md` (carried `main → dev` by `/release-sync`, so always current on `dev`), with robust fallbacks: highest semver tag across all refs (`git tag --sort=-v:refname`) → short HEAD → `unknown`. The `v` prefix the field renders today is preserved.
- **#501 — shape-only fallback for non-GitHub trackers.** `validate-pr-create.sh` and `verify-commit-refs.sh` hardwired a GitHub-issue existence check, so a project with `.tracker.kind = linear`/`jira`/etc. could not open a PR or commit referencing a real tracker key when the tracker CLI was absent or not queryable — the hook looked for a GitHub issue that would never exist and blocked at creation. Now, when `TRACKER_KIND != gh` **and** `tracker_view` returns empty, both hooks fall back to shape-only validation (the key already passed the title/commit regex against `tracker_id_pattern`), emit a one-line advisory to stderr, and exit 0. The hard existence block is retained **only** for `TRACKER_KIND == gh` — GitHub behaviour is entirely unchanged.

## Testing

- `bash .claude/hooks/tests/test_tracker_aware_hooks.sh` → **22 passed, 0 failed.** Added cases for #501: non-gh tracker not queryable → shape-only PASS (both hooks); ill-formed title still fails the shape check under a non-gh tracker; gh fabricated `#N` still BLOCKS (gh behaviour unchanged, both hooks). The pre-existing "linear: missing ticket → blocked" case was updated to the new #501 contract (a non-gh CLI returning empty is indistinguishable from "not queryable" → shape-only PASS); the closed-state (Linear "Done", Jira "Resolved") block cases remain green.
- `bash .claude/hooks/tests/test_site_counts.sh` → **PASS.** The new version-drift guard reports `ok site softwareVersion=2.2.0 matches CHANGELOG top entry 2.2.0`. Verified it FAILS (exit 1) on a synthesised drift fixture (CHANGELOG `3.0.0` vs site `2.2.0`).
- **#503 snippet on this `dev` checkout:** new snippet yields `FW_VERSION = v2.2.0` (correct); the old `git describe --tags --abbrev=0` yields the stale `v1.1.0`.
- `shellcheck` on `validate-pr-create.sh` and `verify-commit-refs.sh`: **no new warnings.** `validate-pr-create.sh` carries the same 3 pre-existing info-level warnings (SC1091, SC2059, SC2086) as the `upstream/dev` baseline; `verify-commit-refs.sh` is warning-clean in both.

## Glossary

| Term | Definition |
|------|------------|
| Release-cut model | Branch model where `dev` accumulates daily merges and `main` receives tagged release PRs (`vX.Y.Z`); tags are not ancestors of `dev`. |
| Release-cut drift | Version labels going stale because the release flow updates the tag but not hard-coded site strings. |
| `softwareVersion` | The JSON-LD `SoftwareApplication` field in `site/index.html` that advertises the current framework version. |
| `git describe --tags --abbrev=0` | Returns the most recent tag reachable from the current HEAD — misses release tags that aren't ancestors of `dev`. |
| `.tracker.kind` | Project-config field selecting the active tracker (`gh`, `jira`, `linear`, `asana`, `custom`, `none`). |
| Shape-only validation | Confirming a ticket key matches `tracker_id_pattern` without asserting it exists in a tracker. |
| `tracker_view` | `_lib-tracker.sh` function that dispatches the configured tracker's view command and emits normalised JSON; empty output = not found / not queryable. |

Closes #493
Closes #503
Closes #501
