### PR TITLE
feat(#758): route /code-review through tracker-agnostic review submission

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -24,21 +24,29 @@ You have **two** required outputs and they are NOT interchangeable:
 1. **The local approval marker IS the merge-gate signal.** On an APPROVED verdict, write `.claude/session/reviews/<owner>__<repo>__<pr>-rex.approved` (the repo-qualified `$REX_MARKER` path — see "Approval marker" below). This is the file `block-unreviewed-merge.sh` actually reads; **writing it is the required gate output.** Without it the merge stays blocked no matter what you posted to GitHub.
 2. **Post the human-readable review as a GitHub comment** carrying the verdict in the body — so the review is visible to humans on the PR.
 
+Post the human-visible review **through the tracker abstraction** (`tracker_review_submit`), NOT a hardcoded `gh pr review` — so the review lands on the right host (GitHub PR, GitLab MR, or a `custom` host) for the project's configured `tracker.kind` (#758). Write your review to a temp body-file and pass the `comment` verdict:
+
 ```bash
-# Post the human-readable review. Use --comment as the canonical happy path and
-# put the verdict (APPROVED / CHANGES REQUESTED) in the body — see below for why.
-gh pr review {number} --comment --body "your review (verdict in the body)"
+# Full resolution — source the lib, resolve $PR_REPO, write $REVIEW_BODY_FILE —
+# is in the "Approval marker" section below (reuses the same $MARKER_HOME).
+tracker_review_submit "$PR_REPO" {number} comment "$REVIEW_BODY_FILE"
 ```
 
-### Use `--comment`, not `--approve` — and treat an `--approve` block as expected, not a failure
+### Pass the `comment` verdict, not `approve` — and treat an `approve` block as expected, not a failure
 
-The verdict that drives the merge gate is the **local marker**, NOT GitHub's "Approved" review state. So:
+The verdict that drives the merge gate is the **local marker**, NOT the host's "Approved" review state. So:
 
-- **Canonical happy path:** post the review with `gh pr review {number} --comment` and state the verdict (`APPROVED` / `CHANGES REQUESTED`) in the comment body. This always works, in interactive and auto-mode sessions alike.
-- **Do NOT attempt `gh pr review --approve` by default.** In the common single-account / auto-mode setup, GitHub refuses to let an account approve its own PR ("Cannot approve your own PR"), and an auto-mode write-classifier may additionally flag the attempt. **This block is expected and is not a failure** — a GitHub "Approved" state is optional and unavailable when reviewing your own account's PR. Do not retry it, do not escalate it, and do not report the review as incomplete because of it. The local marker (output #1) is what satisfies the gate.
-- `--request-changes` is fine to use when you have a non-approving verdict and want it reflected in GitHub's review state; it does not hit the self-approval restriction.
+- **Canonical happy path:** call `tracker_review_submit "$PR_REPO" {number} comment "$REVIEW_BODY_FILE"` and state the verdict (`APPROVED` / `CHANGES REQUESTED`) in the body itself. This always works — on gh it maps to `gh pr review --comment`; on glab to an MR note; on custom to the operator's `review_command`.
+- **Do NOT pass the `approve` verdict by default.** On gh it maps to `gh pr review --approve`, which in the common single-account / auto-mode setup GitHub refuses ("Cannot approve your own PR"), and an auto-mode write-classifier may additionally flag it. **That block is expected and is not a failure** — a host "Approved" state is optional and unavailable when reviewing your own account's PR. Do not retry it, do not escalate it, and do not report the review as incomplete because of it. The local marker (output #1) is what satisfies the gate.
+- The `request-changes` verdict is fine for a non-approving result you want reflected in the host's review state (on gh it does not hit the self-approval restriction; on glab it posts a note, since GitLab has no request-changes state).
 
-**Do NOT** return without (a) writing the marker on APPROVED and (b) posting the `--comment` review. The review must be visible on GitHub; the marker must exist on disk.
+**Do NOT** return without (a) writing the marker on APPROVED and (b) posting the `comment` review via `tracker_review_submit`. The review must be visible on the host; the marker must exist on disk.
+
+**Submit-vs-marker contract (they are orthogonal).** `tracker_review_submit` posts the *human-visible* review; the `*-rex.approved` marker is the *machine* gate signal. They are independent:
+
+- Exit 0 → posted. Good.
+- Exit 3 → `tracker.kind=none`: there is no host CLI. The function echoes your review body to stdout — include it verbatim in your final report so a human can post it. This is NOT a failure.
+- Any other non-zero → the host CLI failed (network / auth / transient). **Warn loudly and include the full review body in your final report** so it isn't lost, but still write the approval marker on an APPROVED verdict — the marker is the gate signal and the review *was performed*; a transient post failure must not block a legitimate merge. Tell the operator to re-post manually.
 
 ---
 
@@ -588,14 +596,17 @@ fallow fix --dry-run
 
 3. Review each file against the checklist
 
-4. Post a review comment (MUST include the commit SHA!) — verdict goes in the body.
-   gh pr review {number} --comment --body "review content (verdict: APPROVED / CHANGES REQUESTED)"
+4. Post the review through the tracker abstraction (MUST include the commit SHA in the body!).
+   Write the review to a temp file, then (after resolving $PR_REPO — see marker section):
+   tracker_review_submit "$PR_REPO" {number} comment "$REVIEW_BODY_FILE"   # verdict in the body
 
-   OR if you want a non-approving verdict reflected in GitHub's review state:
-   gh pr review {number} --request-changes --body "issues found"
+   OR for a non-approving result you want reflected in the host's review state:
+   tracker_review_submit "$PR_REPO" {number} request-changes "$REVIEW_BODY_FILE"
 
-   Do NOT use --approve — GitHub blocks self-approval on single-account setups and
-   it is NOT required (the local marker is the gate signal). See the HARD STOP above.
+   Do NOT pass the `approve` verdict — on gh it maps to --approve, which GitHub blocks on
+   single-account setups, and it is NOT required (the local marker is the gate signal).
+   On gh it maps to `gh pr review`; on glab to an MR note; on custom to review_command.
+   See the HARD STOP above for the submit-vs-marker (orthogonal) contract.
 
 5. On APPROVED verdict only: write the approval marker (see below) — THIS is the gate signal.
 ```
@@ -643,10 +654,27 @@ fi
 MARKER_HOME="${OPS_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 # shellcheck source=/dev/null
 . "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
+# Also source the tracker abstraction — this is what posts the human-visible
+# review to the right host (gh PR / glab MR / custom) instead of a hardcoded gh.
+# shellcheck source=/dev/null
+. "$MARKER_HOME/.claude/hooks/_lib-tracker.sh"
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
-# Resolve the repo this PR belongs to — required for the qualified marker name.
+# Resolve the repo this PR belongs to — required for the qualified marker name
+# AND for tracker_review_submit (it selects the adapter from this repo's config).
 PR_REPO=$(gh pr view {number} --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
 REX_MARKER=$(review_marker_path "$PR_REPO" {number} rex "$MARKER_HOME")
+
+# Write your review to a temp body-file, then submit it through the abstraction.
+# A file (not inline text) is the uniform path: gh takes --body-file, glab reads
+# the file contents into an MR note, custom exposes it via $TRACKER_REVIEW_BODY_FILE.
+REVIEW_BODY_FILE=$(mktemp)
+cat > "$REVIEW_BODY_FILE" <<'REVIEW'
+<your full review text — verdict (APPROVED / CHANGES REQUESTED) stated in the body>
+REVIEW
+tracker_review_submit "$PR_REPO" {number} comment "$REVIEW_BODY_FILE"; submit_rc=$?
+# submit_rc: 0 = posted · 3 = kind=none (echo the body in your report) · other =
+# host CLI failed (warn + include the body in your report; still write the marker
+# on APPROVED — the review WAS performed and the marker is the orthogonal gate signal).
 ```
 
 ### The command

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -27,9 +27,10 @@ You have **two** required outputs and they are NOT interchangeable:
 Post the human-visible review **through the tracker abstraction** (`tracker_review_submit`), NOT a hardcoded `gh pr review` — so the review lands on the right host (GitHub PR, GitLab MR, or a `custom` host) for the project's configured `tracker.kind` (#758). Write your review to a temp body-file and pass the `comment` verdict:
 
 ```bash
-# Full resolution — source the lib, resolve $PR_REPO, write $REVIEW_BODY_FILE —
-# is in the "Approval marker" section below (reuses the same $MARKER_HOME).
-tracker_review_submit "$PR_REPO" {number} comment "$REVIEW_BODY_FILE"
+# Full resolution — source the lib, resolve $PR_HOST_REPO (the PR/MR base repo,
+# NOT the fork), write $REVIEW_BODY_FILE — is in the "Approval marker" section
+# below (reuses the same $MARKER_HOME).
+tracker_review_submit "$PR_HOST_REPO" {number} comment "$REVIEW_BODY_FILE"
 ```
 
 ### Pass the `comment` verdict, not `approve` — and treat an `approve` block as expected, not a failure
@@ -597,11 +598,12 @@ fallow fix --dry-run
 3. Review each file against the checklist
 
 4. Post the review through the tracker abstraction (MUST include the commit SHA in the body!).
-   Write the review to a temp file, then (after resolving $PR_REPO — see marker section):
-   tracker_review_submit "$PR_REPO" {number} comment "$REVIEW_BODY_FILE"   # verdict in the body
+   Write the review to a temp file, then (after resolving $PR_HOST_REPO — the PR/MR
+   base repo, NOT the fork; see marker section):
+   tracker_review_submit "$PR_HOST_REPO" {number} comment "$REVIEW_BODY_FILE"   # verdict in the body
 
    OR for a non-approving result you want reflected in the host's review state:
-   tracker_review_submit "$PR_REPO" {number} request-changes "$REVIEW_BODY_FILE"
+   tracker_review_submit "$PR_HOST_REPO" {number} request-changes "$REVIEW_BODY_FILE"
 
    Do NOT pass the `approve` verdict — on gh it maps to --approve, which GitHub blocks on
    single-account setups, and it is NOT required (the local marker is the gate signal).
@@ -659,10 +661,19 @@ MARKER_HOME="${OPS_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 # shellcheck source=/dev/null
 . "$MARKER_HOME/.claude/hooks/_lib-tracker.sh"
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
-# Resolve the repo this PR belongs to — required for the qualified marker name
-# AND for tracker_review_submit (it selects the adapter from this repo's config).
+# Resolve the head (fork) repo — used for the qualified marker filename.
 PR_REPO=$(gh pr view {number} --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
 REX_MARKER=$(review_marker_path "$PR_REPO" {number} rex "$MARKER_HOME")
+
+# Resolve the PR/MR HOST (base) repo — where the review must be POSTED and the
+# repo tracker_review_submit selects its adapter from. On a cross-fork PR this
+# differs from the fork above (posting to the fork fails: the PR lives on the
+# base). gh pr view has no baseRepository field, but the PR URL is ALWAYS on the
+# base repo — parse owner/repo from it (works for gh /pull/ and glab
+# /-/merge_requests/, incl. nested GitLab groups). Falls back to PR_REPO when
+# base == head (the common same-repo case).
+PR_HOST_REPO=$(gh pr view {number} --json url --jq '.url' 2>/dev/null | sed -E 's#^https?://[^/]+/(.+)/(pull|-/merge_requests)/[0-9].*#\1#')
+[ -z "$PR_HOST_REPO" ] && PR_HOST_REPO="$PR_REPO"
 
 # Write your review to a temp body-file, then submit it through the abstraction.
 # A file (not inline text) is the uniform path: gh takes --body-file, glab reads
@@ -671,7 +682,7 @@ REVIEW_BODY_FILE=$(mktemp)
 cat > "$REVIEW_BODY_FILE" <<'REVIEW'
 <your full review text — verdict (APPROVED / CHANGES REQUESTED) stated in the body>
 REVIEW
-tracker_review_submit "$PR_REPO" {number} comment "$REVIEW_BODY_FILE"; submit_rc=$?
+tracker_review_submit "$PR_HOST_REPO" {number} comment "$REVIEW_BODY_FILE"; submit_rc=$?
 # submit_rc: 0 = posted · 3 = kind=none (echo the body in your report) · other =
 # host CLI failed (warn + include the body in your report; still write the marker
 # on APPROVED — the review WAS performed and the marker is the orthogonal gate signal).

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -23,6 +23,14 @@
 #                                      key entirely (consumers read it as `.body // empty`) until one
 #                                      needs it (jira `.description` is ADF, not a grep-able string;
 #                                      linear/asana bodies have no consumer yet).
+#   tracker_create <owner/repo> <title> [<body_file>] [<labels_csv>]
+#                                      creates a ticket via the per-project CLI; emits {ref,url}.
+#   tracker_review_submit <owner/repo> <pr> <verdict> [<body_file>]  (#758)
+#                                      submits a PR/MR review to the git host. verdict is one of
+#                                      approve|comment|request-changes (default comment). gh + glab
+#                                      adapters built in, `custom` review_command template, `none`
+#                                      no-op (returns 3, echoes body). Exit 0 = submitted; non-zero
+#                                      = CLI errored; 3 = shape-only (kind=none, nothing to call).
 #
 # Per-project resolution (#670 / AgDR-0072): tracker_kind / tracker_id_pattern /
 # tracker_view take an OPTIONAL owner/repo. When supplied, a `tracker:` block on
@@ -728,6 +736,153 @@ tracker_label_ensure() {
     *)    : ;;  # jira / linear / asana / custom / none — no-op
   esac
   return 0
+}
+
+# ------------------------------------------------------------------------------
+# PR/MR review submission (#758) — tracker/git-host-agnostic review posting.
+#
+# Mirrors tracker_create's shape: kind-dispatched adapters for gh + glab, a
+# `custom` review_command template, and a `none` no-op. The code-reviewer agent
+# (Rex) / /code-review call tracker_review_submit instead of shelling out to
+# `gh pr review` directly, so a GitLab-hosted adopter's review lands on the MR
+# rather than silently assuming GitHub.
+#
+# ORTHOGONAL to the merge gate. This function only posts the HUMAN-VISIBLE review
+# to the git host. The load-bearing `*-rex.approved` marker is a plain local file
+# (already tracker-agnostic) written separately by the agent — a failed submit
+# here does NOT touch it. See .claude/agents/code-reviewer.md § "Approval marker".
+#
+# Verdict vocabulary (faithful to gh's three verbs): approve | comment |
+# request-changes. This is a thin wrapper — the POLICY of "prefer --comment over
+# --approve on single-account self-review" lives in the agent (which passes
+# `comment`), not here.
+# ------------------------------------------------------------------------------
+
+# Internal adapter: gh → `gh pr review`. Args passed as an array (never an eval'd
+# string) so a body full of shell metacharacters is inert. 2>/dev/null hides the
+# expected self-approval refusal noise; gh's exit status still propagates.
+_tracker_review_gh() {
+  local repo="$1" pr="$2" verdict="$3" body_file="$4"
+  local -a args
+  args=(pr review "$pr" --repo "$repo")
+  case "$verdict" in
+    approve)         args+=(--approve) ;;
+    request-changes) args+=(--request-changes) ;;
+    comment|*)       args+=(--comment) ;;
+  esac
+  if [ -n "$body_file" ] && [ -f "$body_file" ]; then
+    args+=(--body-file "$body_file")
+  fi
+  gh "${args[@]}" 2>/dev/null
+}
+
+# Internal adapter: glab (GitLab) → `glab mr approve` / `glab mr note create`.
+#
+# GitLab has NO "request-changes" review state, so that verdict posts the review
+# body as an MR note (the verdict is stated in the body — same shape as gh's
+# --comment happy path). `approve` posts the approval and, when a body is given,
+# adds it as a note too (glab mr approve carries no message). `glab mr note
+# create` is the non-deprecated replacement for the old top-level `glab mr note
+# -m` (GitLab prints a deprecation notice steering to `create`); it is flagged
+# EXPERIMENTAL in glab 1.103.x — verified by CLI surface, not a live MR.
+_tracker_review_glab() {
+  local repo="$1" pr="$2" verdict="$3" body_file="$4"
+  local body=""
+  [ -n "$body_file" ] && [ -f "$body_file" ] && body="$(cat "$body_file")"
+  case "$verdict" in
+    approve)
+      glab mr approve "$pr" -R "$repo" 2>/dev/null || return 1
+      if [ -n "$body" ]; then
+        glab mr note create "$pr" -R "$repo" -m "$body" 2>/dev/null || return 1
+      fi
+      ;;
+    comment|request-changes|*)
+      [ -n "$body" ] || return 1   # a comment/notes verdict needs a body
+      glab mr note create "$pr" -R "$repo" -m "$body" 2>/dev/null || return 1
+      ;;
+  esac
+}
+
+# Internal: resolve the review_command template for the `custom` kind — the
+# per-project override (registry) wins over a global .tracker.review_command.
+# Empty when neither is set (custom kind without a template can't submit).
+_tracker_review_template() {
+  local repo="${1:-}"
+  if [ -n "$repo" ]; then
+    local pv
+    if pv=$(_tracker_project_value "$repo" review_command) && [ -n "$pv" ]; then
+      echo "$pv"
+      return 0
+    fi
+  fi
+  _tracker_load_config_lib
+  local tpl
+  tpl=$(config_get_or '.tracker.review_command' '' 2>/dev/null)
+  if [ -n "$tpl" ] && [ "$tpl" != "null" ]; then
+    echo "$tpl"
+  fi
+}
+
+# Internal adapter: custom → operator-supplied review_command template.
+#
+# Injection model (identical to _tracker_create_custom): only the SAFE
+# placeholders — {owner_repo} (registry slug), {pr} (numeric), {verdict}
+# (validated enum) — are substituted into the eval'd template. The one arbitrary,
+# untrusted value (the review body) is exposed as an ENVIRONMENT VARIABLE
+# ($TRACKER_REVIEW_BODY_FILE, a path) that the operator references with a
+# double-quoted expansion — so a body full of `; rm -rf …` is inert.
+_tracker_review_custom() {
+  local repo="$1" pr="$2" verdict="$3" body_file="$4"
+  local tpl
+  tpl=$(_tracker_review_template "$repo")
+  if [ -z "$tpl" ]; then
+    return 1
+  fi
+  local cmd="$tpl"
+  cmd="${cmd//\{owner_repo\}/$repo}"
+  cmd="${cmd//\{pr\}/$pr}"
+  cmd="${cmd//\{verdict\}/$verdict}"
+  TRACKER_REPO="$repo" TRACKER_PR="$pr" TRACKER_VERDICT="$verdict" \
+    TRACKER_REVIEW_BODY_FILE="$body_file" \
+    eval "$cmd" 2>/dev/null
+}
+
+# Public: tracker_review_submit <owner/repo> <pr> <verdict> [<body_file>]
+#
+# NOTE on the tracker.kind axis: kind describes the ISSUE tracker, but a review
+# targets the PR/MR HOST (the git remote). For gh+github and glab+gitlab they
+# coincide, which is exactly the pair this ticket (#758) covers. The wildcard
+# default below assumes a non-gh/glab issue tracker (jira/linear/asana) is paired
+# with a GitHub code host — correct for the common jira-issues+github-code setup,
+# but a jira-issues+gitlab-code adopter would need `tracker.kind=custom` with a
+# review_command (or a future dedicated review-host config).
+tracker_review_submit() {
+  local repo="$1" pr="$2" verdict="${3:-comment}" body_file="${4:-}"
+  if [ -z "$repo" ] || [ -z "$pr" ]; then
+    return 1
+  fi
+  case "$verdict" in
+    approve|comment|request-changes) ;;
+    *) verdict="comment" ;;   # normalise anything unexpected to the safe default
+  esac
+
+  local kind
+  kind=$(tracker_kind "$repo")
+  case "$kind" in
+    none)
+      # Shape-only mode: no git-host CLI to call. Emit the review body (if given)
+      # so the operator can post it manually, and return 3 (documented
+      # "shape-only" code) so callers don't misreport it as a CLI/auth error.
+      if [ -n "$body_file" ] && [ -f "$body_file" ]; then
+        cat "$body_file"
+      fi
+      return 3
+      ;;
+    gh)     _tracker_review_gh     "$repo" "$pr" "$verdict" "$body_file" ;;
+    glab)   _tracker_review_glab   "$repo" "$pr" "$verdict" "$body_file" ;;
+    custom) _tracker_review_custom "$repo" "$pr" "$verdict" "$body_file" ;;
+    *)      _tracker_review_gh     "$repo" "$pr" "$verdict" "$body_file" ;;  # see NOTE above
+  esac
 }
 
 # ------------------------------------------------------------------------------

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -861,6 +861,12 @@ tracker_review_submit() {
   if [ -z "$repo" ] || [ -z "$pr" ]; then
     return 1
   fi
+  # {pr} is documented numeric and is substituted into the custom adapter's
+  # eval'd template — reject a non-numeric value as defense-in-depth (gh/glab
+  # require numeric PR/MR ids anyway).
+  case "$pr" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
   case "$verdict" in
     approve|comment|request-changes) ;;
     *) verdict="comment" ;;   # normalise anything unexpected to the safe default

