### PR TITLE
docs(#560): re-fork & data-preservation guide in upgrading.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ The hooks fire on every `git` / `gh` command, the portfolio skills aggregate acr
 
 Full setup guide with directory layout, daily workflow, and FAQ: [`docs/multi-project.md`](docs/multi-project.md).
 
+Keeping a fork current — upgrade in place, when to re-fork instead, and how to preserve your portfolio data either way: [`docs/upgrading.md`](docs/upgrading.md).
+
 ## Why ApexYard?
 
 **The problem**: Claude Code is powerful, but without structure it produces inconsistent results. Every team reinvents the same processes -- role definitions, review checklists, document templates, workflow gates.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -8,7 +8,7 @@ This doc covers:
 - The version anchor file (`.claude/framework-version`)
 - What each migration does (table)
 - Common scenarios (multi-hop, missing anchor, skip-migrations, dry-run)
-- **When upgrading isn't enough — re-forking and keeping your data**
+- **When `/update` isn't enough — re-forking and keeping your data**
 - Authoring a new migration (framework maintainers only)
 
 For the daily-sync UX, see `.claude/skills/update/SKILL.md`. For the design rationale, see [`docs/agdr/AgDR-0032-update-chain-migrations.md`](agdr/AgDR-0032-update-chain-migrations.md).
@@ -149,87 +149,52 @@ When you use `--from-dev` to pull from `upstream/dev`, the migration chain is au
 
 ---
 
-## When upgrading isn't enough — re-fork & keep your data
+## When `/update` isn't enough — re-forking & keeping your data
 
-`/update` handles the common case. Two situations need more than a sync — and
-both hinge on one mental model.
+Most of the time `/update` is all you need. The exception is when your fork has
+drifted so far that upgrading is a wall of conflicts — then you re-fork. Either
+way, the only thing you have to protect is **your own work**.
 
-### Your data vs. the framework
+One idea makes this easy: everything in your fork is either **the framework** or
+**your data**.
 
-Everything in a fork falls into one of two buckets:
+- **The framework** — `.claude/`, `workflows/`, `templates/`, `docs/`. Upstream
+  owns it; upgrades overwrite it. Let them.
+- **Your data** — your registry (`apexyard.projects.yaml`), `onboarding.yaml`,
+  `projects/`, `workspace/`, `handbooks/`, and any custom skills. This is what
+  must survive.
 
-| Bucket | Examples | Lifecycle |
-|--------|----------|-----------|
-| **The framework** | `.claude/hooks/`, `.claude/skills/`, `.claude/agents/`, `.claude/rules/`, `workflows/`, `templates/`, `docs/` | Owned by upstream — replaced on every upgrade |
-| **Your portfolio data** | `apexyard.projects.yaml` (registry), `onboarding.yaml`, `projects/<name>/`, `workspace/<name>/`, `handbooks/`, custom skills | Owned by you — must survive every upgrade |
+### Upgrade or re-fork?
 
-Upgrades replace the **framework** bucket. The whole game is keeping your **data**
-bucket out of the line of fire. Split-portfolio mode does that structurally; the
-manual approach does it by copy-out / copy-back.
+Run `/update --dry-run`. A clean or small merge → just `/update`. Conflicts
+across most of `.claude/` — or a PR from your fork to upstream that touches the
+*whole* framework tree → your base has drifted too far; re-fork.
 
-### Re-fork (when the fork has drifted too far)
+### Re-forking without losing anything
 
-Sometimes a fork has been edited so heavily — or branched from such an old base —
-that merging upstream is more painful than starting fresh. Symptoms:
-
-- `/update` (or `/update --dry-run`) reports conflicts across most of `.claude/`.
-- A PR opened from your fork against upstream shows a diff touching the *entire*
-  framework tree.
-
-Upgrade vs. re-fork — quick decision:
-
-| Situation | Do this |
-|-----------|---------|
-| `/update --dry-run` shows a clean or small merge | **Upgrade** (`/update`) |
-| A few conflicts in files you knowingly customised | **Upgrade**, resolve conflicts |
-| Conflicts across most of `.claude/` | **Re-fork** |
-| You don't know what diverged | **Re-fork** (cleanest reset) |
-
-To re-fork safely:
-
-1. **Get your data out of the line of fire first** (see below).
-2. Re-fork `me2resh/apexyard` (a fresh fork, or a fresh clone you re-point
-   `origin` at).
-3. Re-attach your data (split-portfolio: nothing to do — it lives elsewhere;
-   manual: copy your data bucket back in).
-4. Re-add the `upstream` remote so future `/update`s work:
-
-   ```bash
-   git remote add upstream https://github.com/me2resh/apexyard.git
-   ```
-
-### Preserving your data
-
-**Best — split-portfolio mode (makes the fork disposable).** Your portfolio data
-lives in a **separate private repo**; the framework fork only holds framework code
-plus a `.claude/project-config.json` pointing at the sibling. Once split,
-upgrading or re-forking the framework **never touches your data**.
+Keep your data somewhere a re-fork can't reach. **Split-portfolio mode does
+exactly that** — `/split-portfolio` moves your data into a separate private repo,
+so the framework fork becomes throwaway: re-fork or upgrade it anytime and your
+data never moves.
 
 ```bash
-/split-portfolio            # gated, destructive migration — every step confirms
-/split-portfolio --dry-run  # walk the steps without executing
-/split-portfolio --verify   # read-only state report
+/split-portfolio            # one-time migration — every step asks first
+/split-portfolio --dry-run  # preview the steps without running them
 ```
 
-**Fallback — manual copy-out / copy-back** around a re-fork:
+Not split yet? Do it by hand — copy your data out, re-fork `me2resh/apexyard`,
+copy it back, then re-add the upstream remote:
 
-1. Copy your **data bucket** out of the old fork: `apexyard.projects.yaml`,
-   `onboarding.yaml`, `projects/`, `workspace/` (if used), `handbooks/`, custom
-   skills.
-2. Re-fork `me2resh/apexyard`.
-3. Copy the data bucket back into the fresh fork.
-4. Re-add the `upstream` remote (above).
+```bash
+git remote add upstream https://github.com/me2resh/apexyard.git
+```
 
-This works but repeats on every re-fork. Split-portfolio is the one-time
-investment that removes the chore.
+### Seeing your project's tickets show up here?
 
-### A common trap: project tickets filed against the framework repo
-
-On older forks (before per-project tracker routing landed), `/feature`, `/bug`,
-and `/task` could file tickets against the **framework** repo instead of your
-own project's repo. If your project's tickets/PRs show up on `me2resh/apexyard`,
-your fork is out of date — **upgrade (`/update`)**, which fixes the routing and
-enables leak-protection so private project names don't leak into public trackers.
+If `/feature`, `/bug`, or `/task` file tickets against `me2resh/apexyard` instead
+of your own repo, your fork predates per-project tracker routing. Run `/update` —
+it fixes the routing and turns on leak-protection so private names stay out of
+public trackers.
 
 ---
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -8,6 +8,7 @@ This doc covers:
 - The version anchor file (`.claude/framework-version`)
 - What each migration does (table)
 - Common scenarios (multi-hop, missing anchor, skip-migrations, dry-run)
+- **When upgrading isn't enough — re-forking and keeping your data**
 - Authoring a new migration (framework maintainers only)
 
 For the daily-sync UX, see `.claude/skills/update/SKILL.md`. For the design rationale, see [`docs/agdr/AgDR-0032-update-chain-migrations.md`](agdr/AgDR-0032-update-chain-migrations.md).
@@ -145,6 +146,90 @@ If a migration script reports a conflict (exit code 1), the chain pauses. The an
 ### `--from-dev` (pre-release sync)
 
 When you use `--from-dev` to pull from `upstream/dev`, the migration chain is automatically skipped — pre-release work has no release tag to anchor against. The anchor file is NOT advanced; `--from-dev` is the only path that leaves the anchor untouched.
+
+---
+
+## When upgrading isn't enough — re-fork & keep your data
+
+`/update` handles the common case. Two situations need more than a sync — and
+both hinge on one mental model.
+
+### Your data vs. the framework
+
+Everything in a fork falls into one of two buckets:
+
+| Bucket | Examples | Lifecycle |
+|--------|----------|-----------|
+| **The framework** | `.claude/hooks/`, `.claude/skills/`, `.claude/agents/`, `.claude/rules/`, `workflows/`, `templates/`, `docs/` | Owned by upstream — replaced on every upgrade |
+| **Your portfolio data** | `apexyard.projects.yaml` (registry), `onboarding.yaml`, `projects/<name>/`, `workspace/<name>/`, `handbooks/`, custom skills | Owned by you — must survive every upgrade |
+
+Upgrades replace the **framework** bucket. The whole game is keeping your **data**
+bucket out of the line of fire. Split-portfolio mode does that structurally; the
+manual approach does it by copy-out / copy-back.
+
+### Re-fork (when the fork has drifted too far)
+
+Sometimes a fork has been edited so heavily — or branched from such an old base —
+that merging upstream is more painful than starting fresh. Symptoms:
+
+- `/update` (or `/update --dry-run`) reports conflicts across most of `.claude/`.
+- A PR opened from your fork against upstream shows a diff touching the *entire*
+  framework tree.
+
+Upgrade vs. re-fork — quick decision:
+
+| Situation | Do this |
+|-----------|---------|
+| `/update --dry-run` shows a clean or small merge | **Upgrade** (`/update`) |
+| A few conflicts in files you knowingly customised | **Upgrade**, resolve conflicts |
+| Conflicts across most of `.claude/` | **Re-fork** |
+| You don't know what diverged | **Re-fork** (cleanest reset) |
+
+To re-fork safely:
+
+1. **Get your data out of the line of fire first** (see below).
+2. Re-fork `me2resh/apexyard` (a fresh fork, or a fresh clone you re-point
+   `origin` at).
+3. Re-attach your data (split-portfolio: nothing to do — it lives elsewhere;
+   manual: copy your data bucket back in).
+4. Re-add the `upstream` remote so future `/update`s work:
+
+   ```bash
+   git remote add upstream https://github.com/me2resh/apexyard.git
+   ```
+
+### Preserving your data
+
+**Best — split-portfolio mode (makes the fork disposable).** Your portfolio data
+lives in a **separate private repo**; the framework fork only holds framework code
+plus a `.claude/project-config.json` pointing at the sibling. Once split,
+upgrading or re-forking the framework **never touches your data**.
+
+```bash
+/split-portfolio            # gated, destructive migration — every step confirms
+/split-portfolio --dry-run  # walk the steps without executing
+/split-portfolio --verify   # read-only state report
+```
+
+**Fallback — manual copy-out / copy-back** around a re-fork:
+
+1. Copy your **data bucket** out of the old fork: `apexyard.projects.yaml`,
+   `onboarding.yaml`, `projects/`, `workspace/` (if used), `handbooks/`, custom
+   skills.
+2. Re-fork `me2resh/apexyard`.
+3. Copy the data bucket back into the fresh fork.
+4. Re-add the `upstream` remote (above).
+
+This works but repeats on every re-fork. Split-portfolio is the one-time
+investment that removes the chore.
+
+### A common trap: project tickets filed against the framework repo
+
+On older forks (before per-project tracker routing landed), `/feature`, `/bug`,
+and `/task` could file tickets against the **framework** repo instead of your
+own project's repo. If your project's tickets/PRs show up on `me2resh/apexyard`,
+your fork is out of date — **upgrade (`/update`)**, which fixes the routing and
+enables leak-protection so private project names don't leak into public trackers.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Extends `docs/upgrading.md`** (rather than adding a new file — avoids doc fragmentation) with a new section, *"When upgrading isn't enough — re-fork & keep your data"*, covering the gap that let external adopters mis-file project tickets upstream from stale forks (the batch just triaged: #551, #556, #558, PR #552).
- The section adds: the **data-vs-framework mental model** (what gets overwritten on upgrade vs. what must survive), an **upgrade-vs-re-fork decision table**, **data-preservation** guidance (split-portfolio mode as the durable answer + a manual copy-out/copy-back fallback), and a callout for the **"project tickets filed against the framework repo"** trap with the `/update` fix.
- **Links `docs/upgrading.md` from the README** — it was previously only reachable from `docs/multi-project.md`.

## Testing

1. `npx markdownlint-cli2 docs/upgrading.md README.md` → 0 errors (matches the pre-push gate).
2. Read the new section — verify the `/update` and `/split-portfolio` references match their current SKILL.md behaviour.

Refs #560

## Glossary

| Term | Definition |
|------|------------|
| upgrade-in-place | Syncing a fork to the latest framework version via `/update` without re-forking. |
| re-fork | Creating a fresh fork of `me2resh/apexyard` when the existing fork has diverged too far to merge. |
| split-portfolio mode | Layout separating the public framework fork from a private portfolio repo (registry/docs/onboarding/workspaces), making the fork disposable. |
| portfolio data | The adopter's own work (registry, project docs, onboarding, workspaces, handbooks, custom skills) as distinct from framework code. |
| data-vs-framework boundary | The mental model that everything in a fork is either upstream-owned framework code or adopter-owned data. |