### PR TITLE
fix(#693): re-root validate-pr-create + validate-branch-name to the cd-target

### DIFF
--- a/.claude/hooks/tests/test_validate_branch_name_pushref.sh
+++ b/.claude/hooks/tests/test_validate_branch_name_pushref.sh
@@ -27,6 +27,7 @@ SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 HOOK_SRC="$SRC_ROOT/.claude/hooks/validate-branch-name.sh"
 LIB_SRC="$SRC_ROOT/.claude/hooks/_lib-extract-push-ref.sh"
 LIB_CONFIG_SRC="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+LIB_PR_REPO_SRC="$SRC_ROOT/.claude/hooks/_lib-pr-repo.sh"
 
 for f in "$HOOK_SRC" "$LIB_SRC"; do
   if [ ! -f "$f" ]; then
@@ -62,6 +63,9 @@ make_sandbox_with_wrong_local_branch() {
   cp "$LIB_SRC"  "$sb/.claude/hooks/_lib-extract-push-ref.sh"
   if [ -f "$LIB_CONFIG_SRC" ]; then
     cp "$LIB_CONFIG_SRC" "$sb/.claude/hooks/_lib-read-config.sh"
+  fi
+  if [ -f "$LIB_PR_REPO_SRC" ]; then
+    cp "$LIB_PR_REPO_SRC" "$sb/.claude/hooks/_lib-pr-repo.sh"
   fi
   if [ -f "$SRC_ROOT/.claude/project-config.defaults.json" ]; then
     cp "$SRC_ROOT/.claude/project-config.defaults.json" "$sb/.claude/project-config.defaults.json"
@@ -195,6 +199,91 @@ run_case "regression: explicit ref passes (no refspec)" \
 
 run_case "regression: non-conforming explicit ref still blocks" \
   "git push origin bogus-branch" 2
+
+# ---- #693: cd-target re-root for the no-ref fallback --------------------
+#
+# Scenario: from an ops-fork session whose cwd branch is non-conforming
+# (`dev` / a bogus host branch), the operator runs
+#   `cd <other-repo> && git push origin`
+# with NO explicit source ref. The hook fires BEFORE the shell `cd` runs,
+# so its cwd is still the host sandbox. Pre-#693 the fallback resolves the
+# branch via `git branch --show-current` in the host cwd (non-conforming →
+# false BLOCK, e.g. "Branch 'dev' missing ticket ID"). Post-#693 the hook
+# re-roots the fallback to the cd-target via pr_cmd_cd_target.
+#
+# These cases need a SECOND repo (the cd-target) checked out on a known
+# branch, while the host sandbox stays on the non-conforming branch.
+
+# Build a target repo checked out on the given branch. Echoes its path.
+make_target_repo_on_branch() {
+  local target_branch="$1" tdir
+  tdir=$(mktemp -d)
+  (
+    cd "$tdir" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    : > onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+    git checkout -q -B "$target_branch"
+  )
+  echo "$tdir"
+}
+
+# Like run_case, but the command `cd`s into a separate target repo that is
+# checked out on $target_branch. The host sandbox's local branch stays
+# non-conforming, so a correct re-root is the ONLY way these pass/fail as
+# expected.
+run_cd_case() {
+  local label="$1" target_branch="$2" want_rc="$3"
+  local sb tgt; sb=$(make_sandbox_with_wrong_local_branch)
+  tgt=$(make_target_repo_on_branch "$target_branch")
+  local cmd="cd $tgt && git push origin"
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_rc got_stderr
+  got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/validate-branch-name.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb" "$tgt"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc" >&2
+    echo "    cmd: $cmd" >&2
+    echo "    stderr: ${got_stderr:0:300}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# (a) False-positive gone: cd-target is on a CONFORMING branch, host cwd is
+#     non-conforming, no source ref → PASS (pre-#693 this BLOCKED on the
+#     host's bogus branch).
+run_cd_case "#693: cd-target on conforming branch, no ref → PASS (false-positive gone)" \
+  "feature/GH-693-cd-target" 0
+
+# (b) cd-target on the framework trunk `dev` → exempt → PASS. (Proves the
+#     re-root reads the TARGET's branch: host is bogus, target is dev.)
+run_cd_case "#693: cd-target on dev (trunk), no ref → PASS via trunk exemption" \
+  "dev" 0
+
+# (c) Still fires: cd-target itself is on a genuinely non-conforming branch →
+#     BLOCK. Proves the re-root targets the right tree, not a blanket no-op.
+run_cd_case "#693: cd-target on non-conforming branch, no ref → still BLOCKS (true-negative)" \
+  "bogus-no-ticket-branch" 2
+
+# (d) No-`cd` path unchanged: explicit conforming ref still passes; explicit
+#     non-conforming ref still blocks; no-ref falls back to host HEAD (bogus)
+#     and blocks. (These mirror the existing cases above but are re-asserted
+#     here to lock the byte-for-byte no-`cd` equivalence the #693 fix promises.)
+run_case "#693: no-cd explicit conforming ref still passes" \
+  "git push origin feature/GH-693-no-cd" 0
+run_case "#693: no-cd explicit non-conforming ref still blocks" \
+  "git push origin bogus-branch" 2
+run_case "#693: no-cd no-ref falls back to host HEAD (bogus) → blocks" \
+  "git push origin" 2
 
 # ---- Summary ------------------------------------------------------------
 

--- a/.claude/hooks/tests/test_validate_pr_create_head.sh
+++ b/.claude/hooks/tests/test_validate_pr_create_head.sh
@@ -22,6 +22,7 @@ SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 HOOK_SRC="$SRC_ROOT/.claude/hooks/validate-pr-create.sh"
 LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
 LIB_TRACKER="$SRC_ROOT/.claude/hooks/_lib-tracker.sh"
+LIB_PR_REPO="$SRC_ROOT/.claude/hooks/_lib-pr-repo.sh"
 DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
 
 # shellcheck source=_lib-mock-gh.sh
@@ -57,6 +58,7 @@ make_sandbox() {
   cp "$HOOK_SRC" "$sb/.claude/hooks/validate-pr-create.sh"
   if [ -f "$LIB_CFG" ]; then cp "$LIB_CFG" "$sb/.claude/hooks/_lib-read-config.sh"; fi
   if [ -f "$LIB_TRACKER" ]; then cp "$LIB_TRACKER" "$sb/.claude/hooks/_lib-tracker.sh"; fi
+  if [ -f "$LIB_PR_REPO" ]; then cp "$LIB_PR_REPO" "$sb/.claude/hooks/_lib-pr-repo.sh"; fi
   if [ -f "$DEFAULTS" ]; then cp "$DEFAULTS" "$sb/.claude/project-config.defaults.json"; fi
   chmod +x "$sb/.claude/hooks/validate-pr-create.sh"
   echo "$sb"
@@ -140,6 +142,92 @@ run_case "--head later in command line still resolves" \
 
 run_case "--head before --title still resolves" \
   "--head feature/GH-194-foo --base dev" 0 ""
+
+# ---- #693: cd-target re-root for the local-HEAD fallback ----------------
+#
+# Scenario: from an ops-fork session whose cwd branch is non-conforming, the
+# operator runs `cd <other-repo> && gh pr create …` WITHOUT a --head flag.
+# The hook fires BEFORE the shell `cd` runs, so its cwd is still the host
+# sandbox. Pre-#693 the fallback resolves the branch via `git branch
+# --show-current` in the host cwd (non-conforming → false BLOCK "missing
+# ticket ID"). Post-#693 the hook re-roots the fallback to the cd-target via
+# pr_cmd_cd_target. The --head path and the cwd-independent PR-title check
+# are unaffected.
+
+# Build a target repo checked out on $1. Echoes its path.
+make_target_repo_on_branch() {
+  local target_branch="$1" tdir
+  tdir=$(mktemp -d)
+  (
+    cd "$tdir" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    : > onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+    git checkout -q -B "$target_branch"
+  )
+  echo "$tdir"
+}
+
+# Runs `cd <target> && gh pr create …` (no --head). Host sandbox stays on the
+# non-conforming branch; the target is on $target_branch. A correct re-root is
+# the only way these reach the expected verdict.
+run_cd_case() {
+  local label="$1" target_branch="$2" want_rc="$3" want_stderr_regex="$4"
+  local sb tgt; sb=$(make_sandbox)
+  mock_gh_install "$sb"
+  tgt=$(make_target_repo_on_branch "$target_branch")
+  local body_file="$sb/body.md"
+  printf '%s' "$BODY_OK" > "$body_file"
+
+  local cmd="cd $tgt && gh pr create --repo me2resh/apexyard --title 'fix(#693): test' --body-file $body_file"
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/validate-pr-create.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb" "$tgt"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc" >&2
+    echo "    target_branch: $target_branch" >&2
+    echo "    stderr: ${got_stderr:0:300}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# (a) False-positive gone: cd-target on a CONFORMING branch, host cwd bogus,
+#     no --head → PASS (pre-#693 this BLOCKED on the host's bogus branch).
+run_cd_case "#693: cd-target on conforming branch, no --head → PASS (false-positive gone)" \
+  "feature/GH-693-cd-target" 0 ""
+
+# (b) cd-target on `main` → exempt → PASS. Proves the re-root reads the
+#     TARGET's branch (host is bogus, target is main).
+run_cd_case "#693: cd-target on main (trunk), no --head → PASS via trunk exemption" \
+  "main" 0 ""
+
+# (c) Still fires: cd-target itself on a genuinely non-conforming branch →
+#     BLOCK. Proves the re-root targets the right tree, not a blanket no-op.
+run_cd_case "#693: cd-target on non-conforming branch, no --head → still BLOCKS (true-negative)" \
+  "bogus-no-ticket-branch" 2 "missing ticket ID"
+
+# (d) No-`cd` path unchanged: --head still wins, no-head still falls back to
+#     host HEAD (bogus → block). Re-asserted to lock byte-for-byte equivalence.
+run_case "#693: no-cd --head conforming still passes" \
+  "--head feature/GH-693-no-cd" 0 ""
+run_case "#693: no-cd no --head falls back to host HEAD (bogus) → blocks" \
+  "" 2 "missing ticket ID"
 
 # ---- Summary ------------------------------------------------------------
 

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -45,8 +45,40 @@ if [ -f "$HOOK_DIR/_lib-extract-push-ref.sh" ]; then
   PUSH_REF=$(extract_push_ref "$COMMAND")
 fi
 
+# When the push has no explicit source ref (no-arg `git push`, `git push
+# origin` relying on upstream tracking), we fall back to the current branch.
+# That fallback MUST be resolved against the repo the command actually runs
+# in — not the hook's own cwd. The harness fires this PreToolUse hook BEFORE
+# the shell executes the command, so a `cd <repo> && git push …` prefix has
+# NOT yet changed the working dir: the hook's cwd is still the ops fork (on,
+# e.g., `dev`). Without re-rooting, the fallback reads the ops-fork's branch
+# and false-blocks a push for a *different* managed repo (e.g. "Branch 'dev'
+# missing ticket ID"). Same class as #669/#687 for the merge gates + arch-PR
+# hook. See me2resh/apexyard#693.
+#
+# Re-root via pr_cmd_cd_target from _lib-pr-repo.sh: if the command begins
+# with `cd <path> && …`, resolve the fallback branch with `git -C <path>`.
+# When there's no leading `cd` (or <path> isn't a git tree), this is a no-op
+# and the fallback stays byte-for-byte equivalent to the pre-#693 behaviour.
+BRANCH_DIR=""
+if [ -f "$HOOK_DIR/_lib-pr-repo.sh" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$HOOK_DIR/_lib-pr-repo.sh"
+  CD_TARGET=$(pr_cmd_cd_target "$COMMAND")
+  if [ -n "$CD_TARGET" ]; then
+    CD_TOPLEVEL=$(git -C "$CD_TARGET" rev-parse --show-toplevel 2>/dev/null)
+    if [ -n "$CD_TOPLEVEL" ]; then
+      BRANCH_DIR="$CD_TOPLEVEL"
+    fi
+    # If <path> is not a readable git tree, fall through with BRANCH_DIR empty
+    # — the fallback uses the hook's own cwd, no worse than pre-#693.
+  fi
+fi
+
 if [ -n "$PUSH_REF" ]; then
   CURRENT_BRANCH="$PUSH_REF"
+elif [ -n "$BRANCH_DIR" ]; then
+  CURRENT_BRANCH=$(git -C "$BRANCH_DIR" branch --show-current 2>/dev/null)
 else
   CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
 fi

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -471,8 +471,40 @@ fi
 # harness $PWD may still be a sibling worktree's directory). Falls back
 # to local HEAD when `--head` isn't passed — preserves today's behaviour
 # for anyone using the implicit-branch shape. See me2resh/apexyard#194.
+#
+# The local-HEAD fallback MUST resolve against the repo the command actually
+# runs in — not the hook's own cwd. The harness fires this PreToolUse hook
+# BEFORE the shell executes the command, so a `cd <repo> && gh pr create …`
+# prefix has NOT yet changed the working dir: the hook's cwd is still the ops
+# fork (on, e.g., `dev`). Without re-rooting, the fallback reads the ops-fork's
+# branch and false-blocks a PR for a *different* managed repo (e.g. "Branch
+# 'dev' missing ticket ID"). Same class as #669/#687 for the merge gates +
+# arch-PR hook. See me2resh/apexyard#693.
+#
+# Re-root via pr_cmd_cd_target (from _lib-pr-repo.sh, already sourced above as
+# $CMD_REPO is parsed): if the command begins with `cd <path> && …`, resolve
+# the fallback branch with `git -C <path>`. With no leading `cd` (or <path>
+# not a git tree), this is a no-op and the fallback stays byte-for-byte
+# equivalent to the pre-#693 behaviour. The `--head` path is unaffected, and
+# the PR-title check above is independent of cwd.
+BRANCH_DIR=""
+if command -v pr_cmd_cd_target >/dev/null 2>&1; then
+  CD_TARGET=$(pr_cmd_cd_target "$COMMAND")
+  if [ -n "$CD_TARGET" ]; then
+    CD_TOPLEVEL=$(git -C "$CD_TARGET" rev-parse --show-toplevel 2>/dev/null)
+    if [ -n "$CD_TOPLEVEL" ]; then
+      BRANCH_DIR="$CD_TOPLEVEL"
+    fi
+  fi
+fi
 HEAD_FLAG=$(echo "$COMMAND" | sed -nE 's/.*--head[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
-CURRENT_BRANCH="${HEAD_FLAG:-$(git branch --show-current 2>/dev/null)}"
+if [ -n "$HEAD_FLAG" ]; then
+  CURRENT_BRANCH="$HEAD_FLAG"
+elif [ -n "$BRANCH_DIR" ]; then
+  CURRENT_BRANCH=$(git -C "$BRANCH_DIR" branch --show-current 2>/dev/null)
+else
+  CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+fi
 if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "main" ] && [ "$CURRENT_BRANCH" != "master" ]; then
   # Release-cut branches are exempt — same recognition `validate-branch-name.sh`
   # added in me2resh/apexyard#168 / #169. Release branches don't carry a


### PR DESCRIPTION
## Summary

- **Re-rooted `validate-branch-name.sh` to the command's `cd`-target** — when a `git push` carries no explicit source ref, the hook fell back to `git branch --show-current` in its **own** cwd. Because the PreToolUse hook fires *before* the shell runs `cd <other-repo> && git push`, that cwd is still the ops fork (typically on `dev`), so pushing for a *different* managed repo false-blocked with "Branch 'dev' missing ticket ID". The fallback now resolves via `git -C <cd-target>` using `pr_cmd_cd_target` from `_lib-pr-repo.sh`. Same fix class as #669/#687 (which re-rooted the arch-PR hook + merge gates).
- **Re-rooted `validate-pr-create.sh`'s branch-ticket-ID check the same way** — its local-HEAD fallback (used when `--head` is absent) had the identical cwd bug for `cd <other-repo> && gh pr create`. The `--head` path and the cwd-independent **PR-title existence check** are deliberately untouched.
- **Not weakened — the gate still fires on a genuinely non-compliant target.** A non-conforming branch *in the cd-target* still BLOCKS (true-negative regression case `(c)` in both test files). The proof is `#693: cd-target on non-conforming branch … → still BLOCKS`. The no-`cd` path stays byte-for-byte equivalent (case `(d)` in both files), and when there is no leading `cd` (or the target isn't a git tree) the resolution falls through to the original cwd behaviour.
- **Regression tests, failing-first verified** — extended `test_validate_branch_name_pushref.sh` (+6 cases) and `test_validate_pr_create_head.sh` (+5 cases). Stashing the hook fix makes the two false-positive cases fail (rc=2 instead of 0) while the true-negative still blocks, confirming the tests pin the bug. Full `bin/run-hook-tests.sh` suite is green (55 PASS, 0 FAIL); both hooks and tests are `bash -n` clean.

## Testing

1. `bash .claude/hooks/tests/test_validate_branch_name_pushref.sh` → 34 PASS, 0 FAIL.
2. `bash .claude/hooks/tests/test_validate_pr_create_head.sh` → 13 PASS, 0 FAIL.
3. `bash bin/run-hook-tests.sh` → exit 0, all 55 hook tests PASS.
4. Failing-first proof: `git stash push -- .claude/hooks/validate-branch-name.sh .claude/hooks/validate-pr-create.sh` then re-run the two test files — the `cd-target … → PASS (false-positive gone)` cases fail (rc=2), the `cd-target on non-conforming branch … → still BLOCKS` case still passes. `git stash pop` restores the fix.

Closes #693

## Glossary

| Term | Definition |
|------|------------|
| PreToolUse hook | A shell hook the harness runs *before* the tool command executes. Its cwd is the session's working dir — a leading `cd <path> &&` in the command has not run yet, so the hook must parse the cd-target itself to know where the command will actually run. |
| cd-target | The directory in a `cd <path> && <cmd>` command. `pr_cmd_cd_target` (in `_lib-pr-repo.sh`, added by #669) extracts `<path>` from a leading `cd`. |
| Re-rooting | Running working-tree git operations against the cd-target's repo (`git -C <cd-target>`) instead of the hook's own cwd, so a cross-repo command is evaluated against the repo it really targets. |
| False positive (here) | The gate blocking a compliant action — pushing/PR-ing a correctly-named branch in another managed repo got blocked because the hook read the ops-fork's `dev` branch instead. |
| True negative (here) | The gate correctly blocking a genuinely non-compliant branch in the target repo — preserved by this fix, proving the gate was not turned into a no-op. |
| Source ref / `--head` | The explicit branch a `git push origin <ref>` / `gh pr create --head <ref>` names. When present it is already authoritative (no cwd dependence); the bug only affected the no-ref / no-`--head` fallback. |
