### PR TITLE
sync(#403): main→dev after v3.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to ApexYard are documented here.
 
+## [3.1.3] — 2026-06-09
+
+Patch release — game scoring fix.
+
+### Fixed
+
+- (#614) game (`site/game.html`): total score could exceed the 1100 max (share text showed "1188/1100"). `level1` and `levelTemp` called `addScore()` per round but recorded only the per-level average; `levelTemp` also double-divided, capping it at ~33. Each level now adds its 0–100 once — total maxes at 1100 and matches the breakdown, and Temperature scores correctly (2224a53)
+
+### Closes
+
+- Closes #614
+
 ## [3.1.2] — 2026-06-09
 
 Patch release — game mobile fix.

--- a/site/game.html
+++ b/site/game.html
@@ -1262,8 +1262,6 @@ function level1(){
       colA.appendChild(ac); cmp.appendChild(colA);
       main.appendChild(cmp);
 
-      addScore(rs);
-
       // manual continue to next word, or finish
       revealBtn.textContent = roundIdx < ROUNDS.length-1 ? 'Next word →' : 'Finish →';
       const nb = revealBtn.cloneNode(true); revealBtn.replaceWith(nb);
@@ -1273,6 +1271,7 @@ function level1(){
         else {
           const avg = Math.round(totalScore / ROUNDS.length);
           state.levelScores[state.level] = avg;
+          addScore(avg);
           showResult(avg, 100,
             `<b>Key idea —</b> tokens aren't words. A token is a subword chunk a model has seen often during training — a whole word, a root, a suffix, or punctuation. More tokens means more <b>cost</b>, slower <b>speed</b>, and less room in the <b>context window</b>. Notice short common words stayed whole, while long or rare words shattered into pieces.`,
             'var(--iris)');
@@ -2218,9 +2217,7 @@ function levelTemp(){
       const [lo,hi] = sc.band;
       if (temp>=lo && temp<=hi) rs = 100;
       else { const d = temp<lo ? lo-temp : temp-hi; rs = Math.max(0, Math.round(100 - d*120)); }
-      const pts = Math.round(rs/3);
-      totalScore += pts;
-      addScore(pts);
+      totalScore += rs;
 
       // verdict
       const ok = temp>=lo && temp<=hi;
@@ -2246,6 +2243,7 @@ function levelTemp(){
         else {
           const avg = Math.round(totalScore/SCEN.length);
           state.levelScores[state.level] = avg;
+          addScore(avg);
           showResult(avg, 100,
             `<b>Key idea —</b> temperature is a creativity dial, not a quality dial. Near <b>0</b> the model almost always picks its single most-likely token, so you get the same reliable answer — perfect for extraction, classification, or code. Crank it up and it samples less-likely tokens too, giving variety — great for brainstorming, bad for facts. The right setting depends entirely on whether you want <b>repeatability</b> or <b>range</b>.`,
             'var(--iris)');

--- a/site/index.html
+++ b/site/index.html
@@ -51,7 +51,7 @@
   "url": "https://yard.apexscript.com/",
   "description": "Ship AI-built software like a real engineering team. Automatic code review, launch-readiness checks, one inbox for every product — on Claude Code.",
   "license": "https://opensource.org/licenses/MIT",
-  "softwareVersion": "3.1.2",
+  "softwareVersion": "3.1.3",
   "downloadUrl": "https://github.com/me2resh/apexyard",
   "datePublished": "2026-04-09",
   "dateModified": "2026-06-09",
@@ -1574,7 +1574,7 @@ a:hover { color: var(--accent); }
     <h1 class="hero__title rise rise-2">apexyard</h1>
 
     <p class="hero__version rise rise-2" style="margin:-0.5em 0 0.5em;font-size:13px;opacity:0.55;letter-spacing:0.05em;">
-      <a href="https://github.com/me2resh/apexyard/releases/tag/v3.1.2" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v3.1.2</a>
+      <a href="https://github.com/me2resh/apexyard/releases/tag/v3.1.3" style="color:inherit;text-decoration:none;" target="_blank" rel="noopener">v3.1.3</a>
       &nbsp;·&nbsp;
       <a href="https://github.com/me2resh/apexyard/blob/main/CHANGELOG.md" style="color:inherit;text-decoration:underline;text-underline-offset:3px;" target="_blank" rel="noopener">changelog</a>
     </p>
@@ -1693,7 +1693,7 @@ a:hover { color: var(--accent); }
       <span>PRs reviewed &amp; merged · last 90 days</span>
     </div>
     <div class="hero__metric">
-      <strong>17</strong>
+      <strong>18</strong>
       <span>Production releases shipped (v0.1 → v3.1)</span>
     </div>
     <div class="hero__metric">


### PR DESCRIPTION
## Summary

- **Syncs main→dev after the v3.1.3 release** — makes the v3.1.3 squash commit an ancestor of `dev` so the next `dev→main` release PR only sees genuinely-new commits.
- **Merge strategy: `-X ours`** — dev wins on conflicts (it already carries the released code's un-squashed equivalents).
- **Main-leads files (`CHANGELOG.md`, `site/index.html`) came across clean** — both byte-match `main`; no carry-forward needed.
- **No functional changes** — bookkeeping merge only.

## Background

apexyard squash-merges dev→main on every release; this merge makes the squash commit an ancestor of dev. See [#403](https://github.com/me2resh/apexyard/issues/403).

## Testing

1. After merge: `git log upstream/dev..upstream/main --oneline` returns empty.
2. `bash .claude/hooks/tests/test_site_counts.sh` green; CHANGELOG + site/index.html byte-match `main`.

Refs #403

---

## Glossary

| Term | Definition |
|------|------------|
| Squash divergence | A squash-merge to main yields a commit whose SHA differs from dev's history until a sync merge makes it an ancestor. |
| `-X ours` | Merge strategy resolving conflicts in favour of the dev-based branch. |
| Main-leads file | A file the release flow edits on `main` (CHANGELOG.md, site/index.html) that must track forward to dev. |
