### PR TITLE
fix(#669): re-root arch-PR diff to the command's cd-target

### DIFF
--- a/.claude/hooks/_lib-pr-repo.sh
+++ b/.claude/hooks/_lib-pr-repo.sh
@@ -31,6 +31,13 @@
 #       (or if there is no `--repo` flag, in which case they implicitly match).
 #       Returns 1 if they differ (cross-repo context).
 #
+#   pr_cmd_cd_target <command>
+#       Echoes the path from a leading `cd <path> && …` (or `cd <path>; …`)
+#       prefix in the command, or empty string if absent. Used by PR-create
+#       hooks to discover the directory the `gh` call is ABOUT to run in — the
+#       PreToolUse hook fires before the in-command `cd` executes, so the
+#       hook's own cwd is NOT yet the PR's repo (me2resh/apexyard#669).
+#
 # USAGE
 # -----
 #   . "$(dirname "$0")/_lib-pr-repo.sh"
@@ -115,6 +122,26 @@ git_origin_repo() {
   local url
   url=$(git -C "$git_dir" remote get-url origin 2>/dev/null) || return 1
   _git_remote_to_slug "$url"
+}
+
+# Public: pr_cmd_cd_target <command>
+#   Echoes the path from a leading `cd <path> && …` / `cd <path>; …` prefix,
+#   or empty string when the command does not start with a `cd`.
+#
+#   Only a `cd` at the START of the command is honoured (the harness-generated
+#   `cd <repo> && gh pr …` pattern). A `cd` buried later in a pipeline is
+#   intentionally ignored — it does not establish the directory the leading
+#   `gh` runs in. Handles unquoted, single-quoted, and double-quoted paths so
+#   `cd '../my repo' && …` resolves correctly.
+pr_cmd_cd_target() {
+  local cmd="$1"
+  # Strip leading whitespace, then match `cd ` followed by a quoted or bare
+  # path up to the first `&&`, `;`, or `|` separator.
+  printf '%s' "$cmd" | sed -nE \
+    "s/^[[:space:]]*cd[[:space:]]+\"([^\"]+)\"[[:space:]]*(&&|;|\|).*/\1/p;
+     s/^[[:space:]]*cd[[:space:]]+'([^']+)'[[:space:]]*(&&|;|\|).*/\1/p;
+     s/^[[:space:]]*cd[[:space:]]+([^&;|[:space:]]+)[[:space:]]*(&&|;|\|).*/\1/p" \
+    | head -1
 }
 
 # Public: pr_repo_matches_cwd <command> [<git-dir>]

