### PR TITLE
test(#528): drain quarantine — pin-escape audit + handover rewrite

### DIFF
--- a/.claude/hooks/tests/test_agent_routing_sync_and_drift.sh
+++ b/.claude/hooks/tests/test_agent_routing_sync_and_drift.sh
@@ -59,6 +59,15 @@
 
 set -u
 
+# Test isolation (#528): apply-agent-routing.sh resolves the ops root via
+# _lib-ops-root.sh, which — inside a real Claude Code session — honours the
+# session pin ($APEXYARD_OPS_PIN_DIR/ops-root-$CLAUDE_CODE_SESSION_ID) and
+# points at the REAL fork, NOT our mktemp sandbox. That made the hook rewrite
+# the real .claude/agents/*.md and write a stray snapshot there, while every
+# sandbox assertion failed. Disable the pin so ops-root resolves by walk-up to
+# the sandbox. (Hooks run headless in CI have no pin, so this is a no-op there.)
+export APEXYARD_OPS_DISABLE_PIN=1
+
 SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 SYNC_HOOK="$SRC_ROOT/.claude/hooks/apply-agent-routing.sh"
 DRIFT_HOOK="$SRC_ROOT/.claude/hooks/block-agent-routing-drift.sh"
@@ -196,6 +205,70 @@ read_model_line() {
   awk '/^---/{count++; next} count==1 && /^model:/ {sub(/^model:[[:space:]]*/, ""); print; exit}' "$1"
 }
 
+# ===========================================================================
+# Mock curl helper for the endpoint/Ollama-path cases (case 4 + cases 9-13).
+#
+# Drops a fake `curl` script onto $PATH that consults $APEXYARD_MOCK_CURL_DIR
+# for canned responses. Each fixture is named by the sanitised URL and
+# contains `<HTTP_STATUS>\n<BODY>`. Missing fixture = simulated network
+# failure (exit 7). Honours `--fail` so the hook's reachability check
+# behaves like real curl would. Defined here (near the top) so cases earlier
+# than the Ollama block (e.g. case 4 idempotency) can also use it. (#528)
+# ===========================================================================
+make_mock_curl() {
+  local sb="$1"
+  local fixture_dir="$sb/.test-curl-fixtures/bin"
+  mkdir -p "$fixture_dir"
+  cat > "$fixture_dir/curl" <<'CURL_MOCK'
+#!/bin/bash
+# Mock curl — for hook tests only.
+url=""
+fail=0
+output_target=""
+expect_output_target=0
+for arg in "$@"; do
+  if [ "$expect_output_target" = "1" ]; then
+    output_target="$arg"
+    expect_output_target=0
+    continue
+  fi
+  case "$arg" in
+    -s|--silent) ;;
+    -f|--fail)   fail=1 ;;
+    -o)          expect_output_target=1 ;;
+    --max-time)  expect_output_target=1 ;;
+    --max-time=*) ;;
+    http*) url="$arg" ;;
+    *) ;;
+  esac
+done
+# If `--max-time <N>` consumed N as the output_target, undo that.
+case "$output_target" in
+  ''|[0-9]*) output_target="" ;;
+esac
+[ -z "$url" ] && exit 1
+key=$(printf '%s' "$url" | tr '/:?&=' '_____' | tr -s '_')
+fixture="${APEXYARD_MOCK_CURL_DIR:-/nonexistent}/$key"
+if [ -f "$fixture" ]; then
+  status=$(head -1 "$fixture")
+  body=$(tail -n +2 "$fixture")
+  if [ "$status" -ge 400 ] && [ "$fail" = "1" ]; then
+    exit 22
+  fi
+  if [ "$output_target" = "/dev/null" ] || [ -z "$output_target" ]; then
+    printf '%s' "$body"
+  else
+    printf '%s' "$body" > "$output_target"
+  fi
+  exit 0
+fi
+# No fixture = unreachable / connection refused
+exit 7
+CURL_MOCK
+  chmod +x "$fixture_dir/curl"
+  echo "$fixture_dir"
+}
+
 # emit the JSON envelope a PreToolUse hook expects on stdin.
 hook_stdin() {
   local cmd="$1"
@@ -297,6 +370,14 @@ rm -rf "$SB"
 # same end state, no compounded writes.
 # ===========================================================================
 SB=$(make_fork)
+# Mock the endpoint as reachable so the ANTHROPIC_BASE_URL row is written
+# deterministically (without a real listener on :11434 the hook correctly
+# filters the unreachable endpoint, and the endpoint_count assertion below
+# would be testing the environment, not idempotency). #528
+MOCK_BIN=$(make_mock_curl "$SB")
+APEXYARD_MOCK_CURL_DIR=$(mktemp -d)
+export APEXYARD_MOCK_CURL_DIR
+printf '200\n[]\n' > "$APEXYARD_MOCK_CURL_DIR/http_localhost_11434_v1_models"
 cat > "$SB/agent-routing.yaml" <<'YAML'
 version: 1
 agents:
@@ -307,7 +388,7 @@ agents:
       MY_VAR: hello
 YAML
 
-(cd "$SB" && bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true) >/dev/null
+(cd "$SB" && ANTHROPIC_BASE_URL=http://localhost:11434 PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true) >/dev/null
 
 # Capture state after first run.
 first_qa=$(read_model_line "$SB/.claude/agents/qa-engineer.md")
@@ -315,7 +396,7 @@ first_env=""
 [ -f "$SB/.claude/session/agent-env/qa-engineer.env" ] && first_env=$(cat "$SB/.claude/session/agent-env/qa-engineer.env")
 
 # Run again.
-(cd "$SB" && bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true) >/dev/null
+(cd "$SB" && ANTHROPIC_BASE_URL=http://localhost:11434 PATH="$MOCK_BIN:$PATH" bash .claude/hooks/apply-agent-routing.sh 2>&1 < /dev/null || true) >/dev/null
 
 second_qa=$(read_model_line "$SB/.claude/agents/qa-engineer.md")
 second_env=""
@@ -455,68 +536,8 @@ else
 fi
 rm -rf "$SB"
 
-# ===========================================================================
-# Mock curl helper for the Ollama-path cases (cases 9-13).
-#
-# Drops a fake `curl` script onto $PATH that consults $APEXYARD_MOCK_CURL_DIR
-# for canned responses. Each fixture is named by the sanitised URL and
-# contains `<HTTP_STATUS>\n<BODY>`. Missing fixture = simulated network
-# failure (exit 7). Honours `--fail` so the hook's reachability check
-# behaves like real curl would.
-# ===========================================================================
-make_mock_curl() {
-  local sb="$1"
-  local fixture_dir="$sb/.test-curl-fixtures/bin"
-  mkdir -p "$fixture_dir"
-  cat > "$fixture_dir/curl" <<'CURL_MOCK'
-#!/bin/bash
-# Mock curl — for hook tests only.
-url=""
-fail=0
-output_target=""
-expect_output_target=0
-for arg in "$@"; do
-  if [ "$expect_output_target" = "1" ]; then
-    output_target="$arg"
-    expect_output_target=0
-    continue
-  fi
-  case "$arg" in
-    -s|--silent) ;;
-    -f|--fail)   fail=1 ;;
-    -o)          expect_output_target=1 ;;
-    --max-time)  expect_output_target=1 ;;
-    --max-time=*) ;;
-    http*) url="$arg" ;;
-    *) ;;
-  esac
-done
-# If `--max-time <N>` consumed N as the output_target, undo that.
-case "$output_target" in
-  ''|[0-9]*) output_target="" ;;
-esac
-[ -z "$url" ] && exit 1
-key=$(printf '%s' "$url" | tr '/:?&=' '_____' | tr -s '_')
-fixture="${APEXYARD_MOCK_CURL_DIR:-/nonexistent}/$key"
-if [ -f "$fixture" ]; then
-  status=$(head -1 "$fixture")
-  body=$(tail -n +2 "$fixture")
-  if [ "$status" -ge 400 ] && [ "$fail" = "1" ]; then
-    exit 22
-  fi
-  if [ "$output_target" = "/dev/null" ] || [ -z "$output_target" ]; then
-    printf '%s' "$body"
-  else
-    printf '%s' "$body" > "$output_target"
-  fi
-  exit 0
-fi
-# No fixture = unreachable / connection refused
-exit 7
-CURL_MOCK
-  chmod +x "$fixture_dir/curl"
-  echo "$fixture_dir"
-}
+# (make_mock_curl is defined near the top, alongside read_model_line, so the
+# earlier endpoint cases — e.g. case 4 idempotency — can use it too. #528)
 
 # ===========================================================================
 # CASE 9 — Ollama agent with reachable proxy + pulled model.

