### PR TITLE
fix(#631): printf not echo when re-emitting captured JSON (pre-push-gate + tracker)

### DIFF
--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -152,10 +152,10 @@ _tracker_normalise_gh() {
     return 1
   fi
   # If raw isn't valid JSON, bail.
-  if ! echo "$raw" | jq -e . >/dev/null 2>&1; then
+  if ! printf '%s' "$raw" | jq -e . >/dev/null 2>&1; then
     return 1
   fi
-  echo "$raw" | jq -c '{
+  printf '%s' "$raw" | jq -c '{
     state:  (.state // ""),
     title:  (.title // ""),
     url:    (.url // ""),
@@ -174,8 +174,8 @@ _tracker_normalise_gh() {
 _tracker_normalise_linear() {
   local raw="$1"
   if [ -z "$raw" ]; then return 1; fi
-  if ! echo "$raw" | jq -e . >/dev/null 2>&1; then return 1; fi
-  echo "$raw" | jq -c '{
+  if ! printf '%s' "$raw" | jq -e . >/dev/null 2>&1; then return 1; fi
+  printf '%s' "$raw" | jq -c '{
     state:  ((.state | if type == "object" then .name else . end) // ""),
     title:  (.title // ""),
     url:    (.url // ""),
@@ -193,8 +193,8 @@ _tracker_normalise_linear() {
 _tracker_normalise_jira() {
   local raw="$1"
   if [ -z "$raw" ]; then return 1; fi
-  if ! echo "$raw" | jq -e . >/dev/null 2>&1; then return 1; fi
-  echo "$raw" | jq -c '{
+  if ! printf '%s' "$raw" | jq -e . >/dev/null 2>&1; then return 1; fi
+  printf '%s' "$raw" | jq -c '{
     state:  ((.fields.status.name // .status // "") | tostring),
     title:  ((.fields.summary // .summary // .title // "") | tostring),
     url:    ((.self // .url // "") | tostring),
@@ -212,8 +212,8 @@ _tracker_normalise_jira() {
 _tracker_normalise_asana() {
   local raw="$1"
   if [ -z "$raw" ]; then return 1; fi
-  if ! echo "$raw" | jq -e . >/dev/null 2>&1; then return 1; fi
-  echo "$raw" | jq -c '
+  if ! printf '%s' "$raw" | jq -e . >/dev/null 2>&1; then return 1; fi
+  printf '%s' "$raw" | jq -c '
     (.data // .) as $t |
     {
       state:  (if ($t.completed == true) then "Closed" else "Open" end),
@@ -235,7 +235,7 @@ _tracker_normalise_asana() {
 _tracker_normalise_custom() {
   local raw="$1"
   if [ -z "$raw" ]; then return 1; fi
-  if ! echo "$raw" | jq -e . >/dev/null 2>&1; then return 1; fi
+  if ! printf '%s' "$raw" | jq -e . >/dev/null 2>&1; then return 1; fi
 
   _tracker_load_config_lib
   local jq_expr
@@ -243,7 +243,7 @@ _tracker_normalise_custom() {
   if [ -z "$jq_expr" ] || [ "$jq_expr" = "null" ]; then
     jq_expr='.'
   fi
-  echo "$raw" | jq -c "$jq_expr" 2>/dev/null
+  printf '%s' "$raw" | jq -c "$jq_expr" 2>/dev/null
 }
 
 # ------------------------------------------------------------------------------
@@ -319,7 +319,7 @@ tracker_view() {
 tracker_state() {
   local json
   json=$(tracker_view "$@") || return $?
-  echo "$json" | jq -r '.state // empty' 2>/dev/null
+  printf '%s' "$json" | jq -r '.state // empty' 2>/dev/null
 }
 
 # ------------------------------------------------------------------------------

--- a/.claude/hooks/pre-push-gate.sh
+++ b/.claude/hooks/pre-push-gate.sh
@@ -85,15 +85,19 @@ fi
 cd "$REPO_ROOT" || exit 0
 
 FAILURES=""
-NUM_CMDS=$(echo "$CMDS_JSON" | jq 'length' 2>/dev/null)
+# printf '%s', NOT echo: CMDS_JSON comes from config_get and may carry a JSON
+# backslash escape (the markdownlint `tr '\n' '\0'` command). echo would mangle
+# it under an escape-interpreting shell, zeroing NUM_CMDS and silently skipping
+# every pre-push check. Same bug class as #629. See #631.
+NUM_CMDS=$(printf '%s' "$CMDS_JSON" | jq 'length' 2>/dev/null)
 if [ -z "$NUM_CMDS" ] || [ "$NUM_CMDS" = "null" ]; then
   exit 0
 fi
 
 i=0
 while [ "$i" -lt "$NUM_CMDS" ]; do
-  NAME=$(echo "$CMDS_JSON" | jq -r ".[$i].name // \"step-$i\"" 2>/dev/null)
-  RUN=$(echo "$CMDS_JSON" | jq -r ".[$i].run // empty" 2>/dev/null)
+  NAME=$(printf '%s' "$CMDS_JSON" | jq -r ".[$i].name // \"step-$i\"" 2>/dev/null)
+  RUN=$(printf '%s' "$CMDS_JSON" | jq -r ".[$i].run // empty" 2>/dev/null)
   i=$((i + 1))
 
   if [ -z "$RUN" ]; then


### PR DESCRIPTION
## Summary

- **Follow-up to #629** (same `echo "$captured_json" | jq` bug class, surfaced during that PR's review). Under an XSI / `xpg_echo` shell — or a skill bash-block run in the agent's shell — `echo` interprets backslash escapes, corrupting captured JSON so jq aborts.
- **`pre-push-gate.sh`** re-emitted `CMDS_JSON=$(config_get '.pre_push.commands')` via `echo`; that value carries the shipped markdownlint `tr '\n' '\0'` command (JSON `\\0`). The mangle zeroed `NUM_CMDS`, so the gate **silently ran zero pre-push checks** — a green-looking push that validated nothing.
- **`_lib-tracker.sh`** (sourced by `/start-ticket`, `/handover`, `/fan-out` in the agent shell) re-emitted `gh issue` JSON the same way at 11 sites; an issue **body/title containing a backslash escape** broke `tracker_view`, so ticket verification could spuriously fail.
- **Fix:** switch every captured-JSON re-emit to `printf '%s'`, which never interprets its operand. The 40 `echo "$INPUT" | jq` hook-stdin readers run under `#!/bin/bash` (no `xpg_echo`) and are intentionally **out of scope**.

## Testing

1. **Functional proof** under `shopt -s xpg_echo` with a `\\0`-bearing command list: old `echo` → `NUM_CMDS` empty (gate skipped); new `printf` → `2` (correct).
2. **Tracker suite** `test_tracker_aware_hooks.sh` → **22/0**.
3. `test_config_get_backslash_escape.sh` (#629) + `test_detect_deprecated_config.sh` still green.
4. `bash -n` clean on both files.

Closes #631

---

## Glossary

| Term | Definition |
|------|------------|
| `xpg_echo` | Bash option (and default XSI/POSIX `echo`) that interprets backslash escapes (`\n`, `\0`, `\\`) in `echo`'s argument. |
| Captured-JSON re-emit | `echo "$var" \| jq` where `$var` holds JSON captured from config or a CLI — the pattern that corrupts under an escape-interpreting `echo`. |
| `tracker_view` | `_lib-tracker.sh` helper that fetches + normalises a tracker issue to `{state,title,url,labels}`; used by `/start-ticket` to verify a ticket exists. |
| Pre-push gate | `pre-push-gate.sh` — runs the configured `pre_push.commands` (lint/typecheck/test/build) before a push. |
