### PR TITLE
chore(#511): relax release-gated semgrep to fail-on-ERROR

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -39,8 +39,11 @@ permissions:
   contents: read
 
 env:
-  # Semgrep: fail on WARNING (= medium) and above
-  SEMGREP_FAIL_SEVERITY: ${{ inputs.fail_on_severity || 'WARNING' }}
+  # Semgrep severity policy (#511 / AgDR-0063): fail the release-gated scan on
+  # ERROR only. WARNING (= medium) findings stay advisory — surfaced in the step
+  # summary, never red a release. A release-gated scan must not hard-fail on
+  # pre-existing low-severity lint. Override per-run via the fail_on_severity input.
+  SEMGREP_FAIL_SEVERITY: ${{ inputs.fail_on_severity || 'ERROR' }}
 
 jobs:
   # --------------------------------------------------------------------------

--- a/docs/agdr/AgDR-0063-semgrep-severity-policy.md
+++ b/docs/agdr/AgDR-0063-semgrep-severity-policy.md
@@ -1,0 +1,31 @@
+# Semgrep release-gate severity policy: fail-on-ERROR
+
+> In the context of the release-gated Security Scan (semgrep `r/bash`, added in #487), facing a first real run that red-flagged the v2.3.0 release on 0 ERROR + 4 WARNING pre-existing findings, I decided to set the fail threshold to ERROR (WARNING advisory) to achieve a gate that catches high-severity issues without blocking releases on pre-existing low-severity lint, accepting that medium-severity findings no longer hard-fail and must be watched via the step summary.
+
+## Context
+
+The release-gated scan runs on the tag push (post-merge), so it did not block v2.3.0 — but with `SEMGREP_FAIL_SEVERITY=WARNING`, any WARNING reds the scan, and it would red **every** release until the 4 pre-existing `r/bash` WARNING findings are resolved. Classic brand-new-strict-gate-meets-existing-debt (#511). The same default ships in the adopter golden-path template (`golden-paths/pipelines/security.yml`), so every adopter inherits the strict behaviour on their first scan too.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| (a) Relax to fail-on-ERROR; WARNING advisory | Stops releases reding on pre-existing low-severity lint; sane default for a freshly-added scan; one-line, reversible; same fix benefits adopters | Medium-severity findings no longer block — must be watched in the step summary |
+| (b) Fix/suppress the 4 WARNING findings, keep fail-on-WARNING | Strictest gate retained | Pins the gate to a moving target (next new rule re-reds); doesn't help adopters who hit their own pre-existing WARNINGs; more work, recurring |
+
+## Decision
+
+Chosen: **(a) fail-on-ERROR**, WARNING advisory, in both `.github/workflows/security-scan.yml` (framework) and `golden-paths/pipelines/security.yml` (adopter template), because a release-gate's job is to stop genuinely dangerous changes, not to enforce zero low-severity lint at release time. WARNING findings remain visible in the step summary; teams that want stricter gating set `SEMGREP_FAIL_SEVERITY=WARNING` (template) or pass `fail_on_severity: WARNING` (framework workflow input).
+
+## Consequences
+
+- A clean release no longer reds on pre-existing WARNING-only findings.
+- Medium-severity (WARNING) findings are advisory; track them in the step summary and address in normal PR flow.
+- The 4 existing `r/bash` WARNINGs can be cleaned up later as ordinary debt, no longer release-blocking.
+- Adopters get the same non-blocking-on-low-severity default; opting into stricter gating is a one-line change.
+
+## Artifacts
+
+- Issue: me2resh/apexyard#511
+- Files: `.github/workflows/security-scan.yml`, `golden-paths/pipelines/security.yml`
+- Originating run: v2.3.0 tag, run 26980436235 (0 ERROR + 4 WARNING)

--- a/golden-paths/pipelines/security.yml
+++ b/golden-paths/pipelines/security.yml
@@ -37,8 +37,11 @@ permissions:
 env:
   # Semgrep configs to run — adjust for your stack (see header comment)
   SEMGREP_CONFIGS: "p/security-audit p/owasp-top-ten p/typescript p/nodejs"
-  # Fail on WARNING (medium) and above; set to ERROR to only fail on high+
-  SEMGREP_FAIL_SEVERITY: "WARNING"
+  # Severity policy: fail on ERROR (high) only; WARNING (medium) findings are
+  # advisory (surfaced in the step summary, do not fail the job). Set to
+  # "WARNING" for stricter gating. Rationale: a new scan should not hard-fail on
+  # a project's pre-existing low-severity lint (apexyard #511 / AgDR-0063).
+  SEMGREP_FAIL_SEVERITY: "ERROR"
   # npm audit threshold: critical, high, moderate, low
   NPM_AUDIT_LEVEL: high
 


### PR DESCRIPTION
## Summary
- **Stops the release-gated Security Scan reding clean releases on pre-existing low-severity lint** — the scan (semgrep `r/bash`, added in #487) failed its first real run on the v2.3.0 tag with `0 ERROR + 4 WARNING`, because `SEMGREP_FAIL_SEVERITY` was `WARNING`. It runs post-merge on the tag so it didn't block v2.3.0, but it would red **every** future release until the 4 findings are cleaned up.
- **Flips the default to `ERROR` in both places** — the framework's own `.github/workflows/security-scan.yml` and the adopter golden-path template `golden-paths/pipelines/security.yml`. The existing fail logic already supported both modes, so this is purely a threshold change.
- **WARNING stays advisory, not silenced** — medium findings are still surfaced in the step summary; only ERROR (high) fails the gate. Teams wanting stricter gating set `SEMGREP_FAIL_SEVERITY=WARNING` (template) or pass `fail_on_severity: WARNING` (framework workflow input).
- **Chose option (a) over (b)** (fix/suppress the 4 findings) — a freshly-added gate shouldn't pin releases to a moving target, and the same relaxation benefits every adopter who hits their own pre-existing WARNINGs. Recorded in `AgDR-0063-semgrep-severity-policy`.

## Testing
1. `python3 yaml.safe_load` on both workflow files → parse clean.
2. Confirmed both now set `SEMGREP_FAIL_SEVERITY` to `ERROR` and the existing `FAIL_SEV` branch logic handles ERROR-only correctly (lines ~163 / ~127).
3. `markdownlint` clean on the new AgDR.
4. A real validation is the next release-tag run going green — can't trigger a release from a PR; called out for post-merge confirmation (matches the ticket's AC).

The 4 pre-existing `r/bash` WARNING findings remain as ordinary, non-release-blocking debt and can be cleaned up in a follow-up.

Closes #511

---

## Glossary
| Term | Definition |
|------|------------|
| `SEMGREP_FAIL_SEVERITY` | Threshold at/above which a semgrep finding fails the CI job (WARNING = medium, ERROR = high). |
| Release-gated scan | A security scan that runs on the release tag push (post-merge) rather than on every PR. |
| Advisory finding | A finding surfaced in the step summary that does not fail the job. |
| AgDR | Agent Decision Record — ApexYard's lightweight ADR capturing the why + alternatives for a decision. |
