### PR TITLE
docs(#756): add star-history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,16 @@ Thanks to everyone who has helped forge ApexYard:
 
 <sub>External contributors' PRs are squash-merged, so GitHub's commit-author graph under-counts them — this list credits the humans directly. New contributor? Open a PR and you'll be added.</sub>
 
+## Star History
+
+<a href="https://star-history.com/#me2resh/apexyard&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=me2resh/apexyard&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=me2resh/apexyard&type=Date" />
+    <img alt="ApexYard Star History Chart" src="https://api.star-history.com/svg?repos=me2resh/apexyard&type=Date" width="600" />
+  </picture>
+</a>
+
 ## License
 
 MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

- **Adds a `## Star History` section to the README** — embeds the star-history.com growth chart for `me2resh/apexyard` so anyone landing on the README sees the adoption curve at a glance (the repo recently crossed 220 forks / 450+ stars); social proof is a credibility signal for a framework whose pitch is real-world adoption.
- **Light + dark variants** — uses a `<picture>` element with `prefers-color-scheme` so the chart reads well in both GitHub themes.
- **Docs-only** — single-file change to `README.md`, placed between Contributors and License. No code, hooks, or behaviour touched.

## Testing

1. Open the rendered README on the branch and confirm the Star History section shows the live chart.
2. Toggle GitHub light/dark mode — the dark variant should load via `prefers-color-scheme: dark`.
3. Confirm the chart links through to https://star-history.com/#me2resh/apexyard&Date

Closes #756

---

## Glossary

| Term | Definition |
|------|------------|
| Star History | A third-party service (star-history.com) that renders a repo's GitHub-stars-over-time as an embeddable SVG chart. |
| `<picture>` / `prefers-color-scheme` | HTML/CSS mechanism that serves a different image source depending on the viewer's light/dark theme preference. |
