### PR TITLE
fix(#584): extract_push_ref no longer over-matches '->' in commit messages

### DIFF
--- a/.claude/hooks/_lib-extract-push-ref.sh
+++ b/.claude/hooks/_lib-extract-push-ref.sh
@@ -48,7 +48,9 @@ is_tag_push() {
   # Strip everything after the first shell redirection/pipe so the check isn't
   # fooled by `2>&1 | tail` appended to the command.
   local clean_cmd
-  clean_cmd=$(echo "$cmd" | sed 's/[[:space:]]*[0-9]*[>|][&>|0-9].*$//')
+  # require a WHITESPACE boundary before the redirection/pipe operator so a bare
+  # `>` inside an ASCII arrow `->` in a commit message is not treated as one (#584).
+  clean_cmd=$(echo "$cmd" | sed 's/[[:space:]][0-9]*[>|].*$//')
 
   # --tags flag: `git push [opts] --tags [remote]`
   if echo "$clean_cmd" | grep -qE '\bgit\s+push\b.*\s--tags(\s|$)'; then
@@ -122,10 +124,13 @@ extract_push_ref() {
   #   - `NNN>` (e.g. `2>`, `1>`, plain `>`)
   #   - `|` pipe
   # This is conservative: we drop from the FIRST such operator to end-of-line.
-  # The sed expression matches optional digits, then `>` or `|`, followed by
-  # anything: `[[:space:]]*[0-9]*[>|].*`
+  # The sed expression requires a WHITESPACE token boundary before the operator,
+  # then optional fd digits, then `>` or `|`, then anything: `[[:space:]][0-9]*[>|].*`.
+  # The leading whitespace is the #584 fix: the old `[[:space:]]*` (zero-width) let a
+  # bare `>` inside an ASCII arrow `->` in a commit message match, truncating the
+  # command before the trailing `&& git push <branch>` and falsely blocking the push.
   local stripped_cmd
-  stripped_cmd=$(echo "$cmd" | sed 's/[[:space:]]*[0-9]*[>|].*$//')
+  stripped_cmd=$(echo "$cmd" | sed 's/[[:space:]][0-9]*[>|].*$//')
 
   # Isolate the `git push ...` segment up to the first command separator
   # (|, ;, &&, &) so `git push origin foo && echo bar` doesn't pick up `echo`

--- a/.claude/hooks/tests/test_extract_push_ref_arrow.sh
+++ b/.claude/hooks/tests/test_extract_push_ref_arrow.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Regression test for me2resh/apexyard#584.
+#
+# extract_push_ref() stripped shell redirections with `[[:space:]]*[0-9]*[>|].*`.
+# The zero-width `[[:space:]]*` let a bare `>` inside an ASCII arrow `->` in a
+# commit message match, truncating a compound `commit ... && git push <branch>`
+# before the push segment → extract_push_ref returned empty → the caller fell
+# back to local HEAD and falsely BLOCKED the push. The fix requires a whitespace
+# token boundary before the operator.
+
+set -u
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=/dev/null
+. "$HOOK_DIR/_lib-extract-push-ref.sh"
+
+pass=0; fail=0
+eq() { # eq <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then echo "  ok: $1"; pass=$((pass + 1));
+  else echo "  FAIL: $1 — expected [$2] got [$3]"; fail=$((fail + 1)); fi
+}
+is() { # is <label> <expect 0|1> <cmd...>
+  if is_tag_push "$3"; then got=0; else got=1; fi
+  eq "$1" "$2" "$got"
+}
+
+# --- the #584 bug: arrow in the commit message must not eat the push segment ---
+eq "arrow in commit msg keeps the push ref" "feature/GH-1-foo" \
+  "$(extract_push_ref 'git add a && git commit -m "fix: remap blue->info, purple->violet" && git push origin feature/GH-1-foo')"
+
+eq "multiple arrows still keep the ref" "feature/GH-2-bar" \
+  "$(extract_push_ref 'git commit -m "a->b->c->d" && git push -u origin feature/GH-2-bar')"
+
+# --- redirections must STILL be stripped (no regression) ---
+eq "real redirection still stripped" "feature/GH-1-foo" \
+  "$(extract_push_ref 'git push upstream HEAD:feature/GH-1-foo 2>&1 | tail -5')"
+
+eq "pipe suffix still stripped" "feature/GH-3-baz" \
+  "$(extract_push_ref 'git push origin feature/GH-3-baz | cat')"
+
+# --- unchanged baselines ---
+eq "plain push" "feature/GH-9-x" "$(extract_push_ref 'git push origin feature/GH-9-x')"
+eq "refspec dst" "feature/GH-9-y" "$(extract_push_ref 'git push origin HEAD:feature/GH-9-y')"
+
+# --- is_tag_push not fooled by an arrow either ---
+is "arrow in commit msg is not a tag push" 1 'git commit -m "blue->info" && git push origin feature/GH-1-foo'
+is "real tag push still detected" 0 'git push origin --tags'
+is "refs/tags push still detected" 0 'git push origin refs/tags/v1.0.0'
+
+echo ""
+if [ "$fail" -eq 0 ]; then echo "All $pass test(s) passed."; exit 0; else echo "$fail test(s) failed."; exit 1; fi


### PR DESCRIPTION
## Summary

- **Fixes a false push-block** — `extract_push_ref()` (and the sibling `is_tag_push()`) stripped shell redirections with `[[:space:]]*[0-9]*[>|].*`. The leading `[[:space:]]*` is zero-width, so a bare `>` inside an ASCII arrow `->` — extremely common in commit messages (`"remap blue->info"`) — matched as a redirection. A one-line `git commit -m "...->..." && git push origin <branch>` got truncated at the arrow, so `extract_push_ref` returned empty, the caller fell back to `git branch --show-current` (in split-portfolio/workspace setups that's often the ops fork on a protected branch), and the push was **falsely BLOCKED**.
- **Fix** — require a real **whitespace token boundary** before the operator: `[[:space:]][0-9]*[>|].*`. An arrow `->` has a non-space (`-`) before the `>`, so it no longer matches; genuine redirections/pipes (` 2>&1`, ` | tail`, ` >file`) still do. Applied to both `extract_push_ref()` and `is_tag_push()` for consistency.
- **Regression test** — new `test_extract_push_ref_arrow.sh` (9 cases): arrows-in-message keep the push ref, real redirections still stripped, tag-push detection unaffected.

## Testing

1. New `test_extract_push_ref_arrow.sh` → **9/9**.
2. No regression on the existing suites: `test_validate_branch_name_pushref` **28/0**, `test_block_main_push` **31/0**, `test_pre_push_gate` **9/0**, `test_extract_pr` **14/0**.

Closes #584

---

## Glossary

| Term | Definition |
|------|------------|
| `extract_push_ref` | Helper in `_lib-extract-push-ref.sh` that reads the destination branch from a `git push` command; sourced by `block-main-push.sh` and `validate-branch-name.sh`. |
| Redirection strip | Removing shell redirection/pipe tokens (`2>&1`, `\| tail`, `>file`) before token-parsing the command, so they aren't mistaken for branch names. |
| Zero-width quantifier | A regex piece (`*`) that can match the empty string — here it let the operator match without a preceding space, catching `->`. |
| Token boundary | A whitespace separating shell tokens; requiring one before `>`/`\|` distinguishes a real redirection from a `>` inside a word. |
