### PR TITLE
feat(#651): opt-in gate mode for suggest-mcp-search.sh (force MCP-first on exploratory search)

### DIFF
--- a/.claude/hooks/suggest-mcp-search.sh
+++ b/.claude/hooks/suggest-mcp-search.sh
@@ -29,9 +29,19 @@
 
 set -u
 
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/_lib-read-config.sh" 2>/dev/null || true
+
 INPUT=$(cat)
 
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+
+# Gate mode (#651): only the Bash exploratory-search branch is gate-eligible;
+# Read/Glob/Grep stay advisory-only so read→edit is never blocked. `escape`
+# is the per-call/operator opt-out that lets a search proceed when MCP can't
+# serve it (empty index, non-indexable repo, stale index).
+gate_eligible=false
+escape=false
 
 # ---------------------------------------------------------------------------
 # Branch on tool type. Bash uses the original grep/find command scanner.
@@ -101,6 +111,14 @@ if [ "$TOOL_NAME" = "Bash" ]; then
 
   $targets_framework || exit 0
 
+  # This Bash exploratory search over indexed paths is gate-eligible (#651).
+  gate_eligible=true
+  # Escape hatch: a real env var (operator/session) OR the per-call token in
+  # the command itself (`APEXYARD_MCP_FALLBACK=1 grep …` on a retry).
+  if [ "${APEXYARD_MCP_FALLBACK:-}" = "1" ] || printf '%s' "$COMMAND" | grep -q 'APEXYARD_MCP_FALLBACK=1'; then
+    escape=true
+  fi
+
 else
   # -------------------------------------------------------------------------
   # READ / GLOB / GREP BRANCH (#489): fire when the target path is inside a
@@ -143,6 +161,33 @@ for mcp_json in "$ops_root/.mcp.json" "${APEXYARD_PORTFOLIO_ROOT:-}/.mcp.json"; 
 done
 
 $mcp_has_search || exit 0
+
+# --- Gate mode (#651): opt-in soft-block before the advisory ----------------
+# When `mcp_search.gate_mode` is true AND this is a gate-eligible Bash search
+# AND the escape hatch isn't set, soft-block (exit 2) and instruct MCP-first.
+# Default-off, so this is a no-op for everyone who hasn't opted in. AgDR-0070.
+
+GATE_MODE=$(config_get_or '.mcp_search.gate_mode' 'false' 2>/dev/null || echo false)
+
+if $gate_eligible && [ "$GATE_MODE" = "true" ] && ! $escape; then
+  cat >&2 <<'EOF'
+BLOCKED (mcp_search.gate_mode): use the apexyard-search MCP index first.
+
+This is an exploratory grep/find over indexed framework/project paths. Run
+  mcp__apexyard-search__search_code   (managed-project codebases)
+  mcp__apexyard-search__search_docs   (framework docs)
+instead — semantic, targeted excerpts, ~3-5x fewer tokens. Load via
+  ToolSearch("select:mcp__apexyard-search__search_code,mcp__apexyard-search__search_docs").
+
+If MCP already returned nothing (empty/stale index, or a non-indexable repo),
+retry the exact command with the escape hatch prefix:
+  APEXYARD_MCP_FALLBACK=1 <your command>
+
+(Gate mode is opt-in via .claude/project-config.json → mcp_search.gate_mode.
+ Read/Glob/Grep are never blocked — only exploratory shell search.)
+EOF
+  exit 2
+fi
 
 # --- Emit advisory as additionalContext on stdout (non-blocking) -----------
 

--- a/.claude/hooks/tests/test_suggest_mcp_search.sh
+++ b/.claude/hooks/tests/test_suggest_mcp_search.sh
@@ -152,6 +152,72 @@ assert_silent "Write tool: not triggered" \
 assert_silent "Edit tool: not triggered" \
   '{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"workspace/example-app/src/foo.ts","old_string":"x","new_string":"y"}}' "$MCP_DIR"
 
+# ===========================================================================
+# Gate mode (#651, AgDR-0070): opt-in soft-block (exit 2) on gate-eligible
+# Bash searches, with a per-call escape hatch. Read/Glob/Grep never blocked.
+# ===========================================================================
+
+# A temp ops root the config lib will resolve to (via the `.apexyard-fork`
+# anchor) with mcp_search.gate_mode enabled + apexyard-search configured.
+GATE_ROOT=$(mktemp -d)
+touch "$GATE_ROOT/.apexyard-fork"
+mkdir -p "$GATE_ROOT/.claude"
+printf '%s' '{"mcp_search":{"gate_mode":false}}' > "$GATE_ROOT/.claude/project-config.defaults.json"
+printf '%s' '{"mcp_search":{"gate_mode":true}}' > "$GATE_ROOT/.claude/project-config.json"
+printf '%s' '{"mcpServers":{"apexyard-search":{"command":"apexyard-search"}}}' > "$GATE_ROOT/.mcp.json"
+cleanup_gate() { rm -rf "$GATE_ROOT"; }
+trap 'cleanup; cleanup_gate' EXIT
+
+# run from cwd=GATE_ROOT so config resolves gate_mode=true; APEXYARD_PORTFOLIO_ROOT
+# points the install-gate at the apexyard-search .mcp.json. Pin disabled so the
+# resolver walks up to the GATE_ROOT anchor rather than a session pin.
+# args: <input-json> [extra env assignment]  → echoes exit code
+gate_exit() {
+  local input="$1" extra="${2:-}"
+  ( cd "$GATE_ROOT" && echo "$input" | \
+      env APEXYARD_OPS_DISABLE_PIN=1 APEXYARD_PORTFOLIO_ROOT="$GATE_ROOT" $extra bash "$HOOK" >/dev/null 2>&1 )
+  echo $?
+}
+
+assert_exit() {
+  local desc="$1" want="$2" got="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc — expected exit $want, got $got"
+  fi
+}
+
+SEARCH_CMD='{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"grep -r \"activation\" roles/"}}'
+ESCAPE_CMD='{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"APEXYARD_MCP_FALLBACK=1 grep -r \"activation\" roles/"}}'
+READ_CMD='{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"workspace/example-app/src/index.ts"}}'
+
+assert_exit "gate ON: exploratory Bash search soft-blocks (exit 2)" 2 "$(gate_exit "$SEARCH_CMD")"
+assert_exit "gate ON + per-call escape token → proceeds (exit 0)" 0 "$(gate_exit "$ESCAPE_CMD")"
+assert_exit "gate ON + env escape APEXYARD_MCP_FALLBACK=1 → proceeds (exit 0)" 0 "$(gate_exit "$SEARCH_CMD" "APEXYARD_MCP_FALLBACK=1")"
+assert_exit "gate ON: Read on workspace/ is NOT blocked (read→edit, exit 0)" 0 "$(gate_exit "$READ_CMD")"
+
+# Gate ON but apexyard-search NOT configured → install-gate keeps it silent (0).
+NOGATE_ROOT=$(mktemp -d)
+touch "$NOGATE_ROOT/.apexyard-fork"; mkdir -p "$NOGATE_ROOT/.claude"
+printf '%s' '{"mcp_search":{"gate_mode":false}}' > "$NOGATE_ROOT/.claude/project-config.defaults.json"
+printf '%s' '{"mcp_search":{"gate_mode":true}}' > "$NOGATE_ROOT/.claude/project-config.json"
+printf '%s' '{"mcpServers":{"other":{}}}' > "$NOGATE_ROOT/.mcp.json"
+nogate_exit=$( cd "$NOGATE_ROOT" && echo "$SEARCH_CMD" | env APEXYARD_OPS_DISABLE_PIN=1 APEXYARD_PORTFOLIO_ROOT="$NOGATE_ROOT" bash "$HOOK" >/dev/null 2>&1; echo $? )
+assert_exit "gate ON but no apexyard-search → install-gate silent (exit 0)" 0 "$nogate_exit"
+rm -rf "$NOGATE_ROOT"
+
+# Gate OFF (default) + exploratory search → advisory, never blocks (exit 0).
+GATEOFF_ROOT=$(mktemp -d)
+touch "$GATEOFF_ROOT/.apexyard-fork"; mkdir -p "$GATEOFF_ROOT/.claude"
+printf '%s' '{"mcp_search":{"gate_mode":false}}' > "$GATEOFF_ROOT/.claude/project-config.defaults.json"
+printf '%s' '{"mcp_search":{"gate_mode":false}}' > "$GATEOFF_ROOT/.claude/project-config.json"
+printf '%s' '{"mcpServers":{"apexyard-search":{"command":"apexyard-search"}}}' > "$GATEOFF_ROOT/.mcp.json"
+gateoff_exit=$( cd "$GATEOFF_ROOT" && echo "$SEARCH_CMD" | env APEXYARD_OPS_DISABLE_PIN=1 APEXYARD_PORTFOLIO_ROOT="$GATEOFF_ROOT" bash "$HOOK" >/dev/null 2>&1; echo $? )
+assert_exit "gate OFF (default) → advisory, never blocks (exit 0)" 0 "$gateoff_exit"
+rm -rf "$GATEOFF_ROOT"
+
 # --- Report ----------------------------------------------------------------
 echo ""
 echo "suggest-mcp-search: $PASS passed, $FAIL failed"

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -105,6 +105,11 @@
     "multi_close_skip_marker": "<!-- multi-close: approved -->"
   },
 
