### PR TITLE
feat(#733): apexyard-search auto-reindex on session-start + broaden agent MCP allowlists

### DIFF
--- a/.claude/agents/data-analyst.md
+++ b/.claude/agents/data-analyst.md
@@ -2,7 +2,7 @@
 name: data-analyst
 description: Writes SQL, builds dashboards, runs A/B-test analysis, and investigates metrics. Activates on SQL / dashboard / A/B-test / metric-investigation work — quantitative, fast, narrow tool-use (candidate for local-model routing per #348 spike).
 model: haiku
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Nadia
 ---
 

--- a/.claude/agents/head-of-data.md
+++ b/.claude/agents/head-of-data.md
@@ -2,7 +2,7 @@
 name: head-of-data
 description: Owns analytics strategy, data governance, reporting architecture, and cross-project data modelling. Activates on cross-project data calls, governance decisions, reporting-architecture reviews, and strategic data tooling choices.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Khalil
 ---
 

--- a/.claude/agents/head-of-design.md
+++ b/.claude/agents/head-of-design.md
@@ -2,7 +2,7 @@
 name: head-of-design
 description: Owns the design system, UX principles, and visual standards across products. Activates on design-system changes, UX principles decisions, or cross-project visual-standards calls.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Maha
 ---
 

--- a/.claude/agents/head-of-engineering.md
+++ b/.claude/agents/head-of-engineering.md
@@ -2,7 +2,7 @@
 name: head-of-engineering
 description: Owns engineering strategy, architecture standards, and engineering culture across the portfolio. Activates on architecture review, new tech stack additions, cross-project engineering calls, and Tech Lead escalations.
 model: opus
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Khalid
 ---
 

--- a/.claude/agents/head-of-product.md
+++ b/.claude/agents/head-of-product.md
@@ -2,7 +2,7 @@
 name: head-of-product
 description: Owns product strategy, roadmap prioritisation, and feasibility studies. Activates on roadmap prioritisation, feasibility calls, strategic product decisions, or cross-product resource allocation.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Omar
 ---
 

--- a/.claude/agents/head-of-security.md
+++ b/.claude/agents/head-of-security.md
@@ -2,7 +2,7 @@
 name: head-of-security
 description: Owns security strategy, threat-model gating, compliance calls, and cross-project security architecture. Activates on strategic security decisions, organisation-level threat-model reviews, compliance-deadline calls, and escalations from the Security Auditor.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Faisal
 ---
 

--- a/.claude/agents/penetration-tester.md
+++ b/.claude/agents/penetration-tester.md
@@ -2,7 +2,7 @@
 name: penetration-tester
 description: Adversarial security testing, exploit discovery, API security review, and pre-release security sign-off. Activates on explicit invocation for active testing, exploit reasoning, or hardening checks; not auto-fired on diff content.
 model: opus
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Hamza
 ---
 

--- a/.claude/agents/product-analyst.md
+++ b/.claude/agents/product-analyst.md
@@ -2,7 +2,7 @@
 name: product-analyst
 description: Provides data-driven insights, market research, and competitive analysis to support product decisions and feasibility studies. Activates on market research, competitive analysis, metric investigation, or data-driven product calls.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Hanan
 ---
 

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -2,7 +2,7 @@
 name: product-manager
 description: Translates approved product strategy into detailed PRDs with acceptance criteria, coordinates with Design and Engineering, and removes delivery blockers. Activates on PRD creation, user-story breakdown, acceptance-criteria authoring, or sprint planning.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Mariam
 ---
 

--- a/.claude/agents/sre.md
+++ b/.claude/agents/sre.md
@@ -2,7 +2,7 @@
 name: sre
 description: Ensures systems are reliable, observable, and resilient — applies engineering to operational problems. Activates on production incidents, SLO breaches, monitoring / alerting work, or on-call rotation.
 model: opus
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Saif
 ---
 

--- a/.claude/agents/ui-designer.md
+++ b/.claude/agents/ui-designer.md
@@ -2,7 +2,7 @@
 name: ui-designer
 description: Defines the visual language and component specifications that guide UI implementation. Activates on visual design, component specifications, design tokens, or pixel-level work.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Nour
 ---
 

--- a/.claude/agents/ux-designer.md
+++ b/.claude/agents/ux-designer.md
@@ -2,7 +2,7 @@
 name: ux-designer
 description: Focuses on user flows, information architecture, and usability — documenting journeys and ensuring products are intuitive and efficient. Activates on user flows, information architecture, usability review, or wireframing.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 persona_name: Iman
 ---
 

--- a/.claude/hooks/reindex-on-session-start.sh
+++ b/.claude/hooks/reindex-on-session-start.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# SessionStart hook: emits an advisory when the apexyard-search index is stale,
+# instructing the agent to run an incremental reindex before its first search.
+#
+# Why this exists
+# ---------------
+# The index is normally updated via the post-pull / post-clone advisory hooks,
+# but sessions often start hours or days after the last reindex. When that
+# happens, search_code / search_docs silently return stale results and agents
+# fall back to grep+Read — exactly the failure mode the MCP is meant to avoid.
+# This hook closes the "stale on cold session start" gap by detecting staleness
+# before the agent's first query, so results are accurate from the first search.
+#
+# Behaviour
+# ---------
+#   - Fires when ALL conditions are true:
+#       1. `apexyard-search` CLI is on PATH (MCP server installed)
+#       2. A `.mcp.json` is found in or above the ops-root directory (MCP active)
+#       3. The vector-store directory is older than APEXYARD_SEARCH_STALE_THRESHOLD
+#          seconds (default: 3600 — 1 hour). Set to 0 to always prompt.
+#   - Emits a banner to stderr naming the incremental reindex MCP call.
+#   - Exits 0 ALWAYS — never blocks session start.
+#   - Silent no-op when the CLI is absent, MCP is not configured, or index is fresh.
+#   - Timeout-guarded: stat + date calls run inside a 10 s subshell guard so a
+#     stalled network mount never hangs session start.
+#   - Resolves the cache dir via APEXYARD_SEARCH_CACHE_DIR → XDG_CACHE_HOME →
+#     ~/.cache/apexyard-search — mirrors paths.py exactly.
+#
+# Index location
+# --------------
+# The vector store lives at <cache_dir>/lancedb/. The mtime of that directory
+# is updated whenever the adapter drops and recreates the chunks table on any
+# reindex run, making it a reliable staleness signal.
+#
+# Threshold
+# ---------
+# Default: 3600 s (1 hour). Override via APEXYARD_SEARCH_STALE_THRESHOLD.
+# Set to 0 to always emit the prompt; set to a large number to suppress it.
+#
+# Design: why a banner and not a direct CLI call?
+# -----------------------------------------------
+# `apexyard-search` is an MCP server binary — it exposes `reindex` as an MCP
+# tool, not as a shell subcommand. The hook therefore cannot invoke reindex
+# directly; it instructs the agent (which CAN call MCP tools) to do it. Same
+# advisory shape as suggest-mcp-reindex-after-pull.sh and remind-mcp-tools.sh.
+#
+# Tests at .claude/hooks/tests/test_reindex_on_session_start.sh.
+
+set -u
+
+# --- Prerequisite 1: apexyard-search CLI is on PATH -------------------------
+# Most adopters have no apexyard-search installed; this single check makes the
+# hook a silent no-op for them with zero overhead.
+if ! command -v apexyard-search >/dev/null 2>&1; then
+  exit 0
+fi
+
+# --- Prerequisite 2: .mcp.json exists (MCP is configured) ------------------
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$REPO_ROOT" ] || exit 0
+
+mcp_configured=false
+r="$REPO_ROOT"
+while [ -n "$r" ] && [ "$r" != "/" ]; do
+  if [ -f "$r/.mcp.json" ]; then
+    mcp_configured=true
+    break
+  fi
+  parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
+done
+$mcp_configured || exit 0
+
+# --- Resolve cache dir (mirrors apexyard_search/paths.py) -------------------
+if [ -n "${APEXYARD_SEARCH_CACHE_DIR:-}" ]; then
+  CACHE_DIR="${APEXYARD_SEARCH_CACHE_DIR}"
+elif [ -n "${XDG_CACHE_HOME:-}" ]; then
+  CACHE_DIR="${XDG_CACHE_HOME}/apexyard-search"
+else
+  CACHE_DIR="${HOME}/.cache/apexyard-search"
+fi
+
+LANCEDB_DIR="${CACHE_DIR}/lancedb"
+
+# --- Staleness check (timeout-guarded against stalled network mounts) -------
+THRESHOLD="${APEXYARD_SEARCH_STALE_THRESHOLD:-3600}"
+
+# Portable timeout: GNU coreutils `timeout` or macOS/brew `gtimeout`.
+_TO=""
+if command -v timeout >/dev/null 2>&1; then _TO="timeout -k 2 10"
+elif command -v gtimeout >/dev/null 2>&1; then _TO="gtimeout -k 2 10"; fi
+
+# Run the mtime check in a subshell; on timeout the guard exits non-zero and
+# STALE_INFO stays empty → hook exits 0 silently (safe-fail = no banner).
+STALE_INFO=""
+if [ -n "$_TO" ]; then
+  STALE_INFO=$($_TO bash -c '
+    LANCEDB_DIR="$1"; THRESHOLD="$2"
+    if [ ! -d "$LANCEDB_DIR" ]; then
+      echo "missing"
+      exit 0
+    fi
+    NOW=$(date +%s)
+    # Portable mtime: macOS uses -f %m, GNU/Linux uses -c %Y.
+    if MTIME=$(stat -f %m "$LANCEDB_DIR" 2>/dev/null) ||
+       MTIME=$(stat -c %Y "$LANCEDB_DIR" 2>/dev/null); then
+      AGE=$(( NOW - MTIME ))
+      if [ "$AGE" -ge "$THRESHOLD" ]; then
+        echo "stale:${AGE}"
+      fi
+    fi
+    # stat unavailable or index fresh → print nothing (caller exits 0 silently)
+  ' -- "$LANCEDB_DIR" "$THRESHOLD" 2>/dev/null) || STALE_INFO=""
+else
+  # No timeout binary available — run inline. stat on local fs never hangs.
+  if [ ! -d "$LANCEDB_DIR" ]; then
+    STALE_INFO="missing"
+  else
+    NOW=$(date +%s)
+    if MTIME=$(stat -f %m "$LANCEDB_DIR" 2>/dev/null) ||
+       MTIME=$(stat -c %Y "$LANCEDB_DIR" 2>/dev/null); then
+      AGE=$(( NOW - MTIME ))
+      if [ "$AGE" -ge "$THRESHOLD" ]; then
+        STALE_INFO="stale:${AGE}"
+      fi
+    fi
+    # stat unavailable or index fresh → STALE_INFO stays empty
+  fi
+fi
+
+# Nothing to do when the index is fresh (or stat was unavailable).
+[ -n "$STALE_INFO" ] || exit 0
+
+# --- Emit banner ------------------------------------------------------------
+if [ "$STALE_INFO" = "missing" ]; then
+  cat >&2 <<'MSG'
+> apexyard-search: no index found. Run a full reindex before your first search:
+    mcp__apexyard-search__reindex(scope="all")
+  If the MCP server is unavailable, print a one-line warning and continue.
+MSG
+  exit 0
+fi
+
+# Build a human-readable age string for the banner.
+AGE_SECONDS="${STALE_INFO#stale:}"
+if [ "$AGE_SECONDS" -ge 86400 ]; then
+  AGE_HUMAN="$((AGE_SECONDS / 86400))d"
+elif [ "$AGE_SECONDS" -ge 3600 ]; then
+  AGE_HUMAN="$((AGE_SECONDS / 3600))h"
+else
+  AGE_HUMAN="$((AGE_SECONDS / 60))m"
+fi
+
+cat >&2 <<MSG
+> apexyard-search: index is stale (${AGE_HUMAN} since last reindex). Reindex
+  before your first search so results are accurate:
+    mcp__apexyard-search__reindex(scope="framework")
+  Use scope="all" to also pick up managed-project code changes. If the MCP
+  server is unavailable, print a one-line warning and continue.
+MSG
+
+exit 0

--- a/.claude/hooks/tests/test_reindex_on_session_start.sh
+++ b/.claude/hooks/tests/test_reindex_on_session_start.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+# Tests for reindex-on-session-start.sh SessionStart hook.
+# Run: bash .claude/hooks/tests/test_reindex_on_session_start.sh
+
+set -u
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/reindex-on-session-start.sh"
+PASS=0
+FAIL=0
+FAILED=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+assert_silent() {
+  local label="$1" output="$2"
+  if [ -z "$output" ]; then
+    echo "PASS [$label] — silent (no banner)"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label] — expected silent, got: $output" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+  fi
+}
+
+assert_contains() {
+  local label="$1" output="$2" needle="$3"
+  if echo "$output" | grep -qF "$needle"; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label] — expected '$needle' in output, got: $output" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+  fi
+}
+
+assert_exit_zero() {
+  local label="$1" rc="$2"
+  if [ "$rc" -eq 0 ]; then
+    echo "PASS [$label] — exit 0"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label] — expected exit 0, got exit $rc" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+  fi
+}
+
+# Run the hook from a given directory, with given env overrides.
+# Returns output on stdout; exit code is captured separately.
+run_hook() {
+  local dir="$1"; shift
+  ( cd "$dir" || exit 1; env "$@" bash "$HOOK_SRC" 2>&1 )
+}
+run_hook_rc() {
+  local dir="$1"; shift
+  ( cd "$dir" || exit 1; env "$@" bash "$HOOK_SRC" >/dev/null 2>&1; echo $? )
+}
+
+# ---------------------------------------------------------------------------
+# Test fixture setup: a minimal git repo that looks like an apexyard ops root
+# ---------------------------------------------------------------------------
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+make_ops_repo() {
+  # $1 = base dir for the repo; creates a minimal git repo with onboarding.yaml
+  # and optionally a .mcp.json if MCP_CONFIGURED=1 (caller sets before call)
+  local base="$1"
+  local with_mcp="${2:-1}"  # default: with .mcp.json
+  mkdir -p "$base"
+  (
+    cd "$base" || exit 1
+    git init -q -b main
+    git config user.email t@t && git config user.name t
+    echo "company: test" > onboarding.yaml
+    git add onboarding.yaml && git commit -q -m "init"
+    if [ "$with_mcp" = "1" ]; then
+      echo '{"mcpServers":{}}' > .mcp.json
+    fi
+  )
+  echo "$base"
+}
+
+make_stale_index() {
+  # Create a lancedb dir under APEXYARD_SEARCH_CACHE_DIR with a mtime in the past.
+  # $1 = cache dir root; $2 = age in seconds
+  local cache_dir="$1"
+  local age="${2:-7200}"  # default 2 h stale
+  local lancedb="${cache_dir}/lancedb"
+  mkdir -p "$lancedb"
+  # Set mtime to NOW - age using touch -t (portable: macOS + Linux).
+  local target_ts
+  target_ts=$(date -r "$(($(date +%s) - age))" "+%Y%m%d%H%M.%S" 2>/dev/null \
+    || date -d "@$(($(date +%s) - age))" "+%Y%m%d%H%M.%S" 2>/dev/null \
+    || echo "")
+  if [ -n "$target_ts" ]; then
+    touch -t "$target_ts" "$lancedb"
+  else
+    # Fallback: just ensure the dir is older than 1 h by touching a sentinel
+    # and not touching lancedb, then set mtime via perl if available.
+    perl -e "utime(time()-$age, time()-$age, '$lancedb')" 2>/dev/null || true
+  fi
+}
+
+make_fresh_index() {
+  # Create a lancedb dir that was just updated (mtime = now).
+  local cache_dir="$1"
+  local lancedb="${cache_dir}/lancedb"
+  mkdir -p "$lancedb"
+  touch "$lancedb"
+}
+
+mock_path_dir() {
+  # Create a mock `apexyard-search` binary in $1/bin that exits 0 silently.
+  local bin="${1}/bin"
+  mkdir -p "$bin"
+  printf '#!/bin/sh\n# mock apexyard-search\nexit 0\n' > "${bin}/apexyard-search"
+  chmod +x "${bin}/apexyard-search"
+  echo "$bin"
+}
+
+# ---------------------------------------------------------------------------
+# Test: CLI absent → silent no-op, exit 0
+# ---------------------------------------------------------------------------
+OPS_REPO="${TMPDIR_ROOT}/ops-no-cli"
+make_ops_repo "$OPS_REPO" 1 >/dev/null
+CACHE="${TMPDIR_ROOT}/cache-no-cli"
+make_stale_index "$CACHE"
+
+# Run with PATH that has no apexyard-search
+OUT=$(run_hook "$OPS_REPO" "PATH=/usr/bin:/bin" "APEXYARD_SEARCH_CACHE_DIR=$CACHE")
+RC=$(run_hook_rc "$OPS_REPO" "PATH=/usr/bin:/bin" "APEXYARD_SEARCH_CACHE_DIR=$CACHE")
+assert_silent "CLI absent — no banner" "$OUT"
+assert_exit_zero "CLI absent — exit 0" "$RC"
+
+# ---------------------------------------------------------------------------
+# Test: CLI present but no .mcp.json → silent no-op, exit 0
+# ---------------------------------------------------------------------------
+OPS_REPO="${TMPDIR_ROOT}/ops-no-mcp"
+make_ops_repo "$OPS_REPO" 0 >/dev/null  # no .mcp.json
+CACHE="${TMPDIR_ROOT}/cache-no-mcp"
+make_stale_index "$CACHE"
+MOCK_BIN=$(mock_path_dir "${TMPDIR_ROOT}/mock-no-mcp")
+
+OUT=$(run_hook "$OPS_REPO" "PATH=${MOCK_BIN}:/usr/bin:/bin" "APEXYARD_SEARCH_CACHE_DIR=$CACHE")
+RC=$(run_hook_rc "$OPS_REPO" "PATH=${MOCK_BIN}:/usr/bin:/bin" "APEXYARD_SEARCH_CACHE_DIR=$CACHE")
+assert_silent "no .mcp.json — no banner" "$OUT"
+assert_exit_zero "no .mcp.json — exit 0" "$RC"
+
+# ---------------------------------------------------------------------------
+# Test: CLI present, .mcp.json present, index fresh → silent no-op, exit 0
+# ---------------------------------------------------------------------------
+OPS_REPO="${TMPDIR_ROOT}/ops-fresh"
+make_ops_repo "$OPS_REPO" 1 >/dev/null
+CACHE="${TMPDIR_ROOT}/cache-fresh"
+make_fresh_index "$CACHE"
+MOCK_BIN=$(mock_path_dir "${TMPDIR_ROOT}/mock-fresh")
+
+OUT=$(run_hook "$OPS_REPO" "PATH=${MOCK_BIN}:/usr/bin:/bin" "APEXYARD_SEARCH_CACHE_DIR=$CACHE" "APEXYARD_SEARCH_STALE_THRESHOLD=3600")
+RC=$(run_hook_rc "$OPS_REPO" "PATH=${MOCK_BIN}:/usr/bin:/bin" "APEXYARD_SEARCH_CACHE_DIR=$CACHE" "APEXYARD_SEARCH_STALE_THRESHOLD=3600")
+assert_silent "fresh index — no banner" "$OUT"
+assert_exit_zero "fresh index — exit 0" "$RC"
+
+# ---------------------------------------------------------------------------
+# Test: CLI present, .mcp.json present, index stale → banner with reindex call
+# ---------------------------------------------------------------------------
+OPS_REPO="${TMPDIR_ROOT}/ops-stale"
+make_ops_repo "$OPS_REPO" 1 >/dev/null
+CACHE="${TMPDIR_ROOT}/cache-stale"
+make_stale_index "$CACHE" 7200  # 2 hours stale; threshold default 3600
+MOCK_BIN=$(mock_path_dir "${TMPDIR_ROOT}/mock-stale")
+
+OUT=$(run_hook "$OPS_REPO" "PATH=${MOCK_BIN}:/usr/bin:/bin" "APEXYARD_SEARCH_CACHE_DIR=$CACHE" "APEXYARD_SEARCH_STALE_THRESHOLD=3600")
+RC=$(run_hook_rc "$OPS_REPO" "PATH=${MOCK_BIN}:/usr/bin:/bin" "APEXYARD_SEARCH_CACHE_DIR=$CACHE" "APEXYARD_SEARCH_STALE_THRESHOLD=3600")
+assert_contains "stale index — banner emitted" "$OUT" "apexyard-search: index is stale"
+assert_contains "stale index — banner names reindex call" "$OUT" "mcp__apexyard-search__reindex"
+assert_contains "stale index — banner names scope param" "$OUT" "scope="
+assert_exit_zero "stale index — exit 0 even when stale" "$RC"
+
+# Stale age is human-readable (should show "2h" for 2-hour staleness)
+assert_contains "stale index — banner shows human-readable age" "$OUT" "2h"
+
+# ---------------------------------------------------------------------------
+# Test: index directory missing entirely → banner with scope=all reindex
+# ---------------------------------------------------------------------------
+OPS_REPO="${TMPDIR_ROOT}/ops-missing"
+make_ops_repo "$OPS_REPO" 1 >/dev/null
+CACHE="${TMPDIR_ROOT}/cache-missing"
+# Deliberately do NOT create the lancedb dir
+mkdir -p "$CACHE"  # cache root exists but no lancedb subdir
+MOCK_BIN=$(mock_path_dir "${TMPDIR_ROOT}/mock-missing")
+
+OUT=$(run_hook "$OPS_REPO" "PATH=${MOCK_BIN}:/usr/bin:/bin" "APEXYARD_SEARCH_CACHE_DIR=$CACHE")
+RC=$(run_hook_rc "$OPS_REPO" "PATH=${MOCK_BIN}:/usr/bin:/bin" "APEXYARD_SEARCH_CACHE_DIR=$CACHE")
+assert_contains "missing index — banner emitted" "$OUT" "no index found"
+assert_contains "missing index — banner names reindex call" "$OUT" "mcp__apexyard-search__reindex"
+assert_contains "missing index — banner uses scope=all" "$OUT" 'scope="all"'
+assert_exit_zero "missing index — exit 0" "$RC"
+
+# ---------------------------------------------------------------------------
+# Test: threshold=0 → always emit (even if just-created lancedb dir)
+# ---------------------------------------------------------------------------
+OPS_REPO="${TMPDIR_ROOT}/ops-threshold-zero"
+make_ops_repo "$OPS_REPO" 1 >/dev/null
+CACHE="${TMPDIR_ROOT}/cache-threshold-zero"
+make_fresh_index "$CACHE"
+MOCK_BIN=$(mock_path_dir "${TMPDIR_ROOT}/mock-threshold-zero")
+
+OUT=$(run_hook "$OPS_REPO" "PATH=${MOCK_BIN}:/usr/bin:/bin" "APEXYARD_SEARCH_CACHE_DIR=$CACHE" "APEXYARD_SEARCH_STALE_THRESHOLD=0")
+assert_contains "threshold=0 — always fires" "$OUT" "mcp__apexyard-search__reindex"
+
+# ---------------------------------------------------------------------------
+# Test: exit 0 always — even when the threshold check would produce a banner
+# ---------------------------------------------------------------------------
+OPS_REPO="${TMPDIR_ROOT}/ops-exit0"
+make_ops_repo "$OPS_REPO" 1 >/dev/null
+CACHE="${TMPDIR_ROOT}/cache-exit0"
+make_stale_index "$CACHE" 86400  # 24 h stale
+MOCK_BIN=$(mock_path_dir "${TMPDIR_ROOT}/mock-exit0")
+
+RC=$(run_hook_rc "$OPS_REPO" "PATH=${MOCK_BIN}:/usr/bin:/bin" "APEXYARD_SEARCH_CACHE_DIR=$CACHE")
+assert_exit_zero "always exit 0 — banner case" "$RC"
+
+# ---------------------------------------------------------------------------
+# Test: timeout guard is present in the hook (grep the source)
+# ---------------------------------------------------------------------------
+if grep -q "timeout" "$HOOK_SRC"; then
+  echo "PASS [timeout guard present in hook source]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [timeout guard present in hook source] — 'timeout' not found in hook" >&2
+  FAIL=$((FAIL+1)); FAILED="${FAILED}timeout-guard-present "
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,6 +43,10 @@
           {
             "type": "command",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/remind-mcp-tools.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/reindex-on-session-start.sh\"'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- **Auto-reindex hook** (`reindex-on-session-start.sh`) fires at `SessionStart` and emits an advisory banner when the apexyard-search vector-store is stale (default threshold: 1 hour), instructing the agent to call `mcp__apexyard-search__reindex` before its first search — closing the \"stale on cold session\" gap that caused agents to silently fall back to grep+Read
- **Staleness detection** uses the mtime of `~/.cache/apexyard-search/lancedb/` (or `$APEXYARD_SEARCH_CACHE_DIR`), mirroring `paths.py` exactly; threshold is overridable via `APEXYARD_SEARCH_STALE_THRESHOLD`; a missing index emits a `scope=\"all\"` prompt; a stale one emits a cheaper `scope=\"framework\"` incremental prompt
- **Agent allowlists broadened** — added `mcp__apexyard-search__search_code` and `mcp__apexyard-search__search_docs` to 12 role agents that do code/doc lookups but previously lacked access: ux-designer, ui-designer, head-of-design, head-of-data, penetration-tester, head-of-product, product-manager, head-of-security, head-of-engineering, sre, product-analyst, data-analyst; dependency-auditor / pr-manager / ticket-manager omitted (no semantic code lookup)

## Safety properties

- `exit 0` **always** — never blocks session start
- **No-op** for the typical adopter: silently skips when `apexyard-search` is not on PATH, `.mcp.json` is absent, or the index is fresh
- **Timeout-guarded**: stat + date run inside a 10 s subshell (`timeout -k 2 10` / `gtimeout`) so stalled network mounts never hang startup
- Consistent with the advisory pattern of `remind-mcp-tools.sh` and `suggest-mcp-reindex-after-pull.sh`

## Testing

Run from the repo root after checking out this branch:

```bash
# Hook tests (18 cases: CLI absent, no MCP, fresh, stale, missing, threshold=0, exit-0, timeout-guard)
bash .claude/hooks/tests/test_reindex_on_session_start.sh

# Sibling hook regression checks
bash .claude/hooks/tests/test_suggest_mcp_reindex_after_clone.sh
bash .claude/hooks/tests/test_suggest_mcp_reindex_after_pull.sh

# Shell syntax + lint
bash -n .claude/hooks/reindex-on-session-start.sh
shellcheck -S warning .claude/hooks/reindex-on-session-start.sh

# settings.json validity + hook count
python3 -c "import json; d=json.load(open('.claude/settings.json')); print(len(d['hooks']['SessionStart'][0]['hooks']), 'SessionStart hooks')"
# Expected: 11 SessionStart hooks
```

Closes #733
Cross-ref: me2resh/apexyard-premium#362

---

## Glossary

| Term | Definition |
|------|------------|
| Staleness threshold | The minimum age (in seconds) of the vector-store directory that triggers the reindex advisory; default 3600 s (1 hour), tunable via `APEXYARD_SEARCH_STALE_THRESHOLD` |
| Incremental reindex | `mcp__apexyard-search__reindex(scope=\"framework\")` — reindexes only framework docs (roles, skills, rules, workflows), not managed-project codebases; faster and sufficient for daily framework updates |
| Cache dir | `~/.cache/apexyard-search/` (or `$APEXYARD_SEARCH_CACHE_DIR`) — where the LanceDB vector store lives; resolved to match `paths.py` exactly so the hook and the MCP server agree on the location |
| Advisory banner | A message printed to stderr that informs the agent what to do; never blocks execution (always `exit 0`); same shape as `suggest-mcp-reindex-after-pull.sh` |
| Allowlist | The `allowed-tools:` frontmatter field in an agent `.md` file — determines which tools that agent may invoke; adding MCP tool names here is what \"broadening the allowlist\" means |