--- a/.claude/hooks/tests/test_handover_clone_prompt.sh
+++ b/.claude/hooks/tests/test_handover_clone_prompt.sh
@@ -1,24 +1,25 @@
 #!/bin/bash
-# Smoke tests for /handover's clone-first deep-dive prompt
-# (me2resh/apexyard#188 — LSP spike Option 3).
+# Smoke tests for /handover's clone behaviour.
 #
-# /handover is a markdown skill spec the model executes; this test
-# exercises two things:
+# History: the original design (me2resh/apexyard#188) offered a clone-first
+# deep-dive prompt at step 8 with a `[y / n / later]` choice. That was
+# REDESIGNED — the repo is now cloned by DEFAULT at step 1.5-clone (no prompt;
+# `--no-clone` opts out), and step 8 became a follow-up-skills offer against the
+# already-cloned repo. This test was rewritten (#528) to pin the current spec
+# instead of the removed prompt.
 #
-#   1. SPEC SHAPE — the SKILL.md file contains the prompt text at the
-#      right location (after step 7 "Append to the portfolio registry",
-#      before what becomes the final summary), and surfaces the five
-#      cost-transparency facts the ticket's AC requires.
+# /handover is a markdown skill spec the model executes; this test exercises:
 #
-#   2. RUNTIME SHAPE — a small bash simulator that mirrors the clone
-#      branch the spec documents, exercised against an isolated sandbox
-#      with a mocked `git` binary so no network call ever fires. Verifies:
+#   1. SPEC SHAPE — SKILL.md documents clone-by-default at step 1.5-clone
+#      (skip-if-`.git`-exists, `--no-clone` to decline), the step-8 follow-up
+#      offer, the LSP cost-transparency facts, and the surrounding step order.
 #
