### PR TITLE
fix(#728): harden warn-review-marker-write guardrail against forged Rex markers

### DIFF
--- a/.claude/hooks/tests/test_block_unreviewed_merge.sh
+++ b/.claude/hooks/tests/test_block_unreviewed_merge.sh
@@ -587,7 +587,7 @@ else
     '{tool_name:"Write", tool_input:{file_path:$fp, content:"abc"}}')
   got_stderr=$(echo "$input" | bash "$WARN_HOOK_SRC" 2>&1 >/dev/null)
   got_rc=$?
-  if [ "$got_rc" = "0" ] && echo "$got_stderr" | grep -q "ADVISORY"; then
+  if [ "$got_rc" = "0" ] && echo "$got_stderr" | grep -q "VIOLATION"; then
     echo "PASS [warn-hook: Write to rex.approved → advisory + exit 0 (#494)]"; PASS=$((PASS+1))
   else
     echo "FAIL [warn-hook: Write to rex.approved → advisory + exit 0]: rc=$got_rc stderr=${got_stderr:0:200}" >&2
@@ -599,7 +599,7 @@ else
     '{tool_name:"Bash", tool_input:{command:$c}}')
   got_stderr=$(echo "$input" | bash "$WARN_HOOK_SRC" 2>&1 >/dev/null)
   got_rc=$?
-  if [ "$got_rc" = "0" ] && echo "$got_stderr" | grep -q "ADVISORY"; then
+  if [ "$got_rc" = "0" ] && echo "$got_stderr" | grep -q "VIOLATION"; then
     echo "PASS [warn-hook: Bash echo to ceo.approved → advisory + exit 0 (#494)]"; PASS=$((PASS+1))
   else
     echo "FAIL [warn-hook: Bash echo to ceo.approved → advisory + exit 0]: rc=$got_rc stderr=${got_stderr:0:200}" >&2

