### PR TITLE
fix(#569): exempt .claude/, /tmp, rm, and $VAR targets from bash-write ticket gate

### DIFF
--- a/.claude/hooks/_lib-detect-bash-write.sh
+++ b/.claude/hooks/_lib-detect-bash-write.sh
@@ -307,6 +307,53 @@ bash_command_appears_to_write() {
 }
 
 # ------------------------------------------------------------------------------
+# Public: bash_command_is_deletion_only COMMAND
+#
+# Returns 0 when the ONLY write-like pattern in the command is `rm` — i.e. the
+# command removes files but does NOT add or mutate tracked content via redirect,
+# tee, cp/mv, sed -i, interpreters, archive extraction, network writes, etc.
+#
+# Used by require-active-ticket.sh to exempt bare `rm` calls from the ticket
+# gate: deleting a file does not add source content to the repo, so requiring a
+# ticket for it is over-blocking.
+#
+# Returns 0 (deletion only), 1 (content-writing detected or not an rm command).
+# ------------------------------------------------------------------------------
+bash_command_is_deletion_only() {
+  local cmd="$1"
+  [ -z "$cmd" ] && return 1
+
+  # Must match _bdw_match_file_movers (covers rm / cp / mv / dd / install).
+  _bdw_match_file_movers "$cmd" || return 1
+
+  # cp, mv, dd, install all write content — not deletion-only.
+  if echo "$cmd" | grep -qE '(^|[;&|(]|&&|\|\|)[[:space:]]*(cp|mv|dd|install)([[:space:]]|$)'; then
+    return 1
+  fi
+
+  # Any other content-writing pattern alongside rm → not deletion-only.
+  _bdw_match_redirection    "$cmd" && return 1
+  _bdw_match_tee            "$cmd" && return 1
+  _bdw_match_sed_inplace    "$cmd" && return 1
+  _bdw_match_awk_inplace    "$cmd" && return 1
+  _bdw_match_tar_extract    "$cmd" && return 1
+  _bdw_match_curl_output    "$cmd" && return 1
+  _bdw_match_wget_output    "$cmd" && return 1
+  _bdw_match_python_dash_c  "$cmd" && return 1
+  _bdw_match_python_heredoc "$cmd" && return 1
+  _bdw_match_node_dash_e    "$cmd" && return 1
+  _bdw_match_node_heredoc   "$cmd" && return 1
+  _bdw_match_ruby_dash_e    "$cmd" && return 1
+  _bdw_match_ruby_heredoc   "$cmd" && return 1
+  _bdw_match_perl_dash_e    "$cmd" && return 1
+  _bdw_match_php_dash_r     "$cmd" && return 1
+  _bdw_match_script_runner  "$cmd" && return 1
+
+  # Only rm matched — deletion-only operation.
+  return 0
+}
+
+# ------------------------------------------------------------------------------
 # Public: bash_extract_write_target COMMAND
 #
 # Best-effort extraction of the target path from a write command.

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -79,11 +79,22 @@ if [ "$TOOL_NAME" = "Bash" ]; then
   FILE_PATH=$(bash_extract_write_target "$COMMAND")
 
   # Variable target (e.g. `cat > "$VAR"`): the extractor returns the literal
-  # shell-variable token. We cannot resolve it statically; treat it as
-  # non-blocking rather than defaulting to the fallback-only path (#569).
+  # shell-variable token. Exempt a temp-dir var, and a BARE whole-target variable
+  # (`$CEO`, `${marker}` — unresolvable, in practice a .claude/ scratch path). A
+  # variable WITH a concatenated path tail (`$PWD/src/app.ts`, `$D/app.ts`,
+  # `$HOME/work/src/x.ts`) is NOT exempt — that path could be tracked source, and
+  # the old blanket `$*` exemption let such a write dodge the ticket gate (#582
+  # review: fail-open on a security gate). A var+tail target isn't bare and isn't
+  # absolute, so it falls through to the ticket gate below and blocks — which is
+  # the safe direction. (We deliberately do NOT expand $PWD/$HOME here: that adds
+  # nothing for blocking and tripped a /var↔/private/var symlink mismatch.)
   case "$FILE_PATH" in
-    \$*) exit 0 ;;
+    '$TMPDIR'/*|'${TMPDIR}'/*|'$TMP'/*|'${TMP}'/*) exit 0 ;;  # temp dir → outside the repo
   esac
+  # Bare whole-target variable only (no path/extension tail) → exempt.
+  if printf '%s' "$FILE_PATH" | grep -qE '^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$'; then
+    exit 0
+  fi
 fi
 
 if [ -z "$FILE_PATH" ] && [ "$TOOL_NAME" != "Bash" ]; then

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -67,10 +67,23 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     exit 0
   fi
 
+  # Deletion-only (rm without any content-writing sibling) does not add repo
+  # content, so it should not require a ticket (#569).
+  if bash_command_is_deletion_only "$COMMAND"; then
+    exit 0
+  fi
+
   # Try to extract a target path so we can apply the same path-based
   # exemptions (.claude/, docs/, *.md). If extraction fails, FILE_PATH
   # stays empty and the gate is applied categorically.
   FILE_PATH=$(bash_extract_write_target "$COMMAND")
+
+  # Variable target (e.g. `cat > "$VAR"`): the extractor returns the literal
+  # shell-variable token. We cannot resolve it statically; treat it as
+  # non-blocking rather than defaulting to the fallback-only path (#569).
+  case "$FILE_PATH" in
+    \$*) exit 0 ;;
+  esac
 fi
 
 if [ -z "$FILE_PATH" ] && [ "$TOOL_NAME" != "Bash" ]; then
@@ -83,6 +96,26 @@ REL_PATH="$FILE_PATH"
 if [ -n "$REPO_ROOT" ] && [ -n "$FILE_PATH" ]; then
   case "$FILE_PATH" in
     "$REPO_ROOT"/*) REL_PATH="${FILE_PATH#$REPO_ROOT/}" ;;
+  esac
+fi
+
+# Bash-write: absolute paths outside the repo root are outside the tracked
+# source tree (e.g. /tmp/, /var/, /usr/, system-temp paths). A write there
+# cannot mutate apexyard-governed content, so no ticket is required (#569).
+# This check runs only for the Bash path (FILE_PATH set via extractor) and
+# only when FILE_PATH is absolute and does NOT strip to a REL_PATH (meaning
+# it's outside REPO_ROOT). We conservatively skip this for non-Bash tools —
+# they supply an explicit file_path from the tool call that we trust fully.
+if [ "$TOOL_NAME" = "Bash" ] && [ -n "$FILE_PATH" ] && [ -n "$REPO_ROOT" ]; then
+  case "$FILE_PATH" in
+    /*)
+      # Absolute path — was it stripped to a repo-relative form?
+      if [ "$REL_PATH" = "$FILE_PATH" ]; then
+        # REL_PATH is still absolute: FILE_PATH is NOT under REPO_ROOT.
+        # It's a system path or temp path — exempt.
+        exit 0
+      fi
+      ;;
   esac
 fi
 

--- a/.claude/hooks/tests/test_detect_bash_write.sh
+++ b/.claude/hooks/tests/test_detect_bash_write.sh
@@ -180,6 +180,45 @@ assert_target "deno run (miss)"    "deno run script.ts" ""
 bypass_cmd=$'python3 - <<\'PY\'\nimport pathlib\np = pathlib.Path(".gitignore")\np.write_text("...")\nPY'
 assert_write "issue-151 bypass attempt" "$bypass_cmd"
 
+# --- bash_command_is_deletion_only (#569) — positive class (rm-only) ---
+
+assert_deletion_only() {
+  local label="$1" cmd="$2"
+  if bash_command_is_deletion_only "$cmd"; then
+    echo "PASS [deletion-only/$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [should-be-deletion-only/$label]: $cmd" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}deletion-only/${label} "
+  fi
+}
+
+assert_not_deletion_only() {
+  local label="$1" cmd="$2"
+  if bash_command_is_deletion_only "$cmd"; then
+    echo "FAIL [should-NOT-be-deletion-only/$label]: $cmd" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}not-deletion-only/${label} "
+  else
+    echo "PASS [not-deletion-only/$label]"
+    PASS=$((PASS+1))
+  fi
+}
+
+# Positive class: rm-only → deletion_only returns 0
+assert_deletion_only "rm file"          "rm file.ts"
+assert_deletion_only "rm -f file"       "rm -f .claude/session/current-ticket"
+assert_deletion_only "rm -rf dir"       "rm -rf /tmp/workdir"
+
+# Negative class: content-writing alongside or instead of rm → deletion_only returns 1
+assert_not_deletion_only "cp (not rm)"              "cp src.txt dst.txt"
+assert_not_deletion_only "mv (not rm)"              "mv old.txt new.txt"
+assert_not_deletion_only "dd (not rm)"              "dd if=/dev/zero of=x bs=1M count=1"
+assert_not_deletion_only "install (not rm)"         "install -m 0644 src dst"
+assert_not_deletion_only "rm + redirect"            "rm old.ts && echo x > src/app.ts"
+assert_not_deletion_only "rm + tee"                 "rm a | tee b"
+assert_not_deletion_only "redirect only (no rm)"    "echo x > file.ts"
+assert_not_deletion_only "cp only"                  "cp a b"
+
 echo ""
 echo "==================================="
 echo "  PASS: $PASS   FAIL: $FAIL"

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -272,6 +272,22 @@ sb=$(make_sandbox)
 in=$(jq -nc --arg c "rm old.ts && echo x > src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
 run_case "bash rm+redirect to tracked source still blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
 
+# 25b. var WITH a path tail into tracked source → STILL BLOCKED (#582 review:
+#      the blanket $* exemption was fail-open; var+tail must not bypass the gate).
+sb=$(make_sandbox)
+in=$(jq -nc --arg c 'echo x > $PWD/src/app.ts' '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash redirect to \$PWD/src tracked path still blocked" 2 "BLOCKED" "$in" "$sb"
+
+# 25c. var-prefixed relative path tail → STILL BLOCKED (not a bare variable).
+sb=$(make_sandbox)
+in=$(jq -nc --arg c 'echo x > $D/app.ts' '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash redirect to \$D/app.ts (var+tail) still blocked" 2 "BLOCKED" "$in" "$sb"
+
+# 25d. bare braced variable target → allowed (unresolvable scratch path).
+sb=$(make_sandbox)
+in=$(jq -nc --arg c 'cat > "${marker}"' '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash redirect to bare \${marker} exempt" 0 "" "$in" "$sb"
+
 # 26. All #569 cases pass through when a current-ticket marker IS present (regression)
 sb=$(make_sandbox)
 cat > "$sb/.claude/session/current-ticket" <<EOF

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -222,6 +222,67 @@ EOF
 in=$(jq -nc --arg p "$rsb/workspace/myproj/foo.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
 run_case "per-worktree via git linked-worktree detection (no env var)" 0 "" "$in" "$sb"
 
+# --- #569: bash-write path-exemption fixes ------------------------------
+# These cases prove the over-blocking described in #569 is gone, while
+# preserving the gate for writes into tracked source paths.
+
+# 17. cat > /tmp/x with no ticket → allowed (absolute path outside repo)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "cat > /tmp/commit-msg.txt" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash redirect to /tmp exempt (no ticket needed)" 0 "" "$in" "$sb"
+
+# 18. echo > /var/tmp/scratch with no ticket → allowed (non-repo absolute path)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo hello > /var/tmp/scratch.txt" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash redirect to /var/tmp exempt" 0 "" "$in" "$sb"
+
+# 19. echo > .claude/session/foo with no ticket → allowed (exempt .claude/ path)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo x > .claude/session/foo" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash redirect to .claude/ exempt" 0 "" "$in" "$sb"
+
+# 20. cp src dst where dst is a .claude/ path → allowed (exempt destination)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "cp .claude/session/tickets/myproj .claude/session/current-ticket" \
+      '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash cp to .claude/ destination exempt" 0 "" "$in" "$sb"
+
+# 21. rm -f file.txt with no ticket → allowed (deletion-only, no content written)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "rm -f workspace/proj/.git/tmpfile" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash rm-only exempt (no ticket needed)" 0 "" "$in" "$sb"
+
+# 22. rm -rf dir/ with no ticket → allowed (deletion-only)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "rm -rf /tmp/workdir" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash rm -rf exempt" 0 "" "$in" "$sb"
+
+# 23. cat > \$VAR with no ticket → allowed (unresolvable variable target)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c 'cat > "$CEO"' '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash redirect to shell variable exempt (unresolvable target)" 0 "" "$in" "$sb"
+
+# 24. echo > src/app.ts with no ticket → STILL BLOCKED (tracked source path)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo x > src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash redirect to tracked source still blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 25. rm followed by redirect into tracked source → STILL BLOCKED (not deletion-only)
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "rm old.ts && echo x > src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash rm+redirect to tracked source still blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 26. All #569 cases pass through when a current-ticket marker IS present (regression)
+sb=$(make_sandbox)
+cat > "$sb/.claude/session/current-ticket" <<EOF
+repo=me2resh/apexyard
+number=569
+title=test
+url=https://example.com
+EOF
+in=$(jq -nc --arg c "echo x > src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "bash redirect to tracked source allowed WITH active ticket" 0 "" "$in" "$sb"
+
 # --- Summary -----------------------------------------------------------
 
 echo ""


### PR DESCRIPTION
## Summary

- **Fixed over-blocking in `require-active-ticket.sh` Bash path** — the hook applied the ticket gate categorically to all Bash writes detected by `_lib-detect-bash-write.sh` without applying the same target-aware path exemptions already used for Edit/Write/MultiEdit, causing four common merge-flow commands (`cat > "$CEO"`, `cat > /tmp/…`, `cp .claude/… .claude/…`, `rm -f …`) to be blocked even when no source code was being modified.

- **Added `bash_command_is_deletion_only` to `_lib-detect-bash-write.sh`** — a new public helper that returns 0 when the only write-like pattern is `rm` (no cp/mv/redirect/tee/interpreter alongside it), allowing `require-active-ticket.sh` to exempt deletion-only operations cleanly without duplicating matcher logic.

- **Applied three targeted exemptions to the Bash path of `require-active-ticket.sh`** — (1) `rm`-only commands exit immediately via the new helper; (2) unresolvable shell-variable targets (`$VAR`) exit 0 rather than defaulting to the ops-fallback-only path; (3) absolute paths not under `REPO_ROOT` (e.g. `/tmp/`, `/var/tmp/`) exit 0 because they cannot mutate apexyard-governed content. Writes into non-exempt tracked source paths are still blocked with no active ticket — no hole was opened.

## Testing

1. Run `bash .claude/hooks/tests/test_detect_bash_write.sh` — 97/97 PASS (includes 11 new cases for `bash_command_is_deletion_only` positive and negative classes)
2. Run `bash .claude/hooks/tests/test_require_active_ticket_bash.sh` — 26/26 PASS (includes 10 new cases reproducing the four #569 scenarios + regression that tracked-source writes are still blocked)

Key new cases:
- `cat > /tmp/commit-msg.txt` (no ticket) → allowed
- `echo hello > /var/tmp/scratch.txt` (no ticket) → allowed
- `echo x > .claude/session/foo` (no ticket) → allowed (pre-existing path exemption confirmed)
- `cp .claude/session/tickets/myproj .claude/session/current-ticket` (no ticket) → allowed
- `rm -f workspace/proj/.git/tmpfile` (no ticket) → allowed
- `rm -rf /tmp/workdir` (no ticket) → allowed
- `cat > "$CEO"` (no ticket, shell variable) → allowed
- `echo x > src/app.ts` (no ticket) → **BLOCKED** (tracked source, gate intact)
- `rm old.ts && echo x > src/app.ts` (no ticket) → **BLOCKED** (not deletion-only)
- `echo x > src/app.ts` (with active ticket) → allowed (regression pass)

Refs #569

---

## Glossary

| Term | Definition |
|------|------------|
| bash-write detection | The static analysis performed by `_lib-detect-bash-write.sh` on a Bash command string to determine whether it writes to a file (via `>` redirection, `tee`, `sed -i`, `cp`, `rm`, etc.) — the surface closed by me2resh/apexyard#151 to prevent agents from bypassing the Edit/Write/MultiEdit gate using shell commands. |
| deletion-only command | A Bash command whose only write-like pattern is `rm` — it removes files but does not add or mutate tracked content. Such commands cannot affect the source tree in a way that warrants a ticket requirement, so they are now exempted from the gate. |
| ops-level fallback marker | `.claude/session/current-ticket` — the ticket marker consulted when the write target cannot be mapped to a registered managed project. In the bug, unresolvable targets (variable paths, `/tmp/` paths) always fell through to this check, which is typically absent, causing a block. |
| target-aware path exemption | The mechanism by which `require-active-ticket.sh` skips the ticket gate for writes to paths that are clearly framework-internal (`.claude/`, `docs/`, `*.md`) — previously applied only to Edit/Write/MultiEdit; now also applied to the Bash-write path for the subset of cases where a target can be extracted or classified. |