### PR TITLE
ci(#526): gate the hook test suite in CI

### DIFF
--- a/.claude/skills/setup/tests/test_setup_reset.sh
+++ b/.claude/skills/setup/tests/test_setup_reset.sh
@@ -22,7 +22,11 @@
 set -u
 
 ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
-TEMPLATE_SRC="$ROOT/onboarding.yaml"
+# Since #517 the tracked placeholder template is onboarding.example.yaml
+# (onboarding.yaml is gitignored real config). /setup --reset now does
+# `cp onboarding.example.yaml onboarding.yaml`, so the template source here is
+# the example file.
+TEMPLATE_SRC="$ROOT/onboarding.example.yaml"
 
 if [ ! -f "$TEMPLATE_SRC" ]; then
   echo "FAIL: framework template $TEMPLATE_SRC not found" >&2
@@ -33,7 +37,7 @@ fi
 # placeholder. If this ever changes, this test (and the SKILL.md
 # detection grep) must change too.
 if ! grep -q '"Your Company Name"' "$TEMPLATE_SRC"; then
-  echo "FAIL: framework onboarding.yaml lacks the 'Your Company Name' placeholder — template detection grep in SKILL.md Step 1 is broken" >&2
+  echo "FAIL: framework onboarding.example.yaml lacks the 'Your Company Name' placeholder — template detection grep in SKILL.md Step 1 is broken" >&2
   exit 1
 fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: tests
+
+# Runs the framework's mechanical-enforcement test suites (the ~60 test_*.sh
+# under .claude/**/tests/) on every PR and on push to dev/main. Until now these
+# tests were advisory — only 2 ran in CI — so a hook regression could ship
+# green. This job makes the whole suite a gate. See me2resh/apexyard#526.
+
+on:
+  pull_request:
+  push:
+    branches: [dev, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hook-tests:
+    name: hook test suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install jq (used by the hooks + their tests)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
+
+      - name: Configure git identity (test sandboxes run git init/commit)
+        run: |
+          git config --global user.email "ci@apexyard.test"
+          git config --global user.name "apexyard-ci"
+          git config --global init.defaultBranch main
+
+      - name: Run the hook test suite
+        run: bash bin/run-hook-tests.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,7 @@ One-line summary per skill; canonical details live in each `.claude/skills/<name
 | `/codify-rule` | Turn a review comment that caught a Rex-miss into a draft handbook entry |
 | `/investigation` | Create an investigation ticket + live-doc for sustained root-cause work |
 | `/idea` | Capture a new product idea to the shared backlog |
-| `/handover` | Onboard an external repo + score harnessability across 5 codebase dimensions + checklist-pick which docs to generate (per-doc template choice; `--all` for the full non-interactive set) + offer to file Next Steps as tracker tickets |
+| `/handover` | Onboard an external repo — harnessability scoring across 5 dimensions, checklist-pick which docs to generate, and offer to file Next Steps as tracker tickets |
 | `/onboard` | Deprecated alias — redirects to `/setup` or `/handover` |
 | `/extract-features` | Six-axis Feature Inventory (routes / models / jobs / tests / UI / docs) for rewrites |
 | `/feature-diagram` | Per-feature Mermaid flowchart of routes / models / jobs / screens involved |

--- a/bin/run-hook-tests.sh
+++ b/bin/run-hook-tests.sh
@@ -23,7 +23,13 @@ cd "$ROOT" || exit 1
 # --- Quarantine list (path :: reason). Empty by default; populated only with
 # --- evidence (a CI failure that is environmental, not a real regression). ---
 QUARANTINE=(
-  # "path/to/test_x.sh :: needs gh auth / network — cannot run headless"
+  # Pre-existing failures on dev (NOT caused by the gate) — tracked in #528 to
+  # fix + un-quarantine. Each cites why it fails headless / is stale.
+  ".claude/skills/pdf/tests/test_md_to_pdf_fallback.sh :: runs 'npx -y md-to-pdf' (network npm + headless chromium) when npx is present; heavy/flaky in CI — #528"
+  ".claude/hooks/tests/test_handover_clone_prompt.sh :: asserts the pre-restructure /handover clone-prompt spec; SKILL moved clone to step 1.5 — #528"
+  ".claude/hooks/tests/test_agent_routing_sync_and_drift.sh :: case-2 qa-engineer override drift vs committed agent-routing.yaml — #528"
+  ".claude/skills/handover/tests/test_harnessability_scoring.sh :: 1/14 scoring case drifted from the current rubric — #528"
+  ".claude/hooks/tests/test_token_efficiency_wave1.sh :: doc-hygiene drift (plan-initiative desc >200 chars; /release-sync missing from CLAUDE.md table) — #528"
 )
 
 is_quarantined() {

--- a/bin/run-hook-tests.sh
+++ b/bin/run-hook-tests.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Discovery test runner for the ApexYard mechanical-enforcement test suites.
+#
+# Finds every test_*.sh (and *.test.sh) under the framework's tests/ trees,
+# runs each in isolation, prints a per-test PASS/FAIL/SKIP line, and exits
+# non-zero if ANY non-quarantined test fails. Reusable locally and in CI
+# (.github/workflows/tests.yml). See me2resh/apexyard#526.
+#
+# Usage:
+#   bin/run-hook-tests.sh            # run the whole suite
+#   bin/run-hook-tests.sh --list     # list discovered tests, run nothing
+#
+# Quarantine: tests that genuinely cannot run headless (or are known-failing
+# and tracked for a fix) are listed in QUARANTINE below, each with a reason.
+# They are SKIPPED and logged — never silently dropped. Keep this list short
+# and every entry must cite why.
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT" || exit 1
+
+# --- Quarantine list (path :: reason). Empty by default; populated only with
+# --- evidence (a CI failure that is environmental, not a real regression). ---
+QUARANTINE=(
+  # "path/to/test_x.sh :: needs gh auth / network — cannot run headless"
+)
+
+is_quarantined() {
+  local t="$1" entry
+  [ "${#QUARANTINE[@]}" -gt 0 ] || return 1
+  for entry in "${QUARANTINE[@]}"; do
+    [ "${entry%% ::*}" = "$t" ] && return 0
+  done
+  return 1
+}
+
+# Per-test wall-clock cap (Linux `timeout`; falls back to no cap if absent).
+TIMEOUT_BIN=""
+command -v timeout >/dev/null 2>&1 && TIMEOUT_BIN="timeout 120"
+command -v gtimeout >/dev/null 2>&1 && TIMEOUT_BIN="gtimeout 120"
+
+# Portable array population (bash 3.2 on macOS has no `mapfile`).
+TESTS=()
+while IFS= read -r _t; do
+  [ -n "$_t" ] && TESTS+=("$_t")
+done < <(
+  find .claude/hooks/tests .claude/agents/tests .claude/rules/tests .claude/skills \
+       -type f \( -name 'test_*.sh' -o -name '*.test.sh' \) 2>/dev/null | sort
+)
+
+if [ "${1:-}" = "--list" ]; then
+  [ "${#TESTS[@]}" -gt 0 ] && printf '%s\n' "${TESTS[@]}"
+  echo "(${#TESTS[@]} tests discovered)"
+  exit 0
+fi
+
+pass=0 fail=0 skip=0
+FAILED=()
+
+for t in "${TESTS[@]}"; do
+  if is_quarantined "$t"; then
+    reason=""
+    for entry in "${QUARANTINE[@]}"; do
+      [ "${entry%% ::*}" = "$t" ] && reason="${entry#* :: }"
+    done
+    printf 'SKIP %s  (quarantined: %s)\n' "$t" "$reason"
+    skip=$((skip+1))
+    continue
+  fi
+  # shellcheck disable=SC2086
+  if $TIMEOUT_BIN bash "$t" </dev/null >/tmp/_hooktest.out 2>&1; then
+    printf 'PASS %s\n' "$t"
+    pass=$((pass+1))
+  else
+    rc=$?
+    printf 'FAIL %s  (rc=%s)\n' "$t" "$rc"
+    tail -n 15 /tmp/_hooktest.out | sed 's/^/      | /'
+    fail=$((fail+1))
+    FAILED+=("$t")
+  fi
+done
+
+echo
+echo "============================================================"
+echo "  hook test suite: PASS=$pass  FAIL=$fail  SKIP(quarantined)=$skip  TOTAL=${#TESTS[@]}"
+echo "============================================================"
+if [ "$fail" -gt 0 ]; then
+  printf 'FAILED:\n'; printf '  - %s\n' "${FAILED[@]}"
+  exit 1
+fi
+exit 0

--- a/docs/agdr/AgDR-0067-gate-hook-test-suite-in-ci.md
+++ b/docs/agdr/AgDR-0067-gate-hook-test-suite-in-ci.md
@@ -1,0 +1,37 @@
+# Gate the hook test suite in CI
+
+> In the context of ~64 mechanical-enforcement test scripts of which only 2 ran in CI, facing the fact that a hook regression ships green because the suites are advisory, I decided to add a discovery runner (`bin/run-hook-tests.sh`) + a `tests.yml` workflow that runs the whole suite on every PR and fails the job on any failure, with a documented quarantine list for tests that genuinely can't run headless, to achieve real regression protection, accepting that a small, explicitly-listed set of environment-dependent tests is excluded (and tracked) rather than letting them flake the gate.
+
+## Context
+
+The framework's safety is the hooks (merge gate, ticket-first + per-worktree tiers, onboarding/secrets/leak guards, validators, portfolio path resolution). ~64 `test_*.sh` assert that behaviour, but only `test_subpack_extraction` and `test_site_counts` ran in CI; `shellcheck.yml` lints syntax, never runs the suites. So the tests were advisory — several issues this session (review-marker naming, worktree detection) were caught only by running suites by hand. #526.
+
+A local triage on macOS showed 52/64 passing; the 12 failures split into (a) macOS `/private/var` symlink artifacts that pass on Linux, and (b) genuinely stale/drifted tests. CI on Linux is the authoritative oracle for which is which.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Discovery runner + tests.yml, fail-on-any, short documented quarantine (chosen) | Real gate immediately; no hardcoded test list to maintain; quarantine is explicit + logged | A few env-dependent tests excluded until fixed |
+| Hardcode the list of tests to run in the workflow | Simple | Drifts the moment a test is added; the gap that created this problem |
+| Fix every failing test first, then gate with zero quarantine | Purest gate | Couples the gate to unbounded pre-existing test debt; delays protection indefinitely |
+| Allowed-failures (run but don't fail the job) | Nothing blocks | Not a gate — same advisory non-enforcement we're replacing |
+
+## Decision
+
+Chosen: **`bin/run-hook-tests.sh` (glob-discovery, per-test timeout, fail-on-any) + `.github/workflows/tests.yml` (PR + push to dev/main, jq installed, git identity set)**. Tests that genuinely can't run headless, or are known-failing and tracked, go in the runner's `QUARANTINE` array — each entry must cite a reason and is printed as `SKIP` (never silently dropped). The quarantine is a **ratchet**: the gate enforces the passing majority now; quarantined entries get follow-up tickets to fix + un-quarantine.
+
+Linux CI determines the real failing set (macOS symlink noise excluded). Genuinely-stale failures are either fixed in-scope when trivial, or quarantined with a tracking ticket when they represent separate debt.
+
+## Consequences
+
+- Hook regressions now fail CI on the PR that introduces them — the suite is a gate, not a suggestion.
+- The runner is reusable locally (`bash bin/run-hook-tests.sh`), so contributors get the same signal pre-push.
+- A small, visible quarantine set remains until follow-ups clear it; the list is in one place with reasons.
+- Adding a new `test_*.sh` is auto-discovered — no workflow edit needed.
+
+## Artifacts
+
+- Issue: me2resh/apexyard#526
+- Files: `bin/run-hook-tests.sh`, `.github/workflows/tests.yml`
+- The exact quarantine list + any in-scope test fixes are recorded in the PR.


### PR DESCRIPTION
## Summary
- **Turns the test corpus into an actual gate** — ~65 `test_*.sh` suites assert the mechanical-enforcement layer (merge gate, ticket-first + per-worktree tiers, onboarding/secrets/leak guards, validators, portfolio paths), but only 2 ran in CI; a hook regression shipped green. This adds a glob-discovery runner + a `tests.yml` workflow that runs the whole suite on every PR and on push to `dev`/`main`, failing the job on any failure.
- **`bin/run-hook-tests.sh`** — discovers every `test_*.sh` / `*.test.sh` under `.claude/**/tests/`, runs each with a per-test timeout, prints PASS/FAIL/SKIP, exits non-zero on any failure. Bash-3.2-portable so it's reusable locally (`bash bin/run-hook-tests.sh`). A documented `QUARANTINE` array skips (and logs) tests that genuinely can't run headless — never a silent drop.
- **`.github/workflows/tests.yml`** — `ubuntu-latest`, installs `jq`, sets a git identity (sandboxes do `git init`/`commit`), runs the runner.
- Decision + quarantine policy in **AgDR-0067**.

## Status / how I'm finalizing the quarantine
A local macOS run showed 52/65 passing; the 12 failures were a mix of macOS `/private/var` symlink artifacts (which pass on Linux) and genuinely stale tests. Rather than guess, this PR runs **everything** so the PR's own `tests` check is the Linux oracle. I'll then:
- leave the gate enforcing all tests that pass on Linux,
- quarantine (with a cited reason + follow-up ticket) only the genuinely-stale/headless-incompatible ones,
- fix any trivially-in-scope failures (e.g. tests that #517 outdated).

So the `tests` check on this PR may be red on the first run by design — I'll drive it green before requesting merge.

## Testing
1. `bash bin/run-hook-tests.sh --list` → discovers 65 tests (verified locally, bash 3.2).
2. `bash bin/run-hook-tests.sh` locally → 52 pass / 12 fail (macOS); failures triaged via this PR's Linux `tests` check.
3. `python3 yaml.safe_load` on `tests.yml` + `shellcheck -S error bin/run-hook-tests.sh` → clean.
4. Pre-merge smoke: a deliberately-broken hook will be confirmed to make the job go red (AC), and the final `tests` check will be green.

Refs #526

---

## Glossary
| Term | Definition |
|------|------------|
| Discovery runner | A script that finds test files by glob and runs them all, instead of a hardcoded list that drifts. |
| Quarantine | An explicit, logged skip-list for tests that can't run headless or are known-failing-and-tracked — visible, not silent. |
| Gated test | A test whose failure fails CI (blocks merge), vs an advisory test that only runs if someone remembers. |
| Linux oracle | Using the actual CI environment to determine the true pass/fail set, free of local macOS artifacts. |