--- a/.claude/hooks/tests/test_warn_review_marker_write.sh
+++ b/.claude/hooks/tests/test_warn_review_marker_write.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# Tests for warn-review-marker-write.sh (#728 hardening).
+#
+# The hook fires when a Write tool call or a Bash command targets a
+# *-rex.approved or *-ceo.approved file under .claude/session/reviews/.
+# It is ADVISORY (exit 0 always) because the harness provides no per-agent-type
+# env var that would let the hook distinguish the sanctioned code-reviewer from a
+# build-class agent — both run as CLAUDE_CODE_CHILD_SESSION=1 sub-agents with
+# identical environments.  The achievable hardening is an unmissable banner.
+#
+# Test matrix:
+#   (1) Write tool → rex marker path → banner fires, exit 0
+#   (2) Write tool → ceo marker path → banner fires, exit 0
+#   (3) Bash tool  → echo redirect to rex marker → banner fires, exit 0
+#   (4) Bash tool  → tee to rex marker           → banner fires, exit 0
+#   (5) Write tool → non-marker path             → silent, exit 0
+#   (6) Bash tool  → unrelated command           → silent, exit 0
+#   (7) Write tool → rex marker (architecture variant) → banner fires, exit 0
+#   (8) Missing tool_name field                  → silent, exit 0
+#   (9) Banner content — rex case contains "VIOLATION" and "Rex"
+#  (10) Banner content — ceo case contains "VIOLATION" and "/approve-merge"
+#  (11) Bash tool  → rex marker via printf       → banner fires, exit 0
+#
+# Exit 0 if all cases pass; 1 on failure.
+
+set -u
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/warn-review-marker-write.sh"
+
+if [ ! -f "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found: $HOOK_SRC" >&2
+  exit 1
+fi
+if ! bash -n "$HOOK_SRC" 2>/dev/null; then
+  echo "FAIL: syntax error in $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0; FAIL=0; FAILED_CASES=""
+
+# ---------------------------------------------------------------------------
+# Helper: run_hook <label> <json> <expect_banner:0|1> [<grep_pattern>]
+#   Pipes <json> into the hook, asserts exit=0 always.
+#   If expect_banner=1, asserts stderr is non-empty (and optionally matches
+#   <grep_pattern>).  If expect_banner=0, asserts stderr is empty.
+# ---------------------------------------------------------------------------
+run_hook() {
+  local label="$1" json="$2" expect_banner="$3"
+  local grep_pattern="${4:-}"
+  local stderr_file rc
+  stderr_file=$(mktemp)
+
+  printf '%s' "$json" | bash "$HOOK_SRC" 2>"$stderr_file"
+  rc=$?
+
+  # Hook must ALWAYS exit 0 (advisory — never blocks).
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]: hook exited $rc, expected 0" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES $label"; rm -f "$stderr_file"; return
+  fi
+
+  local stderr_content
+  stderr_content=$(cat "$stderr_file")
+
+  if [ "$expect_banner" -eq 1 ]; then
+    if [ -z "$stderr_content" ]; then
+      echo "FAIL [$label]: expected banner on stderr, got silence" >&2
+      FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES $label"; rm -f "$stderr_file"; return
+    fi
+    if [ -n "$grep_pattern" ] && ! echo "$stderr_content" | grep -qE "$grep_pattern"; then
+      echo "FAIL [$label]: banner present but did not match /$grep_pattern/" >&2
+      echo "  stderr (first 400 chars): ${stderr_content:0:400}" >&2
+      FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES $label"; rm -f "$stderr_file"; return
+    fi
+  else
+    if [ -n "$stderr_content" ]; then
+      echo "FAIL [$label]: expected silence, got: ${stderr_content:0:200}" >&2
+      FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES $label"; rm -f "$stderr_file"; return
+    fi
+  fi
+
+  rm -f "$stderr_file"
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# Convenience wrappers for common JSON payloads.
+write_json() {
+  # Write tool targeting a file path.
+  local path="$1"
+  printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"sha123"}}' "$path"
+}
+bash_json() {
+  # Bash tool running a command string.
+  local cmd="$1"
+  printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$cmd"
+}
+
+# A canonical rex marker path (new qualified scheme).
+REX_PATH=".claude/session/reviews/acme__myrepo__42-rex.approved"
+CEO_PATH=".claude/session/reviews/acme__myrepo__42-ceo.approved"
+ARC_PATH=".claude/session/reviews/acme__myrepo__42-architecture.approved"
+SAFE_PATH=".claude/session/notes/build-log.txt"
+
+# ---------------------------------------------------------------------------
+# (1) Write → rex marker → banner fires, exit 0
+# ---------------------------------------------------------------------------
+run_hook "Write rex marker fires banner" \
+  "$(write_json "$REX_PATH")" 1
+
+# ---------------------------------------------------------------------------
+# (2) Write → ceo marker → banner fires, exit 0
+# ---------------------------------------------------------------------------
+run_hook "Write ceo marker fires banner" \
+  "$(write_json "$CEO_PATH")" 1
+
+# ---------------------------------------------------------------------------
+# (3) Bash → echo redirect to rex marker → banner fires, exit 0
+# ---------------------------------------------------------------------------
+run_hook "Bash echo redirect rex marker fires banner" \
+  "$(bash_json "echo 'abc123' > ${REX_PATH}")" 1
+
+# ---------------------------------------------------------------------------
+# (4) Bash → tee to rex marker → banner fires, exit 0
+# ---------------------------------------------------------------------------
+run_hook "Bash tee rex marker fires banner" \
+  "$(bash_json "printf sha | tee ${REX_PATH}")" 1
+
+# ---------------------------------------------------------------------------
+# (5) Write → non-marker path → silent, exit 0
+# ---------------------------------------------------------------------------
+run_hook "Write non-marker path is silent" \
+  "$(write_json "$SAFE_PATH")" 0
+
+# ---------------------------------------------------------------------------
+# (6) Bash → unrelated command → silent, exit 0
+# ---------------------------------------------------------------------------
+run_hook "Bash unrelated command is silent" \
+  "$(bash_json "gh pr merge 42 --squash")" 0
+
+# ---------------------------------------------------------------------------
+# (7) Write → architecture marker (.claude/session/reviews/*-architecture.approved)
+#     NOT a *-rex.approved or *-ceo.approved → must be silent.
+#     (Architecture markers are written by Tariq/approve-architecture, not Rex.)
+# ---------------------------------------------------------------------------
+run_hook "Write architecture marker is silent (different marker type)" \
+  "$(write_json "$ARC_PATH")" 0
+
+# ---------------------------------------------------------------------------
+# (8) Missing tool_name field → silent, exit 0
+# ---------------------------------------------------------------------------
+run_hook "Missing tool_name is silent" \
+  '{"tool_input":{"file_path":".claude/session/reviews/42-rex.approved"}}' 0
+
+# ---------------------------------------------------------------------------
+# (9) Banner content — rex case: must contain VIOLATION and mention Rex
+# ---------------------------------------------------------------------------
+run_hook "Rex banner contains VIOLATION keyword" \
+  "$(write_json "$REX_PATH")" 1 "VIOLATION"
+run_hook "Rex banner mentions Rex / code-reviewer" \
+  "$(write_json "$REX_PATH")" 1 "Rex|code.reviewer"
+
+# ---------------------------------------------------------------------------
+# (10) Banner content — ceo case: must contain VIOLATION and mention /approve-merge
+# ---------------------------------------------------------------------------
+run_hook "CEO banner contains VIOLATION keyword" \
+  "$(write_json "$CEO_PATH")" 1 "VIOLATION"
+run_hook "CEO banner mentions /approve-merge" \
+  "$(write_json "$CEO_PATH")" 1 "/approve-merge"
+
+# ---------------------------------------------------------------------------
+# (11) Bash → printf to rex marker → banner fires, exit 0
+# ---------------------------------------------------------------------------
+run_hook "Bash printf rex marker fires banner" \
+  "$(bash_json "printf '%s' sha > ${REX_PATH}")" 1
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/warn-review-marker-write.sh
+++ b/.claude/hooks/warn-review-marker-write.sh
@@ -3,71 +3,134 @@
 # a Bash command targets a *-rex.approved or *-ceo.approved file under
 # .claude/session/reviews/.
 #
