### PR TITLE
ci(#588): exempt dependabot/sync branches from ticket-ID check; target dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
   # (e.g. a build tool under site/), add its ecosystem here. #518.
   - package-ecosystem: "github-actions"
     directory: "/"
+    # Follow the release-cut model — open bump PRs against dev, not the default
+    # main branch (main only receives release PRs, AgDR-0007). #588.
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -26,6 +26,16 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
+            const headRef = context.payload.pull_request.head.ref || '';
+
+            // Bot / automation branches carry no ticket by design — dependabot
+            // bump PRs ("chore: bump X from A to B") and release-sync merges.
+            // Exempt them, mirroring the local hooks' sync/ exemption (#545).
+            // See #588.
+            if (/^(dependabot\/|sync\/)/.test(headRef)) {
+              console.log(`✅ Exempt automation branch (${headRef}) — ticket ID not required.`);
+              return;
+            }
 
             // Pattern matches:
             //   Project tracker: ABC-123, ENG-456, PROJ-789 (2-10 char uppercase prefix + dash + digits)


### PR DESCRIPTION
## Summary

- **`pr-title-check.yml`** — the "Verify Ticket ID" job now early-returns success when the PR head ref starts with `dependabot/` or `sync/`. Dependabot bump PRs and release-sync merges carry no ticket ID by design, so they were failing the check on every run (#539–#543); this mirrors the local hooks' existing `sync/` exemption (#545). Normal feature PRs are unaffected — they still require a ticket ID.
- **`dependabot.yml`** — set `target-branch: dev` so future bump PRs open against `dev` (the daily-work trunk) instead of `main`, per the release-cut model where `main` only receives release PRs.

## Testing

1. The exemption is a head-ref regex check at the top of the script step; a `dependabot/*` PR hits the early-return and logs "Exempt automation branch". Verified by reading the control flow — once this lands on `dev`, retargeting #539–#543 to `dev` will re-run the check from `dev`'s workflow and pass.
2. A normal `feature/GH-x-…` branch still falls through to the existing tracker/GitHub-issue pattern match (unchanged).

Closes #588

## Glossary

| Term | Definition |
|------|------------|
| Verify Ticket ID | The `pr-title-check.yml` CI job that fails a PR whose title lacks a tracker / GitHub ticket ID. |
| Release-cut model | Daily PRs merge to `dev`; `main` only receives release PRs (AgDR-0007). |
| `target-branch` | dependabot.yml setting controlling which branch its PRs open against. |