### PR TITLE
fix(#743): parse gh pr create structurally (body-file, multi-line, body-example) (AgDR-0081)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_create_structural_parse.sh
+++ b/.claude/hooks/tests/test_validate_pr_create_structural_parse.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+# Tests for validate-pr-create.sh structural parsing (apexyard#743).
+#
+# Covers three classes of bug where scanning the raw command string was wrong:
+#
+#   Bug 1 — --body-file content treated as invisible.
+#     When the body is in a file the sections check must read that file and
+#     validate its content.  An absolute-path --body-file with both required
+#     sections must PASS; one with a missing section must BLOCK.
+#
+#   Bug 2 — backslash-continued multi-line commands mis-resolve --repo.
+#     Line continuations must be normalised before flag extraction so that
+#     --repo on a continuation line is parsed correctly, not garbled.
+#
+#   Bug 3 — matcher fires on "gh pr create" text inside a body payload.
+#     A 'gh issue create --body "... gh pr create ..."' command must not
+#     trigger pr-create validation.  The gate check operates on the command
+#     head (stripped of body content), not the raw command string.
+#
+#   Regression — existing inline --body behaviour must be unchanged.
+#
+# Test harness mirrors the style of the sibling test files in this directory:
+#   - isolated sandbox per case (mktemp -d)
+#   - mock_gh_install for the ticket-existence check
+#   - pipes JSON {tool_input:{command:...}} to the hook
+#   - asserts exit code + optional stderr regex
+#
+# Exit 0 if all cases pass; exit 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/validate-pr-create.sh"
+LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+LIB_TRACKER="$SRC_ROOT/.claude/hooks/_lib-tracker.sh"
+LIB_PR_REPO="$SRC_ROOT/.claude/hooks/_lib-pr-repo.sh"
+DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+
+# shellcheck source=_lib-mock-gh.sh
+source "$(cd "$(dirname "$0")" && pwd)/_lib-mock-gh.sh"
+
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# ---------------------------------------------------------------------------
+# Sandbox helpers
+# ---------------------------------------------------------------------------
+
+# make_sandbox [local_branch]
+#   Creates an isolated git repo wired with the hook and its libraries.
+#   Default local branch is 'fix/#743-test' (has a ticket ID so the branch
+#   check does not fire on cases that are testing something else).
+make_sandbox() {
+  local branch="${1:-fix/#743-test}"
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    git remote add origin "git@github.com:me2resh/apexyard.git"
+    : > onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+    git checkout -q -B "$branch"
+  )
+  mkdir -p "$sb/.claude/hooks"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/validate-pr-create.sh"
+  chmod +x "$sb/.claude/hooks/validate-pr-create.sh"
+  [ -f "$LIB_CFG" ]     && cp "$LIB_CFG"     "$sb/.claude/hooks/_lib-read-config.sh"
+  [ -f "$LIB_TRACKER" ] && cp "$LIB_TRACKER"  "$sb/.claude/hooks/_lib-tracker.sh"
+  [ -f "$LIB_PR_REPO" ] && cp "$LIB_PR_REPO"  "$sb/.claude/hooks/_lib-pr-repo.sh"
+  [ -f "$DEFAULTS" ]    && cp "$DEFAULTS"      "$sb/.claude/project-config.defaults.json"
+  echo "$sb"
+}
+
+# run_case label command want_rc [want_stderr_regex]
+#   Pipes the command as a PreToolUse JSON blob into the hook, asserts exit
+#   code and (optionally) a stderr pattern.
+run_case() {
+  local label="$1" cmd="$2" want_rc="$3" want_stderr_regex="${4:-}"
+  local sb; sb=$(make_sandbox)
+  mock_gh_install "$sb"
+
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && printf '%s' "$input" | bash .claude/hooks/validate-pr-create.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:300})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! printf '%s' "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# ---------------------------------------------------------------------------
+# Bug 1 — --body-file content is read and validated
+# ---------------------------------------------------------------------------
+
+BODY_WITH_SECTIONS="## Summary
+Change description.
+
+## Testing
+1. Run the tests.
+
+## Glossary
+| Term | Definition |
+|------|------------|
+| #743 | structural parse bug |"
+
+BODY_MISSING_GLOSSARY="## Summary
+Change description.
+
+## Testing
+1. Run the tests."
+
+# Write the test body files to /tmp (absolute paths) so they are visible to
+# the hook regardless of the sandbox's working directory.
+BODY_FILE_FULL=$(mktemp /tmp/test-743-body-full.XXXXXX.md)
+BODY_FILE_PARTIAL=$(mktemp /tmp/test-743-body-partial.XXXXXX.md)
+printf '%s' "$BODY_WITH_SECTIONS"    > "$BODY_FILE_FULL"
+printf '%s' "$BODY_MISSING_GLOSSARY" > "$BODY_FILE_PARTIAL"
+
+run_case "Bug1: --body-file with both sections → PASS" \
+  "gh pr create --repo me2resh/apexyard --title 'fix(#743): test' --body-file $BODY_FILE_FULL" \
+  0 ""
+
+run_case "Bug1: --body-file missing ## Glossary → BLOCK" \
+  "gh pr create --repo me2resh/apexyard --title 'fix(#743): test' --body-file $BODY_FILE_PARTIAL" \
+  2 "missing required '## Glossary' section"
+
+rm -f "$BODY_FILE_FULL" "$BODY_FILE_PARTIAL"
+
+# ---------------------------------------------------------------------------
+# Bug 2 — backslash-continued multi-line command resolves --repo correctly
+# ---------------------------------------------------------------------------
+#
+# The command below is split across lines with backslash continuations.
+# Before the fix the sed extraction of --repo could capture the trailing '\'
+# (or produce empty), yielding a garbled TRACKER_REPO and a false block.
+# After the fix, line-continuation normalisation runs first so --repo is
+# extracted as 'me2resh/apexyard'.
+#
+# We use a body-file with the required sections so the only potential block
+# is the garbled-repo path.
+
+BF2=$(mktemp /tmp/test-743-bug2-body.XXXXXX.md)
+printf '%s' "$BODY_WITH_SECTIONS" > "$BF2"
+
+# Embed actual backslash-newlines in the command string via $'...'
+MULTI_LINE_CMD=$'gh pr create \\\n  --repo me2resh/apexyard \\\n  --title \'fix(#743): multiline\' \\\n  --head fix/#743-test \\\n  --body-file '"$BF2"
+
+run_case "Bug2: backslash-continued multi-line --repo resolves cleanly → PASS" \
+  "$MULTI_LINE_CMD" \
+  0 ""
+
+rm -f "$BF2"
+
+# ---------------------------------------------------------------------------
+# Bug 3 — gate does NOT fire when 'gh pr create' appears only in a body
+# ---------------------------------------------------------------------------
+#
+# Case A: inline --body contains 'gh pr create' sample text.
+# The gate check strips --body payload before the subcommand test, so the
+# leading 'gh issue create' verb wins and validation is skipped entirely.
+
+run_case "Bug3A: gh issue create --body with embedded 'gh pr create' text → no-op (exit 0)" \
+  "gh issue create --repo me2resh/apexyard --title '[Bug] test' --body 'Example: gh pr create --title feat(#1): x --body body'" \
+  0 ""
+
+# Case B: --body-file on a non-pr-create command.
+# The body file content (which could contain 'gh pr create') is never consulted
+# for the gate decision — only the command head matters.
+BF3=$(mktemp /tmp/test-743-bug3-body.XXXXXX.md)
+printf 'Example usage:\n\ngh pr create --title "feat(#1): x" --body "body"\n' > "$BF3"
+
+run_case "Bug3B: gh issue create --body-file whose content has 'gh pr create' → no-op (exit 0)" \
+  "gh issue create --repo me2resh/apexyard --title '[Bug] test' --body-file $BF3" \
+  0 ""
+
+rm -f "$BF3"
+
+# ---------------------------------------------------------------------------
+# Regression — existing inline --body behaviour unchanged
+# ---------------------------------------------------------------------------
+
+# Use a body file for the regression test so actual newlines are present —
+# the section grep requires '## Heading' at a real line start, which literal
+# '\n' in a shell string does not provide.
+BF_REG_PASS=$(mktemp /tmp/test-743-reg-pass.XXXXXX.md)
+BF_REG_FAIL=$(mktemp /tmp/test-743-reg-fail.XXXXXX.md)
+printf '## Summary\nfoo\n\n## Testing\nbar\n' > "$BF_REG_FAIL"
+printf '## Summary\nfoo\n\n## Testing\nbar\n\n## Glossary\n| t | d |\n' > "$BF_REG_PASS"
+
+run_case "Regression: --body-file missing ## Glossary still BLOCKS" \
+  "gh pr create --repo me2resh/apexyard --title 'fix(#743): test' --head fix/#743-test --body-file $BF_REG_FAIL" \
+  2 "missing required '## Glossary' section"
+
+run_case "Regression: --body-file with both sections → PASS" \
+  "gh pr create --repo me2resh/apexyard --title 'fix(#743): test' --head fix/#743-test --body-file $BF_REG_PASS" \
+  0 ""
+
+rm -f "$BF_REG_PASS" "$BF_REG_FAIL"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_validate_pr_create_structural_parse.sh
+++ b/.claude/hooks/tests/test_validate_pr_create_structural_parse.sh
@@ -163,10 +163,19 @@ rm -f "$BODY_FILE_FULL" "$BODY_FILE_PARTIAL"
 BF2=$(mktemp /tmp/test-743-bug2-body.XXXXXX.md)
 printf '%s' "$BODY_WITH_SECTIONS" > "$BF2"
 
