### PR TITLE
feat(#518): harden framework security scanning (CodeQL + Scorecard + Dependabot + SECURITY.md + release-artifact guard)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # The framework has no package manifests (no package.json / requirements.txt /
+  # go.mod) — its only declared dependency surface is the GitHub Actions pinned
+  # in .github/workflows/**. Keep those patched. If a manifest is added later
+  # (e.g. a build tool under site/), add its ecosystem here. #518.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+# Semantic code scanning (free for public repos). The framework is mostly
+# markdown + shell — CodeQL doesn't analyse bash (that's covered by Semgrep
+# r/bash in security-scan.yml) — but it DOES cover:
+#   - actions: the GitHub Actions workflows themselves (workflow injection,
+#     unpinned actions, excessive token scope)
+#   - javascript-typescript: site/copy-for-ai.js and any future JS/TS
+#
+# Results surface in the repo's Security > Code scanning tab. #518.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    - cron: '27 3 * * 1'   # weekly, Monday 03:27 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # required to upload CodeQL results
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/extract-subpacks-on-release.yml
+++ b/.github/workflows/extract-subpacks-on-release.yml
@@ -65,6 +65,28 @@ jobs:
       - name: Run the extraction smoke test
         run: bash .claude/hooks/tests/test_subpack_extraction.sh
 
+      # Release-artifact content guard (#518): scan the BUILT bundle (filesystem,
+      # not git history) for secrets, and for a filled-in onboarding.yaml (the
+      # placeholder-diff signal from #517). Fails the build before anything is
+      # published, so sensitive data can't ship inside a release artifact.
+      - name: Release-artifact content guard (secrets + filled-in config)
+        run: |
+          echo "Scanning built marketplace/ bundle for secrets…"
+          docker run --rm -v "$PWD:/repo" ghcr.io/gitleaks/gitleaks:v8.18.4 \
+            detect --no-git --source /repo/marketplace --redact -v --exit-code 1
+
+          # Placeholder-diff: a filled-in onboarding.yaml must never be bundled.
+          if [ -f onboarding.example.yaml ]; then
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              if ! diff -q "$f" onboarding.example.yaml >/dev/null 2>&1; then
+                echo "::error::Release artifact bundles a filled-in onboarding.yaml: $f"
+                exit 1
+              fi
+            done < <(find marketplace -name 'onboarding.yaml' 2>/dev/null)
+          fi
+          echo "Artifact content guard: clean."
+
       - name: Upload extracted sub-packs as build artefacts
         if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v4

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,50 @@
+name: Scorecard supply-chain security
+
+# OSSF Scorecard — assesses the repo's supply-chain security posture (branch
+# protection, token permissions, pinned actions, dangerous workflow patterns,
+# etc.) and publishes results to the Security > Code scanning tab. Free for
+# public repos; the score also drives the README badge. #518.
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '19 4 * * 1'   # weekly, Monday 04:19 UTC
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload results to code-scanning
+      id-token: write          # publish results to the OSSF API (badge)
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true   # enables the README badge
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ApexYard
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/me2resh/apexyard/badge)](https://securityscorecards.dev/viewer/?uri=github.com/me2resh/apexyard)
+
 **Where projects get forged.**
 
 A multi-project ops repo where your projects reference each other, learn from shared experience, and ship production-ready under a strict SDLC. Built for founders who ship alone, or companies standing up AI-enabled squads.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+ApexYard is a framework of plain markdown, shell hooks, and CI templates — it
+ships no runtime service and has no package dependencies. Its security surface
+is (1) the shell hooks that run on a contributor's machine, (2) the CI workflows
+in this repo, and (3) the example configs/templates adopters copy. We take all
+three seriously and dog-food the strongest version of the tooling we ship.
+
+## Supported versions
+
+The framework uses a release-cut model (`dev` → `main`, tagged with semver).
+Security fixes land on `dev` and ship in the next release. Only the latest
+released minor is supported; please upgrade (`/update`) before reporting.
+
+| Version | Supported |
+|---------|-----------|
+| Latest released minor (`main`) | ✅ |
+| Older tags | ❌ — upgrade first |
+
+## Reporting a vulnerability
+
+**Do not open a public issue for a security vulnerability.**
+
+Use GitHub's private vulnerability reporting:
+**Security → Report a vulnerability** on https://github.com/me2resh/apexyard
+(the "Report a vulnerability" button under the Security tab). This opens a
+private advisory only the maintainers can see.
+
+Please include:
+
+- What the issue is and the security impact (e.g. a hook that can be bypassed,
+  a workflow that leaks a token, an example template that ships a real secret).
+- Steps to reproduce, and the affected file(s) / version.
+- Any suggested remediation.
+
+We aim to acknowledge within **5 business days** and to ship a fix or a
+mitigation plan within **30 days** for confirmed issues, coordinating disclosure
+with you.
+
+## Scope
+
+In scope:
+
+- Hook bypasses that defeat a documented gate (merge gate, ticket-first,
+  secrets/onboarding/leak guards).
+- CI workflow weaknesses (injection, excessive `GITHUB_TOKEN` scope, unpinned
+  actions, artifact poisoning).
+- Secrets or filled-in private config shipped in the repo, an example template,
+  or a release artifact.
+
+Out of scope:
+
+- Vulnerabilities in a fork's *own* managed-project code (report those in that
+  project's tracker).
+- Social-engineering of maintainers; issues requiring a malicious local actor
+  who already has commit access.
+
+## Our own scanning
+
+This repo runs, on itself: gitleaks (full-history secret scan), Semgrep
+(`r/bash`), CodeQL (`actions` + `javascript-typescript`), OSSF Scorecard,
+Dependabot (GitHub Actions), a release-artifact content guard, and the
+commit-time `check-secrets.sh` / `block-onboarding-in-git.sh` /
+`block-private-refs-in-public-repos.sh` hooks. See
+`.github/workflows/security-scan.yml` and `docs/agdr/AgDR-0065-framework-security-hardening.md`.

--- a/docs/agdr/AgDR-0065-framework-security-hardening.md
+++ b/docs/agdr/AgDR-0065-framework-security-hardening.md
@@ -1,0 +1,44 @@
+# Harden the framework repo's own security scanning
+
+> In the context of a public framework that ships security tooling to adopters, facing several high-value, zero-cost protections going unused on our own repo, I decided to add CodeQL, OSSF Scorecard, Dependabot (GitHub Actions), a SECURITY.md, and a release-artifact content guard — and to document the GitHub-native settings toggles for the operator — to achieve an exemplary, dog-fooded posture, accepting that the native-settings half (secret scanning + push protection, code-scanning default setup, Dependabot alerts) can't be set from code and must be flipped in repo Settings.
+
+## Context
+
+The repo already runs `security-scan.yml` (gitleaks full-history + Semgrep `r/bash`), release-gated. Missing, and mostly **free for public repos**: CodeQL, OSSF Scorecard, Dependabot, native secret scanning + push protection, a `SECURITY.md`, and a guard on the *release artifact* (the extracted marketplace sub-packs) rather than just source. We ship security tooling to adopters; the framework repo should run the strongest version of it. (#518.)
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Add CodeQL + Scorecard + Dependabot + SECURITY.md + artifact guard; document the native-settings toggles (chosen) | Closes the gaps that are code-expressible now; the rest is a 4-line operator checklist; dog-foods the strongest posture | Two-part delivery (code now, settings toggles by the operator) |
+| Code workflows only, ignore native settings | Single PR, no operator action | Leaves the highest-leverage freebies (push protection) off |
+| Toggle native settings via `gh api` in this PR | One-stop | Externally-visible admin changes on the public repo from an agent — wrong actor; the operator explicitly chose a checklist |
+| New parallel security pipeline | Clean separation | Duplicates the existing `security-scan.yml`; the ticket says extend, not fork |
+
+## Decision
+
+Chosen: **extend in place**.
+
+- `codeql.yml` — `actions` + `javascript-typescript` (CodeQL doesn't analyse bash; that stays on Semgrep `r/bash`).
+- `scorecard.yml` — OSSF Scorecard + README badge.
+- `dependabot.yml` — `github-actions` ecosystem (the repo's only real dependency surface; no package manifests).
+- `SECURITY.md` — private-reporting policy + supported versions.
+- **Release-artifact content guard** — a step in `extract-subpacks-on-release.yml` that scans the *built* `marketplace/` bundle with gitleaks (filesystem mode) **and** placeholder-diffs any bundled `onboarding.yaml` against `onboarding.example.yaml` (#517's signal), failing the build before publish.
+- Full-history secret sweep is already covered by the existing gitleaks job (`fetch-depth: 0`).
+- Broadening Semgrep beyond `r/bash` is a **no-op** here — the only JS is a static `site/copy-for-ai.js` snippet; CodeQL `javascript-typescript` already covers it. Documented, not added as noise.
+
+The **GitHub-native settings** — secret scanning + push protection, code-scanning default setup, Dependabot alerts — cannot be expressed in committed files. They are delivered as an operator checklist (the operator declined having the agent flip them via `gh api`, since they are externally-visible admin changes on the public repo).
+
+## Consequences
+
+- CodeQL + Scorecard results appear under Security › Code scanning; the README carries a live Scorecard badge.
+- Dependabot keeps pinned GitHub Actions patched.
+- Release artifacts are scanned for secrets + filled-in config before publish.
+- The ticket (#518) stays partially open until the operator flips the native-settings toggles — called out in the PR.
+- New workflows mean more Actions minutes; CodeQL/Scorecard run weekly + on push/PR, which is the conventional cadence.
+
+## Artifacts
+
+- Issue: me2resh/apexyard#518
+- Files: `.github/workflows/codeql.yml`, `.github/workflows/scorecard.yml`, `.github/dependabot.yml`, `SECURITY.md`, `.github/workflows/extract-subpacks-on-release.yml` (artifact guard), `README.md` (badge)
+- Related: #517 (placeholder-diff reused by the artifact guard), #487 (the existing release-gated scan), #511/AgDR-0063 (semgrep severity)


### PR DESCRIPTION
## Summary
- **Dog-foods the strongest security posture on the framework's own repo** — we ship security tooling to adopters, so the public framework repo should run the best free-for-public-repos version of it. Adds the code-expressible half now; the GitHub-native settings are a short operator checklist below.
- **CodeQL** (`.github/workflows/codeql.yml`) — `actions` + `javascript-typescript` matrix (CodeQL doesn't analyse bash — that stays on the existing Semgrep `r/bash` job — but it now covers the GitHub Actions workflows themselves and `site/copy-for-ai.js`). `security-extended` queries; results to the Code scanning tab.
- **OSSF Scorecard** (`.github/workflows/scorecard.yml`) + a live **README badge** — weekly supply-chain posture (branch protection, token scope, pinned actions, dangerous-workflow patterns).
- **Dependabot** (`.github/dependabot.yml`) — `github-actions` ecosystem weekly. That's the repo's *only* real dependency surface (no `package.json`/`requirements.txt`/`go.mod`); the config is structured so a future manifest just adds an ecosystem.
- **SECURITY.md** — private vulnerability-reporting policy (GitHub private advisories), supported-versions table tied to the release-cut model, scope in/out.
- **Release-artifact content guard** — `extract-subpacks-on-release.yml` now scans the *built* `marketplace/` bundle (filesystem, not git history) with gitleaks **and** placeholder-diffs any bundled `onboarding.yaml` against `onboarding.example.yaml` (reusing #517's signal), failing the build before publish. Closes the "secrets/config shipped inside a release artifact" gap.

## Deliberately NOT added (with reasons)
- **Broadening Semgrep beyond `r/bash`** — the repo has no real JS/TS app source (only a static `site/copy-for-ai.js`), which CodeQL `javascript-typescript` now covers. Adding JS Semgrep rulesets would be noise on an empty surface.
- **Full-history secret sweep** — already runs: the existing `security-scan.yml` gitleaks job checks out with `fetch-depth: 0` (full history). No new job needed.

## ⚠️ Operator checklist — GitHub-native settings (can't be set from code)
These are repo *Settings* toggles, externally-visible on the public repo. Per your call, I did **not** flip them via `gh api`; please enable them in **Settings → Code security**:
- [ ] **Secret scanning** + **Push protection** (free for public repos)
- [ ] **Code scanning** — confirm CodeQL default/advanced setup is enabled (this PR adds the workflow; verify it's not disabled by a default-setup conflict)
- [ ] **Dependabot alerts** + **security updates** (the `dependabot.yml` here covers *version* updates; alerts are a settings toggle)

#518 stays **partially open** until the four boxes above are ticked — hence `Refs #518`, not `Closes`.

## Testing
1. `python3 yaml.safe_load` on all four workflow/config files → valid.
2. `actionlint` on the three workflows → no errors (only pre-existing shellcheck-style notes in the untouched summary block).
3. `bash -n` on the artifact-guard run block (docker + process-substitution idiom) → parses clean.
4. `markdownlint` clean on `SECURITY.md` + the AgDR.
5. The CodeQL/Scorecard runs themselves will execute once merged (they need the workflows on the default branch / a real run).

Refs #518

---

## Glossary
| Term | Definition |
|------|------------|
| CodeQL | GitHub's semantic code-scanning engine; the `actions` language scans workflow files, `javascript-typescript` scans JS/TS. |
| OSSF Scorecard | Open-source supply-chain security posture score (branch protection, token scope, pinned deps, etc.). |
| Push protection | GitHub feature that blocks a push containing a detected secret (a Settings toggle, not a workflow). |
| Dependabot | Automated dependency update PRs (config here) + vulnerability alerts (a Settings toggle). |
| Release-artifact guard | A scan of the *built/published* bundle — not just source — for secrets and filled-in config. |
| Placeholder-diff | Detecting filled-in config by comparing it against the shipped `*.example` placeholders (from #517). |
