### PR TITLE
fix(#718): graceful degrade for tracker.kind=none in /task /feature /bug

### DIFF
--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -576,7 +576,16 @@ tracker_create() {
   local kind
   kind=$(tracker_kind "$repo")
   case "$kind" in
-    none) return 1 ;;
+    none)
+      # Shape-only mode (tracker.kind=none): no tracker CLI to call. Emit the
+      # rendered ticket body to stdout so the operator can file it in their
+      # external system, and return 3 (a documented "shape-only / file
+      # externally" code) so callers don't misreport it as a CLI/auth error.
+      if [ -n "$body_file" ] && [ -f "$body_file" ]; then
+        cat "$body_file"
+      fi
+      return 3
+      ;;
   esac
 
   local raw rc

--- a/.claude/hooks/tests/test_tracker_create.sh
+++ b/.claude/hooks/tests/test_tracker_create.sh
@@ -113,7 +113,8 @@ assert_eq "tracker_create gh failure → empty stdout"  ""  "$out"
 
 rm -rf "$SB"
 
-# Failure contract — kind=none disables creation → non-zero exit, no CLI call.
+# Shape-only contract — kind=none does not call a CLI; it returns 3 and emits
+# the body (if given) to stdout for manual/external filing. NOT a failure path.
 SBN=$(make_sandbox)
 cat > "$SBN/.claude/project-config.defaults.json" <<'JSON'
 { "tracker": { "kind": "none" } }
@@ -124,11 +125,16 @@ JSON
   . "$SBN/.claude/hooks/_lib-tracker.sh"
   tracker_clear_cache
   out=$(tracker_create "o/r" "t"); rc=$?
-  printf '%s\t%s\n' "$rc" "$out"
+  bf=$(mktemp); printf 'TICKET BODY LINE\n' > "$bf"
+  out_body=$(tracker_create "o/r" "t" "$bf"); rcb=$?
+  rm -f "$bf"
+  printf '%s|%s|%s|%s\n' "$rc" "$out" "$rcb" "$out_body"
 ) > "$SBN/r"
-IFS=$'\t' read -r n_rc n_out < "$SBN/r"
-assert_eq "tracker_create kind=none → non-zero exit" "1" "$n_rc"
-assert_eq "tracker_create kind=none → empty stdout"  ""  "$n_out"
+IFS="|" read -r n_rc n_out nb_rc nb_out < "$SBN/r"
+assert_eq "tracker_create kind=none → exit 3 (shape-only, not a CLI error)" "3" "$n_rc"
+assert_eq "tracker_create kind=none (no body) → empty stdout" "" "$n_out"
+assert_eq "tracker_create kind=none (with body) → exit 3" "3" "$nb_rc"
+assert_eq "tracker_create kind=none (with body) → emits body for manual filing" "TICKET BODY LINE" "$nb_out"
 rm -rf "$SBN"
 
 # Case 4 — per-project glab override dispatches glab (needs a YAML parser).

--- a/.claude/skills/bug/SKILL.md
+++ b/.claude/skills/bug/SKILL.md
@@ -207,12 +207,21 @@ BODY
 
 # tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
 # Gated by require-skill-for-issue-create.sh; the step-0 marker keeps it allowed.
-result="$(tracker_create "{owner/repo}" "[{P0|P1|P2}] {title}" "$body_file" "bug,{priority}")" || {
-  rm -f "$body_file"
+result="$(tracker_create "{owner/repo}" "[{P0|P1|P2}] {title}" "$body_file" "bug,{priority}")"
+rc=$?
+rm -f "$body_file"
+if [ "$rc" -eq 3 ]; then
+  # tracker.kind=none (shape-only): no tracker to create in. tracker_create
+  # printed the rendered ticket body to stdout — surface it for manual /
+  # external filing instead of a non-existent CLI/auth failure.
+  echo "Tracker is 'none' (shape-only) — nothing was created in a tracker." >&2
+  echo "File this in your external system (e.g. Jira/Linear via MCP):" >&2
+  printf '%s\n' "$result"
+  exit 0
+elif [ "$rc" -ne 0 ] || [ -z "$result" ]; then
   echo "Issue creation failed — check the tracker CLI / auth. Nothing was created." >&2
   exit 1
-}
-rm -f "$body_file"
+fi
 ```
 
 ### 8. Return the result

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -201,12 +201,21 @@ BODY
 
 # tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
 # Gated by require-skill-for-issue-create.sh; the step-0 marker keeps it allowed.
-result="$(tracker_create "{owner/repo}" "[Feature] {title}" "$body_file" "enhancement,{priority}")" || {
-  rm -f "$body_file"
+result="$(tracker_create "{owner/repo}" "[Feature] {title}" "$body_file" "enhancement,{priority}")"
+rc=$?
+rm -f "$body_file"
+if [ "$rc" -eq 3 ]; then
+  # tracker.kind=none (shape-only): no tracker to create in. tracker_create
+  # printed the rendered ticket body to stdout — surface it for manual /
+  # external filing instead of a non-existent CLI/auth failure.
+  echo "Tracker is 'none' (shape-only) — nothing was created in a tracker." >&2
+  echo "File this in your external system (e.g. Jira/Linear via MCP):" >&2
+  printf '%s\n' "$result"
+  exit 0
+elif [ "$rc" -ne 0 ] || [ -z "$result" ]; then
   echo "Issue creation failed — check the tracker CLI / auth. Nothing was created." >&2
   exit 1
-}
-rm -f "$body_file"
+fi
 ```
 
 ### 8. Return the result

