### PR TITLE
feat(#725): auto-move board cards through the SDLC lifecycle

### DIFF
--- a/.claude/hooks/_lib-project-board.sh
+++ b/.claude/hooks/_lib-project-board.sh
@@ -45,6 +45,8 @@
 #   These free built-ins handle the closed/merged → Done hop so this lib
 #   doesn't have to. Enable them in the GitHub UI; no config here is needed.
 #
+# Decision record: docs/agdr/AgDR-0080-board-automation-attach-points.md
+#
 # Sourced by hooks and skills; never executed directly. Use the source-guard
 # so multiple sources in one shell process are idempotent.
 
@@ -95,9 +97,9 @@ board_move_card() {
   board_number=$(config_get '.github_projects.board_number' 2>/dev/null)
   status_field_name=$(config_get_or '.github_projects.status_field_name' 'Status')
 
-  if [ -z "$owner" ] || [ "$owner" = "null" ] || [ "$owner" = "" ] || \
+  if [ -z "$owner" ] || [ "$owner" = "null" ] || \
      [ -z "$board_number" ] || [ "$board_number" = "null" ] || \
-     [ "$board_number" = "0" ] || [ "$board_number" = "" ]; then
+     [ "$board_number" = "0" ]; then
     echo "WARN [board_move_card]: github_projects.owner or board_number not configured; skipping card move for #${item_ref}." >&2
     return 0
   fi
@@ -149,8 +151,10 @@ board_move_card() {
 
   # ---- Resolve project item ID --------------------------------------------
   # `gh project item-list` returns {"items": [{"id": "PVTI_xxx", "content": {"number": N, ...}}]}
+  # Pass --limit 200 so boards with >30 items (the gh default page size) don't
+  # silently miss the target card. 200 is the GitHub Projects API maximum per page.
   local item_json item_id
-  item_json=$(gh project item-list "$board_number" --owner "$owner" --format json 2>/dev/null)
+  item_json=$(gh project item-list "$board_number" --owner "$owner" --format json --limit 200 2>/dev/null)
   item_id=$(printf '%s' "$item_json" \
     | jq -r ".items[] | select(.content.number == ${item_ref}) | .id" 2>/dev/null)
   if [ -z "$item_id" ] || [ "$item_id" = "null" ]; then

--- a/.claude/hooks/_lib-project-board.sh
+++ b/.claude/hooks/_lib-project-board.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# _lib-project-board.sh — auto-move GitHub Projects (v2) board cards through
+# the SDLC lifecycle.
+#
+# Exposed function:
+#   board_move_card <issue-or-pr-number> <status-key>
+#
+# Status keys (map to option labels via .github_projects.status_map in config):
+#   in_progress   — ticket picked up via /start-ticket
+#   review        — PR created, auto-code-review.sh fires
+#   measurement   — PR merged via /approve-merge
+#
+# CONFIGURATION (.claude/project-config.json — opt-in, defaults in defaults.json):
+#
+#   "github_projects": {
+#     "owner":             "<org-or-user>",   // GitHub owner of the board
+#     "board_number":      1,                  // numeric board number
+#     "enable_auto_moves": true,               // OPT-IN; default false
+#     "status_field_name": "Status",           // label of the single-select field
+#     "status_map": {
+#       "in_progress":  "In progress",
+#       "review":       "In review",
+#       "measurement":  "Measurement"
+#     }
+#   }
+#
+# GRACEFUL DEGRADE GUARANTEE:
+#   Any failure (board/field/item not found, missing scope, bad config) warns
+#   to stderr and returns 0. This lib NEVER exits non-zero — it must never
+#   block the lifecycle action that called it.
+#
+# OPS-ROOT:
+#   Config is resolved pin-first via resolve_ops_root() from _lib-ops-root.sh,
+#   matching the same strategy used by all other apexyard hooks. Do NOT use
+#   plain `git rev-parse --show-toplevel` here — in split-portfolio mode or
+#   when running from workspace/<project>/ the toplevel is the project clone,
+#   NOT the ops fork where the config lives. See me2resh/apexyard#381.
+#
+# GITHUB-NATIVE WORKFLOW NOTE:
+#   For transitions outside the three SDLC attach-points above, use
+#   GitHub Projects' built-in Workflows (Settings → Workflows):
+#     - "Item added to project"  → auto-add issues/PRs when opened
+#     - "Item closed"            → move to Done when an issue is closed
+#     - "Pull request merged"    → move to Done when a PR is merged
+#   These free built-ins handle the closed/merged → Done hop so this lib
+#   doesn't have to. Enable them in the GitHub UI; no config here is needed.
+#
+# Sourced by hooks and skills; never executed directly. Use the source-guard
+# so multiple sources in one shell process are idempotent.
+
+[ -n "${_LIB_PROJECT_BOARD_SOURCED:-}" ] && return 0
+_LIB_PROJECT_BOARD_SOURCED=1
+
+# ---------------------------------------------------------------------------
+# Source sibling libs — located in the same .claude/hooks/ directory.
+# Use BASH_SOURCE so the path is correct even when the lib is sourced from a
+# different cwd (e.g. from a skill that cd'd into a project clone).
+# ---------------------------------------------------------------------------
+_lib_board_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Pin-first ops-root resolver (provides resolve_ops_root).
+if [ -f "$_lib_board_dir/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$_lib_board_dir/_lib-ops-root.sh"
+fi
+
+# Config reader (provides config_get / config_get_or; internally sources
+# _lib-ops-root.sh for ops-root resolution — idempotent due to source-guard).
+if [ -f "$_lib_board_dir/_lib-read-config.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$_lib_board_dir/_lib-read-config.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# board_move_card <item-number> <status-key>
+#
+#   <item-number> — GitHub issue or PR number (plain integer)
+#   <status-key>  — one of: in_progress, review, measurement
+# ---------------------------------------------------------------------------
+board_move_card() {
+  local item_ref="$1"
+  local status_key="$2"
+
+  # ---- Guard: enable_auto_moves must be exactly "true" --------------------
+  # Default is false (opt-in). Absent or any non-"true" value → silent no-op.
+  local enabled
+  enabled=$(config_get '.github_projects.enable_auto_moves' 2>/dev/null)
+  if [ "$enabled" != "true" ]; then
+    return 0
+  fi
+
+  # ---- Read board coordinates from config ---------------------------------
+  local owner board_number status_field_name
+  owner=$(config_get '.github_projects.owner' 2>/dev/null)
+  board_number=$(config_get '.github_projects.board_number' 2>/dev/null)
+  status_field_name=$(config_get_or '.github_projects.status_field_name' 'Status')
+
+  if [ -z "$owner" ] || [ "$owner" = "null" ] || [ "$owner" = "" ] || \
+     [ -z "$board_number" ] || [ "$board_number" = "null" ] || \
+     [ "$board_number" = "0" ] || [ "$board_number" = "" ]; then
+    echo "WARN [board_move_card]: github_projects.owner or board_number not configured; skipping card move for #${item_ref}." >&2
+    return 0
+  fi
+
+  # ---- Map status key to board option label --------------------------------
+  local option_label
+  option_label=$(config_get ".github_projects.status_map.${status_key}" 2>/dev/null)
+  if [ -z "$option_label" ] || [ "$option_label" = "null" ]; then
+    echo "WARN [board_move_card]: no status_map entry for key '${status_key}'; skipping card move for #${item_ref}." >&2
+    return 0
+  fi
+
+  # ---- gh availability check ----------------------------------------------
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "WARN [board_move_card]: gh not found; skipping card move for #${item_ref}." >&2
+    return 0
+  fi
+
+  # ---- Resolve project node ID -------------------------------------------
+  # `gh project list` returns {"projects": [{"id": "PVT_xxx", "number": N, ...}]}
+  local project_json project_id
+  project_json=$(gh project list --owner "$owner" --format json 2>/dev/null)
+  project_id=$(printf '%s' "$project_json" \
+    | jq -r ".projects[] | select(.number == ${board_number}) | .id" 2>/dev/null)
+  if [ -z "$project_id" ] || [ "$project_id" = "null" ]; then
+    echo "WARN [board_move_card]: project #${board_number} not found for owner '${owner}'; skipping card move for #${item_ref}." >&2
+    return 0
+  fi
+
+  # ---- Resolve status field ID and option ID ------------------------------
+  # `gh project field-list` returns {"fields": [{"id": "PVTF_xxx", "name": "Status",
+  #   "type": "single_select", "options": [{"id": "opt_xxx", "name": "In progress"}, ...]}]}
+  local field_json field_id option_id
+  field_json=$(gh project field-list "$board_number" --owner "$owner" --format json 2>/dev/null)
+
+  field_id=$(printf '%s' "$field_json" \
+    | jq -r ".fields[] | select(.name == \"${status_field_name}\") | .id" 2>/dev/null)
+  if [ -z "$field_id" ] || [ "$field_id" = "null" ]; then
+    echo "WARN [board_move_card]: field '${status_field_name}' not found on board #${board_number}; skipping card move for #${item_ref}." >&2
+    return 0
+  fi
+
+  option_id=$(printf '%s' "$field_json" \
+    | jq -r ".fields[] | select(.name == \"${status_field_name}\") | .options[] | select(.name == \"${option_label}\") | .id" 2>/dev/null)
+  if [ -z "$option_id" ] || [ "$option_id" = "null" ]; then
+    echo "WARN [board_move_card]: option '${option_label}' not found in field '${status_field_name}'; skipping card move for #${item_ref}." >&2
+    return 0
+  fi
+
+  # ---- Resolve project item ID --------------------------------------------
+  # `gh project item-list` returns {"items": [{"id": "PVTI_xxx", "content": {"number": N, ...}}]}
+  local item_json item_id
+  item_json=$(gh project item-list "$board_number" --owner "$owner" --format json 2>/dev/null)
+  item_id=$(printf '%s' "$item_json" \
+    | jq -r ".items[] | select(.content.number == ${item_ref}) | .id" 2>/dev/null)
+  if [ -z "$item_id" ] || [ "$item_id" = "null" ]; then
+    echo "WARN [board_move_card]: item #${item_ref} not found on board #${board_number}; skipping card move." >&2
+    return 0
+  fi
+
+  # ---- Move the card -------------------------------------------------------
+  if ! gh project item-edit \
+       --id "$item_id" \
+       --project-id "$project_id" \
+       --field-id "$field_id" \
+       --single-select-option-id "$option_id" 2>/dev/null; then
+    echo "WARN [board_move_card]: gh project item-edit failed for item #${item_ref}; skipping." >&2
+    return 0
+  fi
+
+  return 0
+}

--- a/.claude/hooks/auto-code-review.sh
+++ b/.claude/hooks/auto-code-review.sh
@@ -47,7 +47,7 @@ if [ -n "$PR_NUMBER" ]; then
 fi
 
 # Auto-move board card to "In review" (opt-in via github_projects.enable_auto_moves).
-# Recover owner/repo from $PR_URL so the ops-root resolver has full context.
+# Board owner/number come from github_projects config, resolved via the ops root.
 # Degrades gracefully — never blocks on failure.
 if [ -n "$PR_NUMBER" ]; then
   HOOKS_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/.claude/hooks/auto-code-review.sh
+++ b/.claude/hooks/auto-code-review.sh
@@ -46,6 +46,18 @@ if [ -n "$PR_NUMBER" ]; then
   echo "${PR_URL}" > "${REPO_ROOT:-.}/.claude/session/pending-reviews/${PR_NUMBER}"
 fi
 
+# Auto-move board card to "In review" (opt-in via github_projects.enable_auto_moves).
+# Recover owner/repo from $PR_URL so the ops-root resolver has full context.
+# Degrades gracefully — never blocks on failure.
+if [ -n "$PR_NUMBER" ]; then
+  HOOKS_DIR="$(cd "$(dirname "$0")" && pwd)"
+  if [ -f "$HOOKS_DIR/_lib-project-board.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$HOOKS_DIR/_lib-project-board.sh"
+    board_move_card "$PR_NUMBER" "review"
+  fi
+fi
+
 cat >&2 <<MSG
 AUTO CODE REVIEW REQUIRED
 

--- a/.claude/hooks/tests/test_lib_project_board.sh
+++ b/.claude/hooks/tests/test_lib_project_board.sh
@@ -209,6 +209,7 @@ case2() {
     cd "$sb" || exit 1
     export APEXYARD_OPS_DISABLE_PIN=1
     unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    # shellcheck source=/dev/null
     . "$LIB"
     stderr_output=$(board_move_card 42 "in_progress" 2>&1)
     rc=$?
@@ -235,6 +236,7 @@ case2b() {
     cd "$sb" || exit 1
     export APEXYARD_OPS_DISABLE_PIN=1
     unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    # shellcheck source=/dev/null
     . "$LIB"
     board_move_card 42 "review" 2>/dev/null
     rc=$?
@@ -260,6 +262,7 @@ case2c() {
     cd "$sb" || exit 1
     export APEXYARD_OPS_DISABLE_PIN=1
     unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    # shellcheck source=/dev/null
     . "$LIB"
     board_move_card 42 "measurement" 2>/dev/null
     rc=$?
@@ -285,6 +288,7 @@ case3() {
     cd "$sb" || exit 1
     export APEXYARD_OPS_DISABLE_PIN=1
     unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    # shellcheck source=/dev/null
     . "$LIB"
     stderr_out=$(board_move_card 42 "in_progress" 2>&1)
     rc=$?
@@ -310,6 +314,7 @@ case4() {
     cd "$sb" || exit 1
     export APEXYARD_OPS_DISABLE_PIN=1
     unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    # shellcheck source=/dev/null
     . "$LIB"
     stderr_out=$(board_move_card 42 "in_progress" 2>&1)
     rc=$?
@@ -336,6 +341,7 @@ case5() {
     cd "$sb" || exit 1
     export APEXYARD_OPS_DISABLE_PIN=1
     unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    # shellcheck source=/dev/null
     . "$LIB"
     stderr_out=$(board_move_card 42 "in_progress" 2>&1)
     rc=$?
@@ -363,6 +369,7 @@ case6() {
     cd "$sb" || exit 1
     export APEXYARD_OPS_DISABLE_PIN=1
     unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    # shellcheck source=/dev/null
     . "$LIB"
     stderr_out=$(board_move_card 42 "in_progress" 2>&1)
     rc=$?
@@ -390,6 +397,7 @@ JSON
     cd "$sb" || exit 1
     export APEXYARD_OPS_DISABLE_PIN=1
     unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    # shellcheck source=/dev/null
     . "$LIB"
     stderr_out=$(board_move_card 42 "in_progress" 2>&1)
     rc=$?
@@ -414,6 +422,7 @@ case8() {
     cd "$sb" || exit 1
     export APEXYARD_OPS_DISABLE_PIN=1
     unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    # shellcheck source=/dev/null
     . "$LIB"
     stderr_out=$(board_move_card 42 "nonexistent_key" 2>&1)
     rc=$?

--- a/.claude/hooks/tests/test_lib_project_board.sh
+++ b/.claude/hooks/tests/test_lib_project_board.sh
@@ -1,0 +1,454 @@
+#!/bin/bash
+# Tests for .claude/hooks/_lib-project-board.sh (me2resh/apexyard#725)
+#
+# Covers:
+#   1. opt-in off (enable_auto_moves=false/absent) → silent no-op, gh never called
+#   2. config parse + status-key→option mapping → happy path, gh project item-edit called
+#   3. graceful degrade: missing project (project list returns empty)
+#   4. graceful degrade: missing status field on the board
+#   5. graceful degrade: item not found on the board
+#   6. graceful degrade: gh project item-edit fails
+#   7. graceful degrade: owner not configured → warn, exit 0
+#   8. unknown status_key → warn, exit 0
+#
+# Isolation: each case runs in a subshell with its own sandbox dir and a
+# custom `gh` shim installed on PATH. The _CONFIG_CACHE global is reset per
+# subshell. Tests MUST NOT make real GitHub API calls.
+#
+# Exit 0 if all cases pass; exit 1 on failure.
+
+set -u
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not installed; _lib-project-board.sh requires jq" >&2
+  exit 0
+fi
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+LIB="$SRC_ROOT/.claude/hooks/_lib-project-board.sh"
+
+if [ ! -f "$LIB" ]; then
+  echo "FAIL: lib not found at $LIB" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+pass_case() { echo "  PASS [$1]"; PASS=$((PASS + 1)); }
+fail_case() { echo "  FAIL [$1]: $2" >&2; FAIL=$((FAIL + 1)); FAILED_CASES="${FAILED_CASES}${1} "; }
+
+# make_sandbox: create a temp dir, write the fork anchor (.apexyard-fork) and
+# a defaults.json with enable_auto_moves enabled by default (callers override).
+# Prints the sandbox path.
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  : > "$sb/.apexyard-fork"
+  mkdir -p "$sb/.claude"
+
+  # Write the defaults config with board automation enabled and a real board.
+  cat > "$sb/.claude/project-config.defaults.json" <<'JSON'
+{
+  "github_projects": {
+    "owner": "test-org",
+    "board_number": 7,
+    "enable_auto_moves": true,
+    "status_field_name": "Status",
+    "status_map": {
+      "in_progress": "In progress",
+      "review": "In review",
+      "measurement": "Measurement"
+    }
+  }
+}
+JSON
+  echo "$sb"
+}
+
+# install_mock_gh: install a fake `gh` in <sandbox>/bin and prepend to PATH.
+# The mock reads state from files under <sandbox>/.mock-board/:
+#   project_found   — "1" → project list returns a match; absent/0 → empty
+#   field_found     — "1" → field list returns a match; absent/0 → empty
+#   item_found      — "1" → item list returns a match; absent/0 → empty
+#   item_edit_fail  — "1" → item-edit exits 1; absent/0 → exits 0
+#   calls           — a file to which each intercepted call appends one line
+install_mock_gh() {
+  local sb="$1"
+  local mock_state="$sb/.mock-board"
+  mkdir -p "$mock_state"
+  mkdir -p "$sb/bin"
+
+  cat > "$sb/bin/gh" <<GHEOF
+#!/bin/bash
+STATE_DIR="$mock_state"
+
+log() {
+  echo "\$*" >> "\$STATE_DIR/calls"
+}
+
+# Reconstruct the subcommand (first two non-flag args).
+subcmd="\$1 \$2"
+
+case "\$subcmd" in
+
+  "project list")
+    log "project list \$*"
+    found=\$(cat "\$STATE_DIR/project_found" 2>/dev/null || echo "")
+    if [ "\$found" = "1" ]; then
+      printf '{"projects":[{"id":"PVT_abc123","number":7,"title":"My Board"}]}\n'
+    else
+      printf '{"projects":[]}\n'
+    fi
+    exit 0
+    ;;
+
+  "project field-list")
+    log "project field-list \$*"
+    found=\$(cat "\$STATE_DIR/field_found" 2>/dev/null || echo "")
+    if [ "\$found" = "1" ]; then
+      printf '{"fields":[{"id":"PVTF_f1","name":"Status","type":"single_select","options":[{"id":"OPT_ip","name":"In progress"},{"id":"OPT_rv","name":"In review"},{"id":"OPT_ms","name":"Measurement"}]}]}\n'
+    else
+      printf '{"fields":[]}\n'
+    fi
+    exit 0
+    ;;
+
+  "project item-list")
+    log "project item-list \$*"
+    found=\$(cat "\$STATE_DIR/item_found" 2>/dev/null || echo "")
+    if [ "\$found" = "1" ]; then
+      printf '{"items":[{"id":"PVTI_i1","content":{"number":42,"type":"Issue"}}]}\n'
+    else
+      printf '{"items":[]}\n'
+    fi
+    exit 0
+    ;;
+
+  "project item-edit")
+    log "project item-edit \$*"
+    fail=\$(cat "\$STATE_DIR/item_edit_fail" 2>/dev/null || echo "")
+    if [ "\$fail" = "1" ]; then
+      echo "gh: error: item-edit failed (mock)" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+
+  *)
+    echo "[mock-gh] unhandled: \$*" >&2
+    exit 127
+    ;;
+esac
+GHEOF
+  chmod +x "$sb/bin/gh"
+  # Prepend the mock bin to PATH (subshell-safe because each test case runs
+  # inside its own subshell).
+  PATH="$sb/bin:$PATH"
+  export PATH
+}
+
+# mock_set: write a flag file into the mock state dir.
+#   mock_set <sandbox> <flag> <value>
+mock_set() {
+  local sb="$1" flag="$2" value="$3"
+  echo "$value" > "$sb/.mock-board/$flag"
+}
+
+# call_count: count lines in the calls log that match a pattern.
+call_count() {
+  local sb="$1" pattern="$2"
+  grep -c "$pattern" "$sb/.mock-board/calls" 2>/dev/null || echo 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: opt-in off → silent no-op, gh never called
+# ---------------------------------------------------------------------------
+case1() {
+  local label="opt-in off → no-op, gh not called"
+  result=$(
+    sb=$(make_sandbox)
+    install_mock_gh "$sb"
+    # Override with enable_auto_moves=false
+    cat > "$sb/.claude/project-config.json" <<'JSON'
+{"github_projects": {"enable_auto_moves": false}}
+JSON
+    cd "$sb" || exit 1
+    export APEXYARD_OPS_DISABLE_PIN=1
+    unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    # shellcheck source=/dev/null
+    . "$LIB"
+    board_move_card 42 "in_progress"
+    rc=$?
+    gh_calls=$(call_count "$sb" "project")
+    echo "rc=$rc gh_calls=$gh_calls"
+  )
+  if echo "$result" | grep -q "rc=0" && echo "$result" | grep -q "gh_calls=0"; then
+    pass_case "$label"
+  else
+    fail_case "$label" "expected rc=0 and 0 gh calls; got: $result"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: happy path — project/field/item found, item-edit succeeds
+# ---------------------------------------------------------------------------
+case2() {
+  local label="happy path → item-edit called for 'in_progress'"
+  result=$(
+    sb=$(make_sandbox)
+    install_mock_gh "$sb"
+    mock_set "$sb" project_found 1
+    mock_set "$sb" field_found   1
+    mock_set "$sb" item_found    1
+    cd "$sb" || exit 1
+    export APEXYARD_OPS_DISABLE_PIN=1
+    unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    . "$LIB"
+    stderr_output=$(board_move_card 42 "in_progress" 2>&1)
+    rc=$?
+    edit_calls=$(call_count "$sb" "item-edit")
+    echo "rc=$rc edit_calls=$edit_calls stderr=[$stderr_output]"
+  )
+  if echo "$result" | grep -q "rc=0" && echo "$result" | grep -qE "edit_calls=[1-9]" && \
+     ! echo "$result" | grep -q "WARN"; then
+    pass_case "$label"
+  else
+    fail_case "$label" "expected rc=0, >=1 item-edit call, no WARN; got: $result"
+  fi
+}
+
+# Case 2b: verify that 'review' maps to the correct option
+case2b() {
+  local label="happy path → item-edit called for 'review'"
+  result=$(
+    sb=$(make_sandbox)
+    install_mock_gh "$sb"
+    mock_set "$sb" project_found 1
+    mock_set "$sb" field_found   1
+    mock_set "$sb" item_found    1
+    cd "$sb" || exit 1
+    export APEXYARD_OPS_DISABLE_PIN=1
+    unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    . "$LIB"
+    board_move_card 42 "review" 2>/dev/null
+    rc=$?
+    edit_calls=$(call_count "$sb" "item-edit")
+    echo "rc=$rc edit_calls=$edit_calls"
+  )
+  if echo "$result" | grep -q "rc=0" && echo "$result" | grep -qE "edit_calls=[1-9]"; then
+    pass_case "$label"
+  else
+    fail_case "$label" "expected rc=0 and >=1 item-edit; got: $result"
+  fi
+}
+
+# Case 2c: verify 'measurement' maps
+case2c() {
+  local label="happy path → item-edit called for 'measurement'"
+  result=$(
+    sb=$(make_sandbox)
+    install_mock_gh "$sb"
+    mock_set "$sb" project_found 1
+    mock_set "$sb" field_found   1
+    mock_set "$sb" item_found    1
+    cd "$sb" || exit 1
+    export APEXYARD_OPS_DISABLE_PIN=1
+    unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    . "$LIB"
+    board_move_card 42 "measurement" 2>/dev/null
+    rc=$?
+    edit_calls=$(call_count "$sb" "item-edit")
+    echo "rc=$rc edit_calls=$edit_calls"
+  )
+  if echo "$result" | grep -q "rc=0" && echo "$result" | grep -qE "edit_calls=[1-9]"; then
+    pass_case "$label"
+  else
+    fail_case "$label" "expected rc=0 and >=1 item-edit; got: $result"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: graceful degrade — project not found
+# ---------------------------------------------------------------------------
+case3() {
+  local label="graceful degrade: project not found → warn, exit 0"
+  result=$(
+    sb=$(make_sandbox)
+    install_mock_gh "$sb"
+    # project_found NOT set → mock returns empty list
+    cd "$sb" || exit 1
+    export APEXYARD_OPS_DISABLE_PIN=1
+    unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    . "$LIB"
+    stderr_out=$(board_move_card 42 "in_progress" 2>&1)
+    rc=$?
+    echo "rc=$rc stderr=[$stderr_out]"
+  )
+  if echo "$result" | grep -q "rc=0" && echo "$result" | grep -q "WARN"; then
+    pass_case "$label"
+  else
+    fail_case "$label" "expected rc=0 + WARN; got: $result"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: graceful degrade — status field not found on board
+# ---------------------------------------------------------------------------
+case4() {
+  local label="graceful degrade: field not found → warn, exit 0"
+  result=$(
+    sb=$(make_sandbox)
+    install_mock_gh "$sb"
+    mock_set "$sb" project_found 1
+    # field_found NOT set → mock returns empty field list
+    cd "$sb" || exit 1
+    export APEXYARD_OPS_DISABLE_PIN=1
+    unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    . "$LIB"
+    stderr_out=$(board_move_card 42 "in_progress" 2>&1)
+    rc=$?
+    echo "rc=$rc stderr=[$stderr_out]"
+  )
+  if echo "$result" | grep -q "rc=0" && echo "$result" | grep -q "WARN"; then
+    pass_case "$label"
+  else
+    fail_case "$label" "expected rc=0 + WARN; got: $result"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: graceful degrade — item not on board
+# ---------------------------------------------------------------------------
+case5() {
+  local label="graceful degrade: item not on board → warn, exit 0"
+  result=$(
+    sb=$(make_sandbox)
+    install_mock_gh "$sb"
+    mock_set "$sb" project_found 1
+    mock_set "$sb" field_found   1
+    # item_found NOT set → mock returns empty items list
+    cd "$sb" || exit 1
+    export APEXYARD_OPS_DISABLE_PIN=1
+    unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    . "$LIB"
+    stderr_out=$(board_move_card 42 "in_progress" 2>&1)
+    rc=$?
+    echo "rc=$rc stderr=[$stderr_out]"
+  )
+  if echo "$result" | grep -q "rc=0" && echo "$result" | grep -q "WARN"; then
+    pass_case "$label"
+  else
+    fail_case "$label" "expected rc=0 + WARN; got: $result"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 6: graceful degrade — gh project item-edit fails
+# ---------------------------------------------------------------------------
+case6() {
+  local label="graceful degrade: item-edit fails → warn, exit 0"
+  result=$(
+    sb=$(make_sandbox)
+    install_mock_gh "$sb"
+    mock_set "$sb" project_found  1
+    mock_set "$sb" field_found    1
+    mock_set "$sb" item_found     1
+    mock_set "$sb" item_edit_fail 1
+    cd "$sb" || exit 1
+    export APEXYARD_OPS_DISABLE_PIN=1
+    unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    . "$LIB"
+    stderr_out=$(board_move_card 42 "in_progress" 2>&1)
+    rc=$?
+    echo "rc=$rc stderr=[$stderr_out]"
+  )
+  if echo "$result" | grep -q "rc=0" && echo "$result" | grep -q "WARN"; then
+    pass_case "$label"
+  else
+    fail_case "$label" "expected rc=0 + WARN; got: $result"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 7: graceful degrade — owner not configured
+# ---------------------------------------------------------------------------
+case7() {
+  local label="graceful degrade: owner not configured → warn, exit 0"
+  result=$(
+    sb=$(make_sandbox)
+    install_mock_gh "$sb"
+    # Override config to clear owner but keep enable_auto_moves=true
+    cat > "$sb/.claude/project-config.json" <<'JSON'
+{"github_projects": {"owner": "", "board_number": 7, "enable_auto_moves": true}}
+JSON
+    cd "$sb" || exit 1
+    export APEXYARD_OPS_DISABLE_PIN=1
+    unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    . "$LIB"
+    stderr_out=$(board_move_card 42 "in_progress" 2>&1)
+    rc=$?
+    echo "rc=$rc stderr=[$stderr_out]"
+  )
+  if echo "$result" | grep -q "rc=0" && echo "$result" | grep -q "WARN"; then
+    pass_case "$label"
+  else
+    fail_case "$label" "expected rc=0 + WARN; got: $result"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 8: graceful degrade — unknown status key
+# ---------------------------------------------------------------------------
+case8() {
+  local label="graceful degrade: unknown status key → warn, exit 0"
+  result=$(
+    sb=$(make_sandbox)
+    install_mock_gh "$sb"
+    mock_set "$sb" project_found 1
+    cd "$sb" || exit 1
+    export APEXYARD_OPS_DISABLE_PIN=1
+    unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+    . "$LIB"
+    stderr_out=$(board_move_card 42 "nonexistent_key" 2>&1)
+    rc=$?
+    edit_calls=$(call_count "$sb" "item-edit")
+    echo "rc=$rc edit_calls=$edit_calls stderr=[$stderr_out]"
+  )
+  if echo "$result" | grep -q "rc=0" && echo "$result" | grep -q "WARN" && \
+     echo "$result" | grep -q "edit_calls=0"; then
+    pass_case "$label"
+  else
+    fail_case "$label" "expected rc=0 + WARN + no item-edit calls; got: $result"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Run all cases
+# ---------------------------------------------------------------------------
+case1
+case2
+case2b
+case2c
+case3
+case4
+case5
+case6
+case7
+case8
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -203,5 +203,18 @@
     },
     "threshold": 60,
     "timeout_minutes": 90
+  },
+
+  "github_projects": {
+    "_comment": "GitHub Projects (v2) board integration. Set enable_auto_moves=true to auto-move cards on SDLC lifecycle events (start-ticket → In progress, PR created → In review, merge → Measurement). board_number and owner must identify your project board. status_map keys map to the option labels on your board's Status single-select field — adjust them to match your board's column names. Override this whole block in .claude/project-config.json. See .claude/hooks/_lib-project-board.sh and me2resh/apexyard#725.",
+    "owner": "",
+    "board_number": 0,
+    "enable_auto_moves": false,
+    "status_field_name": "Status",
+    "status_map": {
+      "in_progress": "In progress",
+      "review": "In review",
+      "measurement": "Measurement"
+    }
   }
 }

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -198,7 +198,27 @@ After a successful merge, capture and report the merge commit SHA:
 gh pr view <pr> --repo <owner/repo> --json mergeCommit -q '.mergeCommit.oid'
 ```
 
-### 8. Report
+### 8. Move the board card to "Measurement" (opt-in)
+
+After a successful merge, call `board_move_card` to signal that the work has
+shipped and is entering the measurement/observe phase. This is a no-op unless
+`enable_auto_moves` is `true` in the fork's `github_projects` config.
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-project-board.sh"
+board_move_card "<pr>" "measurement"
+```
+
+`board_move_card` degrades gracefully — any failure warns to stderr and returns
+0. It never blocks the merge report.
+
+> **Tip — GitHub-native "Done" transition:** the "PR merged → Done" and
+> "Item closed → Done" built-in Workflows in GitHub Projects (Settings →
+> Workflows) handle the final Done hop for free. Enable them in the GitHub UI
+> and your board will reflect closed tickets automatically without any
+> additional hook wiring.
+
+### 9. Report
 
 Single-line confirmation (include the merge strategy used so the operator can see it):
 
@@ -218,7 +238,7 @@ If the merge gate blocked, surface the exact error and tell the user how to retr
 ✗ Merge blocked: <reason from gate>. Marker still on disk at <CEO path from review_marker_path> — run `gh pr merge <pr> --repo <owner/repo> <strategy> --delete-branch` once the issue is fixed (no need to re-invoke /approve-merge).
 ```
 
-### 9. Optional: post-merge child-issue closure
+### 10. Optional: post-merge child-issue closure
 
 If the PR's merge commit / PR body contains `Closes <owner/repo>#<N>` references that GitHub's auto-closer didn't catch (squash merges with cross-repo refs sometimes silently miss), you can offer to close them with a comment. This is **out of scope for the default flow** — only do it if the user explicitly asks. Don't auto-close child issues; that's another externally-visible action that needs its own per-issue confirmation.
 

--- a/.claude/skills/start-ticket/SKILL.md
+++ b/.claude/skills/start-ticket/SKILL.md
@@ -188,7 +188,22 @@ suggested_branch=<branch>
 started_at=<ISO-8601>
 ```
 
-### 6. Confirm to the User
+### 6. Move the board card to "In progress" (opt-in)
+
+After writing the marker, call `board_move_card` so the GitHub Projects board
+reflects the ticket being picked up. This is a no-op unless `enable_auto_moves`
+is `true` in the fork's `github_projects` config.
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-project-board.sh"
+board_move_card "<number>" "in_progress"
+```
+
+`board_move_card` degrades gracefully: if the board is not configured, the item
+is not on the board, or `gh project` scope is absent, it warns to stderr and
+returns 0 — it never blocks the ticket start.
+
+### 7. Confirm to the User
 
 Output a two-line confirmation that names the marker path so the user sees which scope this ticket is active on:
 

--- a/docs/agdr/AgDR-0080-board-automation-attach-points.md
+++ b/docs/agdr/AgDR-0080-board-automation-attach-points.md
@@ -1,0 +1,72 @@
+# AgDR-0080 — Board automation: CLI attach-points with graceful-degrade vs GitHub Actions vs GitHub-native Workflows
+
+> In the context of surfacing the SDLC lifecycle on a GitHub Projects (v2) board automatically,
+> facing the choice of where and how to trigger card moves,
+> I decided to use three framework attach-points (skills + hook) calling `gh project item-edit` directly,
+> with full graceful degrade and an opt-in default,
+> to achieve zero-friction board updates without requiring adopters to configure external Actions or bots,
+> accepting the limitation that `gh project` scope must be present in the auth token.
+
+## Context
+
+ApexYard already fires at precise SDLC moments: `/start-ticket` (ticket activated),
+`auto-code-review.sh` PostToolUse (PR created), and `/approve-merge` (PR merged).
+Writing a board `Status` field at those moments gives a live board view for free.
+
+Three implementation shapes were evaluated:
+
+1. **Framework hook/skill calling `gh project item-edit`** — the CLI already exists,
+   no extra workflow files needed, no GitHub App required, and the hook machinery
+   (PostToolUse, skill steps) is exactly where these lifecycle events already fire.
+2. **GitHub Actions workflow** — event-driven (issue_event, pull_request, etc.),
+   lives in `.github/workflows/`, requires each managed project to configure secrets
+   and install the workflow. Adds per-project boilerplate for what is fundamentally
+   a portfolio-level concern.
+3. **GitHub Projects built-in Workflows** — free, no code needed, but only cover
+   three events (item added, item closed, PR merged). They handle the "Done" hop
+   (closed → Done, merged → Done) well, but cannot fire on "ticket activated" or
+   "PR created" because those are apexyard-specific lifecycle concepts, not GitHub
+   primitive events.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Framework CLI attach-points (chosen)** | No extra files; hooks already own these moments; opt-in is one config key; graceful degrade keeps the feature safe by default; composable with GitHub-native Workflows for remaining hops | Requires `project` scope in `gh` auth; `gh project item-list` has a default page limit; card moves happen in-process (slight overhead) |
+| GitHub Actions workflow | Event-driven, decoupled, idiomatic GitHub | Per-project boilerplate (secrets, workflow file); doesn't map to apexyard lifecycle concepts natively; adds CI dependency for a UX feature |
+| GitHub-native Workflows only | Zero code, free | Only three events; cannot fire on apexyard's "ticket activated" or "PR created" concepts; no config-driven status mapping |
+
+## Decision
+
+Chosen: **Framework CLI attach-points** via `_lib-project-board.sh`, with the
+following design constraints:
+
+- **Opt-in**: `enable_auto_moves` defaults `false`. Adopters without a board are
+  byte-for-byte unaffected.
+- **Graceful degrade everywhere**: any failure (project/field/item not found,
+  no `project` gh scope, misconfigured owner) warns to stderr and exits 0.
+  The helper never exits non-zero and never blocks the lifecycle action.
+- **Pin-first ops-root**: config is resolved via `resolve_ops_root()` from
+  `_lib-ops-root.sh`, not plain `git rev-parse`, so split-portfolio adopters
+  running inside `workspace/<project>/` see the ops-fork config.
+- **Composable with GitHub-native Workflows**: the docs note encourages adopters
+  to enable the "PR merged → Done" and "Item closed → Done" built-in Workflows
+  for the transitions not covered by the three attach-points.
+
+## Consequences
+
+- Board card moves happen synchronously inside the hook/skill turn. On very large
+  boards (>100 items), `gh project item-list` may be slow or miss items beyond
+  the default page limit (mitigated by passing `--limit 200` to `item-list`).
+- The `project` OAuth scope is required. Adopters using a fine-grained PAT without
+  that scope will see graceful-degrade warnings until they re-auth.
+- Future: a `--limit` config key under `github_projects` could let adopters tune
+  the pagination ceiling without framework changes.
+
+## Artifacts
+
+- Implementation: `.claude/hooks/_lib-project-board.sh`
+- Config: `.claude/project-config.defaults.json` → `github_projects`
+- Docs: `docs/project-config.md` § "GitHub Projects board auto-move"
+- Closes: me2resh/apexyard#725
+- Cross-ref: me2resh/apexyard-premium#363

--- a/docs/project-config.md
+++ b/docs/project-config.md
@@ -91,6 +91,58 @@ scheme=$(config_get_or '.ticket.label_priority_scheme' 'P0,P1,P2,P3')
 
 The reader uses `jq` for merging and path lookups. If `jq` is unavailable, the reader emits `{}` (quiet fallback) and prints a one-time warning on stderr — callers should apply their own safety nets.
 
+## GitHub Projects board auto-move (opt-in, `github_projects`)
+
+ApexYard can auto-move board cards at three SDLC lifecycle moments:
+
+| Trigger | Status key | Default option label |
+|---------|------------|----------------------|
+| `/start-ticket` | `in_progress` | "In progress" |
+| `gh pr create` (auto-code-review hook) | `review` | "In review" |
+| `/approve-merge` | `measurement` | "Measurement" |
+
+This is **opt-in** — the default config has `enable_auto_moves: false`. To enable:
+
+```json
+{
+  "github_projects": {
+    "owner": "my-org",
+    "board_number": 3,
+    "enable_auto_moves": true,
+    "status_field_name": "Status",
+    "status_map": {
+      "in_progress": "In progress",
+      "review":      "In review",
+      "measurement": "Measurement"
+    }
+  }
+}
+```
+
+- `owner` — GitHub organisation or user that owns the board.
+- `board_number` — the numeric ID shown in the board URL (`/projects/<N>`).
+- `status_field_name` — the name of the single-select field on your board. Default: `"Status"`.
+- `status_map` — maps the three SDLC keys to the exact option label strings on your board. Adjust these to match your board's column names if they differ from the defaults.
+
+### Graceful degrade
+
+Any failure (board not found, item not on the board, missing `project` scope in `gh` auth, misconfigured owner/number) emits a `WARN` to stderr and returns 0. The lifecycle action that triggered the move — starting a ticket, creating a PR, merging — is never blocked.
+
+### GitHub-native Workflows for the remaining transitions
+
+For the "closed → Done" and "merged → Done" hops that happen outside the three
+attach-points above, use GitHub Projects' built-in **Workflows** (open your board →
+Settings → Workflows):
+
+- **"Item added to project"** — auto-add issues/PRs when they are opened.
+- **"Item closed"** — move a card to Done when its linked issue is closed.
+- **"Pull request merged"** — move a card to Done when the linked PR is merged.
+
+These are free, built-in, and require no configuration here. Enable them in the
+GitHub UI and your board will reflect the full lifecycle without additional hook wiring.
+
+The lib that implements board moves lives at `.claude/hooks/_lib-project-board.sh`.
+
 ## Backward compatibility
 
 `validate-commit-format.sh` previously read a flat `commit_types` top-level key from `.claude/project-config.json`. That reader is still honoured as a fallback, so forks that customised commit types before apexyard#109 keep working without edits. New customisations should use the nested `commit.type_whitelist` form.


### PR DESCRIPTION
## Summary

- Introduces `.claude/hooks/_lib-project-board.sh` — a new opt-in helper that exposes `board_move_card <number> <status-key>`. It resolves the ops root pin-first via `resolve_ops_root()`, reads board config from `_lib-read-config.sh`, then calls `gh project item-edit` to update the card's Status field. Any failure (project/field/item not found, missing `project` gh scope, misconfigured owner) warns to stderr and exits 0 — it never blocks the lifecycle action that triggered it.
- Adds a `github_projects` block to `.claude/project-config.defaults.json` with `enable_auto_moves: false` (opt-in off by default) so adopters without a board are byte-for-byte unaffected.
- Wires three SDLC transitions: `/start-ticket` → In progress (step 6), `auto-code-review.sh` on `gh pr create` → In review, `/approve-merge` after merge → Measurement (step 8). All three are additive-only edits.
- Adds a docs note in `docs/project-config.md` on enabling board auto-moves and the GitHub-native Workflows (item closed → Done, PR merged → Done, auto-add) that cover the remaining lifecycle transitions for free.

## Testing

1. Run the new test suite: `bash .claude/hooks/tests/test_lib_project_board.sh` — 10 cases, all pass.
2. Confirm `bash -n` syntax-clean on all changed `.sh` files.
3. Confirm `jq . .claude/project-config.defaults.json` exits 0 (valid JSON).
4. To smoke-test the full board integration, set `enable_auto_moves: true` with a real board in `.claude/project-config.json` and run `/start-ticket <N>` — the card should move to "In progress".

## Glossary

| Term | Definition |
|------|------------|
| Attach point | A lifecycle moment where the ticket/PR number is known, making a board Status write safe |
| Pin-first ops-root | Resolving the ops fork via the session pin before walking up the tree — required for split-portfolio correctness |
| Graceful degrade | Helper warns to stderr and exits 0 on any failure; the lifecycle action is never blocked |
| Opt-in | `enable_auto_moves` defaults `false`; absent/false is a silent no-op with no `gh` calls |
| Status key | Internal key (`in_progress`, `review`, `measurement`) mapped to board column labels via `status_map` config |
| GitHub-native Workflow | GitHub Projects built-in automation (Settings → Workflows) for transitions not covered by framework attach-points |

Closes #725

Cross-ref: me2resh/apexyard-premium#363

🤖 Generated with [Claude Code](https://claude.com/claude-code)