--- a/.claude/hooks/require-agdr-for-arch-pr.sh
+++ b/.claude/hooks/require-agdr-for-arch-pr.sh
@@ -148,32 +148,76 @@ if [ -z "$REPO_ROOT" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# 2a-0. Source the PR-repo lib up front. We need two things from it:
+#   - pr_cmd_cd_target  → re-root the diff to the cd-target (#669)
+#   - pr_repo_matches_cwd → the cross-repo guard (#464)
+# ---------------------------------------------------------------------------
+
+HOOK_DIR_AGDR="$(cd "$(dirname "$0")" && pwd)"
+PR_REPO_LIB_OK=0
+if [ -f "$HOOK_DIR_AGDR/_lib-pr-repo.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR_AGDR/_lib-pr-repo.sh"
+  PR_REPO_LIB_OK=1
+fi
+
+# ---------------------------------------------------------------------------
+# 2a-i-a. Re-root the diff to the command's `cd` target (me2resh/apexyard#669).
+#
+# The harness fires this PreToolUse hook BEFORE the shell runs the command, so
+# a `cd <repo> && gh pr create …` prefix has NOT yet changed the working dir —
+# the hook's cwd is still the ops fork. Without re-rooting, the diff below
+# reflects the FORK's working tree (which may carry recent arch-path commits),
+# producing a phantom "architecture changes" block on a PR that is actually
+# being created in a DIFFERENT repo (a split-portfolio private repo, or a
+# `workspace/<project>/` clone in single-fork mode) and touches none of them.
+#
+# Fix: if the command begins with `cd <path> &&`, evaluate all working-tree
+# git operations against <path>'s repo. Config + session markers stay anchored
+# to REPO_ROOT (the ops fork) — only the *diff* tree moves.
+# ---------------------------------------------------------------------------
+
+DIFF_DIR="$REPO_ROOT"
+if [ "$PR_REPO_LIB_OK" = 1 ]; then
+  CD_TARGET=$(pr_cmd_cd_target "$COMMAND")
+  if [ -n "$CD_TARGET" ]; then
+    CD_TOPLEVEL=$(git -C "$CD_TARGET" rev-parse --show-toplevel 2>/dev/null)
+    if [ -n "$CD_TOPLEVEL" ]; then
+      DIFF_DIR="$CD_TOPLEVEL"
+    fi
+    # If <path> is not a readable git tree, fall through with DIFF_DIR=REPO_ROOT
+    # — no worse than the pre-#669 behaviour.
+  fi
+fi
+
+# All working-tree git operations below run against DIFF_DIR (the repo the PR
+# is actually being created in). Markers + config remain anchored to REPO_ROOT.
+gitd() { git -C "$DIFF_DIR" "$@"; }
+
+# ---------------------------------------------------------------------------
 # 2a-i. Cross-repo guard (me2resh/apexyard#464).
 #
-# When the hook fires on a `gh pr create --repo <X>` command but the current
-# git working tree belongs to a DIFFERENT repo (e.g. the session is pinned to
-# the ops-fork while the command targets a sibling repo), the diff computed
-# below reflects the ops-fork's changed files — NOT the PR's actual diff.
-# That produces false-positive blocks for PRs that don't touch any framework
+# When the hook fires on a `gh pr create --repo <X>` command but the diff tree
+# belongs to a DIFFERENT repo (e.g. the session is pinned to the ops-fork while
+# the command targets a sibling repo with no local checkout), the diff computed
+# below reflects the wrong working tree — NOT the PR's actual diff. That
+# produces false-positive blocks for PRs that don't touch any framework
 # architecture paths.
 #
 # Fix: compare the PR target repo (--repo flag, or implicit same-repo) to the
-# origin remote of the current working tree. If they differ, we cannot compute
-# a meaningful diff for this PR from this cwd → exit 0 (no-op).
+# origin remote of the diff tree. If they differ, we cannot compute a
+# meaningful diff for this PR from here → exit 0 (no-op).
 #
 # Framework gating is preserved: when creating a me2resh/apexyard PR from the
 # framework cwd, the --repo value matches origin → the guard does NOT fire and
 # the diff check runs as usual.
 # ---------------------------------------------------------------------------
 
-HOOK_DIR_AGDR="$(cd "$(dirname "$0")" && pwd)"
-if [ -f "$HOOK_DIR_AGDR/_lib-pr-repo.sh" ]; then
-  # shellcheck source=/dev/null
-  . "$HOOK_DIR_AGDR/_lib-pr-repo.sh"
-  if ! pr_repo_matches_cwd "$COMMAND" "$REPO_ROOT"; then
-    # PR targets a different repo than this working tree — cannot evaluate
-    # the arch-path diff from here. Silently pass; the hook in that repo's
-    # own CI context will gate this correctly.
+if [ "$PR_REPO_LIB_OK" = 1 ]; then
+  if ! pr_repo_matches_cwd "$COMMAND" "$DIFF_DIR"; then
+    # PR targets a different repo than the diff tree — cannot evaluate the
+    # arch-path diff from here. Silently pass; the hook in that repo's own CI
+    # context will gate this correctly.
     exit 0
   fi
 else
@@ -254,7 +298,7 @@ spike_pr_exempt() {
 
   # (c) branch named spike/... or prototype/...
   local branch
-  branch=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null)
+  branch=$(gitd branch --show-current 2>/dev/null)
   if echo "$branch" | grep -qE '^(spike|prototype)/'; then
     return 0
   fi
@@ -283,7 +327,7 @@ BASE_REF=""
 resolve_ref() {
   # Verify a ref exists; echo it if so, else empty.
   local ref="$1"
-  if git rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then
+  if gitd rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then
     echo "$ref"
   fi
 }
@@ -308,12 +352,12 @@ if [ -z "$BASE_REF" ]; then
   exit 0
 fi
 
-MERGE_BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null)
+MERGE_BASE=$(gitd merge-base HEAD "$BASE_REF" 2>/dev/null)
 if [ -z "$MERGE_BASE" ]; then
   exit 0
 fi
 
-CHANGED_FILES=$(git diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null)
+CHANGED_FILES=$(gitd diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null)
 if [ -z "$CHANGED_FILES" ]; then
   # No files changed — nothing to evaluate.
   exit 0
@@ -443,8 +487,8 @@ while IFS= read -r depfile; do
     [ -z "$file" ] && continue
     case "$depfile" in
       package.json)
