### PR TITLE
feat(#674): automate /release — one-command bump + changelog + release PR

### DIFF
--- a/.claude/hooks/tests/test_release_changelog.sh
+++ b/.claude/hooks/tests/test_release_changelog.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Tests for bin/release-changelog.sh (AgDR-0076).
+#
+# Strategy: create a temporary git repo with fake commits, then call the
+# script against that repo and assert on the stdout output. No network
+# calls; no reliance on the main repo's actual history.
+#
+# Each test function runs its git commands via a subshell that cd's into
+# a fresh tmpdir, so tests never bleed into one another or into the main
+# repo's history.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="$(cd "$SCRIPT_DIR/../../../bin" && pwd)"
+CHANGELOG_SCRIPT="$BIN_DIR/release-changelog.sh"
+
+pass=0; fail=0
+
+# ── Assertion helpers ────────────────────────────────────────────────────────
+
+eq() {  # eq <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    echo "  ok: $1"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $1"
+    echo "       expected: [$2]"
+    echo "       got:      [$3]"
+    fail=$((fail + 1))
+  fi
+}
+
+contains() {  # contains <label> <needle> <haystack>
+  if echo "$3" | grep -qF "$2"; then
+    echo "  ok: $1"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $1 — expected to find [$2] in output"
+    echo "  Output was:"
+    echo "$3" | head -20 | sed 's/^/    /'
+    fail=$((fail + 1))
+  fi
+}
+
+not_contains() {  # not_contains <label> <needle> <haystack>
+  if ! echo "$3" | grep -qF "$2"; then
+    echo "  ok: $1"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $1 — expected NOT to find [$2] in output"
+    echo "  Offending line:"
+    echo "$3" | grep -F "$2" | head -3 | sed 's/^/    /'
+    fail=$((fail + 1))
+  fi
+}
+
+# ── Per-test repo runner ─────────────────────────────────────────────────────
+# run_in_repo <shell-function-body>
+# Creates a tmpdir, sources a mini-function that can call git, then cleans up.
+# Returns the captured output + exit code from the inner body.
+
+run_test() {
+  # $@ is a list of git commands + the final assertion call
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  (
+    cd "$tmpdir" || exit 1
+    git init -q
+    git config user.email "test@test.local"
+    git config user.name "Test"
+    git config init.defaultBranch main 2>/dev/null || true
+
+    mc() {  # make_commit <msg>
+      local f="f$RANDOM.txt"
+      echo "$RANDOM" > "$f"
+      git add "$f"
+      git commit -q -m "$1"
+    }
+
+    # Run the caller-supplied body
+    eval "$1"
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
+# ── Test: missing required env var fails with exit 1 ────────────────────────
+
+echo "--- missing env var ---"
+out=$(PREV_TAG="" HEAD_REF="HEAD" VERSION="v1.0.0" DATE="2026-01-01" \
+  bash "$CHANGELOG_SCRIPT" 2>&1 || true)
+contains "missing PREV_TAG prints error" "PREV_TAG is required" "$out"
+
+# ── Test: empty commit range (patch with 0 commits) ─────────────────────────
+
+echo "--- empty commit range ---"
+out=$(run_test '
+  mc "chore: initial setup"
+  git tag v0.0.1
+  PREV_TAG="v0.0.1" HEAD_REF="HEAD" VERSION="v0.0.2" DATE="2026-01-01" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "header line present" "## [v0.0.2] — 2026-01-01" "$out"
+contains "patch release description" "Patch release" "$out"
+not_contains "no Added section" "### Added" "$out"
+not_contains "no Fixed section" "### Fixed" "$out"
+
+# ── Test: feat commits → Added section, minor bump description ──────────────
+
+echo "--- feat commits ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v1.0.0
+  mc "feat(#101): add auto-tag workflow"
+  mc "feat(#102): add dry-run mode to release skill"
+  PREV_TAG="v1.0.0" HEAD_REF="HEAD" VERSION="v1.1.0" DATE="2026-06-21" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "header line" "## [v1.1.0] — 2026-06-21" "$out"
+contains "minor bump" "Minor release" "$out"
+contains "Added section" "### Added (feat)" "$out"
+contains "first feat subject" "add auto-tag workflow" "$out"
+contains "second feat subject" "add dry-run mode" "$out"
+contains "PR ref 101" "(#101)" "$out"
+contains "PR ref 102" "(#102)" "$out"
+contains "Closes section" "### Closes" "$out"
+contains "closes 101 in closes" "#101" "$out"
+
+# ── Test: fix commits → Fixed section, patch bump description ───────────────
+
+echo "--- fix commits ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v2.0.0
+  mc "fix(#200): correct tag placement after squash merge"
+  PREV_TAG="v2.0.0" HEAD_REF="HEAD" VERSION="v2.0.1" DATE="2026-06-21" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "patch bump" "Patch release" "$out"
+contains "Fixed section" "### Fixed (fix)" "$out"
+contains "fix subject" "correct tag placement" "$out"
+not_contains "no Added section" "### Added" "$out"
+
+# ── Test: breaking commit → Breaking section, major bump description ─────────
+
+echo "--- breaking commit ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v1.2.3
+  mc "feat(#300)!: remove deprecated v1 skill API"
+  PREV_TAG="v1.2.3" HEAD_REF="HEAD" VERSION="v2.0.0" DATE="2026-06-21" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "major bump" "Major release" "$out"
+contains "Breaking section" "### Breaking" "$out"
+contains "breaking subject" "remove deprecated v1 skill API" "$out"
+
+# ── Test: mixed commit types → multiple sections ─────────────────────────────
+
+echo "--- mixed commit types ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v3.0.0
+  mc "feat(#401): new skill /foo"
+  mc "fix(#402): fix bar edge case"
+  mc "chore(#403): update dependencies"
+  mc "docs(#404): improve getting-started guide"
+  PREV_TAG="v3.0.0" HEAD_REF="HEAD" VERSION="v3.1.0" DATE="2026-06-21" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "Added section" "### Added (feat)" "$out"
+contains "Fixed section" "### Fixed (fix)" "$out"
+contains "Changed section" "### Changed (refactor / chore / docs)" "$out"
+contains "feat subject" "new skill /foo" "$out"
+contains "fix subject" "fix bar edge case" "$out"
+contains "chore subject" "update dependencies" "$out"
+contains "docs subject" "improve getting-started guide" "$out"
+
+# ── Test: commits without PR numbers still appear (no (#N) required) ─────────
+
+echo "--- commits without PR numbers ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v4.0.0
+  mc "fix: correct shell quoting in release script"
+  PREV_TAG="v4.0.0" HEAD_REF="HEAD" VERSION="v4.0.1" DATE="2026-06-21" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "fix without PR num appears" "correct shell quoting" "$out"
+not_contains "no spurious closes section" "### Closes" "$out"
+
+# ── Test: NONE as PREV_TAG includes all commits ──────────────────────────────
+
+echo "--- NONE prev tag ---"
+out=$(run_test '
+  mc "feat(#500): initial feature"
+  PREV_TAG="NONE" HEAD_REF="HEAD" VERSION="v1.0.0" DATE="2026-06-21" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "feat from beginning" "initial feature" "$out"
+
+# ── Test: sync and release commits are excluded ──────────────────────────────
+
+echo "--- excluded commit types ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v5.0.0
+  mc "feat(#600): real feature"
+  mc "sync: merge main into dev after v5.0.0 release"
+  mc "release(#601): v5.1.0"
+  PREV_TAG="v5.0.0" HEAD_REF="HEAD" VERSION="v5.1.0" DATE="2026-06-21" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "real feat included" "real feature" "$out"
+not_contains "sync commit excluded" "merge main into dev" "$out"
+not_contains "release commit excluded" "release(#601)" "$out"
+
+# ── Test: Merge branch commits excluded, Merge pull request kept ──────────────
+
+echo "--- merge commit filtering ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v6.0.0
+  mc "feat(#700): add something"
+  mc "Merge branch main into dev"
+  PREV_TAG="v6.0.0" HEAD_REF="HEAD" VERSION="v6.1.0" DATE="2026-06-21" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "feat included" "add something" "$out"
+not_contains "branch merge excluded" "Merge branch main" "$out"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "All $pass test(s) passed."
+  exit 0
+else
+  echo "$fail test(s) FAILED (${pass} passed)."
+  exit 1
+fi

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: release
-description: Cut an apexyard release — diff dev↔main, pick semver bump, generate CHANGELOG, open release PR, tag + push after merge.
-argument-hint: "<optional explicit version, e.g. v1.2.0>"
+description: Cut an apexyard release — diff dev↔main, pick semver bump, generate CHANGELOG, open release PR, auto-tag on merge.
+argument-hint: "[--dry-run] [<version, e.g. v1.2.0>]"
 allowed-tools: Bash, Read, Write
 ---
 
 # /release — Cut an apexyard release
 
-Standardises the `dev` → `main` release flow introduced by AgDR-0007. Reads the conventional-commit log between `main` and `dev`, proposes a semver bump, generates a CHANGELOG entry, opens the release PR, and (after the user merges) tags the resulting commit and pushes the tag.
+Standardises the `dev` → `main` release flow introduced by AgDR-0007. Reads the conventional-commit log between `main` and `dev`, proposes a semver bump, **generates and writes the CHANGELOG entry**, **opens the release PR** (dev→main), and triggers the `auto-tag-on-release-pr-merge` GitHub Actions workflow that tags the squash commit and creates a GitHub Release after merge. One command drives the operator from "nothing" to "PR open, ready for Rex + CEO". The tag and GitHub Release entry are created automatically by CI when the PR merges. Design rationale: AgDR-0076.
 
 This skill is **framework-only** — it's for cutting apexyard releases, not for releasing managed projects under governance. Managed projects stay trunk-based and don't have a release-cut flow.
 
@@ -16,7 +16,8 @@ This skill is **framework-only** — it's for cutting apexyard releases, not for
 ```
 /release             # auto-detect bump from conventional commits
 /release v1.2.0      # explicit version, skip auto-detect
-/release --dry-run   # preview only, don't create the PR
+/release --dry-run   # preview changelog + PR body without writing any files
+/release --dry-run v1.2.0
 ```
 
 ## Process
@@ -34,7 +35,7 @@ Verify:
 
 If `<version>` arg was passed, use it (must match `v\d+\.\d+\.\d+`).
 
-Otherwise auto-detect from the conventional-commit types in `git log main..upstream/dev`:
+Otherwise auto-detect from the conventional-commit types in `git log upstream/main..upstream/dev`:
 
 | Found | Bump |
 |-------|------|
@@ -42,7 +43,15 @@ Otherwise auto-detect from the conventional-commit types in `git log main..upstr
 | Any `feat:` / `feat(...):` (and no breaking) | **MINOR** |
 | Only `fix:` / `chore:` / `docs:` / `refactor:` / `test:` / `style:` / `perf:` / `build:` / `ci:` (and no `feat:` or breaking) | **PATCH** |
 
-Read the current latest tag (`git describe --tags --abbrev=0 main` or `gh api repos/me2resh/apexyard/releases/latest`) and bump accordingly. Show the user:
+Read the current latest tag:
+
+```bash
+PREV_TAG=$(git describe --tags --abbrev=0 upstream/main 2>/dev/null \
+           || gh api repos/me2resh/apexyard/releases/latest --jq '.tag_name' 2>/dev/null \
+           || echo "NONE")
+```
+
+Bump accordingly. Show the user:
 
 ```
 Current latest tag: vX.Y.Z
@@ -52,14 +61,26 @@ Override? [Enter to accept, or type a version like v1.3.0]
 
 ### 3. Generate the CHANGELOG draft
 
-Run `git log <prev-tag>..upstream/dev --pretty=format:'%h %s'` and group by conventional-commit type:
+Call the helper script `bin/release-changelog.sh`, which encapsulates the `git log` + conventional-commit grouping + PR-number extraction logic and is independently tested:
+
+```bash
+PREV_TAG="vX.Y.Z" \
+HEAD_REF="upstream/dev" \
+VERSION="vA.B.C" \
+DATE="$(date +%F)" \
+  bash bin/release-changelog.sh
+```
+
+The helper emits markdown to stdout in the format:
 
 ```markdown
-## vX.Y.Z — YYYY-MM-DD
+## [vA.B.C] — YYYY-MM-DD
+
+Minor release — N features, M fixes.
 
 ### Added (feat)
 - (#NN) <subject> — <short-sha>
-- ...
+...
 
 ### Fixed (fix)
 - (#NN) <subject> — <short-sha>
@@ -71,92 +92,150 @@ Run `git log <prev-tag>..upstream/dev --pretty=format:'%h %s'` and group by conv
 - <only if breaking-marker commits exist>
 
 ### Closes
-- <enumerate every `Closes #N` from PR bodies merged to dev since last tag>
+- Closes #N, #M, ...
 ```
 
-Show the draft and let the user edit interactively before opening the PR.
+**Show the draft** and let the user edit interactively before proceeding. On `--dry-run`, print the draft and stop here with:
 
-### 4. Open the release PR
+```
+Dry run — no changes made. Remove --dry-run to execute.
+```
 
-Branch from `dev`: `release/vA.B.C`. Push to `upstream`. Open PR:
+### 4. Prepare and push the release branch
 
-- **Base**: `main`
-- **Head**: `release/vA.B.C`
-- **Title**: `release(#<release-ticket>): vA.B.C` — e.g. `release(#160): v1.2.0`. The release-cut ticket (filed via the standard ticket flow) is the natural scope, and `release` was added to the `pr.title_type_whitelist` in #168 so this title shape passes `validate-pr-create.sh` like every other PR title.
-- **Body**: the CHANGELOG draft + an explicit "this PR will tag `vA.B.C` on `main` after merge"
+Skip all of steps 4–5 on `--dry-run`.
 
-The PR body should aggregate every `Closes #N` from the included commits so that merging the release PR auto-closes all of them on GitHub at once.
+```bash
+# Check out the release branch from dev
+git fetch upstream
+git checkout -b "release/vA.B.C" upstream/dev
 
-Skip-marker note: the release PR's body legitimately has many `Closes #N`. The hook from #114 (single-Closes-per-PR) will block it. Use `<!-- multi-close: approved -->` to bypass — release PRs are exactly the umbrella case the marker is designed for.
+# Write the CHANGELOG entry at the top of CHANGELOG.md
+# (prepend the draft from step 3 above the previous top entry)
 
-### 5. Wait for review + merge
+git add CHANGELOG.md
+git commit -m "chore: release vA.B.C
+
+- Prepend CHANGELOG section for vA.B.C
+
+Refs #<release-ticket>"
+
+# Push to upstream (not origin — release PRs target me2resh/apexyard)
+git push upstream "release/vA.B.C"
+```
+
+### 5. Open the release PR
+
+```bash
+gh pr create \
+  --repo me2resh/apexyard \
+  --base main \
+  --head "release/vA.B.C" \
+  --title "release(#<release-ticket>): vA.B.C" \
+  --body-file /tmp/release-pr-body.md
+```
+
+**PR body template** (write to `/tmp/release-pr-body.md` before the `gh pr create` call):
+
+```markdown
+<!-- multi-close: approved -->
+
+## Summary
+
+- **Releases vA.B.C** — see CHANGELOG section below for the full list of changes included in this release
+- **CHANGELOG.md updated** — new section prepended at the top with grouped feat/fix/chore entries and PR refs
+- **Auto-tag on merge** — `.github/workflows/auto-tag-on-release-pr-merge.yml` will tag the squash commit on main and create a GitHub Release entry automatically when this PR merges (AgDR-0076)
+
+## CHANGELOG
+
+<paste the draft from step 3>
+
+## Testing
+
+1. After merge, confirm CI creates tag `vA.B.C` on `main` (check the `auto-tag-on-release-pr-merge` workflow run)
+2. Verify `git describe --tags --abbrev=0 upstream/main` returns `vA.B.C`
+3. Run `/release-sync vA.B.C` to sync main→dev and prevent squash divergence
+
+Refs #<release-ticket>
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| Squash merge | GitHub merges all commits on the PR branch into a single commit on main; the branch HEAD is discarded and the resulting main tip has a new SHA |
+| Auto-tag | The `auto-tag-on-release-pr-merge.yml` workflow fires on `pull_request` → `closed` + `merged` for `release/v*` branches, tags `github.sha` (the squash commit), and creates a GitHub Release |
+| Ancestry guard | `git merge-base --is-ancestor <sha> main` — fails if the tag would not be reachable from main, preventing a mis-placed tag like v2.3.0 |
+| `/release-sync` | The mandatory follow-up skill that merges main→dev after a squash-merge release, preventing SHA divergence accumulation |
+```
+
+**PR title format** (`release` is whitelisted in `pr.title_type_whitelist` since #168):
+
+```
+release(#<release-ticket>): vA.B.C
+```
+
+### 6. Wait for review + merge (operator step)
 
 The release PR runs through the normal flow:
 
-- Code Reviewer (Rex) on the PR
+- Code Reviewer (Rex) on the PR via `/code-review`
 - CEO `/approve-merge`
 - Merge gate green
 - Squash-merge to `main`
 
-`/release` does not auto-merge. The CEO retains the discrete moment.
+`/release` does **not** auto-merge. The CEO retains the discrete moment. The tag and GitHub Release are created automatically by the `auto-tag-on-release-pr-merge.yml` CI workflow **after** the merge.
 
-### 6. Tag + push (after merge)
+### 7. Tag + GitHub Release (automated via CI)
 
-Once the release PR squash-merges to `main`, the tag must point at the **squash commit that landed on `main`** — never at the release-branch HEAD. When a PR is squash-merged, GitHub creates a single new commit on `main` whose SHA is different from every commit on the source branch. Tagging the release-branch HEAD produces a tag that is not reachable from `main`, breaking `git describe`, `git merge-base`, and any ancestry-based tooling (see issue #550).
+When the release PR is squash-merged to `main`, the `.github/workflows/auto-tag-on-release-pr-merge.yml` workflow fires automatically:
 
-The user invokes `/release --tag vA.B.C` (or runs the suggested commands manually):
+1. Extracts the version from the branch name (`release/vA.B.C` → `vA.B.C`).
+2. Uses `github.sha` (the squash commit SHA — already the correct commit on `main`).
+3. Runs the ancestry guard: `git merge-base --is-ancestor <sha> main`.
+4. Creates an annotated tag and pushes it with `git push origin --tags`.
+5. Creates a GitHub Release entry from the CHANGELOG section in the PR body (in the same job — a tag pushed via GITHUB_TOKEN does not trigger a secondary release workflow).
+
+**No manual tagging required** after merge. The workflow handles it.
+
+#### Manual fallback (if CI workflow fails)
+
+If the auto-tag workflow fails for any reason, follow the manual steps:
 
 ```bash
-# Step 1 — fetch so upstream/main points at the squash commit just merged.
+# 1. Fetch so upstream/main points at the squash commit.
 git fetch upstream
 
-# Step 2 — tag the tip of upstream/main.
-#           This IS the squash commit. Do NOT use the release-branch HEAD —
-#           it was discarded by the squash and is no longer in main's ancestry.
+# 2. Tag the tip of upstream/main (the squash commit, NOT the branch HEAD).
 git tag vA.B.C upstream/main
 
-# Step 3 — ancestry guard: assert the tag is reachable from main BEFORE pushing.
-#           If this exits non-zero, the tag is mis-placed — delete and re-tag.
+# 3. Ancestry guard before pushing.
 if ! git merge-base --is-ancestor vA.B.C upstream/main; then
-  echo "ERROR: vA.B.C is not an ancestor of upstream/main — tag is mis-placed." >&2
-  echo "Delete the tag with: git tag -d vA.B.C" >&2
-  echo "Then re-run from Step 1 after confirming the PR was squash-merged." >&2
+  echo "ERROR: tag is mis-placed — delete and re-tag." >&2
   exit 1
 fi
 
-# Step 4 — push only after the guard passes.
-git push upstream vA.B.C
+# 4. Push the tag (use --tags, not the bare tag name, to avoid the
+#    branch-name validator hook misfiring on tag-push commands).
+git push upstream --tags
 ```
 
 #### Post-tag release checklist
 
-Before announcing the release, verify all three assertions hold:
+Verify all three assertions hold (CI workflow also checks these):
 
-- [ ] `git merge-base --is-ancestor vA.B.C upstream/main` exits 0 (tag is an ancestor of main)
-- [ ] `git describe --tags --abbrev=0 upstream/main` returns `vA.B.C` (tag is discoverable from main)
-- [ ] `git rev-parse vA.B.C^{}` equals `git rev-parse upstream/main` (tag points at the exact tip — true for a clean release with no post-merge commits; will differ if post-merge work has landed, which is fine as long as the first two assertions hold)
-
-> **One-time note on v2.3.0:** the existing `v2.3.0` tag is mis-placed (release-branch HEAD, not the squash commit on `main`). Re-pointing it is an operational step — force-updating a published tag — that must be done by the maintainer outside this skill. This fix prevents the same mistake on all future releases.
-
-### 7. Optional: GitHub Release
-
-If the user wants a Release entry on GitHub:
-
-```bash
-gh release create vA.B.C \
-  --repo me2resh/apexyard \
-  --title "vA.B.C" \
-  --notes-file <changelog-section>
-```
-
-The CHANGELOG section from step 3 is the body.
+- [ ] `git merge-base --is-ancestor vA.B.C upstream/main` exits 0
+- [ ] `git describe --tags --abbrev=0 upstream/main` returns `vA.B.C`
+- [ ] GitHub Release entry exists at `https://github.com/me2resh/apexyard/releases/tag/vA.B.C`
 
 ### 8. Confirm
 
 ```
-Released vA.B.C — tag pushed to upstream/main.
+Released vA.B.C — auto-tag workflow running on CI, will tag main + create GitHub Release.
 N tickets auto-closed via the release PR.
 Drift banner on adopters' forks will fire on next session.
+Next: /release-sync vA.B.C
 ```
 
 ### 9. Open the main→dev sync PR (MANDATORY after every release)
@@ -180,13 +259,18 @@ This files a `sync/main-to-dev-after-vA.B.C → dev` PR that merges `upstream/ma
 3. **Always show the bump for confirmation** — auto-detection is a proposal, not a fait accompli. The CEO's eyes are the final check on semver intent.
 4. **CHANGELOG is editable** before the release PR opens. Don't auto-file what hasn't been reviewed.
 5. **Never auto-merge the release PR.** Rex + CEO approval applies as for any PR. The skill stops at "PR opened."
-6. **Never tag before merge, and never tag the release-branch HEAD.** After a squash-merge the release branch's HEAD is not in `main`'s ancestry. Always tag `upstream/main` (the squash commit) and assert `git merge-base --is-ancestor vA.B.C upstream/main` before pushing the tag. See step 6 for the full guard.
+6. **Never tag before merge, and never tag the release-branch HEAD.** The auto-tag workflow handles tagging after merge, always using `github.sha` (the squash commit). The manual fallback similarly tags `upstream/main`. See step 7 for the full guard.
 7. **`<!-- multi-close: approved -->`** in the release PR body is required — release PRs legitimately close many tickets at once.
+8. **`--dry-run` stops before writing any files.** The draft CHANGELOG section and PR body are shown; nothing is committed, branched, pushed, or filed.
 
 ## Related
 
-- `AgDR-0007` — the decision record this skill enacts
+- `AgDR-0007` — the release-cut branch model this skill enacts
+- `AgDR-0076` — the automation design record (this enhancement)
+- `bin/release-changelog.sh` — the changelog generation helper script, independently tested
 - `docs/release-process.md` — the prose runbook (this skill is the automation; the doc is the manual fallback)
+- `.github/workflows/auto-tag-on-release-pr-merge.yml` — the CI workflow that tags the squash commit after merge
+- `golden-paths/pipelines/auto-tag-on-release-pr-merge.yml` — the reusable template for managed projects
 - `.claude/skills/update/SKILL.md` — the inverse skill, used by adopters pulling new releases into their fork
 - `.claude/skills/release-sync/SKILL.md` — the mandatory follow-up skill that syncs main back to dev after every release, preventing squash-divergence accumulation
 

--- a/.github/workflows/auto-tag-on-release-pr-merge.yml
+++ b/.github/workflows/auto-tag-on-release-pr-merge.yml
@@ -1,0 +1,197 @@
+name: auto-tag-on-release-pr-merge
+
+# Automatically tags the squash commit on main when a release PR merges,
+# and creates a GitHub Release entry from the PR body's changelog section.
+#
+# This workflow closes the post-merge-tagging gap described in AgDR-0076:
+# the v2.3.0 tag was mis-placed on the release-branch HEAD (not the squash
+# commit on main). By triggering on `pull_request` → `closed` after merge,
+# `github.sha` is already the squash commit on main — the exact commit to tag.
+#
+# The tag push uses `git push origin --tags` (not `git push origin <tag>`)
+# to avoid the apexyard branch-name validator hook misfiring on tag-push
+# commands (per ApexYard memory: avoid-apexyard-branch-hook-on-tag-push).
+#
+# Trigger conditions:
+#   - PR closed (merged) where head branch matches `release/v*`
+#   - Manual dispatch (operator can re-run if something fails post-merge)
+#
+# Permissions:
+#   - contents: write (create tag + GitHub Release)
+#
+# No new secrets required — uses the default GITHUB_TOKEN.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag (e.g. v3.3.0) — must already be merged to main"
+        required: true
+      sha:
+        description: "Commit SHA on main to tag (defaults to HEAD of main if omitted)"
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    name: tag release + create GitHub Release
+    runs-on: ubuntu-latest
+    # Only run on merged release PRs (not just any closed PR, and not on forks)
+    if: |
+      (
+        github.event_name == 'workflow_dispatch'
+      ) || (
+        github.event.pull_request.merged == true &&
+        startsWith(github.event.pull_request.head.ref, 'release/v')
+      )
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          # Checkout main so git commands work against the right branch
+          ref: main
+
+      - name: Determine version and SHA
+        id: meta
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_INPUT_VERSION: ${{ github.event.inputs.version }}
+          GH_INPUT_SHA: ${{ github.event.inputs.sha }}
+          GH_PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          if [ "$GH_EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$GH_INPUT_VERSION"
+            SHA="$GH_INPUT_SHA"
+            if [ -z "$SHA" ]; then
+              SHA=$(git rev-parse HEAD)
+            fi
+          else
+            # Extract version from branch name: release/v3.3.0 → v3.3.0
+            BRANCH="$GH_PR_HEAD_REF"
+            VERSION="${BRANCH#release/}"
+            # github.sha is the merge commit SHA on main for pull_request events
+            SHA="$GH_SHA"
+          fi
+
+          # Validate version format
+          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Version '$VERSION' does not match v<major>.<minor>.<patch>" >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA"         >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+          echo "SHA:     $SHA"
+
+      - name: Check tag does not already exist
+        id: tag-check
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          if git tag -l "$VERSION" | grep -q "$VERSION"; then
+            echo "Tag $VERSION already exists — skipping tag creation."
+            echo "already_tagged=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_tagged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ancestry guard
+        if: steps.tag-check.outputs.already_tagged == 'false'
+        run: |
+          SHA="${{ steps.meta.outputs.sha }}"
+          # Assert the SHA is an ancestor of main (reachable from HEAD which is main)
+          if ! git merge-base --is-ancestor "$SHA" HEAD; then
+            echo "ERROR: $SHA is not an ancestor of main." >&2
+            echo "This indicates the release PR was not squash-merged to main, or" >&2
+            echo "the SHA is mis-specified. Tag creation aborted." >&2
+            exit 1
+          fi
+          echo "Ancestry guard passed: $SHA is reachable from main."
+
+      - name: Create and push annotated tag
+        if: steps.tag-check.outputs.already_tagged == 'false'
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          SHA="${{ steps.meta.outputs.sha }}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" "$SHA" -m "$VERSION"
+          # Use --tags (not the bare tag name) to avoid branch-name validator
+          # hook misfiring on tag-push commands. See AgDR-0076 § auto-tag design.
+          git push origin --tags
+          echo "Pushed tag $VERSION pointing at $SHA"
+
+      - name: Extract CHANGELOG section from PR body
+        id: notes
+        if: github.event_name == 'pull_request'
+        env:
+          GH_PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          PR_BODY="$GH_PR_BODY"
+
+          # Extract the section starting at "## [VERSION]" up to the next "## ["
+          NOTES=$(echo "$PR_BODY" | \
+            awk "/^## \[$VERSION\]/{found=1; next} found && /^## \[/{exit} found{print}" \
+          )
+
+          if [ -z "$NOTES" ]; then
+            # Fallback: use the full PR body trimmed of boilerplate markers
+            NOTES=$(echo "$PR_BODY" | grep -v '<!-- multi-close' | head -80)
+          fi
+
+          # Write to a temp file (avoids quoting issues with multiline output)
+          echo "$NOTES" > /tmp/release-notes.md
+          echo "notes_file=/tmp/release-notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        if: steps.tag-check.outputs.already_tagged == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          NOTES_FILE="${{ steps.notes.outputs.notes_file }}"
+
+          if [ -n "$NOTES_FILE" ] && [ -f "$NOTES_FILE" ]; then
+            gh release create "$VERSION" \
+              --repo "${{ github.repository }}" \
+              --title "$VERSION" \
+              --notes-file "$NOTES_FILE"
+          else
+            # Manual dispatch — no PR body available; create minimal release
+            gh release create "$VERSION" \
+              --repo "${{ github.repository }}" \
+              --title "$VERSION" \
+              --notes "Release $VERSION — see CHANGELOG.md for details."
+          fi
+          echo "GitHub Release $VERSION created."
+
+      - name: Summary
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          SHA="${{ steps.meta.outputs.sha }}"
+          ALREADY="${{ steps.tag-check.outputs.already_tagged }}"
+          if [ "$ALREADY" = "true" ]; then
+            STATUS="Tag already existed — skipped"
+          else
+            STATUS="Tagged + GitHub Release created"
+          fi
+          {
+            echo "## Release tag summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Version | \`$VERSION\` |"
+            echo "| SHA | \`$SHA\` |"
+            echo "| Status | $STATUS |"
+            echo ""
+            echo "Next step: run \`/release-sync $VERSION\` to sync main→dev."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/bin/release-changelog.sh
+++ b/bin/release-changelog.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# bin/release-changelog.sh — Generate a CHANGELOG section from git log between two refs.
+#
+# Used by the /release skill (AgDR-0076) to automate the changelog-generation
+# step. Emits markdown to stdout; never writes files (callers decide where to put it).
+#
+# Environment variables (all required):
+#   PREV_TAG   — the previous release tag (e.g. v3.2.0); used as the start of
+#                git log range. Pass "NONE" if there is no previous tag.
+#   HEAD_REF   — the end of the git log range (e.g. upstream/dev or a branch name)
+#   VERSION    — the new version string (e.g. v3.3.0)
+#   DATE       — the release date in YYYY-MM-DD format
+#
+# Optional:
+#   REPO_REMOTE — the git remote to use for upstream refs (default: upstream)
+#
+# Output format (matches the existing CHANGELOG.md convention):
+#
+#   ## [VERSION] — DATE
+#
+#   <release description line> (omitted if empty)
+#
+#   ### Added (feat)
+#   - (#NN) <subject> — <short-sha>
+#   ...
+#   ### Fixed (fix)
+#   - (#NN) <subject> — <short-sha>
+#   ...
+#   ### Changed (refactor / chore / docs / style / perf / build / ci / test)
+#   - (#NN) <subject> — <short-sha>
+#   ...
+#   ### Breaking
+#   - <subject> — <short-sha>
+#   ...
+#   ### Closes
+#   - Closes #N, #M, ...
+#
+# Exit codes:
+#   0 — success (even if the commit list is empty; that is a valid patch release)
+#   1 — missing required env var or git command failure
+
+set -euo pipefail
+
+# ── Validate required env vars ──────────────────────────────────────────────
+
+for var in PREV_TAG HEAD_REF VERSION DATE; do
+  if [ -z "${!var:-}" ]; then
+    echo "ERROR: $var is required but not set." >&2
+    echo "Usage: PREV_TAG=v3.2.0 HEAD_REF=upstream/dev VERSION=v3.3.0 DATE=2026-06-21 bash bin/release-changelog.sh" >&2
+    exit 1
+  fi
+done
+
+REPO_REMOTE="${REPO_REMOTE:-upstream}"
+
+# ── Build the git log range ──────────────────────────────────────────────────
+
+if [ "$PREV_TAG" = "NONE" ]; then
+  LOG_RANGE="${HEAD_REF}"
+else
+  LOG_RANGE="${PREV_TAG}..${HEAD_REF}"
+fi
+
+# ── Extract commits ──────────────────────────────────────────────────────────
+# Format: <short-sha> <subject>
+# We use %h (abbreviated sha) and %s (subject) so merge commits are included.
+
+COMMITS=$(git log "$LOG_RANGE" --pretty=format:'%h %s' 2>/dev/null || true)
+
+# ── Classify commits ─────────────────────────────────────────────────────────
+
+added_lines=()
+fixed_lines=()
+changed_lines=()
+breaking_lines=()
+closes_nums=()
+
+# Extract PR number from subject: "Merge pull request #NN from ..." or "(#NN)" in subject
+extract_pr_num() {
+  local subject="$1"
+  # Merge commit format: "Merge pull request #NNN from ..."
+  if echo "$subject" | grep -qE 'Merge pull request #[0-9]+'; then
+    echo "$subject" | grep -oE '#[0-9]+' | head -1
+    return
+  fi
+  # Conventional commit with PR ref: "feat(#NNN): ..." or "feat: something (#NNN)"
+  if echo "$subject" | grep -qE '\(#[0-9]+\)'; then
+    echo "$subject" | grep -oE '#[0-9]+' | head -1
+    return
+  fi
+  echo ""
+}
+
+# Strip conventional-commit prefix from a subject for cleaner display
+strip_cc_prefix() {
+  local subject="$1"
+  # Remove "type(scope): " or "type: " prefix
+  echo "$subject" | sed -E 's/^[a-z]+(\([^)]*\))?!?: //'
+}
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+
+  short_sha="${line%% *}"
+  subject="${line#* }"
+
+  # Skip merge commits for "Merge branch" (sync commits) — only keep "Merge pull request"
+  if echo "$subject" | grep -qE '^Merge branch '; then
+    continue
+  fi
+
+  # Skip release commits themselves
+  if echo "$subject" | grep -qE '^release(\([^)]*\))?!?:'; then
+    continue
+  fi
+
+  # Skip sync commits
+  if echo "$subject" | grep -qE '^sync(\([^)]*\))?!?:'; then
+    continue
+  fi
+
+  pr_num=$(extract_pr_num "$subject")
+  display_subject=$(strip_cc_prefix "$subject")
+
+  # Remove trailing PR reference like "(#NNN)" from end of display subject
+  display_subject=$(echo "$display_subject" | sed -E 's/ \(#[0-9]+\)$//')
+
+  # Build the display line
+  if [ -n "$pr_num" ]; then
+    entry="- ($pr_num) $display_subject — $short_sha"
+    # Collect PR number for Closes section
+    num_only="${pr_num#\#}"
+    closes_nums+=("$num_only")
+  else
+    entry="- $display_subject — $short_sha"
+  fi
+
+  # Classify by conventional-commit type
+  if echo "$subject" | grep -qE '^[a-z]+(\([^)]*\))?!:'; then
+    # Breaking change (any type with !)
+    breaking_lines+=("$entry")
+  elif echo "$subject" | grep -qE '^feat(\([^)]*\))?:'; then
+    added_lines+=("$entry")
+  elif echo "$subject" | grep -qE '^fix(\([^)]*\))?:'; then
+    fixed_lines+=("$entry")
+  elif echo "$subject" | grep -qE '^(refactor|chore|docs|style|perf|build|ci|test)(\([^)]*\))?:'; then
+    changed_lines+=("$entry")
+  elif echo "$subject" | grep -qE '^Merge pull request'; then
+    # Merge commits for PRs are captured above via pr_num extraction;
+    # the commit itself shows up under the type of the PR's own commit.
+    # Skip duplicate merge-commit entries.
+    continue
+  else
+    # Unknown type — put in Changed
+    changed_lines+=("$entry")
+  fi
+
+done <<< "$COMMITS"
+
+# ── Infer release description ─────────────────────────────────────────────────
+
+if [ "${#breaking_lines[@]}" -gt 0 ]; then
+  bump_type="Major release"
+elif [ "${#added_lines[@]}" -gt 0 ]; then
+  bump_type="Minor release"
+else
+  bump_type="Patch release"
+fi
+
+feat_count="${#added_lines[@]}"
+fix_count="${#fixed_lines[@]}"
+desc_parts=()
+[ "$feat_count" -gt 0 ] && desc_parts+=("${feat_count} feature$([ "$feat_count" -gt 1 ] && echo 's' || echo '')")
+[ "$fix_count" -gt 0 ] && desc_parts+=("${fix_count} fix$([ "$fix_count" -gt 1 ] && echo 'es' || echo '')")
+[ "${#changed_lines[@]}" -gt 0 ] && desc_parts+=("${#changed_lines[@]} improvement$([ "${#changed_lines[@]}" -gt 1 ] && echo 's' || echo '')")
+
+if [ "${#desc_parts[@]}" -gt 0 ]; then
+  IFS=', '; release_desc="$bump_type — ${desc_parts[*]}."
+  IFS=$' \t\n'
+else
+  release_desc="$bump_type."
+fi
+
+# ── Emit the CHANGELOG section ───────────────────────────────────────────────
+
+echo "## [$VERSION] — $DATE"
+echo ""
+echo "$release_desc"
+
+if [ "${#added_lines[@]}" -gt 0 ]; then
+  echo ""
+  echo "### Added (feat)"
+  for l in "${added_lines[@]}"; do echo "$l"; done
+fi
+
+if [ "${#fixed_lines[@]}" -gt 0 ]; then
+  echo ""
+  echo "### Fixed (fix)"
+  for l in "${fixed_lines[@]}"; do echo "$l"; done
+fi
+
+if [ "${#changed_lines[@]}" -gt 0 ]; then
+  echo ""
+  echo "### Changed (refactor / chore / docs)"
+  for l in "${changed_lines[@]}"; do echo "$l"; done
+fi
+
+if [ "${#breaking_lines[@]}" -gt 0 ]; then
+  echo ""
+  echo "### Breaking"
+  for l in "${breaking_lines[@]}"; do echo "$l"; done
+fi
+
+if [ "${#closes_nums[@]}" -gt 0 ]; then
+  echo ""
+  echo "### Closes"
+  # Deduplicate and sort
+  unique_nums=$(printf '%s\n' "${closes_nums[@]}" | sort -un | tr '\n' ' ' | sed 's/ $//')
+  closes_str=""
+  for n in $unique_nums; do closes_str="${closes_str}#${n}, "; done
+  closes_str="${closes_str%, }"  # trim trailing comma+space
+  echo "- Closes $closes_str"
+fi

--- a/docs/agdr/AgDR-0076-release-automation.md
+++ b/docs/agdr/AgDR-0076-release-automation.md
@@ -1,0 +1,124 @@
+---
+id: AgDR-0076
+timestamp: 2026-06-21T00:00:00Z
+agent: claude
+model: claude-sonnet-4-6
+trigger: user-prompt
+status: executed
+---
+
+# Release automation — one-command bump + changelog + release PR + auto-tag
+
+> In the context of the apexyard release-cut model (dev→main + semver tag), facing the gap between the well-documented `/release` skill and the mechanical steps still done by hand (changelog draft, CHANGELOG.md update, release-branch push, PR open, and post-merge tagging), I decided to automate the full preparation cycle — version bump, CHANGELOG generation from merged-PR history, PR creation — plus add a GH Actions workflow that tags the merge commit automatically when the release PR squash-merges to main, to achieve a single `/release` invocation that drives the operator from "nothing" to "PR open, ready for Rex + CEO", accepting that the PR body previews in Claude's output and the operator gets one confirmation moment before any file is written (via `--dry-run`).
+
+## Context
+
+The `/release` skill exists (`.claude/skills/release/SKILL.md`) and documents the process well, but as of v3.2.0 several mechanical steps remained manual:
+
+1. **Changelog text** — operator had to draft `CHANGELOG.md` additions by hand, consulting `git log` themselves.
+2. **CHANGELOG.md file update** — operator manually prepended the new section.
+3. **Release branch creation + push** — operator ran `git checkout -b release/vX.Y.Z` + `git push`.
+4. **Release PR open** — operator ran a `gh pr create` / `gh api` command with the drafted body.
+5. **Post-merge tagging** — after squash-merge, operator had to fetch, tag `upstream/main`, run the ancestry guard, and push the tag. Easy to forget or mis-place (the v2.3.0 tag was placed on the release-branch HEAD rather than the squash commit).
+
+The skill's SKILL.md described what to do but left the operator to execute every step. The result was that releases were slower than necessary and the post-merge tag step was documented with a warning about a known past mistake.
+
+Additionally: apexyard-premium will cut its own releases on a version *matrix* (one version per component), where the changelog-from-commits approach is the same but the version source differs (a `versions.yaml` rather than the single apexyard `CHANGELOG.md` + the version tag). This AgDR captures the shared design so the premium adaptation inherits the right primitives.
+
+**Note on site/ removal:** the marketing site (`site/`) was removed from the framework repo in #663 (moved to `me2resh/apexyard-site`). This implementation does NOT bump any site version strings — the site is now independently deployed. The atlas fork's earlier draft of this work included a Step 3.5 for `site/index.html` bumping; that step is intentionally omitted here since the file no longer exists in this repo.
+
+**Note on auto-tag creating the GitHub Release directly (apexyard-premium#326 lesson):** tags pushed via `GITHUB_TOKEN` do not trigger a separate `on: push: tags:` release workflow in the same repository — GitHub suppresses the secondary event to prevent workflow loops. The `auto-tag-on-release-pr-merge.yml` workflow therefore creates the GitHub Release entry itself (in the same job, after tagging), rather than relying on a separate tag-triggered workflow. This pattern was confirmed working in apexyard-premium#326.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Status quo — SKILL.md is guidance, operator executes** | No new code | Error-prone; releases slow; post-merge tag still mis-placeable; repeated manual effort |
+| **B. Fully autonomous release — skill runs every step including merge + tag** | Maximum automation | Defeats the CEO approval gate; auto-merges are explicitly banned by framework rules |
+| **C. Automate prep + PR creation; auto-tag + create Release via GH Actions after merge (CHOSEN)** | One command from "nothing" to "PR open"; keeps CEO approval as the sole human gate; auto-tag fires AFTER merge so it always lands on the squash commit (never the branch HEAD); workflow creates the GitHub Release in the same job (not via a secondary tag-triggered workflow, per apexyard-premium#326 lesson); reusable GH Actions workflow in `golden-paths/pipelines/` for adopters who want the same pattern on managed projects | Adds a GH Actions workflow; requires `contents: write` permission (already granted by default `GITHUB_TOKEN` on all GH repos) |
+| **D. Automate prep; leave tagging entirely manual** | No GH Actions dependency | Keeps the mis-place risk; the v2.3.0 incident can repeat |
+
+## Decision
+
+Chosen: **Option C** — automate the mechanical prep (changelog generation + CHANGELOG.md update + release-branch push + PR creation) in the `/release` skill, and add a GH Actions workflow that auto-tags the squash commit and creates a GitHub Release when the release PR merges to `main`. Keep the CEO approval gate as the only required human step.
+
+### Version bump
+
+The `/release` skill already specifies the conventional-commit bump algorithm. A new helper script (`bin/release-changelog.sh`) encapsulates:
+
+- `git log <prev-tag>..upstream/dev --pretty=format:'%h %s'` to extract commits
+- Grouping by conventional-commit type (feat / fix / refactor+docs+chore / breaking)
+- PR-number extraction from merge-commit subjects (format: `Merge pull request #N`) or from commit subjects that include `(#N)`
+- Emitting the CHANGELOG section in the format the skill already documents
+
+The helper is a separate shell script (not inline skill prose) so it is:
+
+1. **Testable** — unit tests under `.claude/hooks/tests/`
+2. **Reusable** — the premium adaptation can call the same script with different version sources
+
+### `--dry-run` mode
+
+`/release --dry-run` (or `--dry-run vX.Y.Z`): runs all steps up to and including the CHANGELOG draft and shows what would be written, but does not:
+
+- Write `CHANGELOG.md`
+- Create the release branch
+- Push the branch
+- Open the PR
+
+Output ends with: `Dry run — no changes made. Remove --dry-run to execute.`
+
+### Auto-tag on release PR merge
+
+A new GH Actions workflow (`.github/workflows/auto-tag-on-release-pr-merge.yml` for the framework fork, plus `golden-paths/pipelines/auto-tag-on-release-pr-merge.yml` as a reusable template) triggers on `pull_request` → `closed` + `merged` where the PR's `head.ref` matches `release/v*`. It:
+
+1. Extracts the version from the branch name (`release/v1.2.3` → `v1.2.3`).
+2. Uses `github.sha` (the merge commit SHA already available in the event context on `main`).
+3. Runs the ancestry guard: `git merge-base --is-ancestor <sha> main`.
+4. Creates an annotated tag and pushes it with `git push origin --tags` — NOT `git push origin <tag>`, to avoid the branch-name validator hook misfiring on tag-push commands (per apexyard memory note on `avoid-apexyard-branch-hook-on-tag-push`).
+5. Creates a GitHub Release entry using the CHANGELOG section extracted from the PR body — in the **same job**, because a tag pushed via GITHUB_TOKEN does not trigger a secondary release workflow (apexyard-premium#326).
+
+The workflow requires no new secrets — only the default `GITHUB_TOKEN` with `contents: write` permission.
+
+### Version-source difference: framework vs premium
+
+| Repo | Version source | Changelog source |
+|------|---------------|-----------------|
+| `me2resh/apexyard` (this AgDR) | Git tag; `CHANGELOG.md` heading reflects current version | `git log <prev-tag>..dev` merged-PR history |
+| `me2resh/apexyard-premium` (future) | `versions.yaml` — a matrix of component versions | Per-component `git log` filtered by path; each component gets its own CHANGELOG section |
+
+The `bin/release-changelog.sh` helper is designed around the apexyard single-version case. The premium adaptation will use a separate helper that calls the same `git log` + grouping primitives but loops over components. The GH Actions workflow shape is identical; only the version-extraction line changes (reads `versions.yaml` instead of the branch name).
+
+## Consequences
+
+**Added:**
+
+- `bin/release-changelog.sh` — helper script that generates a CHANGELOG entry from `git log` between two refs; accepts `PREV_TAG`, `HEAD_REF`, `VERSION`, `DATE` env vars; emits markdown to stdout; non-destructive (never writes files).
+- `.claude/hooks/tests/test_release_changelog.sh` — unit tests for the helper covering: empty log (patch with 0 commits), feat-only (minor), breaking (major), mixed groups, PR-number extraction.
+- `.github/workflows/auto-tag-on-release-pr-merge.yml` — the fork's own auto-tag + GitHub Release workflow for apexyard releases.
+- `golden-paths/pipelines/auto-tag-on-release-pr-merge.yml` — reusable template adopters can copy into managed projects that also use the release-cut model.
+- Enhanced `.claude/skills/release/SKILL.md` — step-by-step skill prose updated to reflect fully-automated prep; `--dry-run` flag documented; step 6 rewritten to reference the auto-tag workflow rather than manual commands; step 9 updated to reference `/release-sync`.
+- Updated `docs/release-process.md` — references the new helper script and auto-tag workflow; manual commands preserved as fallback.
+
+**Unchanged:**
+
+- CEO approval gate — the release PR still requires Rex + `/approve-merge`. Automation ends at "PR open."
+- `/release-sync` — unchanged; step 9 of `/release` continues to reference it after the tag is pushed.
+- Branch protection rules on `main` — the auto-tag workflow uses the default `GITHUB_TOKEN`; no new PAT or elevated permissions required.
+- Managed project semantics — this skill and all its artifacts are explicitly framework-only.
+
+**Non-consequences (explicitly):**
+
+- No `site/index.html` bumping — the marketing site was removed from this repo in #663.
+- No hotfix or multi-branch automation.
+- No auto-merge of the release PR.
+- No version-matrix support in this iteration — that is the premium adaptation.
+
+## Artifacts
+
+- Implementing ticket: `me2resh/apexyard#674`
+- Helper script: `bin/release-changelog.sh`
+- Tests: `.claude/hooks/tests/test_release_changelog.sh`
+- Auto-tag workflow (fork): `.github/workflows/auto-tag-on-release-pr-merge.yml`
+- Auto-tag workflow (golden path): `golden-paths/pipelines/auto-tag-on-release-pr-merge.yml`
+- Updated skill: `.claude/skills/release/SKILL.md`
+- Updated docs: `docs/release-process.md`

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -4,7 +4,7 @@ apexyard uses a **release-cut** branch model (sometimes called gitflow-lite) for
 
 **Important — framework only.** This release model is for `me2resh/apexyard` itself, not for managed projects under apexyard governance. Managed projects stay trunk-based (PRs merge to `main`); only the framework has dev/main + tags. See `docs/multi-project.md` for the rationale.
 
-Decision record: [`docs/agdr/AgDR-0007-release-cut-branch-model.md`](agdr/AgDR-0007-release-cut-branch-model.md).
+Decision records: [`docs/agdr/AgDR-0007-release-cut-branch-model.md`](agdr/AgDR-0007-release-cut-branch-model.md) · [`docs/agdr/AgDR-0076-release-automation.md`](agdr/AgDR-0076-release-automation.md).
 
 ## Branch model
 
@@ -18,7 +18,7 @@ main ─────●────────────────●──
 
 - **`dev`** — every feature/fix/chore PR targets here. All hooks + review gates apply unchanged.
 - **`main`** — only receives merges from `dev`, via release PRs. Every merge to `main` is tagged with a semver. Direct pushes blocked by `block-main-push.sh`.
-- Releases are `dev → main` merge commits, tagged `vX.Y.Z`.
+- Releases are `dev → main` squash-merges, tagged `vX.Y.Z` automatically by CI after merge.
 - No `release/*` branches (no stabilisation window needed for docs+hooks).
 - No `hotfix/*` branches (no multi-version support; forks always run latest).
 
@@ -32,9 +32,38 @@ Curated cadence — release when there's a meaningful batch on `dev` that's wort
 
 If `dev` is N commits ahead and nothing's broken, you're free to NOT release — adopters will stay on the previous tag and the drift banner will tell them about the new tag when it's cut.
 
-## Cutting a release — happy path
+## Cutting a release — happy path (automated)
 
-Use `/release` for the full guided flow. Manual steps for reference:
+Run `/release` for the full guided, automated flow:
+
+```
+/release             # auto-detect bump from conventional commits
+/release v1.2.0      # explicit version
+/release --dry-run   # preview changelog + PR body without writing any files
+```
+
+The skill:
+
+1. Pre-flights the repo (clean tree, dev branch, non-empty delta)
+2. Auto-detects the semver bump from conventional commits (or accepts explicit version)
+3. Calls `bin/release-changelog.sh` to generate the CHANGELOG section (independently testable helper)
+4. Shows the draft for review / editing
+5. Writes `CHANGELOG.md` (prepends the new section)
+6. Creates the release branch `release/vX.Y.Z` from dev, commits, and pushes
+7. Opens the release PR (dev→main) with the CHANGELOG section as body
+8. Stops at PR creation — CEO approval gate remains the sole human gate
+
+After the PR merges, the `auto-tag-on-release-pr-merge.yml` CI workflow fires and:
+
+- Tags the squash commit on `main` (using `github.sha` — always the correct commit, never the branch HEAD)
+- Runs the ancestry guard (`git merge-base --is-ancestor <sha> main`)
+- Creates a GitHub Release entry from the CHANGELOG section in the PR body (in the same job — a tag pushed via GITHUB_TOKEN does not trigger a secondary release workflow)
+
+Then run `/release-sync vX.Y.Z` to sync main→dev and prevent squash-divergence accumulation.
+
+## Cutting a release — manual steps (fallback)
+
+If `/release` is unavailable or if you need to debug a release, run the steps manually:
 
 ```bash
 # 1. Verify pre-conditions
@@ -42,34 +71,52 @@ git fetch upstream
 git rev-parse upstream/main upstream/dev    # both should resolve
 git log upstream/main..upstream/dev --oneline | head    # should be non-empty
 
-# 2. Pick the version (e.g. v1.2.0 — minor bump because of feat: commits)
+# 2. Pick the version
+PREV_TAG=$(git describe --tags --abbrev=0 upstream/main)
+# e.g. PREV_TAG=v3.2.0, so next is v3.3.0 (minor bump because of feat: commits)
+VERSION=v3.3.0
 
-# 3. Cut release branch from dev
-git checkout -b release/v1.2.0 upstream/dev
-git push upstream release/v1.2.0
+# 3. Generate the CHANGELOG section
+PREV_TAG="$PREV_TAG" HEAD_REF="upstream/dev" VERSION="$VERSION" DATE="$(date +%F)" \
+  bash bin/release-changelog.sh > /tmp/changelog-section.md
+# Review and edit /tmp/changelog-section.md
 
-# 4. Open release PR
-gh api repos/me2resh/apexyard/pulls -X POST \
-  -f title="release: v1.2.0" \
-  -f body-file=/tmp/changelog-v1.2.0.md \
-  -f head="release/v1.2.0" \
-  -f base="main"
+# 4. Prepend to CHANGELOG.md
+cat /tmp/changelog-section.md CHANGELOG.md > /tmp/cl_new.md
+mv /tmp/cl_new.md CHANGELOG.md
 
-# 5. Run normal review flow on the PR
-#    - Code Reviewer (Rex)
+# 5. Cut release branch from dev
+git checkout -b "release/$VERSION" upstream/dev
+git add CHANGELOG.md
+git commit -m "chore: release $VERSION"
+git push upstream "release/$VERSION"
+
+# 6. Open release PR
+gh pr create \
+  --repo me2resh/apexyard \
+  --base main \
+  --head "release/$VERSION" \
+  --title "release(#<ticket>): $VERSION" \
+  --body-file /tmp/release-pr-body.md
+# Add <!-- multi-close: approved --> to the body
+
+# 7. Run normal review flow on the PR
+#    - /code-review
 #    - /approve-merge <pr>
 #    - gh pr merge <pr> --squash
 
-# 6. After merge: tag main + push the tag
+# 8. After merge: CI auto-tags (auto-tag-on-release-pr-merge.yml)
+#    If CI fails, tag manually:
 git fetch upstream main
-git tag v1.2.0 upstream/main
-git push upstream v1.2.0
+git tag "$VERSION" upstream/main
+if ! git merge-base --is-ancestor "$VERSION" upstream/main; then
+  echo "ERROR: tag is mis-placed" >&2; exit 1
+fi
+# Use --tags not the bare tag name (avoids branch-name validator hook misfiring)
+git push upstream --tags
 
-# 7. Optional: GitHub Release entry
-gh release create v1.2.0 \
-  --repo me2resh/apexyard \
-  --title "v1.2.0" \
-  --notes-file /tmp/changelog-v1.2.0.md
+# 9. Run release-sync
+# /release-sync $VERSION
 ```
 
 ## Release PR caveats
@@ -81,6 +128,34 @@ The release PR's body legitimately contains many `Closes #N` references — ever
 ```
 
 The marker is grep-able on purpose; release PRs are exactly the umbrella case it's designed for.
+
+## Auto-tag workflow
+
+The `.github/workflows/auto-tag-on-release-pr-merge.yml` workflow fires when any PR with a `release/v*` head branch is merged to `main`. It:
+
+- Extracts the version from the head branch name
+- Uses `github.sha` (the squash commit SHA) — always the correct commit, never the release-branch HEAD (which was discarded by the squash)
+- Runs `git merge-base --is-ancestor <sha> main` before tagging
+- Tags and pushes with `git push origin --tags` (not the bare tag name — avoids the branch-name validator hook misfiring)
+- Creates a GitHub Release entry in the same job (a tag pushed via GITHUB_TOKEN does not trigger a secondary release workflow — confirmed in apexyard-premium#326)
+
+This closes the v2.3.0 incident where the tag was placed on the release-branch HEAD rather than the squash commit.
+
+A golden-path copy lives at `golden-paths/pipelines/auto-tag-on-release-pr-merge.yml` for adopters who want the same pattern on managed projects.
+
+## Changelog generation
+
+The `bin/release-changelog.sh` helper encapsulates the changelog-from-commits logic:
+
+```bash
+PREV_TAG=v3.2.0 HEAD_REF=upstream/dev VERSION=v3.3.0 DATE=$(date +%F) \
+  bash bin/release-changelog.sh
+```
+
+Input: `PREV_TAG`, `HEAD_REF`, `VERSION`, `DATE` env vars.
+Output: markdown CHANGELOG section to stdout.
+Never writes files; callers decide where to write the output.
+Tests: `.claude/hooks/tests/test_release_changelog.sh`.
 
 ## Drift banner behaviour
 
@@ -114,7 +189,12 @@ Branch protection on `dev` matches the prior `main` setup — required reviews +
 
 ## Related
 
-- `AgDR-0007` — the decision record
-- `.claude/skills/release/SKILL.md` — the automated flow
+- `AgDR-0007` — the original release-cut branch model decision record
+- `AgDR-0076` — the release-automation design record
+- `.claude/skills/release/SKILL.md` — the automated flow (this doc is the manual fallback)
+- `bin/release-changelog.sh` — the changelog generation helper
+- `.github/workflows/auto-tag-on-release-pr-merge.yml` — the auto-tag CI workflow
+- `golden-paths/pipelines/auto-tag-on-release-pr-merge.yml` — the reusable golden-path copy
 - `.claude/skills/update/SKILL.md` — the inverse skill, for adopters pulling new releases
+- `.claude/skills/release-sync/SKILL.md` — the mandatory main→dev sync after every release
 - `docs/multi-project.md § "Upgrades — pulling from upstream"` — adopter side of the relationship

--- a/golden-paths/pipelines/README.md
+++ b/golden-paths/pipelines/README.md
@@ -13,6 +13,7 @@ Reusable GitHub Actions workflows that integrate ApexYard's automated agents int
 | `swift-ci.yml` | Rex | Swift Package Manager build + guarded test (macOS runner) | Every PR, push to default branch |
 | `review-check.yml` | Rex (verification) | Block merge if Rex hasn't reviewed the latest commit | Every PR + review event |
 | `seo-check.yml` | SEO Check | SEO analysis for content files | Content changes |
+| `auto-tag-on-release-pr-merge.yml` | CI | Auto-tag squash commit + create GitHub Release when a `release/v*` PR merges | PR closed (merged) |
 | `ci.yml` | Combined | All checks in one pipeline | Every PR |
 
 ---

--- a/golden-paths/pipelines/auto-tag-on-release-pr-merge.yml
+++ b/golden-paths/pipelines/auto-tag-on-release-pr-merge.yml
@@ -1,0 +1,165 @@
+name: auto-tag-on-release-pr-merge
+
+# Golden-path template — copy this into your project's .github/workflows/ to
+# automatically tag the squash commit on main when a release PR merges.
+#
+# This closes the manual-tagging gap: after a squash-merge, the correct commit
+# to tag is the squash commit on main (`github.sha` in a pull_request/closed
+# event), NOT the release branch's HEAD (which is discarded by the squash).
+#
+# Design rationale: AgDR-0076 (docs/agdr/AgDR-0076-release-automation.md)
+# Framework-only usage note: for the apexyard framework repo itself, the
+# workflow at .github/workflows/auto-tag-on-release-pr-merge.yml is used.
+# This golden-path copy is for managed projects or adopters that have adopted
+# the release-cut (dev→main + tags) branch model for their own repos.
+#
+# Trigger conditions:
+#   - PR closed (merged) where head branch matches `release/v*`
+#   - Manual dispatch (to re-run or tag a version that was manually merged)
+#
+# Permissions:
+#   - contents: write (create tag + GitHub Release)
+#
+# No new secrets required — uses the default GITHUB_TOKEN.
+#
+# Customisation:
+#   - Change `branches: [main]` to match your default branch name
+#   - Change `release/v*` to match your release branch naming convention
+#   - Remove the `Create GitHub Release` step if you don't want a GH Release entry
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag (e.g. v3.3.0) — must already be merged to main"
+        required: true
+      sha:
+        description: "Commit SHA on main to tag (defaults to HEAD of main if omitted)"
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    name: tag release + create GitHub Release
+    runs-on: ubuntu-latest
+    if: |
+      (
+        github.event_name == 'workflow_dispatch'
+      ) || (
+        github.event.pull_request.merged == true &&
+        startsWith(github.event.pull_request.head.ref, 'release/v')
+      )
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Determine version and SHA
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+            SHA="${{ github.event.inputs.sha }}"
+            if [ -z "$SHA" ]; then
+              SHA=$(git rev-parse HEAD)
+            fi
+          else
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+            VERSION="${BRANCH#release/}"
+            SHA="${{ github.sha }}"
+          fi
+
+          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Version '$VERSION' does not match v<major>.<minor>.<patch>" >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA"         >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+          echo "SHA:     $SHA"
+
+      - name: Check tag does not already exist
+        id: tag-check
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          if git tag -l "$VERSION" | grep -q "$VERSION"; then
+            echo "Tag $VERSION already exists — skipping tag creation."
+            echo "already_tagged=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_tagged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ancestry guard
+        if: steps.tag-check.outputs.already_tagged == 'false'
+        run: |
+          SHA="${{ steps.meta.outputs.sha }}"
+          if ! git merge-base --is-ancestor "$SHA" HEAD; then
+            echo "ERROR: $SHA is not an ancestor of main." >&2
+            echo "The release PR may not have been squash-merged, or the SHA is wrong." >&2
+            exit 1
+          fi
+          echo "Ancestry guard passed: $SHA is reachable from main."
+
+      - name: Create and push annotated tag
+        if: steps.tag-check.outputs.already_tagged == 'false'
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          SHA="${{ steps.meta.outputs.sha }}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" "$SHA" -m "$VERSION"
+          # Use --tags not the bare tag name to avoid branch-validator hooks
+          git push origin --tags
+          echo "Pushed tag $VERSION → $SHA"
+
+      - name: Extract release notes from PR body
+        id: notes
+        if: github.event_name == 'pull_request'
+        env:
+          GH_PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          PR_BODY="$GH_PR_BODY"
+          # Extract the CHANGELOG section for this version (## [VERSION] ... next ## [)
+          NOTES=$(echo "$PR_BODY" | \
+            awk "/^## \[$VERSION\]/{found=1; next} found && /^## \[/{exit} found{print}")
+          if [ -z "$NOTES" ]; then
+            NOTES=$(echo "$PR_BODY" | grep -v '<!--' | head -60)
+          fi
+          echo "$NOTES" > /tmp/release-notes.md
+          echo "notes_file=/tmp/release-notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        if: steps.tag-check.outputs.already_tagged == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          NOTES_FILE="${{ steps.notes.outputs.notes_file }}"
+          if [ -n "$NOTES_FILE" ] && [ -f "$NOTES_FILE" ]; then
+            gh release create "$VERSION" \
+              --repo "${{ github.repository }}" \
+              --title "$VERSION" \
+              --notes-file "$NOTES_FILE"
+          else
+            gh release create "$VERSION" \
+              --repo "${{ github.repository }}" \
+              --title "$VERSION" \
+              --notes "Release $VERSION"
+          fi
+
+      - name: Summary
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          SHA="${{ steps.meta.outputs.sha }}"
+          echo "## Auto-tag summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tag \`$VERSION\` → \`$SHA\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
<!-- multi-close: approved -->

## Summary

- **Automates the `/release` skill** — one command from "nothing" to "PR open, ready for Rex + CEO"; adds `--dry-run` flag for previewing without writing; adds `bin/release-changelog.sh` helper (independently tested, 36 tests green) that generates the CHANGELOG section from `git log` between two refs
- **Auto-tag + GitHub Release on PR merge** — new `.github/workflows/auto-tag-on-release-pr-merge.yml` fires when a `release/v*` PR merges to main; tags the squash commit (via `github.sha`, never the branch HEAD) and creates a GitHub Release in the **same job** (not a secondary tag-triggered workflow — GITHUB_TOKEN-pushed tags don't fire a second workflow, per apexyard-premium#326 lesson)
- **Adaptation: `site/` removed** — the atlas fork's earlier draft included a Step 3.5 that bumped `site/index.html` version strings; that step is intentionally dropped here since `site/` was extracted from this repo in #663 (now lives in `me2resh/apexyard-site`)
- **AgDR-0076** records the full design rationale (options A–D, auto-tag in same job, site/ non-consequence)

Re-landed on me2resh (canonical) from retired atlas fork PR #3 (branch `feature/GH-674-automate-release`).

## Testing

1. `bash bin/run-hook-tests.sh` — 70/70 pass (includes the new 36-test `test_release_changelog.sh`)
2. `bash bin/run-pre-push-checks.sh` — all checks pass (markdownlint, shellcheck, subpacks)
3. `shellcheck -S warning bin/release-changelog.sh .claude/hooks/tests/test_release_changelog.sh` — clean
4. `npx markdownlint-cli2 SKILL.md docs/release-process.md AgDR-0076 README.md` — 0 errors

To test the automation end-to-end: run `/release --dry-run` on a dev branch that's ahead of main and verify the CHANGELOG draft + PR body preview appear correctly without any files being written.

Closes #674

---

## Glossary

| Term | Definition |
|------|------------|
| Squash merge | GitHub merges all commits on a PR branch into a single commit on main; the branch HEAD is discarded and the resulting main tip has a new SHA |
| Auto-tag | The `auto-tag-on-release-pr-merge.yml` workflow fires on `pull_request → closed + merged` for `release/v*` branches, tags `github.sha` (the squash commit), and creates a GitHub Release |
| Ancestry guard | `git merge-base --is-ancestor <sha> main` — aborts if the tag would not be reachable from main, preventing a mis-placed tag (the v2.3.0 incident) |
| `--dry-run` | `/release --dry-run` mode: shows the CHANGELOG draft and PR body without writing any files, branching, pushing, or filing anything |
| GITHUB_TOKEN tag push | A tag pushed via the default `GITHUB_TOKEN` does not trigger a secondary `on: push: tags:` workflow — GitHub suppresses the event to prevent loops; the GitHub Release must be created in the same job (confirmed in apexyard-premium#326) |
| `bin/release-changelog.sh` | Shell helper that accepts `PREV_TAG`, `HEAD_REF`, `VERSION`, `DATE` env vars and emits a markdown CHANGELOG section to stdout; never writes files |