### PR TITLE
feat(#640): consent-gated GA + cookie banner on all site pages

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -136,7 +136,80 @@ footer {
 }
 footer a { color: var(--ink-soft); border-bottom: 1px dotted currentColor; }
 footer a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+/* begin: consent-css — keep in sync across all site/*.html pages (#399) */
+.consent {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--paper);
+  border-top: 1px solid var(--ink);
+  z-index: 100;
+  font-size: 12px;
+  padding: 1rem var(--gutter);
+}
+.consent[hidden] { display: none; }
+.consent__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.consent__msg {
+  flex: 1;
+  min-width: 260px;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+.consent__msg a { color: var(--accent); }
+.consent__actions { display: flex; gap: 0.5rem; }
+.consent__btn {
+  font: inherit;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.consent__btn:hover { border-color: var(--ink); }
+.consent__btn--accept {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.consent__btn--accept:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+/* end: consent-css */
 </style>
+
+<!-- begin: gtag — keep in sync across all site/*.html pages (#399) -->
+<!-- Google tag (gtag.js) with Consent Mode v2 - analytics_storage defaults to denied
+     until the consent banner below records an explicit choice. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G3EMR3CB02"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    'ad_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'analytics_storage': 'denied'
+  });
+  try {
+    if (localStorage.getItem('ay-consent') === 'granted') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+  } catch (e) {}
+  gtag('js', new Date());
+  gtag('config', 'G-G3EMR3CB02');
+</script>
+<!-- end: gtag -->
 </head>
 <body>
 
@@ -165,6 +238,59 @@ footer a:hover { color: var(--accent); border-bottom-color: var(--accent); }
 <footer>
   © 2026 <a href="https://me2resh.com" target="_blank" rel="noopener">me2resh</a> · ApexYard · open source · plain markdown · zero dependencies
 </footer>
+
+<!-- begin: consent — keep in sync across all site/*.html pages (#399) -->
+<!-- ============================================================
+     COOKIE CONSENT BANNER
+     Hidden if a prior choice is stored. On Accept, updates gtag
+     Consent Mode to grant analytics_storage.
+     ============================================================ -->
+<div id="consent" class="consent" role="region" aria-label="Cookie consent" hidden>
+  <div class="consent__inner">
+    <p class="consent__msg">
+      This site uses Google Analytics to count visits. No ads, no cross-site tracking.
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy</a>.
+    </p>
+    <div class="consent__actions">
+      <button type="button" class="consent__btn" data-consent="denied">Decline</button>
+      <button type="button" class="consent__btn consent__btn--accept" data-consent="granted">Accept</button>
+    </div>
+  </div>
+</div>
+<script>
+(function () {
+  var KEY = 'ay-consent';
+  var el = document.getElementById('consent');
+  if (!el) return;
+  var stored = null;
+  try { stored = localStorage.getItem(KEY); } catch (e) {}
+  if (stored !== 'granted' && stored !== 'denied') {
+    el.hidden = false;
+  }
+  function record(choice) {
+    if (el.hidden) return;
+    try { localStorage.setItem(KEY, choice); } catch (e) {}
+    if (choice === 'granted' && typeof gtag === 'function') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+    el.hidden = true;
+  }
+  el.addEventListener('click', function (e) {
+    var btn = e.target.closest('[data-consent]');
+    if (!btn) return;
+    record(btn.getAttribute('data-consent'));
+  });
+  // Escape dismisses the banner as "denied" - keyboard users without
+  // a mouse shouldn't be stuck with a fixed-bottom banner they can't
+  // dismiss. "Denied" is the non-consenting default per Consent Mode v2.
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !el.hidden) {
+      record('denied');
+    }
+  });
+})();
+</script>
+<!-- end: consent -->
 
 </body>
 </html>

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -19,8 +19,8 @@
 <link rel="alternate" type="text/markdown" href="/architecture.md">
 
 <!-- LLM consumers: payload size hints (token estimate = chars / 4). #333 item C. -->
-<meta name="llm:token-count" content="8864">
-<meta name="llm:doc-length" content="35458 chars">
+<meta name="llm:token-count" content="10226">
+<meta name="llm:doc-length" content="40904 chars">
 
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="ApexYard">
@@ -432,7 +432,80 @@ a:hover { color: var(--accent); }
 }
 .page-footer a { color: var(--ink-soft); border-bottom: 1px dotted currentColor; padding-bottom: 1px; }
 .page-footer a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+/* begin: consent-css — keep in sync across all site/*.html pages (#399) */
+.consent {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--paper);
+  border-top: 1px solid var(--ink);
+  z-index: 100;
+  font-size: 12px;
+  padding: 1rem var(--gutter);
+}
+.consent[hidden] { display: none; }
+.consent__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.consent__msg {
+  flex: 1;
+  min-width: 260px;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+.consent__msg a { color: var(--accent); }
+.consent__actions { display: flex; gap: 0.5rem; }
+.consent__btn {
+  font: inherit;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.consent__btn:hover { border-color: var(--ink); }
+.consent__btn--accept {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.consent__btn--accept:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+/* end: consent-css */
 </style>
+
+<!-- begin: gtag — keep in sync across all site/*.html pages (#399) -->
+<!-- Google tag (gtag.js) with Consent Mode v2 - analytics_storage defaults to denied
+     until the consent banner below records an explicit choice. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G3EMR3CB02"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    'ad_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'analytics_storage': 'denied'
+  });
+  try {
+    if (localStorage.getItem('ay-consent') === 'granted') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+  } catch (e) {}
+  gtag('js', new Date());
+  gtag('config', 'G-G3EMR3CB02');
+</script>
+<!-- end: gtag -->
 </head>
 <body>
 
@@ -780,6 +853,59 @@ a:hover { color: var(--accent); }
     <div class="page-footer__meta">© 2026 <a href="https://me2resh.com" target="_blank" rel="noopener">me2resh</a> · ApexYard · open source · plain markdown · zero dependencies</div>
   </div>
 </footer>
+
+<!-- begin: consent — keep in sync across all site/*.html pages (#399) -->
+<!-- ============================================================
+     COOKIE CONSENT BANNER
+     Hidden if a prior choice is stored. On Accept, updates gtag
+     Consent Mode to grant analytics_storage.
+     ============================================================ -->
+<div id="consent" class="consent" role="region" aria-label="Cookie consent" hidden>
+  <div class="consent__inner">
+    <p class="consent__msg">
+      This site uses Google Analytics to count visits. No ads, no cross-site tracking.
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy</a>.
+    </p>
+    <div class="consent__actions">
+      <button type="button" class="consent__btn" data-consent="denied">Decline</button>
+      <button type="button" class="consent__btn consent__btn--accept" data-consent="granted">Accept</button>
+    </div>
+  </div>
+</div>
+<script>
+(function () {
+  var KEY = 'ay-consent';
+  var el = document.getElementById('consent');
+  if (!el) return;
+  var stored = null;
+  try { stored = localStorage.getItem(KEY); } catch (e) {}
+  if (stored !== 'granted' && stored !== 'denied') {
+    el.hidden = false;
+  }
+  function record(choice) {
+    if (el.hidden) return;
+    try { localStorage.setItem(KEY, choice); } catch (e) {}
+    if (choice === 'granted' && typeof gtag === 'function') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+    el.hidden = true;
+  }
+  el.addEventListener('click', function (e) {
+    var btn = e.target.closest('[data-consent]');
+    if (!btn) return;
+    record(btn.getAttribute('data-consent'));
+  });
+  // Escape dismisses the banner as "denied" - keyboard users without
+  // a mouse shouldn't be stuck with a fixed-bottom banner they can't
+  // dismiss. "Denied" is the non-consenting default per Consent Mode v2.
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !el.hidden) {
+      record('denied');
+    }
+  });
+})();
+</script>
+<!-- end: consent -->
 
 <script src="/copy-for-ai.js" defer></script>
 </body>

--- a/site/game.html
+++ b/site/game.html
@@ -815,7 +815,80 @@
     .cost-bill{font-size:26px;}
     .rag-tile{min-width:78px;}
   }
+/* begin: consent-css — keep in sync across all site/*.html pages (#399) */
+.consent {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--paper);
+  border-top: 1px solid var(--ink);
+  z-index: 100;
+  font-size: 12px;
+  padding: 1rem var(--gutter);
+}
+.consent[hidden] { display: none; }
+.consent__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.consent__msg {
+  flex: 1;
+  min-width: 260px;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+.consent__msg a { color: var(--accent); }
+.consent__actions { display: flex; gap: 0.5rem; }
+.consent__btn {
+  font: inherit;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.consent__btn:hover { border-color: var(--ink); }
+.consent__btn--accept {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.consent__btn--accept:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+/* end: consent-css */
 </style>
+
+<!-- begin: gtag — keep in sync across all site/*.html pages (#399) -->
+<!-- Google tag (gtag.js) with Consent Mode v2 - analytics_storage defaults to denied
+     until the consent banner below records an explicit choice. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G3EMR3CB02"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    'ad_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'analytics_storage': 'denied'
+  });
+  try {
+    if (localStorage.getItem('ay-consent') === 'granted') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+  } catch (e) {}
+  gtag('js', new Date());
+  gtag('config', 'G-G3EMR3CB02');
+</script>
+<!-- end: gtag -->
 </head>
 <body>
 <div id="app">
@@ -2724,5 +2797,58 @@ const LEVELS = [
 // boot
 renderIntro();
 </script>
+<!-- begin: consent — keep in sync across all site/*.html pages (#399) -->
+<!-- ============================================================
+     COOKIE CONSENT BANNER
+     Hidden if a prior choice is stored. On Accept, updates gtag
+     Consent Mode to grant analytics_storage.
+     ============================================================ -->
+<div id="consent" class="consent" role="region" aria-label="Cookie consent" hidden>
+  <div class="consent__inner">
+    <p class="consent__msg">
+      This site uses Google Analytics to count visits. No ads, no cross-site tracking.
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy</a>.
+    </p>
+    <div class="consent__actions">
+      <button type="button" class="consent__btn" data-consent="denied">Decline</button>
+      <button type="button" class="consent__btn consent__btn--accept" data-consent="granted">Accept</button>
+    </div>
+  </div>
+</div>
+<script>
+(function () {
+  var KEY = 'ay-consent';
+  var el = document.getElementById('consent');
+  if (!el) return;
+  var stored = null;
+  try { stored = localStorage.getItem(KEY); } catch (e) {}
+  if (stored !== 'granted' && stored !== 'denied') {
+    el.hidden = false;
+  }
+  function record(choice) {
+    if (el.hidden) return;
+    try { localStorage.setItem(KEY, choice); } catch (e) {}
+    if (choice === 'granted' && typeof gtag === 'function') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+    el.hidden = true;
+  }
+  el.addEventListener('click', function (e) {
+    var btn = e.target.closest('[data-consent]');
+    if (!btn) return;
+    record(btn.getAttribute('data-consent'));
+  });
+  // Escape dismisses the banner as "denied" - keyboard users without
+  // a mouse shouldn't be stuck with a fixed-bottom banner they can't
+  // dismiss. "Denied" is the non-consenting default per Consent Mode v2.
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !el.hidden) {
+      record('denied');
+    }
+  });
+})();
+</script>
+<!-- end: consent -->
+
 </body>
 </html>

--- a/site/how-it-works.html
+++ b/site/how-it-works.html
@@ -508,7 +508,80 @@ main { background: var(--paper); }
 }
 .page-footer a { color: var(--ink-soft); border-bottom: 1px dotted currentColor; padding-bottom: 1px; }
 .page-footer a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+/* begin: consent-css — keep in sync across all site/*.html pages (#399) */
+.consent {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--paper);
+  border-top: 1px solid var(--ink);
+  z-index: 100;
+  font-size: 12px;
+  padding: 1rem var(--gutter);
+}
+.consent[hidden] { display: none; }
+.consent__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.consent__msg {
+  flex: 1;
+  min-width: 260px;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+.consent__msg a { color: var(--accent); }
+.consent__actions { display: flex; gap: 0.5rem; }
+.consent__btn {
+  font: inherit;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.consent__btn:hover { border-color: var(--ink); }
+.consent__btn--accept {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.consent__btn--accept:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+/* end: consent-css */
 </style>
+
+<!-- begin: gtag — keep in sync across all site/*.html pages (#399) -->
+<!-- Google tag (gtag.js) with Consent Mode v2 - analytics_storage defaults to denied
+     until the consent banner below records an explicit choice. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G3EMR3CB02"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    'ad_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'analytics_storage': 'denied'
+  });
+  try {
+    if (localStorage.getItem('ay-consent') === 'granted') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+  } catch (e) {}
+  gtag('js', new Date());
+  gtag('config', 'G-G3EMR3CB02');
+</script>
+<!-- end: gtag -->
 </head>
 <body>
 
@@ -747,6 +820,59 @@ main { background: var(--paper); }
     <div class="page-footer__meta">© 2026 <a href="https://me2resh.com" target="_blank" rel="noopener">me2resh</a> · ApexYard · open source · plain markdown · zero dependencies</div>
   </div>
 </footer>
+
+<!-- begin: consent — keep in sync across all site/*.html pages (#399) -->
+<!-- ============================================================
+     COOKIE CONSENT BANNER
+     Hidden if a prior choice is stored. On Accept, updates gtag
+     Consent Mode to grant analytics_storage.
+     ============================================================ -->
+<div id="consent" class="consent" role="region" aria-label="Cookie consent" hidden>
+  <div class="consent__inner">
+    <p class="consent__msg">
+      This site uses Google Analytics to count visits. No ads, no cross-site tracking.
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy</a>.
+    </p>
+    <div class="consent__actions">
+      <button type="button" class="consent__btn" data-consent="denied">Decline</button>
+      <button type="button" class="consent__btn consent__btn--accept" data-consent="granted">Accept</button>
+    </div>
+  </div>
+</div>
+<script>
+(function () {
+  var KEY = 'ay-consent';
+  var el = document.getElementById('consent');
+  if (!el) return;
+  var stored = null;
+  try { stored = localStorage.getItem(KEY); } catch (e) {}
+  if (stored !== 'granted' && stored !== 'denied') {
+    el.hidden = false;
+  }
+  function record(choice) {
+    if (el.hidden) return;
+    try { localStorage.setItem(KEY, choice); } catch (e) {}
+    if (choice === 'granted' && typeof gtag === 'function') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+    el.hidden = true;
+  }
+  el.addEventListener('click', function (e) {
+    var btn = e.target.closest('[data-consent]');
+    if (!btn) return;
+    record(btn.getAttribute('data-consent'));
+  });
+  // Escape dismisses the banner as "denied" - keyboard users without
+  // a mouse shouldn't be stuck with a fixed-bottom banner they can't
+  // dismiss. "Denied" is the non-consenting default per Consent Mode v2.
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !el.hidden) {
+      record('denied');
+    }
+  });
+})();
+</script>
+<!-- end: consent -->
 
 <script src="/copy-for-ai.js" defer></script>
 </body>

--- a/site/skills.html
+++ b/site/skills.html
@@ -19,8 +19,8 @@
 <link rel="alternate" type="text/markdown" href="/skills.md">
 
 <!-- LLM consumers: payload size hints (token estimate = chars / 4). #333 item C. -->
-<meta name="llm:token-count" content="10658">
-<meta name="llm:doc-length" content="42632 chars">
+<meta name="llm:token-count" content="11945">
+<meta name="llm:doc-length" content="47780 chars">
 
 <meta property="og:title" content="ApexYard Skills — 53 active slash commands for Claude Code">
 <meta property="og:description" content="53 active slash commands available in any apexyard-managed project. Run any of these in a Claude Code session inside your fork.">
@@ -427,7 +427,80 @@ main {
 }
 .page-footer a { color: var(--ink-soft); border-bottom: 1px dotted currentColor; padding-bottom: 1px; }
 .page-footer a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+/* begin: consent-css — keep in sync across all site/*.html pages (#399) */
+.consent {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--paper);
+  border-top: 1px solid var(--ink);
+  z-index: 100;
+  font-size: 12px;
+  padding: 1rem var(--gutter);
+}
+.consent[hidden] { display: none; }
+.consent__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.consent__msg {
+  flex: 1;
+  min-width: 260px;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+.consent__msg a { color: var(--accent); }
+.consent__actions { display: flex; gap: 0.5rem; }
+.consent__btn {
+  font: inherit;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.consent__btn:hover { border-color: var(--ink); }
+.consent__btn--accept {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.consent__btn--accept:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+/* end: consent-css */
 </style>
+
+<!-- begin: gtag — keep in sync across all site/*.html pages (#399) -->
+<!-- Google tag (gtag.js) with Consent Mode v2 - analytics_storage defaults to denied
+     until the consent banner below records an explicit choice. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G3EMR3CB02"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    'ad_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'analytics_storage': 'denied'
+  });
+  try {
+    if (localStorage.getItem('ay-consent') === 'granted') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+  } catch (e) {}
+  gtag('js', new Date());
+  gtag('config', 'G-G3EMR3CB02');
+</script>
+<!-- end: gtag -->
 </head>
 <body>
 
@@ -955,6 +1028,59 @@ main {
     <div class="page-footer__meta">© 2026 <a href="https://me2resh.com" target="_blank" rel="noopener">me2resh</a> · ApexYard · open source · plain markdown · zero dependencies</div>
   </div>
 </footer>
+
+<!-- begin: consent — keep in sync across all site/*.html pages (#399) -->
+<!-- ============================================================
+     COOKIE CONSENT BANNER
+     Hidden if a prior choice is stored. On Accept, updates gtag
+     Consent Mode to grant analytics_storage.
+     ============================================================ -->
+<div id="consent" class="consent" role="region" aria-label="Cookie consent" hidden>
+  <div class="consent__inner">
+    <p class="consent__msg">
+      This site uses Google Analytics to count visits. No ads, no cross-site tracking.
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy</a>.
+    </p>
+    <div class="consent__actions">
+      <button type="button" class="consent__btn" data-consent="denied">Decline</button>
+      <button type="button" class="consent__btn consent__btn--accept" data-consent="granted">Accept</button>
+    </div>
+  </div>
+</div>
+<script>
+(function () {
+  var KEY = 'ay-consent';
+  var el = document.getElementById('consent');
+  if (!el) return;
+  var stored = null;
+  try { stored = localStorage.getItem(KEY); } catch (e) {}
+  if (stored !== 'granted' && stored !== 'denied') {
+    el.hidden = false;
+  }
+  function record(choice) {
+    if (el.hidden) return;
+    try { localStorage.setItem(KEY, choice); } catch (e) {}
+    if (choice === 'granted' && typeof gtag === 'function') {
+      gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    }
+    el.hidden = true;
+  }
+  el.addEventListener('click', function (e) {
+    var btn = e.target.closest('[data-consent]');
+    if (!btn) return;
+    record(btn.getAttribute('data-consent'));
+  });
+  // Escape dismisses the banner as "denied" - keyboard users without
+  // a mouse shouldn't be stuck with a fixed-bottom banner they can't
+  // dismiss. "Denied" is the non-consenting default per Consent Mode v2.
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !el.hidden) {
+      record('denied');
+    }
+  });
+})();
+</script>
+<!-- end: consent -->
 
 <script src="/copy-for-ai.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary

- **Consent-gated Google Analytics on all site pages** — `site/index.html` was the only page carrying the GA + cookie-consent setup. This adds the same three `#399`-sync blocks (consent CSS, Consent Mode v2 gtag, cookie banner) to the five remaining pages so analytics fires consistently across the whole site instead of just the landing page.
- **GDPR posture preserved everywhere** — each page's gtag block sets `consent default` with `analytics_storage: 'denied'` and only upgrades to `granted` when the visitor has explicitly opted in (`localStorage 'ay-consent' === 'granted'`). No analytics storage occurs before an explicit Accept on any page, matching index.html exactly.
- **Byte-identical blocks (the #399 requirement)** — the consent-css, gtag, and consent-banner blocks were copied verbatim from `index.html` and are checksum-identical across all 6 pages, so future edits stay in sync. Same GA ID `G-G3EMR3CB02` throughout.
- **Placement matches index.html** — CSS inside each page's existing `<style>`, gtag block inside `<head>` (right after `</style>`), and the consent banner + its script just before `</body>`.

Pages updated: `skills.html`, `architecture.html`, `how-it-works.html`, `game.html`, `404.html`.

## Testing

1. `grep -l googletagmanager site/*.html` lists all 6 pages (index + the 5 added).
2. Each page has exactly one `id="consent"` element (no duplicate IDs introduced): `for f in site/*.html; do grep -c 'id="consent"' "$f"; done` → all `1`.
3. Each of the three blocks is checksum-identical to `index.html` on all 5 target pages (verified with per-block `md5`).
4. All 6 pages parse cleanly via `html.parser`; `<style>` / `<head>` / `<body>` tags stay balanced.
5. Manual: load any page with no `ay-consent` key → banner shows, no analytics_storage; click Accept → `localStorage 'ay-consent' = 'granted'` and consent upgrades; reload → banner stays hidden.

## Glossary

| Term | Definition |
|------|------------|
| Consent Mode v2 | Google's mechanism for gating analytics/ads storage on user consent. `consent default` sets the pre-choice state; `consent update` flips a category (here `analytics_storage`) once the user opts in. |
| `analytics_storage` | The Consent Mode v2 category that governs whether GA may use cookies/local storage for measurement. Defaults to `denied` on every page until explicit opt-in. |
| gtag.js | Google's global site tag library (`googletagmanager.com/gtag/js`) that loads GA and processes `gtag(...)` calls. |
| `ay-consent` | The `localStorage` key storing the visitor's consent choice (`granted` / `denied`); persists the decision so the banner doesn't reappear. |
| G-G3EMR3CB02 | The GA4 Measurement ID for the apexyard site, shared across all pages. |

Closes #640
