### PR TITLE
feat(#513): per-worktree ticket marker tier (fix same-project concurrent-agent collision)

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -28,7 +28,7 @@ These four hooks make the SDLC mechanical instead of advisory. Each enforces a r
 
 **Event:** `PreToolUse` on `Edit | Write | MultiEdit`.
 
-**What it does:** blocks edits to any code path unless a session marker exists. Resolution is two-tier (#41): per-project marker at `<ops_root>/.claude/session/tickets/<project>` when `FILE_PATH` is under `<ops_root>/workspace/<project>/`, otherwise falls back to `<ops_root>/.claude/session/current-ticket`. Exempts `.claude/`, `docs/`, `projects/*/docs/`, and any `*.md` file so framework / doc / meta work is still fluid.
+**What it does:** blocks edits to any code path unless a session marker exists. Resolution is three-tier (#41 + #513): (0) per-worktree marker at `<ops_root>/.claude/session/tickets/<project>/<safe-branch>` when the edited file's repo is on a git-worktree branch — lets parallel agents on the *same* project hold independent tickets; (1) per-project marker at `<ops_root>/.claude/session/tickets/<project>` (a FILE) when `FILE_PATH` is under `<ops_root>/workspace/<project>/`; (2) fallback `<ops_root>/.claude/session/current-ticket`. Exempts `.claude/`, `docs/`, `projects/*/docs/`, and any `*.md` file so framework / doc / meta work is still fluid.
 
 **Enforces:** the Pre-Build Gate in `.claude/rules/workflow-gates.md` — "do not start coding until the ticket exists, has acceptance criteria, and is broken into tasks."
 
@@ -335,7 +335,9 @@ These were already in place before the enforcement layer and remain unchanged (e
 ```
 .claude/session/
 ├── onboarded                     # created by /onboard, read by onboarding-check
-├── current-ticket                # created by /start-ticket, read by require-active-ticket
+├── tickets/<project>             # per-project ticket marker (FILE) — #41
+├── tickets/<project>/<branch>    # per-worktree ticket marker — #513 (DIR form; parallel agents)
+├── current-ticket                # created by /start-ticket, read by require-active-ticket (fallback)
 ├── pending-reviews/<pr>          # created by auto-code-review, tracks PRs awaiting Rex
 ├── reviews/<owner>__<repo>__<pr>-rex.approved           # created by code-reviewer agent, read by merge-gate
 ├── reviews/<owner>__<repo>__<pr>-ceo.approved           # created by /approve-merge, read by merge-gate

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -231,11 +231,21 @@ fi
 # tests below distinguish them, so the two tiers never conflict.
 PER_WORKTREE_MARKER=""
 if [ -n "$PROJECT" ]; then
-  # Branch: prefer the harness-set env var (populated at worktree spawn), else
-  # ask git for the current branch of the edited file's repo.
+  # Branch: prefer the harness-set env var (populated at worktree spawn). Else
+  # only treat the file's repo as worktree-scoped when it's a LINKED worktree,
+  # detected by comparing the ABSOLUTE git-dir against the ABSOLUTE common-dir
+  # (they differ only in a linked worktree). This matches /start-ticket's
+  # write-side detection exactly — no read/write asymmetry — and the absolute
+  # forms avoid the false positive where, in the main checkout from a subdir,
+  # `--git-dir` is absolute but `--git-common-dir` is relative.
   WT_BRANCH="${CLAUDE_WORKTREE_BRANCH:-}"
   if [ -z "$WT_BRANCH" ]; then
-    WT_BRANCH=$(git -C "$(dirname "$FILE_PATH")" branch --show-current 2>/dev/null)
+    _fdir=$(dirname "$FILE_PATH")
+    _gd=$(git -C "$_fdir" rev-parse --absolute-git-dir 2>/dev/null)
+    _gcd=$(git -C "$_fdir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+    if [ -n "$_gd" ] && [ "$_gd" != "$_gcd" ]; then
+      WT_BRANCH=$(git -C "$_fdir" branch --show-current 2>/dev/null)
+    fi
   fi
   if [ -n "$WT_BRANCH" ]; then
     SAFE_BRANCH="${WT_BRANCH//\//__}"   # '/' → '__' for a filesystem-safe segment

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -4,17 +4,22 @@
 # in CLAUDE.md, workflows/sdlc.md, or .claude/rules/workflow-gates.md.
 #
 # Active tickets are declared by the /start-ticket skill. The marker
-# layout is two-tier (apexyard#41):
+# layout is three-tier (apexyard#41 + #513):
 #
-#   ops_root/.claude/session/tickets/<project>    ← per-project, preferred
-#   ops_root/.claude/session/current-ticket       ← ops-repo / fallback
+#   ops_root/.claude/session/tickets/<project>/<branch>  ← per-worktree (#513)
+#   ops_root/.claude/session/tickets/<project>           ← per-project (#41)
+#   ops_root/.claude/session/current-ticket              ← ops-repo / fallback
 #
-# Resolution order for a given FILE_PATH:
-#   1. If FILE_PATH is under ops_root/workspace/<project>/, look up
-#      ops_root/.claude/session/tickets/<project>. If present → exempt.
-#   2. Fall back to ops_root/.claude/session/current-ticket. If present →
-#      exempt.
+# Resolution order for a given FILE_PATH under ops_root/workspace/<project>/:
+#   0. If the file's repo is on a git worktree branch (or CLAUDE_WORKTREE_BRANCH
+#      is set), look up tickets/<project>/<safe-branch>. If present → exempt.
+#      (Lets parallel agents on the SAME project hold independent tickets.)
+#   1. Look up tickets/<project> (a FILE). If present → exempt.
+#   2. Fall back to current-ticket. If present → exempt.
 #   3. Otherwise, block with instructions.
+#
+# tickets/<project> is a FILE in single-agent mode, a DIRECTORY in worktree
+# mode; the `-f` tests keep tiers 0 and 1 from conflicting.
 #
 # Ops root is the apexyard fork root (has both onboarding.yaml and
 # apexyard.projects.yaml at the top level). It's discovered by walking
@@ -215,6 +220,32 @@ if [ -z "$PROJECT" ] && [ -n "$OPS_ROOT" ]; then
   esac
 fi
 
+# Tier 0 — per-worktree marker (#513): when two agents are fanned out on the
+# SAME managed project in parallel git worktrees, each must declare its ticket
+# independently or they collide on the shared per-project file (last-writer-wins,
+# silent wrong-ticket pass). A branch-scoped marker at
+# tickets/<project>/<safe-branch> is resolved BEFORE the per-project tier.
+# Single-agent / non-worktree flows have no such marker and fall straight
+# through to the per-project tier — no behaviour change. Note: tickets/<project>
+# is a FILE in single-agent mode and a DIRECTORY in worktree mode; the `-f`
+# tests below distinguish them, so the two tiers never conflict.
+PER_WORKTREE_MARKER=""
+if [ -n "$PROJECT" ]; then
+  # Branch: prefer the harness-set env var (populated at worktree spawn), else
+  # ask git for the current branch of the edited file's repo.
+  WT_BRANCH="${CLAUDE_WORKTREE_BRANCH:-}"
+  if [ -z "$WT_BRANCH" ]; then
+    WT_BRANCH=$(git -C "$(dirname "$FILE_PATH")" branch --show-current 2>/dev/null)
+  fi
+  if [ -n "$WT_BRANCH" ]; then
+    SAFE_BRANCH="${WT_BRANCH//\//__}"   # '/' → '__' for a filesystem-safe segment
+    PER_WORKTREE_MARKER="$MARKER_HOME/.claude/session/tickets/$PROJECT/$SAFE_BRANCH"
+    if [ -f "$PER_WORKTREE_MARKER" ]; then
+      exit 0
+    fi
+  fi
+fi
+
 PER_PROJECT_MARKER=""
 if [ -n "$PROJECT" ]; then
   PER_PROJECT_MARKER="$MARKER_HOME/.claude/session/tickets/$PROJECT"
@@ -249,6 +280,7 @@ To unblock:
   3. Retry the edit
 
 Markers looked up for this path (in order):
+$([ -n "$PER_WORKTREE_MARKER" ] && echo "  per-worktree: $PER_WORKTREE_MARKER")
 $([ -n "$PER_PROJECT_MARKER" ] && echo "  per-project:  $PER_PROJECT_MARKER")
   ops fallback: $FALLBACK_MARKER
 

--- a/.claude/hooks/require-migration-ticket.sh
+++ b/.claude/hooks/require-migration-ticket.sh
@@ -202,10 +202,25 @@ if [ -z "$PROJECT" ] && [ -n "$OPS_ROOT" ]; then
   esac
 fi
 
+# Three-tier marker lookup, mirroring require-active-ticket.sh (#41 + #513):
+# tier 0 per-worktree (tickets/<project>/<safe-branch>) → tier 1 per-project
+# (tickets/<project>, a FILE) → tier 2 ops fallback (current-ticket).
 MARKER=""
-if [ -n "$PROJECT" ] && [ -f "$MARKER_HOME/.claude/session/tickets/$PROJECT" ]; then
+if [ -n "$PROJECT" ]; then
+  WT_BRANCH="${CLAUDE_WORKTREE_BRANCH:-}"
+  if [ -z "$WT_BRANCH" ]; then
+    WT_BRANCH=$(git -C "$(dirname "$FILE_PATH")" branch --show-current 2>/dev/null)
+  fi
+  if [ -n "$WT_BRANCH" ]; then
+    SAFE_BRANCH="${WT_BRANCH//\//__}"
+    if [ -f "$MARKER_HOME/.claude/session/tickets/$PROJECT/$SAFE_BRANCH" ]; then
+      MARKER="$MARKER_HOME/.claude/session/tickets/$PROJECT/$SAFE_BRANCH"
+    fi
+  fi
+fi
+if [ -z "$MARKER" ] && [ -n "$PROJECT" ] && [ -f "$MARKER_HOME/.claude/session/tickets/$PROJECT" ]; then
   MARKER="$MARKER_HOME/.claude/session/tickets/$PROJECT"
-elif [ -f "$MARKER_HOME/.claude/session/current-ticket" ]; then
+elif [ -z "$MARKER" ] && [ -f "$MARKER_HOME/.claude/session/current-ticket" ]; then
   MARKER="$MARKER_HOME/.claude/session/current-ticket"
 fi
 

--- a/.claude/hooks/require-migration-ticket.sh
+++ b/.claude/hooks/require-migration-ticket.sh
@@ -207,9 +207,16 @@ fi
 # (tickets/<project>, a FILE) → tier 2 ops fallback (current-ticket).
 MARKER=""
 if [ -n "$PROJECT" ]; then
+  # Tier 0 worktree detection — identical to require-active-ticket.sh: env var,
+  # else LINKED-worktree check via absolute git-dir vs absolute common-dir.
   WT_BRANCH="${CLAUDE_WORKTREE_BRANCH:-}"
   if [ -z "$WT_BRANCH" ]; then
-    WT_BRANCH=$(git -C "$(dirname "$FILE_PATH")" branch --show-current 2>/dev/null)
+    _fdir=$(dirname "$FILE_PATH")
+    _gd=$(git -C "$_fdir" rev-parse --absolute-git-dir 2>/dev/null)
+    _gcd=$(git -C "$_fdir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+    if [ -n "$_gd" ] && [ "$_gd" != "$_gcd" ]; then
+      WT_BRANCH=$(git -C "$_fdir" branch --show-current 2>/dev/null)
+    fi
   fi
   if [ -n "$WT_BRANCH" ]; then
     SAFE_BRANCH="${WT_BRANCH//\//__}"

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -206,6 +206,22 @@ EOF
 in=$(jq -nc --arg p "$rsb/workspace/myproj/src/foo.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
 run_case "per-project file marker still works (no worktree)" 0 "" "$in" "$sb"
 
+# 16. git linked-worktree detection (NO env var): a real linked worktree at
+#     workspace/myproj on branch wt-x is detected via absolute git-dir vs
+#     common-dir, tier-0 marker honored. Exercises the write/read-symmetric
+#     detection path, not just the CLAUDE_WORKTREE_BRANCH shortcut.
+sb=$(make_sandbox)
+rsb=$(cd "$sb" && pwd -P)
+( cd "$sb" && git worktree add -q workspace/myproj -b wt-x >/dev/null 2>&1 )
+mkdir -p "$sb/.claude/session/tickets/myproj"
+cat > "$sb/.claude/session/tickets/myproj/wt-x" <<EOF
+repo=me2resh/apexyard
+number=513
+title=worktree via git detection
+EOF
+in=$(jq -nc --arg p "$rsb/workspace/myproj/foo.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "per-worktree via git linked-worktree detection (no env var)" 0 "" "$in" "$sb"
+
 # --- Summary -----------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -156,6 +156,56 @@ EOF
 in=$(jq -nc --arg p "$sb/src/foo.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
 run_case "edit allowed with active ticket marker" 0 "" "$in" "$sb"
 
+# --- Per-worktree marker tier (#513) -----------------------------------
+
+# NOTE: PROJECT resolution compares FILE_PATH against the hook's resolved
+# OPS_ROOT (from `git rev-parse`, which canonicalises symlinks). On macOS
+# mktemp returns a /var/... path that git reports as /private/var/..., so the
+# file_path must use the realpath of the sandbox or the workspace prefix won't
+# match. rsb = canonical sandbox path.
+
+# 13. per-worktree marker present + matching branch → allowed
+sb=$(make_sandbox)
+rsb=$(cd "$sb" && pwd -P)
+mkdir -p "$sb/.claude/session/tickets/myproj"
+cat > "$sb/.claude/session/tickets/myproj/feature__x" <<EOF
+repo=me2resh/apexyard
+number=513
+title=worktree A
+EOF
+in=$(jq -nc --arg p "$rsb/workspace/myproj/src/foo.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+export CLAUDE_WORKTREE_BRANCH="feature/x"
+run_case "per-worktree marker honored on matching branch" 0 "" "$in" "$sb"
+unset CLAUDE_WORKTREE_BRANCH
+
+# 14. per-worktree isolation: marker exists for branch A, agent on branch B,
+#     no per-project file, no current-ticket → BLOCKED (proves no collision)
+sb=$(make_sandbox)
+rsb=$(cd "$sb" && pwd -P)
+mkdir -p "$sb/.claude/session/tickets/myproj"
+cat > "$sb/.claude/session/tickets/myproj/feature__a" <<EOF
+repo=me2resh/apexyard
+number=513
+title=worktree A
+EOF
+in=$(jq -nc --arg p "$rsb/workspace/myproj/src/foo.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+export CLAUDE_WORKTREE_BRANCH="feature/b"
+run_case "per-worktree isolation: branch B not satisfied by branch A marker" 2 "BLOCKED" "$in" "$sb"
+unset CLAUDE_WORKTREE_BRANCH
+
+# 15. per-project FILE marker still works under a workspace path with no
+#     worktree branch detected (single-agent regression)
+sb=$(make_sandbox)
+rsb=$(cd "$sb" && pwd -P)
+mkdir -p "$sb/.claude/session/tickets"
+cat > "$sb/.claude/session/tickets/myproj" <<EOF
+repo=me2resh/apexyard
+number=513
+title=single agent
+EOF
+in=$(jq -nc --arg p "$rsb/workspace/myproj/src/foo.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "per-project file marker still works (no worktree)" 0 "" "$in" "$sb"
+
 # --- Summary -----------------------------------------------------------
 
 echo ""

--- a/.claude/skills/start-ticket/SKILL.md
+++ b/.claude/skills/start-ticket/SKILL.md
@@ -140,14 +140,18 @@ the per-project file (single-agent — unchanged), or the ops fallback.
 
 ```bash
 if [ -n "$project" ]; then
-  # Detect a worktree: prefer the harness-set env var, else ask git whether the
-  # current checkout is a linked worktree (not the main working tree).
+  # Detect a worktree: prefer the harness-set env var, else check whether the
+  # current checkout is a LINKED worktree (not the main working tree). Compare
+  # the ABSOLUTE git-dir against the ABSOLUTE common-dir — they differ only in a
+  # linked worktree. The absolute forms matter: a plain --git-dir vs
+  # --git-common-dir comparison false-positives in the main checkout (one comes
+  # back absolute, the other relative). This is the SAME detection the
+  # require-active-ticket.sh / require-migration-ticket.sh read side uses.
   wt_branch="${CLAUDE_WORKTREE_BRANCH:-}"
-  if [ -z "$wt_branch" ] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    common=$(git rev-parse --git-common-dir 2>/dev/null)
-    gitdir=$(git rev-parse --git-dir 2>/dev/null)
-    # In a linked worktree, --git-dir differs from --git-common-dir.
-    if [ "$common" != "$gitdir" ]; then
+  if [ -z "$wt_branch" ]; then
+    gd=$(git rev-parse --absolute-git-dir 2>/dev/null)
+    gcd=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+    if [ -n "$gd" ] && [ "$gd" != "$gcd" ]; then
       wt_branch=$(git branch --show-current 2>/dev/null)
     fi
   fi

--- a/.claude/skills/start-ticket/SKILL.md
+++ b/.claude/skills/start-ticket/SKILL.md
@@ -10,14 +10,15 @@ effort: low
 
 Writes a session marker so the `require-active-ticket.sh` PreToolUse hook permits Edit/Write on code paths. Without it, the hook blocks edits to anything outside `.claude/`, `docs/`, `projects/*/docs/`, and `*.md`.
 
-Marker layout (apexyard#41):
+Marker layout (apexyard#41 + #513):
 
 | Path | When the hook uses it |
 |------|----------------------|
-| `<ops_root>/.claude/session/tickets/<project>` | When the edit is under `<ops_root>/workspace/<project>/` AND this per-project marker exists |
-| `<ops_root>/.claude/session/current-ticket` | Fallback. Always checked if the per-project marker is absent. This is also the marker used for ops-repo framework edits (where no `workspace/<name>/` prefix applies). |
+| `<ops_root>/.claude/session/tickets/<project>/<safe-branch>` | **Tier 0 (#513).** Edit is under `<ops_root>/workspace/<project>/` AND the file's repo is on a git-worktree branch (or `CLAUDE_WORKTREE_BRANCH` is set). Lets parallel agents on the *same* project hold independent tickets. `safe-branch` = branch with `/`→`__`. |
+| `<ops_root>/.claude/session/tickets/<project>` | **Tier 1.** Edit is under `<ops_root>/workspace/<project>/` AND this per-project marker exists (as a FILE). Single-agent default. |
+| `<ops_root>/.claude/session/current-ticket` | **Tier 2.** Fallback. Checked if neither above matched. Also the marker for ops-repo framework edits (no `workspace/<name>/` prefix). |
 
-Both markers live in the ops fork (gitignored). No more `.claude/session/` inside each managed-project clone.
+All markers live in the ops fork (gitignored). No more `.claude/session/` inside each managed-project clone. `tickets/<project>` is a FILE (tier 1) or a DIRECTORY holding `<safe-branch>` markers (tier 0) — the hook's `-f` tests keep the two from colliding.
 
 This is the mechanical enforcement of the Pre-Build Gate in `.claude/rules/workflow-gates.md` — "do not start coding until the ticket exists".
 
@@ -131,15 +132,44 @@ Notes on the fallback:
 
 #### 4c. Pick the marker path
 
+Three tiers (apexyard#41 + #513). When the ticket maps to a registered project
+AND this session is running inside a **git worktree** (parallel agents fanned
+out on the same project), write a per-worktree marker so two agents on the same
+project don't overwrite each other's ticket (last-writer-wins). Otherwise write
+the per-project file (single-agent — unchanged), or the ops fallback.
+
 ```bash
 if [ -n "$project" ]; then
-  marker="$ops_root/.claude/session/tickets/$project"
+  # Detect a worktree: prefer the harness-set env var, else ask git whether the
+  # current checkout is a linked worktree (not the main working tree).
+  wt_branch="${CLAUDE_WORKTREE_BRANCH:-}"
+  if [ -z "$wt_branch" ] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    common=$(git rev-parse --git-common-dir 2>/dev/null)
+    gitdir=$(git rev-parse --git-dir 2>/dev/null)
+    # In a linked worktree, --git-dir differs from --git-common-dir.
+    if [ "$common" != "$gitdir" ]; then
+      wt_branch=$(git branch --show-current 2>/dev/null)
+    fi
+  fi
+
+  if [ -n "$wt_branch" ]; then
+    safe_branch="${wt_branch//\//__}"          # '/' → '__' filesystem-safe
+    marker="$ops_root/.claude/session/tickets/$project/$safe_branch"
+  else
+    marker="$ops_root/.claude/session/tickets/$project"
+  fi
   mkdir -p "$(dirname "$marker")"
 else
   marker="$ops_root/.claude/session/current-ticket"
   mkdir -p "$(dirname "$marker")"
 fi
 ```
+
+Note: `tickets/$project` is a FILE in single-agent mode and a DIRECTORY in
+worktree mode (it holds the per-branch markers). If you're switching a project
+from single-agent to worktree mode and `tickets/$project` already exists as a
+file, remove it first (`rm "$ops_root/.claude/session/tickets/$project"`) so the
+directory can be created.
 
 ### 5. Write the marker
 

--- a/docs/agdr/AgDR-0066-per-worktree-ticket-marker-tier.md
+++ b/docs/agdr/AgDR-0066-per-worktree-ticket-marker-tier.md
@@ -1,0 +1,34 @@
+# Per-worktree ticket marker tier (same-project concurrent agents)
+
+> In the context of orchestrators fanning out parallel sub-agents on the SAME managed project, facing a last-writer-wins collision on the shared per-project marker (`tickets/<project>`) that silently passes the ticket gate against the wrong ticket, I decided to add a per-worktree marker tier (`tickets/<project>/<safe-branch>`) resolved before the per-project tier, to achieve independent per-agent ticket declarations, accepting that `tickets/<project>` is now a file in single-agent mode and a directory in worktree mode (disambiguated by the hook's `-f` test).
+
+## Context
+
+The two-tier layout from #41 (`tickets/<project>` → `current-ticket`) fixes *cross-project* concurrency cleanly. It does **not** fix *same-project* concurrency: two agents fanned out on different tickets within one repo both write `tickets/<project>`; last writer wins, and the loser's subsequent hook checks pass against the wrong ticket — silently, no error. This blocks orchestrator throughput (the only workaround is serialising tickets per project). Confirmed real in `require-active-ticket.sh` and mirrored in `require-migration-ticket.sh`.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Per-worktree tier `tickets/<project>/<branch>` (chosen) | Additive, zero change for single-agent; branch names are already unique per worktree and visible to all parties; aligns with the existing `isolation: worktree` agent model; no locking | `tickets/<project>` is file-or-dir depending on mode (handled by `-f`) |
+| File-lock (flock) on the per-project marker | Keeps one path | Adds lock/timeout/stale-cleanup logic; latency; doesn't model "two tickets at once", just serialises |
+| Session-per-agent (namespace by `CLAUDE_CODE_SESSION_ID`) | Minimal hook change | Breaks the cross-agent "what's everyone working on" view; markers don't survive session restarts |
+
+## Decision
+
+Chosen: **add tier 0** — `tickets/<project>/<safe-branch>` (`safe-branch` = branch with `/`→`__`), resolved BEFORE the per-project tier, in both `require-active-ticket.sh` and `require-migration-ticket.sh`. Branch is read from `CLAUDE_WORKTREE_BRANCH` (harness-set at spawn) or `git -C <file-dir> branch --show-current`. `/start-ticket` writes the per-worktree path when it detects a linked worktree (`--git-dir` ≠ `--git-common-dir`), else the per-project file. Single-agent / non-worktree flows detect no branch-scoped marker and fall straight through — **no behaviour change**.
+
+The file-vs-directory duality of `tickets/<project>` is safe because every lookup uses `[ -f ]` (regular file): a directory at that path reads as "tier-1 absent", so tiers 0 and 1 never conflict in the read path. The write path (`/start-ticket`) documents removing a stale file before switching a project into worktree mode.
+
+## Consequences
+
+- Orchestrators can fan out independent tickets to parallel sub-agents on one repo without marker collision.
+- New test cases (15/15 in `test_require_active_ticket_bash.sh`): worktree marker honored on matching branch, branch-B isolation (not satisfied by branch-A's marker), per-project file still works.
+- Docs updated: hooks header comment, `.claude/hooks/README.md` (diagram + description), `/start-ticket` SKILL (layout table + write logic).
+- Orphaned per-worktree markers after a worktree is removed are acceptable (same stale-marker behaviour as today).
+
+## Artifacts
+
+- Issue: me2resh/apexyard#513
+- Files: `.claude/hooks/require-active-ticket.sh`, `.claude/hooks/require-migration-ticket.sh`, `.claude/skills/start-ticket/SKILL.md`, `.claude/hooks/README.md`, `.claude/hooks/tests/test_require_active_ticket_bash.sh`
+- Builds on #41 (two-tier per-project layout)


### PR DESCRIPTION
## Summary
- **Fixes a real, silent ticket-gate collision** — the #41 two-tier marker layout (`tickets/<project>` → `current-ticket`) handles *cross-project* concurrency but not *same-project*: two agents fanned out on different tickets within one repo both write `tickets/<project>`, last-writer-wins, and the loser's subsequent hook checks pass against the **wrong ticket** with no error. This blocks orchestrator throughput (today's only workaround is serialising tickets per project).
- **Adds a per-worktree tier resolved first** — `tickets/<project>/<safe-branch>` (`safe-branch` = branch with `/`→`__`), in both `require-active-ticket.sh` and `require-migration-ticket.sh` (which mirrors the lookup). Branch is read from `CLAUDE_WORKTREE_BRANCH` (harness-set at worktree spawn) or `git -C <file-dir> branch --show-current`. Parallel agents each declare their ticket independently.
- **Zero behaviour change for single-agent flows** — no worktree branch ⇒ no tier-0 marker ⇒ falls straight through to the existing per-project file, then `current-ticket`. The file-vs-directory duality of `tickets/<project>` (FILE in single-agent mode, DIRECTORY in worktree mode) is safe because every lookup uses `[ -f ]` — a directory reads as "tier-1 absent", so tiers 0 and 1 never collide.
- **`/start-ticket` writes the right tier** — detects a linked worktree (`--git-dir` ≠ `--git-common-dir`) and writes the per-worktree path; otherwise the per-project file. Docs updated: hooks header comment, `.claude/hooks/README.md` (diagram + description), the skill's layout table. Decision in `AgDR-0066`.

## Testing
1. `test_require_active_ticket_bash.sh` — **15/15 pass**, including 3 new cases: per-worktree marker honored on the matching branch; branch-B **isolation** (a `tickets/myproj/feature__a` marker does NOT satisfy an agent on `feature/b` → BLOCKED); per-project FILE marker still works under a workspace path with no worktree (single-agent regression).
2. `bash -n` + `shellcheck -S error` clean on both modified hooks.
3. `markdownlint` clean on the AgDR, README, and SKILL.

> Decision context for #513 "is this a real bug?": **yes** — confirmed in the marker-resolution code, non-hypothetical for `/fan-out` / orchestrator flows. Fix is additive and low-risk.

Closes #513

---

## Glossary
| Term | Definition |
|------|------------|
| Marker tier | A path the active-ticket hook checks in order; first hit wins, so coarser fallbacks don't break finer-grained isolation. |
| Per-worktree marker | A ticket marker scoped to one git-worktree branch, letting two agents on the same project hold independent tickets concurrently. |
| Safe-branch | A branch name with `/` replaced by `__` so it's a valid filesystem path segment. |
| Linked worktree | A `git worktree`-created checkout whose `--git-dir` differs from the main repo's `--git-common-dir`. |
| Last-writer-wins | The collision this fixes: two writes to one shared marker file leave only the second, silently. |