+  "mcp_search": {
+    "_comment": "Config for suggest-mcp-search.sh. gate_mode is OPT-IN (default false): when true AND the apexyard-search MCP server is configured, the hook SOFT-BLOCKS (exit 2) exploratory `grep -r`/`find` over indexed framework/project paths, instructing the agent to use search_code/search_docs first. Read/Glob/Grep stay advisory-only (never blocked — read→edit needs real line numbers). Per-call escape hatch: prefix the command with APEXYARD_MCP_FALLBACK=1 (or export it) to proceed when MCP genuinely can't serve the query (empty index, non-indexable repo, stale index). Default false keeps the hook advisory-only for everyone who doesn't opt in. See AgDR-0070, #651.",
+    "gate_mode": false
+  },
+
   "leak_protection": {
     "public_framework_repos": [
       "me2resh/apexyard"

--- a/docs/agdr/AgDR-0070-mcp-search-gate-mode.md
+++ b/docs/agdr/AgDR-0070-mcp-search-gate-mode.md
@@ -1,0 +1,49 @@
+# Optional mechanical gate mode for suggest-mcp-search.sh
+
+> In the context of `suggest-mcp-search.sh` being advisory-only (exit 0), facing agents that routinely ignore the nudge and fall straight to `grep -r`/`find` over indexed paths (burning ~3–5× tokens), I decided to add an **opt-in, config-gated soft-block (exit 2) with a per-call escape hatch** to the existing hook, to achieve mechanical enforcement of the MCP-first path for operators who want it, accepting that the gate is strictly opt-in and only covers the Bash exploratory-search branch (never read→edit).
+
+## Context
+
+`suggest-mcp-search.sh` emits an `additionalContext` advisory (exit 0) when an agent runs exploratory `grep -r`/`find` over indexed framework/project paths and `apexyard-search` is configured. It is purely advisory — the agent can ignore it, and routinely does. Operators who rely on the MCP index have no way to *enforce* the token-saving path. Issue #651 asks for an optional mechanical gate.
+
+Constraints that shape the design:
+
+- A hook **cannot call MCP or reindex** — it can only block and instruct. So the gate can't verify "MCP already returned nothing"; the agent must be able to assert that and proceed.
+- The **read→edit flow needs real line numbers** — `Read`/`Glob`/`Grep` before an `Edit` must never be blocked.
+- The feature must be **invisible to free adopters** and those without the search component — same install-gate as the advisory.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Stay advisory-only (status quo) | Zero risk; never blocks legitimate work | The exact problem #651 reports — agents ignore it, no enforcement path |
+| **Opt-in config-gated soft-block (exit 2) on the Bash branch, with a per-call escape hatch** | Mechanical enforcement for operators who want it; default-off so nobody is surprised; read→edit untouched; escape hatch handles the empty-index / non-indexable / stale case | A new config key + env-var contract to document; agent must learn the escape hatch |
+| Hard-block (exit 2, no escape) | Strongest enforcement | Breaks the legitimate empty-result and non-indexable-repo cases — the hook can't know MCP already failed, so this would deadlock the agent |
+| Block Read/Glob/Grep too | Closes the native-tool bypass under the gate | Breaks read→edit (you need line numbers before an Edit); explicitly out of scope per #651 |
+
+## Decision
+
+Chosen: **opt-in config-gated soft-block on the Bash exploratory-search branch, with a per-call escape hatch**, because it gives enforcement to operators who opt in without changing anything for everyone else, and the escape hatch preserves every legitimate case the hook can't detect.
+
+Specifics:
+
+- New config key `mcp_search.gate_mode` (boolean, **default `false`**) in `.claude/project-config.defaults.json`. Gate mode activates only when this is `true` **and** `apexyard-search` is configured (the existing install-gate).
+- The gate applies **only to the Bash `grep -r`/`find`-over-indexed-paths branch**. `Read`/`Glob`/`Grep` stay advisory-only (exit 0) so read→edit is never blocked.
+- **Per-call escape hatch** `APEXYARD_MCP_FALLBACK=1`: recognised both as a real environment variable (operator/session level) and as a token in the command string (`APEXYARD_MCP_FALLBACK=1 grep -r …` — the per-call form the agent uses on a retry). When present, the gate steps aside (falls through to the advisory).
+- On block: **exit 2** with a stderr message (PreToolUse non-zero stderr is surfaced to the agent) explaining why, instructing `search_code`/`search_docs` first, and naming the escape hatch for the empty-index / non-indexable / stale-index case.
+- **Stale-index detection** (the "optionally" in #651) is folded into the escape-hatch message rather than implemented as HEAD-comparison: the hook has no reliable signal for the MCP index's freshness, so it instructs the agent to retry with the escape hatch if MCP already came back empty/stale, rather than asserting false precision.
+
+## Consequences
+
+- Operators who set `mcp_search.gate_mode: true` get mechanical MCP-first enforcement on exploratory shell search; everyone else is unaffected (default-off + install-gated).
+- The agent must use `search_code`/`search_docs` first under the gate, and append `APEXYARD_MCP_FALLBACK=1` to a retried command when MCP genuinely can't serve it.
+- The advisory path (gate off) is byte-for-byte unchanged, so existing behaviour and tests hold.
+- A future enhancement could add real stale-index detection if the search component exposes an index-timestamp signal a hook can read.
+
+## Artifacts
+
+- Issue: me2resh/apexyard#651
+- Hook: `.claude/hooks/suggest-mcp-search.sh`
+- Config: `.claude/project-config.defaults.json` → `mcp_search.gate_mode`
+- Tests: `.claude/hooks/tests/test_suggest_mcp_search.sh`
+- Related: #418 (original), #469 (additionalContext + install-gate), #489 (Read/Glob/Grep extension)


### PR DESCRIPTION
## Summary
- **Added an opt-in, config-gated soft-block to `suggest-mcp-search.sh`** — the hook was advisory-only (exit 0), so an agent could (and routinely did) ignore the nudge and `grep -r`/`find` over indexed paths, burning ~3–5× the tokens the MCP index exists to save. With `mcp_search.gate_mode: true` **and** `apexyard-search` configured, the hook now **soft-blocks (exit 2)** exploratory `grep -r`/`find` over indexed framework/project paths and instructs the agent to use `search_code`/`search_docs` first.
- **Per-call escape hatch `APEXYARD_MCP_FALLBACK=1`** — the hook can't know whether MCP already returned nothing (empty index, non-indexable repo, stale index), so the agent must be able to proceed: setting the env var (operator/session) or prefixing the retried command (`APEXYARD_MCP_FALLBACK=1 grep …`) steps the gate aside. The block message names this explicitly.
- **Read/Glob/Grep stay advisory-only** — only the Bash exploratory-search branch is gate-eligible. Read→edit needs real line numbers before an `Edit`, so those native tools are never blocked (matches #651 scope).
- **Default-off + install-gated** — `mcp_search.gate_mode` defaults to `false`, and the existing install-gate means free adopters / anyone without the search component see zero behaviour change. The advisory path (gate off) is byte-for-byte unchanged.
- **AgDR-0070** records the decision (advisory → opt-in gate, soft-block-with-escape over hard-block, why stale-index detection folds into the escape hatch rather than HEAD-comparison).

## Testing
- `bash .claude/hooks/tests/test_suggest_mcp_search.sh` — 29 pass on a clean checkout. New cases: gate-on soft-block (exit 2), per-call escape token → exit 0, env-var escape → exit 0, Read-on-workspace not blocked, gate-on-but-no-apexyard-search install-gate silent, and gate-off advisory (exit 0). Fixtures use a temp ops-root (`.apexyard-fork` anchor + `project-config.{defaults,}.json`) so the config lib resolves `gate_mode` deterministically.

## Scope / out of scope
- **Out of scope:** the hook calling MCP or reindexing itself (hooks can't invoke MCP) — the gate can only block + instruct.
- Stale-index detection is folded into the escape-hatch message (the hook has no reliable index-freshness signal) rather than implemented as HEAD-comparison.

Closes #651

---

## Glossary
| Term | Definition |
|------|------------|
| Soft-block | Hook exits 2 to refuse a tool call, but with a clear escape hatch — not a permanent hard stop. |
| Gate-eligible | Only the Bash exploratory `grep -r`/`find`-over-indexed-paths branch can be blocked; Read/Glob/Grep never are. |
| Escape hatch | `APEXYARD_MCP_FALLBACK=1` (env var or per-call command prefix) that lets a search proceed when MCP genuinely can't serve it. |
| Install-gate | The pre-existing check that the hook only acts when `apexyard-search` is configured in a resolvable `.mcp.json` — free adopters see nothing. |