### PR TITLE
fix(#559): resolve review-marker home pin-first in Rex + /approve-merge

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -524,22 +524,31 @@ The marker MUST land at `<ops_fork_root>/.claude/session/reviews/{number}-rex.ap
 
 **Resolve `MARKER_HOME` ONCE, at review start, from your initial working directory** — before any `cd`, `git clone`, `gh pr checkout`, or other tool call that might change where you are or what's anchored above you. The walk-up shape below is sensitive to `$PWD`: if you've cloned the fork into `/tmp` for inspection and `cd`'d into the clone first, the walk resolves to that throwaway tree, the marker lands in `/tmp`, and the merge gate (running from the real ops fork) cannot find it. Capture `MARKER_HOME` first; treat it as immutable for the rest of the review. This is the prose discipline; the mechanical safety net is `pin-ops-root.sh` (apexyard#381), which captures the launch-cwd ops root at SessionStart and feeds it to `_lib-ops-root.sh::resolve_ops_root` so adopters on framework versions that ship the hook get the pin automatically — the walk-up below remains as the safety net for older versions and as the resolution method when no pin exists.
 
-Resolve the ops fork root by walking up for `onboarding.yaml` + `apexyard.projects.yaml` (or the `.apexyard-fork` v2 marker), then source the marker path helper (AgDR-0060 / #485):
+Resolve the ops fork root **pin-first** — the SAME strategy the merge gate uses (`_lib-ops-root.sh::resolve_ops_root`), then source the marker path helper (AgDR-0060 / #485). The session pin (`~/.claude/apexyard/ops-root-<session>`) points at the REAL ops fork even from inside a `workspace/<project>/` clone. A plain walk-up does NOT: in split-portfolio mode it resolves to the private portfolio sibling (which has `onboarding.yaml` + `apexyard.projects.yaml`) where `_lib-review-markers.sh` does not exist — so the marker lands in the wrong place under a bare (unqualified) name and the gate can't see it (me2resh/apexyard#559). Read the pin first; fall back to walk-up only when no valid pin exists.
 
 ```bash
-REPO_ROOT=$(git rev-parse --show-toplevel)
+# 1. Pin-first: the pin points at the real ops fork regardless of cwd.
 OPS_ROOT=""
-r="$REPO_ROOT"
-while [ -n "$r" ] && [ "$r" != "/" ]; do
-  if [ -f "$r/.apexyard-fork" ]; then
-    OPS_ROOT="$r"; break
-  fi
-  if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
-    OPS_ROOT="$r"; break
-  fi
-  r=$(dirname "$r")
-done
-MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
+PIN_FILE="${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID:-}"
+if [ -z "${APEXYARD_OPS_DISABLE_PIN:-}" ] && [ -n "${CLAUDE_CODE_SESSION_ID:-}" ] && [ -f "$PIN_FILE" ]; then
+  IFS= read -r OPS_ROOT < "$PIN_FILE" || OPS_ROOT=""
+fi
+# 2. Validate the pin (self-heal a stale one): must satisfy a fork anchor.
+if [ -n "$OPS_ROOT" ] && [ ! -f "$OPS_ROOT/.apexyard-fork" ] && \
+   { [ ! -f "$OPS_ROOT/onboarding.yaml" ] || [ ! -f "$OPS_ROOT/apexyard.projects.yaml" ]; }; then
+  OPS_ROOT=""
+fi
+# 3. Fallback: walk up from the repo root (pre-#381 behaviour, safety net).
+if [ -z "$OPS_ROOT" ]; then
+  r=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  while [ -n "$r" ] && [ "$r" != "/" ]; do
+    if [ -f "$r/.apexyard-fork" ] || { [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; }; then
+      OPS_ROOT="$r"; break
+    fi
+    r=$(dirname "$r")
+  done
+fi
+MARKER_HOME="${OPS_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 # shellcheck source=/dev/null
 . "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
 mkdir -p "$MARKER_HOME/.claude/session/reviews"

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -75,18 +75,33 @@ The CEO approval is a stamp on top of a Rex-approved HEAD, not a standalone acti
 ```bash
 # Resolve the OPS FORK ROOT, not git toplevel. Inside workspace/<project>/,
 # git toplevel is the project clone; markers live in the ops fork above.
-# See me2resh/apexyard#229 + #230.
-REPO_ROOT=$(git rev-parse --show-toplevel)
+# See me2resh/apexyard#229 + #230. Resolve PIN-FIRST — the same strategy the
+# merge gate uses (_lib-ops-root.sh::resolve_ops_root). The session pin points
+# at the real ops fork even from a workspace clone; a plain walk-up resolves to
+# the private portfolio sibling in split-portfolio mode (it has onboarding.yaml
+# + apexyard.projects.yaml) where _lib-review-markers.sh doesn't exist, so the
+# CEO marker lands where the gate can't see it (me2resh/apexyard#559).
 OPS_ROOT=""
-r="$REPO_ROOT"
-while [ -n "$r" ] && [ "$r" != "/" ]; do
-  if [ -f "$r/.apexyard-fork" ]; then OPS_ROOT="$r"; break; fi
-  if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
-    OPS_ROOT="$r"; break
-  fi
-  r=$(dirname "$r")
-done
-MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
+PIN_FILE="${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID:-}"
+if [ -z "${APEXYARD_OPS_DISABLE_PIN:-}" ] && [ -n "${CLAUDE_CODE_SESSION_ID:-}" ] && [ -f "$PIN_FILE" ]; then
+  IFS= read -r OPS_ROOT < "$PIN_FILE" || OPS_ROOT=""
+fi
+# Validate the pin (self-heal a stale one): must satisfy a fork anchor.
+if [ -n "$OPS_ROOT" ] && [ ! -f "$OPS_ROOT/.apexyard-fork" ] && \
+   { [ ! -f "$OPS_ROOT/onboarding.yaml" ] || [ ! -f "$OPS_ROOT/apexyard.projects.yaml" ]; }; then
+  OPS_ROOT=""
+fi
+# Fallback: walk up from git toplevel (pre-#381 behaviour, safety net).
+if [ -z "$OPS_ROOT" ]; then
+  r=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  while [ -n "$r" ] && [ "$r" != "/" ]; do
+    if [ -f "$r/.apexyard-fork" ] || { [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; }; then
+      OPS_ROOT="$r"; break
+    fi
+    r=$(dirname "$r")
+  done
+fi
+MARKER_HOME="${OPS_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 
 # Source the marker path helper — repo-qualified naming (#485, AgDR-0060).
 # shellcheck source=/dev/null


### PR DESCRIPTION
## Summary

- **Fixes the split-portfolio marker-resolution bug (#559)** that blocked every managed-project merge: the merge gate resolves the marker directory pin-first via `_lib-ops-root.sh::resolve_ops_root`, but the **code-reviewer agent** and **`/approve-merge` skill** used a plain filesystem walk-up. From a `workspace/<project>/` clone that walk-up climbs to the **private portfolio sibling** (it has `onboarding.yaml` + `apexyard.projects.yaml`) — where `_lib-review-markers.sh` doesn't exist — so markers were written to the wrong directory under a **bare, unqualified** name the gate can't see.
- **Both writers now resolve pin-first** (read `~/.claude/apexyard/ops-root-<session>`, validate + self-heal a stale pin, fall back to walk-up only when no valid pin exists) — exactly matching the gate's resolution, so writer and reader always agree.
- This is the **write-side companion to #230**, which fixed only the gate's read path. The two halves now use one strategy.

## Testing

1. Ran the new pin-first block from inside a `workspace/<project>/` clone (the failure scenario): resolves `MARKER_HOME` to the real ops fork, `_lib-review-markers.sh` is present, and `review_marker_path` yields the repo-qualified `<owner>__<repo>__<pr>-rex.approved` the gate expects. Pre-fix, the same cwd resolved to the portfolio sibling + bare name.
2. `markdownlint-cli2` on both files → 0 errors.

Refs #559

## Glossary

| Term | Definition |
|------|------------|
| ops fork | The framework fork clone holding `.claude/` hooks + the `.apexyard-fork` pin anchor. |
| session pin | `~/.claude/apexyard/ops-root-<session>` written at SessionStart; points at the real ops fork regardless of cwd. |
| pin-first resolution | Consult the session pin before walking the filesystem — the strategy `resolve_ops_root` already uses; this PR brings the marker writers in line. |
| review marker | `.claude/session/reviews/<owner>__<repo>__<pr>-<role>.approved` recording a Rex/CEO approval at a HEAD SHA. |
| split-portfolio mode | Public framework fork + private portfolio repo (registry/onboarding live in the sibling), which is what breaks the plain walk-up. |