--- a/.claude/hooks/tests/test_tracker_review_submit.sh
+++ b/.claude/hooks/tests/test_tracker_review_submit.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+# test_tracker_review_submit.sh — the #758 review-submission abstraction.
+#
+# tracker_review_submit dispatches PR/MR review posting to the per-project git
+# host CLI, mirroring tracker_create. It is a FUNCTION taking args (the review
+# body reaches the CLI via a file / a quoted -m value / an env var — never an
+# eval'd string), with built-in adapters for gh / glab and a `review_command`
+# template for the `custom` kind. Returns the CLI's exit status; kind=none is a
+# shape-only no-op that returns 3 and echoes the body for manual filing.
+#
+# Tests use MOCK CLIs (a fake gh/glab/custom on PATH) — no real review is posted.
+#
+# Cases:
+#   1. gh happy path → correct `gh pr review` verb + --body-file
+#   2. gh verdict verbs → approve / request-changes map to the right flag
+#   3. gh verdict normalisation → an unknown verdict falls back to --comment
+#   4. gh failure → the CLI's non-zero exit propagates
+#   5. kind=none → returns 3, echoes the body (shape-only, not a CLI error)
+#   6. per-project glab override → mr approve / mr note create dispatch [needs YAML]
+#   7. per-project custom review_command → env-passed body, injection-safe [needs YAML]
+#
+# Exit 0 = all pass. Exit 1 on first failure.
+
+set -u
+unset APEXYARD_OPS_PIN_DIR CLAUDE_CODE_SESSION_ID 2>/dev/null || true
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TRACKER_LIB="$HOOK_DIR/_lib-tracker.sh"
+CONFIG_LIB="$HOOK_DIR/_lib-read-config.sh"
+PORTFOLIO_LIB="$HOOK_DIR/_lib-portfolio-paths.sh"
+OPSROOT_LIB="$HOOK_DIR/_lib-ops-root.sh"
+
+PASS=0
+FAIL=0
+FAILED=""
+pass() { PASS=$((PASS+1)); echo "PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); FAILED="$FAILED\n  - $1"; echo "FAIL: $1"; echo "    expected: [$2]"; echo "    actual:   [$3]"; }
+assert_eq() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1" "$2" "$3"; fi; }
+
+HAVE_YAML=no
+if command -v yq >/dev/null 2>&1 || python3 -c 'import yaml' >/dev/null 2>&1; then HAVE_YAML=yes; fi
+
+# Build a single-fork sandbox; $1 optional registry body (per-project trackers).
+make_sandbox() {
+  local sb registry_body="${1:-}"
+  sb=$(mktemp -d); sb=$(cd "$sb" && pwd -P)
+  mkdir -p "$sb/.claude/hooks" "$sb/bin"
+  touch "$sb/onboarding.yaml"
+  cp "$TRACKER_LIB"   "$sb/.claude/hooks/_lib-tracker.sh"
+  cp "$CONFIG_LIB"    "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$PORTFOLIO_LIB" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  [ -f "$OPSROOT_LIB" ] && cp "$OPSROOT_LIB" "$sb/.claude/hooks/_lib-ops-root.sh"
+  cat > "$sb/.claude/project-config.defaults.json" <<'JSON'
+{ "tracker": { "kind": "gh" } }
+JSON
+  if [ -n "$registry_body" ]; then
+    printf '%s\n' "$registry_body" > "$sb/apexyard.projects.yaml"
+  else
+    printf 'version: 1\nprojects: []\n' > "$sb/apexyard.projects.yaml"
+  fi
+  echo "$sb"
+}
+
+# Mock gh: capture argv (one per line) to $GH_CAPTURE, exit 0.
+install_gh_mock() {
+  local sb="$1"
+  cat > "$sb/bin/gh" <<'EOF'
+#!/bin/bash
+[ -n "${GH_CAPTURE:-}" ] && printf '%s\n' "$@" > "$GH_CAPTURE"
+exit 0
+EOF
+  chmod +x "$sb/bin/gh"
+}
+
+# ---------------------------------------------------------------------------
+SB=$(make_sandbox)
+install_gh_mock "$SB"
+BODY="$SB/rev.md"; printf 'APPROVED — verdict in body.\nSecond line.\n' > "$BODY"
+cd "$SB" || { echo "FAIL: cd sandbox"; exit 1; }
+# shellcheck source=/dev/null
+. "$SB/.claude/hooks/_lib-tracker.sh"
+
+# Case 1 — gh comment: correct verb + --body-file pointing at our file.
+tracker_clear_cache
+PATH="$SB/bin:$PATH" GH_CAPTURE="$SB/c1" tracker_review_submit "o/r" 42 comment "$BODY"; rc=$?
+assert_eq "gh comment → exit 0" "0" "$rc"
+assert_eq "gh comment → 'pr review' subcommand" "review" "$(sed -n '2p' "$SB/c1")"
+assert_eq "gh comment → PR number passed"       "42"     "$(sed -n '3p' "$SB/c1")"
+assert_eq "gh comment → --comment verb"         "1"      "$(grep -c -- '--comment' "$SB/c1")"
+assert_eq "gh comment → --body-file used (not inline --body)" "1" "$(grep -c -- '--body-file' "$SB/c1")"
+got_bf=$(awk 'p{print;exit} /^--body-file$/{p=1}' "$SB/c1")
+assert_eq "gh comment → --body-file points at our file" "$BODY" "$got_bf"
+
+# Case 2 — verdict verbs map to the right gh flag.
+tracker_clear_cache
+PATH="$SB/bin:$PATH" GH_CAPTURE="$SB/c2a" tracker_review_submit "o/r" 42 approve "$BODY" >/dev/null
+assert_eq "gh approve → --approve verb" "1" "$(grep -c -- '--approve' "$SB/c2a")"
+tracker_clear_cache
+PATH="$SB/bin:$PATH" GH_CAPTURE="$SB/c2b" tracker_review_submit "o/r" 42 request-changes "$BODY" >/dev/null
+assert_eq "gh request-changes → --request-changes verb" "1" "$(grep -c -- '--request-changes' "$SB/c2b")"
+
+# Case 3 — an unknown verdict normalises to --comment (never a raw injection).
+tracker_clear_cache
+PATH="$SB/bin:$PATH" GH_CAPTURE="$SB/c3" tracker_review_submit "o/r" 42 'bogus; rm -rf /' "$BODY" >/dev/null
+assert_eq "gh unknown verdict → normalised to --comment"      "1" "$(grep -c -- '--comment' "$SB/c3")"
+assert_eq "gh unknown verdict → no stray --approve"           "0" "$(grep -c -- '--approve' "$SB/c3")"
+
+# Case 4 — the CLI's non-zero exit propagates (2>/dev/null must not mask it).
+cat > "$SB/bin/gh" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x "$SB/bin/gh"
+tracker_clear_cache
+PATH="$SB/bin:$PATH" tracker_review_submit "o/r" 42 comment "$BODY"; rc=$?
+assert_eq "gh failure → non-zero exit propagates" "1" "$rc"
+rm -rf "$SB"
+
+# Case 5 — kind=none: no CLI call; returns 3 and echoes the body for manual
+# filing. NOT a failure path.
+SBN=$(make_sandbox)
+cat > "$SBN/.claude/project-config.defaults.json" <<'JSON'
+{ "tracker": { "kind": "none" } }
+JSON
+(
+  cd "$SBN" || exit 1
+  # shellcheck source=/dev/null
+  . "$SBN/.claude/hooks/_lib-tracker.sh"
+  tracker_clear_cache
+  bf=$(mktemp); printf 'REVIEW BODY TO FILE MANUALLY\n' > "$bf"
+  out=$(tracker_review_submit "o/r" 42 comment "$bf"); rc=$?
+  out2=$(tracker_review_submit "o/r" 42 comment); rc2=$?
+  rm -f "$bf"
+  printf '%s|%s|%s|%s\n' "$rc" "$out" "$rc2" "$out2"
+) > "$SBN/r"
+IFS="|" read -r n_rc n_out nb_rc nb_out < "$SBN/r"
+assert_eq "kind=none → exit 3 (shape-only, not a CLI error)" "3" "$n_rc"
+assert_eq "kind=none (with body) → echoes body for manual filing" "REVIEW BODY TO FILE MANUALLY" "$n_out"
+assert_eq "kind=none (no body) → exit 3" "3" "$nb_rc"
+assert_eq "kind=none (no body) → empty stdout" "" "$nb_out"
+rm -rf "$SBN"
+
+# Case 6 — per-project glab override dispatches glab (needs a YAML parser).
+# The glab mock APPENDS each invocation (space-joined) so approve+note (two
+# calls) are both observable.
+if [ "$HAVE_YAML" = yes ]; then
+  SB2=$(make_sandbox "version: 1
+projects:
+  - name: gl
+    repo: g/p
+    tracker:
+      kind: glab")
+  cat > "$SB2/bin/glab" <<'EOF'
+#!/bin/bash
+[ -n "${GLAB_CAPTURE:-}" ] && printf '%s\n' "$*" >> "$GLAB_CAPTURE"
+exit 0
+EOF
+  chmod +x "$SB2/bin/glab"
+  printf 'glab review body\n' > "$SB2/rev.md"
+  (
+    cd "$SB2" || exit 1
+    # shellcheck source=/dev/null
+    . "$SB2/.claude/hooks/_lib-tracker.sh"
+    # comment → a single `mr note create` with -m
+    tracker_clear_cache
+    : > "$SB2/capc"
+    PATH="$SB2/bin:$PATH" GLAB_CAPTURE="$SB2/capc" tracker_review_submit "g/p" 7 comment "$SB2/rev.md"; rcc=$?
+    note_c=$(grep -c 'mr note create' "$SB2/capc")
+    m_c=$(grep -c -- '-m' "$SB2/capc")
+    # request-changes → also a note (GitLab has no request-changes state)
+    tracker_clear_cache
+    : > "$SB2/capr"
+    PATH="$SB2/bin:$PATH" GLAB_CAPTURE="$SB2/capr" tracker_review_submit "g/p" 7 request-changes "$SB2/rev.md" >/dev/null
+    note_r=$(grep -c 'mr note create' "$SB2/capr")
+    # approve (with body) → an `mr approve` AND a note
+    tracker_clear_cache
+    : > "$SB2/capa"
+    PATH="$SB2/bin:$PATH" GLAB_CAPTURE="$SB2/capa" tracker_review_submit "g/p" 7 approve "$SB2/rev.md" >/dev/null
+    appr_a=$(grep -c 'mr approve' "$SB2/capa")
+    note_a=$(grep -c 'mr note create' "$SB2/capa")
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$rcc" "$note_c" "$m_c" "$note_r" "$appr_a" "$note_a"
+  ) > "$SB2/result"
+  IFS=$'\t' read -r g_rc g_notec g_mc g_noter g_appra g_notea < "$SB2/result"
+  assert_eq "glab comment → exit 0"                        "0" "$g_rc"
+  assert_eq "glab comment → posts via 'mr note create'"    "1" "$g_notec"
+  assert_eq "glab comment → passes body via -m"            "1" "$g_mc"
+  assert_eq "glab request-changes → posts a note (no MR request-changes state)" "1" "$g_noter"
+  assert_eq "glab approve (with body) → calls 'mr approve'" "1" "$g_appra"
+  assert_eq "glab approve (with body) → also attaches a note" "1" "$g_notea"
+  rm -rf "$SB2"
+else
+  echo "SKIP: glab per-project case (no yq / python3+PyYAML)"
+fi
+
+# Case 7 — per-project custom review_command. The body passes via ENV
+# ($TRACKER_REVIEW_BODY_FILE), never string-substituted — so a review body full
+# of shell metacharacters cannot inject. {verdict} / {pr} / {owner_repo} ARE
+# substituted (trusted: enum / numeric / registry slug). (needs a YAML parser.)
+if [ "$HAVE_YAML" = yes ]; then
+  SB3=$(make_sandbox "version: 1
+projects:
+  - name: cu
+    repo: c/u
+    tracker:
+      kind: custom
+      review_command: 'mycli review -R {owner_repo} --pr {pr} --verdict {verdict} --bodyfile \"\$TRACKER_REVIEW_BODY_FILE\"'")
+  cat > "$SB3/bin/mycli" <<'EOF'
+#!/bin/bash
+[ -n "${MYCLI_CAPTURE:-}" ] && printf '%s\n' "$@" > "$MYCLI_CAPTURE"
+exit 0
+EOF
+  chmod +x "$SB3/bin/mycli"
+  # A body path whose CONTENTS are hostile — proves the file route is inert.
+  printf 'hi"; touch PWNED; echo "\n' > "$SB3/rev.md"
+  (
+    cd "$SB3" || exit 1
+    # shellcheck source=/dev/null
+    . "$SB3/.claude/hooks/_lib-tracker.sh"
+    tracker_clear_cache
+    PATH="$SB3/bin:$PATH" MYCLI_CAPTURE="$SB3/cap" tracker_review_submit "c/u" 9 request-changes "$SB3/rev.md"; rc=$?
+    verdict_seen=$(awk 'p{print;exit} /^--verdict$/{p=1}' "$SB3/cap")
+    pr_seen=$(awk 'p{print;exit} /^--pr$/{p=1}' "$SB3/cap")
+    pwned=no; [ -e "$SB3/PWNED" ] && pwned=yes
+    printf '%s\t%s\t%s\t%s\n' "$rc" "$verdict_seen" "$pr_seen" "$pwned"
+  ) > "$SB3/result"
+  IFS=$'\t' read -r c_rc c_verdict c_pr c_pwned < "$SB3/result"
+  assert_eq "custom → exit 0"                              "0" "$c_rc"
+  assert_eq "custom → {verdict} substituted"              "request-changes" "$c_verdict"
+  assert_eq "custom → {pr} substituted"                   "9" "$c_pr"
+  assert_eq "custom → NO shell injection from body (no PWNED)" "no" "$c_pwned"
+  rm -rf "$SB3"
+else
+  echo "SKIP: custom per-project case (no yq / python3+PyYAML)"
+fi
+
+echo "=========================================="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then printf "Failed:%b\n" "$FAILED"; exit 1; fi
+exit 0

--- a/.claude/hooks/tests/test_tracker_review_submit.sh
+++ b/.claude/hooks/tests/test_tracker_review_submit.sh
@@ -114,6 +114,14 @@ chmod +x "$SB/bin/gh"
 tracker_clear_cache
 PATH="$SB/bin:$PATH" tracker_review_submit "o/r" 42 comment "$BODY"; rc=$?
 assert_eq "gh failure → non-zero exit propagates" "1" "$rc"
+
+# Case 4b — a non-numeric PR id is rejected before any dispatch/eval (matches the
+# documented "{pr} is numeric" contract; defense-in-depth for the custom eval).
+install_gh_mock "$SB"
+tracker_clear_cache
+PATH="$SB/bin:$PATH" GH_CAPTURE="$SB/cbad" tracker_review_submit "o/r" '9; rm -rf /' comment "$BODY"; rc=$?
+assert_eq "non-numeric PR id → rejected (non-zero)" "1" "$rc"
+assert_eq "non-numeric PR id → no CLI invoked"      "no" "$([ -f "$SB/cbad" ] && echo yes || echo no)"
 rm -rf "$SB"
 
 # Case 5 — kind=none: no CLI call; returns 3 and echoes the body for manual

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -42,7 +42,7 @@ See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the ful
 4. Check for the required Glossary section
 5. Check for AgDR links if technical decisions were made
 6. On JS/TS diffs, run the Fallow static-analysis pass (§ 9 of the agent) — changed-scope, fail-soft, advisory; render a `### Fallow Findings` table + dry-run fix preview
-7. Submit a GitHub review via `gh pr review`
+7. Submit the review through the tracker-agnostic `tracker_review_submit` (gh PR / glab MR / custom host — #758), not a hardcoded `gh pr review`
 
 ## Review Checklist
 


### PR DESCRIPTION
## Summary

- **New `tracker_review_submit` abstraction in `_lib-tracker.sh`** — closes the last hardcoded-`gh` surface in the review flow. It kind-dispatches PR/MR review posting the same way `tracker_create` does for issue creation (AgDR-0072): built-in **gh** + **glab** adapters, a `custom` `review_command` template, and a `kind=none` no-op that returns 3 and echoes the review body for manual filing. Adopters on GitLab (or a custom host) previously got a broken "submit review" step even though Rex's analysis ran fine — this is the same gap #670 closed for issue *creation*.
- **Verdict vocabulary is `approve | comment | request-changes`** (default `comment`), a faithful map of gh's three verbs. The "prefer `comment` over `approve` on single-account self-review" *policy* stays in the code-reviewer agent (where it already lived); the lib is a thin, un-opinionated wrapper. GitLab has no `request-changes` review state, so that verdict posts an MR **note** carrying the verdict-in-body; `approve` posts the approval and attaches the body as a note (glab's approve carries no message).
- **Routed the code-reviewer agent (Rex) + `/code-review` skill through it** — the review now writes to a temp body-file and submits via the adapter for the project's configured `tracker.kind`, instead of shelling out to `gh pr review` directly. The gh happy path is byte-for-byte unchanged for the default adopter.
- **The local `*-rex.approved` merge-gate marker is untouched and explicitly orthogonal** — it is a plain local file (already tracker-agnostic). A failed *submit* warns loudly and preserves the full review body in Rex's report, but does **not** block the marker write on an APPROVED verdict: the review *was performed*, the marker is the gate signal, and a transient host-CLI failure must not block a legitimate merge. This contract is now spelled out in the agent rather than left to inference.

## Testing

- New `test_tracker_review_submit.sh` — **25 cases, all green**: gh verb selection (`approve`/`comment`/`request-changes`) + `--body-file` passing + unknown-verdict normalisation + non-zero-exit propagation (proving `2>/dev/null` doesn't mask the status); glab `mr approve` / `mr note create` dispatch incl. the request-changes→note and approve+body→two-calls mappings; `custom` injection-safety (review body passed via `$TRACKER_REVIEW_BODY_FILE` env, never string-substituted — a hostile body creates no `PWNED`); `kind=none` shape-only (exit 3 + body echo).
- Regression: `test_tracker_create.sh` (16/16) and `test_per_project_tracker.sh` (6/6) stay green. Four unrelated suites (`test_ops_root`, `test_require_agdr_for_arch_pr`, `test_split_portfolio_v2_migration`, `test_workspace_tracker_resolution`) fail **identically before and after this change** — verified by stashing the diff and re-running — because they resolve the ops-root against the nested dev worktree rather than their `/tmp` sandbox; they pass in a clean CI checkout.

```bash
bash .claude/hooks/tests/test_tracker_review_submit.sh   # 25 PASS / 0 FAIL
```

## Scope / verification notes

- **Scoped to `/code-review` (this ticket).** The abstraction is host-complete, but the two sibling reviewers that carry the identical hardcoded `gh pr review` — Hakim (`/security-review`) and Tariq (`/design-review`, which also writes an architecture sign-off marker) — are a focused follow-up, filed separately (mirrors the #755 → #761 split). Doing all three here would triple the agent-prose surface and pull the architecture-gate marker into scope.
- **`tracker.kind` describes the *issue* tracker; a review targets the *PR/MR host*.** For gh+github and glab+gitlab these coincide (exactly this ticket's cases). The wildcard default assumes a non-gh/glab issue tracker (jira/linear/asana) is paired with a GitHub code host — correct for the common jira-issues+github-code setup; a jira-issues+gitlab-code adopter needs `tracker.kind=custom` with a `review_command`. Flagged inline as a possible future review-host config.
- **glab verification ceiling** (same as #755): the glab write path is verified by CLI-surface inspection + mocks, not a live MR. `glab mr note create` is the non-deprecated replacement for the old top-level `glab mr note -m` (GitLab prints a deprecation notice steering to it) and is flagged **EXPERIMENTAL** in glab 1.103.x.
- No new AgDR: this fills the already-decided **AgDR-0072** abstraction pattern, and `require-agdr-for-arch-pr.sh` does not key on `.claude/hooks/**` (same as #755, which also shipped without a new AgDR).

Closes #758

## Glossary

| Term | Definition |
|------|------------|
| `tracker_review_submit` | New public dispatcher in `_lib-tracker.sh` that posts a PR/MR review to the project's git host (gh/glab/custom), selecting the adapter from the per-project `tracker.kind`. |
| `tracker_create` / AgDR-0072 | The prior sibling abstraction (issue creation) whose kind-dispatch + custom-template + injection model this function mirrors. |
| verdict (`approve`/`comment`/`request-changes`) | The review outcome vocabulary; a faithful map of GitHub's three review verbs. `comment` is the default and the self-review happy path. |
| MR note | A GitLab merge-request comment. Because GitLab has no `request-changes` review *state*, that verdict is posted as a note carrying the verdict in its body. |
| `*-rex.approved` marker | The local file `block-unreviewed-merge.sh` reads as the code-review merge-gate signal — orthogonal to (and unaffected by) the human-visible review this PR routes. |
| shape-only (`kind=none`) | The mode where no host CLI exists; the function returns exit code 3 and echoes the review body so an operator can post it manually. |
