### PR TITLE
fix(#744): anchor active-ticket repo resolution to FILE_PATH not CWD

### DIFF
--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -101,8 +101,68 @@ if [ -z "$FILE_PATH" ] && [ "$TOOL_NAME" != "Bash" ]; then
   exit 0
 fi
 
-# Normalise to repo-relative path when possible
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+# Normalise to repo-relative path when possible.
+#
+# BUG #744 FIX: derive REPO_ROOT from the FILE_PATH's directory, NOT the
+# hook's CWD. The harness can fire with any CWD (e.g. /tmp, the ops root,
+# a totally unrelated directory). Using `git rev-parse --show-toplevel`
+# from the hook process's CWD returns the WRONG root whenever the CWD
+# differs from the file's actual git repo — which breaks the OPS_ROOT
+# walk-up and causes the per-project marker to be missed, blocking edits
+# even when /start-ticket set a valid marker (#744, #745).
+#
+# Resolution order:
+#   1. FILE_PATH is set and absolute: run git in the file's nearest existing
+#      ancestor directory.  Works for new files (dirname of a not-yet-created
+#      path still points at the parent dir).
+#   2. FILE_PATH is set but relative (Bash write-target extracted from the
+#      command): relative paths are relative to the process CWD, so fall
+#      back to the legacy CWD-based git rev-parse — same behaviour as before.
+#   3. FILE_PATH is empty (Bash command, no extractable target): CWD-based
+#      fallback as before.
+REPO_ROOT=""
+if [ -n "$FILE_PATH" ]; then
+  case "$FILE_PATH" in
+    /*)
+      # Absolute path — find the nearest existing ancestor directory.
+      # dirname works on non-existent files; the while loop handles the
+      # case where the new file's parent dir doesn't exist yet.
+      _fp_dir="$(dirname "$FILE_PATH")"
+      while [ -n "$_fp_dir" ] && [ "$_fp_dir" != "/" ] && [ ! -d "$_fp_dir" ]; do
+        _fp_dir="$(dirname "$_fp_dir")"
+      done
+      if [ -d "$_fp_dir" ]; then
+        REPO_ROOT=$(git -C "$_fp_dir" rev-parse --show-toplevel 2>/dev/null)
+        # When the file's repo is a LINKED git worktree the worktree dir
+        # inherits the main branch's files — including anchor files like
+        # onboarding.yaml / apexyard.projects.yaml.  The OPS_ROOT walk-up
+        # below would then stop at the worktree instead of the real ops
+        # fork.  Detect a linked worktree (absolute git-dir ≠ common-dir)
+        # and replace REPO_ROOT with the main-checkout root (dirname of
+        # the common-dir, i.e. parent of the main .git dir).  This keeps
+        # the walk-up anchored to the actual ops fork while leaving the
+        # later per-worktree branch detection (which re-reads git from
+        # _fdir) unaffected.
+        if [ -n "$REPO_ROOT" ]; then
+          _wt_gd=$(git -C "$_fp_dir" rev-parse --absolute-git-dir 2>/dev/null)
+          _wt_gcd=$(git -C "$_fp_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+          if [ -n "$_wt_gd" ] && [ -n "$_wt_gcd" ] && [ "$_wt_gd" != "$_wt_gcd" ]; then
+            _main_root=$(dirname "$_wt_gcd")
+            [ -d "$_main_root" ] && REPO_ROOT="$_main_root"
+          fi
+        fi
+      fi
+      ;;
+    *)
+      # Relative path (Bash write-target): resolve against CWD.
+      REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+      ;;
+  esac
+fi
+# Fallback: FILE_PATH empty (Bash command, no extractable target).
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+fi
 REL_PATH="$FILE_PATH"
 if [ -n "$REPO_ROOT" ] && [ -n "$FILE_PATH" ]; then
   case "$FILE_PATH" in
@@ -164,27 +224,36 @@ fi
 # v1 anchor (onboarding.yaml + apexyard.projects.yaml). Stop at /. If
 # not found, OPS_ROOT stays empty and we treat the REPO_ROOT itself as
 # the marker home (pre-#41 behaviour).
+#
+# Guard change (#744/#745): the lib-based resolver is always invoked when
+# the lib is available — even when REPO_ROOT is empty. This matters for
+# split-portfolio v2 where the workspace is a sibling repo with no git
+# history: REPO_ROOT is empty (no git in the sibling dir) but the
+# session-pin resolver in _lib-ops-root.sh can still locate the ops fork
+# from the pin written at session-start, regardless of start dir.
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 OPS_ROOT=""
-if [ -n "$REPO_ROOT" ]; then
-  if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
-    # shellcheck source=/dev/null
-    . "$HOOK_DIR/_lib-ops-root.sh"
-    OPS_ROOT=$(resolve_ops_root "$REPO_ROOT")
-  else
-    r="$REPO_ROOT"
-    while [ -n "$r" ] && [ "$r" != "/" ]; do
-      if [ -f "$r/.apexyard-fork" ]; then
-        OPS_ROOT="$r"
-        break
-      fi
-      if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
-        OPS_ROOT="$r"
-        break
-      fi
-      parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
-    done
-  fi
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  # Pass REPO_ROOT as the walk-up start dir when available; the pin
+  # resolver ignores the start dir and uses the session pin directly.
+  OPS_ROOT=$(resolve_ops_root "${REPO_ROOT:-}")
+elif [ -n "$REPO_ROOT" ]; then
+  # Inline walk-up fallback when the lib is absent (e.g. minimal test
+  # sandboxes that only copy the core libs).
+  r="$REPO_ROOT"
+  while [ -n "$r" ] && [ "$r" != "/" ]; do
+    if [ -f "$r/.apexyard-fork" ]; then
+      OPS_ROOT="$r"
+      break
+    fi
+    if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
+      OPS_ROOT="$r"
+      break
+    fi
+    parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
+  done
 fi
 
 MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -299,6 +299,164 @@ EOF
 in=$(jq -nc --arg c "echo x > src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
 run_case "bash redirect to tracked source allowed WITH active ticket" 0 "" "$in" "$sb"
 
+# --- #744 + #745: REPO_ROOT anchored to FILE_PATH not CWD (#744, #745) ------
+#
+# These tests exercise the fix for me2resh/apexyard#744 / #745.  The core
+# failure: `git rev-parse --show-toplevel` ran from the HOOK'S CWD, not from
+# the edited file's directory.  When the harness fires with CWD=/tmp (or any
+# dir that isn't the file's git repo), REPO_ROOT resolves to "" or the wrong
+# tree, the OPS_ROOT walk-up never finds the ops fork, MARKER_HOME becomes "."
+# (relative), and the per-project marker is missed → gate fails closed even
+# though /start-ticket set a valid marker.
+
+LIB_OPS_SRC="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
+LIB_PORT_SRC="$SRC_ROOT/.claude/hooks/_lib-portfolio-paths.sh"
+
+# Helper: run hook from an arbitrary CWD, using the hook's absolute path.
+# Args: label want_rc want_stderr_regex input sandbox_dir run_cwd
+# Deletes sandbox_dir on completion (same lifecycle as run_case).
+run_case_cwd() {
+  local label="$1" want_rc="$2" want_stderr_regex="$3" input="$4" sb="$5" run_cwd="$6"
+  local got_stderr got_rc
+  got_stderr=$(cd "$run_cwd" && echo "$input" | bash "$sb/.claude/hooks/require-active-ticket.sh" 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:300})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# 27. #744 core: file under <ops_root>/workspace/myproj/src/x.ts, valid
+#     per-project marker, hook runs with CWD=/tmp.  Before the fix the gate
+#     fails closed (REPO_ROOT="" → MARKER_HOME="." → marker not found).
+#     After the fix REPO_ROOT is derived from FILE_PATH, OPS_ROOT is found
+#     by walking up from the workspace dir, and the marker is found → exit 0.
+sb=$(make_sandbox)
+rsb=$(cd "$sb" && pwd -P)
+mkdir -p "$sb/workspace/myproj/src"
+mkdir -p "$sb/.claude/session/tickets"
+cat > "$sb/.claude/session/tickets/myproj" <<EOF
+repo=me2resh/myproj
+number=744
+title=anchor fix test
+EOF
+in=$(jq -nc --arg p "$rsb/workspace/myproj/src/x.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case_cwd "#744 core: file in workspace, valid marker, CWD=/tmp → exempt" 0 "" "$in" "$sb" "/tmp"
+
+# 28. #744 regression: same layout, NO marker, CWD=/tmp → gate still BLOCKS.
+sb=$(make_sandbox)
+rsb=$(cd "$sb" && pwd -P)
+mkdir -p "$sb/workspace/myproj/src"
+in=$(jq -nc --arg p "$rsb/workspace/myproj/src/x.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case_cwd "#744 regression: no marker, CWD=/tmp → still blocked" 2 "BLOCKED" "$in" "$sb" "/tmp"
+
+# 29. #744 .claude/ path still exempt with CWD=/tmp (path-exemption regression).
+sb=$(make_sandbox)
+rsb=$(cd "$sb" && pwd -P)
+in=$(jq -nc --arg p "$rsb/.claude/hooks/my-hook.sh" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case_cwd "#744 .claude/ path still exempt even with wrong CWD" 0 "" "$in" "$sb" "/tmp"
+
+# 30. #745 split-portfolio: ops fork and workspace are SIBLING directories;
+#     workspace_dir is configured (absolute path) in the ops fork's project-config;
+#     per-project marker lives in the ops fork; ops root is resolved via the
+#     session pin (CLAUDE_CODE_SESSION_ID + pin file at $HOME/.claude/apexyard/).
+#     CWD=/tmp.  Expected: exempt (exit 0).
+#
+#     This mirrors the production split-portfolio v2 scenario where:
+#       <ops_fork>/            ← apexyard framework fork
+#         .apexyard-fork
+#         .claude/project-config.json   (portfolio.workspace_dir = absolute sibling path)
+#         .claude/session/tickets/myproj
+#       <sibling_ws>/          ← private portfolio workspace (sibling, NOT under ops fork)
+#         myproj/src/x.ts      ← file being edited
+#     The session-start pin-ops-root.sh hook records ops_fork in
+#     ~/.claude/apexyard/ops-root-<SESSION_ID> so resolve_ops_root finds it
+#     even when the hook fires with CWD=/tmp.
+_t30_ops=$(mktemp -d)
+_t30_ws=$(mktemp -d)
+_t30_ops_real=$(cd "$_t30_ops" && pwd -P)
+_t30_ws_real=$(cd "$_t30_ws" && pwd -P)
+
+# Bootstrap the ops fork
+(
+  cd "$_t30_ops"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "test"
+  : > .apexyard-fork
+  : > onboarding.yaml
+  : > apexyard.projects.yaml
+  git add .apexyard-fork onboarding.yaml apexyard.projects.yaml
+  git commit -q -m "init"
+)
+
+# Install hook + libs into ops fork
+mkdir -p "$_t30_ops/.claude/hooks"
+cp "$HOOK_SRC"  "$_t30_ops/.claude/hooks/require-active-ticket.sh"
+cp "$LIB_BASH"  "$_t30_ops/.claude/hooks/_lib-detect-bash-write.sh"
+cp "$LIB_CFG"   "$_t30_ops/.claude/hooks/_lib-read-config.sh"
+cp "$DEFAULTS"  "$_t30_ops/.claude/project-config.defaults.json"
+[ -f "$LIB_OPS_SRC" ]  && cp "$LIB_OPS_SRC"  "$_t30_ops/.claude/hooks/_lib-ops-root.sh"
+[ -f "$LIB_PORT_SRC" ] && cp "$LIB_PORT_SRC" "$_t30_ops/.claude/hooks/_lib-portfolio-paths.sh"
+chmod +x "$_t30_ops/.claude/hooks/require-active-ticket.sh"
+
+# Configure workspace_dir to the sibling path (absolute in config so
+# _portfolio_resolve returns it directly without needing _portfolio_root).
+cat > "$_t30_ops/.claude/project-config.json" <<EOF
+{
+  "portfolio": {
+    "workspace_dir": "$_t30_ws_real"
+  }
+}
+EOF
+
+# Per-project marker in ops fork
+mkdir -p "$_t30_ops/.claude/session/tickets"
+cat > "$_t30_ops/.claude/session/tickets/myproj" <<EOF
+repo=me2resh/myproj
+number=745
+title=split-portfolio anchor fix
+EOF
+
+# Project dir in sibling workspace
+mkdir -p "$_t30_ws/myproj/src"
+
+# Write a session pin so resolve_ops_root finds ops_fork from CWD=/tmp
+_t30_sid="apexyard-test745-$$"
+_t30_pin_dir="$HOME/.claude/apexyard"
+mkdir -p "$_t30_pin_dir"
+printf '%s\n' "$_t30_ops_real" > "$_t30_pin_dir/ops-root-${_t30_sid}"
+
+_t30_in=$(jq -nc --arg p "$_t30_ws_real/myproj/src/x.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+
+_t30_stderr=$(cd /tmp && echo "$_t30_in" | \
+  CLAUDE_CODE_SESSION_ID="$_t30_sid" \
+  APEXYARD_OPS_PIN_DIR="$_t30_pin_dir" \
+  bash "$_t30_ops/.claude/hooks/require-active-ticket.sh" 2>&1 >/dev/null)
+_t30_rc=$?
+
+# Cleanup
+rm -rf "$_t30_ops" "$_t30_ws"
+rm -f "$_t30_pin_dir/ops-root-${_t30_sid}"
+
+_t30_label="#745 split-portfolio: sibling workspace, session pin → exempt"
+if [ "$_t30_rc" != "0" ]; then
+  echo "FAIL [$_t30_label]: want rc=0, got $_t30_rc (stderr: ${_t30_stderr:0:300})" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${_t30_label} "
+else
+  echo "PASS [$_t30_label]"
+  PASS=$((PASS+1))
+fi
+
 # --- Summary -----------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -388,7 +388,7 @@ _t30_ws_real=$(cd "$_t30_ws" && pwd -P)
 
 # Bootstrap the ops fork
 (
-  cd "$_t30_ops"
+  cd "$_t30_ops" || exit 1
   git init -q
   git config user.email "test@example.com"
   git config user.name "test"
@@ -430,10 +430,11 @@ EOF
 # Project dir in sibling workspace
 mkdir -p "$_t30_ws/myproj/src"
 
-# Write a session pin so resolve_ops_root finds ops_fork from CWD=/tmp
+# Write a session pin so resolve_ops_root finds ops_fork from CWD=/tmp.
+# Use a HERMETIC temp pin dir (not the real $HOME/.claude/apexyard) so the test
+# is deterministic in CI and never reads/pollutes the operator's real pin store.
 _t30_sid="apexyard-test745-$$"
-_t30_pin_dir="$HOME/.claude/apexyard"
-mkdir -p "$_t30_pin_dir"
+_t30_pin_dir=$(mktemp -d)
 printf '%s\n' "$_t30_ops_real" > "$_t30_pin_dir/ops-root-${_t30_sid}"
 
 _t30_in=$(jq -nc --arg p "$_t30_ws_real/myproj/src/x.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -439,9 +439,14 @@ printf '%s\n' "$_t30_ops_real" > "$_t30_pin_dir/ops-root-${_t30_sid}"
 
 _t30_in=$(jq -nc --arg p "$_t30_ws_real/myproj/src/x.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
 
+# Re-enable the pin for THIS invocation: bin/run-hook-tests.sh exports
+# APEXYARD_OPS_DISABLE_PIN=1 suite-wide (so the suite never reads the operator's
+# real pin), but this case deliberately exercises pin-based split-portfolio
+# resolution, so we override it back to empty for the hook call only.
 _t30_stderr=$(cd /tmp && echo "$_t30_in" | \
   CLAUDE_CODE_SESSION_ID="$_t30_sid" \
   APEXYARD_OPS_PIN_DIR="$_t30_pin_dir" \
+  APEXYARD_OPS_DISABLE_PIN='' \
   bash "$_t30_ops/.claude/hooks/require-active-ticket.sh" 2>&1 >/dev/null)
 _t30_rc=$?
 


### PR DESCRIPTION
## Summary

- **Anchors `REPO_ROOT` to the edited file's directory** (`git -C <file_dir>`) instead of the hook's CWD. When the harness fires from a CWD that isn't the file's repo (e.g. `/tmp`, the ops root, an unrelated dir), the old `git rev-parse --show-toplevel` returned the wrong root — causing the OPS_ROOT walk-up to fail, MARKER_HOME to default to `"."`, and the per-project marker to be missed even when `/start-ticket` had written a valid one (#744).
- **Detects linked git worktrees** and replaces REPO_ROOT with the main-checkout root (dirname of common-dir). A worktree inherits the main branch's files including `onboarding.yaml` / `apexyard.projects.yaml`, causing the OPS_ROOT walk to stop at the worktree instead of the real ops fork. Detecting `git-dir ≠ common-dir` and walking up from the main checkout fixes this without affecting the subsequent per-worktree branch detection (which reads git from `_fdir` directly).
- **Removes the `[ -n "$REPO_ROOT" ]` guard on the lib-based OPS_ROOT resolver** so the session-pin lookup (`resolve_ops_root`) fires even when REPO_ROOT is empty. Required for split-portfolio v2 where the workspace is a sibling repo with no git history — REPO_ROOT is empty but the pin written by `pin-ops-root.sh` at session start still resolves the ops fork (#745).

## Testing

```bash
git clone git@github.com:me2resh/apexyard.git /tmp/apexyard-744-pr
cd /tmp/apexyard-744-pr
git checkout fix/GH-744-active-ticket-path-anchored
bash .claude/hooks/tests/test_require_active_ticket_bash.sh
```

Results: **33 PASS, 0 FAIL** (4 new cases added — tests 27–30 cover the regressions).

New test cases:
- **27** — `#744 core`: file under `workspace/<proj>`, valid per-project marker, CWD=`/tmp` → exempt (exit 0)
- **28** — `#744 regression`: same layout, no marker, CWD=`/tmp` → still blocked (exit 2)
- **29** — `.claude/` path exemption still works even with wrong CWD
- **30** — `#745 split-portfolio`: sibling workspace + session pin → exempt (exit 0)

Closes #744
Closes #745

## Glossary

| Term | Definition |
|------|------------|
| `REPO_ROOT` | The root directory of the git repository or worktree that contains the file being edited. Used as the starting point for OPS_ROOT discovery and path-relative exemption matching. |
| `OPS_ROOT` | The apexyard ops fork root — the directory containing `.apexyard-fork` (v2) or both `onboarding.yaml` + `apexyard.projects.yaml` (v1). All session markers (`.claude/session/tickets/<project>`, `current-ticket`) live under here. |
| `MARKER_HOME` | The directory used as the base for all marker file lookups. Resolves to `OPS_ROOT` when found, then `REPO_ROOT`, then `"."` (relative CWD fallback — the source of the #744 bug). |
| Linked worktree | A git worktree created with `git worktree add` that shares the main repo's object store. Detected by `absolute-git-dir ≠ path-format=absolute --git-common-dir`. Has its own HEAD/branch but checks out the same file tree as the main branch. |
| Session pin | A file at `~/.claude/apexyard/ops-root-<CLAUDE_CODE_SESSION_ID>` written by `pin-ops-root.sh` at session start. `resolve_ops_root` checks this before walking up from the start dir — essential for split-portfolio v2 where the workspace is a sibling and no walk-up can reach the ops fork. |
| Split-portfolio v2 | An apexyard layout where the ops fork (public) and the portfolio data + workspace clones (private) live in sibling repositories rather than a single fork. Configured via `.portfolio.workspace_dir` in `.claude/project-config.json`. |