### PR TITLE
feat(#739): offer an opt-in /challenge nudge from /decide

### DIFF
--- a/.claude/skills/decide/SKILL.md
+++ b/.claude/skills/decide/SKILL.md
@@ -108,7 +108,29 @@ ls docs/agdr/AgDR-*.md 2>/dev/null | sort -V | tail -1 | grep -oE 'AgDR-[0-9]+' 
 # Increment by 1, or start at 0001
 ```
 
-### 7. Return the Decision
+### 7. Offer a Contrarian challenge (optional — opt-in, never forced)
+
+A decision is a high-stakes moment. After drafting the AgDR, surface a **one-line
+nudge** offering to stress-test the call before committing:
+
+```
+Recorded AgDR-{NNNN}. Want Naqid (The Contrarian) to challenge this first?
+Run `/challenge {topic}` — he steelmans it, then attacks hidden assumptions,
+failure modes, and cheaper alternatives. Advisory — it never blocks.
+```
+
+Rules for the offer:
+
+- **Opt-in only.** Never auto-run `/challenge`; the operator decides.
+- **Advisory only.** Its verdict informs; it never vetoes or gates the decision.
+- **Fold the result back.** If the operator runs it and the verdict shifts the
+  call, update the AgDR's Decision / Consequences to reflect the new reasoning and
+  note the challenge under Artifacts.
+
+This mirrors the advisory stance in [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md)
+§ "Optional advisory offer" — see `.claude/skills/challenge/SKILL.md` and AgDR-0078.
+
+### 8. Return the Decision
 
 ```
 Decision: {chosen option}
@@ -124,6 +146,8 @@ Proceeding with: {brief action}
 4. **Justification required** — `because` clause is mandatory
 5. **Timestamp precise** — full ISO-8601 with time
 6. **Slug from title** — lowercase, hyphens, max 50 chars
+7. **Offer a challenge** — after drafting the AgDR, offer `/challenge` (opt-in,
+   advisory, never auto-run); update the AgDR if the verdict shifts the call
 
 ---
 


### PR DESCRIPTION
## Summary
- **Wires `/decide` to `/challenge`** — after `/decide` drafts an AgDR it now offers a one-line, opt-in nudge to run `/challenge <topic>` (Naqid steelmans then attacks the call) before the operator commits. Previously the only prompt to challenge a decision was a prose rule in `role-triggers.md` that the `/decide` skill never referenced, so decisions were recorded without the Contrarian ever being offered.
- **Codifies the advisory contract** — new Rule 7: opt-in only, advisory only (never auto-run, never gates), and fold the result back into the AgDR if the verdict shifts the call. Matches the AgDR-0078 stance.

## Testing
1. Read `.claude/skills/decide/SKILL.md` — step 7 "Offer a Contrarian challenge (opt-in)" sits before the (renumbered) Return step; Rule 7 added.
2. Doc-only change to a skill definition; no code/tests affected.

Closes #739

## Glossary
| Term | Definition |
|------|------------|
| AgDR | Agent Decision Record — the artifact `/decide` writes capturing options, choice, and trade-off |
| The Contrarian (Naqid) | the advisory `/challenge` agent that steelmans then attacks a decision; never blocks (AgDR-0078) |
| opt-in nudge | a one-line offer the operator can accept or ignore — never auto-executed |