-#        - operator response `n`     → no `git clone` invocation, exit clean
-#        - operator response `later` → no `git clone` invocation, exit clean
-#        - operator response `y`     → exactly one `git clone <url> workspace/<name>`
-#                                       invocation with the documented argument shape
-#        - workspace already exists  → no `git clone` invocation (skip-if-exists)
+#   2. RUNTIME SHAPE — a small bash simulator mirroring the spec's clone branch,
+#      run against an isolated sandbox with a mocked `git` (no network). Verifies:
+#        - default (no --no-clone), workspace absent → exactly one
+#          `git clone <url> <workspace>/<name>`
+#        - `--no-clone`                              → no git clone (declined)
+#        - workspace/<name>/.git already exists      → no git clone (skip)
 #
 # Exit 0 if all cases pass; 1 on first failure.
 
@@ -37,7 +38,7 @@ FAIL=0
 FAILED_CASES=""
 
 # ---------------------------------------------------------------------------
-# spec_assert <label> <expected literal substring> [grep-extended-regex flag]
+# spec_assert <label> <expected literal substring>
 # ---------------------------------------------------------------------------
 spec_assert() {
   local label="$1" needle="$2"
@@ -51,177 +52,126 @@ spec_assert() {
 }
 
 # ---------------------------------------------------------------------------
-# Spec-shape tests — verify the SKILL.md contains the documented prompt
-# at the documented location.
+# Spec-shape tests — the current clone-by-default design.
 # ---------------------------------------------------------------------------
 
-# 1. The new step exists, with a heading that names the clone-first option.
-spec_assert "spec-step-heading" \
-  "### 8. Offer the clone-first deep-dive option (recommended)"
+# 1. Clone happens at step 1.5-clone, by default, on the URL path.
+spec_assert "spec-step-1.5-clone-heading" \
+  "### 1.5-clone. Clone the repo (URL path only — default yes)"
+spec_assert "spec-clone-default-yes" \
+  'Default is **yes** — no confirmation needed unless the operator explicitly passes `--no-clone`'
 
-# 2. Insertion point — step 7 (registry append) still precedes step 8, and
-#    step 9 (validation) follows step 8. Catches accidental reordering.
-spec_assert "spec-step-7-still-registry"  \
-  "### 7. Append to the portfolio registry"
-spec_assert "spec-step-9-still-validation" \
-  "### 9. Offer validation (conditional, default-no)"
-spec_assert "spec-step-10-summary" \
-  "### 10. Return a summary"
+# 2. Clone mechanics: workspace resolved via the portfolio helper, skip when a
+#    .git already exists, otherwise clone.
+spec_assert "spec-workspace-dir-helper" "WORKSPACE_DIR=\$(portfolio_workspace_dir)"
+spec_assert "spec-skip-if-git-exists"   'if [ -d "$WORKSPACE_DIR/<name>/.git" ]; then'
+spec_assert "spec-clone-command"        'git clone <repo-url> "$WORKSPACE_DIR/<name>"'
 
-# 3. Five cost-transparency facts (AC #3 of the ticket).
-spec_assert "spec-cost-1-enable-lsp-tool"   "ENABLE_LSP_TOOL=1"
-spec_assert "spec-cost-2-plugin-install"    "plugin install is your problem"
-spec_assert "spec-cost-3-disk-and-gitignore" "gitignored"
-spec_assert "spec-cost-4-cross-project-grep" "Cross-project semantic queries still need grep"
-spec_assert "spec-cost-5-cold-start"         "Cold-start on large monorepos can be 30+ seconds"
+# 3. Clone-status marker drives the downstream read path.
+spec_assert "spec-clone-status-marker"  'CLONE_STATUS="cloned"'
+spec_assert "spec-no-clone-declined"    '$CLONE_STATUS="declined"'
 
-# 4. Three-option prompt response shape.
-spec_assert "spec-prompt-response-options" "[y / n / later]"
+# 4. Step 8 is now a follow-up-skills offer against the already-cloned repo.
+spec_assert "spec-step-8-heading" \
+  "### 8. Offer follow-up deep-dive skills (against the already-cloned repo)"
+spec_assert "spec-step-8-threat-model"   "1. /threat-model"
+spec_assert "spec-step-8-options"        "[1/2/3/all/none — default none]"
 
-# 5. Follow-up skill suggestion on success (AC #4 of the ticket).
-spec_assert "spec-followup-threat-model" \
-  "Want to run /threat-model against the new clone now?"
+# 5. Cost-transparency facts the step-8 offer still surfaces.
+spec_assert "spec-cost-enable-lsp-tool"  "ENABLE_LSP_TOOL=1"
+spec_assert "spec-cost-cold-start"       "Cold-start on large monorepos can be 30+ seconds"
 
-# 6. Skip-if-exists branch is documented. After framework #242 the skill
-# resolves the workspace dir via portfolio_workspace_dir (split-portfolio
-# v2 may point it at a sibling private repo), so the literal becomes
-# `$WORKSPACE_DIR/<name>` rather than `workspace/<name>`. The shape of
-# the skip branch (an `if [ -d ... ]; then` guard around `git clone`)
-# is what the spec test pins.
-spec_assert "spec-skip-if-exists" \
-  'if [ -d "$WORKSPACE_DIR/<name>" ]; then'
-
-# 7. Decline path documented as silent (no side effects).
-spec_assert "spec-decline-silent" \
-  "Skip silently — no side effects"
+# 6. Surrounding step order (catches accidental reordering).
+spec_assert "spec-step-7-registry"    "### 7. Append to the portfolio registry"
+spec_assert "spec-step-9-validation"  "### 9. Offer validation (conditional, default-no)"
+spec_assert "spec-step-10-summary"    "### 10. Return a summary"
 
 # ---------------------------------------------------------------------------
-# Runtime-shape simulator. Mirrors the bash logic the spec documents in
-# the "On `y`" branch. The simulator never touches the real `git`; we
-# point PATH at a mock that records its argv and exits 0.
+# Runtime-shape simulator. Mirrors the clone branch the spec documents in
+# step 1.5-clone. Never touches the real `git`; PATH points at a mock that
+# records its argv and exits 0.
 #
-# simulate <answer> <workspace-pre-exists?> <name> <repo-url>
+# simulate <no_clone_flag> <workspace-git-pre-exists?> <name> <repo-url>
 #   → echoes the recorded `git clone` argv to stdout (empty if no call)
-#   → returns simulator exit code
 # ---------------------------------------------------------------------------
 simulate() {
-  local answer="$1" pre_exists="$2" name="$3" repo_url="$4"
+  local no_clone="$1" pre_exists="$2" name="$3" repo_url="$4"
   local sb log
   sb=$(mktemp -d)
   sb=$(cd "$sb" && pwd -P)
   log="$sb/.git-clone-calls.log"
   : > "$log"
 
-  # Mock `git` — only handles `git clone <url> <dest>`; for anything else,
-  # the simulator never calls it, so we just record + exit 0.
   cat > "$sb/git" <<MOCK
 #!/usr/bin/env bash
 if [ "\$1" = "clone" ]; then
   printf '%s\n' "\$*" >> "$log"
-  # Pretend the clone succeeded — make the destination dir so any
-  # subsequent skip-if-exists logic in a re-run sees a real workspace.
-  if [ -n "\$3" ]; then
-    mkdir -p "\$3"
-  fi
+  [ -n "\$3" ] && mkdir -p "\$3"
   exit 0
 fi
 exit 0
 MOCK
   chmod +x "$sb/git"
 
-  # Optionally pre-create workspace/<name>/ to exercise the skip branch.
+  # WORKSPACE_DIR resolves to workspace/ in single-fork mode (what the sandbox
+  # models). Optionally pre-create workspace/<name>/.git to exercise the skip.
   if [ "$pre_exists" = "1" ]; then
-    mkdir -p "$sb/workspace/$name"
+    mkdir -p "$sb/workspace/$name/.git"
   fi
 
-  # The simulator: a faithful translation of the spec's "On y" + skip
-  # branches. Lives inside this test on purpose — the spec is the source
-  # of truth, and any divergence between this and the spec is a test
-  # failure to triage. All status output goes to stderr; only the
-  # captured git-clone argv from $log lands on stdout.
+  # Faithful translation of the spec's step-1.5-clone branch. Status → stderr;
+  # only the captured git-clone argv lands on stdout.
   (
     cd "$sb" || exit 1
     PATH="$sb:$PATH"
-    case "$answer" in
-      y|Y|yes)
-        if [ -d "workspace/$name" ]; then
-          echo "skip-existing" >&2
-        else
-          git clone "$repo_url" "workspace/$name" >/dev/null 2>&1
-          echo "cloned" >&2
-        fi
-        ;;
-      n|N|no|later|"")
-        echo "skipped" >&2
-        ;;
-      *)
-        # Unknown input → treat as `n` per the spec.
-        echo "skipped" >&2
-        ;;
-    esac
+    WORKSPACE_DIR="workspace"
+    if [ "$no_clone" = "1" ]; then
+      echo "declined (--no-clone)" >&2
+    elif [ -d "$WORKSPACE_DIR/$name/.git" ]; then
+      echo "preserved (already exists)" >&2
+    else
+      git clone "$repo_url" "$WORKSPACE_DIR/$name" >/dev/null 2>&1
+      echo "cloned" >&2
+    fi
   )