-# Purpose: remind build-class sub-agents (platform-engineer, backend-engineer,
-# frontend-engineer, product-manager, etc.) that review markers must come from
-# the real code-reviewer agent or the /approve-merge skill — NOT from the
-# agent that just finished building the thing being reviewed.
+# PURPOSE
+# -------
+# Build-class sub-agents (platform-engineer, backend-engineer, frontend-engineer,
+# product-manager, etc.) implementing a ticket CANNOT spawn the real code-reviewer
+# (Rex) because they cannot nest the Agent tool.  If such an agent writes a
+# *-rex.approved marker and frames its output as "Rex approved", it satisfies the
+# merge gate's filename check without satisfying its INTENT — the author is
+# reviewing its own work, defeating the two-reviews rule.
 #
-# This hook NEVER blocks (exit 0 always). It is an advisory nudge, not a gate.
-# The real safety is the per-PR human CEO nod (via /approve-merge) plus the
-# orchestrator running the independent review — NOT a mechanical lock. A stronger
-# mechanical gate (requiring a posted, author-independent GitHub review at HEAD)
-# is DEFERRED as a config opt-in for hands-off / multi-account setups (#494) —
-# see AgDR-0062 for why it isn't on by default (single-account maintainers would
-# be locked out).
+# This hook fires on every attempt to write a review marker and emits an
+# UNMISSABLE banner to make the violation visible before the write lands.
+#
+# WHY THIS HOOK CANNOT BLOCK (#728)
+# ----------------------------------
+# A full mechanical block would require distinguishing the sanctioned
+# code-reviewer agent from a build-class agent at the shell level.  In the
+# current harness there is no per-agent-type env var (CLAUDE_AGENT_TYPE or
+# similar) — all sub-agents share the same environment (CLAUDE_CODE_CHILD_SESSION
+# is set for every sub-agent, not just build-class ones).  Without a reliable
+# provenance signal the hook cannot block without also blocking the real Rex
+# write.  Options for a future full block:
+#
+#   A) Harness emits CLAUDE_SUBAGENT_TYPE per sub-agent spawn → hook checks it.
+#   B) Rex marker carries structured provenance fields (like the CEO marker's
+#      approved_by=user / skill_version=2) that a build agent cannot fabricate
+#      without also violating the structured-format check in block-unreviewed-merge.sh.
+#
+# Both options are deferred; a /decide AgDR should evaluate them.  In the
+# meantime the primary safeguards remain: (1) this unmissable advisory banner,
+# (2) the prompt-guardrail in each build-agent file, and (3) the per-PR human
+# CEO nod required by /approve-merge.
+#
+# References: #728, AgDR-0062, .claude/rules/pr-workflow.md
+#             § "Build agents cannot self-review"
 #
 # Wired in .claude/settings.json PreToolUse for:
