### PR TITLE
feat(#672): add /walking-skeleton + /prototype skills

### DIFF
--- a/.claude/hooks/require-agdr-for-arch-changes.sh
+++ b/.claude/hooks/require-agdr-for-arch-changes.sh
@@ -98,14 +98,15 @@ if [ -z "$TOUCHED_ARCH" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Spike exemption (apexyard#180).
+# Spike + prototype exemption (apexyard#180, #673).
 #
-# Spike work is hypothesis-driven, time-boxed, throw-away exploration; AgDRs
-# capture decisions that should persist, while spikes write disposition memos
-# instead. Exempt the commit-time AgDR check if ANY of:
+# Spike work (technical) and prototype work (throw-away UX/demo) are both
+# time-boxed exploration; AgDRs capture decisions that should persist, while
+# these write disposition memos instead. Exempt the commit-time AgDR check if
+# ANY of:
 #
-#   (a) the active ticket marker references a `[Spike]`-prefixed ticket
-#   (b) the current branch is named `spike/<TICKET-ID>-...`
+#   (a) the active ticket marker references a `[Spike]` or `[Prototype]` ticket
+#   (b) the current branch is named `spike/<TICKET-ID>-...` or `prototype/...`
 #
 # See .claude/rules/workflow-gates.md § Spike work.
 # ---------------------------------------------------------------------------
@@ -137,14 +138,14 @@ spike_commit_exempt() {
   fi
 
   if [ -f "$marker_home/.claude/session/current-ticket" ]; then
-    if grep -qE '^title=\[Spike\]' "$marker_home/.claude/session/current-ticket" 2>/dev/null; then
+    if grep -qE '^title=\[(Spike|Prototype)\]' "$marker_home/.claude/session/current-ticket" 2>/dev/null; then
       return 0
     fi
   fi
   if [ -d "$marker_home/.claude/session/tickets" ]; then
     for marker in "$marker_home/.claude/session/tickets"/*; do
       [ -f "$marker" ] || continue
-      if grep -qE '^title=\[Spike\]' "$marker" 2>/dev/null; then
+      if grep -qE '^title=\[(Spike|Prototype)\]' "$marker" 2>/dev/null; then
         return 0
       fi
     done
@@ -152,7 +153,7 @@ spike_commit_exempt() {
 
   local branch
   branch=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null)
-  if echo "$branch" | grep -qE '^spike/'; then
+  if echo "$branch" | grep -qE '^(spike|prototype)/'; then
     return 0
   fi
 
@@ -160,7 +161,7 @@ spike_commit_exempt() {
 }
 
 if spike_commit_exempt; then
-  echo "WARN: spike commit detected — require-agdr-for-arch-changes bypassed. AgDRs not required for hypothesis-driven throw-away work; ship a memo on /spike-close instead. See .claude/rules/workflow-gates.md § Spike work." >&2
+  echo "WARN: spike/prototype commit detected — require-agdr-for-arch-changes bypassed. AgDRs not required for throw-away exploration; ship a memo on /spike-close or /prototype-close instead. See .claude/rules/workflow-gates.md § Spike work." >&2
   exit 0
 fi
 

--- a/.claude/hooks/require-agdr-for-arch-pr.sh
+++ b/.claude/hooks/require-agdr-for-arch-pr.sh
@@ -190,26 +190,28 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 2b. Spike exemption (apexyard#180).
+# 2b. Spike + prototype exemption (apexyard#180, #673).
 #
-# Spike work is hypothesis-driven, time-boxed, throw-away exploration. AgDRs
-# capture decisions that should persist; spikes write disposition memos
-# instead. The exemption fires when ANY of:
+# Spike work (technical) and prototype work (throw-away UX/demo) are both
+# time-boxed exploration. AgDRs capture decisions that should persist; these
+# write disposition memos instead. The exemption fires when ANY of:
 #
-#   (a) the PR title carries `spike(...)` as the conventional-commit type
-#   (b) the active ticket marker references a `[Spike]`-prefixed ticket
-#   (c) the branch is named `spike/<TICKET-ID>-...`
+#   (a) the PR title carries `spike(...)` or `prototype(...)` as the type
+#   (b) the active ticket marker references a `[Spike]` or `[Prototype]` ticket
+#   (c) the branch is named `spike/<TICKET-ID>-...` or `prototype/...`
 #
 # Code review (Rex) and the security auditor still apply — exemptions are
 # surgical, not blanket. See .claude/rules/workflow-gates.md § Spike work.
 # ---------------------------------------------------------------------------
 spike_pr_exempt() {
-  # (a) spike(...) PR title
-  if echo "$TITLE" | grep -qE '^spike\([^)]+\)!?:'; then
+  # (a) spike(...) PR title. Prototype work (apexyard#673) is throw-away
+  # UX/demo exploration and shares the spike exemption: `prototype(...)` PR
+  # type, `[Prototype]` ticket prefix, or `prototype/` branch all bypass too.
+  if echo "$TITLE" | grep -qE '^(spike|prototype)\([^)]+\)!?:'; then
     return 0
   fi
 
-  # (b) active ticket marker has [Spike] prefix
+  # (b) active ticket marker has [Spike] or [Prototype] prefix
   local marker_home="${REPO_ROOT}"
   # Walk up to find the ops root. Honours both the v2 `.apexyard-fork`
   # marker and the legacy v1 anchor (onboarding.yaml + apexyard.projects.yaml).
@@ -237,23 +239,23 @@ spike_pr_exempt() {
   fi
 
   if [ -f "$marker_home/.claude/session/current-ticket" ]; then
-    if grep -qE '^title=\[Spike\]' "$marker_home/.claude/session/current-ticket" 2>/dev/null; then
+    if grep -qE '^title=\[(Spike|Prototype)\]' "$marker_home/.claude/session/current-ticket" 2>/dev/null; then
       return 0
     fi
   fi
   if [ -d "$marker_home/.claude/session/tickets" ]; then
     for marker in "$marker_home/.claude/session/tickets"/*; do
       [ -f "$marker" ] || continue
-      if grep -qE '^title=\[Spike\]' "$marker" 2>/dev/null; then
+      if grep -qE '^title=\[(Spike|Prototype)\]' "$marker" 2>/dev/null; then
         return 0
       fi
     done
   fi
 
-  # (c) branch named spike/...
+  # (c) branch named spike/... or prototype/...
   local branch
   branch=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null)
-  if echo "$branch" | grep -qE '^spike/'; then
+  if echo "$branch" | grep -qE '^(spike|prototype)/'; then
     return 0
   fi
 
@@ -261,7 +263,7 @@ spike_pr_exempt() {
 }
 
 if spike_pr_exempt; then
-  echo "WARN: spike PR detected — require-agdr-for-arch-pr bypassed. AgDRs not required for hypothesis-driven throw-away work; ship a memo on /spike-close instead. See .claude/rules/workflow-gates.md § Spike work." >&2
+  echo "WARN: spike/prototype PR detected — require-agdr-for-arch-pr bypassed. AgDRs not required for throw-away exploration; ship a memo on /spike-close or /prototype-close instead. See .claude/rules/workflow-gates.md § Spike work." >&2
   exit 0
 fi
 

--- a/.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
+++ b/.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
@@ -233,7 +233,7 @@ run_case "non-gh command → no-op" \
 # in body — production rule would BLOCK; spike exemption flips to PASS.
 DIR=$(setup_repo c1_base c1_feat)
 run_case "spike PR title (arch change, no AgDR) → PASS via spike exemption" \
-  "$DIR" 0 "spike PR detected" \
+  "$DIR" 0 "spike/prototype PR detected" \
   "gh pr create --base main --title 'spike(#180): explore X' --body 'just a spike'"
 
 # Spike signal (c): branch name starts with `spike/`. Set the feature branch
@@ -247,7 +247,7 @@ spike_branch_setup() {
 
 DIR=$(spike_branch_setup)
 run_case "spike branch name (arch change, no AgDR, non-spike PR title) → PASS via branch signal" \
-  "$DIR" 0 "spike PR detected" \
+  "$DIR" 0 "spike/prototype PR detected" \
   "gh pr create --base main --title 'feat(#180): tweak domain' --body 'just exploring'"
 
 # Spike signal (b): active-ticket marker references a [Spike] ticket.
@@ -278,8 +278,42 @@ EOF
 
 DIR=$(spike_marker_setup)
 run_case "spike active-ticket marker (arch change, non-spike branch + title) → PASS via marker signal" \
-  "$DIR" 0 "spike PR detected" \
+  "$DIR" 0 "spike/prototype PR detected" \
   "gh pr create --base main --title 'feat(#180): tweak domain' --body 'no AgDR'"
+
+# ---------------------------------------------------------------------------
+# Prototype exemption (apexyard#673) — same three signals as spike; any one
+# wins. Prototype work is throw-away UX/demo exploration and shares the spike
+# AgDR exemption.
+# ---------------------------------------------------------------------------
+
+# Prototype signal (a): PR title type = `prototype(...)`.
+DIR=$(setup_repo c1_base c1_feat)
+run_case "prototype PR title (arch change, no AgDR) → PASS via prototype exemption" \
+  "$DIR" 0 "spike/prototype PR detected" \
+  "gh pr create --base main --title 'prototype(#673): explore look-and-feel' --body 'just a prototype'"
+
+# Prototype signal (c): branch name starts with `prototype/`.
+prototype_branch_setup() {
+  local dir
+  dir=$(setup_repo c1_base c1_feat)
+  ( cd "$dir" && git branch -m prototype/GH-673-explore ) >/dev/null 2>&1
+  echo "$dir"
+}
+
+DIR=$(prototype_branch_setup)
+run_case "prototype branch name (arch change, no AgDR, non-prototype PR title) → PASS via branch signal" \
+  "$DIR" 0 "spike/prototype PR detected" \
+  "gh pr create --base main --title 'feat(#673): tweak domain' --body 'just exploring UX'"
+
+# Prototype signal (b): active-ticket marker referencing a [Prototype] ticket
+# is supported by the hook (see require-agdr-for-arch-pr.sh — the marker grep
+# matches `^title=\[(Spike|Prototype)\]`). It is NOT asserted here because it
+# shares the same in-sandbox ops-root resolution limitation as the pre-existing
+# "spike active-ticket marker" case above (the marker fixture's ops root isn't
+# resolved inside the test sandbox). Signals (a) PR-title-type and (c)
+# branch-name — both exercised above — give the prototype exemption equivalent
+# coverage to the spike exemption's reliably-green signals.
 
 # ---------------------------------------------------------------------------
 # Regression: embedded-quote truncation bug (apexyard#461).

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -12,6 +12,7 @@
       "CI",
       "Docs",
       "Spike",
+      "Prototype",
       "Investigation"
     ],
     "label_priority_scheme": "P0,P1,P2,P3",
@@ -24,6 +25,7 @@
       "Docs": ["Driver", "Acceptance Criteria"],
       "Bug": ["Given / When / Then", "Repro"],
       "Spike": ["Hypothesis", "Budget", "Kill Criteria", "Disposition"],
+      "Prototype": ["Direction Question", "Fidelity", "Budget", "Disposition"],
       "Investigation": ["Trigger", "Hypothesis being tested", "Method", "Findings", "Conclusion", "Follow-up actions"]
     },
     "skip_marker": "<!-- validate-issue-structure: skip -->",
@@ -54,6 +56,7 @@
       "docs",
       "test",
       "spike",
+      "prototype",
       "ci",
       "build",
       "perf",
@@ -75,6 +78,7 @@
       "ci",
       "revert",
       "spike",
+      "prototype",
       "sync"
     ]
   },
@@ -94,6 +98,7 @@
       "revert",
       "release",
       "spike",
+      "prototype",
       "sync"
     ],
     "required_sections": [

--- a/.claude/rules/git-conventions.md
+++ b/.claude/rules/git-conventions.md
@@ -10,7 +10,7 @@ Examples:
 - `fix/GH-45-login-bug`
 - `docs/ENG-99-update-readme`
 
-**Types**: `feature`, `fix`, `refactor`, `chore`, `docs`, `test`, `spike`, `ci`, `build`, `perf`
+**Types**: `feature`, `fix`, `refactor`, `chore`, `docs`, `test`, `spike`, `prototype`, `ci`, `build`, `perf`
 
 The `TICKET-ID` should reference an issue in the project's tracker. Default format: `#58` or `GH-58` (GitHub Issues). The validators in `.claude/hooks/` source the regex from `.tracker.id_pattern` in `.claude/project-config.{defaults,}.json` — the default pattern also matches any uppercase tracker prefix (e.g. `ABC-123`) for teams using Linear, Jira, or similar. See `_lib-tracker.sh` and AgDR-0033 for how to swap the active tracker; ApexYard's out-of-the-box default is per-project GitHub Issues, with one repo's issues never crossing into another repo's PRs.
 
@@ -18,7 +18,7 @@ The `TICKET-ID` should reference an issue in the project's tracker. Default form
 
 Must match: `type(TICKET): description` or `type(TICKET)!: description` (breaking change)
 
-Regex: `^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|spike)\(<TICKET_ID_PATTERN>\)!?:`
+Regex: `^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|spike|prototype)\(<TICKET_ID_PATTERN>\)!?:`
 
 `<TICKET_ID_PATTERN>` is sourced from `.tracker.id_pattern` so adopters get their own tracker's shape validation. Default matches `#123`, `GH-123`, or `[A-Z]{2,10}-[0-9]+` (Jira / Linear / similar).
 

--- a/.claude/rules/loop-mode.md
+++ b/.claude/rules/loop-mode.md
@@ -2,7 +2,7 @@
 
 A "loop" is a setup where you stop prompting an agent step-by-step and instead design a bounded cycle — discover → plan → execute → **verify** → iterate — that runs until a goal is met inside guardrails you set. The shift the field is naming ("design loops that prompt your agents, don't prompt steps") is real, but the durable lesson underneath it is narrower: **a loop is only as good as the skills it calls and its ability to check its own work, and it is only safe if it halts.**
 
-This rule is the **trigger heuristic** — it defines when an agent should *proactively offer* (or, on opt-in, run) a closed loop instead of grinding through repetitive work one prompt at a time. It is the sibling of [`parallel-work.md`](parallel-work.md) (offer `/fan-out`) and [`plan-mode.md`](plan-mode.md) (enter plan mode). ApexYard is unusually well-suited to looping because it already ships the two things a loop needs and most setups lack: a library of **skills** (the 59 slash commands) and a real **eval layer** (Rex, the design/architecture reviews, CI, the merge gates, QA).
+This rule is the **trigger heuristic** — it defines when an agent should *proactively offer* (or, on opt-in, run) a closed loop instead of grinding through repetitive work one prompt at a time. It is the sibling of [`parallel-work.md`](parallel-work.md) (offer `/fan-out`) and [`plan-mode.md`](plan-mode.md) (enter plan mode). ApexYard is unusually well-suited to looping because it already ships the two things a loop needs and most setups lack: a library of **skills** (the 62 slash commands) and a real **eval layer** (Rex, the design/architecture reviews, CI, the merge gates, QA).
 
 ## When to OFFER loop mode (proactively)
 

--- a/.claude/rules/workflow-gates.md
+++ b/.claude/rules/workflow-gates.md
@@ -98,6 +98,8 @@ Default design-artifact patterns (configurable via `.claude/project-config.json`
 
 Spike tickets (prefix `[Spike]`, label `spike`) are hypothesis-driven, time-boxed, throw-away exploration. The full production SDLC is the wrong bar — author avoidance is the failure mode. The exemption set below is **surgical, not blanket**:
 
+> **Prototype work shares this exemption.** Prototype tickets (prefix `[Prototype]`, label `prototype`, branch `prototype/...`, PR type `prototype(...)`) are the throw-away **UX/demo** sibling of spikes — same disposable lifecycle, different question ("what should it look/feel like?" vs "will it work?"). The AgDR + coverage exemptions in the table below apply to prototype work identically; substitute `/prototype` for `/spike` and `/prototype-close` for `/spike-close`. The **walking skeleton** (`/walking-skeleton`) is the deliberate opposite — a **kept** thin end-to-end slice held to the FULL SDLC with **no** exemptions. See `.claude/skills/{spike,prototype,walking-skeleton}/SKILL.md`.
+
 | Gate | Production work | Spike work |
 |------|----------------|------------|
 | Pre-Build (parent epic, story tickets, ACs, design review) | Required | Skipped — the spike ticket IS the unit |
@@ -109,13 +111,13 @@ Spike tickets (prefix `[Spike]`, label `spike`) are hypothesis-driven, time-boxe
 | QA Engineer verification | Required (AC verification) | **Required** (Hypothesis verification: did we answer the question?) |
 | Disposition decision before close | N/A | **Required** — operator must declare PROMOTE or DISCARD via `/spike-close` |
 
-**Detection.** AgDR-required hooks detect a spike PR via:
+**Detection.** AgDR-required hooks detect a spike (or prototype) PR via:
 
-1. PR title carries `spike(...)` as the conventional-commit type
-2. Active ticket marker references a `[Spike]`-prefixed ticket
-3. Branch name starts with `spike/`
+1. PR title carries `spike(...)` or `prototype(...)` as the conventional-commit type
+2. Active ticket marker references a `[Spike]`- or `[Prototype]`-prefixed ticket
+3. Branch name starts with `spike/` or `prototype/`
 
-Any one match exempts the gate; otherwise the production rule applies. See `.claude/skills/spike/SKILL.md`, `.claude/skills/spike-close/SKILL.md`, and `docs/agdr/AgDR-0017-spike-skill-schema-and-exemptions.md`.
+Any one match exempts the gate; otherwise the production rule applies. See `.claude/skills/spike/SKILL.md`, `.claude/skills/spike-close/SKILL.md`, `.claude/skills/prototype/SKILL.md`, `.claude/skills/prototype-close/SKILL.md`, and `docs/agdr/AgDR-0017-spike-skill-schema-and-exemptions.md`.
 
 ## QA State is Mandatory
 

--- a/.claude/skills/prototype-close/SKILL.md
+++ b/.claude/skills/prototype-close/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: prototype-close
+description: Close a prototype via the disposition gate — `--promote` files a [Feature] follow-up, `--discard` writes a memo. Mirror of /spike-close for throwaway UX/demo prototypes.
+argument-hint: "--promote | --discard [<prototype-ticket-number>]"
+allowed-tools: Bash, Read, Write
+---
+
+# /prototype-close — Close a Prototype via the Disposition Gate
+
+The disposition gate prevents the worst-of-both case: a prototype that "looked great in the demo" but never decides what to do with it, leaving a throwaway mockup that quietly gets promoted into production. Every prototype must close with one of two paths:
+
+- **PROMOTE** — the direction was chosen; file a fresh `[Feature]` ticket so the real work goes through the full production SDLC. The prototype artifact is NOT lifted into production — the new feature re-implements based on the chosen direction.
+- **DISCARD** — the direction was rejected (or "not now"); write a memo at `docs/prototype-memos/<slug>.md` so future-us doesn't re-explore the same ground.
+
+This is the UX/demo sibling of `/spike-close` (technical exploration). Same gate, same two paths, different artifact directory (`docs/prototype-memos/` vs `docs/spike-memos/`).
+
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout. See `docs/multi-project.md`.
+
+## Usage
+
+```
+/prototype-close --promote 142
+/prototype-close --discard 142
+/prototype-close --promote          # uses the active-ticket marker
+/prototype-close --discard
+```
+
+## Process
+
+### 1. Resolve the prototype ticket
+
+Two paths:
+
+- If `$ARGUMENTS` includes a number (e.g. `--promote 142` or `--discard owner/repo#142`), use that.
+- Otherwise read the active-ticket marker (`.claude/session/current-ticket` or `.claude/session/tickets/<project>`) and use the ticket recorded there. If neither resolves, ask:
+
+```
+Which prototype are you closing? Pass --promote <number> or --discard <number>,
+or run /start-ticket first.
+```
+
+### 2. Verify it really is a prototype
+
+Run `gh issue view <number> --repo <owner/repo> --json title,labels,state,body`. The skill proceeds if:
+
+- title starts with `[Prototype]`, OR
+- labels include `prototype`
+
+If the ticket is neither, refuse:
+
+```
+Issue {owner/repo}#{number} doesn't look like a prototype (no [Prototype]
+prefix, no `prototype` label). /prototype-close is for prototype disposition
+only — close production-shaped tickets via the normal QA → Done flow, and
+technical spikes via /spike-close.
+```
+
+If the ticket is already CLOSED, warn and ask whether to continue (the user may want to retroactively record disposition):
+
+```
+{owner/repo}#{number} is already closed. Continue and (a) file the follow-
+up artefact only, or (b) abort? (continue / abort)
+```
+
+### 3. Branch on `--promote` vs `--discard`
+
+#### 3a. PROMOTE — three questions, then file a [Feature]
+
+Ask one at a time:
+
+**i) Production-shaped feature title**
+
+```
+The prototype chose a direction. What's the title of the production-shaped
+feature ticket we're filing as the follow-up?
+```
+
+**ii) Production-shaped scope**
+
+```
+What's the scope for the production version? This is the user-facing
+capability, not the prototype's exploration goal.
+(One paragraph or bullets.)
+```
+
+**iii) What's NOT being carried over**
+
+```
+What did the prototype fake that's NOT being lifted into production? (e.g.
+"the mockup used stubbed data; production needs the real API",
+"the demo skipped error states and empty states — we'll design those in
+the feature".)
+```
+
+Then preview the [Feature] ticket and confirm. The body MUST include a
+"Prototype findings" section that links back to the prototype:
+
+```
+**[Feature] {title}**
+
+## User Story
+{prompted from the operator — same as /feature step 3a}
+
+## Acceptance Criteria
+- [ ] {prompted from the operator}
+
+## Prototype findings
+This feature was promoted from {owner/repo}#{prototype-number}.
+The prototype chose the direction: {one-sentence summary of the look/feel decided}.
+
+What is NOT being carried over from the prototype artifact:
+- {item 1}
+- {item 2}
+
+## Out of Scope
+{or "—"}
+```
+
+After confirmation, create the issue:
+
+```bash
+gh issue create --repo {owner/repo} \
+  --title "[Feature] {title}" \
+  --label "enhancement" \
+  --body "{body}"
+```
+
+Capture the new issue number, then close the prototype with a cross-ref comment:
+
+```bash
+gh issue close {prototype-number} --repo {owner/repo} \
+  --comment "Prototype disposition: PROMOTE. Follow-up filed as #{new-number} — {feature-title}. Prototype artifact is NOT being lifted into production; the new feature work re-implements the chosen direction recorded above."
+```
+
+Return both URLs:
+
+```
+Prototype closed: {owner/repo}#{prototype-number}
+Follow-up:        {owner/repo}#{new-number} — {feature-title}
+                  {url}
+```
+
+#### 3b. DISCARD — one question, then write a memo
+
+```
+What did we learn? One paragraph — enough that a future engineer who
+asks the same UX/demo question (or revisits the same flow) finds this memo
+and doesn't re-explore the same ground. Be concrete:
+  - what direction were we exploring?
+  - what did the prototype show?
+  - why is the answer no / not this direction? (or "not now")
+  - what would change the answer? (under what conditions might we revisit?)
+```
+
+Then derive a slug from the prototype title (lowercase, kebab-case, max 40
+chars, stopwords trimmed) and write the memo:
+
+```bash
+mkdir -p docs/prototype-memos
+cat > docs/prototype-memos/{slug}.md <<'EOF'
+# Prototype memo: {title}
+
+> **Disposition: DISCARD** — direction rejected; not pursuing further.
+
+- **Prototype ticket**: {owner/repo}#{number}
+- **Author**: {git config user.name}
+- **Closed**: {ISO-8601 date}
+
+## Direction Question (from the prototype ticket)
+
+{direction question from the original ticket body}
+
+## Findings
+
+{the one-paragraph answer the operator wrote}
+
+## Why we're not pursuing
+
+{extracted from the operator's answer — the "answer is no / not this
+direction" part}
+
+## What would change the answer
+
+{conditions under which we might revisit — extracted from the operator's
+answer, or "—" if not specified}
+
+## Artefacts
+
+- Original prototype ticket: {owner/repo}#{number}
+- Prototype branch: prototype/<TICKET-ID>-<slug> (delete after merge of this memo)
+EOF
+```
+
+The memo is committed in a separate PR (the prototype's PR may or may not have merged — the memo PR is the disposition artefact, separate from any code).
+
+After writing the memo, close the prototype with a cross-ref:
+
+```bash
+gh issue close {prototype-number} --repo {owner/repo} \
+  --comment "Prototype disposition: DISCARD. Memo at docs/prototype-memos/{slug}.md (commit in follow-up PR). Prototype branch can be deleted; nothing is being lifted into production."
+```
+
+Return:
+
+```
+Prototype closed: {owner/repo}#{prototype-number}
+Memo path:        docs/prototype-memos/{slug}.md
+
+Next steps:
+  1. Stage the memo:   git add docs/prototype-memos/{slug}.md
+  2. Commit:           git commit -m "docs: prototype memo for #{prototype-number}"
+  3. Push + PR — the memo is the disposition artefact.
+  4. Delete the prototype branch once the memo PR merges.
+```
+
+## Rules
+
+1. **Disposition is PROMOTE or DISCARD only.** No third path. The whole point of the gate is to forbid "decide later".
+2. **PROMOTE files a fresh [Feature].** The prototype artifact is NOT lifted into production. Promotion creates a new ticket; the production work re-implements the chosen direction.
+3. **DISCARD writes a memo.** Prototype-memo at `docs/prototype-memos/<slug>.md` is the artefact — no memo, no DISCARD.
+4. **One question at a time.** Same conversational rule as `/prototype`, `/spike-close`, and `/feature`.
+5. **No hard block on closing without /prototype-close.** The skill prompts; closure is ultimately the operator's call. The cost of forgetting is no record of what was learned, which is enough downside to motivate running the gate without needing a mechanical block.
+6. **Cross-references both ways.** PROMOTE links the new feature back to the prototype; DISCARD links the memo back to the prototype. Future archaeology should always find the trail.
+
+## Edge cases
+
+- **Prototype PR didn't merge.** Fine — the memo / follow-up feature is the disposition artefact, not the prototype code itself. PROMOTE: file the new feature, close the prototype, abandon the branch. DISCARD: write the memo, close the prototype, abandon the branch.
+- **Direction was partially chosen.** Treat the partial as PROMOTE — file the [Feature] for the parts you're keeping; cover the parts you're dropping in the "What is NOT being carried over" section.
+- **A prototype that turned into a feasibility question.** If the exploration revealed the real open question is technical ("will this even work?"), file a `/spike` for that, and DISCARD the prototype with a memo pointing at the new spike.
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/.claude/skills/prototype/SKILL.md
+++ b/.claude/skills/prototype/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: prototype
+description: Create a throwaway UX/demo prototype ticket (mockup / demo flow) — answers "what should it look and feel like?". DISCARD-by-default; same AgDR + coverage exemptions as /spike.
+argument-hint: "<short title of the prototype>"
+allowed-tools: Bash, Read, Write
+---
+
+# /prototype — Create a Throwaway Prototype Ticket
+
+Creates a structured GitHub Issue for a **prototype** — a disposable UX/demo artifact (clickable mockup, demo flow, interactive proof-of-concept UI) built to answer *"what should this look and feel like?"*. The output is the **learning / chosen direction**, not shippable code: a prototype is thrown away once the direction is decided.
+
+> **The taxonomy — three skills, two axes (throwaway vs kept, technical vs UX).**
+>
+> | Skill | Question it answers | Lifecycle |
+> |-------|---------------------|-----------|
+> | `/spike` | "Will this **technically** work?" | **THROWAWAY** — discarded after the technical answer is in (`/spike-close`). |
+> | **`/prototype`** | "What should this **look and feel** like?" | **THROWAWAY** — discarded after the UX/demo direction is chosen (`/prototype-close`). |
+> | `/walking-skeleton` | "Is the **whole architecture** wired end-to-end?" | **KEPT** — the production spine you flesh out. Full SDLC. |
+>
+> `/prototype` and `/spike` are **both throwaway** — the difference is the *question*. A spike answers a **technical feasibility** question ("will library X scale?", "can we replace Auth0?"). A prototype answers a **UX/demo direction** question ("which onboarding flow feels right?", "what should the dashboard look like for the investor demo?"). If your question is "will it work?", file a `/spike` instead. If you need a minimal-but-**kept** end-to-end slice, you want `/walking-skeleton`. See `workflows/sdlc.md` § Phase 1.
+
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
+## Usage
+
+```
+/prototype Which onboarding flow feels right
+/prototype Dashboard look-and-feel for the investor demo
+/prototype Clickable checkout mockup to test the 2-step vs 1-step
+```
+
+## Process
+
+### 0. Write the active-issue-skill marker (REQUIRED — me2resh/apexyard#268)
+
+Before any `gh issue create` (or other tracker CLI), write this skill's name to the active-issue-skill marker so `require-skill-for-issue-create.sh` lets the command through. At skill entry:
+
+```bash
+ops_root="$(r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;echo $r)"
+mkdir -p "$ops_root/.claude/session"
+echo "prototype" > "$ops_root/.claude/session/active-issue-skill"
+```
+
+Remove the marker on **every** exit path (success, early-exit, user cancel, error):
+
+```bash
+rm -f "$ops_root/.claude/session/active-issue-skill"
+```
+
+The `clear-issue-skill-marker.sh` SessionStart hook sweeps stale markers from killed sessions, but a clean exit should never leave one behind. See AgDR-0030.
+
+### 1. Resolve the target repo
+
+Read `.claude/session/current-ticket` to determine which repo we're working in. If no active ticket, check `apexyard.projects.yaml` for managed projects. If only one project, use it. If multiple, ask:
+
+```
+Which project is this prototype for?
+```
+
+If no projects are registered, ask for the repo in `owner/repo` format.
+
+### 2. Verify the prefix is on the whitelist
+
+Read `.ticket.prefix_whitelist` from `.claude/project-config.*.json`. If `Prototype` (case-insensitive) is not in the list, warn and stop:
+
+```
+This fork's ticket schema doesn't include 'Prototype' as a valid prefix.
+Either add it to .claude/project-config.json → .ticket.prefix_whitelist, or
+file the ticket using whichever prefix the fork uses for exploration work.
+```
+
+(The shipped default in `.claude/project-config.defaults.json` includes `Prototype`. This check exists for forks that have customised the whitelist.)
+
+### 3. Parse or ask for the title
+
+Take the title from `$ARGUMENTS`. If empty, ask:
+
+```
+What's the prototype? Give me a short title.
+```
+
+### 4. Gather details (one question at a time)
+
+Ask conversationally — do NOT batch all questions. Wait for each answer before asking the next. Fields a–d are required; e is optional.
+
+**a) Direction Question (required)**
+
+```
+What's the single "what should this look and feel like?" question this
+prototype answers? Format: "We're exploring {direction}; the prototype
+tells us {what we'll decide}."
+(One sentence. A prototype answers a UX/demo-direction question, NOT a
+technical-feasibility one. If your question is "will this work?", you want
+/spike — push back and redirect.)
+```
+
+If the user gives a technical-feasibility question ("will X scale?", "can we integrate Y?"), stop and redirect to `/spike` — that's a different tool.
+
+**b) Fidelity (required)**
+
+```
+What kind of disposable artifact is this, and how far does it go? Examples:
+  - Clickable mockup (Figma / static HTML, no real backend)
+  - Demo flow (wired screens, stubbed data, happy-path only)
+  - Interactive proof-of-concept UI (real framework, fake everything else)
+
+Whatever you pick, it's a throwaway for learning a direction — not the
+start of production code. Which fidelity?
+```
+
+**c) Budget (required)**
+
+```
+What's the hard cap on time/effort? Examples:
+  - 1 day of one engineer
+  - 2 days, then we decide
+  - Until the stakeholder demo on Friday
+
+At the budget cap, the prototype ENDS regardless of polish. What's yours?
+```
+
+Reject vague answers ("a while", "until it's pretty") — push for an explicit time/effort cap.
+
+**d) Disposition (required — PROMOTE or DISCARD)**
+
+```
+What happens when the prototype closes — PROMOTE or DISCARD?
+
+  PROMOTE — if the direction is chosen, file a fresh [Feature] ticket for
+            production-shaped delivery; the prototype artifact is NOT
+            lifted into production, the feature re-implements the direction.
+  DISCARD — if the direction is rejected (or "not now"), write a memo at
+            docs/prototype-memos/<slug>.md with what we learned.
+
+"Decide later" is NOT allowed — that's how a throwaway mockup gets
+accidentally promoted into production. Pick one.
+```
+
+If the user says "decide later" or "depends", explain the rule and ask again. The author must commit to one path in advance. DISCARD-by-default is the prototype norm — a prototype exists to be thrown away once the direction is clear; PROMOTE just means the *direction*, not the artifact, survives.
+
+**e) Approach (optional)**
+
+```
+Any sketch of what you'll mock up? (or press Enter to skip)
+NOT a tech design, NOT a PRD — a few bullets: which screens / flows, what
+tools (Figma, static HTML, v0, the real framework with stubs), what you're
+deliberately faking.
+```
+
+### 5. Show the formatted ticket for confirmation
+
+Resolve the prototype body template via the portfolio helper so adopter overrides win when present:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+template=$(portfolio_resolve_template tickets/prototype.md)   # → custom-templates/tickets/prototype.md if present, else templates/tickets/prototype.md
+```
+
+Single-fork adopters (no `portfolio` block) and adopters with no override fall straight through to `templates/tickets/prototype.md`. Adopters who want a customised prototype-body shape drop their version at `<private_repo>/custom-templates/tickets/prototype.md`. See `templates/README.md` for the path-mirroring convention.
+
+**Backward-compat fallback**: if `portfolio_resolve_template` returns empty (template file missing — partial adopter setup), fall back to the inline heredoc body below and print a one-line WARN on stderr (`WARN: tickets/prototype.md template missing — using inline fallback`).
+
+Display the full ticket using the resolved template's section headings (the default `templates/tickets/prototype.md` shape is reproduced below):
+
+```
+Here's the ticket I'll create:
+
+---
+**[Prototype] {title}**
+
+## Direction Question
+{direction question}
+
+## Fidelity
+{fidelity}
+
+## Budget
+{budget}
+
+## Disposition
+{PROMOTE | DISCARD}
+{one-sentence rationale}
+
+## Approach
+{approach or "—"}
+---
+
+Labels: prototype
+Repo: {owner/repo}
+
+Suggested branch when you start work:
+  prototype/<TICKET-ID>-{slug}
+
+Create this ticket? (yes / edit / cancel)
+```
+
+### 6. Handle response
+
+- **yes** / **looks good** / **go** → create the issue
+- **edit** / **change X** → ask what to change, update, re-show
+- **cancel** / **no** → abort
+
+### 7. Create the GitHub Issue
+
+```bash
+gh issue create --repo {owner/repo} \
+  --title "[Prototype] {title}" \
+  --label "prototype" \
+  --body "{formatted body}"
+```
+
+The `prototype` label is the trigger that downstream hooks (AgDR-required hooks, coverage gates) read to apply the workflow exemptions — the same mechanism `/spike` uses with the `spike` label. If the label doesn't exist on the target repo, the skill will create it via `gh label create prototype --color "C5DEF5" --description "Throw-away UX/demo prototype; exempt from AgDR + coverage gates"` (idempotent — `gh label create` errors on duplicate, the skill swallows that).
+
+### 8. Return the URL + branch suggestion
+
+```
+Created: {owner/repo}#{number} — {title}
+{url}
+
+When you start work:
+  /start-ticket {owner/repo}#{number}
+  git checkout -b prototype/GH-{number}-{slug}
+```
+
+### 9. Remind the operator about the disposition gate
+
+```
+When the prototype closes, run /prototype-close to record the disposition:
+  /prototype-close --promote   # direction chosen → file a [Feature]
+  /prototype-close --discard   # direction rejected → write a memo
+
+Closing the prototype without running this gate is allowed (closure is the
+operator's call) but skips the memo / promotion artefact and leaves no
+record of what was learned.
+```
+
+## Rules
+
+1. **One question at a time.** Never batch questions. Wait for each answer.
+2. **Always confirm before creating.** Show the full ticket and get explicit "yes".
+3. **All four required fields are mandatory.** Direction Question, Fidelity, Budget, Disposition — none can be skipped or deferred.
+4. **Disposition is PROMOTE or DISCARD only.** "Decide later" is not allowed; reject it and re-ask. DISCARD-by-default is the norm.
+5. **UX/demo question, not a technical one.** If the user's real question is feasibility ("will it work?"), redirect to `/spike`. If they want a kept end-to-end slice, redirect to `/walking-skeleton`.
+6. **Labels.** `prototype` always — it's the exemption trigger. Priority labels (P0/P1/etc.) are NOT applied — prototypes are time-boxed by Budget. The accepted prefix list reads from `.claude/project-config.*.json` → `.ticket.prefix_whitelist`; `[Prototype]` must be in that list.
+7. **Branch suggestion.** Always `prototype/<TICKET-ID>-<slug>`. The branch name is what AgDR-exemption hooks check (alongside the `[Prototype]` active-ticket marker and the `prototype(...)` PR type).
+8. **No PRD, no tech design.** Prototypes describe a direction to explore, not a feature. Don't ask for user stories, ACs, or design specs — those belong on the follow-up `[Feature]` ticket if the disposition is PROMOTE.
+
+## Workflow exemptions for prototype work
+
+A prototype PR is exempt from the production SDLC subset listed below — the **same surgical exemptions as `/spike`**; everything else still applies. The exemptions are mechanical (the AgDR hooks detect the `[Prototype]` prefix, the `prototype(...)` PR type, or the `prototype/` branch and skip), not advisory.
+
+| Gate | Production work | Prototype work |
+|------|----------------|----------------|
+| Pre-Build (parent epic, story tickets, ACs, design review) | Required | Skipped — the prototype ticket IS the unit |
+| AgDR for technical decisions (`require-agdr-for-arch-pr.sh`, `require-agdr-for-arch-changes.sh`) | Required | Skipped — ship a memo on `/prototype-close --discard` instead |
+| Test coverage > 80% | Required | Skipped — coverage is irrelevant for throw-away mockups |
+| Code Reviewer agent (Rex) | Required on every PR | **Required** — even throw-away code gets a sanity check |
+| Security Auditor (auth/crypto/secrets diff) | Required | **Required** — security gates fire regardless of intent |
+| Glossary in PR body | Required | **Required** — prototype PRs explain WHAT DIRECTION WAS LEARNED, which is the artefact |
+| QA Engineer verification | Required (AC verification) | **Required** (Direction verification: did we learn what to build?) |
+| Disposition decision before close | N/A | **Required** — operator must declare PROMOTE or DISCARD via `/prototype-close` |
+
+See `.claude/rules/workflow-gates.md` § Spike work for the rule statement (which covers prototype work under the same exemption set), `.claude/skills/spike/SKILL.md` (the throwaway technical sibling), and `.claude/skills/walking-skeleton/SKILL.md` (the kept end-to-end slice).
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/.claude/skills/walking-skeleton/SKILL.md
+++ b/.claude/skills/walking-skeleton/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: walking-skeleton
+description: Scaffold a [Feature]-class ticket for the thinnest end-to-end slice — one trivial path wired through every architectural layer. KEPT and grown; full SDLC (NOT exempt like /spike).
+argument-hint: "<feature or service the skeleton proves>"
+allowed-tools: Bash, Read, Write
+---
+
+# /walking-skeleton — Scaffold the Thin End-to-End Slice
+
+Creates a structured GitHub Issue for a **walking skeleton** — the thinnest possible end-to-end slice of a new feature or service: one trivial happy path wired through **every** architectural layer (UI → API → domain → store → deploy → back), with **no business logic beyond the thinnest happy path**. The skeleton actually runs and deploys, so integration and architecture are proven early. You then build the real product on top of it.
+
+> **The taxonomy — three skills, two axes (throwaway vs kept, technical vs UX).**
+>
+> | Skill | Question it answers | Lifecycle |
+> |-------|---------------------|-----------|
+> | `/spike` | "Will this **technically** work?" | **THROWAWAY** — discarded after the answer is in (`/spike-close`). |
+> | `/prototype` | "What should this **look and feel** like?" | **THROWAWAY** — discarded after the direction is chosen (`/prototype-close`). |
+> | **`/walking-skeleton`** | "Is the **whole architecture** wired and deployable end-to-end?" | **KEPT** — the production spine you flesh out. Full SDLC. |
+>
+> The walking skeleton is the **opposite** of a spike/prototype: minimal but **production-shaped and kept**. This distinction prevents the common, expensive confusion where a throwaway exploration gets accidentally promoted into production. A walking skeleton is held to the full bar from day one *because* it stays — it is **NOT** exempt from the AgDR + coverage gates the way `/spike` and `/prototype` are. See `workflows/sdlc.md` § Phase 1 and `.claude/rules/workflow-gates.md`.
+
+## Path resolution
+
+Read the registry path via `portfolio_registry`, the per-project docs dir via `portfolio_projects_dir`, and the ideas backlog via `portfolio_ideas_backlog` — all from `.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any bash block that touches those paths:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
+
+Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
+## Usage
+
+```
+/walking-skeleton checkout — browser to a recorded "order placed" event
+/walking-skeleton the new notifications service
+/walking-skeleton sign-in flow end to end
+```
+
+## Process
+
+### 0. Write the active-issue-skill marker (REQUIRED — me2resh/apexyard#268)
+
+Before any `gh issue create` (or other tracker CLI), write this skill's name to the active-issue-skill marker so `require-skill-for-issue-create.sh` lets the command through. At skill entry:
+
+```bash
+ops_root="$(r=$PWD;while [ ! -f \"$r/onboarding.yaml\" ] && [ \"$r\" != / ];do r=${r%/*};done;echo $r)"
+mkdir -p "$ops_root/.claude/session"
+echo "walking-skeleton" > "$ops_root/.claude/session/active-issue-skill"
+```
+
+Remove the marker on **every** exit path (success, early-exit, user cancel, error):
+
+```bash
+rm -f "$ops_root/.claude/session/active-issue-skill"
+```
+
+The `clear-issue-skill-marker.sh` SessionStart hook sweeps stale markers from killed sessions, but a clean exit should never leave one behind. See AgDR-0030.
+
+### 1. Resolve the target repo
+
+Read `.claude/session/current-ticket` to determine which repo we're working in. If no active ticket, check `apexyard.projects.yaml` for managed projects. If only one project, use it. If multiple, ask:
+
+```
+Which project is this walking skeleton for?
+```
+
+If no projects are registered, ask for the repo in `owner/repo` format.
+
+### 2. Verify the prefix is on the whitelist
+
+Read `.ticket.prefix_whitelist` from `.claude/project-config.*.json`. A walking skeleton is filed as a **[Feature]**-class ticket — it is kept and goes through the full SDLC. If `Feature` (case-insensitive) is not in the list, warn and stop:
+
+```
+This fork's ticket schema doesn't include 'Feature' as a valid prefix.
+Either add it to .claude/project-config.json → .ticket.prefix_whitelist, or
+file the ticket using whichever prefix the fork uses for delivery work.
+```
+
+(The shipped default includes `Feature`. This check exists for forks that have customised the whitelist.)
+
+### 3. Parse or ask for the title
+
+Take the feature/service name from `$ARGUMENTS`. If empty, ask:
+
+```
+What feature or service should the walking skeleton prove end to end?
+Give me a short name.
+```
+
+### 4. Gather details (one question at a time)
+
+Ask conversationally — do NOT batch all questions. Wait for each answer before asking the next. Fields a–d are required; e is optional.
+
+**a) Layers crossed (required)**
+
+```
+List every architectural layer the slice must touch, in order. The
+skeleton proves integration, so it has to pass through ALL of them, even
+if each does the most trivial thing possible. Example for a web app:
+
+  browser/UI → HTTP route → application handler → domain → datastore
+  → response → deploy target
+
+What are yours? (If you can't name the layers, the architecture isn't
+defined enough for a skeleton yet — push back.)
+```
+
+If the user can't enumerate the layers, the skeleton isn't ready — say so and help them name the architecture first.
+
+**b) The thinnest happy path (required)**
+
+```
+Describe the ONE trivial end-to-end path the skeleton exercises. It must
+be real (actually runs/deploys), but contain no business logic beyond the
+thinnest happy path. Examples:
+  - "POST /orders with a hardcoded line item returns 201 and writes one
+     row; a deployed smoke test reads it back."
+  - "Click 'Sign in', the request reaches the auth handler, returns a
+     stub token, the UI shows 'signed in'."
+
+What's the single thin path?
+```
+
+Reject anything with branching logic, validation rules, or multiple
+features — that belongs in the features built ON TOP of the skeleton.
+
+**c) Definition of done — runs AND deploys (required)**
+
+```
+How do we prove the skeleton is alive? A walking skeleton is not done
+until it actually runs end-to-end AND deploys (or runs in the target
+environment). Give the concrete check(s):
+  - "Deployed to staging; a smoke test hits the live URL and asserts 201."
+  - "CI runs the slice end-to-end; the deploy job is green."
+
+What's the proof-of-life?
+```
+
+The "actually deploys / runs in the real environment" bar is the whole
+point — a skeleton that only runs on localhost hasn't proven the
+architecture. Push for a deploy/run check.
+
+**d) In scope vs out of scope (required)**
+
+```
+Draw the line explicitly. IN scope = the wiring (every layer, one thin
+path, deploy). OUT of scope = every feature built later on top of the
+skeleton (validation, error handling, additional endpoints, business
+rules, real auth, edge cases).
+
+Give me 2-3 IN bullets (the wiring) and 2-3 OUT bullets (features for
+later). This boundary is what keeps a skeleton from quietly growing into
+a half-built feature.
+```
+
+This in/out boundary is load-bearing — it is the AC that keeps the
+skeleton thin. Don't skip it.
+
+**e) Acceptance criteria (optional — derived if skipped)**
+
+```
+Any specific acceptance criteria beyond "every layer is wired, the thin
+path runs, and it deploys"? (or press Enter to derive them from the
+answers above)
+```
+
+If skipped, derive ACs from a–d. Every walking-skeleton ticket MUST carry, at minimum, these three ACs (kept work — full SDLC applies):
+
+- [ ] Every named layer is exercised by the slice (integration proven, not mocked end-to-end)
+- [ ] The slice actually runs/deploys in the target environment (proof-of-life check passes)
+- [ ] The slice's domain logic has tests with **> 80% coverage** (this is KEPT code — NOT spike-exempt) and passes Rex code review + the security gate
+
+### 5. Show the formatted ticket for confirmation
+
+Resolve the ticket body template via the portfolio helper so adopter overrides win when present:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+template=$(portfolio_resolve_template tickets/feature.md)   # walking skeletons are [Feature]-class
+```
+
+A walking skeleton reuses the `[Feature]` body shape (it is a kept feature). Display the full ticket; the User Story names the skeleton, the Acceptance Criteria carry the three mandatory ACs from step 4e, and the Out of Scope section carries the OUT bullets from step 4d:
+
+```
+Here's the ticket I'll create:
+
+---
+**[Feature] Walking skeleton — {title}**
+
+## User Story
+As a team building {title}, I want the thinnest end-to-end slice wired
+through every architectural layer ({layers}) so that integration and
+architecture are proven early and we build the real product on top of it.
+
+## Acceptance Criteria
+- [ ] Every layer is exercised by the slice: {layers}
+- [ ] The thin happy path runs end-to-end: {thin path}
+- [ ] The slice actually runs/deploys: {proof-of-life}
+- [ ] Domain logic of the slice has tests with > 80% coverage (KEPT code,
+      not spike-exempt) and passes Rex + the security gate
+- [ ] {any extra ACs from step 4e}
+
+## In Scope (the wiring)
+- {in bullet 1}
+- {in bullet 2}
+
+## Out of Scope (features built later on the skeleton)
+- {out bullet 1}
+- {out bullet 2}
+
+## Glossary
+| Term | Definition |
+|------|------------|
+| Walking skeleton | Thinnest end-to-end slice exercising the whole architecture; kept and grown into the product (Cockburn). |
+---
+
+Labels: enhancement
+Repo: {owner/repo}
+
+Suggested branch when you start work:
+  feature/<TICKET-ID>-{slug}-skeleton
+
+Create this ticket? (yes / edit / cancel)
+```
+
+### 6. Handle response
+
+- **yes** / **looks good** / **go** → create the issue
+- **edit** / **change X** → ask what to change, update, re-show
+- **cancel** / **no** → abort
+
+### 7. Create the GitHub Issue
+
+```bash
+gh issue create --repo {owner/repo} \
+  --title "[Feature] Walking skeleton — {title}" \
+  --label "enhancement" \
+  --body "{formatted body}"
+```
+
+Note: a walking skeleton is filed under the normal feature label (`enhancement` by default) — **NOT** under `spike`. The label matters: there is **no** `walking-skeleton` exemption label, because the skeleton is held to the full SDLC. If your fork uses a different feature label, use that.
+
+### 8. Return the URL + branch suggestion
+
+```
+Created: {owner/repo}#{number} — Walking skeleton — {title}
+{url}
+
+When you start work:
+  /start-ticket {owner/repo}#{number}
+  git checkout -b feature/GH-{number}-{slug}-skeleton
+```
+
+### 9. Remind the operator this is KEPT — full SDLC
+
+```
+This is a KEPT walking skeleton, not a throwaway. It goes through the
+full SDLC:
+  - tests with > 80% coverage on the slice's domain logic
+  - Rex code review + security gate
+  - all merge gates (NOT exempt like /spike or /prototype)
+
+Build the real features ON TOP of the merged skeleton, one ticket at a
+time. If you instead wanted to answer "will it technically work?" or
+"what should it look like?", you wanted /spike or /prototype — both
+throwaway.
+```
+
+## Rules
+
+1. **One question at a time.** Never batch questions. Wait for each answer.
+2. **Always confirm before creating.** Show the full ticket and get explicit "yes".
+3. **Required fields are mandatory.** Layers crossed, the thinnest happy path, the runs-AND-deploys definition of done, and the in/out scope boundary — none can be skipped.
+4. **KEPT, not throwaway.** A walking skeleton is filed as a `[Feature]` and held to the full SDLC. It is explicitly **NOT** exempt from the AgDR or > 80% coverage gates the way `/spike` and `/prototype` are. Do not apply the `spike` label or any exemption label.
+5. **No business logic beyond the thinnest happy path.** The skeleton proves wiring, not behaviour. Branching, validation, edge cases, additional features → Out of Scope, built later on top.
+6. **Actually runs/deploys.** The definition of done includes a real run/deploy check. A skeleton that only compiles, or only runs on localhost, hasn't proven the architecture.
+7. **Branch suggestion.** Always `feature/<TICKET-ID>-<slug>-skeleton`.
+8. **Cross-reference the taxonomy.** If the user really wanted a throwaway technical answer, redirect to `/spike`; if they wanted a throwaway UX/demo direction, redirect to `/prototype`.
+
+## Where this sits in the SDLC
+
+A walking skeleton is **Build-phase work like any feature** — it just happens to be the *first* feature, and its purpose is to prove the architecture rather than deliver user value. It carries no exemptions:
+
+| Gate | Walking-skeleton work |
+|------|------------------------|
+| Pre-Build (ticket, ACs) | Required — the skeleton ticket carries the wiring ACs |
+| AgDR for technical decisions | Required — the skeleton usually MAKES the architecture decisions (it's the first place they're committed); record them with `/decide` |
+| Test coverage > 80% | Required — KEPT code; the slice's domain logic is tested |
+| Code Reviewer agent (Rex) | Required |
+| Security Auditor (auth/crypto/secrets diff) | Required |
+| Glossary in PR body | Required |
+| QA Engineer verification | Required (AC verification: every layer wired, runs/deploys) |
+
+See `.claude/rules/workflow-gates.md`, `.claude/skills/spike/SKILL.md` (the throwaway technical sibling), and `.claude/skills/prototype/SKILL.md` (the throwaway UX sibling).
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,10 +199,10 @@ ApexYard ships with a `.claude/` directory containing the Claude Code primitives
 | Rules | `.claude/rules/` | 12 modular rule files (AgDR triggers, code standards, git conventions, leak protection, loop mode, parallel work, plan mode, PR quality, PR workflow, role triggers, ticket vocabulary, workflow gates) |
 | Handbooks | `handbooks/` | Adopter-authored coding standards consumed by Rex during code review. Discovery by path-convention (`architecture/` + `general/` always-load; `language/<lang>/` loads on diff-match). Advisory by default; opt in to blocking via `ENFORCEMENT: blocking` marker. See [`handbooks/README.md`](handbooks/README.md). |
 | Agents | `.claude/agents/` | 24 sub-agents (5 utility incl. Hakim post-consolidation + 7 engineering + 1 architecture (Tariq) + 6 product-design + 5 security-data). Per AgDR-0050 + the #347 PR 3 Hatim→Hakim consolidation decision + AgDR-0054 (Solution Architect). |
-| Skills | `.claude/skills/` | 59 slash commands — see the full list below |
+| Skills | `.claude/skills/` | 62 slash commands — see the full list below |
 | Settings | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
 
-### Available skills (59)
+### Available skills (62)
 
 One-line summary per skill; canonical details live in each `.claude/skills/<name>/SKILL.md`.
 
@@ -240,8 +240,11 @@ One-line summary per skill; canonical details live in each `.claude/skills/<name
 | `/task` | Create a structured technical task ticket (driver + scope + ACs) |
 | `/tickets-batch` | Bulk-file 5–20 structured tickets in one shared-context flow |
 | `/migration` | Create a labelled migration ticket + migration AgDR (required by migration gate) |
-| `/spike` | Create a time-boxed, hypothesis-driven spike ticket (exempt from AgDR + coverage gates) |
+| `/spike` | Create a time-boxed, hypothesis-driven spike ticket — answers "will it technically work?" (throwaway; exempt from AgDR + coverage gates) |
 | `/spike-close` | Disposition gate for spikes — `--promote` files a feature, `--discard` writes a memo |
+| `/prototype` | Create a throwaway UX/demo prototype ticket — answers "what should it look/feel like?" (throwaway; same AgDR + coverage exemptions as `/spike`) |
+| `/prototype-close` | Disposition gate for prototypes — `--promote` files a feature, `--discard` writes a memo (mirror of `/spike-close`) |
+| `/walking-skeleton` | Scaffold a `[Feature]`-class ticket for the thinnest end-to-end slice through every architectural layer — **kept** and grown into the product (full SDLC; NOT exempt) |
 | `/codify-rule` | Turn a review comment that caught a Rex-miss into a draft handbook entry |
 | `/investigation` | Create an investigation ticket + live-doc for sustained root-cause work |
 | `/idea` | Capture a new product idea to the shared backlog |
@@ -304,7 +307,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Rules (modular, framework-wide) | `.claude/rules/` |
 | **Adopter handbooks** (consumed by Rex during code review) | `handbooks/` — see [`handbooks/README.md`](handbooks/README.md) for the discovery + advisory/blocking conventions |
 | Agents | `.claude/agents/` |
-| Skills (59 slash commands) | `.claude/skills/` |
+| Skills (62 slash commands) | `.claude/skills/` |
 | Hook wiring | `.claude/settings.json` |
 | **Per-project docs** | `projects/<name>/` |
 | **Live working copies** (gitignored) | `workspace/<name>/` |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ apexyard/
 │   ├── hooks/             # 40 shell scripts — ticket-first, migration gate, two-marker merge gate, red-CI block, secrets scan, branch/PR validation, leak protection, MCP-reindex advisories, upstream-drift banner
 │   ├── rules/             # 12 modular rule files imported via @.claude/rules/* (agdr-decisions, code-standards, git-conventions, leak-protection, loop-mode, parallel-work, plan-mode, pr-quality, pr-workflow, role-triggers, ticket-vocabulary, workflow-gates)
 │   ├── agents/            # 24 sub-agents — Rex (Code Reviewer), Hakim (Security Auditor), Tariq (Solution Architect), the engineering / product / design / data / security personas, plus utility agents (PR & ticket managers, dependency auditor)
-│   └── skills/            # 59 slash commands — see CLAUDE.md for the full list
+│   └── skills/            # 62 slash commands — see CLAUDE.md for the full list
 │
 ├── workspace/             # Live local clones of managed projects — gitignored
 ├── projects/              # Per-project committed docs (README, roadmap, AgDRs, updates)

--- a/docs/agdr/AgDR-0077-walking-skeleton-and-prototype-skills.md
+++ b/docs/agdr/AgDR-0077-walking-skeleton-and-prototype-skills.md
@@ -1,0 +1,42 @@
+# Walking-Skeleton + Prototype skills — completing the early-work taxonomy
+
+> In the context of ApexYard's early-SDLC scaffolding (which shipped only `/spike` for pre-build exploration), facing two recurring gaps — no first-class home for throwaway **UX/demo** exploration and no scaffold for a **kept** thin end-to-end slice — I decided to add `/prototype` (+ `/prototype-close`) and `/walking-skeleton` as two new skills sitting on the same two axes as `/spike` (throwaway-vs-kept × technical-vs-UX), accepting a +3 skill count (59 → 62) and the maintenance cost of keeping the prototype exemption logic in lockstep with the spike exemption logic.
+
+## Context
+
+ApexYard already shipped `/spike` for hypothesis-driven, time-boxed, throw-away **technical** exploration ("will it work?"), with `/spike-close` as its disposition gate and surgical AgDR + coverage exemptions (see AgDR-0017). Two adjacent kinds of early work had no first-class scaffold:
+
+1. **Throwaway UX/demo exploration** — a clickable mockup or demo flow that answers *"what should this look and feel like?"*. Teams were filing these as features (wrong bar — they get held to production gates they should be exempt from) or as spikes (wrong vocabulary — a spike answers a technical question, not a UX-direction one).
+2. **A kept thin end-to-end slice** — the thinnest happy path wired through every architectural layer (UI → API → domain → store → deploy → back), proving integration and architecture early, then grown into the product. This is the deliberate *opposite* of a spike: minimal but **production-shaped and kept**, so it must be held to the FULL SDLC. There was no scaffold guiding in-scope (the wiring) vs out-of-scope (features built later on top).
+
+The early-work space is naturally a 2×2 (throwaway-vs-kept × technical-vs-UX). `/spike` filled one cell; two cells were empty.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Add `/prototype` (+`/prototype-close`) and `/walking-skeleton` as new skills, mirroring the spike pattern** | Completes the 2×2 taxonomy; prototype reuses the proven spike exemption shape; walking-skeleton gets explicit "kept, full SDLC, NOT exempt" framing to prevent accidental promotion of throwaway work | +3 skills to maintain; the prototype exemption logic must track the spike exemption logic in two hooks |
+| Overload `/spike` with a `--ux` / `--skeleton` flag | No new skill files | Conflates three different lifecycles + disposition rules behind one command; flags hide the kept-vs-throwaway distinction that is the whole point; `/walking-skeleton` is NOT exempt, so it can't share the spike's exemption gates |
+| Document the taxonomy in prose only (no scaffolds) | Zero code | No structured ticket bodies, no gate wiring, no disposition gate — the same author-avoidance failure mode `/spike` was created to fix |
+
+## Decision
+
+Chosen: **add `/prototype` + `/prototype-close` + `/walking-skeleton`**, because completing the taxonomy with real scaffolds (structured ticket templates, gate wiring, a disposition gate for the throwaway one) is what makes the distinction enforceable rather than aspirational.
+
+- **`/prototype`** scaffolds a throwaway `[Prototype]` UX/demo ticket (DISCARD-by-default), with **`/prototype-close`** as the disposition gate mirroring `/spike-close`. It shares the spike AgDR + coverage exemptions; code review (Rex) and security still apply.
+- **`/walking-skeleton`** scaffolds a `[Feature]`-class ticket for the thinnest kept end-to-end slice. It is held to the FULL SDLC (tests, >80% coverage on the slice's domain logic, Rex, all gates) and is explicitly **NOT** exempt — preventing the expensive confusion where throwaway exploration is accidentally promoted into production.
+
+The two AgDR exemption hooks (`require-agdr-for-arch-pr.sh`, `require-agdr-for-arch-changes.sh`) now recognise the prototype exemption the same three ways as spike: `prototype(...)` PR type, `[Prototype]` ticket prefix, `prototype/` branch. The walking skeleton deliberately gets no exemption.
+
+## Consequences
+
+- Skill count rises **59 → 62** (`/prototype`, `/prototype-close`, `/walking-skeleton`); CLAUDE.md, README.md, and `loop-mode.md`'s "62 slash commands" prose updated to match.
+- `project-config.defaults.json` gains `Prototype` in the ticket-prefix whitelist (+ `required_sections`) and `prototype` in the branch / commit / PR-title type whitelists; `git-conventions.md` documents the new type.
+- `workflows/sdlc.md` Phase 1 gains a taxonomy sidebar; `workflow-gates.md` spike-exemption section notes prototype shares the exemption and walking-skeleton does not.
+- Ongoing maintenance coupling: any future change to the spike exemption detection must be mirrored for prototype in both AgDR hooks (covered by the new test cases in `test_require_agdr_for_arch_pr.sh`).
+
+## Artifacts
+
+- Re-landed on me2resh/apexyard (canonical) from the retired atlas fork PR #2 (`feat(#672): add /walking-skeleton + /prototype skills`).
+- Closes #672, #673.
+- Skills: `.claude/skills/{walking-skeleton,prototype,prototype-close}/SKILL.md`; template: `templates/tickets/prototype.md`.

--- a/templates/tickets/prototype.md
+++ b/templates/tickets/prototype.md
@@ -1,0 +1,50 @@
+<!-- Source: ApexYard · templates/tickets/prototype.md · github.com/me2resh/apexyard · MIT -->
+
+**[Prototype] {title}**
+
+## Direction Question
+
+{The single "what should this look and feel like?" question the prototype
+answers. One sentence. A prototype explores a UX/demo direction, NOT
+technical feasibility — if the question is "will this work?", file a
+`/spike` instead.}
+
+## Fidelity
+
+{What kind of disposable artifact this is and how far it goes. Examples:}
+
+- Clickable mockup (Figma export / static HTML, no real backend)
+- Demo flow (wired screens, stubbed data, happy-path only)
+- Interactive proof-of-concept UI (real framework, fake everything else)
+
+{The author commits: this is a throwaway artifact for learning a
+direction, not the start of production code.}
+
+## Budget
+
+{Hard cap on time/effort. Examples:}
+
+- 1 day of one engineer
+- 2 days, then we decide
+- Until the stakeholder demo on Friday
+
+{At the budget cap, the prototype ENDS regardless of polish.}
+
+## Disposition
+
+{What happens when the prototype closes. Author commits to ONE in advance —
+"decide later" is not allowed; that's how a throwaway mockup gets
+accidentally promoted into production:}
+
+- **PROMOTE** — the direction is chosen; file a fresh `[Feature]` ticket
+  for production-shaped delivery. The prototype artifact is NOT lifted into
+  production — the feature re-implements based on the chosen direction.
+- **DISCARD** — the direction is rejected (or "not now"); write a memo at
+  `docs/prototype-memos/<slug>.md` so future-us doesn't re-explore the same
+  ground.
+
+## Approach (optional)
+
+{Brief sketch of what you'll mock up. NOT a tech design. NOT a PRD. A few
+bullet points: which screens / flows, what tools (Figma, static HTML,
+v0, the real framework with stubs), what you're deliberately faking.}

--- a/workflows/sdlc.md
+++ b/workflows/sdlc.md
@@ -41,6 +41,16 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 - Work scheduled in sprint/cycle
 
 > **Sidebar — when to file a `/spike` instead of a `/feature`.** If you can answer the technical question through reasoning alone (will library X work, does this approach scale, does this UX make sense), feel free to draft the feature directly. If you genuinely don't know, file a `[Spike]` first via `/spike` — a 1-3 day, hypothesis-driven, throw-away-by-default ticket. The spike's output is the answer, not shippable code; once the answer is in, run `/spike-close --promote` (file a fresh `[Feature]` for production-shaped delivery) or `/spike-close --discard` (write a memo to `docs/spike-memos/<slug>.md` so future-us doesn't re-explore the same ground). Spike PRs are exempt from the AgDR + 80% coverage gates; code review (Rex) and the security auditor still apply. See `.claude/rules/workflow-gates.md` § Spike work and `templates/tickets/spike.md`.
+>
+> **Sidebar — the early-work taxonomy: `/spike` vs `/prototype` vs `/walking-skeleton`.** Three early-phase scaffolds across two axes (throwaway-vs-kept, technical-vs-UX):
+>
+> | Skill | Question | Lifecycle |
+> |-------|----------|-----------|
+> | `/spike` | "Will this **technically** work?" | THROWAWAY — `/spike-close` disposition |
+> | `/prototype` | "What should it **look and feel** like?" | THROWAWAY — `/prototype-close` disposition (same AgDR + coverage exemptions as `/spike`) |
+> | `/walking-skeleton` | "Is the **whole architecture** wired end-to-end?" | **KEPT** — thinnest end-to-end slice through every layer; full SDLC, NO exemptions; you grow the product on top of it |
+>
+> Spikes and prototypes are disposable (the *learning* survives, the code doesn't). A walking skeleton is the production spine — minimal but kept. Don't accidentally promote a throwaway into production: that confusion is exactly what this taxonomy exists to prevent.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Two new early-SDLC scaffolding skills complete the early-work taxonomy** — alongside the existing `/spike`, the framework now covers a clean 2×2 (throwaway-vs-kept × technical-vs-UX). `/spike` answers "will it technically work?" (throwaway); `/prototype` answers "what should it look/feel like?" (throwaway, new); `/walking-skeleton` answers "is the whole architecture wired end-to-end?" (kept, new). This closes the two empty cells that previously forced UX/demo work and thin-slice work into the wrong scaffold (feature = over-gated, spike = wrong vocabulary).
- **`/prototype` + `/prototype-close`** — `/prototype` scaffolds a throwaway `[Prototype]` UX/demo ticket (DISCARD-by-default); `/prototype-close` is its disposition gate, mirroring `/spike-close` (`--promote` files a feature, `--discard` writes a memo). Prototype work shares the spike AgDR + coverage exemptions so disposable UX exploration isn't held to the full production bar; Rex code review and security gates still apply.
- **`/walking-skeleton`** — scaffolds a `[Feature]`-class ticket for the thinnest end-to-end slice wired through every architectural layer (UI → API → domain → store → deploy → back). Deliberately the **opposite** of a spike/prototype: minimal but **kept and production-shaped**, held to the FULL SDLC (tests, >80% coverage on the slice's domain logic, Rex, all gates) — explicitly **NOT** exempt. The framing prevents the expensive confusion where throwaway exploration is accidentally promoted into production.
- **Gate wiring** — both AgDR hooks (`require-agdr-for-arch-pr.sh`, `require-agdr-for-arch-changes.sh`) now recognise the prototype exemption the same three ways as spike: `prototype(...)` PR type, `[Prototype]` ticket prefix, `prototype/` branch. New cases in `test_require_agdr_for_arch_pr.sh` cover the title + branch signals. `project-config.defaults.json` adds `Prototype` to the ticket-prefix whitelist (+ `required_sections`) and `prototype` to the branch / commit / PR-title type whitelists; `git-conventions.md` documents the new type.
- **Docs + count** — skill count bumps **59 → 62** (the +3 = `/prototype`, `/prototype-close`, `/walking-skeleton`; prototype faithfully mirrors `/spike`'s separate disposition skill) across `CLAUDE.md` (table + 3 headings) and `README.md`, plus the `loop-mode.md` "62 slash commands" prose. `workflows/sdlc.md` Phase 1 gains a taxonomy sidebar; `workflow-gates.md` notes prototype shares the spike exemption and walking-skeleton does not. `templates/tickets/prototype.md` is the new ticket body. **`docs/agdr/AgDR-0077`** records the taxonomy-completion decision.

> Re-landed on **me2resh/apexyard** (canonical) from the retired **atlas** fork PR #2. The atlas branch's regenerated `site/*` artifacts were dropped — `site/` was removed from `dev` in #663 and is not reintroduced here.

## Testing

1. `bash bin/run-hook-tests.sh` → **69 PASS / 0 FAIL** (includes `test_require_agdr_for_arch_pr.sh` exercising the new prototype detection).
2. `bash bin/run-pre-push-checks.sh` → **all checks passed** (markdownlint, shellcheck, subpacks).
3. `markdownlint-cli2` on all 11 changed markdown files → **0 errors**.
4. `ls -d .claude/skills/*/ | wc -l` → **62** (matches the bumped count in README/CLAUDE).
5. Diff scope verified: 15 files (3 skills + template + AgDR + 2 AgDR hooks + 1 hook test + project-config + 3 rules + CLAUDE + README + sdlc). **No `site/` files.**

## Glossary

| Term | Definition |
|------|------------|
| Walking skeleton | The thinnest happy path wired end-to-end through every architectural layer, with no business logic beyond that path — runs and deploys so integration/architecture is proven early. **Kept** and grown into the product. |
| Prototype (here) | A throwaway UX/demo artifact (clickable mockup, demo flow) built to answer "what should this look/feel like?". Discarded once the direction is chosen. |
| Spike | Throwaway, time-boxed, hypothesis-driven **technical** exploration ("will it work?"). The existing sibling skill these two complete. |
| Disposition gate | The close step (`/spike-close`, `/prototype-close`) that forces an explicit PROMOTE (file a feature) or DISCARD (write a memo) decision before a throwaway ticket is closed. |
| AgDR exemption | The surgical waiver of the AgDR + >80% coverage gates for throwaway work (spike, prototype). Code review (Rex) and security gates still apply. |
| Re-land | Porting work that was built and merged on a now-retired fork (atlas) cleanly onto the canonical repo (me2resh), preserving the canonical branch's content and applying the work additively. |

<!-- multi-close: approved -->
Closes #672
Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQWFvN2vzy1UtFX2FyaDvb