-# Embed actual backslash-newlines in the command string via $'...'
-MULTI_LINE_CMD=$'gh pr create \\\n  --repo me2resh/apexyard \\\n  --title \'fix(#743): multiline\' \\\n  --head fix/#743-test \\\n  --body-file '"$BF2"
+# Embed actual backslash-newlines via $'...'. The regression is anchored on the
+# --body-file flag split across a continuation with NO space before the '\'
+# ('--body-file\<newline>PATH'). This makes the proof DETERMINISTIC (no network):
+#   - WITHOUT the collapse, the line-oriented extraction can't recover the path,
+#     the body-file is unreadable, the section check falls back to the (section-
+#     less) command text, and the hook BLOCKS for missing ## Testing/## Glossary.
+#   - WITH the collapse, '\<newline>' → space, so '--body-file PATH' resolves,
+#     the sections are found, and the hook passes.
+# (A --repo-only garble degrades gracefully and would pass either way — i.e. it
+# would pass for the wrong reason, which is exactly the gap Rex flagged.)
+MULTI_LINE_CMD=$'gh pr create --repo me2resh/apexyard \\\n  --title \'fix(#743): multiline\' \\\n  --head fix/GH-743-test \\\n  --body-file\\\n'"$BF2"
 
-run_case "Bug2: backslash-continued multi-line --repo resolves cleanly → PASS" \
+run_case "Bug2: backslash-continued multi-line (--body-file on continuation) resolves cleanly → PASS" \
   "$MULTI_LINE_CMD" \
   0 ""
 

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -22,7 +22,11 @@ fi
 # Fixes apexyard#743 Bug 2: without normalization, a --repo value split onto
 # its own continuation line could be mis-extracted (the trailing '\' captured
 # instead of the repo slug, yielding garbled TRACKER_REPO like "(hook)").