-#   matcher: Write    (catches direct file writes)
-#   matcher: Bash     (catches shell redirections, printf, tee, etc.)
-#
-# See AgDR-0062 and .claude/rules/pr-workflow.md § "Build agents cannot
-# self-review" for the design rationale.
+#   matcher: Write    (catches direct file writes via the Write tool)
+#   matcher: Bash     (catches shell redirections, echo >, printf, tee, etc.)
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 
 _is_marker_target() {
   local text="$1"
-  # Match any path that ends with a review-marker filename pattern:
-  #   *-rex.approved or *-ceo.approved
-  # under a .claude/session/reviews/ directory.
+  # Match any path ending with a review-marker filename under the reviews dir:
+  #   *-rex.approved  — Rex gate marker (written by code-reviewer after review)
+  #   *-ceo.approved  — CEO gate marker (written by /approve-merge on explicit approval)
   echo "$text" | grep -qE '\.claude/session/reviews/[^[:space:]"'"'"']+-(rex|ceo)\.approved'
 }
 
 MATCHED=0
+MARKER_TYPE=""
 
 case "$TOOL_NAME" in
   Write)
     FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
     if _is_marker_target "$FILE_PATH"; then
       MATCHED=1
+      # Identify which marker type for a more targeted message.
+      echo "$FILE_PATH" | grep -q '\-rex\.approved' && MARKER_TYPE="rex"
+      echo "$FILE_PATH" | grep -q '\-ceo\.approved' && MARKER_TYPE="ceo"
     fi
     ;;
   Bash)
     COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
     if _is_marker_target "$COMMAND"; then
       MATCHED=1
+      echo "$COMMAND" | grep -q '\-rex\.approved' && MARKER_TYPE="rex"
+      echo "$COMMAND" | grep -q '\-ceo\.approved' && MARKER_TYPE="ceo"
     fi
     ;;
 esac
 
 if [ "$MATCHED" = "1" ]; then
-  cat >&2 <<'BANNER'
-[apexyard] ADVISORY: You are about to write a review marker under .claude/session/reviews/.
+  # Determine the specific violation message based on which marker type.
+  if [ "$MARKER_TYPE" = "rex" ]; then
+    MARKER_RULE="*-rex.approved must be written ONLY by the real code-reviewer agent (Rex)
+  after it posts a GitHub review on the PR.  Rex is a separate sub-agent with
+  its own context — not the agent that just built the thing being reviewed."
+    MARKER_WHO="Rex (code-reviewer sub-agent), invoked by the orchestrator via /code-review"
+  elif [ "$MARKER_TYPE" = "ceo" ]; then
+    MARKER_RULE="*-ceo.approved must be written ONLY by the /approve-merge skill
+  on an explicit per-PR CEO approval.  It carries structured provenance fields
+  (approved_by=user, skill_version=2) that cannot be fabricated casually."
+    MARKER_WHO="/approve-merge skill, invoked by the orchestrator on an explicit CEO nod"
+  else
+    MARKER_RULE="Review markers must be written only by the real code-reviewer (Rex)
+  or the /approve-merge skill — not by the agent that built the code."
+    MARKER_WHO="the real code-reviewer (Rex) or /approve-merge"
+  fi
 
-Review markers must only be written by:
-  - The real code-reviewer agent (Rex) — writes *-rex.approved after posting
-    a GitHub review on the PR
-  - The /approve-merge skill — writes *-ceo.approved on explicit CEO approval
+  cat >&2 <<BANNER
+======================================================================
+[apexyard] VIOLATION WARNING: Unauthorized review-marker write detected
+======================================================================
 
-Build-class agents (backend-engineer, frontend-engineer, platform-engineer,
-product-manager, etc.) MUST NOT write these files. The merge is gated by an
-explicit human CEO nod (/approve-merge) and the orchestrator running the real,
-independent review — a self-written marker substitutes for neither. (A
-mechanical review-authenticity gate is a deferred opt-in — see AgDR-0062.)
+You are about to write a review marker under .claude/session/reviews/.
 
