### PR TITLE
ci(#590): bump upload-artifact v4→v7 + codeql-action v3→v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,12 +37,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/extract-subpacks-on-release.yml
+++ b/.github/workflows/extract-subpacks-on-release.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload extracted sub-packs as build artefacts
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: marketplace-subpacks
           path: marketplace/

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -38,13 +38,13 @@ jobs:
           publish_results: true   # enables the README badge
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload Semgrep results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: semgrep-results
           path: semgrep-results.json


### PR DESCRIPTION
## Summary

Manual application of the two dependabot bumps that couldn't auto-land on `dev`:

- **`actions/upload-artifact` v4 → v7** — in `extract-subpacks-on-release.yml`, `security-scan.yml`, `scorecard.yml`.
- **`github/codeql-action` v3 → v4** — `codeql.yml` (init + analyze) and `scorecard.yml` (upload-sarif).

Dependabot's #539/#541 were cut from `main` and conflict with `dev`'s diverged workflow files, and dependabot can't target `dev` until the `target-branch: dev` config (merged in #588) reaches `main` via a release. This applies the same bumps directly to `dev`; #539 and #541 will be closed referencing this PR.

## Testing

CI on this PR exercises the bumped actions: the CodeQL workflow runs `codeql-action@v4` (init/analyze), and the upload-artifact steps run `@v7` — green CI is the validation that the major bumps don't break the workflows.

Closes #590

## Glossary

| Term | Definition |
|------|------------|
| Major action bump | Upgrading a GitHub Action across a major version (possible breaking changes), validated by the PR's own CI run. |
| `upload-sarif` | The codeql-action step that uploads SARIF results (used by the OSSF scorecard workflow). |