### PR TITLE
feat(#653): detect (and offer to enable) GitHub Issues in /setup + /handover

### DIFF
--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -323,6 +323,76 @@ tracker_state() {
 }
 
 # ------------------------------------------------------------------------------
+# GitHub-Issues-enabled detection (#653, AgDR-0071)
+#
+# GitHub disables Issues on forks by default, so a fresh github-kind fork will
+# fail every issue-creating skill with a cryptic `gh` error. These helpers let
+# /setup + /handover detect that early and offer to fix it — gated on
+# tracker.kind so linear/jira/none adopters (who legitimately have GH Issues
+# off) are never warned.
+# ------------------------------------------------------------------------------
+
+# Public: tracker_issues_verdict <kind> <has_issues_enabled>
+#   PURE decision (no I/O) — the unit-testable core. Echoes one of:
+#     skip      — non-github tracker; the GH-Issues state is irrelevant
+#     disabled  — github tracker AND issues are off → warn
+#     ok        — github tracker with issues on, OR unknown (don't false-alarm)
+tracker_issues_verdict() {
+  local kind="$1" has="$2"
+  case "$kind" in
+    gh|github) ;;
+    *) echo "skip"; return 0 ;;
+  esac
+  case "$has" in
+    false|False|FALSE) echo "disabled" ;;
+    *) echo "ok" ;;   # true / unknown / empty → never false-alarm
+  esac
+}
+
+# Public: tracker_issues_enabled_raw <owner_repo>
+#   Echoes gh's hasIssuesEnabled ("true"/"false"), or "" when gh is missing or
+#   the call fails (network/auth) — callers treat "" as "unknown, don't warn".
+tracker_issues_enabled_raw() {
+  local repo="$1"
+  command -v gh >/dev/null 2>&1 || { echo ""; return 0; }
+  gh repo view "$repo" --json hasIssuesEnabled -q '.hasIssuesEnabled' 2>/dev/null || echo ""
+}
+
+# Public: tracker_issues_enable_hint <owner_repo>
+#   Echoes the one-line command to enable Issues on <owner_repo>.
+tracker_issues_enable_hint() {
+  echo "gh repo edit $1 --enable-issues"
+}
+
+# Public: tracker_check_issues <owner_repo>
+#   For a github-kind tracker, print a warning + enable hint to STDERR when
+#   Issues are disabled on <owner_repo>. No-op (return 0) for non-github
+#   trackers, enabled repos, or when gh can't answer. Returns 1 ONLY when
+#   issues are confirmed disabled — so a caller can branch on it to offer the
+#   fix. Never mutates anything (enabling is the caller's explicit, opt-in step).
+tracker_check_issues() {
+  local repo="$1"
+  [ -n "$repo" ] || return 0
+  local kind has verdict
+  kind=$(tracker_kind)
+  # Short-circuit: skip the gh round-trip entirely for non-github trackers.
+  case "$kind" in gh|github) ;; *) return 0 ;; esac
+  has=$(tracker_issues_enabled_raw "$repo")
+  verdict=$(tracker_issues_verdict "$kind" "$has")
+  if [ "$verdict" = "disabled" ]; then
+    {
+      echo "⚠ GitHub Issues is DISABLED on $repo, but tracker.kind is \"$kind\"."
+      echo "  Issue-creating skills (/feature, /bug, /task, /tickets-batch, /idea, …) will fail."
+      echo "  Enable it (needs admin):  $(tracker_issues_enable_hint "$repo")"
+      echo "  Or: Settings → General → Features → Issues."
+      echo "  (Tracking elsewhere? Set tracker.kind to linear/jira/none in .claude/project-config.json.)"
+    } >&2
+    return 1
+  fi
+  return 0
+}
+
+# ------------------------------------------------------------------------------
 # Public: tracker_clear_cache
 #   Reset all per-process caches. Used by tests; rarely needed elsewhere.
 # ------------------------------------------------------------------------------

