### PR TITLE
fix(#562): guard hero pill + releases metric against version drift

### DIFF
--- a/.claude/hooks/tests/test_site_counts.sh
+++ b/.claude/hooks/tests/test_site_counts.sh
@@ -248,6 +248,42 @@ if [ "$SITE_VERSION" != "$CHANGELOG_VERSION" ]; then
 fi
 echo "  ok   site softwareVersion=$SITE_VERSION matches CHANGELOG top entry $CHANGELOG_VERSION"
 
+# --- Hero pill + releases-shipped metric vs CHANGELOG (#562) ------------------
+# softwareVersion is only ONE of the seven version strings /release step 3.5
+# bumps. The guard above covered just that one, so the hero pill and the
+# releases-shipped metric silently drifted to v2.2 while CI stayed green at
+# v3.0.0 (#562). Extend the guard to the two most visible remaining strings.
+CHANGELOG_MM=$(printf '%s' "$CHANGELOG_VERSION" | grep -oE '^[0-9]+\.[0-9]+')
+CHANGELOG_COUNT=$(grep -cE '^## \[[0-9]' CHANGELOG.md)
+
+# Hero pill: <span class="pill">apexyard vX.Y</span> (major.minor only).
+PILL_MM=$(grep -oE 'class="pill">apexyard v[0-9]+\.[0-9]+' site/index.html 2>/dev/null \
+  | grep -oE '[0-9]+\.[0-9]+' | head -1)
+if [ "$PILL_MM" != "$CHANGELOG_MM" ]; then
+  echo "FAIL: site hero pill 'apexyard v$PILL_MM' but CHANGELOG major.minor is $CHANGELOG_MM"
+  echo "      Bump the hero pill (site/index.html ~L1568) per SKILL.md step 3.5."
+  exit 1
+fi
+echo "  ok   site hero pill apexyard v$PILL_MM matches CHANGELOG $CHANGELOG_MM"
+
+# Releases-shipped metric: <strong>N</strong> + 'Production releases shipped (v0.1 → vX.Y)'.
+# Match without depending on the literal arrow glyph.
+RANGE_MATCH=$(grep -oE 'Production releases shipped \(v0\.1[^)]*[0-9]+\.[0-9]+\)' site/index.html 2>/dev/null | head -1)
+RANGE_MM=$(printf '%s' "$RANGE_MATCH" | grep -oE '[0-9]+\.[0-9]+' | tail -1)
+if [ "$RANGE_MM" != "$CHANGELOG_MM" ]; then
+  echo "FAIL: site releases-shipped range ends at v$RANGE_MM but CHANGELOG major.minor is $CHANGELOG_MM"
+  echo "      Bump the releases-shipped range (site/index.html ~L1696) per SKILL.md step 3.5."
+  exit 1
+fi
+SHIPPED_COUNT=$(grep -B1 'Production releases shipped' site/index.html 2>/dev/null \
+  | grep -oE '<strong>[0-9]+</strong>' | grep -oE '[0-9]+' | head -1)
+if [ "$SHIPPED_COUNT" != "$CHANGELOG_COUNT" ]; then
+  echo "FAIL: site releases-shipped count=$SHIPPED_COUNT but CHANGELOG has $CHANGELOG_COUNT release entries"
+  echo "      Bump the releases-shipped count (site/index.html ~L1696) per SKILL.md step 3.5."
+  exit 1
+fi
+echo "  ok   site releases-shipped $SHIPPED_COUNT / (v0.1 → v$RANGE_MM) matches CHANGELOG ($CHANGELOG_COUNT entries, $CHANGELOG_MM)"
+
 # --- LLM payload-size meta tags (#333 item C) ---
 # Each main marketing page carries <meta name="llm:token-count" content="N">
 # and <meta name="llm:doc-length" content="M chars">. The token estimate is

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -113,11 +113,15 @@ move with each cut.
 Show the resulting `site/index.html` diff alongside the CHANGELOG diff in the
 dry-run / preview so the operator sees both before the PR opens.
 
-> **Durable guard:** `test_site_counts.sh` asserts `site/index.html`'s JSON-LD
-> `softwareVersion` equals the top-most `## [X.Y.Z]` entry in `CHANGELOG.md`, and
-> the CI workflow `site-counts-check.yml` runs it on every PR. If you bump the
-> CHANGELOG without bumping the site (or vice-versa), CI goes red — the drift can
-> no longer accumulate silently.
+> **Durable guard:** `test_site_counts.sh` asserts that `site/index.html`'s
+> JSON-LD `softwareVersion`, the **hero pill** (`apexyard vX.Y`), and the
+> **releases-shipped metric** (count + `(v0.1 → vX.Y)` range) all match the
+> top-most `## [X.Y.Z]` entry in `CHANGELOG.md` (the count matches
+> `grep -cE '^## \[[0-9]' CHANGELOG.md`). The CI workflow `site-counts-check.yml`
+> runs it on every PR. If you bump the CHANGELOG without bumping these site
+> strings (or vice-versa), CI goes red — the drift can no longer accumulate
+> silently. (Before #562 only `softwareVersion` was guarded, which is how the
+> pill + metric drifted to v2.2 at the v3.0.0 cut.)
 
 ### 4. Open the release PR
 

--- a/site/index.html
+++ b/site/index.html
@@ -1565,7 +1565,7 @@ a:hover { color: var(--accent); }
   <div class="hero__inner">
 
     <div class="hero__eyebrow rise rise-1">
-      <span class="pill">apexyard v2.2</span>
+      <span class="pill">apexyard v3.0</span>
       <span>open source · built for founders shipping with AI</span>
       <button class="copy-for-ai" data-md-url="/index.md" type="button" style="margin-left:auto;font-size:0.75rem;padding:0.25rem 0.6rem;border:1px solid currentColor;border-radius:4px;background:transparent;color:inherit;cursor:pointer;font-family:inherit;">Copy as Markdown for AI</button>
     </div>
@@ -1692,8 +1692,8 @@ a:hover { color: var(--accent); }
       <span>PRs reviewed &amp; merged · last 90 days</span>
     </div>
     <div class="hero__metric">
-      <strong>12</strong>
-      <span>Production releases shipped (v0.1 → v2.2)</span>
+      <strong>14</strong>
+      <span>Production releases shipped (v0.1 → v3.0)</span>
     </div>
     <div class="hero__metric">
       <strong>29</strong>


### PR DESCRIPTION
## Summary

- **Fixes the stale marketing-site version** that shipped with v3.0.0: the hero pill read `apexyard v2.2` (next to a correct `v3.0.0` link) and the releases-shipped metric read `12 / (v0.1 → v2.2)`. Now `v3.0` and `14 / (v0.1 → v3.0)`.
- **Hardens the durable guard** `test_site_counts.sh` so this can't recur: it previously asserted only the JSON-LD `softwareVersion`, leaving six of the seven `/release` §3.5 version strings unguarded — which is exactly how the pill + metric drifted while CI stayed green. The guard now also checks the **hero pill** (major.minor), the **releases-shipped count** (vs `grep -cE '^## \[[0-9]' CHANGELOG.md`), and the **range** against the CHANGELOG top entry.
- **Updates `/release` §3.5's guard note** to match the expanded coverage.

Root cause + analysis filed as #562.

## Testing

1. `bash .claude/hooks/tests/test_site_counts.sh` → PASS (4 version asserts green: softwareVersion, pill, releases count, range).
2. Negative test: revert the pill to `v2.2` → guard exits 1 with `FAIL: site hero pill 'apexyard v2.2' but CHANGELOG major.minor is 3.0`. Restored → PASS.
3. `markdownlint-cli2 .claude/skills/release/SKILL.md` → 0 errors.

Refs #562

## Glossary

| Term | Definition |
|------|------------|
| hero pill | The version badge at top-left of `site/index.html` (`<span class="pill">apexyard vX.Y</span>`). |
| releases-shipped metric | The site stat showing release count + range (`N` · `(v0.1 → vX.Y)`). |
| durable guard | `test_site_counts.sh`, run on every PR via `site-counts-check.yml`, that fails CI when site version strings drift from `CHANGELOG.md`. |
| §3.5 | The `/release` skill step that bumps the seven hard-coded site version strings on each cut. |
| major.minor | The `X.Y` portion of a semver `X.Y.Z` — what the pill and range display. |