-        BASE_JSON=$(git show "$MERGE_BASE:$file" 2>/dev/null)
-        HEAD_JSON=$(git show "HEAD:$file" 2>/dev/null)
+        BASE_JSON=$(gitd show "$MERGE_BASE:$file" 2>/dev/null)
+        HEAD_JSON=$(gitd show "HEAD:$file" 2>/dev/null)
         # File may be newly added → BASE_JSON empty → any deps are additions.
         if [ -z "$BASE_JSON" ]; then
           if [ -n "$HEAD_JSON" ] && command -v jq >/dev/null 2>&1; then
@@ -478,7 +522,7 @@ while IFS= read -r depfile; do
         ;;
       *)
         # Non-JSON heuristic. Pull the unified diff for this file.
-        DIFF=$(git diff "$MERGE_BASE"..HEAD -- "$file" 2>/dev/null)
+        DIFF=$(gitd diff "$MERGE_BASE"..HEAD -- "$file" 2>/dev/null)
         [ -z "$DIFF" ] && continue
         ADDED_LINES=$(echo "$DIFF" | grep -cE '^\+[^+]' || true)
         REMOVED_LINES=$(echo "$DIFF" | grep -cE '^-[^-]' || true)

--- a/.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
+++ b/.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
@@ -351,6 +351,89 @@ run_case "embedded quote, no AgDR ref at all → still BLOCKS (true-negative) [#
   "gh pr create --base main --title 'feat(#3): tweak domain' --body 'Uses \"greedy\" matching but forgot to add the decision record.'"
 
 # ---------------------------------------------------------------------------
+# Two-repo `cd <target> && gh pr create` (no --repo) — me2resh/apexyard#669.
+#
+# The hook fires from the cwd tree (the ops fork, which carries arch changes
+# on HEAD) BEFORE the in-command `cd` executes. Without re-rooting the diff to
+# the cd-target, the hook diffs the cwd tree and false-blocks a docs-only PR
+# that is actually being created in a *different* repo (the split-portfolio
+# private repo, or a `workspace/<project>/` clone in single-fork mode).
+#
+# The fix: when the command begins with `cd <path> && …`, evaluate the PR diff
+# against <path>'s git tree, not the cwd's.
+# ---------------------------------------------------------------------------
+
+# Build a sibling target repo with a docs-only feature branch (no arch paths).
+make_target_repo_docs() {
+  local pdir
+  pdir=$(mktemp -d -t agdr-tgt.XXXXXX)
+  (
+    cd "$pdir" || exit 1
+    git init -q -b main
+    git config user.email t@t.test
+    git config user.name test
+    git remote add origin git@github.com:test-org/portfolio.git
+    mkdir -p docs
+    echo "# registry" > docs/readme.md
+    git add docs/readme.md
+    git commit -q -m "base: docs"
+    git checkout -q -b feature
+    echo "# registry update" >> docs/readme.md
+    git add docs/readme.md
+    git commit -q -m "docs: update registry"
+  )
+  echo "$pdir"
+}
+
+# Build a sibling target repo whose feature branch DOES touch an arch path.
+make_target_repo_arch() {
+  local pdir
+  pdir=$(mktemp -d -t agdr-tgt.XXXXXX)
+  (
+    cd "$pdir" || exit 1
+    git init -q -b main
+    git config user.email t@t.test
+    git config user.name test
+    git remote add origin git@github.com:test-org/portfolio.git
+    mkdir -p src/domain
+    echo "export const x = 1" > src/domain/widget.ts
+    git add src/domain/widget.ts
+    git commit -q -m "base: domain"
+    git checkout -q -b feature
+    echo "export const x = 2" > src/domain/widget.ts
+    git add src/domain/widget.ts
+    git commit -q -m "feat: tweak domain"
+  )
+  echo "$pdir"
+}
+
+# (D) cwd tree has arch changes; cd-target is docs-only → PASS (no false-block).
+#     Pre-fix this BLOCKS because the hook diffs the cwd (fork) tree. [#669]
+FORK_DIR=$(setup_repo c1_base c1_feat)
+TGT_DOCS=$(make_target_repo_docs)
+run_case "cd-target docs-only PR (cwd has arch changes), no --repo → PASS [#669]" \
+  "$FORK_DIR" 0 "" \
+  "cd $TGT_DOCS && gh pr create --base main --title 'chore(#5): update registry docs' --body 'Docs only. No decisions made.'"
+rm -rf "$TGT_DOCS"
+
+# (E) cd-target itself touches an arch path, no AgDR → still BLOCKS.
+#     Proves the re-root targets the right tree rather than just skipping. [#669]
+FORK_DIR2=$(setup_repo c6_base c6_feat)
+TGT_ARCH=$(make_target_repo_arch)
+run_case "cd-target arch PR, no AgDR → still BLOCKS (true-negative) [#669]" \
+  "$FORK_DIR2" 2 "no AgDR reference" \
+  "cd $TGT_ARCH && gh pr create --base main --title 'feat(#6): portfolio domain' --body 'Forgot the decision record.'"
+rm -rf "$TGT_ARCH"
+
+# (F) cd-target arch PR WITH an AgDR reference → PASS. [#669]
+FORK_DIR3=$(setup_repo c1_base c1_feat)
+TGT_ARCH2=$(make_target_repo_arch)
+run_case "cd-target arch PR with AgDR ref → PASS [#669]" \
+  "$FORK_DIR3" 0 "" \
+  "cd $TGT_ARCH2 && gh pr create --base main --title 'feat(#7): portfolio domain' --body 'See AgDR-0009-portfolio-domain for rationale.'"
+rm -rf "$TGT_ARCH2"
+
+# ---------------------------------------------------------------------------
 # Result
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- **Fixed phantom "architecture changes" blocks on cross-repo PRs** — `require-agdr-for-arch-pr.sh` computed its diff against the hook's own cwd. When a PR is created with `cd <repo> && gh pr create …` and **no `--repo` flag** (the natural split-portfolio / `workspace/<project>/` pattern), the PreToolUse hook fires *before* the in-command `cd` runs, so it diffed the **ops fork** instead of the PR's real repo — false-blocking docs-only PRs with arch paths that exist only in the fork. The #464 cross-repo guard only caught the explicit-mismatched-`--repo` case; the no-`--repo` path bypassed it.
- **New `pr_cmd_cd_target` helper in `_lib-pr-repo.sh`** — extracts a leading `cd <path> &&` / `cd <path>;` prefix (unquoted + single/double-quoted), so a PR-create hook can discover the directory the `gh` call is *about* to run in.
- **Re-rooted the diff to that target** — the hook now derives `DIFF_DIR` from the cd-target (only when it resolves to a real git tree; otherwise it falls back to `REPO_ROOT`, i.e. no worse than before), routes every working-tree git call through a `gitd()` wrapper, and feeds `DIFF_DIR` to the cross-repo guard. **Config and session markers stay anchored to the ops fork — only the diff tree moves**, so spike-exemption / ops-root resolution are untouched.
- **Three failing-first regression tests** — proven to fail against the pre-fix hook, now green: a docs-only cd-target PR passes; an arch cd-target PR without an AgDR still blocks (proves the re-root targets the right tree rather than just skipping); an arch cd-target PR with an AgDR passes.