-COMMAND="${COMMAND//$'\\\n'/ }"
+# NOTE: must be bash-3.2-safe (macOS default). The combined ANSI-C pattern
+# ${COMMAND//$'\\\n'/ } is a silent NO-OP under bash 3.2 — the newline in the
+# pattern doesn't match. Holding the newline in a var and escaping the
+# backslash separately works on both 3.2 and 5.x (verified via `od -c`).
+nl=$'\n'; COMMAND="${COMMAND//\\$nl/ }"
 
 # Parse --repo / -R from the gh command for cross-repo PR creation.
 # Handles: --repo VALUE, --repo=VALUE, -R VALUE, -R=VALUE.

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -16,6 +16,14 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
+# Normalize backslash line-continuation sequences so multi-line gh commands
+# parse as a single logical line for all subsequent flag extraction.
+# Replaces every '\<newline>' pair with a single space.
+# Fixes apexyard#743 Bug 2: without normalization, a --repo value split onto
+# its own continuation line could be mis-extracted (the trailing '\' captured
+# instead of the repo slug, yielding garbled TRACKER_REPO like "(hook)").
+COMMAND="${COMMAND//$'\\\n'/ }"
+
 # Parse --repo / -R from the gh command for cross-repo PR creation.
 # Handles: --repo VALUE, --repo=VALUE, -R VALUE, -R=VALUE.
 # Source _lib-pr-repo.sh when available (DRY — it owns the canonical parser).
@@ -46,10 +54,31 @@ else
   fi
 fi
 
