### PR TITLE
fix: prevent double-scoring on multi-round game levels

### DIFF
--- a/site/game.html
+++ b/site/game.html
@@ -1269,6 +1269,7 @@ function level1(){
         roundIdx++;
         if (roundIdx < ROUNDS.length){ renderRound(); }
         else {
+          nb.disabled = true;
           const avg = Math.round(totalScore / ROUNDS.length);
           state.levelScores[state.level] = avg;
           addScore(avg);
@@ -1927,6 +1928,7 @@ function level6(){
         if (roundIdx < DOCS.length){
           renderRound();
         } else {
+          newBtn.disabled = true;
           state.levelScores[state.level] = totalScore;
           addScore(totalScore);
           showResult(totalScore, 100,
@@ -2241,6 +2243,7 @@ function levelTemp(){
         roundIdx++;
         if (roundIdx < SCEN.length) renderRound();
         else {
+          nb.disabled = true;
           const avg = Math.round(totalScore/SCEN.length);
           state.levelScores[state.level] = avg;
           addScore(avg);


### PR DESCRIPTION
```
fix: prevent double-scoring on multi-round game levels
```

## Summary

- **Disabled the Finish button immediately after the final round** in three multi-round game levels (`level1` tokens, `level6` prompt injection, `levelTemp` temperature). On the last round the action button is cloned and replaced with a "Finish →" button whose click handler scores the level and shows the result. Without a guard, rapid double-clicks (or any second click) re-enter the scoring branch and call `addScore()` repeatedly, inflating the total score and producing duplicate result cards. `nb.disabled = true;` (or `newBtn.disabled = true;`) inside the `else` branch stops this after the first click.

## Testing

- [x] Clicked "Finish →" twice rapidly on the last word in the token-splitting level — score no longer increments on second click.
- [x] Same for the last document in prompt injection and the last task in temperature dial.
- [x] Verified that normal single-click flow still completes correctly and advances to the result card.
- [x] Ran `bash bin/run-hook-tests.sh` — green.

## Glossary

| Term | Definition |
|------|------------|
| `addScore` | Global helper that increments `state.score` and updates the header pill. |
| `state.levelScores` | Array storing per-level score; prevents re-scoring a skipped level. |
| `cloneNode(true)` | Used to swap action buttons between rounds, which drops old listeners but leaves the new one unguarded against repeat clicks. |