## Testing
1. `bash .claude/hooks/tests/test_require_agdr_for_arch_pr.sh` → **18/0** (15 prior + 3 new; the 3 `[#669]` cases fail on the base branch, pass here).
2. `bash .claude/hooks/tests/test_pr_hooks_cross_repo.sh` → **18/0** (the #464 cross-repo guard, including the lib-missing degraded-WARN path, is not regressed).
3. `bash .claude/hooks/tests/test_validate_pr_create_head.sh` (8/0) and `…_upstream.sh` (7/0) — the other `_lib-pr-repo.sh` consumer is unaffected.

> Run the suites with `env -u CLAUDE_CODE_SESSION_ID -u APEXYARD_OPS_PIN_DIR` when invoking inside a live Claude Code session — otherwise the session's ops-root pin overrides the spike test's fixture ops-root (a pre-existing test-isolation quirk, unrelated to this change).

## Scope note — merge-time siblings deferred
`require-design-review-for-ui.sh` and `require-architecture-review.sh` share the no-`--repo` root cause, but as an **unreproduced silent-bypass** (not a false-block). Hardening them changes the repo-qualified marker filename they read, which risks converting the bypass into a false-**block** unless the marker write side (`/approve-architecture`, `/design-review`, `/approve-design`) computes the identical qualifier. Tracked separately in **#687**.

Refs #669

## Glossary
| Term | Definition |
|------|------------|
| split-portfolio v2 | apexyard mode where the public framework fork and the private portfolio (registry + `projects/`) live in separate sibling repos |
| cd-target | the directory in a leading `cd <path> && gh …` command prefix — where the `gh` call will actually run, which the PreToolUse hook cannot see via its own cwd |
| cwd-rooted diff | a `git diff` whose result depends on the hook process's working directory rather than the PR's real repo |
| `DIFF_DIR` / `gitd()` | the re-rooted working-tree directory and the `git -C "$DIFF_DIR"` wrapper that confines diff operations to it, leaving markers/config on the ops fork |
| cross-repo guard (#464) | the `pr_repo_matches_cwd` check that skips a PR-diff gate when the command targets a different repo than the diff tree |
