### PR TITLE
fix(#547): parse git-push dst ref, ignore redirections + tag pushes

### DIFF
--- a/.claude/hooks/_lib-extract-push-ref.sh
+++ b/.claude/hooks/_lib-extract-push-ref.sh
@@ -25,23 +25,82 @@
 # -----
 #   . "$(dirname "$0")/_lib-extract-push-ref.sh"
 #   PUSH_REF=$(extract_push_ref "$COMMAND")
+#   # Check is_tag_push first — tag pushes must be no-ops for a branch validator.
+#   if is_tag_push "$COMMAND"; then exit 0; fi
 #   BRANCH="${PUSH_REF:-$(git branch --show-current)}"
 #
-# Refs: me2resh/apexyard#194
+# Refs: me2resh/apexyard#194, me2resh/apexyard#547
 
-# Echoes the source ref from a `git push` command, or empty if none found.
+# Returns true (0) when the command is a tag push that has no branch ref at all.
+# Tag pushes must be a no-op for a *branch*-name validator.
+#
+# Detects:
+#   git push <remote> --tags              → true
+#   git push <remote> tag <name>          → true
+#   git push --tags                       → true
+#   git push <remote> refs/tags/<name>    → true
+#   git push <remote> +refs/tags/<name>:refs/tags/<name>  → true (refspec targeting tags/)
+#   git push <remote> v1.0.0              → NOT detected (bare tag name = branch name,
+#                                            validator falls back to local HEAD)
+is_tag_push() {
+  local cmd="$1"
+
+  # Strip everything after the first shell redirection/pipe so the check isn't
+  # fooled by `2>&1 | tail` appended to the command.
+  local clean_cmd
+  clean_cmd=$(echo "$cmd" | sed 's/[[:space:]]*[0-9]*[>|][&>|0-9].*$//')
+
+  # --tags flag: `git push [opts] --tags [remote]`
+  if echo "$clean_cmd" | grep -qE '\bgit\s+push\b.*\s--tags(\s|$)'; then
+    return 0
+  fi
+
+  # `git push <remote> tag <name>` (explicit `tag` keyword before ref)
+  if echo "$clean_cmd" | grep -qE '\bgit\s+push\b.*\stag\s+\S'; then
+    return 0
+  fi
+
+  # refs/tags/ in any positional argument (e.g. push by full ref or refspec)
+  if echo "$clean_cmd" | grep -qE '\brefs/tags/'; then
+    return 0
+  fi
+
+  return 1
+}
+
+# Echoes the DESTINATION branch ref from a `git push` command, or empty if
+# none found.
+#
+# KEY BEHAVIOUR CHANGES vs the original (me2resh/apexyard#547):
+#
+#   1. Shell redirections and pipes are stripped BEFORE token parsing so that
+#      `2>&1`, `2>`, `>`, `|` tokens are not mistaken for branch names.
+#
+#   2. For a `src:dst` refspec (e.g. `HEAD:feature/GH-1-foo`), the DESTINATION
+#      (right of the colon) is returned for validation, not the source. The
+#      source side may be `HEAD`, a SHA, or an arbitrary local ref name that
+#      the branch-name validator should not block on — the dst is what actually
+#      lands on the remote.
+#
+#   3. Tag pushes are NOT handled here — call is_tag_push() first and exit 0
+#      before calling extract_push_ref. This function still returns empty for
+#      `--tags` (it's a boolean flag), which is the same as before, but the
+#      caller should never reach the branch-name validation step for tag pushes.
 #
 # Recognises:
 #   git push origin <branch>                           → <branch>
-#   git push origin <branch>:<remote-branch>           → <branch>  (LHS of refspec)
+#   git push origin HEAD:<branch>                      → <branch>  (DST of refspec)
+#   git push origin <src>:<dst-branch>                 → <dst-branch>
 #   git push -u origin <branch>                        → <branch>
 #   git push --set-upstream origin <branch>            → <branch>
 #   git push --force origin <branch>                   → <branch>
 #   git push --force-with-lease origin <branch>        → <branch>
-#   git push origin HEAD                               → empty (HEAD is not a ref name we can validate)
+#   git push origin HEAD                               → empty (HEAD alone, no dst)
+#   git push origin --tags                             → empty (tag push, no branch)
 #   git push                                           → empty (relies on upstream tracking)
 #   git push origin                                    → empty (no ref given)
-#   git push origin --delete <branch>                  → empty (deletion, no source-ref check)
+#   git push origin --delete <branch>                  → empty (deletion, no source-ref)
+#   git push upstream HEAD:feature/GH-1-foo 2>&1 | tl → feature/GH-1-foo (redirections stripped)
 #
 # Returns: prints the ref to stdout (or empty), always exits 0.
 extract_push_ref() {
@@ -54,10 +113,25 @@ extract_push_ref() {
     return 0
   fi
 
+  # Strip shell redirections and pipeline suffixes from the raw command before
+  # we extract the push segment.  A command like:
+  #   git push upstream --tags 2>&1 | tail -5
+  # should be seen as:
+  #   git push upstream --tags
+  # We remove everything from the first redirection operator onward:
+  #   - `NNN>` (e.g. `2>`, `1>`, plain `>`)
+  #   - `|` pipe
+  # This is conservative: we drop from the FIRST such operator to end-of-line.
+  # The sed expression matches optional digits, then `>` or `|`, followed by
+  # anything: `[[:space:]]*[0-9]*[>|].*`
+  local stripped_cmd
+  stripped_cmd=$(echo "$cmd" | sed 's/[[:space:]]*[0-9]*[>|].*$//')
+
   # Isolate the `git push ...` segment up to the first command separator
   # (|, ;, &&, &) so `git push origin foo && echo bar` doesn't pick up `echo`
-  # tokens.
-  push_segment=$(echo "$cmd" | grep -oE '\bgit\s+push\b[^|;&]*' | head -1)
+  # tokens.  (After stripping redirections above, the push segment is usually
+  # the whole remaining string, but the separator guard is a useful safety net.)
+  push_segment=$(echo "$stripped_cmd" | grep -oE '\bgit\s+push\b[^|;&]*' | head -1)
   if [ -z "$push_segment" ]; then
     echo ""
     return 0
@@ -73,7 +147,7 @@ extract_push_ref() {
   push_segment="${push_segment#push}"
 
   # Walk the remaining tokens, skipping flags + their values + the remote.
-  # The first non-flag, non-remote positional that isn't HEAD is the source ref.
+  # The first non-flag, non-remote positional is the refspec (or branch).
   #
   # Recognised flags that consume a following value:
   #   -o / --push-option, --recurse-submodules, --signed, --receive-pack /
@@ -131,19 +205,30 @@ extract_push_ref() {
     return 0
   fi
 
-  # `git push origin HEAD` — HEAD isn't a branch name we can validate; let the
-  # caller fall back to local HEAD resolution.
-  if [ "$ref" = "HEAD" ]; then
+  # Strip any leading `+` (force-update marker on a refspec).
+  ref="${ref#+}"
+
+  # Refspec form `<src>:<dst>` — validate the DESTINATION (right side) because:
+  #   - The dst is what lands on the remote and whose name matters for the
+  #     branch-naming convention.
+  #   - The src may be `HEAD`, a SHA, or a differently-named local tracking
+  #     branch — none of which should be validated as a remote branch name.
+  # If there is no `:` the whole token is the branch name.
+  if echo "$ref" | grep -q ':'; then
+    # Take the DST side (right of colon).
+    ref="${ref#*:}"
+  fi
+
+  if [ -z "$ref" ]; then
     echo ""
     return 0
   fi
 
-  # Refspec form `<src>:<dst>` — the LHS is the branch the operator is pushing.
-  # Strip the colon-and-after so `feature/GH-1-x:main` → `feature/GH-1-x`.
-  ref="${ref%%:*}"
-
-  # Strip any leading `+` (force-update marker on a refspec).
-  ref="${ref#+}"
+  # `HEAD` without a refspec dst — not a branch name we can validate.
+  if [ "$ref" = "HEAD" ]; then
+    echo ""
+    return 0
+  fi
 
   # Strip leading `refs/heads/` if present — leave just the branch shorthand.
   ref="${ref#refs/heads/}"

--- a/.claude/hooks/tests/test_validate_branch_name_pushref.sh
+++ b/.claude/hooks/tests/test_validate_branch_name_pushref.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
-# Tests for validate-branch-name.sh's push-source-ref extraction (#194).
+# Tests for validate-branch-name.sh's push-source-ref extraction (#194, #547).
 #
 # Validates that the hook reads the branch from the actual `git push`
 # command's source ref when present, rather than from `git branch
 # --show-current` against the harness's $PWD. This is the worktree-safe
 # behaviour Agent fan-out workers depend on.
+#
+# Also validates the #547 bug fixes:
+#   - `HEAD:dst` refspec → validates DST, not HEAD (was: blocked on "HEAD")
+#   - `--tags 2>&1 | tail` → skipped as tag push (was: blocked on "2>")
+#   - shell redirections stripped before token parsing
 #
 # Each case:
 #   - builds an isolated sandbox with the hook + helper
@@ -141,6 +146,55 @@ run_case "git push --delete: falls back, blocks (local non-conforming)" \
 # Non-push commands → no-op.
 run_case "non-push command exits 0 silently" \
   "git status" 0
+
+# ---- #547 bug fixes -----------------------------------------------------
+#
+# (a) src:dst refspec — validate the DST (right of colon), not the src.
+#     Before fix: hook grabbed "HEAD" from the left side and blocked.
+run_case "#547: HEAD:valid-branch validates dst → passes" \
+  "git push upstream HEAD:feature/GH-547-push-ref-parsing" 0
+
+run_case "#547: HEAD:non-conforming-dst blocks on dst" \
+  "git push upstream HEAD:bogus-branch-name" 2
+
+run_case "#547: sha:dst validates dst → passes" \
+  "git push upstream abc1234:fix/GH-1-some-fix" 0
+
+run_case "#547: local-branch:remote-branch validates remote-dst → passes" \
+  "git push upstream fix/GH-100-local:feature/GH-200-remote" 0
+
+# (b) Tag pushes must be a no-op for a branch-name validator.
+#     Before fix: hook grabbed "2>" from the redirection and blocked.
+run_case "#547: --tags plain → skip (no branch to validate)" \
+  "git push upstream --tags" 0
+
+run_case "#547: --tags with 2>&1 pipe → skip (no branch to validate)" \
+  "git push upstream --tags 2>&1 | tail -5" 0
+
+run_case "#547: --tags before remote → skip" \
+  "git push --tags upstream" 0
+
+run_case "#547: tag <name> keyword form → skip" \
+  "git push upstream tag v1.2.3" 0
+
+run_case "#547: refs/tags/ refspec → skip" \
+  "git push upstream refs/tags/v1.0.0:refs/tags/v1.0.0" 0
+
+# (c) Shell redirections stripped — bare redirect token not mistaken for branch.
+#     Before fix: "2>" or ">" could end up as a positional token.
+run_case "#547: plain 2>&1 redirect on valid push → passes" \
+  "git push upstream feature/GH-547-foo 2>&1" 0
+
+run_case "#547: > redirect on valid push → passes" \
+  "git push upstream fix/GH-1-bar > /tmp/out.txt" 0
+
+# ---- Regression: original #194 cases still pass after #547 fix ----------
+
+run_case "regression: explicit ref passes (no refspec)" \
+  "git push origin feature/GH-194-worktree-cwd-hooks" 0
+
+run_case "regression: non-conforming explicit ref still blocks" \
+  "git push origin bogus-branch" 2
 
 # ---- Summary ------------------------------------------------------------
 

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -26,12 +26,22 @@ fi
 #
 # Falls back to local HEAD when the push has no source ref (no-arg push,
 # `git push origin` with no ref, etc.) — preserves today's behaviour for
-# anyone not passing the ref explicitly. See me2resh/apexyard#194.
+# anyone not passing the ref explicitly. See me2resh/apexyard#194, #547.
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 PUSH_REF=""
 if [ -f "$HOOK_DIR/_lib-extract-push-ref.sh" ]; then
   # shellcheck disable=SC1090,SC1091
   . "$HOOK_DIR/_lib-extract-push-ref.sh"
+
+  # Tag pushes (--tags, `tag <name>`, refs/tags/) have no branch to validate.
+  # Exit cleanly — a branch-name validator has nothing to check here.
+  # This guard runs before extract_push_ref so shell redirections appended
+  # to a tag-push command (e.g. `git push --tags 2>&1 | tail`) don't cause
+  # is_tag_push() to miss the --tags flag. See me2resh/apexyard#547.
+  if is_tag_push "$COMMAND"; then
+    exit 0
+  fi
+
   PUSH_REF=$(extract_push_ref "$COMMAND")
 fi
 


### PR DESCRIPTION
## Summary

- **Extracted DST from `src:dst` refspecs instead of SRC** — `git push upstream HEAD:feature/GH-1-foo` was blocked because the hook read `HEAD` (left side) as the branch name. The fix makes `extract_push_ref()` take the right side of the colon, which is what actually lands on the remote and what the branch-naming convention applies to.
- **Strip shell redirections before token parsing** — a command like `git push upstream --tags 2>&1 | tail` had `2>` mis-parsed as a positional branch-name token. The lib now strips everything from the first redirection operator (`NNN>`, `|`) onward before extracting tokens, so `2>`, `>`, and `|` can never be mistaken for branch names.
- **Tag pushes are a no-op for the branch-name validator** — added `is_tag_push()` to `_lib-extract-push-ref.sh` (detects `--tags`, `tag <name>`, `refs/tags/`) and call it in `validate-branch-name.sh` before any ref extraction; exit 0 immediately. A branch-name validator has nothing to validate on a tag push.

## Testing

```bash
bash .claude/hooks/tests/test_validate_branch_name_pushref.sh
```

28 cases total — 15 pre-existing (#194 behaviour) + 13 new (#547 cases). All pass:

```
PASS [#547: HEAD:valid-branch validates dst → passes]
PASS [#547: HEAD:non-conforming-dst blocks on dst]
PASS [#547: sha:dst validates dst → passes]
PASS [#547: local-branch:remote-branch validates remote-dst → passes]
PASS [#547: --tags plain → skip (no branch to validate)]
PASS [#547: --tags with 2>&1 pipe → skip (no branch to validate)]
PASS [#547: --tags before remote → skip]
PASS [#547: tag <name> keyword form → skip]
PASS [#547: refs/tags/ refspec → skip]
PASS [#547: plain 2>&1 redirect on valid push → passes]
PASS [#547: > redirect on valid push → passes]
PASS [regression: explicit ref passes (no refspec)]
PASS [regression: non-conforming explicit ref still blocks]
===================================
  PASS: 28   FAIL: 0
===================================
```

Refs #547

---

## Glossary

| Term | Definition |
|------|------------|
| Refspec | A `git push` argument of the form `<src>:<dst>` (e.g. `HEAD:feature/GH-1-foo`) specifying the source local ref and the destination remote ref. The branch-naming convention applies only to the dst — what lands on the remote. |
| Shell redirection | Shell operators like `2>&1`, `2>`, `>` that redirect file descriptors. They appear as tokens in the raw command string the hook receives and were previously mis-parsed as branch-name candidates. |
| Tag push | A push that sends git tags to the remote rather than a branch ref. Indicated by `--tags`, `tag <name>`, or a `refs/tags/` refspec. A branch-name validator has no rule to apply and must exit 0. |
| `is_tag_push()` | New helper in `_lib-extract-push-ref.sh` that returns true when the command is a tag push. Called before `extract_push_ref()` so the tag-push guard is correct even when redirections are appended to the command. |
| `extract_push_ref()` | Shared lib function (existing, in `_lib-extract-push-ref.sh`) that parses a `git push` command and returns the branch ref to validate. Updated to return the DST of a refspec and to strip redirections before parsing. |