### PR TITLE
fix(#668): rename jq `def` binding so detection works on jq 1.6

### DIFF
--- a/.claude/hooks/_lib-detect-deprecated-config.sh
+++ b/.claude/hooks/_lib-detect-deprecated-config.sh
@@ -91,9 +91,12 @@ detect_deprecated_config_keys() {
   #   - subtract default keys from override keys
   #   - filter out leading-underscore metadata
   #   - emit one per line, sorted for stable output
-  jq -r --slurpfile def "$defaults" '
+  # NOTE: the slurpfile binding is named `defaults_doc`, not `def`. `def` is a
+  # reserved keyword in jq's grammar (function definitions), and jq 1.6 rejects
+  # it as a variable name with a parse error — see me2resh/apexyard#668.
+  jq -r --slurpfile defaults_doc "$defaults" '
     [keys[]] as $okeys
-    | ($def[0] | keys) as $dkeys
+    | ($defaults_doc[0] | keys) as $dkeys
     | $okeys
     | map(select(
         (. as $k | $dkeys | index($k) | not)

--- a/.claude/hooks/tests/test_detect_deprecated_config.sh
+++ b/.claude/hooks/tests/test_detect_deprecated_config.sh
@@ -203,6 +203,33 @@ fi
 rm -rf "$SB7"
 
 # ---------------------------------------------------------------------------
+# Case 8: no jq binding (--arg / --argjson / --slurpfile / --rawfile) in the
+# helper uses a reserved jq keyword as its variable name (regression for
+# me2resh/apexyard#668). `def` et al. are grammar keywords; jq 1.6 rejects
+# them as variable names with a parse error, while jq 1.8+ is lenient — so a
+# behavioural test on a modern jq can't catch this. A static grep can, on any
+# jq version.
+# ---------------------------------------------------------------------------
+echo
+echo "Case 8: no reserved jq keyword used as a binding name"
+# jq grammar keywords that are invalid as $-variable names.
+reserved="def as import include if then elif else end and or reduce foreach try catch label __loc__"
+bad_bindings=""
+for kw in $reserved; do
+  if grep -Eq -- "--(arg|argjson|slurpfile|rawfile)[[:space:]]+${kw}([[:space:]]|\$)" "$LIB_SRC"; then
+    bad_bindings="$bad_bindings $kw"
+  fi
+done
+if [ -z "$bad_bindings" ]; then
+  PASS=$((PASS + 1))
+  echo "PASS: no reserved jq keyword used as a binding name"
+else
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  - reserved jq keyword binding(s):$bad_bindings"
+  echo "FAIL: reserved jq keyword(s) used as binding name(s):$bad_bindings"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo


### PR DESCRIPTION
See https://github.com/me2resh/apexyard/issues/668

## Summary
- **Root cause** — `detect_deprecated_config_keys` in `_lib-detect-deprecated-config.sh` bound the defaults file to a jq variable named `def` via `--slurpfile def`. `def` is a reserved keyword in jq's grammar (it introduces function definitions), so **jq 1.6 rejects it as a `$`-variable name with a parse error**. jq 1.8+ is lenient, which is why the bug never surfaced in local testing.
- **Fix** — renamed the binding `def` → `defaults_doc` (and the `$def[0]` reference). Pure rename, **zero behavioural change**: same JSON read, same filter, same sorted output.
- **Regression guard** — added Case 8 to `test_detect_deprecated_config.sh`: a **version-independent static check** that fails if any jq binding (`--arg`/`--argjson`/`--slurpfile`/`--rawfile`) uses a reserved jq keyword as its variable name. The existing behavioural tests can't catch this on a lenient jq (1.8+); a static grep catches it on any version. Verified to FAIL on the pre-fix code and PASS on the fix.

## Testing
1. `bash .claude/hooks/tests/test_detect_deprecated_config.sh` → `PASS: 8, FAIL: 0`.
2. Negative check: reintroducing `--slurpfile def` makes Case 8 fail with `reserved jq keyword(s): def`.
3. `grep -n "def" .claude/hooks/_lib-detect-deprecated-config.sh` → no `$def` / `--*file def` references remain; only `--slurpfile defaults_doc` and `--arg k` (both safe).

Closes #668

---

## Glossary
| Term | Definition |
|------|------------|
| jq reserved keyword | A word that is part of jq's grammar (`def`, `as`, `if`, `then`, `reduce`, `try`, `label`, …) and therefore cannot be used as a `$`-variable binding name. jq 1.6 enforces this strictly; jq 1.8+ is lenient. |
| `--slurpfile name file` | jq flag that reads `file` as a JSON stream into an array and binds it to `$name`. The bug was that `name` was `def`. |
| deprecated config key | A top-level key present in a project's `project-config.json` override but no longer present in `project-config.defaults.json` — i.e. config that upstream has removed, surfaced advisorily by `/update`. |
| version-independent test | A test whose pass/fail outcome does not depend on the jq version running it (here: a static `grep`, not a behavioural jq invocation). |