-  local rc=$?
 
-  # Echo whatever git invocations were captured.
-  if [ -s "$log" ]; then
-    cat "$log"
-  fi
-
+  [ -s "$log" ] && cat "$log"
   rm -rf "$sb"
-  return $rc
 }
 
-# Case A: answer `n` → no clone, exit 0
-out=$(simulate "n" 0 "example-app" "https://github.com/example/example-app.git" 2>/dev/null)
-if [ -z "$out" ]; then
-  echo "PASS [runtime-decline-no]"
-  PASS=$((PASS+1))
-else
-  echo "FAIL [runtime-decline-no]: expected no git invocation, got: $out" >&2
-  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}runtime-decline-no "
-fi
+URL="https://github.com/example/example-app.git"
 
-# Case B: answer `later` → no clone, exit 0
-out=$(simulate "later" 0 "example-app" "https://github.com/example/example-app.git" 2>/dev/null)
-if [ -z "$out" ]; then
-  echo "PASS [runtime-decline-later]"
-  PASS=$((PASS+1))
-else
-  echo "FAIL [runtime-decline-later]: expected no git invocation, got: $out" >&2
-  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}runtime-decline-later "
-fi
-
-# Case C: answer `y` → exactly one `git clone <url> workspace/<name>`
-out=$(simulate "y" 0 "example-app" "https://github.com/example/example-app.git" 2>/dev/null)
-expected="clone https://github.com/example/example-app.git workspace/example-app"
+# Case A: default (no --no-clone), workspace absent → exactly one clone.
+out=$(simulate "0" 0 "example-app" "$URL" 2>/dev/null)
+expected="clone $URL workspace/example-app"
 if [ "$out" = "$expected" ]; then
