### PR TITLE
fix(#695): read --body-file when checking the skip marker + required sections

### DIFF
--- a/.claude/hooks/tests/test_validate_issue_structure.sh
+++ b/.claude/hooks/tests/test_validate_issue_structure.sh
@@ -291,6 +291,55 @@ run_case "--body-file path with valid Feature body → pass" \
   0 "" \
   "gh issue create --title '[Feature] X' --body-file $BODY_FILE_PATH"
 
+# --- body-file: skip marker honoured (me2resh/apexyard#695) -----------------
+# An off-template epic body that carries the skip marker must bypass
+# validation when supplied via --body-file, exactly like the inline --body
+# case above.
+SKIP_FILE_PATH="$TMPDIR/skip-body.md"
+cat > "$SKIP_FILE_PATH" <<'EOF'
+free-form epic body, no required sections.
+<!-- validate-issue-structure: skip -->
+EOF
+
+run_case "--body-file with skip marker → bypass (#695)" \
+  0 "validate-issue-structure bypassed" \
+  "gh issue create --title '[Feature] epic via file' --body-file $SKIP_FILE_PATH"
+
+# --- body-file: missing required section still blocks -----------------------
+MISSING_FILE_PATH="$TMPDIR/missing-body.md"
+cat > "$MISSING_FILE_PATH" <<'EOF'
+## User Story
+As a user I want a thing.
+EOF
+
+run_case "--body-file missing Acceptance Criteria → block (#695)" \
+  2 "missing section: ## Acceptance Criteria" \
+  "gh issue create --title '[Feature] incomplete via file' --body-file $MISSING_FILE_PATH"
+
+# --- gh-api field form: -F body=@<path> (me2resh/apexyard#695) --------------
+# `gh api … -F body=@<file>` is the REST shape for posting an issue body from
+# a file. Pre-#695 the field-value path after the `@` sigil was never resolved
+# (the `-F` handler rejected any value containing `=`), AND a single-dash flag
+# after a quoted --title broke title extraction — so the skip marker and the
+# section checks were both blind to the file content. Cover skip-marker-honour
+# and missing-section-block across -F / --field / -f.
+
+run_case "-F body=@file with skip marker → bypass (#695)" \
+  0 "validate-issue-structure bypassed" \
+  "gh issue create --title '[Feature] epic via field' -F body=@$SKIP_FILE_PATH"
+
+run_case "-F body=@file missing Acceptance Criteria → block (#695)" \
+  2 "missing section: ## Acceptance Criteria" \
+  "gh issue create --title '[Feature] incomplete via field' -F body=@$MISSING_FILE_PATH"
+
+run_case "--field body=@file missing section → block (#695)" \
+  2 "missing section: ## Acceptance Criteria" \
+  "gh issue create --title '[Feature] incomplete via --field' --field body=@$MISSING_FILE_PATH"
+
+run_case "-f body=@file missing section → block (#695)" \
+  2 "missing section: ## Acceptance Criteria" \
+  "gh issue create --title '[Feature] incomplete via -f' -f body=@$MISSING_FILE_PATH"
+
 # --- Embedded double quotes in body — me2resh/apexyard#227 -----------------
 # Pre-227 the awk extractor's non-greedy `"([^"]*)"` regex truncated the
 # body at the FIRST embedded `"`, so any `##` heading past that point was

--- a/.claude/hooks/validate-issue-structure.sh
+++ b/.claude/hooks/validate-issue-structure.sh
@@ -80,21 +80,28 @@ extract_flag_value() {
     END {
       s = buf
       # Double-quoted value: greedy `(.*)` anchored on next flag or EOS.
-      re = "(" FLAG_RE ")[[:space:]]+\"(.*)\"([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
+      # Boundary matches single-dash (`-F`, `-f`, `-t`) OR double-dash
+      # (`--field`, `--body-file`) flags. The earlier `--[a-zA-Z]`-only anchor
+      # failed when a single-dash flag followed a quoted value — e.g.
+      # `--title "[Feature] F" -F body=@file` parsed the title as `"[Feature]`
+      # via the unquoted fallback, so the bracketed prefix never resolved and
+      # the gh-api body-file shape silently bypassed validation
+      # (me2resh/apexyard#695).
+      re = "(" FLAG_RE ")[[:space:]]+\"(.*)\"([[:space:]]+-{1,2}[a-zA-Z]|[[:space:]]*$)"
       if (match(s, re)) {
         chunk = substr(s, RSTART, RLENGTH)
         sub("^(" FLAG_RE ")[[:space:]]+\"", "", chunk)
-        sub("\"([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
+        sub("\"([[:space:]]+-{1,2}[a-zA-Z].*)?$", "", chunk)
         sub("\"[[:space:]]*$", "", chunk)
         print chunk
         exit
       }
       # Single-quoted value: same greedy + anchor treatment.
-      re = "(" FLAG_RE ")[[:space:]]+" SQ "(.*)" SQ "([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
+      re = "(" FLAG_RE ")[[:space:]]+" SQ "(.*)" SQ "([[:space:]]+-{1,2}[a-zA-Z]|[[:space:]]*$)"
       if (match(s, re)) {
         chunk = substr(s, RSTART, RLENGTH)
         sub("^(" FLAG_RE ")[[:space:]]+" SQ, "", chunk)
-        sub(SQ "([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
+        sub(SQ "([[:space:]]+-{1,2}[a-zA-Z].*)?$", "", chunk)
         sub(SQ "[[:space:]]*$", "", chunk)
         print chunk
         exit
@@ -127,6 +134,19 @@ if [ -z "$BODY_FILE" ]; then
   fi
   if [ -n "$F_VAL" ] && ! echo "$F_VAL" | grep -q '='; then
     BODY_FILE="$F_VAL"
+  fi
+fi
+
+# `gh api … -F body=@<path>` (or --field / -f, raw `body@=<path>`) is the
+# canonical REST shape for posting an issue body from a file — distinct from
+# the `gh issue create --body-file <path>` form handled above. Here the field
+# VALUE carries the file path after an `@` sigil, so the skip-marker + section
+# checks were blind to the file's content (me2resh/apexyard#695). Extract the
+# path from any `body=@<path>` / `body@=<path>` field on -F / --field / -f.
+if [ -z "$BODY_FILE" ]; then
+  BODY_AT=$(echo "$COMMAND" | sed -nE "s/.*(^|[[:space:]])(-F|--field|-f)[[:space:]]+[\"']?body@?=@([^[:space:]\"']+).*/\3/p" | head -1)
+  if [ -n "$BODY_AT" ]; then
+    BODY_FILE="$BODY_AT"
   fi
 fi
 


### PR DESCRIPTION
## Summary

- **Fixed silent validation bypass for the gh-API field-file shape** — `validate-issue-structure.sh` never saw an issue body supplied via `gh issue create -F body=@<path>` (the canonical REST way to post a body from a file). Two distinct gaps combined: the title couldn't be parsed when a single-dash flag followed it, and the `@`-prefixed file path was never resolved. As a result a legitimately off-template epic carrying the `<!-- validate-issue-structure: skip -->` marker via the field-file shape was **blocked** (skip marker invisible), and — worse — a field-file body missing a required section was **silently allowed** (sections invisible). This is the user-facing symptom in #695.
- **Widened the flag-boundary anchor in `extract_flag_value` to `-{1,2}[a-zA-Z]`** — the greedy quoted-value matcher previously anchored only on double-dash (`--`) flags, so `--title "[Feature] F" -F body=@file` fell through to the unquoted fallback and extracted `"[Feature]` (leading quote, truncated). The bracketed prefix then failed to resolve and the hook exited 0. The anchor now stops at single-dash (`-F`, `-f`, `-t`) flags too, so the title — and any quoted value followed by a single-dash flag — extracts cleanly.
- **Added a dedicated `body=@<path>` field extractor** — the existing `-F` handler rejected any value containing `=`, so `body=@<path>` was discarded. A new block reads the path after the `@` sigil from `body=@<path>` / `body@=<path>` on `-F` / `--field` / `-f`, feeding the file content into the same `FULL_BODY` that the skip-marker and section checks already inspect.
- **Inline `--body` and `--body-file <path>` behaviour is unchanged** — verified by the existing suite plus new regression cases.
- **Tests** — six new cases in `test_validate_issue_structure.sh` cover skip-marker honour and missing-section blocking across `--body-file`, `-F body=@`, `--field body=@`, and `-f body=@`. The full hook suite is green (71/71); the per-hook suite is 30/30.

Closes #695

## Testing

1. `bash .claude/hooks/tests/test_validate_issue_structure.sh` → `Passed: 30  Failed: 0`
2. `bash bin/run-hook-tests.sh` → `PASS=71  FAIL=0  SKIP=0  TOTAL=71`
3. Manual: `gh issue create --title '[Feature] F' -F body=@<file-with-missing-sections>` now exits 2 (blocks); the same with the skip marker exits 0 with a `validate-issue-structure bypassed` warning.

## Glossary

| Term | Definition |
|------|------------|
| Skip marker | The HTML comment `<!-- validate-issue-structure: skip -->` that, when present in an issue body, makes the hook exit 0 (a visible, logged bypass) so legitimately off-template tickets like epics aren't blocked. |
| `-F body=@<path>` | A `gh`/`gh api` field flag whose value, prefixed with `@`, names a file whose contents become the field value (here, the issue body). The canonical REST shape for posting a body from a file. |
| Flag-boundary anchor | The regex fragment in `extract_flag_value` that marks where a quoted flag value ends — i.e. the next CLI flag or end-of-string. Previously matched only `--`-style flags; now matches single- and double-dash flags. |
| `FULL_BODY` | The combined body text the hook validates: inline `--body` plus any resolved `--body-file` / `-F body=@` file content. |
| PreToolUse hook | A Claude Code hook that runs before a tool call (here, `Bash` invoking `gh issue create`) and can block it by exiting non-zero. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQWFvN2vzy1UtFX2FyaDvb