-# Only check on gh pr create
-if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+create\b'; then
+# Extract the cd-target early so it is available for --body-file path
+# resolution below AND for the branch-name fallback near the end.
+# pr_cmd_cd_target is provided by _lib-pr-repo.sh, sourced above.
+CD_TARGET=""
+if command -v pr_cmd_cd_target >/dev/null 2>&1; then
+  CD_TARGET=$(pr_cmd_cd_target "$COMMAND")
+fi
+
+# Gate: only validate when the COMMAND HEAD is 'gh pr create'.
+#
+# Checking the raw command string (the pre-#743 approach) fires on any command
+# whose --body inline content happens to mention "gh pr create" — for example,
+# a bug-report filed via 'gh issue create --body "example: gh pr create ..."'.
+# Stripping the body payload (--body / --body-file / -F and everything after)
+# before the gate check means only the actual command verb is tested.
+# Fixes apexyard#743 Bug 3.
+_cmd_for_gate=$(printf '%s' "$COMMAND" \
+  | sed -E 's/[[:space:]]--body-file[[:space:]].*//' \
+  | sed -E 's/[[:space:]]--body[[:space:]].*//' \
+  | sed -E 's/[[:space:]]-F[[:space:]].*//')
+if ! printf '%s' "$_cmd_for_gate" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+create\b'; then
+  unset _cmd_for_gate
   exit 0
 fi
+unset _cmd_for_gate
 
 ERRORS=""
 
@@ -336,9 +365,26 @@ fi
 # the check with a visible stderr WARN. Default marker is
 # `<!-- pr-sections: skip -->`.
 BODY_CONTENT=""
