### PR TITLE
test(#528): fix + un-quarantine agent_routing (test-isolation bug)

### DIFF
--- a/.claude/hooks/tests/test_agent_routing_sync_and_drift.sh
+++ b/.claude/hooks/tests/test_agent_routing_sync_and_drift.sh
@@ -59,6 +59,15 @@
 
 set -u
 
+# Test isolation (#528): apply-agent-routing.sh resolves the ops root via
+# _lib-ops-root.sh, which — inside a real Claude Code session — honours the
+# session pin ($APEXYARD_OPS_PIN_DIR/ops-root-$CLAUDE_CODE_SESSION_ID) and
+# points at the REAL fork, NOT our mktemp sandbox. That made the hook rewrite
+# the real .claude/agents/*.md and write a stray snapshot there, while every
+# sandbox assertion failed. Disable the pin so ops-root resolves by walk-up to
+# the sandbox. (Hooks run headless in CI have no pin, so this is a no-op there.)
+export APEXYARD_OPS_DISABLE_PIN=1
+
 SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 SYNC_HOOK="$SRC_ROOT/.claude/hooks/apply-agent-routing.sh"
 DRIFT_HOOK="$SRC_ROOT/.claude/hooks/block-agent-routing-drift.sh"
@@ -196,6 +205,70 @@ read_model_line() {
   awk '/^---/{count++; next} count==1 && /^model:/ {sub(/^model:[[:space:]]*/, ""); print; exit}' "$1"
 }
 
+# ===========================================================================
+# Mock curl helper for the endpoint/Ollama-path cases (case 4 + cases 9-13).
+#
+# Drops a fake `curl` script onto $PATH that consults $APEXYARD_MOCK_CURL_DIR
+# for canned responses. Each fixture is named by the sanitised URL and
+# contains `<HTTP_STATUS>\n<BODY>`. Missing fixture = simulated network
+# failure (exit 7). Honours `--fail` so the hook's reachability check
+# behaves like real curl would. Defined here (near the top) so cases earlier
+# than the Ollama block (e.g. case 4 idempotency) can also use it. (#528)
+# ===========================================================================
+make_mock_curl() {
+  local sb="$1"
+  local fixture_dir="$sb/.test-curl-fixtures/bin"
+  mkdir -p "$fixture_dir"
+  cat > "$fixture_dir/curl" <<'CURL_MOCK'
+#!/bin/bash
+# Mock curl — for hook tests only.
+url=""
+fail=0
+output_target=""
+expect_output_target=0
+for arg in "$@"; do
+  if [ "$expect_output_target" = "1" ]; then
+    output_target="$arg"
+    expect_output_target=0
+    continue
+  fi
+  case "$arg" in
+    -s|--silent) ;;
+    -f|--fail)   fail=1 ;;
+    -o)          expect_output_target=1 ;;
+    --max-time)  expect_output_target=1 ;;
+    --max-time=*) ;;
+    http*) url="$arg" ;;
+    *) ;;
+  esac
+done
+# If `--max-time <N>` consumed N as the output_target, undo that.
+case "$output_target" in
+  ''|[0-9]*) output_target="" ;;
+esac
+[ -z "$url" ] && exit 1
+key=$(printf '%s' "$url" | tr '/:?&=' '_____' | tr -s '_')
+fixture="${APEXYARD_MOCK_CURL_DIR:-/nonexistent}/$key"
+if [ -f "$fixture" ]; then
+  status=$(head -1 "$fixture")
+  body=$(tail -n +2 "$fixture")
+  if [ "$status" -ge 400 ] && [ "$fail" = "1" ]; then
+    exit 22
+  fi
+  if [ "$output_target" = "/dev/null" ] || [ -z "$output_target" ]; then
+    printf '%s' "$body"
+  else
+    printf '%s' "$body" > "$output_target"
+  fi
+  exit 0
+fi
+# No fixture = unreachable / connection refused
+exit 7
+CURL_MOCK
+  chmod +x "$fixture_dir/curl"
+  echo "$fixture_dir"
+}
+
 # emit the JSON envelope a PreToolUse hook expects on stdin.
 hook_stdin() {
   local cmd="$1"
@@ -297,6 +370,14 @@ rm -rf "$SB"
 # same end state, no compounded writes.
 # ===========================================================================
 SB=$(make_fork)
+# Mock the endpoint as reachable so the ANTHROPIC_BASE_URL row is written
+# deterministically (without a real listener on :11434 the hook correctly
+# filters the unreachable endpoint, and the endpoint_count assertion below
+# would be testing the environment, not idempotency). #528
+MOCK_BIN=$(make_mock_curl "$SB")
+APEXYARD_MOCK_CURL_DIR=$(mktemp -d)
+export APEXYARD_MOCK_CURL_DIR
+printf '200\n[]\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_11434_v1_models"
 cat > "$SB/agent-routing.yaml" <<'YAML'
 version: 1
 agents:
@@ -307,7 +388,7 @@ agents:
       MY_VAR: hello
 YAML
 
-(cd "$SB" && bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true) >/dev/null
+(cd "$SB" && ANTHROPIC_BASE_URL=http://localhost:11434 PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true) >/dev/null
 
 # Capture state after first run.
 first_qa=$(read_model_line "$SB/.claude/agents/qa-engineer.md")
@@ -315,7 +396,7 @@ first_env=""
 [ -f "$SB/.claude/session/agent-env/qa-engineer.env" ] && first_env=$(cat "$SB/.claude/session/agent-env/qa-engineer.env")
 
 # Run again.
-(cd "$SB" && bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true) >/dev/null
+(cd "$SB" && ANTHROPIC_BASE_URL=http://localhost:11434 PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true) >/dev/null
 
 second_qa=$(read_model_line "$SB/.claude/agents/qa-engineer.md")
 second_env=""
@@ -455,68 +536,8 @@ else
 fi
 rm -rf "$SB"
 
-# ===========================================================================
-# Mock curl helper for the Ollama-path cases (cases 9-13).
-#
-# Drops a fake `curl` script onto $PATH that consults $APEXYARD_MOCK_CURL_DIR
-# for canned responses. Each fixture is named by the sanitised URL and
-# contains `<HTTP_STATUS>\n<BODY>`. Missing fixture = simulated network
-# failure (exit 7). Honours `--fail` so the hook's reachability check
-# behaves like real curl would.
-# ===========================================================================
-make_mock_curl() {
-  local sb="$1"
-  local fixture_dir="$sb/.test-curl-fixtures/bin"
-  mkdir -p "$fixture_dir"
-  cat > "$fixture_dir/curl" <<'CURL_MOCK'
-#!/bin/bash
-# Mock curl — for hook tests only.
-url=""
-fail=0
-output_target=""
-expect_output_target=0
-for arg in "$@"; do
-  if [ "$expect_output_target" = "1" ]; then
-    output_target="$arg"
-    expect_output_target=0
-    continue
-  fi
-  case "$arg" in
-    -s|--silent) ;;
-    -f|--fail)   fail=1 ;;
-    -o)          expect_output_target=1 ;;
-    --max-time)  expect_output_target=1 ;;
-    --max-time=*) ;;
-    http*) url="$arg" ;;
-    *) ;;
-  esac
-done
-# If `--max-time <N>` consumed N as the output_target, undo that.
-case "$output_target" in
-  ''|[0-9]*) output_target="" ;;
-esac
-[ -z "$url" ] && exit 1
-key=$(printf '%s' "$url" | tr '/:?&=' '_____' | tr -s '_')
-fixture="${APEXYARD_MOCK_CURL_DIR:-/nonexistent}/$key"
-if [ -f "$fixture" ]; then
-  status=$(head -1 "$fixture")
-  body=$(tail -n +2 "$fixture")
-  if [ "$status" -ge 400 ] && [ "$fail" = "1" ]; then
-    exit 22
-  fi
-  if [ "$output_target" = "/dev/null" ] || [ -z "$output_target" ]; then
-    printf '%s' "$body"
-  else
-    printf '%s' "$body" > "$output_target"
-  fi
-  exit 0
-fi
-# No fixture = unreachable / connection refused
-exit 7
-CURL_MOCK
-  chmod +x "$fixture_dir/curl"
-  echo "$fixture_dir"
-}
+# (make_mock_curl is defined near the top, alongside read_model_line, so the
+# earlier endpoint cases — e.g. case 4 idempotency — can use it too. #528)
 
 # ===========================================================================
 # CASE 9 — Ollama agent with reachable proxy + pulled model.

