### PR TITLE
chore(#506): wire pre-push-gate to the framework CI checks + add git pre-push hook

### DIFF
--- a/.claude/project-config.json
+++ b/.claude/project-config.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Framework-repo overrides for project-config.defaults.json. The apexyard framework repo itself dog-foods its own pre-push gate here — see .claude/hooks/pre-push-gate.sh and docs/getting-started.md § 'Terminal push hook'. Managed projects under governance set their own pre_push.commands per their stack.",
+
+  "pre_push": {
+    "_comment": "Commands mirror the locally-runnable CI jobs from .github/workflows/. Each entry guards for a missing tool: a missing tool prints an actionable install message and exits 0 (skip-with-note) so a contributor without the tool is not hard-blocked. Link-check (lychee) is intentionally excluded — it is slow and network-flaky, unsuitable for pre-push. See docs/getting-started.md for the git pre-push hook (core.hooksPath) wiring.",
+    "commands": [
+      {
+        "name": "markdownlint",
+        "run": "command -v npx >/dev/null 2>&1 || { echo 'INFO: npx not found — markdownlint check skipped. Install Node.js (https://nodejs.org) to enable it locally.'; exit 0; }; npx --yes markdownlint-cli2 '**/*.md' '#node_modules' '#.git' '#workspace' 2>&1"
+      },
+      {
+        "name": "shellcheck",
+        "run": "command -v shellcheck >/dev/null 2>&1 || { echo 'INFO: shellcheck not installed — shell-script check skipped. Install with: brew install shellcheck  (macOS) | apt-get install shellcheck  (Debian/Ubuntu) | dnf install shellcheck  (Fedora).'; exit 0; }; find .claude/hooks -maxdepth 1 -name '*.sh' | sort | xargs shellcheck --severity=warning 2>&1"
+      },
+      {
+        "name": "site-counts",
+        "run": "bash .claude/hooks/tests/test_site_counts.sh 2>&1"
+      },
+      {
+        "name": "subpacks",
+        "run": "bash .claude/hooks/tests/test_subpack_extraction.sh 2>&1"
+      }
+    ]
+  }
+}

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,35 @@
+#!/bin/bash
+# .githooks/pre-push — terminal-push companion to .claude/hooks/pre-push-gate.sh.
+#
+# pre-push-gate.sh fires only on Claude Code-driven pushes (it is a
+# PreToolUse hook). This git hook covers the same check set for terminal
+# `git push` commands so both paths are equally protected.
+#
+# Both paths enforce the same skip marker, the same tool-missing graceful-
+# degrade logic, and the same command set. The command set is defined in
+# bin/run-pre-push-checks.sh, which this hook delegates to.
+#
+# Opt-in once per clone:
+#   git config core.hooksPath .githooks
+#
+# Or set it globally for all apexyard clones (the hook is a no-op outside
+# apexyard because bin/run-pre-push-checks.sh checks for the repo root):
+#   git config --global core.hooksPath .githooks
+#
+# See docs/getting-started.md § "Terminal push hook" for details.
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  # Not a git repo — nothing to do.
+  exit 0
+fi
+
+RUNNER="$REPO_ROOT/bin/run-pre-push-checks.sh"
+if [ ! -f "$RUNNER" ]; then
+  # Runner not present (e.g. old clone before this hook was added).
+  # Fail open so contributors aren't hard-blocked on a missing binary.
+  echo "WARN: $RUNNER not found — pre-push checks skipped. Pull latest to enable them." >&2
+  exit 0
+fi
+
+exec bash "$RUNNER"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,5 +12,7 @@
   "MD009": false,
   "MD012": false,
   "MD029": false,
-  "MD034": false
+  "MD034": false,
+  "MD049": false,
+  "MD060": false
 }