-  echo "PASS [runtime-accept-y]"
+  echo "PASS [runtime-default-clones]"
   PASS=$((PASS+1))
 else
-  echo "FAIL [runtime-accept-y]: argv mismatch" >&2
+  echo "FAIL [runtime-default-clones]: argv mismatch" >&2
   echo "    expected: $expected" >&2
   echo "    got:      $out" >&2
-  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}runtime-accept-y "
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}runtime-default-clones "
 fi
 
-# Case D: workspace pre-exists → answer `y` skips the clone
-out=$(simulate "y" 1 "example-app" "https://github.com/example/example-app.git" 2>/dev/null)
+# Case B: --no-clone → no git clone.
+out=$(simulate "1" 0 "example-app" "$URL" 2>/dev/null)
+if [ -z "$out" ]; then
+  echo "PASS [runtime-no-clone-declines]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [runtime-no-clone-declines]: expected no git invocation, got: $out" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}runtime-no-clone-declines "
+fi
+
+# Case C: workspace/<name>/.git pre-exists → skip the clone.
+out=$(simulate "0" 1 "example-app" "$URL" 2>/dev/null)
 if [ -z "$out" ]; then
   echo "PASS [runtime-skip-if-exists]"
   PASS=$((PASS+1))
 else
-  echo "FAIL [runtime-skip-if-exists]: expected no git invocation when workspace exists, got: $out" >&2
+  echo "FAIL [runtime-skip-if-exists]: expected no git invocation when clone exists, got: $out" >&2
   FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}runtime-skip-if-exists "
