### PR TITLE
chore(#679): scorecard publish_results false (stop failing run)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true   # enables the README badge
+          publish_results: false  # disabled: publish step failed the run (#679); SARIF still uploads to code-scanning
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## Summary
- **Set `publish_results: false`** in `.github/workflows/scorecard.yml` — the OpenSSF publish step couldn't reach the API and was exiting the whole action non-zero on every push to `main` (the recurring "Scorecard supply-chain security / Failing after 33s" red check).
- SARIF results still upload to **Security → Code scanning** (the `upload-sarif` step is unchanged); only the public-badge publish is disabled.

## Testing
- Workflow YAML lints; the next push to `main` should show the Scorecard run succeed (publish step no longer runs).

Closes #679

## Glossary
| Term | Definition |
|------|------------|
| publish_results | OSSF Scorecard option that publishes the score to the public OpenSSF API (drives the README badge). |