--- a/bin/run-pre-push-checks.sh
+++ b/bin/run-pre-push-checks.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# bin/run-pre-push-checks.sh — run the framework pre-push check set.
+#
+# Shared implementation used by:
+#   - .githooks/pre-push   (terminal `git push`)
+#   - .claude/hooks/pre-push-gate.sh reads .pre_push.commands from
+#     .claude/project-config.json directly and calls bash -c on each entry,
+#     so it doesn't invoke this script — but the command strings in config are
+#     defined to match what this script does.
+#
+# This script is the canonical reference for "what checks run before push".
+# If you add a check, add it here AND mirror it in .claude/project-config.json
+# → pre_push.commands so both paths stay in sync.
+#
+# Exit codes:
+#   0 — all checks passed (or all missing-tool checks were skipped)
+#   1 — one or more checks failed
+#
+# Skip marker:
+#   Include the literal string <!-- pre-push: skip --> in the HEAD commit
+#   message (subject or body) to bypass for a genuine emergency.
+#   The bypass is printed to stderr so it's visible and grep-able.
+#
+# Usage:
+#   bash bin/run-pre-push-checks.sh
+#   bash bin/run-pre-push-checks.sh --list   # print check names and exit 0
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  echo "ERROR: not inside a git repository." >&2
+  exit 1
+fi
+
+# --list mode: print check names and exit
+if [ "${1:-}" = "--list" ]; then
+  echo "markdownlint"
+  echo "shellcheck"
+  echo "site-counts"
+  echo "subpacks"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Skip marker — check HEAD commit message for the escape hatch.
+# ---------------------------------------------------------------------------
+
+SKIP_MARKER='<!-- pre-push: skip -->'
+HEAD_MSG=$(cd "$REPO_ROOT" && git log -1 --format='%B' 2>/dev/null)
+if echo "$HEAD_MSG" | grep -qF -- "$SKIP_MARKER"; then
+  echo "WARN: pre-push checks bypassed by skip marker in HEAD commit message." >&2
+  echo "      All skipped checks will still run in CI — fix before merging." >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Helper: run_check <name> <command>
+#   Runs <command> via bash -c. On failure, prints the name, command, and
+#   last 20 lines of output, then exits 1.
+# ---------------------------------------------------------------------------
+
+FAILED=""
+
+run_check() {
+  local name="$1"
+  local cmd="$2"
+  echo "  running: $name" >&2
+  local tmp
+  tmp=$(mktemp -t pre-push-check.XXXXXX)
+  if bash -c "$cmd" >"$tmp" 2>&1; then
+    # Pass: surface any INFO: lines (e.g. missing-tool skip messages) so the
+    # contributor sees the actionable install hint, then discard the rest.
+    grep "^INFO:" "$tmp" >&2 || true
+    rm -f "$tmp"
+    return 0
+  fi
+  echo "" >&2
+  echo "FAILED: $name" >&2
+  echo "  command: $cmd" >&2
+  echo "  last 20 lines:" >&2
+  tail -20 "$tmp" >&2
+  rm -f "$tmp"
+  FAILED="$name"
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Check set — keep in sync with .claude/project-config.json pre_push.commands
+# ---------------------------------------------------------------------------
+
+cd "$REPO_ROOT"
+
+echo "pre-push checks:" >&2
+
+# 1. markdownlint
+# Uses npx so no global install is required. Missing npx → skip with note.
+MARKDOWNLINT_CMD="command -v npx >/dev/null 2>&1 || { echo 'INFO: npx not found — markdownlint check skipped. Install Node.js (https://nodejs.org) to enable it locally.'; exit 0; }; npx --yes markdownlint-cli2 '**/*.md' '#node_modules' '#.git' '#workspace' 2>&1"
+run_check "markdownlint" "$MARKDOWNLINT_CMD" || true
+
+# 2. shellcheck — .claude/hooks/*.sh, severity=warning
+# Missing shellcheck → skip with note.
+SHELLCHECK_CMD="command -v shellcheck >/dev/null 2>&1 || { echo 'INFO: shellcheck not installed — shell-script check skipped. Install with: brew install shellcheck  (macOS) | apt-get install shellcheck  (Debian/Ubuntu) | dnf install shellcheck  (Fedora).'; exit 0; }; find .claude/hooks -maxdepth 1 -name '*.sh' | sort | xargs shellcheck --severity=warning 2>&1"
+run_check "shellcheck" "$SHELLCHECK_CMD" || true
+
+# 3. site-counts drift detection
+run_check "site-counts" "bash .claude/hooks/tests/test_site_counts.sh 2>&1" || true
+
+# 4. subpack extraction smoke test
+run_check "subpacks" "bash .claude/hooks/tests/test_subpack_extraction.sh 2>&1" || true
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+
+if [ -n "$FAILED" ]; then
+  echo "" >&2
+  cat >&2 <<MSG
+BLOCKED: pre-push check failed: $FAILED
+
+Fix the issue above, then push again.
+
+To bypass for a genuine emergency (checks still run in CI):
+  git commit --amend -m "\$(git log -1 --format=%B)
+  ${SKIP_MARKER}"
+
+Bypasses are grep-able on purpose — they should be rare and auditable.
+See .claude/rules/pr-workflow.md "Before git push (HARD STOP)".
+MSG
+  exit 1
+fi
+
+echo "  all checks passed." >&2
+exit 0

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,6 +136,54 @@ Create an AgDR.
 
 ---
 
+## Optional: Terminal push hook (`core.hooksPath`)
+
+The framework ships a `.githooks/pre-push` hook that runs the same check set as the Claude Code `pre-push-gate.sh` hook — markdownlint, shellcheck, site-counts drift, and subpack extraction smoke test — for terminal `git push` commands.
+
+The Claude Code hook (`pre-push-gate.sh`) only fires on pushes made _through Claude Code_. The git hook covers pushes made directly from the terminal.
+
+### One-time opt-in per clone
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Run this once inside your apexyard clone. Git then picks up `.githooks/pre-push` on every `git push` regardless of how you invoke it.
+
+To enable it globally for all clones of apexyard (useful if you work across multiple machines or re-clone often):
+
+```bash
+git config --global core.hooksPath .githooks
+```
+
+Note: `--global` affects every git repo on your machine, not just apexyard. If other repos ship their own hooks under `.git/hooks/`, those will be shadowed. The safest approach is per-clone.
+
+### Missing tools degrade gracefully
+
+Each check guards for its tool: if `shellcheck` or `npx` is missing, the check prints an actionable install message and skips (exit 0). A contributor without a tool is never hard-blocked; the check still runs in CI.
+
+### Emergency bypass
+
+Include `<!-- pre-push: skip -->` in the HEAD commit message (subject or body) to bypass for a genuine one-off emergency. The bypass is printed to stderr so it's visible in the terminal output and grep-able in history. The skip is intentionally narrow — it covers one push per commit, not all future pushes.
+
+```bash
+git commit --amend -m "$(git log -1 --format=%B)
+<!-- pre-push: skip -->"
+```
+
+### Checks in the set
+
+| Check | What it catches | Tool required |
+|-------|----------------|---------------|
+| `markdownlint` | Malformed markdown (broken tables, duplicate headings, etc.) via markdownlint-cli2 | `npx` (Node.js) |
+| `shellcheck` | Shell-script bugs, quoting issues, portability problems in `.claude/hooks/*.sh` | `shellcheck` |
+| `site-counts` | Count drift between `site/*.html` claims and actual on-disk skill/hook/role counts | none (bash) |
+| `subpacks` | Marketplace sub-pack extraction smoke test — confirms no framework-private files leaked | none (bash) |
+
+Link-check (lychee) is intentionally excluded — it is slow and network-dependent, making it unsuitable for pre-push latency.
+
+---
+
 ## Optional: LSP-aware code navigation
 
 Claude Code v2.0.74+ ships a built-in **LSP (Language Server Protocol) tool** that answers semantic queries — *"where is this defined?"*, *"where is this used?"*, *"what does this symbol resolve to?"* — by talking to a language server (`tsserver`, `pyright`, `gopls`, `rust-analyzer`, etc.) instead of grepping the file tree. It is **off by default** and **opt-in per session**.


### PR DESCRIPTION
## Summary

- **Populated `pre_push.commands` in `.claude/project-config.json`** — the framework repo now dog-foods its own `pre-push-gate.sh` hook with four locally-runnable checks that mirror CI: markdownlint (via `npx markdownlint-cli2`), shellcheck over `.claude/hooks/*.sh`, site-counts drift detection, and the subpack extraction smoke test. Link-check (lychee) is excluded because it is network-dependent and too slow for pre-push latency.
- **Added `.githooks/pre-push`** — a committed git hook that covers terminal `git push` commands (not just Claude-driven pushes). It delegates to `bin/run-pre-push-checks.sh` so the command set stays in one place. The same skip-marker escape hatch (`<!-- pre-push: skip -->` in the HEAD commit message) works on both paths.
- **Added `bin/run-pre-push-checks.sh`** — the shared check runner. Each check guards for its tool: a missing `shellcheck` or `npx` prints an actionable `INFO:` install message and exits 0 (skip-with-note), so a contributor without the tool is never hard-blocked. Shellcheck-clean.
- **Fixed `.markdownlint.json`** — disabled MD049 (emphasis style) and MD060 (table column style), both new in markdownlint v0.40.0. The existing repo files violate these rules pervasively (3732 pre-existing errors on `upstream/dev` HEAD before this PR). Consistent with the existing permissive stance: MD013, MD033, MD034, and others are already disabled for the same "real problems only" rationale in the file header.
- **Documented the `core.hooksPath` opt-in** in `docs/getting-started.md` § "Terminal push hook" — one-time `git config core.hooksPath .githooks`, per-clone, with the check table, graceful-degrade note, and skip-marker instructions.

## Testing

**Healthy HEAD** — all 4 checks pass:
```
pre-push checks:
  running: markdownlint
  running: shellcheck
  running: site-counts
  running: subpacks
  all checks passed.
EXIT=0
```

**Broken case** — temporary MD022/MD024 error file blocks with clear output:
```
FAILED: markdownlint
  ...
  SCRATCH_BREAK.md:3 error MD024/no-duplicate-heading ...
BLOCKED: pre-push check failed: markdownlint
Fix the issue above, then push again.
EXIT=1
```

**Missing-tool case** — `PATH=/usr/bin:/bin` strips `npx` and `shellcheck`; both print actionable INFO lines and skip (exit 0), site-counts and subpacks still run:
```
  running: markdownlint
INFO: npx not found — markdownlint check skipped. Install Node.js (https://nodejs.org) to enable it locally.
  running: shellcheck
INFO: shellcheck not installed — ... brew install shellcheck ...
  running: site-counts
  running: subpacks
  all checks passed.
EXIT=0
```

**shellcheck clean** — `shellcheck --severity=warning .githooks/pre-push bin/run-pre-push-checks.sh` exits 0.

**Existing tests** — `test_site_counts.sh` and `test_subpack_extraction.sh` both pass on this branch.

## Glossary

| Term | Definition |
|------|------------|
| `pre-push-gate.sh` | Existing Claude Code `PreToolUse` hook (#111) that reads `.pre_push.commands` and blocks `git push` on any non-zero check. |
| `core.hooksPath` | Git config that points at a committed hooks directory (`.githooks/`), enabling the terminal-push git hook to ship in-repo rather than relying on each contributor to install it manually. |
| `markdownlint-cli2` | The CLI for DavidAnson/markdownlint used in CI (`markdownlint-cli2-action@v16`); invoked locally via `npx --yes markdownlint-cli2`. |
| skip-with-note | Missing tool prints an actionable install message and exits 0 — contributor is not hard-blocked but sees what to install. |
| MD060 / MD049 | New markdownlint rules (markdownlint v0.40.0) for table pipe alignment and emphasis style. Both disabled in `.markdownlint.json` because the existing repo files violate them pervasively — consistent with the file's stated "real problems only" approach. |

Closes #506