--- a/bin/run-hook-tests.sh
+++ b/bin/run-hook-tests.sh
@@ -23,12 +23,11 @@ cd "$ROOT" || exit 1
 # --- Quarantine list (path :: reason). Empty by default; populated only with
 # --- evidence (a CI failure that is environmental, not a real regression). ---
 QUARANTINE=(
-  # Remaining pre-existing failures (NOT caused by the gate) — tracked in #528.
-  # The other three originally-quarantined tests (token_efficiency_wave1,
-  # harnessability_scoring, md_to_pdf_fallback) were FIXED and un-quarantined.
-  # These two need deeper work:
-  ".claude/hooks/tests/test_handover_clone_prompt.sh :: ~8 literal-substring assertions pin the PRE-restructure /handover clone-prompt spec (clone moved to step 1.5, follow-up to step 8); needs an assertion rewrite — #528"
-  ".claude/hooks/tests/test_agent_routing_sync_and_drift.sh :: 4 cases drift (override/idempotent/drift-guard) vs committed agent-routing.yaml; may be a real config regression — needs investigation, not a test patch — #528"
+  # One remaining pre-existing failure — tracked in #528. The other four
+  # originally-quarantined tests (token_efficiency_wave1, harnessability_scoring,
+  # md_to_pdf_fallback, agent_routing_sync_and_drift) have been FIXED and
+  # un-quarantined. This last one needs a test REWRITE, not a patch:
+  ".claude/hooks/tests/test_handover_clone_prompt.sh :: spec-pins a clone-prompt design that no longer exists — the /handover SKILL was redesigned (clone-by-default at step 1.5 + follow-up offer at step 8), so the [y/n/later]-prompt assertions test a removed feature; needs a rewrite against the current spec — #528"
 )
 
 is_quarantined() {


### PR DESCRIPTION
## Summary
Fixes the 4th of 5 quarantined tests from #528 — and the root cause turned out to be a **test-isolation bug with a real side-effect**, not the config regression I'd flagged.

- **Root cause:** `apply-agent-routing.sh` resolves the ops root via `_lib-ops-root.sh`, which — inside a real Claude Code session — honours the session pin (`$APEXYARD_OPS_PIN_DIR/ops-root-$CLAUDE_CODE_SESSION_ID`) and resolves to the **real fork**, not the test's `mktemp` sandbox. So the hook rewrote the real `.claude/agents/*.md` (and dropped a stray `.framework-defaults.json`) while every sandbox assertion failed. (It also silently mutated my working copy — restored.)
- **Fix 1 — isolation:** `export APEXYARD_OPS_DISABLE_PIN=1` at the top of the test so ops-root resolves by walk-up to the sandbox. No-op in headless CI (no pin). This alone took the suite **4/14 → 13/14** and stopped the real-repo mutation.
- **Fix 2 — case 4 (idempotency):** it declared `endpoint: http://localhost:11434` but, unlike cases 9–13, never mocked `curl` — so the unreachable endpoint was *correctly* filtered by the hook and the `endpoint_count` assertion was testing the environment, not idempotency. Hoisted `make_mock_curl` above case 4 and mocked the endpoint reachable → **14/14**.
- Un-quarantined `agent_routing_sync_and_drift` in `bin/run-hook-tests.sh`.

## What remains in #528 (1 of 5)
`test_handover_clone_prompt` stays quarantined — but I've sharpened the reason: it **spec-pins a clone-prompt design that no longer exists** (a `[y / n / later]` prompt at step 8). The `/handover` SKILL was redesigned to clone-by-default at step 1.5 with a follow-up offer at step 8, so this needs a **test rewrite against the current spec**, not a string patch. Left for a focused follow-up under #528. `Refs #528`.

## Testing
1. `bash .claude/hooks/tests/test_agent_routing_sync_and_drift.sh` → **14 passed, 0 failed**.
2. Verified the real repo is no longer mutated by a test run (`git status .claude/agents/` shows only pre-existing WIP).
3. `shellcheck -S error` clean on the test and `bin/run-hook-tests.sh`.
4. `bash bin/run-hook-tests.sh` → agent_routing PASS, only handover_clone_prompt SKIP; this PR's `tests` gate on Linux is the check (expected green, now enforcing 64).

Refs #528

---

## Glossary
| Term | Definition |
|------|------------|
| Session pin | `_lib-ops-root.sh` resolving the ops root from `$APEXYARD_OPS_PIN_DIR/ops-root-$CLAUDE_CODE_SESSION_ID` inside a live session. |
| `APEXYARD_OPS_DISABLE_PIN` | Env flag that disables the pin lookup so resolution falls back to directory walk-up — the correct neutralizer for sandboxed tests. |
| Mock curl | A fake `curl` on `$PATH` that returns canned fixtures, making endpoint reachability deterministic in tests. |
| Spec-pin test | A test asserting literal substrings exist in a SKILL doc; obsolete once the documented design changes. |