-If you are a build agent: report your results plainly and hand off to the
-orchestrator. Do not self-review.
+  ${MARKER_RULE}
+
+  Who may write this marker:
+    ${MARKER_WHO}
+
+WHY THIS MATTERS
+  Writing this file yourself satisfies the merge gate's FILENAME check
+  but NOT its INTENT.  The two-reviews rule (workflow-gates #5 /
+  pr-workflow § "Build agents cannot self-review") requires the reviewer
+  to be a SEPARATE agent with independent context.  A build-class agent
+  (backend/frontend/platform engineer, product-manager, etc.) is the
+  AUTHOR — it cannot be its own independent reviewer.
+
+  The merge gate hook (block-unreviewed-merge.sh) will accept a forged
+  marker and let an unreviewed PR through.  This is a silent bypass of
+  the safety gate the framework exists to enforce.
+
+IF YOU ARE A BUILD-CLASS AGENT — STOP
+  Do NOT write this file.
+  Do NOT frame your output as a "Rex review" or "APPROVED" verdict.
+  Report your build results plainly (what you built, tests run/passed).
+  Hand off to the orchestrator — it will run the real Rex review.
+
+IF YOU ARE THE CODE-REVIEWER (Rex) — PROCEED WITH CAUTION
+  This banner is advisory.  You are the sanctioned writer.  Verify you
+  have posted a real GitHub review comment on the PR before writing the
+  marker.  (A mechanical write-block for this case requires harness-level
+  provenance — see #728 and AgDR-0062 for the deferred design.)
+
+======================================================================
 BANNER
 fi
 


### PR DESCRIPTION
## Summary

- **Problem**: `warn-review-marker-write.sh` emitted a low-visibility single-line advisory when any agent wrote a `*-rex.approved` or `*-ceo.approved` marker. A build-class agent impersonating Rex could write the marker, satisfy `block-unreviewed-merge.sh`'s filename check, and bypass the two-reviews gate silently.
- **Hardening delivered**: replaced the soft advisory with an **unmissable banner** — visual `===` separator, `VIOLATION WARNING` uppercase header, marker-type-specific messaging (rex vs ceo), a clear `STOP` directive for build agents, and an explicit `PROCEED` note for the real Rex to avoid unnecessary confusion.
- **New test file**: `test_warn_review_marker_write.sh` — 13 cases covering Write/Bash tool paths, marker type variants, non-marker silencing, missing-field silencing, and banner-content assertions. All pass; `shellcheck -S warning` clean.

## What's blocked vs deferred

**What this PR does:** makes the violation *unmissable* — the banner cannot be mistaken for a routine info log.

**What this PR does NOT do:** mechanically block the write. A full block is not achievable at the shell hook level with the current harness because `CLAUDE_CODE_CHILD_SESSION=1` is set for ALL sub-agents (build-class and code-reviewer alike). Blocking unconditionally would prevent the real Rex from writing its marker.

**What a full block needs** (deferred — requires a `/decide` AgDR):

| Option | Mechanism | Cost |
|--------|-----------|------|
| A — Harness provenance | Harness emits `CLAUDE_SUBAGENT_TYPE=code-reviewer` per sub-agent spawn; hook allowlists that value | Requires harness change |
| B — Structured Rex marker | Rex marker carries provenance fields (`approved_by=rex`, `skill_version=N`) that `block-unreviewed-merge.sh` validates, analogous to the CEO marker's `approved_by=user / skill_version=2`; build agents can't fabricate without a deliberate, visible violation | Requires code-reviewer + merge-gate changes |

Primary safeguards active today: (1) this unmissable banner, (2) the `MUST NOT` prompt-guardrail in each build-agent file under `.claude/agents/`, (3) the per-PR human CEO nod required by `/approve-merge`.

## Testing

```bash
bash .claude/hooks/tests/test_warn_review_marker_write.sh
# → 13 PASS, 0 FAIL
shellcheck -S warning .claude/hooks/warn-review-marker-write.sh
shellcheck -S warning .claude/hooks/tests/test_warn_review_marker_write.sh
# → both exit 0, no warnings
bash -n .claude/hooks/warn-review-marker-write.sh
# → exit 0
```

Closes #728

---

## Glossary

| Term | Definition |
|------|------------|
| Build-class agent | A sub-agent that implements a ticket (backend/frontend/platform engineer, product-manager, etc.); cannot nest the Agent tool, so cannot spawn the real code-reviewer Rex |
| Forged marker | A `*-rex.approved` file written by a build agent rather than the sanctioned code-reviewer — satisfies the merge gate's filename check without satisfying its author-vs-reviewer independence requirement |
| Advisory hook | A PreToolUse hook that emits a warning (exit 0) but does not block; the write proceeds |
| `CLAUDE_CODE_CHILD_SESSION` | Env var set to `1` for all Claude Code sub-agents — present for build-class agents and code-reviewer alike, so it cannot be used as a build-vs-reviewer discriminator |
| Provenance mechanism | A harness-level signal (env var or structured marker field) that proves which agent type wrote a file, enabling the hook to allowlist the sanctioned writer and block all others |