### PR TITLE
docs(#720): drop bot-thanking from the README contributors note

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Thanks to everyone who has helped forge ApexYard:
   </tr>
 </table>
 
-<sub>Plus Dependabot and AI agents (Claude) on co-authored commits. PRs from external contributors are squash-merged, so the GitHub commit-author graph under-counts them — this list credits the humans directly. New contributor? Open a PR and you'll be added.</sub>
+<sub>External contributors' PRs are squash-merged, so GitHub's commit-author graph under-counts them — this list credits the humans directly. New contributor? Open a PR and you'll be added.</sub>
 
 ## License
 


### PR DESCRIPTION
## Summary
- Trims the contributors sub-note so it no longer reads as crediting **Dependabot / AI agents (Claude)** as contributors — keeps only the squash-merge under-counting rationale + the open-a-PR invite. One-line follow-up to #714.

## Testing
1. Render the PR README preview → the contributors note no longer mentions Dependabot/AI agents; the 4-human grid + squash-merge explanation remain intact.

Closes #720

## Glossary
| Term | Definition |
|------|------------|
| squash-merge under-counting | GitHub attributes a squash-merged PR to the merger, so external authors miss the commit-author graph (contrib.rocks) |
