### PR TITLE
chore(#517): onboarding guard literal filename match (grep -Fxq)

### DIFF
--- a/.claude/hooks/block-onboarding-in-git.sh
+++ b/.claude/hooks/block-onboarding-in-git.sh
@@ -40,9 +40,10 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 [ -z "$REPO_ROOT" ] && exit 0
 
-# Is onboarding.yaml staged for this commit?
+# Is onboarding.yaml staged for this commit? Use -F (fixed string) so the '.'
+# is a literal dot, not a regex wildcard — '-x' already anchors the whole line.
 STAGED=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null)
-echo "$STAGED" | grep -qx 'onboarding.yaml' || exit 0
+echo "$STAGED" | grep -Fxq 'onboarding.yaml' || exit 0
 
 # Placeholder-diff: if the staged onboarding.yaml is byte-identical to the
 # shipped example template, it carries no real values → allow. Otherwise it's


### PR DESCRIPTION
## Summary
- **Hardens the onboarding commit guard's filename match** — follow-up to the #517 review (merged PR #522). `block-onboarding-in-git.sh` checked the staged file list with `grep -qx 'onboarding.yaml'`, where the `.` is a regex wildcard, so it would also match an (implausible) `onboardingXyaml`. Switched to `grep -Fxq` (fixed string, still whole-line-anchored via `-x`) so only the literal filename matches.
- **No behaviour change in practice** — no such over-matching file exists; this removes a latent correctness gap Rex flagged as a non-blocking nit. The 6-case guard test suite stays green.

## Testing
1. `.claude/hooks/tests/test_block_onboarding_in_git.sh` → 6/6 pass (filled-in blocked, placeholder allowed, both escape hatches, non-onboarding unaffected, non-commit ignored).
2. `bash -n` + `shellcheck -S error` clean.

Refs #517

---

## Glossary
| Term | Definition |
|------|------------|
| `grep -Fxq` | Fixed-string (`-F`, no regex), whole-line (`-x`), quiet (`-q`) match — the precise literal-filename form. |
| Onboarding guard | `block-onboarding-in-git.sh` — blocks committing a filled-in `onboarding.yaml` (#517). |
