### PR TITLE
ci(#545): exempt sync/ branches from the PR-create ticket-ID rule

### DIFF
--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -476,9 +476,13 @@ CURRENT_BRANCH="${HEAD_FLAG:-$(git branch --show-current 2>/dev/null)}"
 if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "main" ] && [ "$CURRENT_BRANCH" != "master" ]; then
   # Release-cut branches are exempt — same recognition `validate-branch-name.sh`
   # added in me2resh/apexyard#168 / #169. Release branches don't carry a
-  # ticket-id because the release itself is the ticket.
-  if echo "$CURRENT_BRANCH" | grep -qE '^release/v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$'; then
-    :  # release branch, exempt — fall through to the rest of the validator
+  # ticket-id because the release itself is the ticket. The /release-sync
+  # branch `sync/main-to-dev-after-vN.N.N` is exempt for the same reason
+  # (the release being synced is the ticket) — see apexyard#458 and the
+  # /release-sync skill. The PR title still references a live ticket via
+  # `sync(#N):`, which the title check above validates.
+  if echo "$CURRENT_BRANCH" | grep -qE '^release/v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$|^sync/main-to-dev-after-v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    :  # release-cut or release-sync branch, exempt — fall through to the rest of the validator
   elif ! echo "$CURRENT_BRANCH" | grep -qE '[A-Z]{2,10}-[0-9]+|GH-[0-9]+|#[0-9]+'; then
     ERRORS="${ERRORS}Branch '$CURRENT_BRANCH' missing ticket ID.\n"
   fi


### PR DESCRIPTION
## Summary

- **Exempts `sync/main-to-dev-after-vN.N.N` branches from the branch-ticket-ID rule in `validate-pr-create.sh`** — these `/release-sync` branches carry no ticket ID by design (the release being synced *is* the ticket), exactly like the `release/vN.N.N` branches the hook already exempts. Without this, every post-release sync PR is blocked with `missing ticket ID`.
- **One-line change to the existing exemption alternation** — adds `|^sync/main-to-dev-after-v[0-9]+\.[0-9]+\.[0-9]+$` alongside the release-cut pattern, plus a clarifying comment citing apexyard#458. The PR-title path already accepts the `sync(#N):` shape; only the branch path was wrong.
- **Closes the gap between the hook and its documented behaviour** — `validate-branch-name.sh` whitelists the `sync` type (#458) and the `/release-sync` skill states sync branches are exempt, but this hook never implemented it. Surfaced live while cutting v3.0.0 (the sync PR had to be unblocked with a local edit, which this PR lands properly).

## Testing

1. `bash bin/run-hook-tests.sh` → green (no regression in the hook suite).
2. Manual: a branch named `sync/main-to-dev-after-v3.0.0` now passes the branch-ticket-ID check; `release/v3.0.0` still passes; a genuinely malformed branch (e.g. `foo-bar`) is still rejected.
3. `shellcheck --severity=warning .claude/hooks/validate-pr-create.sh` → clean.

Closes #545

---

## Glossary

| Term | Definition |
|------|------------|
| release-sync | The mandatory main→dev sync PR after each squash-release; its branch is `sync/main-to-dev-after-vN.N.N`. |
| Ticket-ID exemption | Branches whose name encodes no tracker ID because the work *is* the ticket (release-cut, release-sync) skip the branch-ticket-ID validator rule. |
| Exemption alternation | The `grep -E` pattern in the hook that lists branch shapes allowed to skip the ticket-ID requirement. |
