### PR TITLE
ci(#600): pin ossf/scorecard-action to v2.4.3

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

- **Pins `ossf/scorecard-action@v2` → `@v2.4.3`** in `.github/workflows/scorecard.yml`. The floating `v2` major tag is no longer published by the action, so the Scorecard job failed at setup on every `push` to `main` with `unable to find version v2` (observed on the v3.1.0 release merge, run [27188194993](https://github.com/me2resh/apexyard/actions/runs/27188194993)).
- **Restores the supply-chain posture scan** — without a resolvable action ref, no Scorecard SARIF is produced and the README badge goes stale. v2.4.3 (published 2025-09-30) is the latest release.
- **One-line, lowest-risk fix** — same class as #590 (artifact/codeql action version bumps). No other action refs change.

## Testing

1. CI on this PR resolves the action and the Scorecard job sets up without the version error.
2. After merge, the next `push`-to-`main` (or a manual `workflow_dispatch`) Scorecard run completes and uploads SARIF.

Closes #600

---

## Glossary

| Term | Definition |
|------|------------|
| OpenSSF Scorecard | Supply-chain security posture scanner that scores a repo against best-practice checks and uploads SARIF. |
| Floating major tag | A moving tag (`v2`) pointing at the latest `v2.x`; references break when the publisher stops maintaining it. |
