### PR TITLE
fix(#614): game total score exceeding max (level1 + levelTemp double-count)

### DIFF
--- a/site/game.html
+++ b/site/game.html
@@ -1262,8 +1262,6 @@ function level1(){
       colA.appendChild(ac); cmp.appendChild(colA);
       main.appendChild(cmp);
 
-      addScore(rs);
-
       // manual continue to next word, or finish
       revealBtn.textContent = roundIdx < ROUNDS.length-1 ? 'Next word →' : 'Finish →';
       const nb = revealBtn.cloneNode(true); revealBtn.replaceWith(nb);
@@ -1273,6 +1271,7 @@ function level1(){
         else {
           const avg = Math.round(totalScore / ROUNDS.length);
           state.levelScores[state.level] = avg;
+          addScore(avg);
           showResult(avg, 100,
             `<b>Key idea —</b> tokens aren't words. A token is a subword chunk a model has seen often during training — a whole word, a root, a suffix, or punctuation. More tokens means more <b>cost</b>, slower <b>speed</b>, and less room in the <b>context window</b>. Notice short common words stayed whole, while long or rare words shattered into pieces.`,
             'var(--iris)');
@@ -2218,9 +2217,7 @@ function levelTemp(){
       const [lo,hi] = sc.band;
       if (temp>=lo && temp<=hi) rs = 100;
       else { const d = temp<lo ? lo-temp : temp-hi; rs = Math.max(0, Math.round(100 - d*120)); }
-      const pts = Math.round(rs/3);
-      totalScore += pts;
-      addScore(pts);
+      totalScore += rs;
 
       // verdict
       const ok = temp>=lo && temp<=hi;
@@ -2246,6 +2243,7 @@ function levelTemp(){
         else {
           const avg = Math.round(totalScore/SCEN.length);
           state.levelScores[state.level] = avg;
+          addScore(avg);
           showResult(avg, 100,
             `<b>Key idea —</b> temperature is a creativity dial, not a quality dial. Near <b>0</b> the model almost always picks its single most-likely token, so you get the same reliable answer — perfect for extraction, classification, or code. Crank it up and it samples less-likely tokens too, giving variety — great for brainstorming, bad for facts. The right setting depends entirely on whether you want <b>repeatability</b> or <b>range</b>.`,
             'var(--iris)');


### PR DESCRIPTION
## Summary

- **Fixes the game total score exceeding the max** (you caught it: the share text read **"1188 / 1100"**, and the breakdown summed to 922, not the shared total).
- **Root cause** — two levels called `addScore()` *per round* (so `state.score` got the sum of the rounds) while recording only the *average* in `state.levelScores` (what the results breakdown shows):
  - **`level1` (Token splitter)** — 3 rounds × per-round `addScore(rs)`, recorded `avg`. Over-added ~200.
  - **`levelTemp` (Temperature dial)** — per-round `addScore(pts)`, recorded `avg`. Over-added ~67. Plus a **double-division** bug: `pts = rs/3` *and then* `avg = totalScore/SCEN.length`, which capped the level at ~33/100 even on a perfect play (why it showed 33).
  - 200 + 67 ≈ the 266 gap between 1188 (`state.score`) and 922 (Σ `levelScores`).
- **Fix** — drop the per-round `addScore`; call `addScore(avg)` **once** at each level's finish (after `levelScores` is set), so every level contributes exactly its recorded 0–100 (the pattern `level6` already uses). In `levelTemp`, accumulate `totalScore += rs` (not `rs/3`) so the average is true and a perfect run scores 100. Net: total maxes at **1100** and matches the breakdown.

## Testing

1. `node --check` on the inline script — clean; `LEVELS` still 11; `addScore` is now called once per level (11 calls + the definition).
2. No per-round `addScore(rs|pts|roundScore)` remain; the `pts` double-division variable is removed.
3. Play-through: total can no longer exceed 1100; Temperature scores up to 100 on a correct/in-band answer.

Closes #614

---

## Glossary

| Term | Definition |
|------|------------|
| `state.score` | The running total shown in the score pill + share text. |
| `state.levelScores[]` | Per-level scores in the results breakdown (last value per level). |
| Over-count | `state.score` receiving more additions than the per-level scores sum to. |