-BODY_FILE=$(echo "$COMMAND" | sed -nE 's/.*--body-file[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
-if [ -n "$BODY_FILE" ] && [ -f "$BODY_FILE" ]; then
-  BODY_CONTENT=$(cat "$BODY_FILE")
+# Extract --body-file path. Handles --body-file and the -F short form.
+# After continuation normalization (above) the command is one logical line.
+BODY_FILE=$(printf '%s' "$COMMAND" | sed -nE 's/.*--body-file[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+if [ -z "$BODY_FILE" ]; then
+  BODY_FILE=$(printf '%s' "$COMMAND" | sed -nE 's/.*[[:space:]]-F[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+fi
+if [ -n "$BODY_FILE" ]; then
+  # Resolve relative paths against the command's cd-target (if any), so
+  # 'cd /project && gh pr create --body-file body.md' finds the file at
+  # /project/body.md rather than testing against the hook's own CWD.
+  # Fixes apexyard#743 Bug 1 for the relative-path variant.
+  if [[ "$BODY_FILE" != /* ]] && [ -n "$CD_TARGET" ]; then
+    BODY_FILE="${CD_TARGET}/${BODY_FILE}"
+  fi
+  if [ -f "$BODY_FILE" ]; then
+    BODY_CONTENT=$(cat "$BODY_FILE")
+  else
+    echo "WARN: validate-pr-create.sh: --body-file '${BODY_FILE}' not readable from hook context; section check may miss content." >&2
+    # Do not hard-block: we cannot inspect a file we cannot read.
+  fi
 fi
 
 if echo "$COMMAND" | grep -qE '\-\-body(-file)?\b'; then
@@ -489,14 +535,13 @@ fi
 # not a git tree), this is a no-op and the fallback stays byte-for-byte
 # equivalent to the pre-#693 behaviour. The `--head` path is unaffected, and
 # the PR-title check above is independent of cwd.
+# CD_TARGET was extracted early (near top of script) for --body-file path
+# resolution; reuse it here for the branch-name fallback below.
 BRANCH_DIR=""
-if command -v pr_cmd_cd_target >/dev/null 2>&1; then
-  CD_TARGET=$(pr_cmd_cd_target "$COMMAND")
-  if [ -n "$CD_TARGET" ]; then
-    CD_TOPLEVEL=$(git -C "$CD_TARGET" rev-parse --show-toplevel 2>/dev/null)
-    if [ -n "$CD_TOPLEVEL" ]; then
-      BRANCH_DIR="$CD_TOPLEVEL"
-    fi
+if [ -n "$CD_TARGET" ]; then
+  CD_TOPLEVEL=$(git -C "$CD_TARGET" rev-parse --show-toplevel 2>/dev/null)
+  if [ -n "$CD_TOPLEVEL" ]; then
+    BRANCH_DIR="$CD_TOPLEVEL"
   fi
 fi
 HEAD_FLAG=$(echo "$COMMAND" | sed -nE 's/.*--head[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)

--- a/docs/agdr/AgDR-0081-pr-create-structural-parse.md
+++ b/docs/agdr/AgDR-0081-pr-create-structural-parse.md
@@ -1,0 +1,96 @@
+# Parse gh pr create structurally — body-file, multi-line, body-example
+
+> In the context of the `validate-pr-create.sh` PreToolUse hook, facing three
+> distinct false-positive / false-negative failures caused by scanning the raw
+> command string instead of its logical structure, I decided to parse the command
+> structurally — normalise line continuations first, gate on the command head
+> (not raw text), and resolve body-file paths from the command's CWD — to achieve
+> correct validation under all three bug scenarios, accepting a modest increase
+> in preprocessing complexity.
+
+## Context
+
+`validate-pr-create.sh` validates `gh pr create` invocations for PR title format,
+required body sections (`## Testing`, `## Glossary`), and ticket existence. It
+extracted flags by scanning the raw `COMMAND` string as received from the
+PreToolUse JSON payload.
+
+Three independent bugs all trace back to the same root cause: raw-string scanning
+instead of structural parsing.
+
+**Bug 1 — `--body-file` relative-path invisible.**
+The hook checked `[ -f "$BODY_FILE" ]` against the hook's own CWD, not the
+`cd`-prefixed target directory in the command. A relative `--body-file body.md`
+in `cd /project && gh pr create --body-file body.md` resolved to the hook's CWD,
+not `/project/body.md`, so `BODY_CONTENT` was empty and the section check false-blocked.
+
+**Bug 2 — multi-line `\`-continued commands mis-resolved `--repo`.**
+Without normalisation, `sed` processes multi-line strings line by line. When
+`--repo <value>` sits on a continuation line ending with `\`, the `\` could be
+captured as part of the value (or the value garbled by adjacent shell comment
+text), yielding a garbage `TRACKER_REPO` like `(hook)` and a spurious "issue does
+not exist in (hook)" block.
+
+**Bug 3 — gate fires on `gh pr create` inside a body payload.**
+The guard `grep '\bgh\s+pr\s+create\b'` ran against the full raw command. A
+`gh issue create --body "...example: gh pr create..."` matched the pattern, and
+the hook proceeded to validate the issue-create command as if it were a PR-create.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Raw string scanning (status quo) | Simple, no preprocessing | Three independent failure modes; brittle against multi-line commands, body content, and CWD-relative paths |
+| Full shell AST parser (e.g. `bash -n` + eval) | Perfectly correct | Requires executing untrusted code; security risk; no standard cross-platform AST tool in scope |
+| Structural preprocessing: normalise continuations + strip body before gate + CWD-aware path resolution | Eliminates all three bugs; no untrusted execution; uses only bash + sed + grep primitives already in scope | Slightly more preprocessing steps; depends on the convention that `--body` / `--body-file` / `-F` flags precede no other positional flags (true for `gh pr create`) |
+
+## Decision
+
+Chosen: **structural preprocessing**, because it eliminates all three failure modes
+using the same portable primitives the hook already relies on, without executing
+untrusted command content.
+
+Three targeted changes:
+
+1. **Line-continuation normalisation** — replace every `\<newline>` pair with a
+   single space immediately after COMMAND extraction. This is a one-liner bash
+   parameter expansion (`COMMAND="${COMMAND//$'\\\n'/ }"`) and makes all
+   subsequent `sed` flag extractions see a single logical command line.
+
+2. **Gate on command head, not raw text** — before checking for `gh pr create`,
+   strip the `--body` / `--body-file` / `-F` payload and everything after it from
+   the command, then test the remainder. This eliminates Bug 3 by excluding body
+   content from the subcommand detection.
+
+3. **CWD-aware `--body-file` resolution** — after extracting the body-file path,
+   resolve relative paths against `CD_TARGET` (extracted via `pr_cmd_cd_target`
+   from `_lib-pr-repo.sh`, which is already sourced for `CMD_REPO` parsing).
+   This eliminates Bug 1's relative-path case. Absolute paths are unaffected.
+   Unreadable files emit a `WARN` and degrade gracefully rather than hard-blocking.
+
+`CD_TARGET` extraction is moved to just after `CMD_REPO` parsing so it is
+available for both body-file path resolution (new) and the branch-name fallback
+(existing), removing the duplicate `pr_cmd_cd_target` call.
+
+## Consequences
+
+- All three bugs are closed. Existing tests (28 cases across three test files)
+  are unaffected.
+- Seven new regression tests in
+  `test_validate_pr_create_structural_parse.sh` cover Bug 1 (absolute body-file,
+  pass + block), Bug 2 (multi-line continuation), Bug 3 (inline body + body-file
+  variants), and two regressions.
+- The gate-stripping sed pipeline (`--body-file` → `--body` → `-F`, in that order
+  to avoid `--body` matching the prefix of `--body-file`) assumes `gh pr create`
+  does not use `-F` for a flag other than `--body-file`. This is true for all
+  `gh` releases at time of writing.
+- The note in the Bug 3 description about `block-unreviewed-merge` matching
+  `gh pr merge` inside heredoc bodies is a related but distinct issue, intentionally
+  out of scope for this PR.
+
+## Artifacts
+
+- PR: `fix/GH-743-pr-create-structural-parse`
+- Files changed: `.claude/hooks/validate-pr-create.sh`,
+  `.claude/hooks/tests/test_validate_pr_create_structural_parse.sh`
+- Closes: me2resh/apexyard#743


### PR DESCRIPTION
## Summary

- **Bug 1 fixed — `--body-file` relative paths now resolve against the command's cd-target.** Previously the hook checked `[ -f "$BODY_FILE" ]` against its own CWD; a relative path in `cd /project && gh pr create --body-file body.md` resolved to the wrong directory, leaving `BODY_CONTENT` empty and false-blocking on "missing section".
- **Bug 2 fixed — backslash line-continuations normalised before flag extraction.** Multi-line `gh pr create` invocations (e.g. `--repo` on its own continuation line) could yield a garbled `TRACKER_REPO` (the trailing `\` captured instead of the slug) and a spurious "issue does not exist in \\" block. A single bash parameter expansion collapses all `\<newline>` pairs before any `sed` flag extraction.
- **Bug 3 fixed — gate now checks command head, not raw command text.** `gh issue create --body "...example: gh pr create..."` matched the old grep guard and was mis-validated as a PR creation. The `--body` / `--body-file` / `-F` payload (and everything after it) is stripped from the command before the `gh pr create` subcommand check.
- **`CD_TARGET` extraction consolidated.** The `pr_cmd_cd_target` call that previously lived only in the branch-name section is moved up so it is available for body-file path resolution too, removing a duplicate call.

Note: the broader class of raw-substring matching (e.g. `block-unreviewed-merge` matching `gh pr merge` inside a heredoc body) is a related but intentionally out-of-scope issue — it merits its own ticket.

## Testing

```bash
# Clone the branch
git clone git@github.com:me2resh/apexyard.git /tmp/apexyard-743-verify
cd /tmp/apexyard-743-verify
git checkout fix/GH-743-pr-create-structural-parse

# Run the new regression tests
bash .claude/hooks/tests/test_validate_pr_create_structural_parse.sh
# Expected: PASS: 7   FAIL: 0

# Run the three pre-existing test suites
bash .claude/hooks/tests/test_validate_pr_required_sections.sh
# Expected: PASS: 8   FAIL: 0

bash .claude/hooks/tests/test_validate_pr_create_head.sh
# Expected: PASS: 13  FAIL: 0

bash .claude/hooks/tests/test_validate_pr_create_upstream.sh
# Expected: PASS: 7   FAIL: 0
```

Real output at commit time:

```
test_validate_pr_create_structural_parse.sh: PASS: 7   FAIL: 0
test_validate_pr_required_sections.sh:       PASS: 8   FAIL: 0
test_validate_pr_create_head.sh:             PASS: 13  FAIL: 0
test_validate_pr_create_upstream.sh:         PASS: 7   FAIL: 0
```

Closes #743

## Glossary

| Term | Definition |
|------|------------|
| Backslash line-continuation | Shell syntax where `\<newline>` at the end of a line joins it with the next line; the `\<newline>` pair is treated as whitespace by the shell but was passed verbatim in the JSON `tool_input.command` string the hook receives |
| `TRACKER_REPO` | The `owner/repo` slug resolved from `--repo`, the git `origin` remote, or `project-config.json`; used as the target for `gh issue view` ticket-existence checks |
| Command head | The portion of a `gh` command before any `--body` / `--body-file` / `-F` payload; used for subcommand detection to avoid false-positives on body content |
| `CD_TARGET` | The directory extracted from a leading `cd <path> &&` prefix in the command; used to resolve relative `--body-file` paths and as the git root for the branch-name fallback |
| `AgDR-0081` | Agent Decision Record documenting the structural-parse approach (`docs/agdr/AgDR-0081-pr-create-structural-parse.md`) |