--- a/.claude/skills/report-apexyard-bug/SKILL.md
+++ b/.claude/skills/report-apexyard-bug/SKILL.md
@@ -95,7 +95,7 @@ carries `main → dev`, so it is always current on `dev`:
 ```bash
 # Primary: top-most `## [X.Y.Z]` heading in CHANGELOG.md (carried main→dev by
 # /release-sync, so always the canonical current version on dev).
-FW_VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$ops_root/CHANGELOG.md" 2>/dev/null \
+FW_VERSION=$(grep -m1 -oE '^## \[v?[0-9]+\.[0-9]+\.[0-9]+\]' "$ops_root/CHANGELOG.md" 2>/dev/null \
   | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 if [ -n "$FW_VERSION" ]; then
   FW_VERSION="v$FW_VERSION"          # keep the `v` prefix the field renders today

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -205,12 +205,21 @@ BODY
 # tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
 # It is gated by require-skill-for-issue-create.sh; the active-issue-skill
 # marker written in step 0 keeps this call allowed.
-result="$(tracker_create "{owner/repo}" "[{type}] {title}" "$body_file" "{priority}")" || {
-  rm -f "$body_file"
+result="$(tracker_create "{owner/repo}" "[{type}] {title}" "$body_file" "{priority}")"
+rc=$?
+rm -f "$body_file"
+if [ "$rc" -eq 3 ]; then
+  # tracker.kind=none (shape-only): no tracker to create in. tracker_create
+  # printed the rendered ticket body to stdout — surface it for manual /
+  # external filing instead of a non-existent CLI/auth failure.
+  echo "Tracker is 'none' (shape-only) — nothing was created in a tracker." >&2
+  echo "File this in your external system (e.g. Jira/Linear via MCP):" >&2
+  printf '%s\n' "$result"
+  exit 0
+elif [ "$rc" -ne 0 ] || [ -z "$result" ]; then
   echo "Ticket creation failed — check the tracker CLI / auth. Nothing was created." >&2
   exit 1
-}
-rm -f "$body_file"
+fi
 ```
 
 ### 8. Return the result


### PR DESCRIPTION
## Summary
- **Fixes the `tracker.kind = none` hard-fail** (#718): `/task`, `/feature`, `/bug` were unusable for shape-only adopters because `tracker_create` returned `1` for `none`, which the skills reported as *"creation failed — check the tracker CLI / auth"* — misdiagnosing an intentional code path as an auth fault.
- **`_lib-tracker.sh`** — `kind=none` now emits the rendered ticket body to stdout and returns a distinct **exit 3** ("shape-only / file externally"), so callers can tell it apart from a real CLI/auth failure.
- **task / feature / bug skills** — handle `rc=3`: print the formatted ticket for manual/external filing (e.g. Jira/Linear via MCP) and exit 0, instead of the misleading error.
- **`/report-apexyard-bug`** — version-capture regex now matches `## [v4.0.0]` CHANGELOG headings (the `v` prefix was missed, causing stale-version reports — the bonus nit called out in #718).
- **tests** — `test_tracker_create.sh` asserts the new exit-3 + emit-body contract.

Completes the `none`-case coverage gap in AgDR-0072 (#670). No new tracker behavior for gh/glab/custom.

## Testing
1. `bash .claude/hooks/tests/test_tracker_create.sh` → **16/16 PASS** (was 13, +3 for the none contract).
2. Manual: set `.tracker.kind = "none"`, run `/task` → prints the formatted ticket for external filing + exits 0 (no auth error).

Closes #718

## Glossary
| Term | Definition |
|------|------------|
| `tracker.kind = none` | Shape-only mode — the framework validates ticket shape but doesn't call a tracker CLI (for teams tracking work in an external system, e.g. Jira/Linear via MCP) |
| graceful degrade | Falling back to a useful no-CLI behavior (print the body to file externally) instead of erroring |
| exit 3 | The new documented `tracker_create` return for `none`: "shape-only, body emitted, not a failure" |
