### PR TITLE
fix(#549): block-main-push checks the operation's target branch, not session cwd

### DIFF
--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -130,12 +130,19 @@ if echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
   #   cd /abs/path && git commit …
   # Match `cd` as the first meaningful token before any separator.
   WORKTREE_PATH=""
-  if echo "$COMMAND" | grep -qE '^\s*cd\s+\S'; then
-    # Extract the path token immediately following `cd`.
-    # Uses POSIX sed: strip leading whitespace, match `cd <token>`, capture token.
-    WORKTREE_PATH=$(echo "$COMMAND" | \
-      sed -n 's/^[[:space:]]*cd[[:space:]]\{1,\}\([^[:space:];&|][^[:space:];&|]*\).*/\1/p' | \
-      head -1)
+  if echo "$COMMAND" | grep -qE '(^|[;&|[:space:]])cd[[:space:]]+\S'; then
+    # Resolve the LAST `cd <path>` in the chain (so `cd a && cd b && git commit`
+    # targets b, not a) and STRIP surrounding quotes. Quote-stripping is the
+    # security-critical part: without it, `cd "path" && git commit` would pass
+    # `"path"` (quotes included) to `git -C`, which errors → empty branch → the
+    # protected-branch check is skipped and a commit into a protected-branch
+    # worktree slips through. That false-negative was caught in the #580 review
+    # of this fix (#549). Handles double-quoted, single-quoted (incl. spaces),
+    # and bare paths.
+    WORKTREE_PATH=$(echo "$COMMAND" \
+      | grep -oE "cd[[:space:]]+(\"[^\"]*\"|'[^']*'|[^[:space:];&|]+)" \
+      | tail -n 1 \
+      | sed -E "s/^cd[[:space:]]+//; s/^[\"']//; s/[\"']\$//")
   fi
 
   if [ -n "$WORKTREE_PATH" ]; then

--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -7,6 +7,25 @@
 # that legitimately use `dev` as a daily-work trunk under their own
 # convention can override the protected list via
 # `.claude/project-config.json` → `.git.protected_branches[]`.
+#
+# WORKTREE-SAFE (me2resh/apexyard#549)
+# -------------------------------------
+# Previously both the push-check and the commit-check resolved the current
+# branch via `git branch --show-current` against the hook's cwd (the harness's
+# primary checkout). When the operator runs a command in a separate git worktree
+# while the primary checkout sits on a protected branch, the old code
+# false-blocked legitimate feature-branch work.
+#
+# Fix:
+#   Push:   reuse `_lib-extract-push-ref.sh` (already used by
+#           validate-branch-name.sh for the same reason) to read the DESTINATION
+#           branch directly from the push command. Tag pushes are no-ops. Falls
+#           back to local HEAD only when no ref is present in the command (e.g.
+#           bare `git push` relying on upstream tracking).
+#   Commit: detect the `cd <path> && git commit` shell compound pattern and run
+#           `git -C <path> branch --show-current` against the TARGET worktree.
+#           Falls back to the session cwd for plain `git commit` (no `cd`
+#           prefix) — preserving the original behaviour for the normal case.
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -14,6 +33,10 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 if [ -z "$COMMAND" ]; then
   exit 0
 fi
+
+# Resolve the hook's own directory so we can source sibling libs reliably
+# regardless of the harness's $PWD.
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Resolve protected-branch list from project config (shared reader, #109).
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -27,10 +50,45 @@ if [ -z "$PROTECTED" ]; then
   PROTECTED="main|master|dev|develop"
 fi
 
+# ---------------------------------------------------------------------------
 # Block: git push <remote> <protected>
-if echo "$COMMAND" | grep -qE "\bgit\s+push\s+\S+\s+(${PROTECTED})(\s|$)"; then
-  cat >&2 <<MSG
-BLOCKED: Cannot push directly to a protected branch.
+#
+# Use _lib-extract-push-ref.sh to read the DESTINATION branch from the actual
+# push command rather than from the session cwd's HEAD. This is the same
+# worktree-safe approach validate-branch-name.sh uses (#194, #547).
+#
+# Fallback: when no ref is found in the command (bare `git push` / `git push
+# origin` relying on upstream tracking), fall back to local HEAD so the hook
+# still catches pushes on protected branches made without an explicit ref.
+# ---------------------------------------------------------------------------
+if echo "$COMMAND" | grep -qE '\bgit\s+push\b'; then
+  # Source the shared push-ref extractor if available.
+  if [ -f "$HOOK_DIR/_lib-extract-push-ref.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$HOOK_DIR/_lib-extract-push-ref.sh"
+
+    # Tag pushes are never subject to a branch-protection check.
+    if is_tag_push "$COMMAND"; then
+      exit 0
+    fi
+
+    PUSH_DST=$(extract_push_ref "$COMMAND")
+  else
+    # Lib missing — best-effort fallback: no explicit ref extracted.
+    PUSH_DST=""
+  fi
+
+  # Determine which branch to check against the protected list.
+  if [ -n "$PUSH_DST" ]; then
+    TARGET_PUSH_BRANCH="$PUSH_DST"
+  else
+    # Bare `git push` / no explicit ref — fall back to local HEAD.
+    TARGET_PUSH_BRANCH=$(git branch --show-current 2>/dev/null)
+  fi
+
+  if [ -n "$TARGET_PUSH_BRANCH" ] && echo "$TARGET_PUSH_BRANCH" | grep -qE "^(${PROTECTED})$"; then
+    cat >&2 <<MSG
+BLOCKED: Cannot push directly to a protected branch ('${TARGET_PUSH_BRANCH}').
 
 All changes must go through a PR (.claude/rules/git-conventions.md
 § "No Direct Main"). Protected branches: ${PROTECTED//|/, }.
@@ -50,15 +108,47 @@ protection from a default-protected branch (e.g. you legitimately use
 protection to a new branch, write the array INCLUDING it. The hook
 trusts whichever list you provide — get the direction right.
 MSG
-  exit 2
+    exit 2
+  fi
 fi
 
+# ---------------------------------------------------------------------------
 # Block: git commit on a protected branch
+#
+# For the `cd <path> && git commit …` compound shell pattern, resolve the
+# branch of the TARGET worktree (the `cd` destination) rather than the
+# session cwd. This is the exact failure mode reported in #549: the harness
+# resets cwd to the primary checkout (on e.g. `dev`), but the actual commit
+# targets a feature-branch worktree reached via `cd ../wt && git commit`.
+#
+# For plain `git commit` (no `cd` prefix) fall back to the session cwd —
+# preserving the original behaviour for the normal single-worktree case.
+# ---------------------------------------------------------------------------
 if echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
-  CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+  # Detect `cd <path>` prefix in compound commands, e.g.:
+  #   cd ../wt && git commit -m "msg"
+  #   cd /abs/path && git commit …
+  # Match `cd` as the first meaningful token before any separator.
+  WORKTREE_PATH=""
+  if echo "$COMMAND" | grep -qE '^\s*cd\s+\S'; then
+    # Extract the path token immediately following `cd`.
+    # Uses POSIX sed: strip leading whitespace, match `cd <token>`, capture token.
+    WORKTREE_PATH=$(echo "$COMMAND" | \
+      sed -n 's/^[[:space:]]*cd[[:space:]]\{1,\}\([^[:space:];&|][^[:space:];&|]*\).*/\1/p' | \
+      head -1)
+  fi
+
+  if [ -n "$WORKTREE_PATH" ]; then
+    # Resolve branch in the target worktree, not the session cwd.
+    CURRENT_BRANCH=$(git -C "$WORKTREE_PATH" branch --show-current 2>/dev/null)
+  else
+    # Plain `git commit` with no `cd` — use session cwd (original behaviour).
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+  fi
+
   if [ -n "$CURRENT_BRANCH" ] && echo "$CURRENT_BRANCH" | grep -qE "^(${PROTECTED})$"; then
     cat >&2 <<MSG
-BLOCKED: Cannot commit directly on protected branch '$CURRENT_BRANCH'.
+BLOCKED: Cannot commit directly on protected branch '${CURRENT_BRANCH}'.
 
 All changes must go through a PR (.claude/rules/git-conventions.md
 § "No Direct Main").
@@ -70,14 +160,14 @@ To unblock:
   2. Retry the commit on the feature branch
   3. Push and open a PR when ready
 
-If you've already committed locally to '$CURRENT_BRANCH' by accident,
+If you've already committed locally to '${CURRENT_BRANCH}' by accident,
 the recovery is a three-step rescue (NOT a separate To-unblock — the
 gate is still the one above): create a recovery branch pointing at the
-current commit, reset $CURRENT_BRANCH to drop the accidental commit
+current commit, reset ${CURRENT_BRANCH} to drop the accidental commit
 locally, then check out the recovery branch.
 
        git branch feature/GH-<ticket>-recovery
-       git reset --hard HEAD~1   # drops the commit from $CURRENT_BRANCH
+       git reset --hard HEAD~1   # drops the commit from ${CURRENT_BRANCH}
        git checkout feature/GH-<ticket>-recovery
 MSG
     exit 2

--- a/.claude/hooks/tests/test_block_main_push.sh
+++ b/.claude/hooks/tests/test_block_main_push.sh
@@ -201,12 +201,7 @@ run_case "cd wt && git commit -am passes (worktree=feature, cwd=dev)" \
   "$SB" "$SB" "cd ${WT} && git commit -am 'wip'" 0
 
 # Worktree is on a protected branch — cd into it must still block.
-WT_PROTECTED=$(make_worktree "$SB" "main-local")
-# Detach and reattach to main: git worktree add creates a new branch by
-# default; we need to put a protected branch name in it.
-(cd "$SB" && git worktree add -q "$SB/wt-main" main 2>/dev/null || \
-  git worktree add -q "$SB/wt-main" -b main-protected 2>/dev/null || true)
-# Use a simpler approach: create a secondary repo on 'main' and point cd at it.
+# Use a secondary sandbox repo on 'main' and point cd at it.
 SB2=$(make_sandbox "main")   # second sandbox with primary on main
 run_case "cd protected-wt && git commit blocks (worktree on main)" \
   "$SB" "$SB" "cd ${SB2} && git commit -m 'bad'" 2

--- a/.claude/hooks/tests/test_block_main_push.sh
+++ b/.claude/hooks/tests/test_block_main_push.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+# Tests for block-main-push.sh worktree-safe fix (me2resh/apexyard#549).
+#
+# The bug: the hook resolved the current branch via `git branch --show-current`
+# in the hook's cwd (the harness primary checkout). When the primary checkout
+# sat on a protected branch (e.g. `dev`) but the actual operation targeted a
+# feature-branch worktree via `cd ../wt && git commit`, the hook false-blocked.
+#
+# The fix:
+#   Push:   read the DESTINATION branch from the push command via
+#           _lib-extract-push-ref.sh (same lib as validate-branch-name.sh).
+#           A push whose explicit destination is a non-protected branch passes
+#           even when the session cwd is on a protected branch.
+#   Commit: detect `cd <path> && git commit` and resolve the branch of the
+#           TARGET worktree (`git -C <path> branch --show-current`) instead
+#           of the session cwd.
+#
+# Test cases:
+#   (a) push to a protected branch still blocks                  [regression]
+#   (b) push to a feature branch passes when cwd is on dev/main  [bug fix]
+#   (c) tag push passes                                           [regression]
+#   (d) cd ../wt && git commit on feature-branch wt passes        [bug fix]
+#       while the session cwd is on dev
+#   (e) plain git commit on a protected branch still blocks       [regression]
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/block-main-push.sh"
+LIB_SRC="$SRC_ROOT/.claude/hooks/_lib-extract-push-ref.sh"
+LIB_CONFIG_SRC="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+LIB_OPS_ROOT_SRC="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
+
+for f in "$HOOK_SRC" "$LIB_SRC"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: required source missing: $f" >&2
+    exit 1
+  fi
+done
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# make_git_repo <dir> <branch>
+# Initialise a minimal git repo checked out to <branch>.
+make_git_repo() {
+  local dir="$1" branch="$2"
+  mkdir -p "$dir"
+  (
+    cd "$dir" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    : > README
+    git add README
+    git commit -q -m "init"
+    git checkout -q -B "$branch"
+  )
+}
+
+# make_sandbox <primary-branch>
+# Build an isolated sandbox with:
+#   $sb/          — the PRIMARY checkout (session cwd), on <primary-branch>
+#   $sb/.claude/hooks/  — the hook + libs
+#
+# Returns the sandbox root path in $SANDBOX_ROOT.
+make_sandbox() {
+  local primary_branch="${1:-dev}"
+  local sb
+  sb=$(mktemp -d)
+
+  # Primary checkout — the harness cwd is here.
+  make_git_repo "$sb" "$primary_branch"
+
+  # Install hook + libs.
+  mkdir -p "$sb/.claude/hooks"
+  cp "$HOOK_SRC"        "$sb/.claude/hooks/block-main-push.sh"
+  cp "$LIB_SRC"         "$sb/.claude/hooks/_lib-extract-push-ref.sh"
+  if [ -f "$LIB_CONFIG_SRC" ]; then
+    cp "$LIB_CONFIG_SRC"  "$sb/.claude/hooks/_lib-read-config.sh"
+  fi
+  if [ -f "$LIB_OPS_ROOT_SRC" ]; then
+    cp "$LIB_OPS_ROOT_SRC" "$sb/.claude/hooks/_lib-ops-root.sh"
+  fi
+  if [ -f "$SRC_ROOT/.claude/project-config.defaults.json" ]; then
+    cp "$SRC_ROOT/.claude/project-config.defaults.json" \
+       "$sb/.claude/project-config.defaults.json"
+  fi
+  chmod +x "$sb/.claude/hooks/block-main-push.sh"
+
+  echo "$sb"
+}
+
+# make_worktree <sandbox-root> <feature-branch>
+# Add a linked git worktree at $sb/wt checked out to <feature-branch>.
+make_worktree() {
+  local sb="$1" branch="$2"
+  (
+    cd "$sb" || exit 1
+    git worktree add -q -b "$branch" "$sb/wt"
+  )
+  echo "$sb/wt"
+}
+
+# run_case <label> <sandbox-root> <cwd-for-hook> <command> <want-rc>
+# Pipe the command as a PreToolUse JSON payload to block-main-push.sh
+# evaluated with cwd set to <cwd-for-hook>.
+run_case() {
+  local label="$1" sb="$2" hook_cwd="$3" cmd="$4" want_rc="$5"
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_rc got_stderr
+  got_stderr=$(cd "$hook_cwd" && echo "$input" | bash .claude/hooks/block-main-push.sh 2>&1 >/dev/null)
+  got_rc=$?
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc" >&2
+    echo "    cmd:    $cmd" >&2
+    echo "    stderr: ${got_stderr:0:300}" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# ---------------------------------------------------------------------------
+# (a) Push to a protected branch still blocks — regardless of session cwd
+# ---------------------------------------------------------------------------
+SB=$(make_sandbox "feature/GH-1-safe")   # cwd on a NON-protected branch
+run_case "push to main blocks (explicit ref)" \
+  "$SB" "$SB" "git push origin main" 2
+run_case "push to dev blocks (explicit ref)" \
+  "$SB" "$SB" "git push upstream dev" 2
+run_case "push to master blocks" \
+  "$SB" "$SB" "git push origin master" 2
+run_case "push to develop blocks" \
+  "$SB" "$SB" "git push origin develop" 2
+run_case "push HEAD:main (refspec dst) blocks" \
+  "$SB" "$SB" "git push origin HEAD:main" 2
+run_case "push HEAD:dev (refspec dst) blocks" \
+  "$SB" "$SB" "git push upstream HEAD:dev" 2
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# (b) Push to a feature branch passes even when session cwd is on dev
+#     This is the primary regression from #549.
+# ---------------------------------------------------------------------------
+SB=$(make_sandbox "dev")   # cwd is on PROTECTED branch 'dev'
+run_case "push feature branch passes (cwd=dev, explicit ref)" \
+  "$SB" "$SB" "git push origin feature/GH-549-fix" 0
+run_case "push fix branch passes (cwd=dev, -u flag)" \
+  "$SB" "$SB" "git push -u origin fix/GH-100-foo" 0
+run_case "push with HEAD:feature refspec passes (cwd=dev)" \
+  "$SB" "$SB" "git push upstream HEAD:feature/GH-549-fix" 0
+run_case "push feature branch passes (cwd=dev, --force)" \
+  "$SB" "$SB" "git push --force origin feature/GH-1-bar" 0
+
+# Bare push with no explicit ref falls back to local HEAD (dev) → should block.
+run_case "bare push (no ref) on dev falls back to local HEAD → blocks" \
+  "$SB" "$SB" "git push" 2
+run_case "push origin (no ref) on dev falls back to local HEAD → blocks" \
+  "$SB" "$SB" "git push origin" 2
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# (c) Tag push passes — never subject to branch-protection check
+# ---------------------------------------------------------------------------
+SB=$(make_sandbox "dev")   # cwd on protected branch
+run_case "tag push --tags passes (cwd=dev)" \
+  "$SB" "$SB" "git push origin --tags" 0
+run_case "tag push refs/tags/ passes (cwd=dev)" \
+  "$SB" "$SB" "git push origin refs/tags/v1.0.0:refs/tags/v1.0.0" 0
+run_case "tag push 'tag <name>' passes (cwd=dev)" \
+  "$SB" "$SB" "git push upstream tag v3.0.0" 0
+run_case "tag push --tags with 2>&1 pipe passes" \
+  "$SB" "$SB" "git push upstream --tags 2>&1 | tail -5" 0
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# (d) cd <path> && git commit on a feature-branch worktree passes
+#     while the session cwd is on a protected branch (the #549 scenario).
+# ---------------------------------------------------------------------------
+SB=$(make_sandbox "dev")   # primary checkout on protected 'dev'
+WT=$(make_worktree "$SB" "feature/GH-549-worktree-fix")
+
+# The hook cwd is the primary checkout ($SB, on 'dev').
+# The command targets the worktree via 'cd'.
+run_case "cd wt && git commit passes (worktree=feature, cwd=dev)" \
+  "$SB" "$SB" "cd ${WT} && git commit -m 'wip'" 0
+
+run_case "cd wt && git commit -am passes (worktree=feature, cwd=dev)" \
+  "$SB" "$SB" "cd ${WT} && git commit -am 'wip'" 0
+
+# Worktree is on a protected branch — cd into it must still block.
+WT_PROTECTED=$(make_worktree "$SB" "main-local")
+# Detach and reattach to main: git worktree add creates a new branch by
+# default; we need to put a protected branch name in it.
+(cd "$SB" && git worktree add -q "$SB/wt-main" main 2>/dev/null || \
+  git worktree add -q "$SB/wt-main" -b main-protected 2>/dev/null || true)
+# Use a simpler approach: create a secondary repo on 'main' and point cd at it.
+SB2=$(make_sandbox "main")   # second sandbox with primary on main
+run_case "cd protected-wt && git commit blocks (worktree on main)" \
+  "$SB" "$SB" "cd ${SB2} && git commit -m 'bad'" 2
+rm -rf "$SB2"
+
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# (e) Plain git commit on a protected branch still blocks — regression
+# ---------------------------------------------------------------------------
+SB=$(make_sandbox "main")   # cwd on protected 'main'
+run_case "plain git commit on main blocks" \
+  "$SB" "$SB" "git commit -m 'bad'" 2
+rm -rf "$SB"
+
+# Rebuild cleanly for the dev case.
+SB=$(make_sandbox "dev")
+run_case "plain git commit on dev blocks" \
+  "$SB" "$SB" "git commit -m 'bad'" 2
+run_case "plain git commit -am on dev blocks (clean sandbox)" \
+  "$SB" "$SB" "git commit -am 'bad'" 2
+run_case "plain git commit --allow-empty on dev blocks" \
+  "$SB" "$SB" "git commit --allow-empty -m 'bad'" 2
+rm -rf "$SB"
+
+# Plain commit on a feature branch must pass.
+SB=$(make_sandbox "feature/GH-549-fix")
+run_case "plain git commit on feature branch passes" \
+  "$SB" "$SB" "git commit -m 'good'" 0
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Non-git commands must be no-ops.
+# ---------------------------------------------------------------------------
+SB=$(make_sandbox "dev")
+run_case "non-git command is no-op" \
+  "$SB" "$SB" "echo hello" 0
+run_case "gh pr create is no-op" \
+  "$SB" "$SB" "gh pr create --base dev --head feature/GH-1-foo" 0
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_block_main_push.sh
+++ b/.claude/hooks/tests/test_block_main_push.sh
@@ -212,6 +212,28 @@ run_case "cd protected-wt && git commit blocks (worktree on main)" \
   "$SB" "$SB" "cd ${SB2} && git commit -m 'bad'" 2
 rm -rf "$SB2"
 
+# --- #580 review follow-ups: quoted-path + chained-cd resolution ---
+SB3=$(make_sandbox "main")   # a separate checkout on protected 'main'
+
+# Quoted cd into a protected worktree must STILL block. Before the fix the
+# quotes reached `git -C`, which errored → empty branch → silent slip-through.
+run_case "cd \"protected\" (double-quoted) && commit blocks" \
+  "$SB" "$SB" "cd \"${SB3}\" && git commit -m 'bad'" 2
+run_case "cd 'protected' (single-quoted) && commit blocks" \
+  "$SB" "$SB" "cd '${SB3}' && git commit -m 'bad'" 2
+
+# Quoted cd into a feature worktree must still PASS (quote-strip must not over-block).
+run_case "cd \"feature-wt\" (quoted) && commit passes" \
+  "$SB" "$SB" "cd \"${WT}\" && git commit -m 'wip'" 0
+
+# Chained cd resolves the LAST target, not the first.
+run_case "chained cd: last=feature passes (cd main && cd wt && commit)" \
+  "$SB" "$SB" "cd ${SB3} && cd ${WT} && git commit -m 'wip'" 0
+run_case "chained cd: last=protected blocks (cd wt && cd main && commit)" \
+  "$SB" "$SB" "cd ${WT} && cd ${SB3} && git commit -m 'bad'" 2
+
+rm -rf "$SB3"
+
 rm -rf "$SB"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fixed false-blocking of feature-branch pushes when session cwd is on a protected branch** — the hook previously called `git branch --show-current` against the hook's cwd (the harness primary checkout). When the primary checkout sat on `dev` or `main` but the actual `git push` targeted a feature branch, the hook blocked the push incorrectly. Now reuses `_lib-extract-push-ref.sh` (the same lib `validate-branch-name.sh` uses for the identical worktree-cwd problem, #194/#547) to read the DESTINATION branch directly from the push command — the ground truth regardless of $PWD.
- **Fixed false-blocking of worktree commits made via `cd <path> && git commit`** — for compound shell commands that `cd` into a different worktree before committing, the hook now resolves the branch of the TARGET worktree via `git -C <path> branch --show-current` instead of the session cwd. Plain `git commit` (no `cd` prefix) retains the original behaviour, preserving the normal single-worktree case.
- **Added 26-case test suite** (`test_block_main_push.sh`) covering all five required scenarios: push to protected still blocks, push to feature branch passes when cwd=dev, tag push passes, `cd wt && git commit` on a feature-branch worktree passes while cwd=dev, and plain commit on a protected branch still blocks.

## Testing

```bash
bash .claude/hooks/tests/test_block_main_push.sh
# Expected: PASS: 26  FAIL: 0
```

To reproduce the original bug manually:
1. Check out the primary checkout to `dev` (a protected branch).
2. `git worktree add ../wt some-feature-branch`.
3. From a context whose cwd is the primary checkout, run:
   `echo '{"tool_input":{"command":"cd ../wt && git commit -m test"}}' | bash .claude/hooks/block-main-push.sh`
4. Before fix: exits 2 (false block). After fix: exits 0.

Refs #549

---

## Glossary

| Term | Definition |
|------|------------|
| Worktree | A linked working tree (`git worktree`) that shares one git object store but is checked out to a different branch/directory. The harness fan-out pattern creates one worktree per parallel agent. |
| Session cwd | The working directory the Claude Code harness resets to before each tool call — typically the primary checkout of the ops repo, which may be on a protected branch even during feature-branch work happening in a sibling worktree. |
| Protected branch | A long-lived integration branch (`main`, `master`, `dev`, `develop`) that must not receive direct commits or pushes; all changes must go through a PR. Configurable via `.claude/project-config.json → .git.protected_branches[]`. |
| Destination branch (push) | The remote branch that a `git push` will write to, extracted from the command's explicit ref or `src:dst` refspec. Distinct from the source branch, which may be `HEAD` or a local tracking branch. |
| `_lib-extract-push-ref.sh` | Shared bash library that parses the destination branch from a `git push` command string, handling flags, refspecs, redirections, and tag pushes. Already used by `validate-branch-name.sh` for the same worktree-cwd reason. |