### PR TITLE
fix(#690): make hook directory-walks and upstream fetch cross-platform

### DIFF
--- a/.claude/hooks/_lib-migration-chain.sh
+++ b/.claude/hooks/_lib-migration-chain.sh
@@ -52,7 +52,7 @@ _migration_ops_root() {
       echo "$cur"
       return 0
     fi
-    cur=$(dirname "$cur")
+    parent=$(dirname "$cur"); [ "$parent" = "$cur" ] && break; cur="$parent"
   done
   echo "$r"
 }

--- a/.claude/hooks/_lib-ops-root.sh
+++ b/.claude/hooks/_lib-ops-root.sh
@@ -100,7 +100,7 @@ resolve_ops_root_walk() {
       printf '%s' "$r"
       return 0
     fi
-    r=$(dirname "$r")
+    parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
   done
   return 0
 }

--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -78,7 +78,7 @@ _portfolio_root() {
       echo "$cur"
       return 0
     fi
-    cur=$(dirname "$cur")
+    parent=$(dirname "$cur"); [ "$parent" = "$cur" ] && break; cur="$parent"
   done
 
   # Not under an apexyard fork — fall back to git toplevel so callers

--- a/.claude/hooks/apply-agent-routing.sh
+++ b/.claude/hooks/apply-agent-routing.sh
@@ -82,7 +82,7 @@ else
       ROOT="$cur"
       break
     fi
-    cur=$(dirname "$cur")
+    parent=$(dirname "$cur"); [ "$parent" = "$cur" ] && break; cur="$parent"
   done
 fi
 

--- a/.claude/hooks/block-agent-routing-drift.sh
+++ b/.claude/hooks/block-agent-routing-drift.sh
@@ -76,7 +76,7 @@ else
   while [ -n "$cur" ] && [ "$cur" != "/" ]; do
     if [ -f "$cur/.apexyard-fork" ]; then ROOT="$cur"; break; fi
     if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then ROOT="$cur"; break; fi
-    cur=$(dirname "$cur")
+    parent=$(dirname "$cur"); [ "$parent" = "$cur" ] && break; cur="$parent"
   done
 fi
 

--- a/.claude/hooks/block-private-refs-in-public-repos.sh
+++ b/.claude/hooks/block-private-refs-in-public-repos.sh
@@ -134,7 +134,7 @@ while [ -n "$r" ] && [ "$r" != "/" ]; do
     REGISTRY="$r/apexyard.projects.yaml"
     break
   fi
-  r=$(dirname "$r")
+  parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
 done
 
 if [ -z "$REGISTRY" ]; then

--- a/.claude/hooks/check-jq-installed.sh
+++ b/.claude/hooks/check-jq-installed.sh
@@ -50,7 +50,7 @@ else
     if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
       ops_root="$r"; break
     fi
-    r=$(dirname "$r")
+    parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
   done
 fi
 

--- a/.claude/hooks/check-portfolio-config.sh
+++ b/.claude/hooks/check-portfolio-config.sh
@@ -47,7 +47,7 @@ else
       ROOT="$cur"
       break
     fi
-    cur=$(dirname "$cur")
+    parent=$(dirname "$cur"); [ "$parent" = "$cur" ] && break; cur="$parent"
   done
 fi
 

--- a/.claude/hooks/check-upstream-drift.sh
+++ b/.claude/hooks/check-upstream-drift.sh
@@ -65,7 +65,10 @@ if [ "$SHOULD_FETCH" = "1" ]; then
   # silently — we don't want a startup banner yelling about offline state.
   # `--tags --prune-tags` pulls tag refs and removes local copies of any tag
   # upstream has retracted (rare, but keeps the local tag view honest).
-  if ! timeout 5 git fetch upstream --tags --prune-tags --quiet 2>/dev/null; then
+  _TO=""
+  if command -v timeout >/dev/null 2>&1; then _TO="timeout -k 2 5"
+  elif command -v gtimeout >/dev/null 2>&1; then _TO="gtimeout -k 2 5"; fi
+  if ! GIT_TERMINAL_PROMPT=0 $_TO git fetch upstream --tags --prune-tags --quiet 2>/dev/null; then
     exit 0
   fi
   mkdir -p "$CACHE_DIR"

--- a/.claude/hooks/clear-bootstrap-marker.sh
+++ b/.claude/hooks/clear-bootstrap-marker.sh
@@ -45,7 +45,7 @@ else
       ROOT="$cur"
       break
     fi
-    cur=$(dirname "$cur")
+    parent=$(dirname "$cur"); [ "$parent" = "$cur" ] && break; cur="$parent"
   done
 fi
 

--- a/.claude/hooks/clear-issue-skill-marker.sh
+++ b/.claude/hooks/clear-issue-skill-marker.sh
@@ -41,7 +41,7 @@ else
       ROOT="$cur"
       break
     fi
-    cur=$(dirname "$cur")
+    parent=$(dirname "$cur"); [ "$parent" = "$cur" ] && break; cur="$parent"
   done
 fi
 

--- a/.claude/hooks/link-custom-skills.sh
+++ b/.claude/hooks/link-custom-skills.sh
@@ -67,7 +67,7 @@ else
     if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
       ops_root="$cur"; break
     fi
-    cur=$(dirname "$cur")
+    parent=$(dirname "$cur"); [ "$parent" = "$cur" ] && break; cur="$parent"
   done
 fi
 

--- a/.claude/hooks/remind-mcp-tools.sh
+++ b/.claude/hooks/remind-mcp-tools.sh
@@ -27,7 +27,7 @@ while [ -n "$r" ] && [ "$r" != "/" ]; do
     mcp_configured=true
     break
   fi
-  r=$(dirname "$r")
+  parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
 done
 
 $mcp_configured || exit 0

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -182,7 +182,7 @@ if [ -n "$REPO_ROOT" ]; then
         OPS_ROOT="$r"
         break
       fi
-      r=$(dirname "$r")
+      parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
     done
   fi
 fi

--- a/.claude/hooks/require-agdr-for-arch-changes.sh
+++ b/.claude/hooks/require-agdr-for-arch-changes.sh
@@ -133,7 +133,7 @@ spike_commit_exempt() {
         marker_home="$r"
         break
       fi
-      r=$(dirname "$r")
+      parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
     done
   fi
 

--- a/.claude/hooks/require-agdr-for-arch-pr.sh
+++ b/.claude/hooks/require-agdr-for-arch-pr.sh
@@ -234,7 +234,7 @@ spike_pr_exempt() {
         marker_home="$r"
         break
       fi
-      r=$(dirname "$r")
+      parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
     done
   fi
 

--- a/.claude/hooks/require-migration-ticket.sh
+++ b/.claude/hooks/require-migration-ticket.sh
@@ -98,7 +98,7 @@ if [ -n "$REPO_ROOT" ]; then
         OPS_ROOT="$r"
         break
       fi
-      r=$(dirname "$r")
+      parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
     done
   fi
 fi

--- a/.claude/hooks/require-skill-for-issue-create.sh
+++ b/.claude/hooks/require-skill-for-issue-create.sh
@@ -50,7 +50,7 @@ else
     if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
       OPS_ROOT="$cur"; break
     fi
-    cur=$(dirname "$cur")
+    parent=$(dirname "$cur"); [ "$parent" = "$cur" ] && break; cur="$parent"
   done
 fi
 MARKER_HOME="${OPS_ROOT:-${REPO_ROOT:-.}}"


### PR DESCRIPTION
## Summary

- Ancestor-directory walks (`while [ "$d" != "/" ]; do d=$(dirname "$d"); done`) never terminate on Windows/Git Bash: `git rev-parse --show-toplevel` yields a drive path (`C:/…`) and `dirname` bottoms out at `C:`, never `/`. SessionStart hooks such as `remind-mcp-tools.sh` then spin forever and leave the Claude Code session blank. Added a no-progress guard (`[ "$parent" = "$d" ] && break`) to all 17 walk loops — a no-op on Linux/macOS where the walk already reaches `/`.
- `check-upstream-drift.sh` used `timeout 5 git fetch`, which cannot bound git on Windows (git ignores SIGTERM) and silently no-ops on macOS (no `timeout`; it is `gtimeout`). Now detects `timeout`/`gtimeout`, hard-kills with `-k`, and sets `GIT_TERMINAL_PROMPT=0` so a credential prompt cannot stall startup.

## Testing

- `bash bin/run-hook-tests.sh` → **PASS=70 FAIL=0** (Linux).
- Windows (Git Bash): full SessionStart hook chain now completes; previously `remind-mcp-tools.sh` looped forever (blank session).
- Guard verified as a no-op on POSIX paths — the walk still terminates at `/`.

## Glossary

- **Ancestor walk** — climbing parent directories to locate the ops-root marker (`.apexyard-fork`).
- **Ops root** — the fork root ApexYard hooks resolve to.
- **SessionStart hook** — a hook Claude Code runs at session start; a hang here blanks the UI.

Resolves #690.