### PR TITLE
chore(#655): document orchestrator cost model + cost levers

### DIFF
--- a/docs/agdr/AgDR-0074-orchestrator-cost-model.md
+++ b/docs/agdr/AgDR-0074-orchestrator-cost-model.md
@@ -1,0 +1,85 @@
+# AgDR-0074 — Orchestrator cost model: in-thread persona adoption defeats the per-agent model matrix for in-flow work
+
+> In the context of [AgDR-0050](AgDR-0050-agent-runtime-overhaul.md)'s per-agent model matrix (build engineers → `sonnet`, reviewers → `opus`, analysts → `haiku`), facing operator reports that the **main agent dominates token spend** despite that matrix, I decided to **document the structural tension** — the matrix only applies to *spawned* sub-agents, but AgDR-0050 § Axis 6 deliberately keeps *in-flow* work (implementation / PM / design) **in-thread**, so the bulk of work runs on the operator's primary tier (typically Opus) and the `sonnet` implementation default never takes effect — and to record the recommended cost levers (`opusplan`, a thin-orchestrator pattern, and populating `agent-routing.yaml`) rather than silently re-litigating the Axis-6 decision, to achieve a predictable + documented cost model for operators, accepting that the biggest single win (`opusplan`) is a harness-level operator choice the framework can recommend but not enforce.
+>
+> **Status**: ACCEPTED — documentation + frontmatter-conformance confirmation. Does not change the Axis-6 in-thread-vs-spawned split; it makes that split's cost consequence explicit and gives operators the levers to manage it.
+
+**Metadata** — Status: ACCEPTED · Category: architecture · Supersedes: none · Related: [AgDR-0050](AgDR-0050-agent-runtime-overhaul.md) (agent runtime overhaul — the per-agent matrix + Axis 6 in-thread/spawned split), [AgDR-0068](AgDR-0068-governed-looping.md) (governed looping — the thin-orchestrator-as-loop-coordinator shape), [`.claude/rules/plan-mode.md`](../../.claude/rules/plan-mode.md) (`opusplan` prior art). (Body-H1 only, no YAML frontmatter — per the live convention; markdownlint MD025 trips on a YAML title + body H1 together.)
+
+## Context
+
+[AgDR-0050](AgDR-0050-agent-runtime-overhaul.md) shipped a 24-entry **per-agent model matrix** (Axis 2): Opus for depth-bound roles (Tech Lead, SRE, Pen Tester, Security Auditor, Code Reviewer), Sonnet for the implementation majority (Backend / Frontend / Platform / Data Engineer, Product Manager, designers), Haiku for checklist-shaped repeatable work (QA Engineer, Data Analyst). The intent was per-agent cost / quality optimisation — a QA AC-check shouldn't pay Opus prices, a build-engineer edit shouldn't pay the same rate as an architectural design.
+
+The matrix is **real and correct** — but it has a structural blind spot that AgDR-0050 itself created and did not call out as a cost consequence.
+
+AgDR-0050 § **Axis 6 (Hybrid, option C)** split role activations into two classes:
+
+- **Isolated-work-class** roles (QA Engineer, Pen Tester, Data Analyst, the Heads-of-X, Security Auditor, Tech Lead reviews) — auto-triggers **spawn a sub-agent**. The sub-agent's `model:` frontmatter applies, so the matrix takes effect.
+- **In-flow-class** roles (Backend Engineer, Frontend Engineer, Platform Engineer, Data Engineer, Product Manager, UI / UX Designer) — auto-triggers keep **in-thread persona adoption**, because spawning out-of-thread loses the shared "what just happened" context that ship-the-code flow depends on.
+
+The model matrix is a property of a **spawned sub-agent's frontmatter**. In-thread persona adoption does not spawn anything — it injects the role file into the main thread, which keeps running on whatever model is driving the conversation (typically the operator's primary tier, Opus). So:
+
+- **Reviews route correctly.** Rex (Code Reviewer) and Hakim (Security Auditor) are spawned → their `opus` frontmatter applies.
+- **The bulk — implementation — does not.** Backend / Frontend Engineer work is adopted in-thread per Axis 6 → the `sonnet` default in their frontmatter is never consulted. Implementation, the highest-volume work in any SDLC, runs at the operator's primary tier.
+
+The net effect operators observe: the main agent dominates token spend, and the matrix's cost optimisation appears not to work. It *does* work — but only on the spawned minority, not the in-thread majority. AgDR-0050 § Consequences mentioned "cost of running sub-agents vs in-thread persona adoption" as a *risk to the sub-agent approach*; it did not flag the inverse — that the in-thread approach defeats the matrix for the work that costs the most. This AgDR records that tension explicitly.
+
+A compounding, separable issue: agent **frontmatter drift**. The matrix specifies `sonnet` for Backend + Frontend Engineer, but a working-tree drift had set those agent files to `model: opus` in some adopter forks — so even *spawning* a build engineer would not hit the cheap tier. (On the `dev` branch at the time of this AgDR the committed values were already `sonnet`, so this AgDR records the conformant state rather than editing the files; it documents the matrix-conformance check and points operators at `agent-routing.yaml` to pin the tiers so the drift can't recur silently.)
+
+## Options Considered
+
+### Axis A — Where to document the tension
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A1. New AgDR referencing AgDR-0050** | Keeps AgDR-0050's accepted decision immutable; a clean, citable record of the *cost consequence* + levers; discoverable via `/agdr search cost` | One more file in the AgDR sequence |
+| A2. Amend AgDR-0050 in place | Single source for everything about the runtime overhaul | Mutates an ACCEPTED cross-cutting AgDR that 10+ PRs reference; the cost tension is a *consequence*, not a *decision axis*, so it doesn't fit the option-matrix shape; harder to cite in isolation |
+
+### Axis B — What to do about the in-flow cost
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **B1. Document levers, keep Axis 6 unchanged** | Preserves the Axis-6 shared-context benefit for in-flow work; operators opt into cost levers per their workload; biggest win (`opusplan`) needs no framework change | Cost optimisation is operator-driven, not automatic |
+| B2. Flip in-flow roles to spawned sub-agents | Matrix applies automatically to implementation | Reverses Axis 6's load-bearing decision — loses shared context for ship-the-code flow, the exact failure mode Axis 6 chose against; spawning has cache-miss latency per invocation |
+| B3. Force the main thread onto Sonnet | Cheapest default | Defeats the operator's choice of primary tier; bad default for planning / coordination, which genuinely benefits from Opus depth |
+
+### Axis C — The recommended cost levers
+
+Three levers, not mutually exclusive, ordered by effort-to-win ratio:
+
+| Lever | Effort | Win |
+|-------|--------|-----|
+| **C1. `opusplan`** — Opus plans, Sonnet executes (harness model alias) | Zero framework change; one operator config | Largest single win — the high-volume *execution* phase drops to Sonnet while planning keeps Opus depth |
+| **C2. Thin-orchestrator pattern** — keep the Opus loop as planner / coordinator; delegate well-scoped implementation to *spawned* `sonnet` build agents via `/fan-out` or `Workflow` | Operator workflow change; no framework change | Routes the in-flow majority through the matrix by *spawning* it, recovering the `sonnet` default for implementation while the coordinator stays Opus |
+| **C3. Populate `agent-routing.yaml`** — pin / adjust per-agent tiers (it ships empty) | One file edit + re-session | Makes the matrix tunable per adopter; pins build engineers to `sonnet` explicitly so frontmatter drift can't silently raise the tier |
+
+## Decision
+
+1. **Axis A — A1 (new AgDR).** This document. Keeps AgDR-0050 immutable and gives the cost tension + levers a citable home. AgDR-0050 stands as the accepted runtime design; this AgDR records a consequence of its Axis-6 decision and the operator-facing mitigations.
+
+2. **Axis B — B1 (document levers, keep Axis 6).** Axis 6's in-thread choice for in-flow work is correct for shared-context reasons; the answer is to make its cost consequence explicit and give operators levers, not to reverse it. The thin-orchestrator pattern (Axis C, C2) is the *opt-in* route for operators who want the matrix to apply to implementation — they get it by *choosing* to spawn, without the framework forcing the spawn on everyone.
+
+3. **Axis C — all three levers, documented in operator-facing docs** (`docs/orchestrator-cost-model.md`, cross-referenced from `docs/getting-started.md`), in effort-to-win order: `opusplan` first (biggest win, no framework change), thin-orchestrator second (recovers the matrix for implementation via spawning), `agent-routing.yaml` third (per-adopter tuning surface).
+
+4. **Frontmatter drift fix — confirm + guard.** `backend-engineer` and `frontend-engineer` agent files must read `model: sonnet` per the AgDR-0050 Axis-2 matrix. On the `dev` branch they are *already* `sonnet` (the `opus` drift the ticket describes existed only in an uncommitted working tree, never on `dev`), so this AgDR records the conformant state rather than editing the files — and points operators at `agent-routing.yaml` to *pin* these tiers so the drift can't silently recur. Review-agent routing is unchanged: Rex (`code-reviewer`) and Hakim (`security-reviewer`) stay `opus`; Nour (`ui-designer`) stays `sonnet`. No other agent's tier changes.
+
+## Consequences
+
+- **The cost model is documented, not surprising.** Operators reading `docs/orchestrator-cost-model.md` understand *why* the main agent dominates spend (in-flow work is in-thread by Axis-6 design) and *what to do about it* (the three levers).
+- **Axis 6 is unchanged.** In-flow roles keep in-thread adoption; shared-context benefit preserved. This AgDR adds no new spawn behaviour.
+- **The thin-orchestrator pattern is an opt-in mode**, not a default. Operators who want the matrix to apply to implementation spawn build agents via `/fan-out` / `Workflow` and keep the Opus loop thin (planner / coordinator). This composes directly with [AgDR-0068](AgDR-0068-governed-looping.md) — a governed loop with an Opus coordinator and spawned Sonnet build agents is exactly the thin-orchestrator shape, with the loop's halt-at-the-merge-gate guardrails.
+- **Build-engineer tiers are confirmed matrix-conformant.** `backend-engineer` / `frontend-engineer` are already `sonnet` on `dev` — no agent file is edited by this AgDR. The drift guard (`block-agent-routing-drift.sh`, from AgDR-0050 Axis 4) catches any future re-drift on commit / push; operators can additionally pin the tiers via `agent-routing.yaml` so the matrix value is explicit.
+- **No review-routing regression.** Rex / Hakim stay `opus`; Nour stays `sonnet`. No agent frontmatter changes in this PR.
+- **`agent-routing.yaml` remains the per-adopter tuning surface.** The docs now point operators at it as a cost lever (pin tiers, route specific agents through cheaper models), closing the "ships empty, tuning surface unused" gap noted in the ticket.
+
+## Artifacts
+
+- This AgDR file: `docs/agdr/AgDR-0074-orchestrator-cost-model.md`
+- Operator-facing cost-lever doc: `docs/orchestrator-cost-model.md`
+- Agent frontmatter confirmed matrix-conformant (unchanged by this PR): `.claude/agents/backend-engineer.md`, `.claude/agents/frontend-engineer.md` (both `model: sonnet`)
+- Related AgDRs:
+  - [AgDR-0050 — agent runtime overhaul](AgDR-0050-agent-runtime-overhaul.md) — the per-agent matrix (Axis 2) + the Axis-6 in-thread/spawned split this AgDR documents the cost consequence of
+  - [AgDR-0068 — governed looping](AgDR-0068-governed-looping.md) — the loop shape the thin-orchestrator pattern composes with
+- Related rule:
+  - [`.claude/rules/plan-mode.md`](../../.claude/rules/plan-mode.md) — `opusplan` prior art (Opus plans, Sonnet executes)
+- Implementation ticket: [me2resh/apexyard#655](https://github.com/me2resh/apexyard/issues/655)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -184,6 +184,16 @@ Link-check (lychee) is intentionally excluded — it is slow and network-depende
 
 ---
 
+## Managing model cost — why the main agent dominates spend
+
+The per-agent model matrix ([AgDR-0050](agdr/AgDR-0050-agent-runtime-overhaul.md)) only applies to *spawned* sub-agents (reviews, QA, analysts). *In-flow* work — implementation, PM, design — is adopted **in-thread** by design, so it runs on your primary tier (usually Opus) and the `sonnet` implementation default never takes effect. That's why operators see the main agent dominating token spend.
+
+Three levers manage it, ordered by effort-to-win ratio: (1) **`opusplan`** — Opus plans, Sonnet executes (biggest win, no framework change); (2) the **thin-orchestrator pattern** — keep the Opus loop as a planner / coordinator and delegate implementation to spawned `sonnet` build agents via `/fan-out` or `Workflow`; (3) populate **`agent-routing.yaml`** to pin or route per-agent tiers.
+
+Full explanation + the opt-in thin-orchestrator mode: [`docs/orchestrator-cost-model.md`](orchestrator-cost-model.md).
+
+---
+
 ## Optional: LSP-aware code navigation
 
 Claude Code v2.0.74+ ships a built-in **LSP (Language Server Protocol) tool** that answers semantic queries — *"where is this defined?"*, *"where is this used?"*, *"what does this symbol resolve to?"* — by talking to a language server (`tsserver`, `pyright`, `gopls`, `rust-analyzer`, etc.) instead of grepping the file tree. It is **off by default** and **opt-in per session**.

--- a/docs/orchestrator-cost-model.md
+++ b/docs/orchestrator-cost-model.md
@@ -1,0 +1,112 @@
+# Orchestrator cost model — why the main agent dominates spend, and the three levers
+
+If you run ApexYard and notice the **main agent dominating your token bill**, this is expected behaviour with a structural cause — not a misconfiguration. This doc explains *why*, then gives you three levers to manage it, ordered by effort-to-win ratio.
+
+Full design rationale: [AgDR-0074](agdr/AgDR-0074-orchestrator-cost-model.md). Underlying runtime design: [AgDR-0050](agdr/AgDR-0050-agent-runtime-overhaul.md).
+
+---
+
+## Why the main agent dominates spend
+
+[AgDR-0050](agdr/AgDR-0050-agent-runtime-overhaul.md) ships a **per-agent model matrix** — a default tier per sub-agent:
+
+| Tier | Agents (examples) | Why |
+|------|-------------------|-----|
+| `opus` | Tech Lead, SRE, Pen Tester, **Security Auditor (Hakim)**, **Code Reviewer (Rex)** | Depth-bound reasoning |
+| `sonnet` | **Backend / Frontend Engineer**, Platform / Data Engineer, Product Manager, **UI Designer (Nour)**, UX Designer | Implementation + tool-use default |
+| `haiku` | QA Engineer, Data Analyst | Checklist-shaped, repeatable work |
+
+The matrix is real and correct — **but it only applies to *spawned* sub-agents.** A sub-agent's model comes from its frontmatter (`model:` in `.claude/agents/<name>.md`), which the harness reads when it *spawns* the agent.
+
+Per [AgDR-0050 § Axis 6](agdr/AgDR-0050-agent-runtime-overhaul.md), role activations split into two classes:
+
+- **Isolated-work-class** roles (QA, Pen Tester, Data Analyst, Heads-of-X, **Security Auditor, Code Reviewer**, Tech Lead reviews) → auto-triggers **spawn a sub-agent**. The matrix applies. ✅
+- **In-flow-class** roles (**Backend / Frontend Engineer**, Platform / Data Engineer, Product Manager, UI / UX Designer) → auto-triggers keep **in-thread persona adoption**, because spawning out-of-thread loses the shared "what just happened" context that ship-the-code flow needs.
+
+In-thread adoption **does not spawn anything** — it injects the role file into the main thread, which keeps running on whatever model is driving the conversation (typically your primary tier, usually **Opus**). So:
+
+- **Reviews route correctly** — Rex + Hakim are spawned, so their `opus` frontmatter applies.
+- **Implementation does not** — Backend / Frontend Engineer work is adopted in-thread, so the `sonnet` default in their frontmatter is never consulted. Implementation — the highest-volume work in any SDLC — runs at your primary tier.
+
+That's the tension in one line: **the matrix optimises the spawned minority (reviews); the in-thread majority (implementation) runs on your primary tier.** The matrix works — it just can't reach the work that costs the most, by Axis-6 design (which is the right call for shared context).
+
+---
+
+## The three levers
+
+You don't reverse Axis 6 to fix this — in-flow work genuinely benefits from shared context. Instead you pick one (or more) of these levers. They are ordered by effort-to-win ratio: do C1 first.
+
+### Lever 1 — `opusplan` (biggest single win, no framework change)
+
+The harness ships an `opusplan` model alias: **Opus runs during plan mode** (deeper reasoning while the choices matter), **Sonnet runs during execution** (cheaper while the choices are mechanical). The high-volume *execution* phase — which is where the in-thread implementation work lives — drops to Sonnet, while planning keeps Opus depth.
+
+This is the single biggest win and requires **zero framework change** — it's an operator model-config choice. See [Claude Code model configuration](https://code.claude.com/docs/en/model-config) for the alias and tier-routing semantics, and [`.claude/rules/plan-mode.md`](../.claude/rules/plan-mode.md) § "Prior art" for how it lines up with ApexYard's plan-mode discipline.
+
+```text
+opusplan:  Opus (plan mode) ──▶ Sonnet (execution)
+```
+
+If you do nothing else, do this.
+
+### Lever 2 — the thin-orchestrator pattern (recover the matrix for implementation)
+
+Keep the **Opus main loop as a thin planner / coordinator** — it plans, decomposes, sequences, and gates — and **delegate well-scoped implementation to *spawned* `sonnet` build agents** via [`/fan-out`](../.claude/skills/fan-out/SKILL.md) (N independent items, one pass each) or the `Workflow` tool (a verifying fleet). Because the build agents are *spawned*, the model matrix applies — implementation runs on `sonnet`, the coordinator stays Opus.
+
+This is the opt-in route for operators who want the matrix to apply to implementation *without* giving up shared-context for the planning loop. You get the cheap tier for the bulk by *choosing* to spawn, instead of the framework forcing a spawn on everyone.
+
+```text
+Opus loop (thin: plan · decompose · sequence · gate)
+   │
+   ├─▶ /fan-out  ──▶ sonnet backend-engineer   (ticket A)
+   ├─▶ /fan-out  ──▶ sonnet frontend-engineer  (ticket B)
+   └─▶ spawn     ──▶ opus  code-reviewer (Rex) ──▶ HALT at CEO merge gate
+```
+
+**Guardrails (from [AgDR-0068 — governed looping](agdr/AgDR-0068-governed-looping.md), and [`.claude/rules/loop-mode.md`](../.claude/rules/loop-mode.md)):** a thin-orchestrator loop **MUST halt at the per-PR CEO merge gate** — it never self-approves. Its verify stage runs **build + tests + Rex**, not just build. And it has a **budget / iteration ceiling**. The thin-orchestrator pattern *is* a governed loop with an Opus coordinator and spawned Sonnet workers — the loop-mode guardrails apply unchanged.
+
+#### Opt-in "thin-orchestrator mode"
+
+Treat this as an explicit mode you opt into for a session, not a silent default. When you want it, say so up front — e.g. *"run thin-orchestrator: you stay Opus as planner, fan implementation out to Sonnet build agents, halt at every merge gate."* The agent then:
+
+1. Plans + decomposes in the Opus loop (ideally under `opusplan`, so even planning's execution sub-steps are Sonnet).
+2. Spawns `sonnet` build agents per well-scoped ticket (`/fan-out` for independent items; `Workflow` for a verifying fleet).
+3. Runs the real `opus` reviewers (Rex / Hakim) as separate spawns — build agents **cannot** self-review (see [`.claude/rules/pr-workflow.md`](../.claude/rules/pr-workflow.md) § "Build agents cannot self-review").
+4. **Stops at the per-PR CEO merge gate** and hands back for the explicit approval.
+
+This composes with `opusplan` (Lever 1): use both — `opusplan` cheapens the coordinator's own execution sub-steps, thin-orchestrator cheapens the delegated implementation.
+
+### Lever 3 — populate `agent-routing.yaml` (per-adopter tuning)
+
+`agent-routing.yaml` ships **empty** (`agents: {}`), so the per-agent tuning surface is unused by default. It's the one-file place to pin or adjust per-agent tiers — including **pinning the build engineers to `sonnet` explicitly** so frontmatter drift can't silently raise the tier, or routing specific agents through cheaper / local models.
+
+```yaml
+# agent-routing.yaml
+version: 1
+agents:
+  backend-engineer:
+    model: sonnet          # framework default; explicit pin guards against drift
+  frontend-engineer:
+    model: sonnet          # framework default; explicit pin
+  data-analyst:
+    model: haiku           # framework default; or bump to sonnet for richer SQL
+```
+
+At SessionStart the sync hook (`apply-agent-routing.sh`) rewrites the affected agent-file frontmatter in place; drift guards keep adopter routing choices out of the public fork. See [`agent-routing.yaml.example`](../agent-routing.yaml.example) for the full schema (model / endpoint / env / timeout) and [`docs/local-model-setup.md`](local-model-setup.md) for routing specific agents through a local Ollama endpoint as a further cost / privacy lever.
+
+> **Note:** `agent-routing.yaml` tunes the model of *spawned* sub-agents. It does **not** change the tier of *in-thread* in-flow work — that's governed by your primary tier and Lever 1 (`opusplan`). Use Lever 3 to make the matrix tunable; use Levers 1 + 2 to reach the in-thread majority.
+
+---
+
+## Quick reference
+
+| Symptom | Lever | Effort | Reaches |
+|---------|-------|--------|---------|
+| Main agent dominates spend | **1 — `opusplan`** | Operator config, zero framework change | Execution phase of the in-thread loop → Sonnet |
+| Want the matrix to apply to implementation | **2 — thin-orchestrator** | Operator workflow change | Delegated implementation → spawned Sonnet build agents |
+| Want per-adopter tier control | **3 — `agent-routing.yaml`** | One file edit + re-session | Spawned sub-agents (pin / route / local) |
+
+Start with Lever 1. Add Lever 2 for implementation-heavy sessions. Use Lever 3 to make the whole matrix tunable for your fork.
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*


### PR DESCRIPTION
## Summary

- **New `docs/orchestrator-cost-model.md`** — explains the structural reason operators see the main agent dominating their token bill: the per-agent model matrix from [AgDR-0050](https://github.com/me2resh/apexyard/blob/dev/docs/agdr/AgDR-0050-agent-runtime-overhaul.md) only applies to *spawned* sub-agents, but § Axis 6 deliberately keeps *in-flow* work (implementation / PM / design) **in-thread**, so the highest-volume work runs on the operator's primary tier (usually Opus) and the `sonnet` implementation default never takes effect. The doc gives three cost levers in effort-to-win order — `opusplan`, the thin-orchestrator pattern, and populating `agent-routing.yaml` — so the cost model is documented rather than surprising.
- **`docs/getting-started.md`** — adds a short "Managing model cost — why the main agent dominates spend" section that summarises the tension and the three levers, linking out to the full doc.
- **New AgDR-0074** — records the in-thread-vs-matrix cost tension as a *consequence* of AgDR-0050's Axis-6 decision (kept immutable) and the decision to **document levers rather than reverse Axis 6** (which would lose the shared-context benefit in-flow work depends on).
- **Agent frontmatter — confirm-not-edit.** The ticket flagged a possible `opus→sonnet` drift on `backend-engineer` / `frontend-engineer`. On me2resh/dev both are **already `sonnet`** (the drift existed only in a local uncommitted working tree, never on the canonical repo), so **no agent files were edited** — the AgDR records the conformant state instead. Rex (`code-reviewer`, opus), Hakim (`security-reviewer`, opus), and Nour (`ui-designer`, sonnet) are untouched.

## Testing

1. `bash bin/run-hook-tests.sh` → **PASS 69 / FAIL 0**
2. `bash .claude/agents/tests/test_agent_wrap_shape.sh` → **PASS** (agent frontmatter baselines + Axis-2 tiers unchanged)
3. `npx markdownlint-cli2 docs/getting-started.md docs/orchestrator-cost-model.md docs/agdr/AgDR-0074-orchestrator-cost-model.md` → **0 errors** (uses the repo's `.markdownlint.json`)
4. Diff scope verified: only the cost-model doc + the getting-started section + AgDR-0074. No agent / hook / source files changed.

## Glossary

| Term | Definition |
|------|------------|
| **Per-agent model matrix** | AgDR-0050's mapping of each sub-agent to a default model tier (`opus` for depth-bound roles, `sonnet` for implementation, `haiku` for checklist work). Only applies when an agent is *spawned*. |
| **In-thread persona adoption** | Activating a role by injecting its role file into the main conversation thread (no sub-agent spawn). The thread keeps running on the operator's primary tier, so the matrix's `model:` frontmatter never applies. |
| **In-flow-class role** | A role (Backend/Frontend/Platform/Data Engineer, PM, UI/UX Designer) that AgDR-0050 § Axis 6 keeps in-thread to preserve shared "what just happened" context. |
| **Isolated-work-class role** | A role (reviewers, QA, analysts, Heads-of-X) that Axis 6 spawns as a sub-agent — so the matrix tier applies. |
| **`opusplan`** | Harness model alias: Opus during plan mode, Sonnet during execution. The largest single cost win and needs no framework change. |
| **Thin-orchestrator pattern** | Keep the Opus loop as a thin planner/coordinator and delegate well-scoped implementation to *spawned* `sonnet` build agents via `/fan-out` or `Workflow`, recovering the matrix for implementation by choosing to spawn. |
| **`agent-routing.yaml`** | The per-adopter tuning surface (ships empty) for pinning/routing per-agent model tiers; synced into agent frontmatter at SessionStart by `apply-agent-routing.sh`. |

Closes #655

---

Re-landed on me2resh (canonical) from the retired atlas fork PR #6 (`feature/GH-655-orchestrator-cost-model`). The atlas branch numbered this AgDR 0073; on me2resh, 0072 and 0073 are claimed by in-flight PRs #671 and #675, so it was renumbered to **AgDR-0074** (verified collision-free on `dev` and across open PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQWFvN2vzy1UtFX2FyaDvb
