### PR TITLE
fix(#568): PR extractor ignores redirection tokens + unexpanded var args

### DIFF
--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -48,20 +48,75 @@ is_merge_command() {
 # Echoes the PR number extracted from the command, or empty if none found.
 # Tries (in order):
 #   1. `gh api .../pulls/<N>/merge` URL path
-#   2. `gh pr merge <N>` first numeric arg
+#   2. `gh pr merge <N>` first numeric arg (strict: must be a bare integer token
+#      immediately following `merge`; NOT a digit scraped from a redirection such
+#      as `2>&1`, and NOT an unexpanded shell variable such as `$pr` or `$PR`).
+#      When the token is a shell variable the function returns empty so the
+#      caller's step-3 fallback can invoke `gh pr view`.
 #   3. falls back to `gh pr view --json number` (current branch's PR)
+#
+# BUG #568 — root cause and fix:
+#   The old step-2 span `[^|;&]*` included `2>&1` because the `&` lookahead
+#   was not anchored before the pipe, causing `grep -oE '[0-9]+'` to return `2`
+#   (the stderr fd number) instead of the PR number when the invocation was
+#   `gh pr merge $pr --squash 2>&1 | tail -5` and `$pr` was unexpanded at hook
+#   evaluation time.
+#
+#   Fix: strip redirection tokens from the span before the digit search, then
+#   require that the first post-`merge` token is a bare integer — not a shell
+#   variable, not a flag. If it is a variable or absent, return empty.
 extract_pr_number() {
   local cmd="$1"
   local pr=""
 
   # 1. gh api path extraction — greps the /pulls/<N>/merge segment directly.
+  #    The PR number lives in the URL path, so redirections cannot affect it.
   pr=$(echo "$cmd" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | grep -oE '/pulls/[0-9]+/' | grep -oE '[0-9]+' | head -1)
 
-  # 2. gh pr merge positional arg — first bare number after `gh pr merge`,
-  #    ignoring anything on the right side of a pipe / && / ; to avoid picking
-  #    up a number from a follow-up command.
+  # 2. gh pr merge positional arg.
   if [ -z "$pr" ]; then
-    pr=$(echo "$cmd" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*' | grep -oE '[0-9]+' | head -1)
+    # a) Isolate the `gh pr merge …` span up to the first shell separator
+    #    (pipe, &&, ;). The [^|;&]* fence keeps us from reading past a piped
+    #    follow-up command (e.g. `| tail -5`).
+    local span
+    span=$(echo "$cmd" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*')
+
+    # b) Strip all redirection tokens so that `2>&1`, `2>file`, `&>file`,
+    #    `>>file`, `>file` etc. cannot contribute digits to the PR search.
+    #    Patterns (ordered most-specific first to avoid partial matches):
+    #      [0-9]*>&[0-9]*   — fd-to-fd redirections like `2>&1`, `1>&2`
+    #      &>[^[:space:]]*  — Bash &> combined redirect
+    #      >>[^[:space:]]* — append redirect
+    #      >[^[:space:]]*  — overwrite redirect
+    local clean_span
+    clean_span=$(echo "$span" | sed \
+      -e 's/[0-9]*>&[0-9]*/  /g' \
+      -e 's/&>[^[:space:]]*/  /g' \
+      -e 's/>>[^[:space:]]*/  /g' \
+      -e 's/>[^[:space:]]*/  /g')
+
+    # c) After `merge`, take the first whitespace-delimited token.
+    #    - If it starts with `$` → unexpanded variable → PR number unknown.
+    #      Return empty; step 3 will ask `gh pr view`.
+    #    - If it is a bare integer → that is the PR number.
+    #    - Anything else (flag, string) → no literal PR number present;
+    #      return empty. Do NOT scan further for stray digits — that is
+    #      precisely the bug.
+    #
+    #    Use `grep -oE '\bmerge\b …'` rather than `sed 's/.*\bmerge\b…'`
+    #    because BSD sed on macOS does not support \b word boundaries.
+    local first_token
+    first_token=$(echo "$clean_span" | grep -oE '\bmerge\b[[:space:]]+[^[:space:]]*' | awk 'NR==1 {print $NF}')
+
+    if echo "$first_token" | grep -qE '^\$'; then
+      # Unexpanded variable — cannot determine PR number from command text.
+      pr=""
+    elif echo "$first_token" | grep -qE '^[0-9]+$'; then
+      pr="$first_token"
+    else
+      # No bare integer immediately after merge; leave pr empty.
+      pr=""
+    fi
   fi
 
   # 3. Last resort: ask gh which PR the current branch points at.

--- a/.claude/hooks/tests/test_extract_pr.sh
+++ b/.claude/hooks/tests/test_extract_pr.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Tests for extract_pr_number() in _lib-extract-pr.sh — regression suite for
+# bug #568 (stderr redirect `2>&1` digit contamination when PR arg is a shell
+# variable) plus happy-path and gh-api-shape coverage.
+#
+# Cases:
+#   1. `gh pr merge 42 --squash`                              → 42
+#   2. `gh pr merge 42 --squash 2>&1 | tail -5`              → 42 (NOT 2)
+#   3. `gh pr merge $pr --squash 2>&1`                       → empty (unexpanded var)
+#   4. `gh api repos/o/r/pulls/42/merge -X PUT`              → 42
+#   5. `gh api .../pulls/7/merge 2>&1`                       → 7  (NOT 2)
+#   6. `gh pr merge 123 --repo foo/bar --squash 2>&1 | tail` → 123 (NOT 2)
+#   7. `gh pr merge ${PR_NUMBER} --squash`                   → empty (unexpanded braces)
+#   8. `gh pr merge 42 2>err.log`                            → 42 (NOT 2)
+#   9. `gh pr merge 42 &>out.log`                            → 42
+#  10. `gh pr merge 42 >>out.log`                            → 42
+#
+# Note: cases where pr="" fall through to the `gh pr view` fallback inside the
+# real library. In these tests we only source the library function and do NOT
+# mock `gh`, so the fallback will also return empty (no real GitHub API call).
+# That is intentional — we are testing the string-parsing layer only.
+#
+# Exit 0 if all cases pass; exit 1 on first failure.
+
+set -u
+
+LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-extract-pr.sh"
+if [ ! -f "$LIB_SRC" ]; then
+  echo "FAIL: lib not found at $LIB_SRC" >&2
+  exit 1
+fi
+
+# Source the library. We need to shim `gh` so that the step-3 fallback
+# (`gh pr view …`) returns empty rather than making a real network call.
+# Drop a minimal shim on PATH before sourcing.
+SHIM_DIR=$(mktemp -d)
+cat > "$SHIM_DIR/gh" <<'GHEOF'
+#!/bin/bash
+# Shim: return empty for all calls — test only cares about string parsing.
+exit 0
+GHEOF
+chmod +x "$SHIM_DIR/gh"
+export PATH="$SHIM_DIR:$PATH"
+
+# shellcheck source=/dev/null
+. "$LIB_SRC"
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+assert_pr() {
+  local label="$1" cmd="$2" want="$3"
+  local got
+  got=$(extract_pr_number "$cmd")
+  if [ "$got" = "$want" ]; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label]: cmd=[$cmd]  want=[$want]  got=[$got]" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+  fi
+}
+
+# --- Happy path: literal PR number, no redirections ----------------------
+
+assert_pr "plain merge 42" \
+  "gh pr merge 42 --squash" \
+  "42"
+
+assert_pr "merge with --repo flag" \
+  "gh pr merge 99 --repo me2resh/apexyard --squash" \
+  "99"
+
+# --- Bug #568: redirect tokens must not donate digits --------------------
+
+# Core repro: 2>&1 before a pipe — the old code returned 2 here.
+assert_pr "merge 42 with 2>&1 pipe (bug #568 repro)" \
+  "gh pr merge 42 --squash 2>&1 | tail -5" \
+  "42"
+
+# Unexpanded shell variable + 2>&1: old code returned 2, correct is empty.
+assert_pr "merge \$pr with 2>&1 → empty (var unexpanded)" \
+  'gh pr merge $pr --squash 2>&1' \
+  ""
+
+# Curly-brace unexpanded variable.
+assert_pr "merge \${PR_NUMBER} → empty (var unexpanded)" \
+  'gh pr merge ${PR_NUMBER} --squash' \
+  ""
+
+# Append redirect (>>).
+assert_pr "merge 42 with >> redirect" \
+  "gh pr merge 42 >>out.log" \
+  "42"
+
+# Overwrite redirect (>).
+assert_pr "merge 42 with > redirect" \
+  "gh pr merge 42 >out.log" \
+  "42"
+
+# Combined Bash &> redirect.
+assert_pr "merge 42 with &> redirect" \
+  "gh pr merge 42 &>out.log" \
+  "42"
+
+# fd-specific write redirect.
+assert_pr "merge 42 with 2>err.log" \
+  "gh pr merge 42 2>err.log" \
+  "42"
+
+# All together: repo flag, redirect, pipe.
+assert_pr "merge 123 with --repo + 2>&1 + pipe" \
+  "gh pr merge 123 --repo foo/bar --squash 2>&1 | tail" \
+  "123"
+
+# --- gh api URL path shape -----------------------------------------------
+
+assert_pr "gh api pulls/42/merge" \
+  "gh api repos/o/r/pulls/42/merge -X PUT" \
+  "42"
+
+# gh api with 2>&1 — the 2 must NOT win; the URL path number must.
+assert_pr "gh api pulls/7/merge with 2>&1" \
+  "gh api repos/me2resh/apexyard/pulls/7/merge -X PUT 2>&1" \
+  "7"
+
+# --- Edge cases ----------------------------------------------------------
+
+# No PR number at all → empty (triggers gh pr view fallback, returns empty in test).
+assert_pr "merge with no number → empty" \
+  "gh pr merge --squash" \
+  ""
+
+# Unrelated command → empty.
+assert_pr "gh pr view is not a merge command" \
+  "gh pr view 42" \
+  ""
+
+# --- Cleanup -------------------------------------------------------------
+rm -rf "$SHIM_DIR"
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **Stripped redirection operators before digit search** — the old `extract_pr_number` step 2 used `grep -oE '[0-9]+' | head -1` on the raw span `gh pr merge … 2>&1`, which returned `2` (the stderr file-descriptor number) instead of the real PR number. The fix strips all fd-to-fd (`2>&1`), combined (`&>`), append (`>>`), and overwrite redirect (`>file`) tokens from the span before any digit match, so redirection syntax can no longer donate digits to the extractor.

- **Unexpanded shell variable → return empty, not a stray digit** — when a caller uses a loop variable (`gh pr merge $pr --squash 2>&1`) and `$pr` is unexpanded at hook-eval time, the fixed extractor detects that the first post-`merge` token starts with `$` and returns empty. The existing `gh pr view` fallback (step 3) then resolves the PR from the current branch, instead of the extractor fabricating a wrong PR number from the redirect.

- **Portable word-boundary extraction** — replaced `sed 's/.*\bmerge\b…'` (BSD sed on macOS does not support `\b`) with `grep -oE '\bmerge\b[[:space:]]+[^[:space:]]*'`, which works correctly on both GNU and BSD (macOS) grep.

- **Focused regression test `test_extract_pr.sh`** — 14 unit tests for `extract_pr_number` covering: bare merge with literal number, all redirect forms (`2>&1`, `2>`, `&>`, `>>`, `>`), unexpanded `$var` and `${VAR}`, the `gh api` URL path shape, and edge cases (no number after merge, non-merge command). All 14 pass; the 29 existing `test_block_unreviewed_merge.sh` cases continue to pass.

## Testing

```
# Run the new focused test
bash .claude/hooks/tests/test_extract_pr.sh
# Expected: 14 PASS, 0 FAIL

# Run the existing merge-gate regression suite
bash .claude/hooks/tests/test_block_unreviewed_merge.sh
# Expected: 29 PASS, 0 FAIL
```

Live repro (issue #568): running `gh pr merge $pr --repo "$REPO" --squash --delete-branch 2>&1 | tail -5` inside a `for pr in 564 565 566; do …` loop — where `$pr` is a literal string at hook-eval time — caused `block-unreviewed-merge.sh` to block with `BLOCKED: PR #2 has no recorded code-reviewer approval`, latching onto the `2` from `2>&1` instead of the real PR number.

Refs #568

---

## Glossary

| Term | Definition |
|------|------------|
| PR extractor | `extract_pr_number()` in `_lib-extract-pr.sh` — the shared function that parses a PR number from a `gh pr merge` or `gh api …/pulls/N/merge` command string; used by all four merge-gate hooks. |
| Stderr redirect (`2>&1`) | Shell syntax that sends file descriptor 2 (stderr) to file descriptor 1 (stdout). The `2` is an fd number, not a PR number — the bug was confusing the two. |
| Unexpanded shell variable | A variable reference like `$pr` or `${PR_NUMBER}` that is present as a literal string in the command text evaluated by the hook, because the hook receives the raw command before the shell expands variables in loop bodies. |
| `gh pr view` fallback (step 3) | The last-resort lookup in `extract_pr_number` — when string parsing cannot determine the PR number, the function calls `gh pr view --json number` to ask GitHub which PR the current branch points at. |