### PR TITLE
fix(#755): route migration gate through tracker abstraction (GitLab support)

### DIFF
--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -16,7 +16,12 @@
 #   tracker_owner_repo_param <slug>    formats the owner/repo parameter (gh: "owner/repo"; others: empty)
 #   tracker_view <id> [<owner_repo>]   dispatches the view command and emits normalised JSON on stdout
 #                                      Exit 0 = ticket exists; non-zero = doesn't, or CLI errored.
-#                                      JSON shape: {"state":..., "title":..., "url":..., "labels":[...]}
+#                                      JSON shape: {"state":..., "title":..., "url":..., "labels":[...], "body":...}
+#                                      `body` is populated for the gh and glab adapters (the kinds
+#                                      that have a consumer needing it — the migration gate reads it
+#                                      to find the linked AgDR, #755). Other adapters emit body:""
+#                                      until a consumer needs it (jira `.description` is ADF, not a
+#                                      grep-able string; linear/asana bodies have no consumer yet).
 #
 # Per-project resolution (#670 / AgDR-0072): tracker_kind / tracker_id_pattern /
 # tracker_view take an OPTIONAL owner/repo. When supplied, a `tracker:` block on
@@ -208,7 +213,7 @@ tracker_id_pattern() {
 # ------------------------------------------------------------------------------
 _TRACKER_VIEW_TPL_CACHE=""
 _tracker_view_template() {
-  local repo="${1:-}"
+  local repo="${1:-}" kind="${2:-}"
   if [ -n "$repo" ]; then
     local pv
     if pv=$(_tracker_project_value "$repo" view_command) && [ -n "$pv" ]; then
@@ -222,9 +227,21 @@ _tracker_view_template() {
   fi
   _tracker_load_config_lib
   local tpl
-  tpl=$(config_get_or '.tracker.view_command' 'gh issue view {id} --repo {owner_repo} --json state,title,url,labels' 2>/dev/null)
+  # An explicit .tracker.view_command (registry per-project or config) always
+  # wins. With none set, fall back to a per-KIND built-in default: glab gets a
+  # first-class GitLab command (parity with _tracker_create_glab, #755); every
+  # other kind gets the gh shape. linear/jira/asana adopters still supply their
+  # own view_command (unchanged contract) — they only land on the gh default if
+  # they forgot to set one. The default view_command is deliberately NOT pinned
+  # in project-config.defaults.json, so this kind-aware fallback can fire (a
+  # pinned default would deep-merge over a glab adopter's `kind: glab` and force
+  # the gh command — the exact #755 bug at the config layer).
+  tpl=$(config_get_or '.tracker.view_command' '' 2>/dev/null)
   if [ -z "$tpl" ] || [ "$tpl" = "null" ]; then
-    tpl='gh issue view {id} --repo {owner_repo} --json state,title,url,labels'
+    case "$kind" in
+      glab) tpl='glab issue view {id} -R {owner_repo} --output json' ;;
+      *)    tpl='gh issue view {id} --repo {owner_repo} --json state,title,url,labels,body' ;;
+    esac
   fi
   if [ -z "$repo" ]; then
     _TRACKER_VIEW_TPL_CACHE="$tpl"
@@ -260,8 +277,8 @@ _tracker_substitute() {
 # Internal adapter: gh → normalised JSON.
 #
 # Reads `gh issue view` JSON. The default view_command requests state, title,
-# url, labels — labels comes back as an array of objects with .name keys, so
-# we flatten to a string array.
+# url, labels, body — labels comes back as an array of objects with .name keys,
+# so we flatten to a string array; body is passed through verbatim.
 # ------------------------------------------------------------------------------
 _tracker_normalise_gh() {
   local raw="$1"
@@ -276,7 +293,32 @@ _tracker_normalise_gh() {
     state:  (.state // ""),
     title:  (.title // ""),
     url:    (.url // ""),
-    labels: ((.labels // []) | map(if type == "object" then .name else . end))
+    labels: ((.labels // []) | map(if type == "object" then .name else . end)),
+    body:   (.body // "")
+  }' 2>/dev/null
+}
+
+# ------------------------------------------------------------------------------
+# Internal adapter: glab (GitLab) → normalised JSON.
+#
+# `glab issue view <id> -R <repo> --output json` emits the GitLab REST issue
+# object: .state is "opened"/"closed", .web_url is the URL, .description is the
+# body, and .labels is already an array of strings. State is normalised to
+# OPEN/CLOSED for contract parity with the gh adapter (downstream closed-state
+# classification is case-insensitive, so either casing works — parity is for
+# consumers that read .state directly). glab is a first-class view kind
+# alongside gh, mirroring the existing _tracker_create_glab creation adapter.
+# ------------------------------------------------------------------------------
+_tracker_normalise_glab() {
+  local raw="$1"
+  if [ -z "$raw" ]; then return 1; fi
+  if ! printf '%s' "$raw" | jq -e . >/dev/null 2>&1; then return 1; fi
+  printf '%s' "$raw" | jq -c '{
+    state:  ((.state // "") | if . == "opened" then "OPEN" elif . == "closed" then "CLOSED" else (. | ascii_upcase) end),
+    title:  (.title // ""),
+    url:    (.web_url // .url // ""),
+    labels: ((.labels // []) | map(if type == "object" then .name else . end)),
+    body:   (.description // .body // "")
   }' 2>/dev/null
 }
 
@@ -399,7 +441,7 @@ tracker_view() {
   fi
 
   local tpl cmd raw rc
-  tpl=$(_tracker_view_template "$owner_repo")
+  tpl=$(_tracker_view_template "$owner_repo" "$kind")
   cmd=$(_tracker_substitute "$tpl" "$id" "$owner_repo")
 
   # Run the command; capture stdout. Suppress stderr (CLI errors are visible
@@ -413,6 +455,7 @@ tracker_view() {
   local normalised
   case "$kind" in
     gh)     normalised=$(_tracker_normalise_gh "$raw") ;;
+    glab)   normalised=$(_tracker_normalise_glab "$raw") ;;
     linear) normalised=$(_tracker_normalise_linear "$raw") ;;
     jira)   normalised=$(_tracker_normalise_jira "$raw") ;;
     asana)  normalised=$(_tracker_normalise_asana "$raw") ;;

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -265,12 +265,25 @@ tracker_owner_repo_param() {
 
 # ------------------------------------------------------------------------------
 # Internal: substitute {id} and {owner_repo} placeholders in the view template.
+#
+# The substituted string is run via `eval` in tracker_view, so the {id} /
+# {owner_repo} values must not be able to inject command syntax. Both are
+# shell-quoted with `printf %q` before substitution — a no-op for legitimate
+# ticket IDs / owner-repo slugs, and a neutraliser for anything containing shell
+# metacharacters. This is defence-in-depth behind each caller's own shape check:
+# validate-pr-create.sh / require-migration-ticket.sh validate before calling in,
+# but quoting here guarantees a future caller that forwards unvalidated input into
+# tracker_view can't reopen the injection hole. (#755 security review — Rex/Hakim.)
 # ------------------------------------------------------------------------------
 _tracker_substitute() {
   local tpl="$1" id="$2" owner_repo="$3"
+  local q_id q_owner_repo
+  # printf -v is available in bash 3.2 (macOS default); %q shell-escapes.
+  printf -v q_id '%q' "$id"
+  printf -v q_owner_repo '%q' "$owner_repo"
   # Use POSIX parameter expansion — portable across bash 3.2 (macOS default).
-  tpl="${tpl//\{id\}/$id}"
-  tpl="${tpl//\{owner_repo\}/$owner_repo}"
+  tpl="${tpl//\{id\}/$q_id}"
+  tpl="${tpl//\{owner_repo\}/$q_owner_repo}"
   echo "$tpl"
 }
 

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -19,9 +19,10 @@
 #                                      JSON shape: {"state":..., "title":..., "url":..., "labels":[...], "body":...}
 #                                      `body` is populated for the gh and glab adapters (the kinds
 #                                      that have a consumer needing it — the migration gate reads it
-#                                      to find the linked AgDR, #755). Other adapters emit body:""
-#                                      until a consumer needs it (jira `.description` is ADF, not a
-#                                      grep-able string; linear/asana bodies have no consumer yet).
+#                                      to find the linked AgDR, #755). Other adapters omit the body
+#                                      key entirely (consumers read it as `.body // empty`) until one
+#                                      needs it (jira `.description` is ADF, not a grep-able string;
+#                                      linear/asana bodies have no consumer yet).
 #
 # Per-project resolution (#670 / AgDR-0072): tracker_kind / tracker_id_pattern /
 # tracker_view take an OPTIONAL owner/repo. When supplied, a `tracker:` block on

--- a/.claude/hooks/require-migration-ticket.sh
+++ b/.claude/hooks/require-migration-ticket.sh
@@ -264,30 +264,81 @@ MSG
 fi
 
 # --------- Gate 2: issue is open + has migration label ---------
-ISSUE_JSON=$(gh issue view "$TICKET_NUM" --repo "$TICKET_REPO" --json state,labels,body 2>/dev/null)
+# Resolve the ticket through the tracker abstraction (_lib-tracker.sh) so this
+# gate works for every configured tracker — GitHub (gh), GitLab (glab), Linear,
+# Jira, Asana, custom — not just GitHub. Before #755 this hardcoded
+# `gh issue view`, which returned empty for GitLab-tracked projects and
+# false-blocked every migration edit even when the GitLab ticket was valid.
+# tracker_view emits the normalised {state,title,url,labels,body} shape
+# regardless of tracker; labels come back as a flat string array and body is
+# populated for gh/glab (the kinds the migration gate reads).
+if [ -f "$HOOK_DIR/_lib-tracker.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-tracker.sh"
+fi
+
+# Resolve the tracker kind for the TICKET's repo (per-project registry override
+# wins over the global config; see #670). tracker.kind=none has no queryable
+# tracker, so existence / label / AgDR can't be verified online — per the #755
+# Expected behaviour, skip the online gates (Gate 1 already proved an active
+# ticket marker exists) and allow the edit, operator-trusted. The skip is
+# printed to stderr so it is auditable, never silent.
+TICKET_KIND="gh"
+if command -v tracker_kind >/dev/null 2>&1; then
+  TICKET_KIND=$(tracker_kind "$TICKET_REPO" 2>/dev/null)
+  [ -n "$TICKET_KIND" ] || TICKET_KIND="gh"
+fi
+if [ "$TICKET_KIND" = "none" ]; then
+  echo "note: tracker.kind=none for ${TICKET_REPO} — skipping migration label/AgDR verification (operator-trusted; #755)." >&2
+  exit 0
+fi
+
+if command -v tracker_view >/dev/null 2>&1; then
+  ISSUE_JSON=$(tracker_view "$TICKET_NUM" "$TICKET_REPO" 2>/dev/null)
+else
+  # Library missing (should not happen in a real fork) — fall back to gh so the
+  # gate still functions on a GitHub tracker rather than bricking, normalising
+  # to the same shape tracker_view emits (labels as a flat string array).
+  ISSUE_JSON=$(gh issue view "$TICKET_NUM" --repo "$TICKET_REPO" --json state,title,url,labels,body 2>/dev/null \
+    | jq -c '{state,title,url,labels:((.labels // []) | map(.name)),body}' 2>/dev/null)
+fi
+
 if [ -z "$ISSUE_JSON" ]; then
   cat >&2 <<MSG
-BLOCKED: Could not fetch ${TICKET_REPO}#${TICKET_NUM} from GitHub.
-Network / auth problem? Or the issue doesn't exist?
+BLOCKED: Could not fetch ${TICKET_REPO}#${TICKET_NUM} from the configured
+tracker (kind: ${TICKET_KIND}). Network / auth problem? Or the issue
+doesn't exist?
 
-Migration files can't be edited without a verifiable migration ticket.
-Check your gh auth status, or run /migration to create a new ticket.
+The migration gate is fail-closed by design — a high-blast-radius change is
+not allowed against a ticket the framework cannot verify. (This is stricter
+than the PR-create / commit-ref existence checks, which fall back to
+shape-only when a non-gh CLI is unreachable, per #501 — a migration edit
+warrants a hard stop.) If your tracker is untracked, set tracker.kind=none.
+
+Check your tracker auth (e.g. gh auth status / glab auth status), or run
+/migration to create a new ticket.
 MSG
   exit 2
 fi
 
-STATE=$(echo "$ISSUE_JSON" | jq -r .state)
-HAS_LABEL=$(echo "$ISSUE_JSON" | jq -r --arg L "$MIGRATION_LABEL" '.labels | map(.name) | index($L) != null')
-BODY=$(echo "$ISSUE_JSON" | jq -r .body)
+STATE=$(echo "$ISSUE_JSON" | jq -r '.state // empty')
+# Normalised labels are a flat string array, so a direct membership test.
+HAS_LABEL=$(echo "$ISSUE_JSON" | jq -r --arg L "$MIGRATION_LABEL" '.labels | index($L) != null')
+BODY=$(echo "$ISSUE_JSON" | jq -r '.body // empty')
 
-if [ "$STATE" != "OPEN" ]; then
-  cat >&2 <<MSG
-BLOCKED: Active ticket ${TICKET_REPO}#${TICKET_NUM} is $STATE, not OPEN.
+# Closed-state recognition is tracker-agnostic — same vocabulary as
+# validate-pr-create.sh / verify-commit-refs.sh: gh/glab "CLOSED", Linear
+# "Done", Jira "Resolved", Asana "Closed", etc.
+STATE_LC=$(echo "$STATE" | tr '[:upper:]' '[:lower:]')
+case "$STATE_LC" in
+  closed|done|cancelled|canceled|resolved|completed)
+    cat >&2 <<MSG
+BLOCKED: Active ticket ${TICKET_REPO}#${TICKET_NUM} is "$STATE", not open.
 Migration files require an OPEN labelled ticket. Run /migration to create
 a fresh one, or /start-ticket on a different OPEN migration ticket.
 MSG
-  exit 2
-fi
+    exit 2 ;;
+esac
 
 if [ "$HAS_LABEL" != "true" ]; then
   cat >&2 <<MSG

--- a/.claude/hooks/require-migration-ticket.sh
+++ b/.claude/hooks/require-migration-ticket.sh
@@ -263,6 +263,39 @@ MSG
   exit 2
 fi
 
+# --------- Shape-guard marker-derived values before the tracker call ---------
+# TICKET_NUM / TICKET_REPO come from the session-local active-ticket marker via
+# `cut -d= -f2-`, which keeps everything after the first `=` — so a marker line
+# like `number=42; touch X` yields TICKET_NUM='42; touch X'. Gate 2 below feeds
+# both values into `tracker_view`, which builds its command by string-substituting
+# {id}/{owner_repo} into a template and running `eval` (_lib-tracker.sh). Without a
+# shape check that is a command-injection sink: the base (pre-#755) hook used direct
+# argv (`gh issue view "$TICKET_NUM" --repo "$TICKET_REPO"`), which was
+# injection-immune; routing through the tracker abstraction reintroduces the eval.
+# The sibling caller `validate-pr-create.sh` reaches the same eval only AFTER its
+# ticket number passed a shape check — this hook must not skip the equivalent guard.
+# Whitelist a conservative charset (no shell metacharacters): ticket IDs like 42,
+# #42, GH-42, ABC-123; owner/repo slugs (incl. GitLab nested groups) of letters,
+# digits, `.`, `_`, `-`, `/`. Anything else fails closed. (#755 security review;
+# defence-in-depth alongside the printf %q quoting _tracker_substitute now applies.)
+if ! printf '%s' "$TICKET_NUM" | grep -qE '^#?[A-Za-z0-9_-]+$'; then
+  cat >&2 <<MSG
+BLOCKED: Active ticket marker at $MARKER has a malformed \`number=\` value.
+Only ticket IDs like 42, #42, GH-42, or ABC-123 are allowed (no shell
+metacharacters). Re-run /start-ticket to rewrite the marker cleanly.
+MSG
+  exit 2
+fi
+if ! printf '%s' "$TICKET_REPO" | grep -qE '^[A-Za-z0-9._/-]+$'; then
+  cat >&2 <<MSG
+BLOCKED: Active ticket marker at $MARKER has a malformed \`repo=\` value.
+Only owner/repo slugs (letters, digits, \`.\`, \`_\`, \`-\`, \`/\`) are
+allowed (no shell metacharacters). Re-run /start-ticket to rewrite the
+marker cleanly.
+MSG
+  exit 2
+fi
+
 # --------- Gate 2: issue is open + has migration label ---------
 # Resolve the ticket through the tracker abstraction (_lib-tracker.sh) so this
 # gate works for every configured tracker — GitHub (gh), GitLab (glab), Linear,

--- a/.claude/hooks/require-migration-ticket.sh
+++ b/.claude/hooks/require-migration-ticket.sh
@@ -362,7 +362,23 @@ MSG
 fi
 
 # --------- Gate 3: body references a migration AgDR ---------
+# The issue body is populated by tracker_view only for the gh and glab adapters
+# (see _lib-tracker.sh). For any other tracker kind the body comes back empty,
+# so this gate cannot see an AgDR link even when one exists — surface that in the
+# failure message rather than blaming the ticket. Adopters on those trackers can
+# set tracker.kind=none to skip online migration verification. (Widening body to
+# jira/linear/asana is tracked separately from #755.)
 if ! echo "$BODY" | grep -qE 'docs/agdr/AgDR-[0-9]+-[^[:space:]]*migration[^[:space:]]*\.md'; then
+  KIND_NOTE=""
+  case "$TICKET_KIND" in
+    gh|glab) ;;
+    *) KIND_NOTE="
+
+NOTE: tracker.kind=${TICKET_KIND} — this gate reads the issue body only for the
+gh and glab trackers, so for ${TICKET_KIND} the body is not fetched and this
+check cannot see an AgDR link even if the ticket has one. Track migrations on a
+gh/glab ticket, or set tracker.kind=none to skip online migration verification." ;;
+  esac
   cat >&2 <<MSG
 BLOCKED: Active ticket ${TICKET_REPO}#${TICKET_NUM} has the
 \`$MIGRATION_LABEL\` label but its body does not reference a migration
@@ -377,7 +393,7 @@ ticket body to include a reference to it:
   gh issue edit $TICKET_NUM --repo $TICKET_REPO --body-file <path>
 
 The regex the hook checks is permissive — any occurrence of the AgDR
-relative path in the body satisfies gate 3.
+relative path in the body satisfies gate 3.${KIND_NOTE}
 MSG
   exit 2
 fi

--- a/.claude/hooks/tests/test_require_migration_ticket.sh
+++ b/.claude/hooks/tests/test_require_migration_ticket.sh
@@ -1,0 +1,330 @@
+#!/bin/bash
+# Tests for require-migration-ticket.sh Gate 2/3 after the #755 refactor that
+# routes issue verification through the tracker abstraction (_lib-tracker.sh)
+# instead of a hardcoded `gh issue view`.
+#
+# Cases:
+#   1. gh happy path — OPEN + migration label + AgDR ref in body → allow (0)
+#   2. glab happy path — GitLab "opened" issue + label + AgDR ref → allow (0)
+#   3. tracker.kind=none — online gates skipped, allow (0), no CLI call
+#   4. missing migration label → block (2)
+#   5. closed ticket (gh CLOSED) → block (2)
+#   6. closed ticket (glab "closed") → block (2)
+#   7. body missing the AgDR reference → block (2)
+#   8. gh unfetchable (issue view empty) → block (2)
+#   9. glab unfetchable → block (2) — migration gate is fail-closed by design
+#  10. non-migration path → pass-through allow (0)
+#  11. no active-ticket marker → block (2)
+#
+# Exit 0 = all pass. Exit 1 on any failure.
+
+set -u
+
+# Test isolation: don't let a live session pin escape onto the real fork.
+unset APEXYARD_OPS_PIN_DIR CLAUDE_CODE_SESSION_ID 2>/dev/null || true
+export APEXYARD_OPS_DISABLE_PIN=1
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK_SCRIPT="$HOOK_DIR/require-migration-ticket.sh"
+DEFAULTS="$(cd "$HOOK_DIR/.." && pwd)/project-config.defaults.json"
+
+for f in "$HOOK_SCRIPT" "$HOOK_DIR/_lib-tracker.sh" "$HOOK_DIR/_lib-read-config.sh" "$DEFAULTS"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: required file not found: $f" >&2
+    exit 1
+  fi
+done
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+record_pass() { PASS=$((PASS + 1)); echo "PASS: $1"; }
+record_fail() {
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  - $1"
+  echo "FAIL: $1"
+  [ -n "${2:-}" ] && echo "  $2"
+}
+
+# -----------------------------------------------------------------------------
+# make_fork: an isolated apexyard fork sandbox with the hook + its libs.
+# -----------------------------------------------------------------------------
+make_fork() {
+  local sb
+  sb=$(mktemp -d)
+  sb=$(cd "$sb" && pwd -P)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    git remote add origin "https://github.com/test-org/test-repo.git" 2>/dev/null || true
+    touch onboarding.yaml
+    printf '' > .apexyard-fork
+    cat > apexyard.projects.yaml <<'YAML'
+version: 1
+projects:
+  - name: example
+    repo: example/example
+YAML
+    mkdir -p .claude/hooks migrations
+    for f in _lib-tracker.sh _lib-read-config.sh _lib-portfolio-paths.sh _lib-ops-root.sh _lib-detect-bash-write.sh; do
+      [ -f "$HOOK_DIR/$f" ] && cp "$HOOK_DIR/$f" ".claude/hooks/$f"
+    done
+    cp "$HOOK_SCRIPT" .claude/hooks/require-migration-ticket.sh
+    chmod +x .claude/hooks/*.sh
+    cp "$DEFAULTS" .claude/project-config.defaults.json
+    git add -A
+    git commit -q -m "test fixture"
+  )
+  echo "$sb"
+}
+
+install_mock() {
+  local sb="$1" name="$2" body="$3"
+  mkdir -p "$sb/bin"
+  cat > "$sb/bin/$name" <<EOF
+#!/bin/bash
+$body
+EOF
+  chmod +x "$sb/bin/$name"
+}
+
+set_marker() {
+  local sb="$1" repo="$2" num="$3"
+  mkdir -p "$sb/.claude/session"
+  printf 'repo=%s\nnumber=%s\n' "$repo" "$num" > "$sb/.claude/session/current-ticket"
+}
+
+# Run the hook (Write tool) against a target path; check exit code.
+run_hook() {
+  local sb="$1" file_path="$2" expected_rc="$3"
+  local input rc
+  input=$(jq -nc --arg fp "$file_path" '{tool_name:"Write", tool_input:{file_path:$fp}}')
+  (
+    cd "$sb" || exit 99
+    PATH="$sb/bin:$PATH" .claude/hooks/require-migration-ticket.sh <<<"$input" >/dev/null 2>&1
+  )
+  rc=$?
+  [ "$rc" = "$expected_rc" ]
+}
+
+MIG="migrations/001_add_table.sql"   # matches */migrations/*.sql
+GH_OPEN_OK='
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  printf "{\"state\":\"OPEN\",\"title\":\"T\",\"url\":\"https://gh/42\",\"labels\":[{\"name\":\"migration\"}],\"body\":\"refs docs/agdr/AgDR-0009-db-migration.md\"}\n"
+  exit 0
+fi
+exit 0
+'
+GLAB_OPEN_OK='
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  printf "{\"state\":\"opened\",\"title\":\"GL\",\"web_url\":\"https://gitlab/g/p/-/issues/42\",\"description\":\"refs docs/agdr/AgDR-0010-schema-migration.md\",\"labels\":[\"migration\"]}\n"
+  exit 0
+fi
+exit 0
+'
+
+# =============================================================================
+# Case 1: gh happy path.
+# =============================================================================
+SB=$(make_fork)
+set_marker "$SB" test-org/test-repo 42
+install_mock "$SB" gh "$GH_OPEN_OK"
+if run_hook "$SB" "$SB/$MIG" 0; then
+  record_pass "gh: OPEN + migration label + AgDR body → allow"
+else
+  record_fail "gh: OPEN + migration label + AgDR body → allow"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 2: glab happy path (the #755 core fix).
+# =============================================================================
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{ "tracker": { "kind": "glab" } }
+JSON
+set_marker "$SB" g/p 42
+install_mock "$SB" glab "$GLAB_OPEN_OK"
+# A gh stub that would fail loudly if the hook wrongly reached for gh.
+install_mock "$SB" gh 'exit 99'
+if run_hook "$SB" "$SB/$MIG" 0; then
+  record_pass "glab: opened + migration label + AgDR body → allow (#755)"
+else
+  record_fail "glab: opened + migration label + AgDR body → allow (#755)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 3: tracker.kind=none → online gates skipped, allow, no CLI call.
+# =============================================================================
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{ "tracker": { "kind": "none" } }
+JSON
+set_marker "$SB" test-org/test-repo 42
+# Any CLI call would be a bug — install stubs that fail.
+install_mock "$SB" gh 'exit 99'
+install_mock "$SB" glab 'exit 99'
+if run_hook "$SB" "$SB/$MIG" 0; then
+  record_pass "none: online verification skipped → allow (operator-trusted)"
+else
+  record_fail "none: online verification skipped → allow (operator-trusted)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 4: missing migration label → block.
+# =============================================================================
+SB=$(make_fork)
+set_marker "$SB" test-org/test-repo 42
+install_mock "$SB" gh '
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  printf "{\"state\":\"OPEN\",\"title\":\"T\",\"url\":\"https://gh/42\",\"labels\":[{\"name\":\"backend\"}],\"body\":\"docs/agdr/AgDR-0009-db-migration.md\"}\n"
+  exit 0
+fi
+exit 0
+'
+if run_hook "$SB" "$SB/$MIG" 2; then
+  record_pass "gh: missing migration label → block"
+else
+  record_fail "gh: missing migration label → block"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 5: closed ticket (gh CLOSED) → block.
+# =============================================================================
+SB=$(make_fork)
+set_marker "$SB" test-org/test-repo 42
+install_mock "$SB" gh '
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  printf "{\"state\":\"CLOSED\",\"title\":\"T\",\"url\":\"https://gh/42\",\"labels\":[{\"name\":\"migration\"}],\"body\":\"docs/agdr/AgDR-0009-db-migration.md\"}\n"
+  exit 0
+fi
+exit 0
+'
+if run_hook "$SB" "$SB/$MIG" 2; then
+  record_pass "gh: CLOSED ticket → block"
+else
+  record_fail "gh: CLOSED ticket → block"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 6: closed ticket (glab "closed") → block (tracker-agnostic state check).
+# =============================================================================
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{ "tracker": { "kind": "glab" } }
+JSON
+set_marker "$SB" g/p 42
+install_mock "$SB" glab '
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  printf "{\"state\":\"closed\",\"title\":\"GL\",\"web_url\":\"https://gitlab/g/p/-/issues/42\",\"description\":\"docs/agdr/AgDR-0010-schema-migration.md\",\"labels\":[\"migration\"]}\n"
+  exit 0
+fi
+exit 0
+'
+if run_hook "$SB" "$SB/$MIG" 2; then
+  record_pass "glab: closed ticket → block (tracker-agnostic state)"
+else
+  record_fail "glab: closed ticket → block (tracker-agnostic state)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 7: body missing the AgDR reference → block (Gate 3).
+# =============================================================================
+SB=$(make_fork)
+set_marker "$SB" test-org/test-repo 42
+install_mock "$SB" gh '
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  printf "{\"state\":\"OPEN\",\"title\":\"T\",\"url\":\"https://gh/42\",\"labels\":[{\"name\":\"migration\"}],\"body\":\"no agdr link here\"}\n"
+  exit 0
+fi
+exit 0
+'
+if run_hook "$SB" "$SB/$MIG" 2; then
+  record_pass "gh: labelled but no AgDR ref in body → block (Gate 3)"
+else
+  record_fail "gh: labelled but no AgDR ref in body → block (Gate 3)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 8: gh unfetchable (issue view empty / exit 1) → block.
+# =============================================================================
+SB=$(make_fork)
+set_marker "$SB" test-org/test-repo 42
+install_mock "$SB" gh '
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then exit 1; fi
+exit 0
+'
+if run_hook "$SB" "$SB/$MIG" 2; then
+  record_pass "gh: unfetchable issue → block (fail-closed)"
+else
+  record_fail "gh: unfetchable issue → block (fail-closed)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 9: glab unfetchable → block. The migration gate is deliberately
+# fail-closed even for non-gh trackers (stricter than the #501 existence
+# checks) — a high-blast-radius edit is not allowed against an unverifiable
+# ticket. Adopters who genuinely can't query set tracker.kind=none.
+# =============================================================================
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{ "tracker": { "kind": "glab" } }
+JSON
+set_marker "$SB" g/p 42
+install_mock "$SB" glab '
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then exit 1; fi
+exit 0
+'
+if run_hook "$SB" "$SB/$MIG" 2; then
+  record_pass "glab: unfetchable issue → block (migration gate fail-closed)"
+else
+  record_fail "glab: unfetchable issue → block (migration gate fail-closed)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 10: non-migration path → pass-through (allow), no tracker call.
+# =============================================================================
+SB=$(make_fork)
+set_marker "$SB" test-org/test-repo 42
+install_mock "$SB" gh 'exit 99'
+if run_hook "$SB" "$SB/src/app.ts" 0; then
+  record_pass "non-migration path → pass-through allow"
+else
+  record_fail "non-migration path → pass-through allow"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 11: no active-ticket marker → block (Gate 1).
+# =============================================================================
+SB=$(make_fork)
+install_mock "$SB" gh 'exit 99'
+if run_hook "$SB" "$SB/$MIG" 2; then
+  record_pass "no active-ticket marker → block (Gate 1)"
+else
+  record_fail "no active-ticket marker → block (Gate 1)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo
+echo "===== test_require_migration_ticket.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed cases:$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_require_migration_ticket.sh
+++ b/.claude/hooks/tests/test_require_migration_ticket.sh
@@ -15,6 +15,10 @@
 #   9. glab unfetchable → block (2) — migration gate is fail-closed by design
 #  10. non-migration path → pass-through allow (0)
 #  11. no active-ticket marker → block (2)
+#  12. non-gh/glab (jira) reaches Gate 3, blocks with body-scoping note (2)
+#  13. injection: metachar marker `number=` → block (2) and NOT executed
+#  14. injection: metachar marker `repo=` → block (2) and NOT executed
+#  15. guard: `#`-prefixed number passes and is shell-safe (printf %q escapes #)
 #
 # Exit 0 = all pass. Exit 1 on any failure.
 
@@ -344,6 +348,59 @@ if [ "$RC" = "2" ] && echo "$OUT" | grep -q "tracker.kind=jira"; then
   record_pass "jira: Gate 3 blocks with body-scoping note (known gh/glab-only limitation)"
 else
   record_fail "jira: Gate 3 blocks with body-scoping note (known gh/glab-only limitation)" "rc=$RC note-present=$(echo "$OUT" | grep -c 'tracker.kind=jira')"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 13: command-injection guard — a marker `number=` carrying shell
+# metacharacters must be BLOCKED (exit 2) and must NOT execute. Regression for
+# the #755 security review: Gate 2 routes marker-derived TICKET_NUM through
+# tracker_view → eval, so an unvalidated `number=42; touch X` would run the
+# injected command. The shape guard rejects it before the tracker call.
+# =============================================================================
+SB=$(make_fork)
+# gh stub returns a valid OPEN+labelled+AgDR issue, so the ONLY thing that can
+# stop the injected `touch` from running is the caller-side shape guard.
+install_mock "$SB" gh "$GH_OPEN_OK"
+mkdir -p "$SB/.claude/session"
+printf 'repo=test-org/test-repo\nnumber=42; touch %s/PWNED_NUM ;\n' "$SB" > "$SB/.claude/session/current-ticket"
+if run_hook "$SB" "$SB/$MIG" 2 && [ ! -e "$SB/PWNED_NUM" ]; then
+  record_pass "injection: metachar number= blocked (exit 2) and not executed"
+else
+  record_fail "injection: metachar number= blocked (exit 2) and not executed" "pwned-exists=$([ -e "$SB/PWNED_NUM" ] && echo yes || echo no)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 14: command-injection guard — same, via the marker `repo=` field
+# ({owner_repo} is independently substituted into the eval'd command).
+# =============================================================================
+SB=$(make_fork)
+install_mock "$SB" gh "$GH_OPEN_OK"
+mkdir -p "$SB/.claude/session"
+printf 'repo=x/y; touch %s/PWNED_REPO #\nnumber=42\n' "$SB" > "$SB/.claude/session/current-ticket"
+if run_hook "$SB" "$SB/$MIG" 2 && [ ! -e "$SB/PWNED_REPO" ]; then
+  record_pass "injection: metachar repo= blocked (exit 2) and not executed"
+else
+  record_fail "injection: metachar repo= blocked (exit 2) and not executed" "pwned-exists=$([ -e "$SB/PWNED_REPO" ] && echo yes || echo no)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 15: the shape guard allows a `#`-prefixed number (a legitimate display
+# form). `#` is the one char in the number whitelist with shell meaning — an
+# UNescaped `#` inside the eval'd command would start a comment and swallow the
+# rest of the args. This asserts `#42` passes the guard AND is handled safely
+# (the lib's printf %q escapes the `#`), so the whole flow allows (exit 0).
+# =============================================================================
+SB=$(make_fork)
+install_mock "$SB" gh "$GH_OPEN_OK"
+mkdir -p "$SB/.claude/session"
+printf 'repo=test-org/test-repo\nnumber=#42\n' > "$SB/.claude/session/current-ticket"
+if run_hook "$SB" "$SB/$MIG" 0; then
+  record_pass "guard: #-prefixed number passes and is shell-safe (printf %q escapes #)"
+else
+  record_fail "guard: #-prefixed number passes and is shell-safe (printf %q escapes #)"
 fi
 rm -rf "$SB"
 

--- a/.claude/hooks/tests/test_require_migration_ticket.sh
+++ b/.claude/hooks/tests/test_require_migration_ticket.sh
@@ -317,6 +317,37 @@ fi
 rm -rf "$SB"
 
 # =============================================================================
+# Case 12: non-gh/glab tracker (jira) reaches Gate 3 but body is unmapped, so it
+# blocks with the scoping note (documents the known limitation; the migration
+# gate's body read is gh/glab-only until body support is widened).
+# =============================================================================
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{ "tracker": { "kind": "jira", "view_command": "jira issue view {id} --raw" } }
+JSON
+set_marker "$SB" test-org/test-repo JIRA-42
+install_mock "$SB" jira '
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  printf "{\"self\":\"https://jira/JIRA-42\",\"fields\":{\"status\":{\"name\":\"In Progress\"},\"summary\":\"S\",\"labels\":[\"migration\"]}}\n"
+  exit 0
+fi
+exit 0
+'
+# Capture stderr to assert the scoping note is present.
+OUT=$(
+  cd "$SB" || exit 99
+  PATH="$SB/bin:$PATH" .claude/hooks/require-migration-ticket.sh \
+    <<<"$(jq -nc --arg fp "$SB/$MIG" '{tool_name:"Write", tool_input:{file_path:$fp}}')" 2>&1
+)
+RC=$?
+if [ "$RC" = "2" ] && echo "$OUT" | grep -q "tracker.kind=jira"; then
+  record_pass "jira: Gate 3 blocks with body-scoping note (known gh/glab-only limitation)"
+else
+  record_fail "jira: Gate 3 blocks with body-scoping note (known gh/glab-only limitation)" "rc=$RC note-present=$(echo "$OUT" | grep -c 'tracker.kind=jira')"
+fi
+rm -rf "$SB"
+
+# =============================================================================
 # Summary
 # =============================================================================
 echo

--- a/.claude/hooks/tests/test_tracker_aware_hooks.sh
+++ b/.claude/hooks/tests/test_tracker_aware_hooks.sh
@@ -601,6 +601,63 @@ else
 fi
 rm -rf "$SB"
 
+# Glab lib smoke (#755): global kind=glab with NO view_command exercises the
+# kind-aware built-in default (glab is first-class alongside gh — a glab adopter
+# only sets `kind`). GitLab-shaped JSON (state "opened", web_url, description)
+# normalises to {state:OPEN, url, body, labels[]}. body must survive because the
+# migration gate reads it for the linked AgDR.
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{ "tracker": { "kind": "glab" } }
+JSON
+install_mock "$SB" glab '
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  printf "{\"state\":\"opened\",\"title\":\"GL1\",\"web_url\":\"https://gitlab/g/p/-/issues/1\",\"description\":\"see docs/agdr/AgDR-0001-schema-migration.md\",\"labels\":[\"migration\",\"backend\"]}\n"
+  exit 0
+fi
+exit 0
+'
+out=$(
+  cd "$SB" || exit 99
+  PATH="$SB/bin:$PATH"
+  . .claude/hooks/_lib-read-config.sh
+  . .claude/hooks/_lib-tracker.sh
+  tracker_clear_cache
+  tracker_view 1 g/p
+)
+got_state=$(echo "$out" | jq -r '.state')
+got_url=$(echo "$out" | jq -r '.url')
+got_body=$(echo "$out" | jq -r '.body')
+got_labels=$(echo "$out" | jq -r '.labels | join(",")')
+if [ "$got_state" = "OPEN" ] && [ "$got_url" = "https://gitlab/g/p/-/issues/1" ] && [ "$got_labels" = "migration,backend" ] && echo "$got_body" | grep -q "AgDR-0001-schema-migration.md"; then
+  record_pass "lib: tracker_view (glab) normalises opened→OPEN, web_url→url, description→body"
+else
+  record_fail "lib: tracker_view (glab) normalises opened→OPEN, web_url→url, description→body" "got state='$got_state' url='$got_url' body='$got_body' labels='$got_labels'"
+fi
+
+# Glab closed-state → CLOSED.
+install_mock "$SB" glab '
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  printf "{\"state\":\"closed\",\"title\":\"done\",\"web_url\":\"https://gitlab/g/p/-/issues/2\",\"description\":\"\",\"labels\":[]}\n"
+  exit 0
+fi
+exit 0
+'
+got_state=$(
+  cd "$SB" || exit 99
+  PATH="$SB/bin:$PATH"
+  . .claude/hooks/_lib-read-config.sh
+  . .claude/hooks/_lib-tracker.sh
+  tracker_clear_cache
+  tracker_view 2 g/p | jq -r '.state'
+)
+if [ "$got_state" = "CLOSED" ]; then
+  record_pass "lib: tracker_view (glab) normalises closed→CLOSED"
+else
+  record_fail "lib: tracker_view (glab) normalises closed→CLOSED" "got state='$got_state'"
+fi
+rm -rf "$SB"
+
 # None: tracker_view returns non-zero.
 SB=$(make_fork)
 cat > "$SB/.claude/project-config.json" <<'JSON'

--- a/.claude/hooks/tests/test_tracker_aware_hooks.sh
+++ b/.claude/hooks/tests/test_tracker_aware_hooks.sh
@@ -678,6 +678,37 @@ else
 fi
 rm -rf "$SB"
 
+# Injection defence-in-depth (#755 security review): tracker_view builds its
+# command via string substitution and runs it through `eval`, so a caller that
+# forwards an unvalidated id must not be able to inject command syntax.
+# _tracker_substitute now printf %q-quotes the {id}/{owner_repo} tokens — verify a
+# metacharacter-laden id neither executes nor produces output, and that a
+# legitimate id still substitutes cleanly (no behaviour change for real values).
+SB=$(make_fork)
+install_mock "$SB" gh 'exit 0'   # any output irrelevant; we assert no execution
+rc=$(
+  cd "$SB" || exit 99
+  PATH="$SB/bin:$PATH"
+  . .claude/hooks/_lib-read-config.sh
+  . .claude/hooks/_lib-tracker.sh
+  tracker_clear_cache
+  tracker_view "1; touch $SB/LIB_PWNED ;" owner/repo >/dev/null 2>&1
+  echo $?
+)
+sub=$(
+  cd "$SB" || exit 99
+  . .claude/hooks/_lib-read-config.sh
+  . .claude/hooks/_lib-tracker.sh
+  tracker_clear_cache
+  _tracker_substitute 'gh issue view {id} --repo {owner_repo}' 42 owner/repo
+)
+if [ ! -e "$SB/LIB_PWNED" ] && [ "$sub" = "gh issue view 42 --repo owner/repo" ]; then
+  record_pass "lib: tracker_view neutralises injection via printf %q (metachar id not executed; legit id unchanged)"
+else
+  record_fail "lib: tracker_view neutralises injection via printf %q" "pwned=$([ -e "$SB/LIB_PWNED" ] && echo yes || echo no) legit-sub='$sub'"
+fi
+rm -rf "$SB"
+
 # =============================================================================
 # Case 10 (#501): non-gh tracker, CLI absent / returns empty → shape-only
 # fallback. The existence check can't run (no working CLI), so a well-formed

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -179,9 +179,8 @@
   },
 
   "tracker": {
-    "_comment": "Tracker dispatch — selects which CLI verifies that ticket-IDs reference real tickets. Default is GH (GitHub Issues via `gh issue view`), matching today's behaviour exactly. Supported `kind` values: gh, linear, jira, asana, custom, none. `view_command` is a template with `{id}` and `{owner_repo}` placeholders — the lib substitutes them and runs the result. `id_pattern` is the regex `validate-branch-name.sh` and `validate-pr-create.sh` use to shape-check ticket IDs (covers GH `#123` / `GH-123` plus enterprise prefixes like `LIN-456` / `JIRA-789` by default). Set `kind = none` to disable existence verification entirely (shape-only). See AgDR-0033 and `.claude/hooks/_lib-tracker.sh`.",
+    "_comment": "Tracker dispatch — selects which CLI verifies that ticket-IDs reference real tickets. Default is GH (GitHub Issues via `gh issue view`), matching today's behaviour exactly. Supported `kind` values: gh, glab, linear, jira, asana, custom, none. `view_command` is a template with `{id}` and `{owner_repo}` placeholders — the lib substitutes them and runs the result. It is intentionally NOT pinned here: the lib picks a KIND-AWARE built-in default (gh → `gh issue view … --json state,title,url,labels,body`; glab → `glab issue view … --output json`), so a glab/gh adopter who only sets `kind` gets the matching command without also having to set `view_command`. Pinning a default here would deep-merge over a `kind: glab` override and force the gh command (me2resh/apexyard#755). linear/jira/asana/custom adopters still set their own `view_command`. `id_pattern` is the regex `validate-branch-name.sh` and `validate-pr-create.sh` use to shape-check ticket IDs (covers GH `#123` / `GH-123` plus enterprise prefixes like `LIN-456` / `JIRA-789` by default). Set `kind = none` to disable existence verification entirely (shape-only). See AgDR-0033 and `.claude/hooks/_lib-tracker.sh`.",
     "kind": "gh",
-    "view_command": "gh issue view {id} --repo {owner_repo} --json state,title,url,labels",
     "id_pattern": "^(#[0-9]+|GH-[0-9]+|[A-Z]{2,10}-[0-9]+)$"
   },
 


### PR DESCRIPTION
## Summary

- **Root cause fixed** — `require-migration-ticket.sh` Gate 2 hardcoded `gh issue view`, so GitLab-tracked (`tracker.kind: glab`) projects false-blocked *every* migration-file edit even when the GitLab ticket was valid and open. Gate 2 now routes through `tracker_view` from `_lib-tracker.sh`, so the migration gate works for any configured tracker.
- **glab is now a first-class view kind** (the issue's "fuller fix", not the local `gh`-then-`glab` fallback patch) — new `_tracker_normalise_glab` adapter (`opened`→`OPEN`, `web_url`→`url`, `description`→`body`, string labels), a `glab)` dispatch case, and a **kind-aware built-in `view_command` default** so a glab/gh adopter who only sets `kind` gets the matching command. Mirrors the existing `_tracker_create_glab` creation adapter.
- **`body` added to the normalised `tracker_view` contract** (gh + glab only) — the migration gate reads it to find the linked AgDR (Gate 3). Scoped to gh/glab deliberately: jira `.description` is ADF (not a grep-able string) and linear/asana bodies have no consumer yet.
- **Unpinned `.tracker.view_command` in `project-config.defaults.json`** — it was deep-merging over a glab adopter's `kind: glab` and forcing the gh command (the bug at the config layer). The lib now owns a kind-aware default, so the pin is unnecessary and harmful.
- **`tracker.kind=none` short-circuits** the online label/AgDR checks (operator-trusted, audible stderr note), per the issue's Expected behaviour. **Closed-state detection is now tracker-agnostic** (shares the `closed|done|cancelled|resolved|…` vocabulary with `validate-pr-create.sh` / `verify-commit-refs.sh`) instead of the gh-only `!= "OPEN"`.

## Design decision — the migration gate is fail-closed on an unfetchable ticket

For a non-gh tracker, the existence checks (`validate-pr-create.sh` / `verify-commit-refs.sh`) fall back to shape-only PASS when the CLI is unreachable (#501). The **migration gate is deliberately stricter**: an unfetchable ticket → block, even for glab, because a migration edit is high-blast-radius. Adopters who genuinely cannot query a tracker set `tracker.kind=none` (which skips the gate). This matches the tested local patch behaviour on the reporting fork.

## Security hardening (review round — commit `86b439f`)

Routing Gate 2 through `tracker_view` reintroduced a command-injection sink that the base hook's direct-argv `gh issue view "$TICKET_NUM"` avoided: `tracker_view` builds its command by string-substituting `{id}`/`{owner_repo}` into a template and running `eval`, and `require-migration-ticket.sh` fed it marker-derived `TICKET_NUM`/`TICKET_REPO` (parsed via `cut -d= -f2-`) with **no shape check**. A marker line like `number=42; touch X` executed arbitrary commands regardless of the gate verdict. Closed in two layers:

- **Caller-side shape guard** (`require-migration-ticket.sh`) — whitelist `TICKET_NUM` (`^#?[A-Za-z0-9_-]+$`) and `TICKET_REPO` (`^[A-Za-z0-9._/-]+$`) before the tracker call; block (exit 2) on any shell metacharacter. Mirrors the shape guarantee `validate-pr-create.sh` / `verify-commit-refs.sh` already get from digit-only extraction — this hook was the sole marker→`tracker_view` caller lacking one.
- **Library defence-in-depth** (`_lib-tracker.sh` `_tracker_substitute`) — `printf %q` the `{id}`/`{owner_repo}` tokens so any future caller forwarding unvalidated input into `tracker_view` can't reopen the sink. No-op for legitimate ids/slugs (incl. nested GitLab groups); also fixes a latent `#42`-starts-a-comment bug in the unquoted default template.

## Testing

1. `bash bin/run-hook-tests.sh` → **77/77 PASS** (includes the new file).
2. `test_require_migration_ticket.sh` (15 cases): gh + glab happy paths, `none` skip, missing-label / closed (gh + glab) / missing-AgDR blocks, gh + glab unfetchable → block, non-migration passthrough, no-marker, jira Gate-3 body-scoping note, **injection: metachar `number=` / `repo=` blocked (exit 2) and not executed**, and `#`-prefixed number passes and is shell-safe.
3. `test_tracker_aware_hooks.sh` +3 lib smoke cases: 2 glab (`opened→OPEN`, `web_url→url`, `description→body`; `closed→CLOSED`) + **1 injection case** (`tracker_view` neutralises a metacharacter id via `printf %q`; legit id substitutes unchanged).
4. glab output shape verified against **live GitLab** (`glab issue view … -R gitlab-org/gitlab-foss --output json`): `state`, `title`, `web_url`, `description`, `labels` are all top-level keys with the expected value shapes.

## Compatibility note

Default forks are unaffected (defaults.json no longer pins `view_command`). The one regression surface: an adopter who *explicitly pinned* the old gh `view_command` (without `body`) in their own `project-config.json` will get an empty body and false-block Gate 3 — they should drop the pin (letting the kind-aware default apply) or append `,body` to their template.

Closes #755

## Glossary

| Term | Definition |
|------|------------|
| `tracker_view` | Public function in `_lib-tracker.sh` that dispatches an issue-view to the configured tracker CLI (gh/glab/linear/jira/asana/custom/none) and emits normalised JSON `{state,title,url,labels,body}`. |
| `_tracker_normalise_<kind>` | Per-tracker adapter that maps a CLI's raw JSON into the normalised contract shape. |
| kind-aware view default | The built-in `view_command` the lib picks when none is configured, chosen by `tracker.kind` (gh → `gh issue view … --json …,body`; glab → `glab issue view … --output json`). |
| migration gate (Gate 3a) | The `require-migration-ticket.sh` rule: a migration-path edit requires an OPEN, `migration`-labelled ticket whose body links a migration AgDR. |
| deep-merge | `jq '.[0] * .[1]'` recursively merges nested objects, so `.tracker.view_command` from defaults survived a `kind`-only override — the config-layer cause of this bug. |
| ADF | Atlassian Document Format — Jira's rich-text body representation (a JSON object, not plain text), which is why `body` is not mapped for the jira adapter. |
| `printf %q` | Bash builtin that emits a shell-quoted (escaped) form of a string, reusable as literal input; used in `_tracker_substitute` so metacharacters in a substituted `{id}`/`{owner_repo}` are neutralised before the `eval` in `tracker_view`. |

