### PR TITLE
feat(#670): per-project tracker config resolution

### DIFF
--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -11,12 +11,19 @@
 #   tracker.id_pattern   — regex for valid ticket-ID shape (no-existence-check fallback)
 #
 # Public functions:
-#   tracker_kind                       echoes the configured tracker kind
-#   tracker_id_pattern                 echoes the configured ID regex
+#   tracker_kind [<owner/repo>]        echoes the configured tracker kind
+#   tracker_id_pattern [<owner/repo>]  echoes the configured ID regex
 #   tracker_owner_repo_param <slug>    formats the owner/repo parameter (gh: "owner/repo"; others: empty)
 #   tracker_view <id> [<owner_repo>]   dispatches the view command and emits normalised JSON on stdout
 #                                      Exit 0 = ticket exists; non-zero = doesn't, or CLI errored.
 #                                      JSON shape: {"state":..., "title":..., "url":..., "labels":[...]}
+#
+# Per-project resolution (#670 / AgDR-0072): tracker_kind / tracker_id_pattern /
+# tracker_view take an OPTIONAL owner/repo. When supplied, a `tracker:` block on
+# that project's apexyard.projects.yaml entry overrides the global config block
+# (per key); when omitted, the global block is used — byte-for-byte the original
+# behaviour. The project is chosen by the OPERATION'S TARGET REPO the caller
+# already holds — never by cwd or a session-global marker.
 #
 # Normalisation: each adapter parses the underlying CLI's JSON (gh / linear /
 # jira / asana / custom) into the common shape above. Consumers should only
@@ -52,12 +59,100 @@ _tracker_load_config_lib() {
 }
 
 # ------------------------------------------------------------------------------
-# Public: tracker_kind
-#   Echoes the configured tracker kind. Default "gh" (GitHub Issues).
+# Internal: ensure _lib-portfolio-paths.sh is loaded so portfolio_registry works.
+# ------------------------------------------------------------------------------
+_tracker_load_portfolio_lib() {
+  if command -v portfolio_registry >/dev/null 2>&1; then
+    return 0
+  fi
+  local hook_dir
+  hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [ -f "$hook_dir/_lib-portfolio-paths.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$hook_dir/_lib-portfolio-paths.sh"
+  fi
+}
+
+# ------------------------------------------------------------------------------
+# Internal: _tracker_project_value <owner/repo> <key>
+#   Reads `.projects[] | select(.repo == <owner/repo>) | .tracker.<key>` from the
+#   portfolio registry (apexyard.projects.yaml) — the per-project override for
+#   one tracker key (kind / id_pattern / view_command / create_command).
+#
+#   The project is selected by the OPERATION'S TARGET REPO passed in by the
+#   caller — never by cwd or a session-global marker (see AgDR-0072 / #670).
+#
+#   Echoes the value and exits 0 when a non-empty override exists; exits 1
+#   (empty stdout) otherwise — so callers fall back to the global config block.
+#
+#   YAML is read via `yq` (mikefarah, matching _lib-portfolio-paths.sh) with a
+#   `python3`+PyYAML fallback. If neither can parse, the lookup returns 1 and the
+#   caller degrades to the global tracker config — single-tracker forks unaffected.
+# ------------------------------------------------------------------------------
+_tracker_project_value() {
+  local repo="$1" key="$2"
+  [ -n "$repo" ] && [ -n "$key" ] || return 1
+  _tracker_load_portfolio_lib
+  command -v portfolio_registry >/dev/null 2>&1 || return 1
+  local registry
+  registry=$(portfolio_registry 2>/dev/null)
+  [ -n "$registry" ] && [ -f "$registry" ] || return 1
+
+  local val=""
+  if command -v yq >/dev/null 2>&1; then
+    # Pass the repo via env + strenv() so an odd repo value can never break out
+    # of the yq expression (defense-in-depth — a real owner/repo can't contain a
+    # quote, but the python3 path below is argv-safe, so match it here). $key is
+    # always a hardcoded literal from callers (kind / id_pattern / view_command),
+    # so substituting it into the path is safe.
+    val=$(REPO="$repo" yq eval ".projects[] | select(.repo == strenv(REPO)) | .tracker.$key // \"\"" "$registry" 2>/dev/null | head -1)
+  fi
+  if { [ -z "$val" ] || [ "$val" = "null" ]; } && command -v python3 >/dev/null 2>&1; then
+    val=$(python3 - "$registry" "$repo" "$key" <<'PY' 2>/dev/null
+import sys
+try:
+    import yaml
+except Exception:
+    sys.exit(0)
+reg, repo, key = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    doc = yaml.safe_load(open(reg)) or {}
+except Exception:
+    sys.exit(0)
+for p in (doc.get("projects") or []):
+    if p.get("repo") == repo:
+        v = (p.get("tracker") or {}).get(key)
+        if v is not None:
+            print(v)
+        break
+PY
+)
+  fi
+
+  if [ -z "$val" ] || [ "$val" = "null" ]; then
+    return 1
+  fi
+  echo "$val"
+}
+
+# ------------------------------------------------------------------------------
+# Public: tracker_kind [<owner/repo>]
+#   Echoes the configured tracker kind. With an optional <owner/repo>, a
+#   per-project `tracker.kind` override in the registry wins; otherwise the
+#   global config block (default "gh"). The no-arg path is byte-for-byte the
+#   original behaviour (cached).
 # ------------------------------------------------------------------------------
 _TRACKER_KIND_CACHE=""
 tracker_kind() {
-  if [ -n "$_TRACKER_KIND_CACHE" ]; then
+  local repo="${1:-}"
+  if [ -n "$repo" ]; then
+    local pv
+    if pv=$(_tracker_project_value "$repo" kind) && [ -n "$pv" ]; then
+      echo "$pv"
+      return 0
+    fi
+  fi
+  if [ -z "$repo" ] && [ -n "$_TRACKER_KIND_CACHE" ]; then
     echo "$_TRACKER_KIND_CACHE"
     return 0
   fi
@@ -67,7 +162,9 @@ tracker_kind() {
   if [ -z "$k" ] || [ "$k" = "null" ]; then
     k="gh"
   fi
-  _TRACKER_KIND_CACHE="$k"
+  if [ -z "$repo" ]; then
+    _TRACKER_KIND_CACHE="$k"
+  fi
   echo "$k"
 }
 
@@ -81,7 +178,15 @@ tracker_kind() {
 # ------------------------------------------------------------------------------
 _TRACKER_ID_PATTERN_CACHE=""
 tracker_id_pattern() {
-  if [ -n "$_TRACKER_ID_PATTERN_CACHE" ]; then
+  local repo="${1:-}"
+  if [ -n "$repo" ]; then
+    local pv
+    if pv=$(_tracker_project_value "$repo" id_pattern) && [ -n "$pv" ]; then
+      echo "$pv"
+      return 0
+    fi
+  fi
+  if [ -z "$repo" ] && [ -n "$_TRACKER_ID_PATTERN_CACHE" ]; then
     echo "$_TRACKER_ID_PATTERN_CACHE"
     return 0
   fi
@@ -91,7 +196,9 @@ tracker_id_pattern() {
   if [ -z "$p" ] || [ "$p" = "null" ]; then
     p='^(#[0-9]+|GH-[0-9]+|[A-Z]{2,10}-[0-9]+)$'
   fi
-  _TRACKER_ID_PATTERN_CACHE="$p"
+  if [ -z "$repo" ]; then
+    _TRACKER_ID_PATTERN_CACHE="$p"
+  fi
   echo "$p"
 }
 
@@ -101,7 +208,15 @@ tracker_id_pattern() {
 # ------------------------------------------------------------------------------
 _TRACKER_VIEW_TPL_CACHE=""
 _tracker_view_template() {
-  if [ -n "$_TRACKER_VIEW_TPL_CACHE" ]; then
+  local repo="${1:-}"
+  if [ -n "$repo" ]; then
+    local pv
+    if pv=$(_tracker_project_value "$repo" view_command) && [ -n "$pv" ]; then
+      echo "$pv"
+      return 0
+    fi
+  fi
+  if [ -z "$repo" ] && [ -n "$_TRACKER_VIEW_TPL_CACHE" ]; then
     echo "$_TRACKER_VIEW_TPL_CACHE"
     return 0
   fi
@@ -111,7 +226,9 @@ _tracker_view_template() {
   if [ -z "$tpl" ] || [ "$tpl" = "null" ]; then
     tpl='gh issue view {id} --repo {owner_repo} --json state,title,url,labels'
   fi
-  _TRACKER_VIEW_TPL_CACHE="$tpl"
+  if [ -z "$repo" ]; then
+    _TRACKER_VIEW_TPL_CACHE="$tpl"
+  fi
   echo "$tpl"
 }
 
@@ -262,8 +379,11 @@ tracker_view() {
     return 1
   fi
 
+  # Per-project resolution: when an owner_repo is supplied, the tracker kind
+  # and view_command come from that project's registry override (if any),
+  # falling back to the global config block. See AgDR-0072 / #670.
   local kind
-  kind=$(tracker_kind)
+  kind=$(tracker_kind "$owner_repo")
 
   case "$kind" in
     none)
@@ -279,7 +399,7 @@ tracker_view() {
   fi
 
   local tpl cmd raw rc
-  tpl=$(_tracker_view_template)
+  tpl=$(_tracker_view_template "$owner_repo")
   cmd=$(_tracker_substitute "$tpl" "$id" "$owner_repo")
 
   # Run the command; capture stdout. Suppress stderr (CLI errors are visible

--- a/.claude/hooks/tests/test_per_project_tracker.sh
+++ b/.claude/hooks/tests/test_per_project_tracker.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# test_per_project_tracker.sh — per-project tracker config resolution (Part A of #670).
+#
+# A registry entry may carry an optional `tracker:` block that overrides the
+# global .claude/project-config.json tracker config FOR THAT PROJECT. The lib
+# selects the project by the OPERATION'S TARGET REPO, threaded as an optional
+# argument to tracker_kind / tracker_id_pattern — NOT a session-global marker,
+# NOT cwd (see AgDR-0072).
+#
+# Cases:
+#   1. tracker_kind <repo-with-override>  → the per-project kind        [discriminator]
+#   2. tracker_kind <repo-without-block>  → the global default          (fallback)
+#   3. tracker_kind  (no arg)             → the global default          (today's behaviour, unchanged)
+#   4. tracker_id_pattern <repo-with-override> → the per-project id_pattern
+#   5. tracker_id_pattern (no arg)        → the global default pattern
+#
+# Exit 0 = all pass. Exit 1 on first failure.
+
+set -u
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TRACKER_LIB="$HOOK_DIR/_lib-tracker.sh"
+CONFIG_LIB="$HOOK_DIR/_lib-read-config.sh"
+PORTFOLIO_LIB="$HOOK_DIR/_lib-portfolio-paths.sh"
+OPSROOT_LIB="$HOOK_DIR/_lib-ops-root.sh"
+
+PASS=0
+FAIL=0
+FAILED=""
+
+pass() { PASS=$((PASS+1)); echo "PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); FAILED="$FAILED\n  - $1"; echo "FAIL: $1"; echo "    expected: [$2]"; echo "    actual:   [$3]"; }
+assert_eq() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1" "$2" "$3"; fi; }
+
+# Build an isolated single-fork sandbox with a global tracker block + a registry
+# whose second project carries a per-project tracker override.
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d); sb=$(cd "$sb" && pwd -P)
+  mkdir -p "$sb/.claude/hooks"
+  touch "$sb/onboarding.yaml"
+  cp "$TRACKER_LIB"   "$sb/.claude/hooks/_lib-tracker.sh"
+  cp "$CONFIG_LIB"    "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$PORTFOLIO_LIB" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  [ -f "$OPSROOT_LIB" ] && cp "$OPSROOT_LIB" "$sb/.claude/hooks/_lib-ops-root.sh"
+
+  # Global tracker config (defaults file present so config_get has a base).
+  cat > "$sb/.claude/project-config.defaults.json" <<'JSON'
+{ "tracker": { "kind": "gh", "id_pattern": "^(#[0-9]+|GH-[0-9]+)$" } }
+JSON
+  # No override file needed — defaults supply the global block.
+
+  # Registry: proj-a has NO tracker block; proj-b overrides kind + id_pattern.
+  cat > "$sb/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: proj-a
+    repo: org/repo-a
+  - name: proj-b
+    repo: org/repo-b
+    tracker:
+      kind: jira
+      id_pattern: "^PROJ-[0-9]+$"
+  - name: proj-c
+    repo: org/repo-c
+    tracker:
+      kind: custom
+      view_command: "printf '%s' '{\"state\":\"Open\",\"title\":\"pp\",\"url\":\"\",\"labels\":[]}'"
+YAML
+  echo "$sb"
+}
+
+SB=$(make_sandbox)
+# Resolve the project from cwd-walk-up; make sure no session pin hijacks it.
+unset APEXYARD_OPS_PIN_DIR CLAUDE_CODE_SESSION_ID 2>/dev/null || true
+
+cd "$SB" || { echo "FAIL: cannot cd to sandbox"; exit 1; }
+# shellcheck source=/dev/null
+. "$SB/.claude/hooks/_lib-tracker.sh"
+
+# Per-project resolution needs a YAML parser (yq OR python3+PyYAML). When neither
+# is present the feature degrades to the global config (by design), so the
+# per-project assertions would not hold — SKIP them rather than fail a bare
+# adopter's suite. The global-fallback / no-arg cases hold regardless.
+HAVE_YAML=no
+if command -v yq >/dev/null 2>&1 || python3 -c 'import yaml' >/dev/null 2>&1; then
+  HAVE_YAML=yes
+fi
+
+# Case 1 — discriminator: per-project override wins for its repo.
+if [ "$HAVE_YAML" = yes ]; then
+  tracker_clear_cache
+  got=$(tracker_kind "org/repo-b")
+  assert_eq "tracker_kind <repo with override> → per-project kind" "jira" "$got"
+else
+  echo "SKIP: tracker_kind per-project override (no yq / python3+PyYAML)"
+fi
+
+# Case 2 — project without a tracker block falls back to the global default.
+# Holds with or without a YAML parser (empty per-project lookup → global).
+tracker_clear_cache
+got=$(tracker_kind "org/repo-a")
+assert_eq "tracker_kind <repo without block> → global default" "gh" "$got"
+
+# Case 3 — no-arg call is unchanged (today's behaviour).
+tracker_clear_cache
+got=$(tracker_kind)
+assert_eq "tracker_kind (no arg) → global default" "gh" "$got"
+
+# Case 4 — per-project id_pattern override.
+if [ "$HAVE_YAML" = yes ]; then
+  tracker_clear_cache
+  got=$(tracker_id_pattern "org/repo-b")
+  assert_eq "tracker_id_pattern <repo with override> → per-project pattern" "^PROJ-[0-9]+$" "$got"
+else
+  echo "SKIP: tracker_id_pattern per-project override (no yq / python3+PyYAML)"
+fi
+
+# Case 5 — no-arg id_pattern is the global default.
+tracker_clear_cache
+got=$(tracker_id_pattern)
+assert_eq "tracker_id_pattern (no arg) → global default" "^(#[0-9]+|GH-[0-9]+)$" "$got"
+
+# Case 6 — tracker_view dispatches the per-project kind + view_command for its
+# repo. proj-c overrides kind=custom + a view_command that emits known JSON;
+# tracker_view must use that (not the global gh path) when given org/repo-c.
+if [ "$HAVE_YAML" = yes ] && command -v jq >/dev/null 2>&1; then
+  tracker_clear_cache
+  got=$(tracker_view "1" "org/repo-c" | jq -r '.title' 2>/dev/null)
+  assert_eq "tracker_view <repo with custom override> dispatches per-project view_command" "pp" "$got"
+else
+  echo "SKIP: tracker_view per-project case (needs jq + yq/python3-yaml)"
+fi
+
+rm -rf "$SB"
+echo "=========================================="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then printf "Failed cases:%b\n" "$FAILED"; exit 1; fi
+exit 0

--- a/.claude/hooks/tests/test_tracker_aware_hooks.sh
+++ b/.claude/hooks/tests/test_tracker_aware_hooks.sh
@@ -17,6 +17,14 @@
 
 set -u
 
+# Pin isolation: per-project tracker resolution (#670) reads the ops-root
+# session pin to find the registry. Run interactively inside a live apexyard
+# session, the pin resolves PAST each mktemp sandbox to the operator's real
+# fork, so the sandboxed hooks gate against the wrong repo. The authoritative
+# runner (bin/run-hook-tests.sh) already disables the pin; unset here too so a
+# direct `bash test_tracker_aware_hooks.sh` is robust under nested invocation.
+unset APEXYARD_OPS_PIN_DIR CLAUDE_CODE_SESSION_ID 2>/dev/null || true
+
 HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TRACKER_LIB="$HOOK_DIR/_lib-tracker.sh"
 CONFIG_LIB="$HOOK_DIR/_lib-read-config.sh"
@@ -67,11 +75,13 @@ YAML
     chmod +x .claude/hooks/*.sh
     cp "$DEFAULTS" .claude/project-config.defaults.json
 
-    # Other libs the consumer hooks transitively source. validate-branch-name.sh
-    # tries to source _lib-extract-push-ref.sh; copy it if present.
-    if [ -f "$HOOK_DIR/_lib-extract-push-ref.sh" ]; then
-      cp "$HOOK_DIR/_lib-extract-push-ref.sh" .claude/hooks/_lib-extract-push-ref.sh
-    fi
+    # Other libs the consumer hooks transitively source:
+    #   _lib-extract-push-ref.sh   — validate-branch-name.sh
+    #   _lib-portfolio-paths.sh    — _lib-tracker.sh per-project resolution (#670)
+    #   _lib-ops-root.sh           — sourced by portfolio-paths / read-config
+    for extra in _lib-extract-push-ref.sh _lib-portfolio-paths.sh _lib-ops-root.sh; do
+      [ -f "$HOOK_DIR/$extra" ] && cp "$HOOK_DIR/$extra" ".claude/hooks/$extra"
+    done
 
     git add -A
     git commit -q -m "test fixture"
@@ -731,6 +741,42 @@ else
   record_fail "#501 commit-refs: gh tracker fabricated #N still BLOCKS (gh behaviour unchanged)"
 fi
 rm -rf "$SB"
+
+# =============================================================================
+# Case (#670): per-project tracker override drives the consumer's TRACKER_KIND.
+# The global tracker is gh; the registry gives THIS fork's repo a per-project
+# kind=none. verify-commit-refs.sh must resolve the PER-PROJECT kind (none →
+# short-circuit, exit 0), NOT the global gh — which would treat the fabricated-
+# looking #N as a missing ticket and BLOCK (exit 2). This proves the consumer's
+# TRACKER_KIND is threaded with the target repo, not the global no-arg value.
+# Guarded on a YAML parser (per-project resolution needs yq or python3+PyYAML).
+# =============================================================================
+if command -v yq >/dev/null 2>&1 || python3 -c 'import yaml' >/dev/null 2>&1; then
+  SB=$(make_fork)
+  # make_fork's origin is test-org/test-repo; give exactly that repo a
+  # per-project kind=none override while the global default stays gh.
+  cat > "$SB/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: example
+    repo: test-org/test-repo
+    tracker:
+      kind: none
+YAML
+  install_mock "$SB" gh 'exit 99'   # any gh call here would be a bug
+  cmd='git commit -m "feat: add thing
+
+Closes #99999
+"'
+  if run_commit_hook "$SB" "$cmd" 0; then
+    record_pass "#670 commit-refs: per-project kind=none short-circuits (global is gh)"
+  else
+    record_fail "#670 commit-refs: per-project kind=none short-circuits (global is gh)"
+  fi
+  rm -rf "$SB"
+else
+  echo "SKIP: #670 per-project consumer case (no yq / python3+PyYAML)"
+fi
 
 # =============================================================================
 # Summary

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -132,30 +132,12 @@ if [ -n "$TICKET_REF" ]; then
   # Extract digits from the ref (works for both #N and PREFIX-N)
   TICKET_NUM=$(echo "$TICKET_REF" | grep -oE '[0-9]+$')
 
-  # Load the tracker library (kind / view command / id pattern).
-  # Source from HOOK_DIR so we don't depend on cwd-relative resolution
-  # (inside workspace/<project>/ the lib still lives at the ops fork). The
-  # lib itself reads config via _lib-read-config.sh which now resolves
-  # from the ops fork too (me2resh/apexyard#310).
-  TRACKER_KIND="gh"
-  if [ -f "$HOOK_DIR/_lib-tracker.sh" ]; then
-    # shellcheck disable=SC1090,SC1091
-    . "$HOOK_DIR/_lib-tracker.sh"
-    TRACKER_KIND=$(tracker_kind)
-  fi
-
-  # Short-circuit: existence verification disabled.
-  if [ "$TRACKER_KIND" = "none" ]; then
-    # Shape-only validation already happened above (PR title regex). Nothing
-    # more to do for this branch.
-    TICKET_NUM=""
-  fi
-
-  # Resolve tracker repo: prefer --repo flag, then ops-fork-rooted
-  # project-config.json (.tracker_repo), then origin remote of the
-  # current cwd's git checkout. The ops-fork-rooted read matters when the
-  # operator is inside workspace/<project>/ — the project clone's git root
-  # is NOT where the framework config lives.
+  # Resolve tracker repo FIRST (before the kind lookup): prefer --repo flag,
+  # then ops-fork-rooted project-config.json (.tracker_repo), then origin
+  # remote of the current cwd's git checkout. The ops-fork-rooted read matters
+  # when the operator is inside workspace/<project>/ — the project clone's git
+  # root is NOT where the framework config lives. Resolved up front so the kind
+  # lookup below can key off the target repo for a per-project override (#670).
   TRACKER_REPO=""
   if [ -n "$CMD_REPO" ]; then
     TRACKER_REPO="$CMD_REPO"
@@ -166,6 +148,26 @@ if [ -n "$TICKET_REF" ]; then
     # Parse owner/repo from origin remote
     ORIGIN_URL=$(git remote get-url origin 2>/dev/null)
     TRACKER_REPO=$(echo "$ORIGIN_URL" | sed -nE 's|.*[:/]([^/:]+/[^/]+)\.git$|\1|p; s|.*[:/]([^/:]+/[^/]+)$|\1|p' | head -1)
+  fi
+
+  # Load the tracker library (kind / view command / id pattern).
+  # Source from HOOK_DIR so we don't depend on cwd-relative resolution
+  # (inside workspace/<project>/ the lib still lives at the ops fork). The
+  # lib itself reads config via _lib-read-config.sh which now resolves
+  # from the ops fork too (me2resh/apexyard#310). The kind is resolved for
+  # TRACKER_REPO so a per-project override wins over the global block (#670).
+  TRACKER_KIND="gh"
+  if [ -f "$HOOK_DIR/_lib-tracker.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$HOOK_DIR/_lib-tracker.sh"
+    TRACKER_KIND=$(tracker_kind "$TRACKER_REPO")
+  fi
+
+  # Short-circuit: existence verification disabled.
+  if [ "$TRACKER_KIND" = "none" ]; then
+    # Shape-only validation already happened above (PR title regex). Nothing
+    # more to do for this branch.
+    TICKET_NUM=""
   fi
 
   # Optional upstream fallback (me2resh/apexyard#207). When the primary

--- a/.claude/hooks/verify-commit-refs.sh
+++ b/.claude/hooks/verify-commit-refs.sh
@@ -162,7 +162,10 @@ TRACKER_KIND="gh"
 if [ -f "$HOOK_DIR/_lib-tracker.sh" ]; then
   # shellcheck disable=SC1090,SC1091
   . "$HOOK_DIR/_lib-tracker.sh"
-  TRACKER_KIND=$(tracker_kind)
+  # Resolve the kind for the OPERATION'S target repo so a per-project tracker
+  # override (apexyard.projects.yaml) wins over the global block (#670). Empty
+  # TRACKER_REPO → no-arg → global default (today's behaviour).
+  TRACKER_KIND=$(tracker_kind "$TRACKER_REPO")
 fi
 
 # `tracker.kind = none` disables existence verification — there's no CLI to

--- a/apexyard.projects.yaml.example
+++ b/apexyard.projects.yaml.example
@@ -52,6 +52,18 @@ version: 1
 #               Override the global ticket prefix per project. Useful when
 #               one project uses GH Issues (`GH`) and another uses Linear
 #               (`ENG`).
+#   tracker     Per-project override of the GLOBAL tracker config in
+#               .claude/project-config.json (#670 / AgDR-0072). Same keys as
+#               the global block — any you omit fall back to the global default,
+#               so a project with no `tracker:` behaves exactly as before:
+#                 kind         gh | linear | jira | asana | custom | none
+#                 id_pattern   regex for valid ticket-ID shape
+#                 view_command template with {id} / {owner_repo} placeholders
+#                 create_command  (Part B) template for issue creation
+#               This is what lets one portfolio mix trackers — e.g. a GitHub
+#               project alongside a GitLab one (see Example 4 below). The
+#               tracker is selected by the operation's target repo, so the
+#               right CLI is used per project, not per session.
 #
 
 projects:
@@ -109,6 +121,28 @@ projects:
     tags:
       - customer-facing
       - low-velocity
+
+  # ---------------------------------------------------------------------------
+  # Example 4: a project on GitLab — per-project tracker override (#670)
+  # The global tracker in .claude/project-config.json stays `gh`; THIS project
+  # resolves to GitLab because of its own `tracker:` block. Both coexist under
+  # one portfolio. Omitted tracker keys fall back to the global default.
+  # ---------------------------------------------------------------------------
+  - name: data-pipeline
+    repo: your-group/data-pipeline
+    workspace: workspace/data-pipeline
+    docs: projects/data-pipeline
+    status: active
+    tier: P1
+    roles:
+      - data-engineer
+      - platform-engineer
+    tracker:
+      kind: custom
+      id_pattern: "^#[0-9]+$"
+      view_command: "glab issue view {id} -R {owner_repo} --output json"
+      # create_command lands in Part B (tracker_create); until then, creation
+      # on this project still uses the global path.
 
 # -----------------------------------------------------------------------------
 # Defaults

--- a/docs/agdr/AgDR-0072-per-project-tracker-config-and-creation-abstraction.md
+++ b/docs/agdr/AgDR-0072-per-project-tracker-config-and-creation-abstraction.md
@@ -1,0 +1,64 @@
+---
+id: AgDR-0072
+timestamp: 2026-06-21T06:00:00Z
+agent: claude
+model: claude-opus-4-8[1m]
+trigger: user-prompt
+status: proposed
+---
+
+# Per-project tracker config + `tracker_create` creation abstraction
+
+> In the context of a portfolio whose projects use **different trackers** (e.g. one on GitHub and one on GitLab) under a single apexyard fork, facing the #310 invariant that tracker config is resolved **once at the ops-fork level** and the fact that issue/PR **creation** still hardcodes `gh issue create` in `/task` / `/feature` / `/bug`, I decided to introduce **per-project tracker config** (an optional per-project override in `apexyard.projects.yaml`, with the global `.claude/project-config.json → tracker` block as the default) **and** a **`tracker_create` creation abstraction** mirroring AgDR-0033's verification-adapter pattern — selecting the project from the **operation's target repo (never cwd, never a session-global marker)** — to achieve coexisting heterogeneous trackers with zero change for single-tracker forks, accepting added config surface and per-CLI create-output parsing.
+
+## Context
+
+- **Verification is already tracker-agnostic** (AgDR-0033 / #283): `_lib-tracker.sh` dispatches `tracker_view` by `tracker.kind` (`gh` / `linear` / `jira` / `asana` / `custom` / `none`) via a `view_command` template. But the `tracker` block is a single, **fork-level** block in `.claude/project-config.json`.
+- **#310 deliberately made tracker resolution fork-global.** Its fix resolved tracker config to the ops-fork anchor *even when invoked from inside `workspace/<project>/`*, because cwd-based resolution silently defaulted to `gh` in workspaces. So "one tracker per portfolio" is an **intentional invariant** — and any per-project design must NOT key the "which project am I?" signal off raw cwd, or it reintroduces #310.
+- **Creation is NOT abstracted.** `/task`, `/feature`, `/bug` hardcode `gh issue create --repo …`. The create *guard* (`require-skill-for-issue-create.sh`, #268) matches `ticket.create_command_patterns` = `gh issue create`, `gh api repos/`, `linear`/`jira`/`asana` create forms — but **not** `glab issue create`, and recognising a command ≠ being able to emit it.
+- **Driver:** a portfolio with one project on GitHub and a prospective project on GitLab cannot be governed under one fork: verification has one global `kind`, and creation is `gh`-hardcoded. Setting `kind: custom` only fixes *verification* — creation still calls `gh`.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Per-project verification only** — per-project `tracker` override in the registry; leave creation `gh`-hardcoded | Small; backward-compatible; unblocks per-project *verification* | **Does not unblock the driver** — still cannot `/task`/`/feature`/`/bug` on the non-GitHub project (creation stays `gh`) |
+| **B. Full: per-project config + `tracker_create` abstraction (implemented A→B)** | Fully unblocks multi-tracker portfolios; reuses AgDR-0033's proven adapter shape; backward-compatible for single-tracker forks | Larger surface; per-CLI create-output parsing (issue number/URL) differs per tracker; relaxes the #310 single-tracker invariant |
+| **C. Per-project config now; creation abstraction as a tracked follow-up** | Ships verification value sooner | Driver stays blocked until the follow-up lands; risks a half-abstracted verify-yes / create-no state |
+
+## Decision
+
+Chosen: **Option B — per-project tracker config + a `tracker_create` creation abstraction, implemented A→B.**
+
+Concrete shape:
+
+1. **Per-project config (A).** Add an optional `tracker:` block to each `apexyard.projects.yaml` entry (same `kind` / `view_command` / `id_pattern` keys as the global block, plus a new `create_command`). `_lib-tracker.sh` merges **per-project over the global default**; an entry with no `tracker:` behaves exactly as today.
+2. **Resolution signal — the operation's target repo, threaded as a parameter.** `tracker_kind` / `tracker_id_pattern` / `_tracker_view_template` (and the future `create_command`) take an **optional `owner/repo` argument**. When supplied, the lib looks up that project's registry `tracker:` block and merges it over the global default; when absent, it returns the global default — **byte-for-byte today's behaviour**. Consumers already hold this repo at the call site (`validate-pr-create` → `CMD_REPO`; `verify-commit-refs` → `TRACKER_REPO`; `/start-ticket` → the ticket's `owner/repo`). The one consumer with no repo in scope (`validate-branch-name`, shape-check only) calls with no argument and correctly gets the global (permissive) pattern. **No session-global marker is read** — a session marker is the wrong signal here, because a hook can fire for project B while the marker points at project A (the exact GitHub+GitLab scenario this feature exists for).
+3. **The #310 guardrail, correctly scoped.** #310's lesson is about locating the config *file* via the ops-fork anchor instead of cwd — already handled by `config_get` / `_config_repo_root`. It was **not** about project *selection* (there was only one tracker then). Selecting *which project's* tracker by the operation's target repo is legitimate — `require-active-ticket.sh` itself keys off the `workspace/<project>/` path. The guardrail this design honours: **never pick the project from raw cwd, and never from a session-global marker** — only from the explicit per-operation target repo.
+4. **Creation abstraction (B).** Add `tracker_create` to `_lib-tracker.sh` (mirroring `tracker_view`) driven by a `create_command` template, with per-`kind` adapters (`gh`, `glab`, `linear`, `jira`, `asana`, `custom`) that map the common fields `{title, body, labels, owner_repo}` to each CLI's create syntax and **parse the returned issue ref** (number + URL) back into a common shape. Refactor `/task`, `/feature`, `/bug` to call `tracker_create` instead of hardcoding `gh issue create`.
+5. **Close the guard gap.** Extend `ticket.create_command_patterns` with `glab issue create` (and the `glab` create forms) so the create guard recognises GitLab.
+
+Because, of the three, only B actually unblocks the driver: per-project verification (A) without creation abstraction leaves the non-GitHub project un-`/task`-able. B reuses the adapter pattern AgDR-0033 already validated, so it is consistent rather than novel, and stays backward-compatible for the common single-tracker fork.
+
+## Consequences
+
+- **Backward-compatible.** Single-tracker forks keep one global `tracker` block and a registry with no per-project `tracker:` — zero behaviour change. The default-config regression test (à la `test_tracker_aware_hooks.sh`) must lock this in.
+- **Phasing is implementation order, not partial value.** A→B is the build sequence; the driver stays **blocked until B (creation) lands**. A alone must not be mistaken for "solved."
+- **#310 is not regressed** *iff* resolution keys off the operation's target repo (passed by the caller). If a future implementer wires it to cwd or a session-global marker, the #310-class bug returns — this AgDR names that explicitly.
+- **Creation adapters carry the real complexity.** Unlike `view`, `create` has heterogeneous flags and must parse each CLI's success output for the new issue number/URL; this is the bulk of the work and the main test surface.
+- **Per-project resolution needs a YAML parser (`yq` or `python3`+PyYAML).** The registry is YAML and `jq` can't read it. When neither parser is present, `_tracker_project_value` returns empty and the lookup **silently degrades to the global tracker** — a single-tracker fork is unaffected, but an adopter who *has* a per-project `tracker:` block on a parser-less machine gets it **silently ignored, with no warning**. Known edge for Part A; a future hardening could emit a one-line advisory when a per-project block exists but no parser is available. The per-project tests SKIP (don't fail) when no parser is present, mirroring the `jq` guard, so a bare adopter's suite stays green.
+- **New config surface** (`create_command` template, per-project `tracker:` block) is documented in `docs/multi-project.md` alongside the existing Linear/Jira/Asana examples.
+
+## Delivery
+
+Shipped as **two stacked PRs against `dev`**, to stay under the <400-line review guideline (`workflows/code-review.md` § Metrics / Anti-Patterns). Each PR is independently reviewable; PR-B builds on PR-A.
+
+- **PR-A — per-project config resolution** (+ this AgDR): registry `tracker:` override, active-ticket/registry resolution (the #310 guardrail), `_lib-tracker.sh` merge of per-project over global, `apexyard.projects.yaml.example` schema, tests. PR body: `Refs #670` (Part 1 — does not close the issue, since the driver is still blocked without creation).
+- **PR-B — creation abstraction**, stacked on PR-A: `tracker_create` + per-`kind` adapters, `/task`·`/feature`·`/bug` refactor, `glab issue create` added to `create_command_patterns`, tests. PR body: `Closes #670` (Part 2 — completes the driver).
+
+## Artifacts
+
+- AgDR-0033 / #283 — the verification-abstraction pattern this mirrors
+- #310 — the fork-global tracker-resolution invariant this relaxes
+- #268 — the create guard / `ticket.create_command_patterns`
+- #670 — the feature request this implements (closed by PR-B)


### PR DESCRIPTION
## Summary
- **Per-project tracker override** — a registry entry (`apexyard.projects.yaml`) may now carry an optional `tracker:` block (`kind` / `id_pattern` / `view_command`, plus `create_command` for Part B) that overrides the global `.claude/project-config.json → tracker` config **for that project only**. `_lib-tracker.sh` merges per-project over global per key. Today a single fork-level block forces one tracker across the whole portfolio; this lets one portfolio mix trackers (e.g. a GitHub project alongside a GitLab one).
- **Selected by the operation's target repo, not a session marker** — `tracker_kind` / `tracker_id_pattern` / `tracker_view` take an optional `owner/repo`; when supplied, the project's override wins, else the global default. This is the #310-safe signal: a session-global marker would mis-resolve when a hook fires for project B while the marker points at project A (the exact GitHub+GitLab case). #310's actual lesson (locate the config *file* via the ops-fork anchor, not cwd) is unchanged.
- **Consumers wired end-to-end** — `validate-pr-create.sh` and `verify-commit-refs.sh` now resolve the tracker **kind** for their target repo (they already passed it to `tracker_view`). Without this, a GitLab project under a global-`gh` fork would compute `TRACKER_KIND=gh` and **block a valid ticket as fabricated** while looking it up via glab — internally inconsistent.
- **Backward-compatible** — a registry with no `tracker:` block and all no-arg calls behave **byte-for-byte as before** (the no-arg path stays cached). The 22 pre-existing consumer tests (global config) regression-protect the change.
- **Part 1 of 2 (`Refs #670`, does not close)** — this is per-project config + verification only. Issue *creation* still hardcodes `gh issue create`; that's PR-B (`tracker_create` + adapters), which closes #670. Split to stay under the <400-line review guideline (`workflows/code-review.md` § Metrics / Anti-Patterns).

## Testing
- `bash bin/run-hook-tests.sh` → **70/70** (authoritative runner; disables the ops-root pin so each sandbox resolves its own root).
- New `.claude/hooks/tests/test_per_project_tracker.sh` → **6/6**: the discriminator (`tracker_kind "org/repo-b"` → per-project `jira` while global stays `gh`), per-project `id_pattern`, `tracker_view` dispatching a per-project `custom` `view_command`, and the no-arg/global-fallback cases.
- `.claude/hooks/tests/test_tracker_aware_hooks.sh` → **23/23**: adds a consumer case proving a per-project `kind: none` makes `verify-commit-refs.sh` short-circuit (exit 0) where the global `gh` path would block (exit 2). `make_fork` now also copies `_lib-portfolio-paths.sh` / `_lib-ops-root.sh` (the per-project resolution needs them).
- Each behavior was written test-first and watched RED→GREEN.
- `bash -n` clean on all changed shell files; `shellcheck` runs in CI.

## Design
Implements Part 1 of **AgDR-0072** (included in this PR's diff). Mirrors the verification-adapter pattern from AgDR-0033 (#283); relaxes the fork-global tracker invariant from #310 with the target-repo signal.

**Known edge (documented in AgDR-0072):** per-project resolution reads YAML, so it needs `yq` or `python3`+PyYAML. With neither, the lookup **silently degrades to the global tracker** — single-tracker forks are unaffected, but a per-project block on a parser-less machine is ignored without warning. The per-project tests SKIP (not fail) in that case.

Refs #670

## Glossary
| Term | Definition |
|------|------------|
| per-project `tracker:` override | optional per-entry block in `apexyard.projects.yaml` that overrides the global tracker config for that project |
| target-repo resolution | selecting which project's tracker by the `owner/repo` the operation targets (passed by the caller), never by cwd or a session marker |
| #310 invariant | the design choice (PR #310) that locates tracker *config* via the ops-fork anchor, not cwd — distinct from project *selection* |
