### PR TITLE
feat(#519): add reusable Swift CI golden-path pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,7 @@ Reusable GitHub Actions workflows live at `golden-paths/pipelines/`:
 |----------|---------|
 | `ci.yml` | Combined pipeline (code quality + security + dependencies) |
 | `code-quality.yml` | TypeScript, ESLint, tests, build |
+| `swift-ci.yml` | Swift Package Manager build + guarded test (macOS) |
 | `security.yml` | Semgrep SAST + npm audit + secrets detection |
 | `dependency-audit.yml` | Weekly vulnerability + license scan |
 | `pr-title-check.yml` | Enforce ticket ID in PR titles |

--- a/golden-paths/pipelines/README.md
+++ b/golden-paths/pipelines/README.md
@@ -10,6 +10,7 @@ Reusable GitHub Actions workflows that integrate ApexYard's automated agents int
 | `security.yml` | Shield | Security scanning (SAST, dependencies, secrets) | Every PR, push to main |
 | `dependency-audit.yml` | Guardian | Dependency vulnerabilities, outdated packages, licenses | Weekly, package changes |
 | `code-quality.yml` | Rex | TypeScript, ESLint, tests, build verification | Every PR |
+| `swift-ci.yml` | Rex | Swift Package Manager build + guarded test (macOS runner) | Every PR, push to default branch |
 | `review-check.yml` | Rex (verification) | Block merge if Rex hasn't reviewed the latest commit | Every PR + review event |
 | `seo-check.yml` | SEO Check | SEO analysis for content files | Content changes |
 | `ci.yml` | Combined | All checks in one pipeline | Every PR |

--- a/golden-paths/pipelines/swift-ci.yml
+++ b/golden-paths/pipelines/swift-ci.yml
@@ -1,0 +1,56 @@
+# Swift CI Pipeline — Build & Test
+# Copy this to .github/workflows/swift-ci.yml in your project.
+#
+# For: Swift Package Manager projects (macOS / iOS apps or libraries).
+# Trigger: every PR + push to the default branch.
+# Purpose: a build gate that works before a test suite exists and upgrades
+#          itself to run tests the moment a test target is added.
+#
+# The Test step is GUARDED: it runs `swift test` only when Package.swift
+# declares a test target, otherwise it prints a skip note. This keeps the
+# pipeline green on a fresh package and auto-enables testing later with no
+# edit to this file.
+
+name: Swift CI
+
+on:
+  pull_request:
+  push:
+    # Adjust to your default branch — many Swift apps use `master`.
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: swift-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build & Test
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          # Pin a concrete version (e.g. '16.2') if you need reproducible builds.
+          xcode-version: latest-stable
+
+      - name: Swift version
+        run: swift --version
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: |
+          if grep -qE '\.testTarget|testTarget\(' Package.swift; then
+            swift test
+          else
+            echo "No test target declared in Package.swift yet — skipping tests."
+          fi


### PR DESCRIPTION
## Summary
- **Adds the first Swift golden-path pipeline** — `golden-paths/pipelines/swift-ci.yml`. Until now every template under `golden-paths/pipelines/` assumed Node/TypeScript (`setup-node`, `npm ci`, `ubuntu-latest`); a Swift/macOS adopter had nothing to copy and had to author CI from scratch. This closes that gap.
- **Guarded test step is the reusable idea** — the workflow greps `Package.swift` for a test target and runs `swift test` only when one exists, else prints a skip note. So the pipeline is green on a package that has no tests yet *and* upgrades itself to run tests the moment a test target is added — no edit to the template needed. That makes it a safe drop-in during adoption, which is exactly when a test suite usually doesn't exist yet.
- **Matches the macOS release toolchain** — `macos-latest` + `maxim-lobanov/setup-xcode@latest-stable`, least-privilege `permissions: contents: read`, and `concurrency` cancel-in-progress to avoid piling up redundant runs on the macOS runner pool.
- **Documented in both indexes** — added to the `golden-paths/pipelines/README.md` "Available Pipelines" table and the CLAUDE.md CI/CD pipelines table, so it's discoverable the same way the other pipelines are.

## Testing
1. `actionlint golden-paths/pipelines/swift-ci.yml` → exit 0.
2. YAML parses clean (`python3 -c "import yaml; yaml.safe_load(...)"`).
3. The same workflow shape was instantiated into a real Swift SPM macOS app and `swift build` verified green locally on Swift 6.3.2; the guard correctly takes the skip branch when no test target is present.
4. `markdownlint` clean on the two changed `.md` files.

Closes #519

---

## Glossary
| Term | Definition |
|------|------------|
| Golden-path pipeline | A reusable GitHub Actions workflow under `golden-paths/pipelines/` that adopters copy into a project's `.github/workflows/`. |
| Swift Package Manager (SPM) | Swift's built-in build/test tool, driven by a `Package.swift` manifest (`swift build` / `swift test`). |
| Guarded test step | A CI step that runs `swift test` only when a test target exists, keeping the pipeline valid before any tests are written. |
| `setup-xcode` (maxim-lobanov) | A GitHub Action that selects the Xcode — and therefore Swift — toolchain on macOS runners. |
| Concurrency / cancel-in-progress | GitHub Actions feature that cancels an older run of the same group (keyed on the git ref) when a newer one starts. |
