### PR TITLE
feat(#670): route /task /feature /bug through tracker_create

### DIFF
--- a/.claude/skills/bug/SKILL.md
+++ b/.claude/skills/bug/SKILL.md
@@ -185,20 +185,43 @@ Create this ticket? (yes / edit / cancel)
 - **edit** / **change X** → ask what to change, update, re-show
 - **cancel** / **no** → abort
 
-### 7. Create the GitHub Issue
+### 7. Create the issue (via the tracker abstraction)
+
+Dispatch through `tracker_create` (#670 / AgDR-0072) so the issue lands in
+**this project's** tracker (GitHub / GitLab / `custom`) per its `tracker:` block
+in `apexyard.projects.yaml`. For a GitHub adopter this runs `gh issue create`
+unchanged.
 
 ```bash
-gh issue create --repo {owner/repo} \
-  --title "[{P0|P1|P2}] {title}" \
-  --label "bug,{priority}" \
-  --body "{formatted body}"
+# Resolve + source the tracker lib (it lives in the ops fork's hooks dir).
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
+body_file="$(mktemp)"
+cat > "$body_file" <<'BODY'
+{formatted body}
+BODY
+
+# tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
+# Gated by require-skill-for-issue-create.sh; the step-0 marker keeps it allowed.
+result="$(tracker_create "{owner/repo}" "[{P0|P1|P2}] {title}" "$body_file" "bug,{priority}")" || {
+  rm -f "$body_file"
+  echo "Issue creation failed — check the tracker CLI / auth. Nothing was created." >&2
+  exit 1
+}
+rm -f "$body_file"
 ```
 
-### 8. Return the URL
+### 8. Return the result
 
-```
-Created: {owner/repo}#{number} — {title}
-{url}
+```bash
+ref="$(printf '%s' "$result" | jq -r '.ref')"
+url="$(printf '%s' "$result" | jq -r '.url')"
+echo "Created: {owner/repo}#${ref} — {title}"
+echo "${url}"
 ```
 
 ## Rules

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -179,20 +179,43 @@ Create this ticket? (yes / edit / cancel)
 - **edit** / **change X** → ask what to change, update, re-show
 - **cancel** / **no** → abort
 
-### 7. Create the GitHub Issue
+### 7. Create the issue (via the tracker abstraction)
+
+Dispatch through `tracker_create` (#670 / AgDR-0072) so the issue lands in
+**this project's** tracker (GitHub / GitLab / `custom`) per its `tracker:` block
+in `apexyard.projects.yaml`. For a GitHub adopter this runs `gh issue create`
+unchanged.
 
 ```bash
-gh issue create --repo {owner/repo} \
-  --title "[Feature] {title}" \
-  --label "enhancement,{priority}" \
-  --body "{formatted body}"
+# Resolve + source the tracker lib (it lives in the ops fork's hooks dir).
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
+body_file="$(mktemp)"
+cat > "$body_file" <<'BODY'
+{formatted body}
+BODY
+
+# tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
+# Gated by require-skill-for-issue-create.sh; the step-0 marker keeps it allowed.
+result="$(tracker_create "{owner/repo}" "[Feature] {title}" "$body_file" "enhancement,{priority}")" || {
+  rm -f "$body_file"
+  echo "Issue creation failed — check the tracker CLI / auth. Nothing was created." >&2
+  exit 1
+}
+rm -f "$body_file"
 ```
 
-### 8. Return the URL
+### 8. Return the result
 
-```
-Created: {owner/repo}#{number} — {title}
-{url}
+```bash
+ref="$(printf '%s' "$result" | jq -r '.ref')"
+url="$(printf '%s' "$result" | jq -r '.url')"
+echo "Created: {owner/repo}#${ref} — {title}"
+echo "${url}"
 ```
 
 ## Rules

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -180,20 +180,48 @@ A fork that extends the whitelist (e.g. adds `[Security]`, `[Perf]`, `[Scaffold]
 - **edit** / **change X** → ask what to change, update, re-show
 - **cancel** / **no** → abort
 
-### 7. Create the GitHub Issue
+### 7. Create the issue (via the tracker abstraction)
+
+Dispatch creation through `tracker_create` (#670 / AgDR-0072) so the issue lands
+in **this project's** tracker — GitHub, GitLab, or a `custom` CLI — per its
+`tracker:` block in `apexyard.projects.yaml`. For a GitHub adopter this runs
+`gh issue create` exactly as before; no behaviour change.
 
 ```bash
-gh issue create --repo {owner/repo} \
-  --title "[{type}] {title}" \
-  --label "{priority}" \
-  --body "{formatted body}"
+# Resolve the tracker lib (it lives in the ops fork's hooks dir) by walking up
+# from the cwd; source it.
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
+# Pass the body via a file (arbitrary markdown — never inline-interpolated).
+body_file="$(mktemp)"
+cat > "$body_file" <<'BODY'
+{formatted body}
+BODY
+
+# tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
+# It is gated by require-skill-for-issue-create.sh; the active-issue-skill
+# marker written in step 0 keeps this call allowed.
+result="$(tracker_create "{owner/repo}" "[{type}] {title}" "$body_file" "{priority}")" || {
+  rm -f "$body_file"
+  echo "Ticket creation failed — check the tracker CLI / auth. Nothing was created." >&2
+  exit 1
+}
+rm -f "$body_file"
 ```
 
-### 8. Return the URL
+### 8. Return the result
 
-```
-Created: {owner/repo}#{number} — {title}
-{url}
+Parse the normalised `{ref, url}` from `tracker_create`:
+
+```bash
+ref="$(printf '%s' "$result" | jq -r '.ref')"
+url="$(printf '%s' "$result" | jq -r '.url')"
+echo "Created: {owner/repo}#${ref} — {title}"
+echo "${url}"
 ```
 
 ## Rules


### PR DESCRIPTION
## Summary
- **Routes `/task` · `/feature` · `/bug` issue creation through `tracker_create`** (the engine from #702 / AgDR-0072), so a ticket lands in *that project's* tracker — GitHub, GitLab, or a `custom` CLI — per its `tracker:` block in the registry. This is the user-facing payoff of the #670 stack: the three structured ticket skills become tracker-agnostic instead of hardcoded `gh issue create`.
- **Zero behaviour change for GitHub adopters** — for a project whose tracker resolves to `gh` (the default), `tracker_create` runs `gh issue create` with the same flags; the only observable difference is the skill now sources the lib and parses a `{ref,url}` return instead of scraping the URL string.
- **Body passed via a temp file, never inline-interpolated** — each skill writes the formatted issue body to a `mktemp` heredoc and hands the *path* to `tracker_create`, so arbitrary markdown (backticks, quotes, `$(…)`) can never be re-tokenised by the shell. Mirrors the injection-safe contract Part B established.
- **Failure is explicit, not silent** — a non-zero `tracker_create` (CLI missing, auth failure, `kind=none`) makes the skill print "Nothing was created" and `exit 1`, rather than reporting a phantom success.

## Scope — Part C of the #670 stack (the closer)
Final slice — it `Closes #670`. Parts A (#671, per-project verify) and B (#702, the `tracker_create` engine) are merged; this wires the engine into the three skills. The long-tail dedicated `linear` / `jira` / `asana` *create* adapters are intentionally deferred to a separate CLI-verified PR — Part B's `custom` kind already covers them today via an operator `create_command`.

Stacked on #702; rebased cleanly onto current `dev` — **73/73** hook tests pass, markdownlint clean on all 3 skill files.

## Testing
```bash
bash bin/run-hook-tests.sh        # 73/73
bash bin/run-pre-push-checks.sh   # markdownlint (the 3 SKILL.md) + subpacks green
```
The wiring calls `tracker_create`, whose adapters carry **14 dedicated test cases** (incl. the injection probe) landed in #702. The skill bodies are runtime instructions; the `gh` path is unchanged from the prior hardcoded form, and the lib-resolution walk-up matches the pattern already used elsewhere in the skills.

## Glossary
| Term | Definition |
|------|------------|
| `tracker_create` | The `_lib-tracker.sh` creation function (#702) the skills now call; dispatches to the per-project tracker CLI and returns `{ref,url}`. |
| `tracker:` block | Optional per-project override in `apexyard.projects.yaml` selecting that project's tracker kind/CLI (from #671). |
| `{ref, url}` | Tracker-agnostic return: `ref` is the issue identifier (`123`, `LIN-42`), `url` the web link. |
| Lib walk-up | The `while [ "$r" != / ]` loop each skill uses to locate `_lib-tracker.sh` in the ops fork's hooks dir from the cwd. |
| `active-issue-skill` marker | The marker written on skill entry that keeps the gated `tracker_create` call allowed (the skill IS the structured creation path). |

Closes #670
