### PR TITLE
feat(#626): grant Rex search_code + prefer semantic search when available

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -3,7 +3,7 @@
 name: code-reviewer
 persona_name: Rex
 description: Expert code review specialist. Reviews PRs for quality, security, and standards compliance. Use proactively after code changes or when a PR needs review.
-tools: Read, Grep, Glob, Bash, mcp__apexyard-search__search_docs
+tools: Read, Grep, Glob, Bash, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 disallowedTools: Write, Edit
 model: opus
 ---
@@ -42,6 +42,16 @@ Invoked when a PR is ready for review.
 
 - PR number or URL
 - Repository (any repository the user authorises)
+
+## Codebase grounding — prefer semantic search when available
+
+When the `apexyard-search` MCP is connected, **prefer `mcp__apexyard-search__search_code` over `grep`/`Read`** to ground the review in the actual codebase rather than the diff alone. Use it to surface:
+
+- existing **constant / enum / helper precedents** the change should reuse instead of re-introducing;
+- the real **call sites** of a modified function/method (blast radius the diff doesn't show);
+- whether a **test actually exercises** the changed branch.
+
+It also lowers review token cost (targeted semantic excerpts vs. broad `grep` + full-file reads). **Graceful-degrade:** if the MCP server is absent the tool simply isn't available — fall back to `grep`/`Glob`/`Read` with no change in behaviour (same pattern as `search_docs`, `/handover`, and `/code-review`). Adopters who don't run the premium MCP are unaffected.
 
 ## Review Checklist
 


### PR DESCRIPTION
## Summary

- **Grants Rex `search_code`** — adds `mcp__apexyard-search__search_code` to the code-reviewer agent's `tools:` (it already carried `search_docs`). Without it, Rex could only `grep`/`Read` the workspace clone during a managed-project review, so the orchestrator had to run `search_code` itself and inject findings into the prompt.
- **Adds a "Codebase grounding" guidance section** — instructs Rex to prefer semantic code search when the `apexyard-search` MCP is connected, to surface existing constant/enum/helper precedents the change should reuse, the real call sites of a modified method (blast radius the diff doesn't show), and whether a test actually exercises the changed branch — and to **fall back to `grep`/`Read`** when the server is absent.
- **No new failure mode** — graceful-degrade exactly like `search_docs` / `/handover` / `/code-review`; adopters who don't run the premium MCP are unaffected (the tool just isn't available and Rex greps). Also lowers review token cost (targeted excerpts vs. broad grep + full-file reads).

## Testing

- Frontmatter `tools:` parses (comma list, same shape as before plus one entry).
- Guidance is advisory prose; no behavioural code path changed. The merge-gate / marker flow is explicitly out of scope.

## Glossary

| Term | Definition |
|------|------------|
| Rex | Persona name of the `code-reviewer` agent — the automated first-pass PR reviewer. |
| `search_code` / `search_docs` | apexyard-search MCP tools for semantic search over managed-project code / framework docs. |
| Graceful-degrade | Use the MCP tool when present; fall back to `grep`/`Read` when the server is absent. |
| Blast radius | The full set of call sites affected by a change — often larger than the diff shows. |
