### PR TITLE
fix(#727): block-main-push.sh — handle the -u/--set-upstream push form

### DIFF
--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -8,24 +8,32 @@
 # convention can override the protected list via
 # `.claude/project-config.json` → `.git.protected_branches[]`.
 #
-# WORKTREE-SAFE (me2resh/apexyard#549)
-# -------------------------------------
+# WORKTREE-SAFE (me2resh/apexyard#549, #727)
+# ------------------------------------------
 # Previously both the push-check and the commit-check resolved the current
 # branch via `git branch --show-current` against the hook's cwd (the harness's
 # primary checkout). When the operator runs a command in a separate git worktree
 # while the primary checkout sits on a protected branch, the old code
 # false-blocked legitimate feature-branch work.
 #
-# Fix:
+# Fix (#549):
 #   Push:   reuse `_lib-extract-push-ref.sh` (already used by
 #           validate-branch-name.sh for the same reason) to read the DESTINATION
-#           branch directly from the push command. Tag pushes are no-ops. Falls
-#           back to local HEAD only when no ref is present in the command (e.g.
-#           bare `git push` relying on upstream tracking).
+#           branch directly from the push command. Tag pushes are no-ops.
 #   Commit: detect the `cd <path> && git commit` shell compound pattern and run
 #           `git -C <path> branch --show-current` against the TARGET worktree.
 #           Falls back to the session cwd for plain `git commit` (no `cd`
 #           prefix) — preserving the original behaviour for the normal case.
+#
+# Fix (#727) — push fallback when no explicit ref is given:
+#   `git push -u origin` (and `--set-upstream`) without an explicit branch
+#   name carries no refspec, so extract_push_ref() returns empty and the old
+#   code fell back to `git branch --show-current` in the HOOK's session cwd.
+#   In a worktree session where the primary checkout is on `dev` but the
+#   active worktree is on a feature branch, this falsely blocked a legitimate
+#   push.  Fix: when the ref is absent and the command has a `cd <path>`
+#   prefix, resolve the current branch from that path (same pattern used by
+#   the commit section above).
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -82,8 +90,29 @@ if echo "$COMMAND" | grep -qE '\bgit\s+push\b'; then
   if [ -n "$PUSH_DST" ]; then
     TARGET_PUSH_BRANCH="$PUSH_DST"
   else
-    # Bare `git push` / no explicit ref — fall back to local HEAD.
-    TARGET_PUSH_BRANCH=$(git branch --show-current 2>/dev/null)
+    # No explicit ref in the command (e.g. `git push -u origin` or bare `git
+    # push`): the push targets the current branch of the repo the command runs
+    # in.  For a compound `cd <path> && git push -u origin` (the worktree case
+    # — #727), we must resolve the branch of the TARGET worktree via the `cd`
+    # destination, NOT the hook's session cwd.  Without this, a developer on a
+    # feature-branch worktree who runs `git push -u origin` is falsely blocked
+    # because the hook's session cwd (the primary checkout) may sit on a
+    # protected branch like `dev`.
+    #
+    # This mirrors the same pattern used in the commit section below for #549.
+    PUSH_WORKTREE_PATH=""
+    if echo "$COMMAND" | grep -qE '(^|[;&|[:space:]])cd[[:space:]]+\S'; then
+      PUSH_WORKTREE_PATH=$(echo "$COMMAND" \
+        | grep -oE "cd[[:space:]]+(\"[^\"]*\"|'[^']*'|[^[:space:];&|]+)" \
+        | tail -n 1 \
+        | sed -E "s/^cd[[:space:]]+//; s/^[\"']//; s/[\"']\$//")
+    fi
+    if [ -n "$PUSH_WORKTREE_PATH" ]; then
+      TARGET_PUSH_BRANCH=$(git -C "$PUSH_WORKTREE_PATH" branch --show-current 2>/dev/null)
+    else
+      # Plain `git push -u origin` with no `cd` prefix — use session cwd.
+      TARGET_PUSH_BRANCH=$(git branch --show-current 2>/dev/null)
+    fi
   fi
 
   if [ -n "$TARGET_PUSH_BRANCH" ] && echo "$TARGET_PUSH_BRANCH" | grep -qE "^(${PROTECTED})$"; then

--- a/.claude/hooks/tests/test_block_main_push.sh
+++ b/.claude/hooks/tests/test_block_main_push.sh
@@ -256,6 +256,43 @@ run_case "plain git commit on feature branch passes" \
 rm -rf "$SB"
 
 # ---------------------------------------------------------------------------
+# (f) cd <wt> && git push -u/--set-upstream origin (no explicit refspec)
+#     resolves the WORKTREE branch, not the hook's session cwd — #727
+#
+# Bug: when `extract_push_ref` returns empty (no explicit ref in the command),
+#      the hook fell back to `git branch --show-current` in the session cwd.
+#      In a worktree session cwd=dev, `git push -u origin` from a feature
+#      worktree was falsely blocked.
+# ---------------------------------------------------------------------------
+SB=$(make_sandbox "dev")   # primary checkout on protected 'dev'
+WT=$(make_worktree "$SB" "feature/GH-727-push-u")
+
+# Hook cwd = $SB (on dev). Command cd-s into feature worktree then pushes
+# without an explicit branch name — must resolve wt branch, not cwd branch.
+run_case "cd wt && push -u origin (no ref) passes (wt=feature, cwd=dev)" \
+  "$SB" "$SB" "cd ${WT} && git push -u origin" 0
+run_case "cd wt && push --set-upstream origin (no ref) passes (wt=feature, cwd=dev)" \
+  "$SB" "$SB" "cd ${WT} && git push --set-upstream origin" 0
+run_case "cd wt && push -u upstream (no ref) passes (wt=feature, cwd=dev)" \
+  "$SB" "$SB" "cd ${WT} && git push -u upstream" 0
+
+# cd into a protected-branch repo + bare -u push must still block.
+SB_PROT=$(make_sandbox "main")
+run_case "cd main-repo && push -u origin blocks (repo=main, cwd=dev)" \
+  "$SB" "$SB" "cd ${SB_PROT} && git push -u origin" 2
+rm -rf "$SB_PROT"
+
+# Bare `git push -u origin` with NO cd prefix — session cwd is dev → blocks.
+run_case "bare push -u origin on dev cwd blocks (no cd)" \
+  "$SB" "$SB" "git push -u origin" 2
+
+# Quoted cd into feature wt must still pass (same quote-stripping as #580).
+run_case "cd \"wt\" && push -u origin (double-quoted) passes" \
+  "$SB" "$SB" "cd \"${WT}\" && git push -u origin" 0
+
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
 # Non-git commands must be no-ops.
 # ---------------------------------------------------------------------------
 SB=$(make_sandbox "dev")


### PR DESCRIPTION
## Summary

- **Root cause**: when `git push -u origin` (or `--set-upstream`) is used without an explicit branch refspec in a compound command like `cd <worktree> && git push -u origin`, `extract_push_ref()` returns empty and the hook fell back to `git branch --show-current` in the hook's session cwd. If the session cwd is on a protected branch (`dev`), the push was falsely blocked even though the actual push targeted a feature-branch worktree.
- **Fix**: in the push section's no-ref fallback, detect a `cd <path>` prefix in the compound command and resolve the current branch via `git -C <path> branch --show-current` — the same pattern the commit section already uses for the analogous #549 worktree case. Plain `git push -u origin` with no `cd` prefix continues to fall back to the session cwd (correct for single-worktree usage).
- **Tests**: 6 new test cases added to `test_block_main_push.sh` (section f) covering the fixed forms, the still-blocked protected-branch push, and quoted-path robustness. All 37 tests pass; `shellcheck -S warning` clean.

## Testing

```bash
bash .claude/hooks/tests/test_block_main_push.sh
# → 37 PASS, 0 FAIL
shellcheck -S warning .claude/hooks/block-main-push.sh
# → exit 0 (no warnings)
bash -n .claude/hooks/block-main-push.sh
# → exit 0
```

Closes #727

---

## Glossary

| Term | Definition |
|------|------------|
| `-u` / `--set-upstream` | The git push flag that sets the remote tracking ref; does not carry an explicit `src:dst` refspec, so the pushed branch must be inferred |
| Session cwd | The working directory the Claude Code harness uses for the current session — may be the primary checkout, which can be on a different branch than a linked worktree |
| Linked worktree | A separate checkout of the same git repo at a different path, on its own branch; created via `git worktree add` |
| `extract_push_ref()` | Helper in `_lib-extract-push-ref.sh` that parses the destination branch from a `git push` command token by token; returns empty when no explicit refspec is present |
| `cd <path>` prefix detection | Pattern borrowed from the commit section's #549 fix: parse the last `cd <path>` in a compound command to identify the target repo path |