-fi
-
-# Case E: unknown input → treated as `n` (no clone)
-out=$(simulate "maybe" 0 "example-app" "https://github.com/example/example-app.git" 2>/dev/null)
-if [ -z "$out" ]; then
-  echo "PASS [runtime-unknown-input-no-clone]"
-  PASS=$((PASS+1))
-else
-  echo "FAIL [runtime-unknown-input-no-clone]: expected no git invocation, got: $out" >&2
-  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}runtime-unknown-input-no-clone "
 fi
 
 # ---------------------------------------------------------------------------

--- a/.claude/hooks/tests/test_link_custom_skills.sh
+++ b/.claude/hooks/tests/test_link_custom_skills.sh
@@ -18,6 +18,13 @@
 
 set -u
 
+# Test isolation (#528): link-custom-skills.sh resolves the ops-root via
+# _lib-ops-root.sh and WRITES symlinks into <ops-root>/.claude/skills/. Inside a
+# live Claude Code session the session pin would resolve to the REAL fork, so a
+# sandbox run would symlink into the real .claude/skills/. Disable the pin so
+# resolution walks up to the sandbox. No-op in headless CI (no pin).
+export APEXYARD_OPS_DISABLE_PIN=1
+
 HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/link-custom-skills.sh"
 LIB_PORTFOLIO_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-portfolio-paths.sh"
 LIB_CONFIG_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-read-config.sh"

