### PR TITLE
fix(#638): escape DOM-sourced email parts in site mailto builder (CodeQL #8)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -2173,7 +2173,7 @@ confirm it skips the missing column before you ship."</span></pre>
       ''
     ].join('\n');
     a.setAttribute('href',
-      'mail' + 'to:' + u + '\u0040' + d +
+      'mail' + 'to:' + encodeURIComponent(u) + '\u0040' + encodeURIComponent(d) +
       '?subject=' + encodeURIComponent(subject) +
       '&body=' + encodeURIComponent(body)
     );


### PR DESCRIPTION
## Summary

- **Clears CodeQL High #8 (`js/xss-through-dom`)** in `site/index.html`. The email-obfuscation snippet assembled a `mailto:` href from the `data-u` / `data-d` DOM attributes (read via `getAttribute`) and concatenated them **unescaped** into the `href` — DOM text flowing into a DOM sink.
- **Fix:** wrap the local-part and domain in `encodeURIComponent` (`'mailto:' + encodeURIComponent(u) + '@' + encodeURIComponent(d) + …`). CodeQL recognises `encodeURIComponent` as a sanitiser, so the alert clears; meta-characters are escaped before the sink.
- **Behaviour unchanged for real addresses** — `encodeURIComponent('ahmed')` / `encodeURIComponent('apexscript.com')` are no-ops (alphanumerics + `.` aren't encoded). The `@` (`@`) separator is preserved. Real-world risk was already low (the data attributes are author-set and the `mailto:` prefix precludes a `javascript:` URL), so this is defence-in-depth + alert hygiene.

## Testing

1. The change wraps two existing variables in `encodeURIComponent` — no structural change; the surrounding IIFE still parses.
2. Manual: hovering/clicking the obfuscated email still produces the correct `mailto:ahmed@…?subject=…&body=…` href.
3. CodeQL `js/xss-through-dom` #8 should resolve on the next scan.

Closes #638

---

## Glossary

| Term | Definition |
|------|------------|
| DOM-XSS (`js/xss-through-dom`) | XSS where text read from the DOM reaches a DOM sink without sanitisation. |
| `encodeURIComponent` | Percent-encodes URL meta-characters; recognised by CodeQL as a sanitiser for this sink. |
| Email obfuscation | Splitting/assembling a `mailto:` at runtime to deter naive address scrapers. |