--- a/.claude/hooks/tests/test_tracker_issues_detection.sh
+++ b/.claude/hooks/tests/test_tracker_issues_detection.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Tests for the GitHub-Issues-enabled detection helpers in _lib-tracker.sh
+# (#653, AgDR-0071). Run: bash .claude/hooks/tests/test_tracker_issues_detection.sh
+#
+# Covers the PURE verdict logic exhaustively, plus tracker_check_issues against
+# a PATH-mocked `gh` (disabled → warn + rc1; enabled → silent + rc0; non-github
+# kind → short-circuit, no gh call, silent + rc0).
+
+set -u
+
+LIB="$(cd "$(dirname "$0")/.." && pwd)/_lib-tracker.sh"
+# shellcheck source=/dev/null
+. "$LIB"
+
+PASS=0
+FAIL=0
+check() { # <desc> <got> <want>
+  if [ "$2" = "$3" ]; then PASS=$((PASS + 1)); else FAIL=$((FAIL + 1)); echo "FAIL: $1 — want '$3' got '$2'"; fi
+}
+
+# --- pure verdict logic ------------------------------------------------------
+check "gh + false → disabled"      "$(tracker_issues_verdict gh false)"      "disabled"
+check "github + false → disabled"  "$(tracker_issues_verdict github false)"  "disabled"
+check "gh + true → ok"             "$(tracker_issues_verdict gh true)"       "ok"
+check "gh + empty → ok"            "$(tracker_issues_verdict gh '')"         "ok"
+check "gh + unknown → ok"          "$(tracker_issues_verdict gh banana)"     "ok"
+check "linear + false → skip"      "$(tracker_issues_verdict linear false)"  "skip"
+check "jira + false → skip"        "$(tracker_issues_verdict jira false)"    "skip"
+check "asana + true → skip"        "$(tracker_issues_verdict asana true)"    "skip"
+check "none + false → skip"        "$(tracker_issues_verdict none false)"    "skip"
+
+# --- enable hint -------------------------------------------------------------
+check "enable hint" "$(tracker_issues_enable_hint owner/repo)" "gh repo edit owner/repo --enable-issues"
+
+# --- tracker_check_issues with a PATH-mocked gh ------------------------------
+MOCK=$(mktemp -d)
+mk_gh() { printf '#!/bin/bash\necho "%s"\n' "$1" > "$MOCK/gh"; chmod +x "$MOCK/gh"; }
+trap 'rm -rf "$MOCK"' EXIT
+
+# github kind + issues disabled → return 1 and warn on stderr
+_TRACKER_KIND_CACHE="gh"
+mk_gh false
+out=$(PATH="$MOCK:$PATH" tracker_check_issues owner/repo 2>&1); rc=$?
+check "disabled → rc 1" "$rc" "1"
+if echo "$out" | grep -q "DISABLED"; then PASS=$((PASS + 1)); else FAIL=$((FAIL + 1)); echo "FAIL: disabled should warn (got: $out)"; fi
+if echo "$out" | grep -q "gh repo edit owner/repo --enable-issues"; then PASS=$((PASS + 1)); else FAIL=$((FAIL + 1)); echo "FAIL: disabled should print enable hint"; fi
+
+# github kind + issues enabled → return 0, silent
+mk_gh true
+out=$(PATH="$MOCK:$PATH" tracker_check_issues owner/repo 2>&1); rc=$?
+check "enabled → rc 0" "$rc" "0"
+check "enabled → silent" "$out" ""
+
+# non-github kind → short-circuit: rc 0, silent, gh NOT consulted (mock says false)
+_TRACKER_KIND_CACHE="linear"
+mk_gh false
+out=$(PATH="$MOCK:$PATH" tracker_check_issues owner/repo 2>&1); rc=$?
+check "linear → rc 0 (short-circuit)" "$rc" "0"
+check "linear → silent" "$out" ""
+
+# empty repo arg → no-op rc 0
+_TRACKER_KIND_CACHE="gh"
+out=$(PATH="$MOCK:$PATH" tracker_check_issues "" 2>&1); rc=$?
+check "empty repo → rc 0" "$rc" "0"
+
+echo ""
+echo "tracker-issues-detection: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -1016,6 +1016,21 @@ Skipping the auto-append. If you want to add it later, copy this into apexyard.p
 
 The assessment's `## Next Steps` section (written in step 5) enumerates concrete follow-up work derived from the risks found. By default those entries are static prose — the operator reads them in the markdown and translates each to a `/feature` / `/task` / `/bug` invocation by hand. Recommendations rot when that translation step has friction. This step closes the loop: surface each next-step entry inline, prompt y/n per item, and dispatch the right ticket-creation skill per accepted item.
 
