### PR TITLE
fix(#629): config_get drops all project-config overrides on a backslash escape

### DIFF
--- a/.claude/hooks/_lib-read-config.sh
+++ b/.claude/hooks/_lib-read-config.sh
@@ -129,7 +129,13 @@ config_get() {
     _CONFIG_CACHE=$(_config_load)
   fi
   if command -v jq >/dev/null 2>&1; then
-    echo "$_CONFIG_CACHE" | jq -r "$filter" 2>/dev/null
+    # printf '%s', NOT echo: under an XSI/POSIX shell `echo` interprets backslash
+    # escapes, collapsing a valid JSON escape in the cached config (e.g. `\\0` in
+    # a pre_push command value) into an invalid one — jq then aborts on the whole
+    # document and config_get returns empty for EVERY key, silently dropping all
+    # project-config overrides (incl. split-portfolio portfolio.* paths).
+    # See me2resh/apexyard#629.
+    printf '%s' "$_CONFIG_CACHE" | jq -r "$filter" 2>/dev/null
   else
     return 0
   fi

--- a/.claude/hooks/tests/test_config_get_backslash_escape.sh
+++ b/.claude/hooks/tests/test_config_get_backslash_escape.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Regression test for me2resh/apexyard#629.
+#
+# `config_get` must keep returning project-config overrides even when the merged
+# config contains a JSON value with a backslash escape (e.g. the shipped
+# `pre_push` markdownlint command contains `tr '\n' '\0'` → JSON `\\n` / `\\0`).
+#
+# The original bug: config_get did `echo "$_CONFIG_CACHE" | jq`. Under a shell
+# whose `echo` interprets backslash escapes (XSI / POSIX `echo`, or bash with
+# `xpg_echo`), `echo` collapses the valid JSON `\\0` into an invalid `\0`, jq
+# aborts on the whole document, and config_get returns empty for EVERY key —
+# silently dropping all overrides (incl. split-portfolio `portfolio.*` paths).
+# The fix uses `printf '%s'`, which never mangles its argument.
+#
+# This test forces the escape-interpreting behaviour with `shopt -s xpg_echo`
+# so it reproduces the bug on the old code and passes on the fixed code. Under a
+# plain bash `echo` (no xpg_echo) the bug is latent, so the guard would be
+# meaningless without forcing the mode.
+
+set -u
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/.claude"
+: > "$TMP/.apexyard-fork"
+
+cat > "$TMP/.claude/project-config.defaults.json" <<'JSON'
+{ "portfolio": { "ideas_backlog": "./projects/ideas-backlog.md" } }
+JSON
+
+# Override carries (a) a portfolio override to assert, and (b) a value with a
+# JSON backslash escape (`\\n` / `\\0`) — the exact shape that broke jq via echo.
+cat > "$TMP/.claude/project-config.json" <<'JSON'
+{
+  "portfolio": { "ideas_backlog": "../portfolio/projects/ideas-backlog.md" },
+  "pre_push": { "commands": [ { "name": "x", "run": "printf '%s' \"$f\" | tr '\\n' '\\0'" } ] }
+}
+JSON
+
+pass=0; fail=0
+ok() { echo "  ok: $1"; pass=$((pass + 1)); }
+no() { echo "  FAIL: $1"; fail=$((fail + 1)); }
+
+result="$(
+  cd "$TMP" || exit 1
+  export APEXYARD_OPS_DISABLE_PIN=1
+  unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+  shopt -s xpg_echo 2>/dev/null || true   # force the escape-interpreting echo that triggered #629
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-read-config.sh"
+  got="$(config_get '.portfolio.ideas_backlog')"
+  if [ "$got" = "../portfolio/projects/ideas-backlog.md" ]; then echo "PASS"; else echo "GOT:[$got]"; fi
+)"
+
+case "$result" in
+  *PASS*) ok "config_get returns the override despite a backslash-escaped config value" ;;
+  *)      no "config_get dropped the override under xpg_echo ($result)" ;;
+esac
+
+# Sanity: an unrelated key still resolves too (the whole document must parse).
+result2="$(
+  cd "$TMP" || exit 1
+  export APEXYARD_OPS_DISABLE_PIN=1
+  unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+  shopt -s xpg_echo 2>/dev/null || true
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-read-config.sh"
+  config_get '.pre_push.commands[0].name'
+)"
+[ "$result2" = "x" ] && ok "unrelated key resolves (document parses cleanly)" || no "unrelated key failed (got: [$result2])"
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "All $pass test(s) passed."
+  exit 0
+else
+  echo "$fail test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **Root cause** — `config_get` re-emitted the cached merged config with `echo "$_CONFIG_CACHE" | jq`. Under an XSI/POSIX shell (or bash with `xpg_echo`) `echo` interprets backslash escapes, collapsing a *valid* JSON `\\0` — from the shipped `pre_push` markdownlint command `tr '\n' '\0'` — into an *invalid* `\0`. jq aborts on the whole document (`Invalid escape …`), the error is swallowed (`2>/dev/null`), and `config_get` returns **empty for every key**, so `config_get_or` falls back to its in-code default for *every* lookup.
- **Impact (why this is more than cosmetic)** — all `.claude/project-config.json` overrides were silently ignored. In **split-portfolio mode** the `portfolio.*` paths resolved to the **in-fork defaults**, so `/idea` wrote to the fork instead of the sibling repo, and **`/handover` failed to detect split-portfolio mode — about to clone managed projects and write their docs into the PUBLIC fork** (`./workspace`, `./projects`) instead of the private portfolio sibling. That's a data-integrity + private-data-exposure risk, not just a wrong path. It also silently disabled `tracker.kind`, `ui_paths`, `design_paths`, and every other configurable key.
- **Fix** — one line: `printf '%s'` instead of `echo` (printf never mangles its argument). Verified the split-portfolio resolvers now return the sibling paths and `portfolio_is_v2` reports `true`.
- **Regression test** — `tests/test_config_get_backslash_escape.sh` forces `xpg_echo` to reproduce the escape-interpreting behaviour (the bug is *latent* under a plain bash `echo`, so a naive test wouldn't guard it), then asserts the override survives a backslash-bearing config value.

## Testing

1. New `test_config_get_backslash_escape.sh` — **2/2 pass** on the fix; proven to fail on the old `echo` form under `xpg_echo`.
2. Existing `test_detect_deprecated_config.sh` — **7/0** still green.
3. Real-repo check post-fix: `config_get '.portfolio.ideas_backlog'` → `../apexyard-portfolio/projects/ideas-backlog.md`; `portfolio_workspace_dir` → sibling `workspace`; `portfolio_is_v2` → `true`.

Closes #629

---

## Glossary

| Term | Definition |
|------|------------|
| `config_get` | Shared hook/skill helper that returns a value from the merged `project-config.{defaults,}.json` via a jq filter. |
| XSI / `xpg_echo` | POSIX/System-V `echo` (and bash's `xpg_echo` option) that interprets backslash escapes (`\n`, `\0`, `\\`) in its argument — unlike bash's default builtin `echo`. |
| Merged config | `project-config.defaults.json` deep-merged with the adopter's `project-config.json` via `jq -s '.[0] * .[1]'`. |
| Split-portfolio mode | Layout where the registry, project docs, ideas backlog and workspace live in a private sibling repo, selected via the `portfolio.*` config keys. |
