### PR TITLE
fix(#687): re-root merge-gate repo to cd-target + repo-aware marker writers

### DIFF
--- a/.claude/agents/solution-architect.md
+++ b/.claude/agents/solution-architect.md
@@ -158,15 +158,28 @@ MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
 . "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
 # Resolve the repo for the qualified marker name.
-PR_REPO=$(gh pr view {number} --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+#
+# In split-portfolio v2 the PR lives in a SIBLING repo, so a bare
+# `gh pr view {number}` (resolved against this cwd = ops fork) returns the WRONG
+# repo — the marker then lands under the ops-fork qualifier and the merge gate,
+# which keys on the PR's real repo, can't find it (false-block). Prefer the repo
+# `/design-review` passes as its optional second arg; this is the SAME slug the
+# gate's read side derives from the merge command's cd-target (me2resh/apexyard#687).
+REPO="{repo}"   # /design-review's optional repo arg, or empty / literal when absent
+[ "$REPO" = "{repo}" ] && REPO=""
+if [ -z "$REPO" ]; then
+  REPO=$(gh pr view {number} --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+fi
+PR_REPO="$REPO"
 ARCH_MARKER=$(review_marker_path "$PR_REPO" {number} architecture "$MARKER_HOME")
 ```
 
 ### The command
 
 ```bash
-# Option B (preferred) — the PR's HEAD on GitHub
-gh pr view {number} --json headRefOid --jq .headRefOid > "$ARCH_MARKER"
+# Option B (preferred) — the PR's HEAD on GitHub. Pass --repo so the SHA is the
+# portfolio PR's HEAD, not an ops-fork PR with the same number (#687).
+gh pr view {number} ${REPO:+--repo "$REPO"} --json headRefOid --jq .headRefOid > "$ARCH_MARKER"
 ```
 
 ### Content — MUST be bare SHA + newline

--- a/.claude/hooks/_lib-pr-repo.sh
+++ b/.claude/hooks/_lib-pr-repo.sh
@@ -31,6 +31,13 @@
 #       (or if there is no `--repo` flag, in which case they implicitly match).
 #       Returns 1 if they differ (cross-repo context).
 #
+#   pr_cmd_cd_target <command>
+#       Echoes the path from a leading `cd <path> && …` (or `cd <path>; …`)
+#       prefix in the command, or empty string if absent. Used by PR-create
+#       hooks to discover the directory the `gh` call is ABOUT to run in — the
+#       PreToolUse hook fires before the in-command `cd` executes, so the
+#       hook's own cwd is NOT yet the PR's repo (me2resh/apexyard#669).
+#
 # USAGE
 # -----
 #   . "$(dirname "$0")/_lib-pr-repo.sh"
@@ -115,6 +122,26 @@ git_origin_repo() {
   local url
   url=$(git -C "$git_dir" remote get-url origin 2>/dev/null) || return 1
   _git_remote_to_slug "$url"
+}
+
+# Public: pr_cmd_cd_target <command>
+#   Echoes the path from a leading `cd <path> && …` / `cd <path>; …` prefix,
+#   or empty string when the command does not start with a `cd`.
+#
+#   Only a `cd` at the START of the command is honoured (the harness-generated
+#   `cd <repo> && gh pr …` pattern). A `cd` buried later in a pipeline is
+#   intentionally ignored — it does not establish the directory the leading
+#   `gh` runs in. Handles unquoted, single-quoted, and double-quoted paths so
+#   `cd '../my repo' && …` resolves correctly.
+pr_cmd_cd_target() {
+  local cmd="$1"
+  # Strip leading whitespace, then match `cd ` followed by a quoted or bare
+  # path up to the first `&&`, `;`, or `|` separator.
+  printf '%s' "$cmd" | sed -nE \
+    "s/^[[:space:]]*cd[[:space:]]+\"([^\"]+)\"[[:space:]]*(&&|;|\|).*/\1/p;
+     s/^[[:space:]]*cd[[:space:]]+'([^']+)'[[:space:]]*(&&|;|\|).*/\1/p;
+     s/^[[:space:]]*cd[[:space:]]+([^&;|[:space:]]+)[[:space:]]*(&&|;|\|).*/\1/p" \
+    | head -1
 }
 
 # Public: pr_repo_matches_cwd <command> [<git-dir>]

--- a/.claude/hooks/require-agdr-for-arch-pr.sh
+++ b/.claude/hooks/require-agdr-for-arch-pr.sh
@@ -148,32 +148,76 @@ if [ -z "$REPO_ROOT" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# 2a-0. Source the PR-repo lib up front. We need two things from it:
+#   - pr_cmd_cd_target  → re-root the diff to the cd-target (#669)
+#   - pr_repo_matches_cwd → the cross-repo guard (#464)
+# ---------------------------------------------------------------------------
+
+HOOK_DIR_AGDR="$(cd "$(dirname "$0")" && pwd)"
+PR_REPO_LIB_OK=0
+if [ -f "$HOOK_DIR_AGDR/_lib-pr-repo.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR_AGDR/_lib-pr-repo.sh"
+  PR_REPO_LIB_OK=1
+fi
+
+# ---------------------------------------------------------------------------
+# 2a-i-a. Re-root the diff to the command's `cd` target (me2resh/apexyard#669).
+#
+# The harness fires this PreToolUse hook BEFORE the shell runs the command, so
+# a `cd <repo> && gh pr create …` prefix has NOT yet changed the working dir —
+# the hook's cwd is still the ops fork. Without re-rooting, the diff below
+# reflects the FORK's working tree (which may carry recent arch-path commits),
+# producing a phantom "architecture changes" block on a PR that is actually
+# being created in a DIFFERENT repo (a split-portfolio private repo, or a
+# `workspace/<project>/` clone in single-fork mode) and touches none of them.
+#
+# Fix: if the command begins with `cd <path> &&`, evaluate all working-tree
+# git operations against <path>'s repo. Config + session markers stay anchored
+# to REPO_ROOT (the ops fork) — only the *diff* tree moves.
+# ---------------------------------------------------------------------------
+
+DIFF_DIR="$REPO_ROOT"
+if [ "$PR_REPO_LIB_OK" = 1 ]; then
+  CD_TARGET=$(pr_cmd_cd_target "$COMMAND")
+  if [ -n "$CD_TARGET" ]; then
+    CD_TOPLEVEL=$(git -C "$CD_TARGET" rev-parse --show-toplevel 2>/dev/null)
+    if [ -n "$CD_TOPLEVEL" ]; then
+      DIFF_DIR="$CD_TOPLEVEL"
+    fi
+    # If <path> is not a readable git tree, fall through with DIFF_DIR=REPO_ROOT
+    # — no worse than the pre-#669 behaviour.
+  fi
+fi
+
+# All working-tree git operations below run against DIFF_DIR (the repo the PR
+# is actually being created in). Markers + config remain anchored to REPO_ROOT.
+gitd() { git -C "$DIFF_DIR" "$@"; }
+
+# ---------------------------------------------------------------------------
 # 2a-i. Cross-repo guard (me2resh/apexyard#464).
 #
-# When the hook fires on a `gh pr create --repo <X>` command but the current
-# git working tree belongs to a DIFFERENT repo (e.g. the session is pinned to
-# the ops-fork while the command targets a sibling repo), the diff computed
-# below reflects the ops-fork's changed files — NOT the PR's actual diff.
-# That produces false-positive blocks for PRs that don't touch any framework
+# When the hook fires on a `gh pr create --repo <X>` command but the diff tree
+# belongs to a DIFFERENT repo (e.g. the session is pinned to the ops-fork while
+# the command targets a sibling repo with no local checkout), the diff computed
+# below reflects the wrong working tree — NOT the PR's actual diff. That
+# produces false-positive blocks for PRs that don't touch any framework
 # architecture paths.
 #
 # Fix: compare the PR target repo (--repo flag, or implicit same-repo) to the
-# origin remote of the current working tree. If they differ, we cannot compute
-# a meaningful diff for this PR from this cwd → exit 0 (no-op).
+# origin remote of the diff tree. If they differ, we cannot compute a
+# meaningful diff for this PR from here → exit 0 (no-op).
 #
 # Framework gating is preserved: when creating a me2resh/apexyard PR from the
 # framework cwd, the --repo value matches origin → the guard does NOT fire and
 # the diff check runs as usual.
 # ---------------------------------------------------------------------------
 
-HOOK_DIR_AGDR="$(cd "$(dirname "$0")" && pwd)"
-if [ -f "$HOOK_DIR_AGDR/_lib-pr-repo.sh" ]; then
-  # shellcheck source=/dev/null
-  . "$HOOK_DIR_AGDR/_lib-pr-repo.sh"
-  if ! pr_repo_matches_cwd "$COMMAND" "$REPO_ROOT"; then
-    # PR targets a different repo than this working tree — cannot evaluate
-    # the arch-path diff from here. Silently pass; the hook in that repo's
-    # own CI context will gate this correctly.
+if [ "$PR_REPO_LIB_OK" = 1 ]; then
+  if ! pr_repo_matches_cwd "$COMMAND" "$DIFF_DIR"; then
+    # PR targets a different repo than the diff tree — cannot evaluate the
+    # arch-path diff from here. Silently pass; the hook in that repo's own CI
+    # context will gate this correctly.
     exit 0
   fi
 else
@@ -254,7 +298,7 @@ spike_pr_exempt() {
 
   # (c) branch named spike/... or prototype/...
   local branch
-  branch=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null)
+  branch=$(gitd branch --show-current 2>/dev/null)
   if echo "$branch" | grep -qE '^(spike|prototype)/'; then
     return 0
   fi
@@ -283,7 +327,7 @@ BASE_REF=""
 resolve_ref() {
   # Verify a ref exists; echo it if so, else empty.
   local ref="$1"
-  if git rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then
+  if gitd rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then
     echo "$ref"
   fi
 }
@@ -308,12 +352,12 @@ if [ -z "$BASE_REF" ]; then
   exit 0
 fi
 
-MERGE_BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null)
+MERGE_BASE=$(gitd merge-base HEAD "$BASE_REF" 2>/dev/null)
 if [ -z "$MERGE_BASE" ]; then
   exit 0
 fi
 
-CHANGED_FILES=$(git diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null)
+CHANGED_FILES=$(gitd diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null)
 if [ -z "$CHANGED_FILES" ]; then
   # No files changed — nothing to evaluate.
   exit 0
@@ -443,8 +487,8 @@ while IFS= read -r depfile; do
     [ -z "$file" ] && continue
     case "$depfile" in
       package.json)
-        BASE_JSON=$(git show "$MERGE_BASE:$file" 2>/dev/null)
-        HEAD_JSON=$(git show "HEAD:$file" 2>/dev/null)
+        BASE_JSON=$(gitd show "$MERGE_BASE:$file" 2>/dev/null)
+        HEAD_JSON=$(gitd show "HEAD:$file" 2>/dev/null)
         # File may be newly added → BASE_JSON empty → any deps are additions.
         if [ -z "$BASE_JSON" ]; then
           if [ -n "$HEAD_JSON" ] && command -v jq >/dev/null 2>&1; then
@@ -478,7 +522,7 @@ while IFS= read -r depfile; do
         ;;
       *)
         # Non-JSON heuristic. Pull the unified diff for this file.
-        DIFF=$(git diff "$MERGE_BASE"..HEAD -- "$file" 2>/dev/null)
+        DIFF=$(gitd diff "$MERGE_BASE"..HEAD -- "$file" 2>/dev/null)
         [ -z "$DIFF" ] && continue
         ADDED_LINES=$(echo "$DIFF" | grep -cE '^\+[^+]' || true)
         REMOVED_LINES=$(echo "$DIFF" | grep -cE '^-[^-]' || true)

--- a/.claude/hooks/require-architecture-review.sh
+++ b/.claude/hooks/require-architecture-review.sh
@@ -50,28 +50,50 @@ fi
 . "$(dirname "$0")/_lib-extract-pr.sh"
 # Repo-qualified marker path helper (#485).
 . "$(dirname "$0")/_lib-review-markers.sh"
+# cd-target → origin recovery for the no---repo split-portfolio merge (#687).
+. "$(dirname "$0")/_lib-pr-repo.sh"
 
 if ! is_merge_command "$COMMAND"; then
   exit 0
 fi
 
-# Parse --repo (for `gh pr merge --repo owner/repo`). Fallback: recover from
-# the `gh api .../pulls/<N>/merge` URL path so downstream `gh pr diff` calls
-# still know which repo to talk to.
+# Resolve the PR's repo. Each step runs only if the prior left CMD_REPO empty:
+#   1. --repo flag      (`gh pr merge --repo owner/repo`)
+#   2. gh api URL path  (`gh api repos/<owner>/<repo>/pulls/<N>/merge`)
+#   3. cd-target origin (`cd <portfolio> && gh pr merge <N>` with NO --repo —
+#                        the split-portfolio v2 pattern; the hook fires BEFORE
+#                        the in-command `cd`, so its own cwd is the ops fork,
+#                        not the PR's repo. me2resh/apexyard#687, the merge-time
+#                        sibling of the create-time fix #669.)
+#   4. extract_repo_from_command fallback (current-branch `gh pr view`)
 CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
 if [ -z "$CMD_REPO" ]; then
   CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
 fi
-REPO_FLAG=""
-if [ -n "$CMD_REPO" ]; then
-  REPO_FLAG="--repo $CMD_REPO"
+if [ -z "$CMD_REPO" ]; then
+  # Recover the repo from a leading `cd <path> &&` prefix — only when the path
+  # resolves to a real git tree (relative paths resolve against the hook's cwd,
+  # which is correct: the hook runs pre-`cd`). Otherwise fall through.
+  CD_TARGET=$(pr_cmd_cd_target "$COMMAND")
+  if [ -n "$CD_TARGET" ] && git -C "$CD_TARGET" rev-parse --git-dir >/dev/null 2>&1; then
+    CMD_REPO=$(git_origin_repo "$CD_TARGET")
+  fi
 fi
 
 PR_NUMBER=$(extract_pr_number "$COMMAND")
 # Resolve the repo for qualified marker paths (#485).
-# CMD_REPO already parsed above; fall back via helper if blank.
+# CMD_REPO already resolved above; fall back via helper if still blank.
 if [ -z "$CMD_REPO" ]; then
   CMD_REPO=$(extract_repo_from_command "$COMMAND")
+fi
+
+# Derive REPO_FLAG from the FULLY-resolved CMD_REPO (#687) so the `gh pr diff`
+# below targets the PR's real repo. If this were set before the cd-target /
+# fallback steps, the no---repo split-portfolio case would diff the ops fork,
+# find no design artifact, and silently bypass the gate.
+REPO_FLAG=""
+if [ -n "$CMD_REPO" ]; then
+  REPO_FLAG="--repo $CMD_REPO"
 fi
 
 if [ -z "$PR_NUMBER" ]; then

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -49,28 +49,50 @@ fi
 . "$(dirname "$0")/_lib-extract-pr.sh"
 # Repo-qualified marker path helper (#485).
 . "$(dirname "$0")/_lib-review-markers.sh"
+# cd-target → origin recovery for the no---repo split-portfolio merge (#687).
+. "$(dirname "$0")/_lib-pr-repo.sh"
 
 if ! is_merge_command "$COMMAND"; then
   exit 0
 fi
 
-# Parse --repo (for `gh pr merge --repo owner/repo`). Fallback: recover from
-# the `gh api .../pulls/<N>/merge` URL path so downstream `gh pr diff` calls
-# still know which repo to talk to.
+# Resolve the PR's repo. Each step runs only if the prior left CMD_REPO empty:
+#   1. --repo flag      (`gh pr merge --repo owner/repo`)
+#   2. gh api URL path  (`gh api repos/<owner>/<repo>/pulls/<N>/merge`)
+#   3. cd-target origin (`cd <portfolio> && gh pr merge <N>` with NO --repo —
+#                        the split-portfolio v2 pattern; the hook fires BEFORE
+#                        the in-command `cd`, so its own cwd is the ops fork,
+#                        not the PR's repo. me2resh/apexyard#687, the merge-time
+#                        sibling of the create-time fix #669.)
+#   4. extract_repo_from_command fallback (current-branch `gh pr view`)
 CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
 if [ -z "$CMD_REPO" ]; then
   CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
 fi
-REPO_FLAG=""
-if [ -n "$CMD_REPO" ]; then
-  REPO_FLAG="--repo $CMD_REPO"
+if [ -z "$CMD_REPO" ]; then
+  # Recover the repo from a leading `cd <path> &&` prefix — only when the path
+  # resolves to a real git tree (relative paths resolve against the hook's cwd,
+  # which is correct: the hook runs pre-`cd`). Otherwise fall through.
+  CD_TARGET=$(pr_cmd_cd_target "$COMMAND")
+  if [ -n "$CD_TARGET" ] && git -C "$CD_TARGET" rev-parse --git-dir >/dev/null 2>&1; then
+    CMD_REPO=$(git_origin_repo "$CD_TARGET")
+  fi
 fi
 
 PR_NUMBER=$(extract_pr_number "$COMMAND")
 # Resolve the repo for qualified marker paths (#485).
-# CMD_REPO already parsed above; fall back via helper if blank.
+# CMD_REPO already resolved above; fall back via helper if still blank.
 if [ -z "$CMD_REPO" ]; then
   CMD_REPO=$(extract_repo_from_command "$COMMAND")
+fi
+
+# Derive REPO_FLAG from the FULLY-resolved CMD_REPO (#687) so the `gh pr diff`
+# below targets the PR's real repo. If this were set before the cd-target /
+# fallback steps, the no---repo split-portfolio case would diff the ops fork,
+# find no UI files, and silently bypass the gate.
+REPO_FLAG=""
+if [ -n "$CMD_REPO" ]; then
+  REPO_FLAG="--repo $CMD_REPO"
 fi
 
 if [ -z "$PR_NUMBER" ]; then

--- a/.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
+++ b/.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
@@ -351,6 +351,89 @@ run_case "embedded quote, no AgDR ref at all → still BLOCKS (true-negative) [#
   "gh pr create --base main --title 'feat(#3): tweak domain' --body 'Uses \"greedy\" matching but forgot to add the decision record.'"
 
 # ---------------------------------------------------------------------------
+# Two-repo `cd <target> && gh pr create` (no --repo) — me2resh/apexyard#669.
+#
+# The hook fires from the cwd tree (the ops fork, which carries arch changes
+# on HEAD) BEFORE the in-command `cd` executes. Without re-rooting the diff to
+# the cd-target, the hook diffs the cwd tree and false-blocks a docs-only PR
+# that is actually being created in a *different* repo (the split-portfolio
+# private repo, or a `workspace/<project>/` clone in single-fork mode).
+#
+# The fix: when the command begins with `cd <path> && …`, evaluate the PR diff
+# against <path>'s git tree, not the cwd's.
+# ---------------------------------------------------------------------------
+
+# Build a sibling target repo with a docs-only feature branch (no arch paths).
+make_target_repo_docs() {
+  local pdir
+  pdir=$(mktemp -d -t agdr-tgt.XXXXXX)
+  (
+    cd "$pdir" || exit 1
+    git init -q -b main
+    git config user.email t@t.test
+    git config user.name test
+    git remote add origin git@github.com:test-org/portfolio.git
+    mkdir -p docs
+    echo "# registry" > docs/readme.md
+    git add docs/readme.md
+    git commit -q -m "base: docs"
+    git checkout -q -b feature
+    echo "# registry update" >> docs/readme.md
+    git add docs/readme.md
+    git commit -q -m "docs: update registry"
+  )
+  echo "$pdir"
+}
+
+# Build a sibling target repo whose feature branch DOES touch an arch path.
+make_target_repo_arch() {
+  local pdir
+  pdir=$(mktemp -d -t agdr-tgt.XXXXXX)
+  (
+    cd "$pdir" || exit 1
+    git init -q -b main
+    git config user.email t@t.test
+    git config user.name test
+    git remote add origin git@github.com:test-org/portfolio.git
+    mkdir -p src/domain
+    echo "export const x = 1" > src/domain/widget.ts
+    git add src/domain/widget.ts
+    git commit -q -m "base: domain"
+    git checkout -q -b feature
+    echo "export const x = 2" > src/domain/widget.ts
+    git add src/domain/widget.ts
+    git commit -q -m "feat: tweak domain"
+  )
+  echo "$pdir"
+}
+
+# (D) cwd tree has arch changes; cd-target is docs-only → PASS (no false-block).
+#     Pre-fix this BLOCKS because the hook diffs the cwd (fork) tree. [#669]
+FORK_DIR=$(setup_repo c1_base c1_feat)
+TGT_DOCS=$(make_target_repo_docs)
+run_case "cd-target docs-only PR (cwd has arch changes), no --repo → PASS [#669]" \
+  "$FORK_DIR" 0 "" \
+  "cd $TGT_DOCS && gh pr create --base main --title 'chore(#5): update registry docs' --body 'Docs only. No decisions made.'"
+rm -rf "$TGT_DOCS"
+
+# (E) cd-target itself touches an arch path, no AgDR → still BLOCKS.
+#     Proves the re-root targets the right tree rather than just skipping. [#669]
+FORK_DIR2=$(setup_repo c6_base c6_feat)
+TGT_ARCH=$(make_target_repo_arch)
+run_case "cd-target arch PR, no AgDR → still BLOCKS (true-negative) [#669]" \
+  "$FORK_DIR2" 2 "no AgDR reference" \
+  "cd $TGT_ARCH && gh pr create --base main --title 'feat(#6): portfolio domain' --body 'Forgot the decision record.'"
+rm -rf "$TGT_ARCH"
+
+# (F) cd-target arch PR WITH an AgDR reference → PASS. [#669]
+FORK_DIR3=$(setup_repo c1_base c1_feat)
+TGT_ARCH2=$(make_target_repo_arch)
+run_case "cd-target arch PR with AgDR ref → PASS [#669]" \
+  "$FORK_DIR3" 0 "" \
+  "cd $TGT_ARCH2 && gh pr create --base main --title 'feat(#7): portfolio domain' --body 'See AgDR-0009-portfolio-domain for rationale.'"
+rm -rf "$TGT_ARCH2"
+
+# ---------------------------------------------------------------------------
 # Result
 # ---------------------------------------------------------------------------
 

--- a/.claude/hooks/tests/test_require_architecture_review.sh
+++ b/.claude/hooks/tests/test_require_architecture_review.sh
@@ -219,6 +219,80 @@ assert_eq "cross-repo: correct repo marker allows gate (#485)" "0" "$code"
 rm -rf "$sb"
 
 echo ""
+echo "D) #687 split-portfolio no---repo merge — repo recovered from the cd-target"
+
+# A sibling portfolio repo: its own git tree whose origin is the portfolio slug.
+# The merge command is `cd <portfolio> && gh pr merge <N>` with NO --repo — so
+# the hook must recover the repo from the cd-target's origin (pr_cmd_cd_target +
+# git_origin_repo), set --repo on the diff, AND key the marker on that slug.
+make_portfolio() {
+  local slug="$1" p
+  p=$(mktemp -d)
+  git -C "$p" init -q
+  git -C "$p" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  git -C "$p" remote add origin "git@github.com:${slug}.git"
+  echo "$p"
+}
+
+# Repo-aware mock gh: answers ONLY when the call carries `--repo <portfolio>`
+# (or the api `repos/<portfolio>/` path). A BARE call (no --repo) models gh
+# resolving against the ops-fork cwd, which does NOT have this PR → empty output.
+# That empty output is exactly what makes the PRE-#687 hook silent-bypass; these
+# cases therefore fail against the old hook and pass against the fixed one.
+install_mock_gh_splitportfolio() {
+  local sb="$1" diff_files="$2" head_sha="$3" portfolio="$4"
+  mkdir -p "$sb/bin"
+  cat > "$sb/bin/gh" <<EOF
+#!/bin/bash
+args="\$*"
+case "\$args" in
+  *"--repo $portfolio"*|*"repos/$portfolio/"*)
+    case "\$args" in
+      *"pr diff"*"--name-only"*) printf '%s\n' $diff_files ;;
+      *"pr view"*headRefOid*)    printf '%s\n' "$head_sha" ;;
+      *"pr view"*headRepository*) printf '%s\n' "$portfolio" ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  *"pr diff"*"--name-only"*) ;;    # bare → no files (ops-fork resolution)
+  *"pr view"*headRefOid*) ;;        # bare → empty
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$sb/bin/gh"
+}
+
+PF_SLUG="me2resh/portfolio-x"
+
+echo ""
+echo "D) no---repo cd-target + design PR + NO marker -> BLOCK (was a silent-bypass pre-#687)"
+sb=$(make_sandbox); pf=$(make_portfolio "$PF_SLUG")
+install_mock_gh_splitportfolio "$sb" '"projects/foo/docs/technical-design-x.md"' "$SHA" "$PF_SLUG"
+code=$(run_gate "$sb" "cd $pf && gh pr merge 77 --squash")
+assert_eq "#687 cd-target: blocks without marker" "2" "$code"
+rm -rf "$sb" "$pf"
+
+echo ""
+echo "D) ROUND-TRIP: no---repo cd-target + marker under the PORTFOLIO qualifier -> ALLOW"
+sb=$(make_sandbox); pf=$(make_portfolio "$PF_SLUG")
+install_mock_gh_splitportfolio "$sb" '"projects/foo/docs/technical-design-x.md"' "$SHA" "$PF_SLUG"
+# The fixed write side keys the marker on the portfolio slug — prove the fixed
+# read side finds it (the symmetry the #687 warning section demands).
+printf '%s\n' "$SHA" > "$(review_marker_path "$PF_SLUG" 77 architecture "$sb")"
+code=$(run_gate "$sb" "cd $pf && gh pr merge 77 --squash")
+assert_eq "#687 round-trip: portfolio-qualified marker allows gate" "0" "$code"
+rm -rf "$sb" "$pf"
+
+echo ""
+echo "D) negative: marker under the WRONG (ops-fork) qualifier -> BLOCK (qualifier is load-bearing)"
+sb=$(make_sandbox); pf=$(make_portfolio "$PF_SLUG")
+install_mock_gh_splitportfolio "$sb" '"projects/foo/docs/technical-design-x.md"' "$SHA" "$PF_SLUG"
+printf '%s\n' "$SHA" > "$(review_marker_path "me2resh/ops-fork" 77 architecture "$sb")"
+code=$(run_gate "$sb" "cd $pf && gh pr merge 77 --squash")
+assert_eq "#687 wrong-qualifier marker still blocks" "2" "$code"
+rm -rf "$sb" "$pf"
+
+echo ""
 echo "==================================="
 echo "  PASS: $PASS   FAIL: $FAIL"
 echo "==================================="

--- a/.claude/hooks/tests/test_require_design_review_for_ui.sh
+++ b/.claude/hooks/tests/test_require_design_review_for_ui.sh
@@ -1,0 +1,292 @@
+#!/bin/bash
+# Tests for require-design-review-for-ui.sh — the UI merge gate that blocks
+# merging a PR touching UI files until a <pr>-design.approved marker exists at a
+# matching HEAD SHA. Mirrors test_require_architecture_review.sh.
+#
+# Before this file the hook had ZERO end-to-end coverage (only
+# test_ui_paths_exclude.sh tested the .ui_paths_exclude filter inline). This
+# adds the full-gate path plus the #687 split-portfolio no---repo regression.
+#
+#   A. Inline-replay of the UI_GLOBS matcher (case-SENSITIVE, like the hook).
+#   B. End-to-end gate behaviour via a self-contained mock `gh` in a sandbox.
+#   C. Cross-repo collision regression (#485) — same PR# in two repos.
+#   D. #687 split-portfolio no---repo merge — repo recovered from the cd-target.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/require-design-review-for-ui.sh"
+LIB_MARKERS="$SRC_ROOT/.claude/hooks/_lib-review-markers.sh"
+
+for f in "$HOOK_SRC" "$LIB_MARKERS"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: required source missing: $f" >&2
+    exit 1
+  fi
+done
+
+# Load the marker lib so test helpers use the same path logic as the hook.
+# shellcheck source=/dev/null
+. "$LIB_MARKERS"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    echo "PASS [$label]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL [$label]: want '$want', got '$got'" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# A) UI_GLOBS — the default UI patterns the hook ships with. Kept in sync with
+# the hook by copying the same list; the matcher replays the hook's grep, which
+# is case-SENSITIVE (grep -qE, NOT -i) — .tsx$/.jsx$ are exact so they do not
+# match plain .ts/.js backend files.
+# ---------------------------------------------------------------------------
+UI_GLOBS='\.tsx$
+\.jsx$
+\.vue$
+\.svelte$
+\.css$
+\.scss$
+\.sass$
+\.less$
+design-tokens'
+
+classify_file() {
+  local file="$1"
+  while IFS= read -r PATTERN; do
+    [ -z "$PATTERN" ] && continue
+    if echo "$file" | grep -qE "$PATTERN"; then
+      echo "match"; return
+    fi
+  done <<< "$UI_GLOBS"
+  echo "no-match"
+}
+
+echo ""
+echo "A) UI_GLOBS matching — UI files match"
+assert_eq "tsx component matches"   "match"    "$(classify_file 'src/components/Button.tsx')"
+assert_eq "jsx component matches"   "match"    "$(classify_file 'src/App.jsx')"
+assert_eq "vue component matches"   "match"    "$(classify_file 'src/Card.vue')"
+assert_eq "svelte component matches" "match"   "$(classify_file 'src/Nav.svelte')"
+assert_eq "css matches"             "match"    "$(classify_file 'styles/main.css')"
+assert_eq "scss matches"            "match"    "$(classify_file 'styles/theme.scss')"
+assert_eq "design-tokens matches"   "match"    "$(classify_file 'src/design-tokens.json')"
+
+echo ""
+echo "A) UI_GLOBS matching — non-UI files do NOT match"
+assert_eq "plain .ts no-match"      "no-match" "$(classify_file 'src/handlers/user.ts')"
+assert_eq "plain .js no-match"      "no-match" "$(classify_file 'scripts/build.js')"
+assert_eq "readme no-match"         "no-match" "$(classify_file 'README.md')"
+assert_eq "go file no-match"        "no-match" "$(classify_file 'cmd/main.go')"
+
+# ---------------------------------------------------------------------------
+# B) End-to-end gate via self-contained mock gh.
+# ---------------------------------------------------------------------------
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  : > "$sb/.apexyard-fork"
+  touch "$sb/onboarding.yaml" "$sb/apexyard.projects.yaml"
+  git -C "$sb" init -q
+  git -C "$sb" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  mkdir -p "$sb/.claude/hooks" "$sb/.claude/session/reviews"
+  cp "$SRC_ROOT/.claude/hooks/_lib-extract-pr.sh" "$sb/.claude/hooks/_lib-extract-pr.sh"
+  cp "$SRC_ROOT/.claude/hooks/_lib-review-markers.sh" "$sb/.claude/hooks/_lib-review-markers.sh"
+  cp "$SRC_ROOT/.claude/hooks/_lib-pr-repo.sh" "$sb/.claude/hooks/_lib-pr-repo.sh"
+  if [ -f "$SRC_ROOT/.claude/hooks/_lib-ops-root.sh" ]; then
+    cp "$SRC_ROOT/.claude/hooks/_lib-ops-root.sh" "$sb/.claude/hooks/_lib-ops-root.sh"
+  fi
+  echo "$sb"
+}
+
+install_mock_gh() {
+  local sb="$1" diff_files="$2" head_sha="$3" repo="${4:-o/r}"
+  mkdir -p "$sb/bin"
+  cat > "$sb/bin/gh" <<EOF
+#!/bin/bash
+args="\$*"
+case "\$args" in
+  *"pr diff"*"--name-only"*)
+    printf '%s\n' $diff_files
+    ;;
+  *"pr view"*headRefOid*)
+    printf '%s\n' "$head_sha"
+    ;;
+  *"pr view"*headRepository*)
+    printf '%s\n' "$repo"
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$sb/bin/gh"
+}
+
+run_gate() {
+  local sb="$1" command="$2"
+  local input
+  input=$(printf '{"tool_input":{"command":"%s"}}' "$command")
+  ( cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash "$HOOK_SRC" >/dev/null 2>&1 <<< "$input" )
+  echo $?
+}
+
+SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+echo ""
+echo "B) UI PR + NO marker -> BLOCK (exit 2)"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"src/components/Button.tsx"' "$SHA"
+code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
+assert_eq "blocks without marker" "2" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "B) UI PR + matching marker -> ALLOW (exit 0)"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"src/components/Button.tsx"' "$SHA"
+printf '%s\n' "$SHA" > "$(review_marker_path "o/r" 77 design "$sb")"
+code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
+assert_eq "allows with matching marker" "0" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "B) UI PR + STALE marker (SHA mismatch) -> BLOCK (exit 2)"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"styles/theme.scss"' "$SHA"
+printf '%s\n' "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" > "$(review_marker_path "o/r" 77 design "$sb")"
+code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
+assert_eq "blocks on stale marker SHA" "2" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "B) non-UI PR -> ALLOW (exit 0, gate is a no-op)"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"src/handlers/user.ts" "cmd/main.go"' "$SHA"
+code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
+assert_eq "no-op on non-UI PR" "0" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "B) non-merge command -> ALLOW (exit 0, not our concern)"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"src/components/Button.tsx"' "$SHA"
+code=$(run_gate "$sb" "gh pr view 77")
+assert_eq "no-op on non-merge command" "0" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "B) gh api merge shape + UI PR + no marker -> BLOCK (exit 2)"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"src/components/Button.tsx"' "$SHA"
+code=$(run_gate "$sb" "gh api repos/o/r/pulls/77/merge -X PUT")
+assert_eq "blocks via gh api shape too" "2" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "C) Cross-repo collision regression (#485) — same PR# in two repos"
+
+echo ""
+echo "C) design marker for repo-A's PR#77 does NOT satisfy repo-B's PR#77 gate"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"src/components/Button.tsx"' "$SHA" "repo-b/project-b"
+printf '%s\n' "$SHA" > "$(review_marker_path "repo-a/project-a" 77 design "$sb")"
+code=$(run_gate "$sb" "gh pr merge 77 --repo repo-b/project-b --squash")
+assert_eq "cross-repo: repo-A marker blocks repo-B gate (#485)" "2" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "C) design marker for repo-B's PR#77 DOES satisfy repo-B's PR#77 gate"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"src/components/Button.tsx"' "$SHA" "repo-b/project-b"
+printf '%s\n' "$SHA" > "$(review_marker_path "repo-b/project-b" 77 design "$sb")"
+code=$(run_gate "$sb" "gh pr merge 77 --repo repo-b/project-b --squash")
+assert_eq "cross-repo: correct repo marker allows gate (#485)" "0" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "D) #687 split-portfolio no---repo merge — repo recovered from the cd-target"
+
+# A sibling portfolio repo whose origin is the portfolio slug. The merge command
+# is `cd <portfolio> && gh pr merge <N>` with NO --repo — so the hook must
+# recover the repo from the cd-target's origin (pr_cmd_cd_target +
+# git_origin_repo), set --repo on the diff, AND key the marker on that slug.
+make_portfolio() {
+  local slug="$1" p
+  p=$(mktemp -d)
+  git -C "$p" init -q
+  git -C "$p" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  git -C "$p" remote add origin "git@github.com:${slug}.git"
+  echo "$p"
+}
+
+# Repo-aware mock gh: answers ONLY when the call carries `--repo <portfolio>`.
+# A BARE call (no --repo) models gh resolving against the ops-fork cwd, which
+# does NOT have this PR → empty output — exactly what makes the PRE-#687 hook
+# silent-bypass. So these cases fail against the old hook, pass against the fix.
+install_mock_gh_splitportfolio() {
+  local sb="$1" diff_files="$2" head_sha="$3" portfolio="$4"
+  mkdir -p "$sb/bin"
+  cat > "$sb/bin/gh" <<EOF
+#!/bin/bash
+args="\$*"
+case "\$args" in
+  *"--repo $portfolio"*|*"repos/$portfolio/"*)
+    case "\$args" in
+      *"pr diff"*"--name-only"*) printf '%s\n' $diff_files ;;
+      *"pr view"*headRefOid*)    printf '%s\n' "$head_sha" ;;
+      *"pr view"*headRepository*) printf '%s\n' "$portfolio" ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  *"pr diff"*"--name-only"*) ;;    # bare → no files (ops-fork resolution)
+  *"pr view"*headRefOid*) ;;        # bare → empty
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$sb/bin/gh"
+}
+
+PF_SLUG="me2resh/portfolio-x"
+
+echo ""
+echo "D) no---repo cd-target + UI PR + NO marker -> BLOCK (was a silent-bypass pre-#687)"
+sb=$(make_sandbox); pf=$(make_portfolio "$PF_SLUG")
+install_mock_gh_splitportfolio "$sb" '"src/components/Button.tsx"' "$SHA" "$PF_SLUG"
+code=$(run_gate "$sb" "cd $pf && gh pr merge 77 --squash")
+assert_eq "#687 cd-target: blocks without marker" "2" "$code"
+rm -rf "$sb" "$pf"
+
+echo ""
+echo "D) ROUND-TRIP: no---repo cd-target + marker under the PORTFOLIO qualifier -> ALLOW"
+sb=$(make_sandbox); pf=$(make_portfolio "$PF_SLUG")
+install_mock_gh_splitportfolio "$sb" '"src/components/Button.tsx"' "$SHA" "$PF_SLUG"
+printf '%s\n' "$SHA" > "$(review_marker_path "$PF_SLUG" 77 design "$sb")"
+code=$(run_gate "$sb" "cd $pf && gh pr merge 77 --squash")
+assert_eq "#687 round-trip: portfolio-qualified marker allows gate" "0" "$code"
+rm -rf "$sb" "$pf"
+
+echo ""
+echo "D) negative: marker under the WRONG (ops-fork) qualifier -> BLOCK (qualifier is load-bearing)"
+sb=$(make_sandbox); pf=$(make_portfolio "$PF_SLUG")
+install_mock_gh_splitportfolio "$sb" '"src/components/Button.tsx"' "$SHA" "$PF_SLUG"
+printf '%s\n' "$SHA" > "$(review_marker_path "me2resh/ops-fork" 77 design "$sb")"
+code=$(run_gate "$sb" "cd $pf && gh pr merge 77 --squash")
+assert_eq "#687 wrong-qualifier marker still blocks" "2" "$code"
+rm -rf "$sb" "$pf"
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/skills/approve-architecture/SKILL.md
+++ b/.claude/skills/approve-architecture/SKILL.md
@@ -27,9 +27,11 @@ Valid invocation triggers:
 
 ## Process
 
-### 1. Parse the PR number
+### 1. Parse the PR number — and the repo
 
-Extract from the argument. If none given, infer from the current branch's open PR (`gh pr view --json number --jq '.number'`) or the user's most recent message. If ambiguous, STOP and ask.
+Extract the PR number from the argument. If none given, infer from the current branch's open PR (`gh pr view --json number --jq '.number'`) or the user's most recent message. If ambiguous, STOP and ask.
+
+**Also resolve the repo (`REPO`).** Accept the fully-qualified `owner/repo#N` form, or an explicit `owner/repo` second token. In split-portfolio v2 the PR lives in a *sibling* repo, so a bare `gh pr view <pr>` resolved against the ops-fork cwd hits the WRONG repo — the marker would then be written under the ops-fork qualifier and the `require-architecture-review.sh` gate (which keys on the PR's real repo, derived from the merge command's cd-target, me2resh/apexyard#687) would never find it → false-block. Pass `--repo "$REPO"` to **every** `gh pr view` call below when `REPO` is known. **Fail loud:** if only a bare number was given and `gh pr view <pr>` cannot resolve the PR from the current cwd, STOP and ask for the `owner/repo#N` form — never write the marker under a guessed qualifier.
 
 ### 2. Sanity-check the user's intent
 
@@ -44,7 +46,7 @@ If any are unclear — STOP and ask a per-PR explicit question.
 ### 3. Verify the PR state
 
 ```bash
-gh pr view <pr> --json state,isDraft,mergeable,headRefOid
+gh pr view <pr> ${REPO:+--repo "$REPO"} --json state,isDraft,mergeable,headRefOid
 ```
 
 - `state` must be `OPEN`. Refuse if `MERGED`, `CLOSED`, or `DRAFT`.
@@ -67,7 +69,10 @@ done
 MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
 # shellcheck source=/dev/null
 . "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
-PR_REPO=$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+# Prefer the repo resolved in step 1 (the base repo the PR lives in — the slug
+# the gate derives from the merge cd-target, #687). Fall back to headRepository
+# only when REPO is unknown (single-fork / same-repo case).
+PR_REPO="${REPO:-$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)}"
 REX=$(review_marker_path "$PR_REPO" <pr> rex "$MARKER_HOME")
 [ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "<headRefOid from step 3>" ]
 ```

--- a/.claude/skills/approve-design/SKILL.md
+++ b/.claude/skills/approve-design/SKILL.md
@@ -33,14 +33,16 @@ The valid invocation triggers look like this:
 
 ## Process
 
-### 1. Parse the PR number
+### 1. Parse the PR number — and the repo
 
-Extract from `$ARGUMENTS`. If no argument is given, try to infer from:
+Extract the PR number from `$ARGUMENTS`. If no argument is given, try to infer from:
 
 - The current branch's open PR via `gh pr view --json number --jq '.number'`
 - The user's most recent message, if it named a PR explicitly
 
 If the PR number is ambiguous, STOP and ask.
+
+**Also resolve the repo (`REPO`).** Accept the fully-qualified `owner/repo#N` form, or an explicit `owner/repo` second token. In split-portfolio v2 the PR lives in a *sibling* repo, so a bare `gh pr view <pr>` resolved against the ops-fork cwd hits the WRONG repo — the marker would then be written under the ops-fork qualifier and the `require-design-review-for-ui.sh` gate (which keys on the PR's real repo, derived from the merge command's cd-target, me2resh/apexyard#687) would never find it → false-block. Pass `--repo "$REPO"` to **every** `gh pr view` call below when `REPO` is known. **Fail loud:** if only a bare number was given and `gh pr view <pr>` cannot resolve the PR from the current cwd, STOP and ask for the `owner/repo#N` form — never write the marker under a guessed qualifier.
 
 ### 2. Sanity-check the user's intent
 
@@ -55,7 +57,7 @@ If any of these are unclear — **STOP**. Reply with a per-PR explicit question:
 
 ### 3. Verify the PR state
 
-Run `gh pr view <pr> --json state,isDraft,mergeable`. Sanity checks:
+Run `gh pr view <pr> ${REPO:+--repo "$REPO"} --json state,isDraft,mergeable`. Sanity checks:
 
 - `state` must be `OPEN`.
 - Refuse if `MERGED`, `CLOSED`, or `DRAFT`.
@@ -77,7 +79,10 @@ done
 MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
 # shellcheck source=/dev/null
 . "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
-PR_REPO=$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+# Prefer the repo resolved in step 1 (the base repo the PR lives in — the slug
+# the gate derives from the merge cd-target, #687). Fall back to headRepository
+# only when REPO is unknown (single-fork / same-repo case).
+PR_REPO="${REPO:-$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)}"
 REX=$(review_marker_path "$PR_REPO" <pr> rex "$MARKER_HOME")
 [ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "$(git rev-parse HEAD)" ]
 ```

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -32,7 +32,7 @@ See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the ful
 
 ## Process
 
-1. Resolve the target — a PR number (preferred: gives a diff + a place to post the verdict + a marker key) or a path to a design artifact.
+1. Resolve the target — a PR number (preferred: gives a diff + a place to post the verdict + a marker key) or a path to a design artifact. **Also resolve the repo**: the optional second arg (`/design-review 42 owner/repo`), or the `owner/repo#N` form. In split-portfolio v2 the PR lives in a sibling repo, so a bare `gh pr view 42` resolved against the ops-fork cwd hits the WRONG repo — pass the resolved repo as `--repo` to **every** `gh pr view` / `gh pr diff` / `gh pr review` call, and thread it into Tariq's spawn so his `<owner>__<repo>__<pr>-architecture.approved` marker is keyed on the PR's real repo. This is the slug the `require-architecture-review.sh` gate derives from the merge command's cd-target (me2resh/apexyard#687). If only a bare number is given and `gh pr view <N>` can't resolve the PR from the current cwd, STOP and ask for the `owner/repo#N` form — never write the marker under a guessed qualifier.
 2. Fetch PR details and the latest commit SHA (when reviewing a PR).
 3. Read the design artifact(s).
 4. Review against the architecture review lens (below) plus discovered handbooks.


### PR DESCRIPTION
## Summary
- **Fixed the no-`--repo` cross-repo bypass in the two merge-time review gates** — `require-architecture-review.sh` and `require-design-review-for-ui.sh` derived the PR's repo only from a `--repo` flag or the `gh api .../merge` URL. In split-portfolio v2 (session cwd = ops fork, PR lives in a sibling portfolio repo) the natural `cd <portfolio> && gh pr merge <N>` form carries **neither**, so `CMD_REPO` came back empty: `gh pr diff` resolved `<N>` against the ops fork → empty diff → the gate **silently bypassed** (`exit 0`, never enforced), and the marker was looked up under the wrong (`unknown`) qualifier. This is the deferred merge-time sibling of #669 (which fixed the create-time gate).
- **Re-rooted the read side to the command's cd-target** — both hooks now extend the `CMD_REPO` chain with a cd-target step (`pr_cmd_cd_target` + `git_origin_repo`, the helpers added in #669) and **derive `REPO_FLAG` after the full resolution**, so `gh pr diff <N> --repo <portfolio>` targets the PR's real repo. The cd-target is used only when it resolves to a real git tree; otherwise it falls through to the existing fallback (no worse than before).
- **Made the marker writers repo-aware (the load-bearing half)** — a read-side-only fix would convert the silent-bypass into a **false-block**: the write side (`/approve-architecture`, `/approve-design`, `/design-review` → Tariq) runs as a skill/agent invocation from the ops-fork cwd with bare `gh pr view <N>` (no `--repo`, and a skill can't carry a `cd` prefix), so it wrote the marker under the *ops-fork* qualifier the fixed read side no longer looks for. These now accept an `owner/repo#N` hint and pass `--repo` to `gh pr view`, keying the marker on the same portfolio slug the read side computes — and **fail loud** (ask for `owner/repo#N`) rather than write a guessed qualifier.
- **Closed a test gap + proved the symmetry** — added a first end-to-end harness for `require-design-review-for-ui.sh` (previously **zero** e2e coverage; only the `ui_paths_exclude` filter was tested inline), plus `#687` cd-target, write→read **round-trip**, and wrong-qualifier cases on **both** gates. The no-marker and wrong-qualifier cases were verified to **fail against the pre-fix hook** and pass after — the explicit read/write symmetry check the issue's warning section demands.

## Scope
Scoped to the two gates #687 names. The rex/ceo gate (`block-unreviewed-merge.sh` + `/approve-merge` + the Rex agent) shares the identical latent no-`--repo` bug but is left untouched on **both** sides (so it stays internally consistent at status-quo); a follow-up should close it the same way.

## Testing
1. `bash bin/run-hook-tests.sh` → **71/0**.
2. `env -u CLAUDE_CODE_SESSION_ID -u APEXYARD_OPS_PIN_DIR bash .claude/hooks/tests/test_require_architecture_review.sh` → **22/0** (15 prior + the new cd-target/round-trip cases).
3. `env -u CLAUDE_CODE_SESSION_ID -u APEXYARD_OPS_PIN_DIR bash .claude/hooks/tests/test_require_design_review_for_ui.sh` → **22/0** (new file).
4. Failing-first check: with the two hook changes stashed, the `#687` no-marker + wrong-qualifier cases FAIL (gate returns `0`/bypass), confirming they exercise the fix.

> Run the suites with `env -u CLAUDE_CODE_SESSION_ID -u APEXYARD_OPS_PIN_DIR` inside a live Claude Code session — otherwise the session's ops-root pin overrides the fixture ops-root (pre-existing test-isolation quirk, same note as #688).

## Dependency
**Depends on #688** (the #669 fix) — this PR consumes `pr_cmd_cd_target` from `_lib-pr-repo.sh`, added there. Please merge #688 first; until then this PR's diff includes #688's commits. After #688 lands on `dev` I'll rebase this onto `dev` (dropping the #688 commits) and re-request review.

Refs #687 · Related: #669, #464 · Marker scheme: AgDR-0060 (repo-qualified markers).

## Glossary
| Term | Definition |
|------|------------|
| split-portfolio v2 | apexyard mode where the public framework fork and the private portfolio (registry + `projects/`) live in separate sibling repos |
| cd-target | the directory in a leading `cd <path> && gh …` prefix — where the `gh` call actually runs, which the PreToolUse hook cannot see via its own cwd (it fires pre-`cd`) |
| silent-bypass | a gate that returns success without actually enforcing its check (here: empty `gh pr diff` → `exit 0`) |
| repo-qualified marker | a review-approval marker filename keyed on the PR's `owner/repo` (`_lib-review-markers.sh`, #485 / AgDR-0060) — `<owner>__<repo>__<pr>-<role>.approved` |
| read/write symmetry | the invariant that the qualifier the gate (read) looks up equals the qualifier the approval skill (write) produces; breaking it turns a missing-marker bypass into a false-block |
