### PR TITLE
fix(#712): exempt framework-filing skills from project issue schema

### DIFF
--- a/.claude/hooks/tests/test_validate_issue_structure.sh
+++ b/.claude/hooks/tests/test_validate_issue_structure.sh
@@ -406,6 +406,76 @@ run_case "Bug body with embedded quotes but missing Repro → still blocks" \
   "gh issue create --title '[Bug] no repro' --body \"$BUG_EMBEDDED_BUT_INCOMPLETE\""
 
 # ---------------------------------------------------------------------------
+# Framework-filing exemption (#712)
+#
+# /request-apexyard-feature and /report-apexyard-bug file [Feature]/[Bug] issues
+# UPSTREAM using their own body template (Problem/Proposed/Why; Given/When/Then),
+# which is deliberately distinct from this project's required-section schema.
+# When one of those skills is the active filing skill (the active-issue-skill
+# marker), the project schema does not apply. The exemption is narrow: only the
+# configured framework-filing skills, detected via the SAME marker that
+# require-skill-for-issue-create.sh reads.
+# ---------------------------------------------------------------------------
+
+# The exemption's ops-root resolution (resolve_ops_root) consults the session
+# pin FIRST — with CLAUDE_CODE_SESSION_ID set it would return the real fork, not
+# this fixture. Disable the pin so it walks up to THIS fixture's anchor. (The
+# authoritative runner bin/run-hook-tests.sh already exports this globally.)
+export APEXYARD_OPS_DISABLE_PIN=1
+
+# Add the v2 ops-root anchor so the hook's ops-root resolution lands on the
+# fixture fork, and create the session dir. The marker is written/removed
+# per-case so it never leaks into the schema cases above.
+touch "$TMPDIR/fork/.apexyard-fork"
+mkdir -p "$TMPDIR/fork/.claude/session"
+MARKER="$TMPDIR/fork/.claude/session/active-issue-skill"
+
+# A [Feature] body in the framework-request template — MISSING the project
+# [Feature] schema (User Story + Acceptance Criteria) by design.
+FRAMEWORK_FEATURE_BODY='## Problem
+The framework lacks X.
+
+## Proposed behaviour
+Add X.
+
+## Why it helps adopters
+Adopters get X today by doing Y manually.'
+
+# Exempt: marker names a framework-filing skill → project schema skipped → pass.
+echo "request-apexyard-feature" > "$MARKER"
+run_case "Framework feature (no User Story/AC), marker=request-apexyard-feature → exempt (pass)" \
+  0 "" \
+  "gh issue create --title '[Feature] add X to the framework' --body \"$FRAMEWORK_FEATURE_BODY\""
+rm -f "$MARKER"
+
+# Report-apexyard-bug is also exempt (covers a [Bug] off-schema body symmetrically).
+FRAMEWORK_BUGISH_BODY='## Affected
+some hook
+
+## Notes
+free-form framework note without the project Bug schema.'
+echo "report-apexyard-bug" > "$MARKER"
+run_case "Framework bug body (no Given/When/Then), marker=report-apexyard-bug → exempt (pass)" \
+  0 "" \
+  "gh issue create --title '[Bug] hook misfires' --body \"$FRAMEWORK_BUGISH_BODY\""
+rm -f "$MARKER"
+
+# NOT exempt: marker names the PROJECT skill (/feature) → schema still enforced.
+echo "feature" > "$MARKER"
+run_case "Framework-shaped [Feature], marker=feature (project skill) → still blocks" \
+  2 "missing section: ## User Story" \
+  "gh issue create --title '[Feature] add X' --body \"$FRAMEWORK_FEATURE_BODY\""
+rm -f "$MARKER"
+
+# NOT exempt: no marker at all → unchanged behaviour, still blocks malformed [Feature].
+run_case "Framework-shaped [Feature], no active-issue-skill marker → still blocks" \
+  2 "missing section: ## User Story" \
+  "gh issue create --title '[Feature] add X' --body \"$FRAMEWORK_FEATURE_BODY\""
+
+# Remove the v2 anchor so it can't influence any later cases.
+rm -f "$TMPDIR/fork/.apexyard-fork"
+
+# ---------------------------------------------------------------------------
 # Result
 # ---------------------------------------------------------------------------
 

--- a/.claude/hooks/validate-issue-structure.sh
+++ b/.claude/hooks/validate-issue-structure.sh
@@ -174,6 +174,7 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 PREFIX_WHITELIST=""
 SKIP_MARKER=""
+EXEMPT_SKILLS=""
 HAVE_CONFIG_LIB=0
 
 if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.claude/hooks/_lib-read-config.sh" ]; then
@@ -182,6 +183,7 @@ if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.claude/hooks/_lib-read-config.sh" ];
   HAVE_CONFIG_LIB=1
   PREFIX_WHITELIST=$(config_get '.ticket.prefix_whitelist[]' 2>/dev/null | tr '\n' ' ')
   SKIP_MARKER=$(config_get_or '.ticket.skip_marker' '<!-- validate-issue-structure: skip -->' 2>/dev/null)
+  EXEMPT_SKILLS=$(config_get '.ticket.schema_exempt_skills[]' 2>/dev/null | tr '\n' ' ')
 fi
 
 # Inline defaults for bare checkouts predating apexyard#109. Mirror the
@@ -190,6 +192,11 @@ if [ -z "$PREFIX_WHITELIST" ]; then
   PREFIX_WHITELIST="Feature Bug Chore Refactor Testing CI Docs Spike"
 fi
 SKIP_MARKER="${SKIP_MARKER:-<!-- validate-issue-structure: skip -->}"
+# Framework-filing skills that file upstream with their own body template
+# (mirrors .ticket.schema_exempt_skills; see the #712 exemption below).
+if [ -z "$EXEMPT_SKILLS" ]; then
+  EXEMPT_SKILLS="request-apexyard-feature report-apexyard-bug"
+fi
 
 # ---------------------------------------------------------------------------
 # Skip marker — visible bypass, logs to stderr.
@@ -198,6 +205,54 @@ SKIP_MARKER="${SKIP_MARKER:-<!-- validate-issue-structure: skip -->}"
 if echo "$FULL_BODY" | grep -qF -- "$SKIP_MARKER"; then
   echo "WARN: $SKIP_MARKER present — validate-issue-structure bypassed." >&2
   exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Framework-filing exemption (me2resh/apexyard#712).
+#
+# /request-apexyard-feature and /report-apexyard-bug file [Feature]/[Bug] issues
+# UPSTREAM (me2resh/apexyard) using their own body template (Problem/Proposed/Why;
+# Affected/Notes), which is deliberately distinct from this project's
+# required_sections schema. When one of those skills is the active filing skill,
+# the project schema does not apply — they are the trusted producers of those
+# bodies. Detected via the SAME active-issue-skill marker that
+# require-skill-for-issue-create.sh reads, so the two hooks agree on its location.
+#
+# Narrow by design: a project /feature or /bug writes ITS OWN name to the marker
+# and is therefore NOT exempt. The exempt list is config-driven
+# (.ticket.schema_exempt_skills) with the inline fallback set above.
+# ---------------------------------------------------------------------------
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+OPS_ROOT=""
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  OPS_ROOT=$(resolve_ops_root "${REPO_ROOT:-$PWD}" 2>/dev/null)
+else
+  # Inline fallback (mirror of require-skill-for-issue-create.sh): walk up for
+  # the v2 .apexyard-fork anchor or the legacy v1 onboarding+projects pair.
+  cur="${REPO_ROOT:-$PWD}"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/.apexyard-fork" ]; then OPS_ROOT="$cur"; break; fi
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      OPS_ROOT="$cur"; break
+    fi
+    cur=$(dirname "$cur")
+  done
+fi
+
+SKILL_MARKER="${OPS_ROOT:-${REPO_ROOT:-.}}/.claude/session/active-issue-skill"
+if [ -f "$SKILL_MARKER" ]; then
+  ACTIVE_SKILL=$(tr -d '[:space:]' < "$SKILL_MARKER" 2>/dev/null)
+  if [ -n "$ACTIVE_SKILL" ]; then
+    for s in $EXEMPT_SKILLS; do
+      if [ "$s" = "$ACTIVE_SKILL" ]; then
+        echo "WARN: active filing skill '$ACTIVE_SKILL' is schema-exempt (.ticket.schema_exempt_skills) — validate-issue-structure skipped." >&2
+        exit 0
+      fi
+    done
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -29,6 +29,11 @@
       "Investigation": ["Trigger", "Hypothesis being tested", "Method", "Findings", "Conclusion", "Follow-up actions"]
     },
     "skip_marker": "<!-- validate-issue-structure: skip -->",
+    "_schema_exempt_skills_comment": "Skills that file [Feature]/[Bug] issues UPSTREAM (me2resh/apexyard) using their own body template, which is deliberately distinct from this project's required_sections schema. When one of these is the active filing skill (marker at .claude/session/active-issue-skill), validate-issue-structure.sh skips the project schema for that create — they are the trusted producers of those bodies. Narrow by design: a project /feature or /bug writes its own name to the marker and is NOT exempted. See me2resh/apexyard#712.",
+    "schema_exempt_skills": [
+      "request-apexyard-feature",
+      "report-apexyard-bug"
+    ],
     "_bootstrap_skills_comment": "Skills that run BEFORE any ticket can exist (fork bootstrap, project handover, framework upstream-sync). When one of these is active (marker at .claude/session/active-bootstrap), require-active-ticket.sh exempts the gate. The marker is written by the skill itself on entry, cleared on completion, AND reset at SessionStart so a stale marker can't carry over. See AgDR-0011-bootstrap-skill-exemption.md and me2resh/apexyard#150.",
     "bootstrap_skills": [
       "setup",

--- a/docs/agdr/AgDR-0079-framework-filing-schema-exemption.md
+++ b/docs/agdr/AgDR-0079-framework-filing-schema-exemption.md
@@ -1,0 +1,63 @@
+# Framework-filing skills are exempt from the project ticket schema
+
+> In the context of `validate-issue-structure.sh` enforcing the project's
+> `required_sections` schema on every `[Feature]`/`[Bug]` `gh issue create`,
+> facing `/request-apexyard-feature` filing upstream with a deliberately
+> different body template, I decided to exempt the configured framework-filing
+> skills (detected via the `active-issue-skill` marker) from the schema check,
+> to achieve conformance-by-construction for those skills, accepting that their
+> bodies are no longer structurally validated locally.
+
+## Context
+
+`validate-issue-structure.sh` keys its required-section schema purely on the
+bracketed title prefix (`[Feature]` → User Story + Acceptance Criteria; `[Bug]`
+→ Given/When/Then + Repro). Two skills emit `[Feature]`/`[Bug]` titles with a
+**different** body template — `/request-apexyard-feature` (Problem / Proposed /
+Why) and `/report-apexyard-bug` (Affected / Given-When-Then / Repro). The
+feature one collides: same prefix, different required body.
+
+Result (me2resh/apexyard#712): the framework-feature skill's own canonical
+output is **blocked** by the validator unless the operator hand-adds the
+`<!-- validate-issue-structure: skip -->` marker — which contradicts the hook's
+own promise that *"the matching interactive skill produces a body that satisfies
+this check by construction."* True for `/feature`; false for
+`/request-apexyard-feature`.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| (a) Skill emits skip marker by construction | Smallest; no hook change | A visible marker in every framework issue; skips **all** validation; per-skill duplication |
+| (b) Validator exempts framework-filing skills via the `active-issue-skill` marker | Centralised; clean issue bodies; config-driven; narrow | Small hook regression surface; skips schema for those skills |
+| (c) Distinct title prefix / framework-`[Feature]` schema variant | Most principled | Biggest change; a new prefix alters UX everywhere, or a schema variant still needs context to disambiguate (collapses into (b)) |
+
+## Decision
+
+Chosen: **(b)**. The validator reads the **same** `active-issue-skill` marker
+that `require-skill-for-issue-create.sh` already relies on; if it names a skill
+in `.ticket.schema_exempt_skills` (default: `request-apexyard-feature`,
+`report-apexyard-bug`), the schema check is skipped. Config-driven with an inline
+fallback, mirroring the hook's existing `PREFIX_WHITELIST` / `SKIP_MARKER`
+pattern, and resolving the marker via the shared `resolve_ops_root` helper so the
+two hooks agree on its location.
+
+## Consequences
+
+- Framework feature/bug requests file cleanly with no manual skip marker; the
+  hook's "conformant by construction" promise now holds for them too.
+- The exemption is **narrow**: a project `/feature` or `/bug` writes its own name
+  to the marker and is still enforced. Spoofing requires deliberately writing a
+  framework-skill name to the marker — the same trust class as adding the skip
+  marker, and a visible, auditable act.
+- Those skills' bodies are no longer structurally validated locally — acceptable
+  because each produces its body by construction and files to an external repo.
+- New config key `.ticket.schema_exempt_skills`; adopters can extend it for
+  custom framework-filing skills.
+
+## Artifacts
+
+- Closes me2resh/apexyard#712
+- `.claude/hooks/validate-issue-structure.sh` — exemption block + `EXEMPT_SKILLS` read
+- `.claude/project-config.defaults.json` — `ticket.schema_exempt_skills`
+- `.claude/hooks/tests/test_validate_issue_structure.sh` — 4 exemption cases (exempt × 2, still-blocks × 2)


### PR DESCRIPTION
## Summary
- **Fixes the schema collision in #712** — `validate-issue-structure.sh` keys its `required_sections` check on the bracketed title prefix, so any `[Feature]` issue must carry `## User Story` + `## Acceptance Criteria`. But `/request-apexyard-feature` files `[Feature]` issues upstream using its own `Problem / Proposed / Why` template, so the skill's **own canonical output** was blocked unless the operator hand-added `<!-- validate-issue-structure: skip -->` — directly contradicting the hook's *"the matching interactive skill produces a body that satisfies this check by construction"* message.
- **Fix (option b, per AgDR-0079): a context-aware validator.** The hook now reads the same `active-issue-skill` marker that `require-skill-for-issue-create.sh` already relies on; when it names a skill in the new `.ticket.schema_exempt_skills` list (default `request-apexyard-feature`, `report-apexyard-bug`), the project schema is skipped for that create. Config-driven with an inline fallback, mirroring the hook's existing `PREFIX_WHITELIST` / `SKIP_MARKER` pattern; ops-root resolved via the shared `resolve_ops_root` helper so both hooks agree on the marker location.
- **Narrow by design** — a project `/feature` or `/bug` writes its *own* name to the marker and is therefore still fully enforced. Spoofing the exemption would require deliberately writing a framework-skill name to the marker — the same trust class (and visibility) as adding the skip marker.
- **Why not the alternatives** — (a) emitting the skip marker from the skill leaves a visible comment in every issue and skips *all* validation; (c) a distinct prefix / schema variant changes UX everywhere or still needs the marker to disambiguate. Full trade-off recorded in AgDR-0079.

## Testing
```bash
bash bin/run-hook-tests.sh        # 73/73 (4 new exemption cases)
bash bin/run-pre-push-checks.sh   # markdownlint + subpacks green
```
Four new cases in `test_validate_issue_structure.sh`: framework-feature body (no User Story/AC) with `marker=request-apexyard-feature` → exempt; `[Bug]` off-schema body with `marker=report-apexyard-bug` → exempt; same body with `marker=feature` (project skill) → still blocks; no marker → still blocks. (The test disables the session pin so `resolve_ops_root` walks up to the fixture — matching what `bin/run-hook-tests.sh` sets globally.)

## Glossary
| Term | Definition |
|------|------------|
| `validate-issue-structure.sh` | PreToolUse hook that checks `gh issue create` bodies against per-title-prefix required-section schemas. |
| `active-issue-skill` marker | Session file (`.claude/session/active-issue-skill`) naming the structured skill currently filing; read by `require-skill-for-issue-create.sh` and now this hook. |
| `.ticket.schema_exempt_skills` | New config list of framework-filing skills whose bodies use their own template and are exempt from the project schema. |
| `resolve_ops_root` | Shared helper (`_lib-ops-root.sh`) resolving the ops-fork root via the session pin or a `.apexyard-fork` walk-up. |

Closes #712
