### PR TITLE
feat(#517): keep onboarding config out of git (example-file + gitignore + guard)

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -324,6 +324,7 @@ These were already in place before the enforcement layer and remain unchanged (e
 | `block-main-push.sh` | PreToolUse / Bash | Blocks pushing to `main` / `master` |
 | `validate-branch-name.sh` | PreToolUse / Bash | **Warns** on non-conforming branch names before push (warning-only; warning→blocker upgrade deferred to a follow-up ticket — breaking change) |
 | `check-secrets.sh` | PreToolUse / Bash | Scans commits for hardcoded secrets |
+| `block-onboarding-in-git.sh` | PreToolUse / Bash | Blocks committing a filled-in `onboarding.yaml` (placeholder-diff vs `onboarding.example.yaml`); env/marker escape hatch (#517) |
 | `pre-push-gate.sh` | PreToolUse / Bash | Reminds to run lint / typecheck / test / build |
 | `validate-pr-create.sh` | PreToolUse / Bash | **Blocks** on title format / glossary / branch ID (upgraded from warning in GH-20). Also **blocks** when the title's issue number doesn't exist in the tracker (extended in GH-14). |
 

--- a/.claude/hooks/block-onboarding-in-git.sh
+++ b/.claude/hooks/block-onboarding-in-git.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Blocks committing a filled-in onboarding.yaml — the Layer-2 backstop for the
+# example-file + gitignore model (#517 / AgDR-0064).
+#
+# onboarding.yaml is gitignored (real, local config). This guard catches the
+# cases gitignore can't: a force-add (`git add -f onboarding.yaml`), or a
+# pre-#517 clone where the file is still tracked. It uses a placeholder-diff
+# signal — comparing the staged onboarding.yaml against the shipped
+# onboarding.example.yaml placeholders — so a pristine template copy is allowed
+# but a filled-in one (real company name, internal URLs, named individuals,
+# tracker instances) is blocked before it can reach a public fork or upstream PR.
+#
+# Sibling to check-secrets.sh (catches credentials) and
+# block-private-refs-in-public-repos.sh (catches private project names in
+# upstream tickets) — same "scan outgoing content for things that should never
+# leave local" shape, wired to git-commit time.
+#
+# Escape hatch (rare, legitimate — e.g. intentionally re-seeding a template):
+#   - env var:    APEXYARD_ALLOW_ONBOARDING_COMMIT=1
+#   - in-message: include  <!-- onboarding: allow -->  in the commit message
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+[ -z "$COMMAND" ] && exit 0
+
+# Only check on git commit
+echo "$COMMAND" | grep -qE '\bgit\s+commit\b' || exit 0
+
+# Escape hatches
+if [ "${APEXYARD_ALLOW_ONBOARDING_COMMIT:-}" = "1" ]; then
+  echo "WARN: onboarding-in-git guard bypassed via APEXYARD_ALLOW_ONBOARDING_COMMIT=1" >&2
+  exit 0
+fi
+if echo "$COMMAND" | grep -q '<!-- onboarding: allow -->'; then
+  echo "WARN: onboarding-in-git guard bypassed via '<!-- onboarding: allow -->' marker" >&2
+  exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+[ -z "$REPO_ROOT" ] && exit 0
+
+# Is onboarding.yaml staged for this commit?
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null)
+echo "$STAGED" | grep -qx 'onboarding.yaml' || exit 0
+
+# Placeholder-diff: if the staged onboarding.yaml is byte-identical to the
+# shipped example template, it carries no real values → allow. Otherwise it's
+# a filled-in template → block.
+EXAMPLE="$REPO_ROOT/onboarding.example.yaml"
+STAGED_CONTENT=$(git show ":onboarding.yaml" 2>/dev/null)
+if [ -f "$EXAMPLE" ] && [ "$STAGED_CONTENT" = "$(cat "$EXAMPLE")" ]; then
+  exit 0
+fi
+
+cat >&2 <<MSG
+BLOCKED: onboarding.yaml is staged for commit with non-placeholder values.
+
+onboarding.yaml holds your private configuration (company name, internal URLs,
+tracker instance, named individuals) and must stay LOCAL — it is gitignored by
+design (#517). Committing it would publish private config to a public fork or
+an upstream pull request, where it is indexed forever.
+
+To unblock:
+  1. Unstage it:        git restore --staged onboarding.yaml
+  2. Confirm it's ignored: grep -q '^onboarding.yaml' .gitignore || echo 'onboarding.yaml' >> .gitignore
+  3. If a teammate needs the SHAPE of the config, edit onboarding.example.yaml
+     (placeholders only) and commit THAT instead.
+  4. Retry the commit.
+
+If you are on a pre-#517 clone where onboarding.yaml is still TRACKED, untrack
+it once with:  git rm --cached onboarding.yaml  (keeps your local copy).
+
+Escape hatch (rare — e.g. deliberately re-seeding a pristine template):
+  APEXYARD_ALLOW_ONBOARDING_COMMIT=1 git commit ...
+  or add  <!-- onboarding: allow -->  to the commit message.
+
+Guard source: .claude/hooks/block-onboarding-in-git.sh — sibling to
+check-secrets.sh. Config leaks are worse than the friction of unstaging.
+MSG
+exit 2

--- a/.claude/hooks/onboarding-check.sh
+++ b/.claude/hooks/onboarding-check.sh
@@ -8,11 +8,14 @@
 # the placeholder value "Your Company Name". If so, the fork hasn't been
 # set up yet and the user should run /setup.
 #
-# Why onboarding.yaml and not a session marker: onboarding.yaml is COMMITTED
-# (to the fork in single-fork mode, to the private portfolio repo in
-# split-portfolio v2 mode), so the setup state persists across clones and
-# team members. A fresh clone of a configured fork already has real
-# values — no per-machine marker needed.
+# Detection model (#517): in single-fork mode `onboarding.yaml` is now
+# GITIGNORED (real config stays local) and `onboarding.example.yaml` is the
+# tracked placeholder template. "Configured" = a real onboarding.yaml exists
+# with a non-placeholder company.name. A fresh clone has only the example (no
+# onboarding.yaml) → unconfigured → prompt /setup, which copies the example to
+# onboarding.yaml and fills it in. In split-portfolio v2 mode the real
+# onboarding.yaml lives (committed) in the private sibling repo, which
+# portfolio_onboarding_path resolves — that path still reads as configured.
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 if [ -z "$REPO_ROOT" ]; then
@@ -35,14 +38,19 @@ if [ -z "$CONFIG" ]; then
   CONFIG="$REPO_ROOT/onboarding.yaml"
 fi
 
-# No onboarding.yaml at the resolved path — not an apexyard fork (or
-# split-portfolio v2 misconfigured); skip silently. check-portfolio-config.sh
-# handles broken paths.
+# No onboarding.yaml at the resolved path. Two cases:
+#   - A tracked onboarding.example.yaml exists → this IS an apexyard fork that
+#     hasn't been configured yet (fresh clone in the #517 model) → prompt /setup.
+#   - No example either → not an apexyard fork (or split-portfolio v2
+#     misconfigured); skip silently. check-portfolio-config.sh handles paths.
 if [ ! -f "$CONFIG" ]; then
+  if [ -f "$REPO_ROOT/onboarding.example.yaml" ]; then
+    echo "ApexYard: not configured yet (no onboarding.yaml). Run /setup — it copies onboarding.example.yaml → onboarding.yaml (gitignored) and fills it in."
+  fi
   exit 0
 fi
 
-# Check if the placeholder is still present
+# onboarding.yaml exists — configured unless the placeholder is still present
 if grep -q '"Your Company Name"' "$CONFIG" 2>/dev/null; then
   echo "ApexYard: onboarding.yaml is unconfigured (placeholder still present). Run /setup to configure this fork."
 fi

--- a/.claude/hooks/tests/test_block_onboarding_in_git.sh
+++ b/.claude/hooks/tests/test_block_onboarding_in_git.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Test fixtures for block-onboarding-in-git.sh (#517).
+#
+# Builds an isolated temp git repo, stages files, and pipes a JSON tool_input
+# payload to the hook — asserting on exit code. No framework — bash + git + jq.
+#
+# Run:  ./.claude/hooks/tests/test_block_onboarding_in_git.sh
+# Exit 0 = all pass, exit 1 = at least one failure.
+
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+HOOK="$REPO_ROOT/.claude/hooks/block-onboarding-in-git.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+EXAMPLE_CONTENT='company:
+  name: "Your Company Name"
+  website: ""'
+
+FILLED_CONTENT='company:
+  name: "Acme Health Inc"
+  website: "https://acme.example"'
+
+make_payload() {
+  # $1 = the shell command string the hook should see
+  jq -nc --arg c "$1" '{tool_input: {command: $c}}'
+}
+
+# run_case <name> <expected_exit> <env_assignment_or_-> <staged_onboarding_content_or_-> <command>
+run_case() {
+  local name="$1" expect="$2" envassign="$3" onboarding="$4" cmd="$5"
+
+  local TMP
+  TMP=$(mktemp -d -t onboarding-guard.XXXXXX)
+  (
+    cd "$TMP" || exit 1
+    git init -q
+    git config user.email t@t.t && git config user.name t
+    # Always ship the example template (the placeholder baseline)
+    printf '%s\n' "$EXAMPLE_CONTENT" > onboarding.example.yaml
+    git add onboarding.example.yaml
+    git commit -qm "seed" >/dev/null 2>&1
+
+    # Stage what the case asks for (and ONLY that)
+    case "$onboarding" in
+      EXAMPLE) cp onboarding.example.yaml onboarding.yaml; git add -f onboarding.yaml ;;
+      FILLED)  printf '%s\n' "$FILLED_CONTENT" > onboarding.yaml; git add -f onboarding.yaml ;;
+      README)  echo "hi" > README.md; git add README.md ;;
+      -)       : ;;
+    esac
+
+    local payload; payload=$(make_payload "$cmd")
+    if [ "$envassign" != "-" ]; then
+      echo "$payload" | env "$envassign" "$HOOK" >/dev/null 2>&1
+    else
+      echo "$payload" | "$HOOK" >/dev/null 2>&1
+    fi
+    exit $?
+  )
+  local got=$?
+
+  if [ "$got" = "$expect" ]; then
+    echo "PASS: $name (exit $got)"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: $name (expected $expect, got $got)" >&2
+    FAIL=$((FAIL+1))
+  fi
+  rm -rf "$TMP"
+}
+
+# 1. Filled-in onboarding.yaml staged → BLOCK (exit 2)
+run_case "filled-in onboarding blocked" 2 - FILLED "git commit -m 'x'"
+
+# 2. onboarding.yaml identical to example → ALLOW (exit 0)
+run_case "placeholder-only onboarding allowed" 0 - EXAMPLE "git commit -m 'x'"
+
+# 3. Env-var escape hatch honored → ALLOW (exit 0)
+run_case "env-var escape hatch" 0 "APEXYARD_ALLOW_ONBOARDING_COMMIT=1" FILLED "git commit -m 'x'"
+
+# 4. In-message marker escape hatch honored → ALLOW (exit 0)
+run_case "marker escape hatch" 0 - FILLED "git commit -m 'x <!-- onboarding: allow -->'"
+
+# 5. Non-onboarding file staged → ALLOW (exit 0)
+run_case "non-onboarding file unaffected" 0 - README "git commit -m 'x'"
+
+# 6. Not a git commit command → ALLOW (exit 0)
+run_case "non-commit command ignored" 0 - FILLED "git status"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,6 +109,11 @@
           {
             "type": "command",
             "if": "Bash(git commit *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-onboarding-in-git.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(git commit *)",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/verify-commit-refs.sh\"'"
           },
           {

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -24,7 +24,7 @@ Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projec
 
 ## When this runs
 
-The `onboarding-check.sh` SessionStart hook detects that `onboarding.yaml` still has placeholder values (e.g. `company.name: "Your Company Name"`) and prompts the user to run `/setup`. After `/setup` fills in real values and commits, the hook goes silent forever — even on fresh clones, because `onboarding.yaml` is committed.
+The `onboarding-check.sh` SessionStart hook prompts the user to run `/setup` when the fork isn't configured — either there's no real `onboarding.yaml` yet (a fresh clone ships only the tracked `onboarding.example.yaml` placeholder), or `onboarding.yaml` still has the `company.name: "Your Company Name"` placeholder. After `/setup` fills in real values, the hook goes silent on this machine. Note (#517): in single-fork mode `onboarding.yaml` is GITIGNORED — real config stays local — so each fresh clone runs `/setup` once (it copies the example and fills it in). In split-portfolio v2 mode the real config is committed in the private sibling repo, so it carries across clones.
 
 Re-running `/setup` on an already-configured fork shows the current config and asks what to update. Use `--reset` to clear everything and start from scratch.
 
@@ -75,12 +75,12 @@ See AgDR-0011 + me2resh/apexyard#150 for the design rationale.
 
 Read `onboarding.yaml`. Four modes:
 
-- **First run** (placeholder values detected): proceed to Step 2.
+- **First run** (`onboarding.yaml` absent, or placeholder values detected): proceed to Step 2. The real file is gitignored (#517), so an absent `onboarding.yaml` with a present `onboarding.example.yaml` is the normal fresh-fork state — Step 6 copies the example before editing.
 - **Already configured** (real values): show a summary of the current config and ask "What would you like to update?" — then jump to the specific section. Don't re-ask everything.
-- **`--reset` flag**: clear `onboarding.yaml` back to the template defaults (copy from the upstream example or regenerate) and proceed as first run.
+- **`--reset` flag**: restore `onboarding.yaml` to the template defaults (`cp onboarding.example.yaml onboarding.yaml`) and proceed as first run.
 - **`--enable-lsp` flag** (retrofit mode): skip Steps 2 / 2a / 2b / 3-7 entirely and jump straight to Step 2c (LSP enablement). Use this when an existing adopter has a fully-configured fork and only wants to turn on LSP without re-running the whole bootstrap. The flag honours the same idempotence rules as a first-run pass through Step 2c — if LSP is already enabled, the step reports "already enabled" and exits cleanly. Step 0 (bootstrap marker) and Step 8 (clear marker) still run so the ticket gate stays coherent.
 
-Detection: `grep -q '"Your Company Name"' onboarding.yaml` — if found, it's still a template.
+Detection: `[ ! -f onboarding.yaml ]` (fresh fork — only the example is present) OR `grep -q '"Your Company Name"' onboarding.yaml` (file present but still a template) → treat as first run.
 
 ### Step 2: One question — describe your world
 
@@ -515,7 +515,15 @@ Don't loop more than twice. If the user keeps correcting, switch to "tell me exa
 
 ### Step 6: Write onboarding.yaml + the .apexyard-fork marker
 
-Read the current `onboarding.yaml` template (in single-fork mode this is at the fork root; in v2 split-portfolio mode it lives in the private sibling repo, resolved via `portfolio_onboarding_path`), replace placeholder values with the confirmed config, and write back. Preserve the file's structure and comments — the comments are documentation for future readers.
+**First, ensure a real `onboarding.yaml` exists to edit (#517).** The real config is now GITIGNORED; a fresh fork ships only the tracked `onboarding.example.yaml` placeholder template. So if `onboarding.yaml` is absent, copy the example to it before editing:
+
+```bash
+ONBOARDING=$(portfolio_onboarding_path)
+EXAMPLE="$(dirname "$ONBOARDING")/onboarding.example.yaml"
+[ -f "$ONBOARDING" ] || cp "$EXAMPLE" "$ONBOARDING"
+```
+
+Then read `onboarding.yaml` (single-fork: fork root; v2 split-portfolio: the private sibling repo, resolved via `portfolio_onboarding_path`), replace placeholder values with the confirmed config, and write back. Preserve the file's structure and comments — the comments are documentation for future readers.
 
 **Important:** use `Edit` tool to modify in-place, not `Write` to overwrite — this preserves comments and structure that the user didn't touch.
 
@@ -535,15 +543,17 @@ In **split-portfolio v2 mode** the marker was already written in Step 2b — ski
 After writing:
 
 ```bash
-# In single-fork mode: stage the in-fork onboarding.yaml.
-# In v2 mode: stage the SIBLING repo's onboarding.yaml.
+# #517: onboarding.yaml is GITIGNORED in single-fork mode — it stays LOCAL and
+# must NOT be staged/committed (the block-onboarding-in-git.sh guard backstops
+# this). In v2 mode the real config lives in the PRIVATE sibling repo, where it
+# is committed (the sibling is private), so staging there is fine.
 ONBOARDING=$(portfolio_onboarding_path)
 case "$ONBOARDING" in
   "$(git rev-parse --show-toplevel)"/*)
-    git add onboarding.yaml
+    : # single-fork — do NOT stage onboarding.yaml; it's gitignored, kept local
     ;;
   *)
-    # v2 mode — onboarding lives in the sibling repo. Stage it there
+    # v2 mode — onboarding lives in the PRIVATE sibling repo. Stage it there
     # so the user can `git -C ../<sibling> diff --cached` before committing.
     sibling_root=$(git -C "$(dirname "$ONBOARDING")" rev-parse --show-toplevel 2>/dev/null)
     if [ -n "$sibling_root" ]; then
@@ -553,14 +563,21 @@ case "$ONBOARDING" in
 esac
 ```
 
-Stage but do NOT commit — let the user review the diff and commit when ready. Tell them:
+In **single-fork mode** the config is intentionally NOT committed — tell the user:
 
 ```
-onboarding.yaml updated and staged. Review with `git diff --cached` and
-commit when you're happy: git commit -m "chore: configure apexyard for <company>"
+onboarding.yaml written locally (it's gitignored — your real config stays on
+this machine and is never published to the public fork or an upstream PR).
+Nothing to commit. If a teammate needs the config SHAPE, edit and commit
+onboarding.example.yaml instead.
 ```
 
-(In v2 mode point them at the sibling repo for the diff + commit.)
+In **v2 split-portfolio mode** the real config is committed in the private sibling repo — point the user there for the diff + commit:
+
+```
+onboarding.yaml updated and staged in the private portfolio repo. Review with
+`git -C ../<sibling> diff --cached` and commit when you're happy.
+```
 
 ### Step 7: Optionally seed the project registry
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 # onboarding flag. Per-machine, per-clone. Never committed.
 .claude/session/
 
+# Real onboarding config (#517). The tracked template is onboarding.example.yaml;
+# /setup copies it to onboarding.yaml (this file) and fills in real values that
+# must stay LOCAL — company name, internal URLs, tracker instance, named people.
+# block-onboarding-in-git.sh backstops this gitignore at commit time.
+onboarding.yaml
+
 # ApexYard per-project config written by /onboard. Contains deploy URLs and
 # sensitive-topic notes that should not leak to git — keep it local.
 .claude/project-config.json

--- a/docs/agdr/AgDR-0064-onboarding-example-file-and-guard.md
+++ b/docs/agdr/AgDR-0064-onboarding-example-file-and-guard.md
@@ -1,0 +1,38 @@
+# Onboarding config: example-file pattern + commit-time guard
+
+> In the context of adopters editing a tracked `onboarding.yaml` in a publicly-forked framework, facing real company config (name, internal URLs, tracker instance, named individuals) landing in public git history and upstream PR refs by default, I decided to adopt the `.env.example` convention (tracked `onboarding.example.yaml` + gitignored `onboarding.yaml`) plus a commit-time placeholder-diff guard, to achieve a safe-by-default config path with a mechanical backstop, accepting that single-fork clones must each run `/setup` once and that pre-existing committed history still needs a separate scrub.
+
+## Context
+
+`onboarding.yaml` was a **tracked** file that adopters filled with real values and committed. Because the framework is forked publicly and contributors open PRs upstream, private config reached public history by default. Split-portfolio v2 (#242) already solved this for v2 adopters (config moves to a private sibling repo), and `.gitignore` already kept a never-committed completion flag — but **single-fork mode (the default) still committed the config**, and nothing caught a filled-in file before it left the machine. This is the #517 gap, addressed in two layers.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Example-file + gitignore + commit guard (chosen) | Safe path is the default; mirrors the universally-understood `.env.example`/`.env` pattern; mechanical backstop catches force-adds; consistent with what v2 already does | Single-fork clones lose "config travels with the repo" — each clone runs `/setup` once |
+| Gitignore only (no guard) | One-line change | A `git add -f` or a pre-existing tracked copy silently re-leaks; no defense-in-depth |
+| Encrypt committed config (git-crypt / SOPS) | Config can stay committed | Key distribution + tooling burden; overkill for non-secret-but-private config; poor DX for a bootstrap file |
+| Rely on split-portfolio v2 only | Already exists | Doesn't help the DEFAULT single-fork adopter — the majority |
+
+## Decision
+
+Chosen: **example-file + gitignore (Layer 1) + a commit-time placeholder-diff guard (Layer 2)**.
+
+- **Layer 1:** ship `onboarding.example.yaml` (placeholders, tracked); gitignore `onboarding.yaml`; `git rm --cached onboarding.yaml`; `/setup` copies example→real and never stages the real file; `onboarding-check.sh` detects configured state from the local real file (or, in v2, the committed private copy) rather than a committed public file.
+- **Layer 2:** `block-onboarding-in-git.sh` (PreToolUse on `git commit`) blocks a staged `onboarding.yaml` whose content differs from the example placeholders (the placeholder-diff signal), with an env-var (`APEXYARD_ALLOW_ONBOARDING_COMMIT=1`) and in-message (`<!-- onboarding: allow -->`) escape hatch. Sibling to `check-secrets.sh` and `block-private-refs-in-public-repos.sh`.
+
+The placeholder-diff (compare staged config to the shipped `*.example`) gives a low-false-positive signal that the template was filled with real values — the same idea #518's release-artifact guard reuses on shipped output.
+
+## Consequences
+
+- Default single-fork forks no longer publish private config; the safe path is the default.
+- Each fresh single-fork clone runs `/setup` once (copies the example, fills it in locally). v2 adopters are unaffected (private committed config carries across clones).
+- A new commit-time gate exists; covered by `.claude/hooks/tests/test_block_onboarding_in_git.sh` (filled-in blocked, placeholder allowed, both escape hatches honored, non-config unaffected, non-commit ignored).
+- **Already-committed history** still contains prior real values until a separate full-history scrub (tracked under the security-hardening work, #518). This PR untracks going forward; it does not rewrite history.
+
+## Artifacts
+
+- Issue: me2resh/apexyard#517
+- Files: `onboarding.example.yaml`, `.gitignore`, `.claude/hooks/block-onboarding-in-git.sh`, `.claude/hooks/tests/test_block_onboarding_in_git.sh`, `.claude/hooks/onboarding-check.sh`, `.claude/settings.json`, `.claude/skills/setup/SKILL.md`, `docs/multi-project.md`, `.claude/hooks/README.md`
+- Related: #518 (release-artifact guard reuses the placeholder-diff), #242 (split-portfolio v2)

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -92,11 +92,23 @@ Now `git fetch upstream` will pull the latest apexyard changes whenever you want
 
 ### 4. Fill in `onboarding.yaml`
 
-Edit the file at the repo root. Set company, team, tech stack, quality bar. Defaults are sensible — change what matters for your team.
+The repo ships a tracked placeholder template, `onboarding.example.yaml`. Your real config lives in `onboarding.yaml`, which is **gitignored** (#517) — it stays local and is never published to your public fork or an upstream PR. Copy the template, then edit it (or just run `/setup`, which does the copy + fill for you):
 
 ```bash
-$EDITOR onboarding.yaml
+cp onboarding.example.yaml onboarding.yaml
+$EDITOR onboarding.yaml      # set company, team, tech stack, quality bar
 ```
+
+Don't commit `onboarding.yaml` — a commit-time guard (`block-onboarding-in-git.sh`) blocks a filled-in copy if you try. If a teammate needs the config *shape*, edit and commit `onboarding.example.yaml` (placeholders only) instead.
+
+> **Migrating an existing fork (pre-#517, where `onboarding.yaml` was tracked):** untrack it once — your local copy is preserved — and let the new gitignore + guard take over:
+>
+> ```bash
+> git rm --cached onboarding.yaml
+> git commit -m "chore: untrack onboarding.yaml (now gitignored, #517)"
+> ```
+>
+> The real values still exist in prior git history; scrub history separately if the fork is public and the old values are sensitive (see the security-hardening full-history sweep).
 
 ### 5. Create the registry
 

--- a/onboarding.example.yaml
+++ b/onboarding.example.yaml
@@ -1,13 +1,18 @@
 # =============================================================================
-# ApexYard Onboarding Configuration
+# ApexYard Onboarding Configuration — EXAMPLE TEMPLATE
 # =============================================================================
 #
-# Fill in this file to customize ApexYard for your team.
-# Claude Code reads this file to understand your company context.
+# This is the TRACKED placeholder template (committed to the repo). Your real
+# configuration lives in `onboarding.yaml`, which is GITIGNORED and never
+# committed — the same convention as `.env.example` / `.env`.
 #
-# After editing, commit this file to your repo. Claude Code will use it
-# to tailor its behavior to your team's structure and processes.
+# Don't edit this file with real values. Instead run `/setup`, which copies
+# this template to `onboarding.yaml` (gitignored) and fills it in locally.
+# A commit-time guard (block-onboarding-in-git.sh) backstops the gitignore so a
+# filled-in `onboarding.yaml` can't reach a public fork or an upstream PR.
 #
+# Split-portfolio v2 adopters: your real config lives in the private sibling
+# repo; this example stays in the public framework fork.
 
 # -----------------------------------------------------------------------------
 # ApexYard Setup
@@ -39,52 +44,47 @@ company:
   # What kind of software you build
   products:
     - name: "Main Platform"
-      description: "REDACTED with REDACTED (REDACTED), serverless AWS backend, and Vue frontend"
+      description: "Describe your primary product in one line"
       type: "saas"
 
 # -----------------------------------------------------------------------------
 # Team Structure
 # -----------------------------------------------------------------------------
 team:
-  - name: "Ahmed"
+  - name: "Your Name"
     role: "head-of-engineering"
     department: "engineering"
     responsibilities:
       - "Platform"
       - "Security"
       - "Architecture"
-    title: "REDACTED"
+    title: "Your Title"
 
 # -----------------------------------------------------------------------------
 # Tech Stack
 # -----------------------------------------------------------------------------
 tech_stack:
-  language: "TypeScript"           # Primary language (SAM lambdas + NestJS BFF)
+  language: "TypeScript"           # Primary language
   runtime: "Node.js"
-  framework: "Vue"                 # Frontend framework
-  backend: "NestJS"                # BFF pattern — ALB + Nginx on 2 Fargate containers
-  database: "MySQL"                # Legacy monolith DB
-  hosting: "AWS"
-  cdn: "Cloudflare"
+  framework: ""                    # Frontend framework (e.g. React, Vue)
+  backend: ""                      # Backend framework (e.g. NestJS, Express)
+  database: ""                     # e.g. PostgreSQL, MySQL
+  hosting: ""                      # e.g. AWS, GCP, Vercel
+  cdn: ""
   ci_cd: "GitHub Actions"
   testing: "Vitest"
   e2e_testing: "Playwright"
-  iac: "AWS SAM"                   # Serverless infrastructure
-
-  # Additional services
-  ehr: "REDACTED"                 # EHR system
-  legacy: "PHP + MySQL monolith"
-  bff_pattern: "ALB + Nginx on Fargate (2 containers, NestJS)"
+  iac: ""                          # e.g. AWS SAM, Terraform, CDK
 
 # -----------------------------------------------------------------------------
 # Project Management
 # -----------------------------------------------------------------------------
 project_management:
-  tool: "Jira"
-  instance: "yourcompany.atlassian.net"
-  sprint_duration: ""              # Kanban — no fixed sprints
+  tool: "GitHub Issues"            # e.g. GitHub Issues, Jira, Linear
+  instance: ""                     # e.g. yourcompany.atlassian.net (Jira/Linear)
+  sprint_duration: ""              # blank for Kanban
   branching_strategy: "feature-branch"
-  ticket_prefix: "PROJ"
+  ticket_prefix: ""                # e.g. PROJ (Jira/Linear); blank for GitHub #N
 
 # -----------------------------------------------------------------------------
 # Quality Standards
@@ -99,7 +99,6 @@ quality:
     - typecheck
     - test
     - build
-    - sam validate --lint
 
   review_style: "thorough"
 
@@ -110,8 +109,8 @@ workflows:
   require_prd: true
   require_technical_design: true
   require_qa_signoff: true
-  require_security_review: true    # Ahmed leads security
-  require_design_review: true      # Vue frontend
+  require_security_review: true
+  require_design_review: true
   use_feature_flags: false
   use_agent_decision_records: true
 

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -542,7 +542,7 @@ a:hover { color: var(--accent); }
 
   <rect x="394" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>
   <text x="410" y="252" font-size="14" font-weight="700" fill="#1E3A5F">[~] Hooks</text>
-  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 39 shell gates</text>
+  <text x="410" y="275" font-size="12" fill="#1A1612">.claude/hooks/  · 40 shell gates</text>
   <text x="410" y="295" font-size="11" fill="#4A6FA5">Merge gate · ticket-first · secrets · …</text>
 
   <rect x="704" y="225" width="290" height="90" fill="#E0E8F0" stroke="#2C4E70" stroke-width="1.3"/>

--- a/site/architecture.md.gen
+++ b/site/architecture.md.gen
@@ -25,7 +25,7 @@ Fork apexyard once and treat the fork as your ops repo. Add an entry to `apexyar
 Declares what's true and what's enforced:
 
 - **Registry** (`apexyard.projects.yaml`) — lists every managed project
-- **Hooks** (`.claude/hooks/`) — 39 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
+- **Hooks** (`.claude/hooks/`) — 40 shell gates: merge gate, ticket-first, secrets scan, AgDR for architecture, migration gate, red-CI block, branch/PR-title validation, leak protection
 - **Rules** (`.claude/rules/`) — 11 modular self-discipline guides
 - **Onboarding** (`onboarding.yaml`) — company name, mission, team, tech stack
 

--- a/site/index.html
+++ b/site/index.html
@@ -51,7 +51,7 @@
   "url": "https://yard.apexscript.com/",
   "description": "Ship AI-built software like a real engineering team. Automatic code review, launch-readiness checks, one inbox for every product — on Claude Code.",
   "license": "https://opensource.org/licenses/MIT",
-  "softwareVersion": "2.2.0",
+  "softwareVersion": "2.3.0",
   "downloadUrl": "https://github.com/me2resh/apexyard",
   "datePublished": "2026-04-09",
   "dateModified": "2026-05-29",
@@ -1573,7 +1573,7 @@ a:hover { color: var(--accent); }
     <h1 class="hero__title rise rise-2">apexyard</h1>
 
     <p class="hero__version rise rise-2" style="margin:-0.5em 0 0.5em;font-size:13px;opacity:0.55;letter-spacing:0.05em;">
-      <a href="https://github.com/me2resh/apexyard/releases/tag/v2.2.0" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v2.2.0</a>
+      <a href="https://github.com/me2resh/apexyard/releases/tag/v2.3.0" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v2.3.0</a>
       &nbsp;·&nbsp;
       <a href="https://github.com/me2resh/apexyard/blob/main/CHANGELOG.md" style="color:inherit;text-decoration:underline;text-underline-offset:3px;" target="_blank" rel="noopener">changelog</a>
     </p>

--- a/site/index.md.gen
+++ b/site/index.md.gen
@@ -75,7 +75,7 @@ The reviewer changes based on what you're working on. Touching auth code? A secu
 
 Want to adopt a project you've inherited? `/handover`. Want to capture an idea before it evaporates? `/idea`. Want to know what's waiting on you across every product? `/inbox`. Want a launch-readiness check before customers see it? `/launch-check`. 54 of these in total — each one is a focused workflow with safety rails.
 
-### Guardrails that stop bad code from shipping · 39 hooks
+### Guardrails that stop bad code from shipping · 40 hooks
 
 Every edit needs a real ticket behind it. Every database change needs a rollback plan. Every merge needs a real review. Secrets in code get caught before they're committed. Mechanically enforced — 32 small scripts that fire at the right moments.
 

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -3,7 +3,7 @@
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and
 > one place for all your products, built on top of Claude Code. 59 skills,
-> 39 hooks, 20 role definitions. Open source, plain markdown and shell, no SaaS,
+> 40 hooks, 20 role definitions. Open source, plain markdown and shell, no SaaS,
 > no lock-in.
 
 This file is the LLM/agent-friendly concatenation of the apexyard marketing

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -3,7 +3,7 @@
 > ApexYard lets founders ship AI-built software like a real engineering team —
 > without hiring one. Automatic code review, launch-readiness checks, and one
 > place for all your products, built on top of Claude Code. 59 skills,
-> 39 hooks, 20 role definitions. Open source, plain markdown and shell,
+> 40 hooks, 20 role definitions. Open source, plain markdown and shell,
 > no SaaS, no lock-in.
 
 ## Pages
@@ -54,7 +54,7 @@
   across the portfolio in ~1 second.
 - **59 slash commands** grouped by outcome: keep quality high, move work
   forward, see everything at once, onboard new code, run things.
-- **39 shell hooks** mechanically enforce the rules — ticket-first, migration
+- **40 shell hooks** mechanically enforce the rules — ticket-first, migration
   gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR-title
   validation, upstream-drift banner, leak protection.
 - **20 role definitions** across 5 departments (Engineering, Product, Design,

--- a/site/skill.md
+++ b/site/skill.md
@@ -43,7 +43,7 @@ what you're trying to do:
 - **Run things** (`/update`, `/split-portfolio`, `/release`, `/debug`,
   `/pdf`, `/fan-out`)
 
-39 shell hooks enforce SDLC rules mechanically — ticket-first, migration
+40 shell hooks enforce SDLC rules mechanically — ticket-first, migration
 gate, two-marker merge gate, red-CI block, secrets scanning, branch / PR
 title validation, decision-record-required-for-architecture, upstream-drift
 banner, leak protection. 20 role definitions activate on triggers (label,


### PR DESCRIPTION
## Summary
- **Makes the safe path the default for onboarding config** — adopts the `.env.example`/`.env` convention: a tracked `onboarding.example.yaml` (placeholders) plus a **gitignored** `onboarding.yaml` (real values). Previously the real config was tracked and committed, so on a publicly-forked framework a CTO's company name, internal URLs, tracker instance, and team roster leaked into public history / upstream PR refs by default. Single-fork mode now matches what split-portfolio v2 already does.
- **Adds a commit-time backstop** — new `block-onboarding-in-git.sh` (PreToolUse on `git commit`) blocks a staged `onboarding.yaml` whose content differs from the example placeholders (a **placeholder-diff** signal), so a `git add -f` or a pre-#517 tracked copy can't silently re-leak. Sibling to `check-secrets.sh`; env-var (`APEXYARD_ALLOW_ONBOARDING_COMMIT=1`) and in-message (`<!-- onboarding: allow -->`) escape hatches. 6-case test suite, all green.
- **Rewires detection + setup, no behaviour loss** — `onboarding-check.sh` now reports "configured" from the local real file (or the v2 private committed copy) and prompts `/setup` on a fresh fork that has only the example; `/setup` copies the example → real and never stages the real file. Split-portfolio v2 is unaffected (private committed config still carries across clones); the only single-fork change is that each fresh clone runs `/setup` once.
- **Migration documented, not silent** — `docs/multi-project.md` + the `/setup` skill carry the one-time `git rm --cached onboarding.yaml` step for existing adopters. Decision recorded in `AgDR-0064`.

## Known follow-up (called out, not hidden)
The *already-committed* history of `onboarding.yaml` still contains prior real values — this PR untracks going forward but does **not** rewrite history. The full-history secret/config sweep is tracked in **#518** (security hardening), which also reuses this PR's placeholder-diff signal for its release-artifact guard.

## Testing
1. `.claude/hooks/tests/test_block_onboarding_in_git.sh` → **6 passed, 0 failed** (filled-in blocked · placeholder-equals-example allowed · env-var escape · marker escape · non-onboarding file unaffected · non-commit ignored).
2. `shellcheck -S error` clean on the new + modified hooks.
3. `python3 yaml.safe_load` on `onboarding.example.yaml`; `json.load` on `.claude/settings.json` → valid.
4. `git rm --cached onboarding.yaml` verified: file untracked, `git check-ignore` confirms ignored, local copy preserved on disk.
5. `markdownlint` clean on the new AgDR.

Closes #517

---

## Glossary
| Term | Definition |
|------|------------|
| Example-file pattern | Tracked `*.example` template + gitignored real file (like `.env.example`/`.env`). |
| Placeholder-diff | Detecting a filled-in template by comparing staged config against the shipped `*.example` placeholders. |
| Commit-time guard | A PreToolUse-on-`git commit` hook that blocks staged content which must never be published. |
| Single-fork vs split-portfolio v2 | Default layout (config at fork root) vs the v2 layout where private config lives in a sibling private repo. |
| Escape hatch | A deliberate, auditable bypass (env var or in-message marker) for the rare legitimate case. |
