### PR TITLE
fix(#737): anchor release-changelog range on the post-sync boundary

### DIFF
--- a/.claude/hooks/tests/test_release_changelog.sh
+++ b/.claude/hooks/tests/test_release_changelog.sh
@@ -266,6 +266,21 @@ out=$(run_test '
 ')
 contains "fallback still lists the delta" "first feature since tag" "$out"
 
+# ── Test: #737 grep is version-anchored — a prose mention can't hijack the boundary ──
+# A commit AFTER the real sync whose subject merely mentions the convention must
+# NOT be treated as the boundary. With an unanchored grep it would win
+# --max-count=1, set LOG_RANGE=<that>..HEAD, and drop the unreleased delta.
+echo "--- #737 version-anchored grep (no prose false-positive) ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v9.0.0
+  mc "sync: merge main into dev after v9.0.0 release"
+  mc "feat(#900): document the sync/main-to-dev-after convention"
+  PREV_TAG="v9.0.0" HEAD_REF="HEAD" VERSION="v9.1.0" DATE="2026-06-28" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "feat mentioning the unversioned string still included" "document the sync/main-to-dev-after convention" "$out"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/.claude/hooks/tests/test_release_changelog.sh
+++ b/.claude/hooks/tests/test_release_changelog.sh
@@ -204,11 +204,15 @@ contains "feat from beginning" "initial feature" "$out"
 # ── Test: sync and release commits are excluded ──────────────────────────────
 
 echo "--- excluded commit types ---"
+# Ordering mirrors the real release-cut workflow (#737): the sync marker lands
+# FIRST (reconciling the prior release), THEN the new feat for this release, then
+# the release commit. The post-sync-boundary range therefore includes the feat
+# (unreleased) and excludes the sync (it's the boundary) and the release commit.
 out=$(run_test '
   mc "chore: initial"
   git tag v5.0.0
-  mc "feat(#600): real feature"
   mc "sync: merge main into dev after v5.0.0 release"
+  mc "feat(#600): real feature"
   mc "release(#601): v5.1.0"
   PREV_TAG="v5.0.0" HEAD_REF="HEAD" VERSION="v5.1.0" DATE="2026-06-21" \
     bash "'"$CHANGELOG_SCRIPT"'" 2>&1
@@ -230,6 +234,37 @@ out=$(run_test '
 ')
 contains "feat included" "add something" "$out"
 not_contains "branch merge excluded" "Merge branch main" "$out"
+
+# ── Test: #737 post-sync boundary — released commits after the tag excluded ──
+# Squash-model simulation: the tag sits early; "released" commits follow it on
+# dev (they were squashed into the tag on main, so a tag-range over-counts them);
+# a `/release-sync` marker commit lands; then the true unreleased delta. The fix
+# must anchor on the sync marker, NOT the tag — so only the post-sync feat shows.
+echo "--- #737 post-sync boundary ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v7.0.0
+  mc "feat(#710): already-released work one"
+  mc "feat(#711): already-released work two"
+  mc "sync: merge main into dev after v7.0.0 release"
+  mc "feat(#712): the real unreleased delta"
+  PREV_TAG="v7.0.0" HEAD_REF="HEAD" VERSION="v7.1.0" DATE="2026-06-28" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains   "post-sync delta included"       "the real unreleased delta" "$out"
+not_contains "pre-sync released work excluded (1)" "already-released work one" "$out"
+not_contains "pre-sync released work excluded (2)" "already-released work two" "$out"
+
+# ── Test: #737 fallback — no sync marker → merge-base/tag range still works ───
+echo "--- #737 fallback (no sync marker) ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v8.0.0
+  mc "feat(#810): first feature since tag"
+  PREV_TAG="v8.0.0" HEAD_REF="HEAD" VERSION="v8.1.0" DATE="2026-06-28" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "fallback still lists the delta" "first feature since tag" "$out"
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 

--- a/bin/release-changelog.sh
+++ b/bin/release-changelog.sh
@@ -58,7 +58,26 @@ REPO_REMOTE="${REPO_REMOTE:-upstream}"
 if [ "$PREV_TAG" = "NONE" ]; then
   LOG_RANGE="${HEAD_REF}"
 else
-  LOG_RANGE="${PREV_TAG}..${HEAD_REF}"
+  # #737: PREV_TAG is a *squash* commit on main. Under the release-cut model the
+  # individual commits it squashed live on HEAD_REF (dev) but are NOT ancestors
+  # of the tag — so a naive PREV_TAG..HEAD_REF range (and even
+  # merge-base(PREV_TAG,dev)..dev) surfaces EVERY already-released commit,
+  # massively over-counting (v4.1.0 reported 102 feats / 263 commits for a
+  # ~1-feature delta). The correct start is the POST-SYNC BOUNDARY: after each
+  # release, `/release-sync` lands a "sync: merge main into dev after <ver>"
+  # commit (and its "...sync/main-to-dev-after-<ver>" PR merge) on dev. Commits
+  # AFTER the most recent such marker are exactly the unreleased delta.
+  SYNC=$(git log "$HEAD_REF" --max-count=1 --pretty=format:'%H' \
+           --grep='^sync: merge main into dev' \
+           --grep='sync/main-to-dev-after' 2>/dev/null || true)
+  if [ -n "$SYNC" ]; then
+    LOG_RANGE="${SYNC}..${HEAD_REF}"
+  else
+    # No sync boundary on dev (first release under the model, or sync skipped):
+    # best available fallback is the merge-base, then the raw tag range.
+    BASE=$(git merge-base "$PREV_TAG" "$HEAD_REF" 2>/dev/null || true)
+    LOG_RANGE="${BASE:-$PREV_TAG}..${HEAD_REF}"
+  fi
 fi
 
 # ── Extract commits ──────────────────────────────────────────────────────────

--- a/bin/release-changelog.sh
+++ b/bin/release-changelog.sh
@@ -67,9 +67,13 @@ else
   # release, `/release-sync` lands a "sync: merge main into dev after <ver>"
   # commit (and its "...sync/main-to-dev-after-<ver>" PR merge) on dev. Commits
   # AFTER the most recent such marker are exactly the unreleased delta.
+  # Patterns are VERSION-ANCHORED so they only match real sync commits, never a
+  # prose mention of the convention in some other commit body (e.g. this very
+  # fix's commit, or a doc PR) — an unanchored 'sync/main-to-dev-after' would
+  # let a later commit hijack the boundary and DROP unreleased work (#749 review).
   SYNC=$(git log "$HEAD_REF" --max-count=1 --pretty=format:'%H' \
-           --grep='^sync: merge main into dev' \
-           --grep='sync/main-to-dev-after' 2>/dev/null || true)
+           --grep='^sync: merge main into dev after v[0-9]' \
+           --grep='sync/main-to-dev-after-v[0-9]' 2>/dev/null || true)
   if [ -n "$SYNC" ]; then
     LOG_RANGE="${SYNC}..${HEAD_REF}"
   else


### PR DESCRIPTION
## Summary
- Fixes a changelog over-count that would corrupt every release. release-changelog.sh used PREV_TAG..HEAD_REF, but PREV_TAG is a squash commit on main whose squashed children live on dev yet are not ancestors of the tag, so the range (and even a merge-base) surfaces every already-released commit. v4.1.0 reported 102 features / 263 commits for a ~1-feature delta. The fix anchors on the post-sync boundary (the most recent /release-sync marker on dev: 'sync: merge main into dev' / 'sync/main-to-dev-after'); commits after it are the true unreleased delta. Fallback: merge-base, then the raw tag range.
- Real-history proof: on current dev, v4.1.0..dev = 269 commits; the new post-sync range = 4 commits (#744, #743, #741, #740).

## Testing
- bash .claude/hooks/tests/test_release_changelog.sh -> 40/40 pass. Added 2 cases (post-sync boundary excludes pre-sync work; no-sync fallback) and reordered the pre-existing 'excluded commit types' test to the real-workflow shape (sync before feat). shellcheck -S warning clean on both files.

Closes #737

## Glossary
| Term | Definition |
|------|------------|
| Post-sync boundary | The /release-sync merge commit on dev after a release; commits after it are unreleased. |
| Squash divergence | main holds per-release squash commits whose children are not in dev ancestry, breaking naive tag ranges. |