--- a/bin/run-hook-tests.sh
+++ b/bin/run-hook-tests.sh
@@ -17,17 +17,28 @@
 
 set -uo pipefail
 
+# Test isolation (#528): many hooks resolve their ops-root via _lib-ops-root.sh,
+# which inside a live Claude Code session honours the session pin
+# ($APEXYARD_OPS_PIN_DIR/ops-root-$CLAUDE_CODE_SESSION_ID) and points at the REAL
+# fork — so a sandbox-based test would escape onto the real repo (wrong results,
+# and for writing hooks like apply-agent-routing / link-custom-skills, real-file
+# mutation). Disable the pin for the whole suite so every test resolves by
+# walk-up to its own sandbox. No-op in headless CI (no pin). Tests that
+# specifically exercise the pin (test_resolve_ops_root_pin.sh) set/unset this
+# per-case, so the suite-level default doesn't interfere.
+export APEXYARD_OPS_DISABLE_PIN=1
+
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$ROOT" || exit 1
 
 # --- Quarantine list (path :: reason). Empty by default; populated only with
 # --- evidence (a CI failure that is environmental, not a real regression). ---
 QUARANTINE=(
-  # One remaining pre-existing failure — tracked in #528. The other four
-  # originally-quarantined tests (token_efficiency_wave1, harnessability_scoring,
-  # md_to_pdf_fallback, agent_routing_sync_and_drift) have been FIXED and
-  # un-quarantined. This last one needs a test REWRITE, not a patch:
-  ".claude/hooks/tests/test_handover_clone_prompt.sh :: spec-pins a clone-prompt design that no longer exists — the /handover SKILL was redesigned (clone-by-default at step 1.5 + follow-up offer at step 8), so the [y/n/later]-prompt assertions test a removed feature; needs a rewrite against the current spec — #528"
+  # Empty — all five originally-quarantined tests (token_efficiency_wave1,
+  # harnessability_scoring, md_to_pdf_fallback, agent_routing_sync_and_drift,
+  # handover_clone_prompt) have been fixed and un-quarantined (#528). The gate
+  # now enforces the entire suite. Add an entry ONLY with evidence (a genuinely
+  # headless-incompatible test), citing why.
 )
 
 is_quarantined() {

--- a/bin/run-hook-tests.sh
+++ b/bin/run-hook-tests.sh
@@ -23,12 +23,11 @@ cd "$ROOT" || exit 1
 # --- Quarantine list (path :: reason). Empty by default; populated only with
 # --- evidence (a CI failure that is environmental, not a real regression). ---
 QUARANTINE=(
-  # Remaining pre-existing failures (NOT caused by the gate) — tracked in #528.
-  # The other three originally-quarantined tests (token_efficiency_wave1,
-  # harnessability_scoring, md_to_pdf_fallback) were FIXED and un-quarantined.
-  # These two need deeper work:
-  ".claude/hooks/tests/test_handover_clone_prompt.sh :: ~8 literal-substring assertions pin the PRE-restructure /handover clone-prompt spec (clone moved to step 1.5, follow-up to step 8); needs an assertion rewrite — #528"
-  ".claude/hooks/tests/test_agent_routing_sync_and_drift.sh :: 4 cases drift (override/idempotent/drift-guard) vs committed agent-routing.yaml; may be a real config regression — needs investigation, not a test patch — #528"
+  # One remaining pre-existing failure — tracked in #528. The other four
+  # originally-quarantined tests (token_efficiency_wave1, harnessability_scoring,
+  # md_to_pdf_fallback, agent_routing_sync_and_drift) have been FIXED and
+  # un-quarantined. This last one needs a test REWRITE, not a patch:
+  ".claude/hooks/tests/test_handover_clone_prompt.sh :: spec-pins a clone-prompt design that no longer exists — the /handover SKILL was redesigned (clone-by-default at step 1.5 + follow-up offer at step 8), so the [y/n/later]-prompt assertions test a removed feature; needs a rewrite against the current spec — #528"
 )
 
 is_quarantined() {


### PR DESCRIPTION
## Summary
Completes #528 — drains the test-runner quarantine to **empty**. (Originally PR #531, which GitHub auto-closed when #530's branch was deleted on merge; re-opened here against `dev` with the same already-Rex-reviewed HEAD `5d2f3b7`.)

**(a) Pin-escape audit + fix.** Many hooks resolve ops-root via `_lib-ops-root.sh`, which inside a live Claude Code session honours the session pin → sandbox tests escape onto the **real fork** (wrong results; real-file mutation for writing hooks). 21 hooks use the pin; only 4 tests guarded.
- **Systemic:** `bin/run-hook-tests.sh` now `export APEXYARD_OPS_DISABLE_PIN=1` — the whole suite resolves by walk-up to its sandbox (no-op in headless CI; `test_resolve_ops_root_pin` sets the var per-case, unaffected). Turned the local run from 7 spurious failures → green.
- **Belt-and-suspenders:** `test_link_custom_skills` (symlinks into `.claude/skills/`) gets its own guard.

**(b) Rewrote `test_handover_clone_prompt`.** Old assertions pinned a removed `[y/n/later]` clone prompt; the SKILL now clones-by-default at step 1.5-clone (skip-if-`.git`, `--no-clone`) + a step-8 follow-up offer. New spec-asserts + a clone-by-default runtime simulator → 18/18.

**Result:** `QUARANTINE` is **empty** — the gate enforces all **65** tests. `Closes #528`.

## Testing
1. `bash bin/run-hook-tests.sh` → **PASS=65, FAIL=0, SKIP=0** (was 7 failing before the pin guard).
2. `bash .claude/hooks/tests/test_handover_clone_prompt.sh` → 18/18.
3. `test_resolve_ops_root_pin` + `test_link_custom_skills` pass under the suite default; no real-repo mutation after runs.
4. `shellcheck -S error` clean on all three changed files.
5. Linux `tests` gate is green enforcing 65.

Closes #528

---

## Glossary
| Term | Definition |
|------|------------|
| Session pin | `_lib-ops-root.sh` resolving the ops root from `$APEXYARD_OPS_PIN_DIR/ops-root-$CLAUDE_CODE_SESSION_ID` inside a live session. |
| `APEXYARD_OPS_DISABLE_PIN` | Env flag that disables the pin so resolution walks up to the sandbox — the correct neutralizer for hermetic tests. |
| Quarantine | The runner's documented skip-list; now empty — every discovered test is enforced. |
| Spec-pin test | A test asserting literal substrings in a SKILL doc; rewritten here to the current clone-by-default design. |
