### PR TITLE
fix(#548): pre-push markdownlint lints tracked files only

### DIFF
--- a/.claude/hooks/tests/test_pre_push_gate.sh
+++ b/.claude/hooks/tests/test_pre_push_gate.sh
@@ -169,7 +169,54 @@ case7() {
   rm -rf "$sb"
 }
 
-case1; case2; case3; case4; case5; case6; case7
+
+# -------------------- CASE 8: untracked bad markdown → no failure --------------------
+# Regression guard for #548: a markdownlint command driven by git ls-files must
+# NOT lint untracked files, so a lint-dirty untracked .md must not block the push.
+# The command string avoids \0 / null-delimiter JSON escapes (jq rejects \0);
+# filenames in sandboxes are space-free so plain xargs (newline-split) is safe here.
+case8() {
+  local sb; sb=$(make_sandbox)
+  # Configure markdownlint using git ls-files (the fixed command shape).
+  # shellcheck disable=SC2016
+  printf '%s\n' \
+    '{"pre_push": {"commands": [{"name": "markdownlint", "run": "command -v npx >/dev/null 2>&1 || { echo INFO; exit 0; }; md_files=$(git ls-files '"'"'*.md'"'"' 2>/dev/null); [ -z \"$md_files\" ] && { echo INFO_SKIP; exit 0; }; echo \"$md_files\" | xargs npx --yes markdownlint-cli2 2>&1"}]}}' \
+    > "$sb/.claude/project-config.json"
+  # Drop a lint-dirty untracked markdown file.
+  # Critically, this file is NOT `git add`-ed, so git ls-files will not see it.
+  mkdir -p "$sb/.claude/skills/external-skill"
+  printf '# Bad heading  \n- item without blank line\n' \
+    > "$sb/.claude/skills/external-skill/DOCS.md"
+  # Push must succeed: the untracked file must be invisible to markdownlint.
+  run_hook "$sb" "$(push_json)" 0 "" "untracked-bad-md-ignored"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 9: tracked bad markdown → failure --------------------
+# Regression guard for #548: a lint error in a TRACKED markdown file must still
+# block the push, so the fix does not weaken the gate for real content.
+# Same command shape as case8 (space-safe xargs without -0, valid JSON).
+case9() {
+  local sb; sb=$(make_sandbox)
+  # shellcheck disable=SC2016
+  printf '%s\n' \
+    '{"pre_push": {"commands": [{"name": "markdownlint", "run": "command -v npx >/dev/null 2>&1 || { echo INFO; exit 0; }; md_files=$(git ls-files '"'"'*.md'"'"' 2>/dev/null); [ -z \"$md_files\" ] && { echo INFO_SKIP; exit 0; }; echo \"$md_files\" | xargs npx --yes markdownlint-cli2 2>&1"}]}}' \
+    > "$sb/.claude/project-config.json"
+  # Create a lint-dirty markdown file and COMMIT it so git ls-files sees it.
+  # MD047 (files-end-with-single-newline) is reliably detectable without a
+  # markdownlint config: just omit the trailing newline.
+  printf '# README\nno-trailing-newline' > "$sb/README.md"
+  (cd "$sb" && git add README.md && git commit -q -m "chore: add bad README")
+  # npx must be available for this case to be meaningful; skip gracefully if not.
+  if ! command -v npx >/dev/null 2>&1; then
+    echo "SKIP [tracked-bad-md-fails]: npx not available, case not executable"
+    return
+  fi
+  run_hook "$sb" "$(push_json)" 2 "markdownlint: FAILED" "tracked-bad-md-fails"
+  rm -rf "$sb"
+}
+
+case1; case2; case3; case4; case5; case6; case7; case8; case9
 
 echo ""
 echo "==================================="

--- a/.claude/project-config.json
+++ b/.claude/project-config.json
@@ -6,7 +6,7 @@
     "commands": [
       {
         "name": "markdownlint",
-        "run": "command -v npx >/dev/null 2>&1 || { echo 'INFO: npx not found — markdownlint check skipped. Install Node.js (https://nodejs.org) to enable it locally.'; exit 0; }; npx --yes markdownlint-cli2 '**/*.md' '#node_modules' '#.git' '#workspace' 2>&1"
+        "run": "command -v npx >/dev/null 2>&1 || { echo 'INFO: npx not found — markdownlint check skipped. Install Node.js (https://nodejs.org) to enable it locally.'; exit 0; }; md_files=$(git ls-files '*.md' 2>/dev/null); [ -z \"$md_files\" ] && { echo 'INFO: no tracked markdown files found — markdownlint check skipped.'; exit 0; }; echo \"$md_files\" | tr '\\n' '\\0' | xargs -0 npx --yes markdownlint-cli2 2>&1"
       },
       {
         "name": "shellcheck",


### PR DESCRIPTION
## Summary

- **Fixed false pre-push failures from untracked markdown** — the old `**/*.md` glob linted any `.md` in the working tree, including installed-skill bundled docs, `.claude/session/*.md` scratch files, and symlinked directories that never reach the repo. Replaced with `git ls-files '*.md'` so the gate lints exactly what a push delivers — matching what CI sees and preventing brittle per-machine ignore-glob workarounds.
- **Added graceful no-op when no tracked markdown exists** — a new repo or a branch with no `.md` files prints an informational note and exits 0, keeping behaviour consistent with the other guarded commands (npx-not-found path).
- **Added two regression-guard test cases** — `case8` proves that a lint-dirty UNTRACKED file does NOT trigger a gate failure; `case9` proves that a lint-dirty TRACKED file still blocks the push, so the fix does not weaken the gate for real content.

## Testing

1. Check out the branch and create a lint-dirty untracked `.md` file (e.g. in `.claude/session/scratch.md` or `.claude/skills/some-tool/DOCS.md`).
2. Make a clean tracked change, run `git push` — gate must pass.
3. Commit the dirty `.md` file (`git add` + `git commit`) and push again — gate must fail with the markdownlint error.
4. Run the test suite: `bash .claude/hooks/tests/test_pre_push_gate.sh` — all 9 cases must pass.

Refs #548

---

## Glossary

| Term | Definition |
|------|------------|
| Tracked files | Files under version control (`git ls-files`); the only content a push actually delivers to the remote and that CI will see. |
| Untracked files | Files present in the working tree but not added to the git index — never pushed, never seen by CI. |
| Pre-push gate | The local hook (`pre-push-gate.sh`) that mirrors CI checks before `git push` to prevent wasting CI minutes on avoidable failures. |
| `git ls-files` | Git plumbing command that lists tracked files; accepts a glob pattern to filter (e.g. `'*.md'` for all tracked markdown). |
| markdownlint-cli2 | The CLI runner for the markdownlint rule engine; accepts a list of file paths (or globs) and exits non-zero when any rule violations are found. |