+#### Pre-check: is GitHub Issues enabled on the project repo? (github tracker only — #653)
+
+Tickets filed here land in the **project's own** repo, and GitHub disables Issues on forks/new repos by default — so this is the moment a `gh issue create` would fail with `the '<owner>/<repo>' repository has disabled issues`. Probe it first (gated on `tracker.kind` — silent no-op for linear/jira/none):
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-tracker.sh"
+# <owner/repo> is the project's repo resolved in step 1 / appended in step 7.
+if ! tracker_check_issues "<owner/repo>"; then
+  : # warning + enable hint already printed to stderr — advisory, non-blocking
+fi
+```
+
+This is **advisory** — if issues are disabled, surface the warning + the `gh repo edit <owner/repo> --enable-issues` hint and let the operator decide before the per-item filing loop (offering to enable it is fine on explicit y/n; never auto-enable). If they decline, skip the filing offer (the tickets can't be created) and note the next steps remain in the assessment markdown.
+
 #### Skip conditions
 
 - **Zero next-step entries** (no risks found, no synthetic "calibrate review standards" / "stakeholder sync" entries either) → skip this step silently

--- a/.claude/skills/idea/SKILL.md
+++ b/.claude/skills/idea/SKILL.md
@@ -214,6 +214,7 @@ Common failure modes and what to do:
 | `could not resolve repository` | Ask the user which repo to file the issue in; the backlog entry was already saved |
 | `missing scope: issues:write` | Tell the user to run `gh auth refresh -s issues` and offer to retry |
 | `label "idea" not found` | Create the label first (`gh label create idea`) then retry |
+| `repository has disabled issues` (#653) | GitHub Issues is off on the repo. Surface the fix: `gh repo edit <owner/repo> --enable-issues` (needs admin), or set `tracker.kind` to your real tracker. Reuse `tracker_check_issues` from `_lib-tracker.sh` to print the hint. The backlog entry is already saved. |
 | `HTTP 403 rate-limited` | Offer to retry after a short wait |
 | Any other error | Show the raw `gh` output, skip the tracking issue, keep the backlog entry |
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -614,6 +614,34 @@ session start. See docs/multi-project.md § "Centralised agent routing".
 
 No file writes here — purely informational. Added in #351 PR 3.
 
+### Step 7b: Check GitHub Issues is enabled (github tracker only — #653)
+
+GitHub disables **Issues on forks by default**, so a fresh fork that tracks via GitHub Issues will fail every issue-creating skill (`/feature`, `/bug`, `/task`, `/tickets-batch`, `/idea`, `/migration`, …) with a cryptic `the '<owner>/<repo>' repository has disabled issues` error. Catch it here, at first-run, instead.
+
+This step is **gated on `tracker.kind`** — for `linear` / `jira` / `none` adopters, GitHub Issues being off is correct, so the probe is a silent no-op. Source the tracker lib and probe the ops fork's repo:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-tracker.sh"
+FORK_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+# tracker_check_issues prints a warning + the enable hint to stderr and returns
+# 1 ONLY when this is a github tracker AND issues are confirmed disabled.
+if [ -n "$FORK_REPO" ] && ! tracker_check_issues "$FORK_REPO"; then
+  : # warning already shown — offer to enable below
+fi
+```
+
+If `tracker_check_issues` reported disabled, **offer** (do not auto-run) to enable it:
+
+```
+GitHub Issues is off on <owner/repo> and your tracker is GitHub Issues.
+Enable it now? (needs admin on the repo)
+  [y] run: gh repo edit <owner/repo> --enable-issues
+  [n] skip — I'll print the command for later
+```
+
+On **y**, run `gh repo edit <FORK_REPO> --enable-issues` and confirm. On **n**, print the one-liner and move on. Never enable silently — it's an externally-visible repo-settings change requiring admin scope, and the adopter may intend to track elsewhere. (In split-portfolio mode, the issue-hosting repo is the **public fork**, not the private portfolio — probe the fork, which is what `gh repo view` returns here.)
+
 ### Step 8: Clear the bootstrap marker (REQUIRED)
 
 ```bash

--- a/docs/agdr/AgDR-0071-detect-github-issues-enabled.md
+++ b/docs/agdr/AgDR-0071-detect-github-issues-enabled.md
@@ -1,0 +1,49 @@
+# Detect (and offer to enable) GitHub Issues during /setup + /handover
+
+> In the context of apexyard's tracker model assuming a working issue tracker, facing GitHub's default of **disabling Issues on forks** (so a fresh github-kind fork fails every issue-creating skill with a cryptic error), I decided to add a **tracker.kind-gated detection** to `/setup` and `/handover` that **warns and offers to enable** (never auto-enables) Issues, plus a shared `_lib-tracker.sh` helper, to achieve early, friendly failure-prevention, accepting that the check is advisory and only meaningful for github-kind trackers.
+
+## Context
+
+GitHub disables Issues on forks (and can on new repos) by default. apexyard's issue-creating skills (`/feature`, `/bug`, `/task`, `/tickets-batch`, `/idea`, `/migration`, `/spike`, `/investigation`) all assume `gh issue create` works against the configured tracker repo. When Issues are off, every one of them fails with `the '<owner>/<repo>' repository has disabled issues` — a silent first-run footgun nothing in the bootstrap flow surfaces. This was hit live while trying to file a fork-maintenance chore.
+
+The tracker is configurable (`.tracker.kind` = `gh` | `linear` | `jira` | `asana` | `custom` | `none`). For non-github kinds, GitHub Issues being off is *correct*, so any check must be gated.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Do nothing (status quo) | No work | The footgun persists; every fresh github fork hits it at first issue-creating skill |
+| **Detect + warn + offer-to-enable in /setup + /handover, gated on tracker.kind** | Catches it at the cheapest moment (bootstrap / adoption); respects non-github trackers; one shared lib helper; never mutates repo settings without consent | A new helper + two SKILL steps to maintain |
+| Auto-enable Issues during setup | Zero-friction fix | Externally-visible repo-settings change without consent; needs admin scope; wrong for adopters who intentionally track elsewhere |
+| Only fix at point-of-use (catch the gh error in each skill) | Fixes the actual failure site | 8 skills to edit; the operator still hits the error once per skill before the hint; misses the "tell me up front" value |
+
+## Decision
+
+Chosen: **detect + warn + offer-to-enable in `/setup` and `/handover`, gated on `tracker.kind`, backed by a shared `_lib-tracker.sh` helper** — with point-of-use graceful-degrade as a complementary (not primary) layer.
+
+Load-bearing principles:
+
+1. **Gate on `tracker.kind`** — github-only (`gh`/`github`); a silent no-op for `linear`/`jira`/`asana`/`custom`/`none`.
+2. **Inform always, enable only on explicit opt-in** — `tracker_check_issues` only *reports*; enabling (`gh repo edit <repo> --enable-issues`) is the caller's explicit y/n step. Never silent (admin scope + externally visible + may be intentional).
+3. **Never false-alarm** — when `gh` can't answer (missing / network / auth), the verdict is `ok`, not `disabled`.
+4. **Pure, testable core** — `tracker_issues_verdict <kind> <has_issues_enabled>` is I/O-free so the decision logic is unit-tested exhaustively; the gh round-trip is a thin wrapper.
+
+Surfaces:
+
+- `_lib-tracker.sh`: `tracker_issues_verdict` (pure), `tracker_issues_enabled_raw` (gh probe), `tracker_issues_enable_hint`, `tracker_check_issues` (compose: warn + return 1 when disabled).
+- `/setup` Step 7b: probe the ops fork repo; offer to enable.
+- `/handover` Step 7.5 pre-check: probe the adopted project's repo before the Next-Steps filing loop; advisory.
+
+## Consequences
+
+- A fresh github-kind fork is told at `/setup` time that Issues are off, with a one-command fix, instead of discovering it via a cryptic error later.
+- Non-github adopters see nothing (gated).
+- No repo settings change without explicit consent.
+- Point-of-use graceful-degrade across all 8 issue-creating skills is a follow-up (the lib helper is the shared mechanism they'll call); this AgDR's scope is the bootstrap/adoption detection + the helper.
+
+## Artifacts
+
+- Issue: me2resh/apexyard#653
+- Lib: `.claude/hooks/_lib-tracker.sh` (`tracker_issues_*`)
+- Skills: `.claude/skills/setup/SKILL.md` (Step 7b), `.claude/skills/handover/SKILL.md` (Step 7.5 pre-check)
+- Tests: `.claude/hooks/tests/test_tracker_issues_detection.sh`


### PR DESCRIPTION
## Summary
- **New `_lib-tracker.sh` detection helpers** — `tracker_issues_verdict` (a pure, I/O-free decision: `skip` for non-github trackers / `disabled` for github+off / `ok` otherwise), `tracker_issues_enabled_raw` (the `gh repo view --json hasIssuesEnabled` probe), `tracker_issues_enable_hint`, and `tracker_check_issues` (composes them: warns to stderr + returns 1 only when issues are *confirmed* disabled). Everything is **gated on `tracker.kind`** — a silent no-op for `linear`/`jira`/`asana`/`custom`/`none` — and **never false-alarms** when `gh` can't answer (unknown → `ok`).
- **`/setup` Step 7b** — probes the ops fork repo at first-run and, when github-kind and issues are off, **offers** to enable via `gh repo edit <repo> --enable-issues` on explicit y/n. Never auto-enables (admin scope, externally-visible, may be intentional).
- **`/handover` Step 7.5 pre-check** — probes the adopted project's repo before the Next-Steps ticket-filing loop, so a `gh issue create` doesn't fail mid-adoption. Advisory.
- **`/idea` graceful-degrade** — a failure-table row for `repository has disabled issues` pointing at the enable hint (the reference for the shared `tracker_check_issues` mechanism other issue-creating skills adopt).
- **AgDR-0071** records the decision: inform-not-auto-enable, gate on `tracker.kind`, pure testable core, never false-alarm.

## Why
GitHub disables Issues on forks by default, so a fresh github-kind fork fails *every* issue-creating skill (`/feature`, `/bug`, `/task`, `/tickets-batch`, `/idea`, `/migration`, `/spike`, `/investigation`) with a cryptic `the '<owner>/<repo>' repository has disabled issues` error — a silent first-run footgun (hit live while filing a fork chore). This surfaces it at the cheapest moment with a one-command fix.

## Testing
- `bash .claude/hooks/tests/test_tracker_issues_detection.sh` — **18 pass**: `tracker_issues_verdict` exhaustively (gh/github/linear/jira/asana/none × on/off/unknown), the enable hint, and `tracker_check_issues` against a PATH-mocked `gh` (disabled → warn + rc 1 + hint; enabled → silent rc 0; non-github → short-circuit, gh not consulted; empty repo → rc 0).
- `bash .claude/hooks/tests/test_tracker_aware_hooks.sh` — 22 pass (no regression).
- `shellcheck -x` clean on the lib + new test.

## Out of scope
- Auto-enabling without confirmation; enabling for non-github trackers.
- Point-of-use graceful-degrade across all 8 issue-creating skills — `/idea` is wired as the reference; the shared `tracker_check_issues` helper is the mechanism the rest adopt (follow-up).

Closes #653

---

## Glossary
| Term | Definition |
|------|------------|
| `tracker.kind` | The configured tracker backend (`gh` / `linear` / `jira` / `asana` / `custom` / `none`); the detection only applies to `gh`/`github`. |
| `hasIssuesEnabled` | The GitHub repo field (`gh repo view --json hasIssuesEnabled`) reporting whether the Issues tab is on. |
| Verdict (`skip`/`disabled`/`ok`) | The pure decision `tracker_issues_verdict` returns so the I/O-free logic can be unit-tested apart from the `gh` call. |
| Fail-open | When `gh` can't answer (missing/network/auth), the verdict is `ok` — the check never blocks or false-alarms. |