### PR TITLE
feat(#627): support fallow static analysis in code review

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -489,6 +489,76 @@ If no handbooks loaded (e.g. the diff doesn't trigger any language handbooks, no
 
 The `*(semantic match — discovery: semantic-search)*` annotation is required on every semantically-discovered handbook citation so the reader can see WHY a handbook fired for content that didn't match its path globs — without that visibility, semantic supplements feel non-deterministic. Path-convention citations stay un-annotated (no clutter for the dominant case).
 
+### 9. Fallow Static Analysis (JS/TS) — advisory, fail-soft
+
+When the diff touches JavaScript / TypeScript, run [Fallow](https://docs.fallow.tools) — a zero-config JS/TS intelligence CLI — over the **changed code** and surface its findings plus a dry-run fix preview. This step mirrors the language-gating of § 8 (handbooks) and the fail-soft posture of the § "Semantic supplement" — it NEVER introduces a new failure mode for adopters who don't use fallow. See AgDR-0069 for the decision rationale.
+
+#### Gate
+
+Run this step only if BOTH hold:
+
+1. The PR diff includes a file matching `**/*.{js,jsx,mjs,cjs,ts,tsx}` (reuse the `DIFF_FILES` set from § 8 discovery).
+2. The adopter hasn't disabled it: `quality.fallow_review` in `onboarding.yaml` is not `false`. (Absent key → treat as enabled; the CLI-presence check below is the real gate.)
+
+#### Fail-soft preflight
+
+```bash
+# Skip silently if the fallow CLI isn't available. Same posture as the MCP
+# semantic supplement — no user-visible warning, identical behaviour to a
+# pre-fallow Rex. Do NOT attempt to install it.
+if ! command -v fallow >/dev/null 2>&1; then
+  FALLOW_STATUS="unavailable"   # note in verbose log only; omit the output section
+fi
+```
+
+If `fallow` is unavailable, set `FALLOW_STATUS=unavailable`, skip the rest of this step, and omit the `### Fallow Findings` output section entirely.
+
+#### Run (changed-scope, JSON, never mutate)
+
+Always append `|| true` — fallow exits **1** when it finds issues (normal), and only exit **2** is a real error. Scope to the PR's merge base so the pass reviews the diff, not the whole repo.
+
+```bash
+BASE=$(gh pr view {number} --json baseRefName --jq .baseRefName)
+
+# Findings (dead code / unused exports + deps / changed-code risk)
+fallow check        --changed-since "origin/$BASE" --format json || true
+# Duplication across the changed set
+fallow find-dupes   --changed-since "origin/$BASE" --format json || true
+# Complexity hotspots / health on changed files
+fallow check-health --changed-since "origin/$BASE" --format json || true
+
+# Proposed fixes — DRY RUN ONLY. Never `fix --yes`. Rex does not mutate the tree.
+fallow fix --dry-run || true
+```
+
+#### Enforcement: advisory
+
+Fallow findings are **advisory** — surface them as `nit:` / `suggestion:` notes and do NOT downgrade the verdict from APPROVED on fallow findings alone. Rationale: fallow surfaces *candidates* (its security output is explicitly unverified) and cleanup opportunities aren't merge blockers. A narrow blocking subset — e.g. a newly-introduced circular dependency — may be added later behind its own AgDR.
+
+#### Output
+
+Add a `### Fallow Findings` section to the review body (between `### Handbook Findings` and `### Suggestions`). A compact table of findings, then a fenced block with the dry-run fix preview. Omit the whole section if `FALLOW_STATUS=unavailable` or the diff isn't JS/TS.
+
+````markdown
+### Fallow Findings  *(advisory — JS/TS static analysis, changed scope)*
+
+| Category | Location | Finding |
+|----------|----------|---------|
+| Unused export | `src/lib/format.ts:14` | `formatLegacyDate` is exported but unreferenced |
+| Duplication | `src/a.ts:30` ↔ `src/b.ts:51` | 18-line clone (`dup:1a2b3c4d`) |
+| Complexity | `src/handlers/order.ts:88` | `processOrder` cyclomatic 24 — refactor candidate |
+
+**Proposed fixes (dry run — not applied):**
+
+```
+fallow fix --dry-run
+- remove unused export formatLegacyDate (src/lib/format.ts)
+- drop unused dependency left-pad (package.json)
+```
+
+(Author can apply locally with `fallow fix --yes` after review.)
+````
+
 ## Process
 
 ```
@@ -639,12 +709,16 @@ Report the failure in plain text with the exact command the caller needs to run.
 - ⚠ Summary Bullet Narrative:  [Pass / Advisory]   ← advisory only, never blocks
 - ✅ Technical Decisions (AgDR):[Pass / Fail / N/A]
 - ✅ Adopter Handbooks:         [Pass / Fail / N/A]   ← N/A if no handbooks loaded
+- ⚠ Fallow Static Analysis (JS/TS): [Pass / Advisory / N/A]   ← advisory only, never blocks; N/A if not JS/TS or CLI absent
 
 ### Issues Found
 [List any issues, or "None"]
 
 ### Handbook Findings
 [Per-handbook list of violations, blocking-first. Omit this section if no handbooks loaded or no findings. See § "Adopter Handbooks" for the format.]
+
+### Fallow Findings
+[JS/TS static-analysis table + dry-run fix preview. Advisory only. Omit if not JS/TS or the fallow CLI is unavailable. See § 9 for the format.]
 
 ### Suggestions
 [Optional improvements, not blocking]
@@ -672,6 +746,7 @@ Report the failure in plain text with the exact command the caller needs to run.
    - The PR author must run `/decide` and link the AgDR before re-review
 8. **Approval marker format is BLOCKING** — on APPROVED verdicts, write the marker at `$REX_MARKER` (the repo-qualified path from `review_marker_path`; form: `.claude/session/reviews/<owner>__<repo>__<pr>-rex.approved`) containing exactly the 40-char HEAD SHA + newline. No labels, no JSON, no extra text. See the "Approval marker — EXACT FORMAT REQUIRED" section above. A malformed marker blocks the merge and forces a rule-violating hand-edit, so getting the format right is as important as the review content.
 9. **Handbooks layer on top of framework rules** — discover and apply handbooks from BOTH the public `handbooks/**/*.md` tree AND (for split-portfolio adopters) the private custom-handbooks dir resolved via `portfolio_custom_handbooks_dir`. See § 8 for the path-convention rules and the discovery shape. Advisory handbooks generate `nit:` / `suggestion:` comments; blocking handbooks (containing `ENFORCEMENT: blocking` at the top of the file) become REQUEST CHANGES verdicts regardless of whether they live in the public or private layer. Adopters extend the standards by adding handbook files; you don't need a code change to teach Rex a new rule.
+10. **Fallow is advisory and fail-soft** — on JS/TS diffs, run the fallow CLI (§ 9) changed-scope and surface a `### Fallow Findings` table + dry-run fix preview. Findings are `nit:` / `suggestion:` only and NEVER flip the verdict on their own. If the `fallow` CLI isn't on PATH, or the diff isn't JS/TS, or `quality.fallow_review` is `false`, skip the step silently and omit the section — no new failure mode. Never run `fallow fix --yes`; the review previews fixes, it doesn't apply them.
 
 ## Example Invocation
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -41,7 +41,8 @@ See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the ful
 3. Review against the checklist (architecture, code quality, testing, security, performance)
 4. Check for the required Glossary section
 5. Check for AgDR links if technical decisions were made
-6. Submit a GitHub review via `gh pr review`
+6. On JS/TS diffs, run the Fallow static-analysis pass (§ 9 of the agent) — changed-scope, fail-soft, advisory; render a `### Fallow Findings` table + dry-run fix preview
+7. Submit a GitHub review via `gh pr review`
 
 ## Review Checklist
 
@@ -99,6 +100,7 @@ Posts a GitHub review comment with:
 - Commit SHA reviewed
 - Checklist results
 - Issues found
+- Fallow findings (advisory; JS/TS diffs only, when the `fallow` CLI is available)
 - Verdict: APPROVED / CHANGES REQUESTED / COMMENT
 
 Invokes: Code Reviewer Agent (Rex)

--- a/docs/agdr/AgDR-0069-fallow-in-code-review.md
+++ b/docs/agdr/AgDR-0069-fallow-in-code-review.md
@@ -1,0 +1,39 @@
+# AgDR-0069 — Run Fallow static analysis as a code-review step on JS/TS diffs
+
+> In the context of ApexYard's automated code review, facing the gap that Rex reasons about a diff but runs **no JS/TS static-analysis pass**, I decided to **add a fail-soft §9 step to the Code Reviewer agent that runs the Fallow CLI on JS/TS diffs (changed-scope) and renders a findings table plus a dry-run fix preview**, rather than wiring it as a hook or orchestrating the `/fallow` skill from the main thread, to achieve earlier detection of dead code, duplication, circular dependencies, and complexity hotspots, accepting an optional external CLI dependency and an advisory-only verdict effect.
+
+## Context
+
+- Rex (`.claude/agents/code-reviewer.md`) already gates language-specific **handbook** loading on the diff (`**/*.{ts,tsx}` → load `handbooks/language/typescript/`). It has no equivalent **tool** pass — nothing actually analyses the changed JS/TS for unused exports, clones, circular dependencies, or complexity.
+- [Fallow](https://docs.fallow.tools) is a zero-config JS/TS intelligence CLI (`fallow check | find-dupes | check-health`, `fix --dry-run`) with `--changed-since` diff scoping and a JSON output mode — a natural fit for a review-time, changed-code-scoped pass. Exit code 1 means "issues found" (normal); only exit 2 is a real error.
+- Two facts constrain the design:
+  1. **Rex has `Bash` but no `Skill`/`Agent` tool** — it can run the `fallow` binary but cannot invoke the `/fallow` skill. The integration is "Rex runs the CLI," not "Rex calls the skill."
+  2. **ApexYard is multi-language.** Not every adopter ships JS/TS, so the step must be invisible (no new failure mode) for projects that don't have fallow — the same fail-soft posture as the MCP semantic supplement (apexyard#449) and opt-in LSP.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| 1. **Rex runs the Fallow CLI (§9 step), fail-soft, advisory** (chosen) | Reuses Rex's existing JS/TS diff gate; no new hook; degrades silently when the CLI is absent; mirrors the handbook + MCP-semantic-supplement precedent | Adds an optional external CLI dependency; review wall-clock grows on JS/TS PRs |
+| 2. PostToolUse hook runs fallow on `gh pr create` | Mechanical, deterministic | A shell hook can't compile a table or stage a model-reasoned dry-run; duplicates the `auto-code-review.sh` nudge; can't reason about which findings matter |
+| 3. Main-thread `/code-review` skill orchestrates `/fallow`, then feeds Rex | Uses the skill as authored | Splits the review across two contexts; the skill surface and the agent drift; more moving parts for the same output |
+| 4. Do nothing — leave fallow as a manual `/fallow` invocation | Zero cost | Loses the "every PR" coverage; relies on humans remembering |
+
+## Decision
+
+Chosen: **Option 1 — Rex runs the Fallow CLI as a new §9 review step**, because it reuses the existing JS/TS diff gate, needs no new hook, and follows the established fail-soft pattern for optional tooling. Findings are **advisory** (`nit:` / `suggestion:`, verdict unaffected) — fallow surfaces *candidates* (its own docs call security findings unverified) and cleanup opportunities aren't merge blockers. The step is scoped to **changed code** (`--changed-since <base>`), and fixes are **dry-run only** (`fix --dry-run`) — Rex carries `disallowedTools: Write, Edit` and never mutates the tree.
+
+## Consequences
+
+- JS/TS PRs gain an automatic dead-code / duplication / circular-dep / complexity pass with a results table and a proposed-fix preview in the review body.
+- Adopters who never install the `fallow` CLI see identical Rex behaviour to before (silent skip) — no hard onboarding requirement.
+- A new opt-in `quality.fallow_review` flag in `onboarding.yaml` lets a JS/TS adopter disable the pass even when the CLI is present.
+- The `/code-review` skill (`.claude/skills/code-review/SKILL.md`) and `workflows/code-review.md` must be kept in sync with the agent's §9.
+- If fallow's blocking value proves high later (e.g. a newly-introduced circular dependency), a narrow blocking subset can be added behind a follow-up AgDR.
+
+## Artifacts
+
+- Ticket: me2resh/apexyard#627
+- Branch: `feature/GH-627-support-fallow` (fork: `tifa64/apexyard`)
+- Touches: `.claude/agents/code-reviewer.md`, `.claude/skills/code-review/SKILL.md`, `workflows/code-review.md`, `onboarding.example.yaml`, `docs/getting-started.md`
+- PR: _(link on open)_

--- a/docs/agdr/AgDR-0069-fallow-in-code-review.md
+++ b/docs/agdr/AgDR-0069-fallow-in-code-review.md
@@ -36,4 +36,4 @@ Chosen: **Option 1 — Rex runs the Fallow CLI as a new §9 review step**, becau
 - Ticket: me2resh/apexyard#627
 - Branch: `feature/GH-627-support-fallow` (fork: `tifa64/apexyard`)
 - Touches: `.claude/agents/code-reviewer.md`, `.claude/skills/code-review/SKILL.md`, `workflows/code-review.md`, `onboarding.example.yaml`, `docs/getting-started.md`
-- PR: _(link on open)_
+- PR: me2resh/apexyard#628

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -325,7 +325,7 @@ To enable it on a JS/TS project:
 1. **Install the `fallow` CLI** — `cargo install fallow-cli`, or run it ad-hoc with `npx fallow`.
 2. **(Optional) toggle it in `onboarding.yaml`** — set `quality.fallow_review: false` to keep the CLI installed but disable the review pass. Absent or `true` → enabled when the CLI is present.
 
-Non-JS/TS stacks need do nothing — leave `quality.fallow_review` unset and the pass never fires.
+Non-JS/TS stacks need do nothing — the language gate means the pass never fires on a non-JS/TS diff regardless of the flag, and an absent `fallow` CLI skips it anyway. (Leaving `quality.fallow_review` unset is equivalent to `true`; it only matters on JS/TS projects that have the CLI installed and want to turn the pass *off*.)
 
 ## Optional: Local agent routing
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -314,6 +314,19 @@ Cargo workspaces with many crates have a slow first index — see the caveat bel
 - **No new failure mode.** Skills that benefit from LSP (`/code-review`, `/threat-model`, `/security-review`) fall back to grep + Read transparently when LSP is absent. There is no "broken without LSP" path — only a faster one with it.
 - **Plugin marketplace links may move.** The plugin ecosystem is young. If a marketplace search turns up multiple options for one language, prefer the one maintained by the language's own community (e.g. official `tsserver` over a third-party wrapper).
 
+## Optional: Fallow static analysis (JS/TS)
+
+For JavaScript / TypeScript projects, the Code Reviewer agent (Rex) can run a [Fallow](https://docs.fallow.tools) static-analysis pass as part of every code review — surfacing dead code, unused exports/dependencies, duplication, circular dependencies, and complexity hotspots in the **changed code**, plus a dry-run preview of the fixes it would apply. See `.claude/agents/code-reviewer.md` § 9 and [AgDR-0069](agdr/AgDR-0069-fallow-in-code-review.md).
+
+**This is opt-in and fail-soft.** Rex only runs it when the diff touches `**/*.{js,jsx,mjs,cjs,ts,tsx}` AND the `fallow` CLI is on `PATH`. If the CLI is absent, the step is skipped silently — there is no "broken without fallow" path, only a richer review with it. Findings are **advisory** (`nit:` / `suggestion:`); they never flip a verdict on their own, and the review only previews fixes (`fallow fix --dry-run`) — it never mutates your tree.
+
+To enable it on a JS/TS project:
+
+1. **Install the `fallow` CLI** — `cargo install fallow-cli`, or run it ad-hoc with `npx fallow`.
+2. **(Optional) toggle it in `onboarding.yaml`** — set `quality.fallow_review: false` to keep the CLI installed but disable the review pass. Absent or `true` → enabled when the CLI is present.
+
+Non-JS/TS stacks need do nothing — leave `quality.fallow_review` unset and the pass never fires.
+
 ## Optional: Local agent routing
 
 Agents can optionally route through a locally-running Ollama instance via a LiteLLM proxy — useful when you want to keep prompts off any cloud API for specific sub-tasks (ticket triage, data-analyst sketches, exploratory rephrasing). See [`local-model-setup.md`](local-model-setup.md) for the install + configuration walkthrough.

--- a/onboarding.example.yaml
+++ b/onboarding.example.yaml
@@ -102,6 +102,13 @@ quality:
 
   review_style: "thorough"
 
+  # Fallow static-analysis pass in code review (JS/TS projects only).
+  # Requires the `fallow` CLI on PATH (cargo install fallow-cli, or npx fallow).
+  # Rex runs it changed-scope on JS/TS diffs and skips silently if the CLI is
+  # absent, so leaving this false (or unset) is safe for non-JS/TS stacks.
+  # See docs/getting-started.md § "Optional: Fallow static analysis".
+  fallow_review: false
+
 # -----------------------------------------------------------------------------
 # Workflows
 # -----------------------------------------------------------------------------

--- a/onboarding.example.yaml
+++ b/onboarding.example.yaml
@@ -105,7 +105,10 @@ quality:
   # Fallow static-analysis pass in code review (JS/TS projects only).
   # Requires the `fallow` CLI on PATH (cargo install fallow-cli, or npx fallow).
   # Rex runs it changed-scope on JS/TS diffs and skips silently if the CLI is
-  # absent, so leaving this false (or unset) is safe for non-JS/TS stacks.
+  # absent. Default when the key is absent or `true` is ENABLED (it only fires
+  # on JS/TS diffs with the CLI present); set `false` to opt a JS/TS project
+  # out. Shipped `false` here as a conservative template default — flip to
+  # `true` (or delete the line) once you've installed the CLI.
   # See docs/getting-started.md § "Optional: Fallow static analysis".
   fallow_review: false
 

--- a/workflows/code-review.md
+++ b/workflows/code-review.md
@@ -127,6 +127,7 @@ QUESTION:   "Why did you choose Map over Object here?"
 - [ ] No code duplication
 - [ ] No dead code
 - [ ] Comments explain why, not what
+- [ ] Fallow static-analysis pass reviewed (JS/TS) — dead code, unused exports/deps, duplication, circular deps, complexity hotspots (advisory; Rex runs it automatically on JS/TS diffs when the `fallow` CLI is available — see `.claude/agents/code-reviewer.md` § 9)
 
 ### Security
 


### PR DESCRIPTION
## Summary

- **Adds a Fallow static-analysis pass to code review (§ 9 of the Rex agent)** — on JS/TS diffs, Rex now runs the `fallow` CLI changed-scope and renders a `### Fallow Findings` table plus a dry-run fix preview, catching dead code, unused exports/deps, duplication, circular deps, and complexity hotspots that pure diff-reading misses.
- **Fail-soft and advisory by design** — the step fires only when the diff is JS/TS *and* the `fallow` CLI is on `PATH`; it skips silently otherwise (no new failure mode for the multi-language portfolio), and findings are `nit:` / `suggestion:` only, so they never flip a verdict. Fixes are dry-run only — Rex never mutates the tree.
- **Three surfaces kept in sync** — the agent (`code-reviewer.md` § 9 + checklist + output template + rule 10), the `/code-review` skill (Process + Output), and `workflows/code-review.md` (reviewer checklist) all describe the same behaviour so they don't drift.
- **Opt-in + documented** — new `quality.fallow_review` flag in `onboarding.example.yaml` lets a JS/TS adopter disable it; `docs/getting-started.md` gains an "Optional: Fallow static analysis" section covering the CLI install and fail-soft posture.
- **Decision recorded** — AgDR-0069 captures the CLI-vs-skill, advisory-vs-blocking, and changed-scope choices.

## Testing

1. `npx markdownlint-cli2 <changed .md files>` → `0 error(s)` (matches the `markdown-lint` CI ruleset).
2. `python3 -c "import yaml; yaml.safe_load(open('onboarding.example.yaml'))"` → parses cleanly.
3. Manual: on a JS/TS PR with the `fallow` CLI installed, Rex runs § 9 and emits the `### Fallow Findings` section; with the CLI absent, the section is omitted and the review is byte-for-byte the prior behaviour.

Refs #627

## Glossary

| Term | Definition |
|------|------------|
| Fallow | Zero-config JS/TS codebase-intelligence CLI (dead code, duplication, circular deps, complexity hotspots). |
| Rex | ApexYard's automated Code Reviewer agent (`.claude/agents/code-reviewer.md`). |
| Fail-soft | Degrade silently when an optional dependency is absent; no new failure mode. |
| Changed-scope | Analysis restricted to the PR diff (`--changed-since <base>`) rather than the whole repo. |
| AgDR | Agent Decision Record — ApexYard's lightweight decision-rationale document. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
