### PR TITLE
fix(#643): block-merge-on-red-ci refuses variable-substituted merges instead of guessing

### DIFF
--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -127,6 +127,52 @@ extract_pr_number() {
   echo "$pr"
 }
 
+# Returns 0 if the merge command's PR positional arg OR its --repo value is an
+# UNEXPANDED shell variable ($VAR / ${VAR}). (#643)
+#
+# WHY THIS EXISTS
+# ---------------
+# Hooks see the LITERAL command string, before the shell expands variables. For
+# `gh pr merge $PR --repo $REPO`, the hook cannot know the real PR/repo:
+#   - extract_pr_number returns empty for `$PR` (good, #568) but then falls back
+#     to `gh pr view` in the CWD — checking a totally UNRELATED PR's CI.
+#   - extract_repo_from_command captures the literal `$REPO`, which `gh` then
+#     rejects with `expected the "[HOST/]OWNER/REPO" format`.
+# Both produce misleading output and can evaluate the wrong PR. A gate that
+# can't resolve its target must not guess — callers should BLOCK with a
+# "re-run with literal values" message. This helper is that detector.
+#
+# Matches `$VAR`, `${VAR}` (the leading char after $ / ${ is a letter or _).
+# Does NOT match a literal repo/number, and does NOT match `$(...)` command
+# substitution as a PR/repo token (those aren't valid PR/repo values anyway).
+merge_command_uses_variable() {
+  local cmd="$1"
+
+  # PR positional arg: first token after `gh pr merge` (reuse the same span +
+  # redirection-stripping discipline as extract_pr_number so `2>&1` etc. don't
+  # masquerade as the positional arg).
+  local span clean_span first_token
+  span=$(echo "$cmd" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*')
+  clean_span=$(echo "$span" | sed \
+    -e 's/[0-9]*>&[0-9]*/  /g' \
+    -e 's/&>[^[:space:]]*/  /g' \
+    -e 's/>>[^[:space:]]*/  /g' \
+    -e 's/>[^[:space:]]*/  /g')
+  first_token=$(echo "$clean_span" | grep -oE '\bmerge\b[[:space:]]+[^[:space:]]*' | awk 'NR==1 {print $NF}')
+  if echo "$first_token" | grep -qE '^\$\{?[A-Za-z_]'; then
+    return 0
+  fi
+
+  # --repo value.
+  local repo_token
+  repo_token=$(echo "$cmd" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+  if echo "$repo_token" | grep -qE '^\$\{?[A-Za-z_]'; then
+    return 0
+  fi
+
+  return 1
+}
+
 # Echoes the PR's HEAD SHA as reported by GitHub, or empty on failure.
 #
 # Why this exists (see #55): merge-gate hooks previously compared approval

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -159,14 +159,17 @@ merge_command_uses_variable() {
     -e 's/>>[^[:space:]]*/  /g' \
     -e 's/>[^[:space:]]*/  /g')
   first_token=$(echo "$clean_span" | grep -oE '\bmerge\b[[:space:]]+[^[:space:]]*' | awk 'NR==1 {print $NF}')
-  if echo "$first_token" | grep -qE '^\$\{?[A-Za-z_]'; then
+  # Match `$VAR`, `${VAR}`, and the quoted forms `"$VAR"` / `'$VAR'` — agents and
+  # operators routinely quote the substitution. The optional leading quote keeps
+  # the anchor from being defeated by it.
+  if echo "$first_token" | grep -qE '^["'"'"']?\$\{?[A-Za-z_]'; then
     return 0
   fi
 
-  # --repo value.
+  # --repo value (same quoted-or-bare variable forms).
   local repo_token
   repo_token=$(echo "$cmd" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
-  if echo "$repo_token" | grep -qE '^\$\{?[A-Za-z_]'; then
+  if echo "$repo_token" | grep -qE '^["'"'"']?\$\{?[A-Za-z_]'; then
     return 0
   fi
 

--- a/.claude/hooks/block-merge-on-red-ci.sh
+++ b/.claude/hooks/block-merge-on-red-ci.sh
@@ -42,13 +42,30 @@ if ! is_merge_command "$COMMAND"; then
   exit 0
 fi
 
-# Parse --repo (for `gh pr merge --repo owner/repo`). Fallback: recover from
-# the `gh api .../pulls/<N>/merge` URL path so `gh pr checks` below is still
-# scoped correctly.
-CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
-if [ -z "$CMD_REPO" ]; then
-  CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
+# Variable-substituted merge (#643): if the PR arg or --repo value is an
+# unexpanded shell variable, this hook can't resolve the real target from the
+# command text — the old code fell back to the CWD's PR and checked an
+# UNRELATED PR's CI (and passed `$REPO` to gh, producing garbage errors). A CI
+# gate must not guess. Block with a clear, accurate instruction instead.
+if merge_command_uses_variable "$COMMAND"; then
+  cat >&2 <<'EOF'
+BLOCKED: cannot verify CI on a variable-substituted merge command.
+
+This gate reads the literal command text and can't resolve shell variables
+(e.g. `gh pr merge $PR --repo $REPO`) to the real PR / repo, so it cannot
+check the correct PR's CI status. Re-run with literal values:
+
+  gh pr merge <number> --repo <owner>/<repo> --squash
+
+(Use the actual PR number and owner/repo — not shell variables.)
+EOF
+  exit 2
 fi
+
+# Parse --repo (for `gh pr merge --repo owner/repo`). Uses the shared extractor,
+# which also recovers the repo from a `gh api .../pulls/<N>/merge` URL path so
+# `gh pr checks` below is still scoped correctly.
+CMD_REPO=$(extract_repo_from_command "$COMMAND")
 REPO_FLAG=""
 if [ -n "$CMD_REPO" ]; then
   REPO_FLAG="--repo $CMD_REPO"

--- a/.claude/hooks/tests/test_extract_pr.sh
+++ b/.claude/hooks/tests/test_extract_pr.sh
@@ -158,6 +158,9 @@ assert_var "var PR \${PR_NUMBER}"  'gh pr merge ${PR_NUMBER} --squash'          
 # Variable --repo value → yes (even with a literal PR number)
 assert_var "var repo \$REPO"       'gh pr merge 378 --repo $REPO --squash'            "yes"
 assert_var "var repo \${REPO}"     'gh pr merge 378 --repo ${REPO} --squash'          "yes"
+# Quoted variable forms → yes (the common shape agents/operators write)
+assert_var "quoted var PR \"\$PR\""    'gh pr merge "$PR" --repo me2resh/apexyard'    "yes"
+assert_var "quoted var repo \"\$REPO\"" 'gh pr merge 378 --repo "$REPO" --squash'      "yes"
 # Both literal → no
 assert_var "literal PR + repo"     'gh pr merge 378 --repo me2resh/apexyard --squash' "no"
 assert_var "literal PR no repo"    'gh pr merge 42 --squash'                          "no"

--- a/.claude/hooks/tests/test_extract_pr.sh
+++ b/.claude/hooks/tests/test_extract_pr.sh
@@ -137,6 +137,35 @@ assert_pr "gh pr view is not a merge command" \
   "gh pr view 42" \
   ""
 
+# --- #643: merge_command_uses_variable (variable-substituted merge detection) ---
+
+assert_var() {
+  local label="$1" cmd="$2" want="$3"   # want: "yes" (uses var) | "no"
+  local got="no"
+  merge_command_uses_variable "$cmd" && got="yes"
+  if [ "$got" = "$want" ]; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label]: cmd=[$cmd]  want=[$want]  got=[$got]" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+  fi
+}
+
+# Variable PR arg → yes
+assert_var "var PR \$PR"            'gh pr merge $PR --repo me2resh/apexyard --squash' "yes"
+assert_var "var PR \${PR_NUMBER}"  'gh pr merge ${PR_NUMBER} --squash'                "yes"
+# Variable --repo value → yes (even with a literal PR number)
+assert_var "var repo \$REPO"       'gh pr merge 378 --repo $REPO --squash'            "yes"
+assert_var "var repo \${REPO}"     'gh pr merge 378 --repo ${REPO} --squash'          "yes"
+# Both literal → no
+assert_var "literal PR + repo"     'gh pr merge 378 --repo me2resh/apexyard --squash' "no"
+assert_var "literal PR no repo"    'gh pr merge 42 --squash'                          "no"
+# Redirections must not be mistaken for a variable PR arg
+assert_var "literal + 2>&1 pipe"   'gh pr merge 42 --squash 2>&1 | tail -5'           "no"
+# gh api shape (literal path) → no
+assert_var "gh api literal path"   'gh api repos/o/r/pulls/42/merge -X PUT'           "no"
+
 # --- Cleanup -------------------------------------------------------------
 rm -rf "$SHIM_DIR"
 


### PR DESCRIPTION
## Summary
- **Root cause**: merge-gate hooks parse the **literal** command string (before the shell expands variables). For `gh pr merge $PR --repo $REPO`, `block-merge-on-red-ci.sh` couldn't resolve the real target — `extract_pr_number` correctly returns empty for `$PR` (#568) but its step-3 fallback then ran `gh pr view` in the **CWD**, checking an *unrelated* PR's CI; and the inline `--repo` parser captured the literal `$REPO`, which `gh` rejected with `expected the "[HOST/]OWNER/REPO" format`. Net: wrong PR number + garbage error, blocking for the wrong reason.
- **Fix**: a CI gate must not guess its target. New shared helper **`merge_command_uses_variable`** in `_lib-extract-pr.sh` detects an unexpanded `$VAR`/`${VAR}` in the PR positional arg or the `--repo` value (reusing the same span + redirection-stripping discipline as `extract_pr_number`, so `2>&1` etc. aren't mistaken for the arg). `block-merge-on-red-ci.sh` now **blocks (exit 2) with a clear "re-run with literal values" message** when a variable is detected — *before any `gh` call* — and switches its inline `--repo` sed to the shared `extract_repo_from_command`.
- **Why block (not skip/guess)**: the hook genuinely cannot expand a shell variable from the command text. Skipping would let a red-CI merge through; guessing (the old CWD fallback) checks the wrong PR. Blocking with an accurate instruction is the only safe option.

## Testing
- `bash .claude/hooks/tests/test_extract_pr.sh` — **24 pass** (10 `merge_command_uses_variable` cases, incl. quoted `"$PR"`/`"$REPO"`: var PR `$PR`/`${PR_NUMBER}`, var repo `$REPO`/`${REPO}`, literal PR+repo → no, literal+`2>&1` pipe → no, gh-api literal path → no).
- `bash .claude/hooks/tests/test_block_unreviewed_merge.sh` — **29 pass** (no regression; shares `_lib-extract-pr.sh`).
- End-to-end: `gh pr merge $PR --repo $REPO` → exit 2 + clear message; non-merge command → exit 0.
- `shellcheck -x` clean (only pre-existing INFO notes: SC1091 sourced-lib, SC2086 intentional `$REPO_FLAG` word-split).

## Scope
Fixes `block-merge-on-red-ci` (the gate that produced the garbage output in the report). The shared `merge_command_uses_variable` helper is now available for the other three merge gates (`block-unreviewed-merge`, `require-design-review-for-ui`, `require-architecture-review`) to adopt the same guard — left as a follow-up to keep this PR focused. Those gates are less dangerous today (they fail-safe: a wrong/empty PR # means marker SHAs don't match → block).

Closes #643

---

## Glossary
| Term | Definition |
|------|------------|
| Variable-substituted merge | A `gh pr merge` invocation whose PR number or `--repo` is a shell variable (`$PR`, `${REPO}`) the hook can't expand from the literal command text. |
| Fail-open vs fail-safe | This gate now **fails safe** (blocks) on unresolvable input rather than failing open (checking an unrelated PR). |
| `extract_pr_number` / `extract_repo_from_command` | Shared parsers in `_lib-extract-pr.sh` used by all four merge gates. |
| CWD fallback | `extract_pr_number`'s last resort (`gh pr view` in the current dir) — correct for a bare `gh pr merge`, wrong for `$PR` (the bug). |