### PR TITLE
feat(#764): make merge-gate HEAD/merge-detection forge-aware (gh/glab)

### DIFF
--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -27,11 +27,58 @@
 #   . "$(dirname "$0")/_lib-extract-pr.sh"
 #   if ! is_merge_command "$COMMAND"; then exit 0; fi
 #   PR_NUMBER=$(extract_pr_number "$COMMAND")
+#
+# FORGE-AWARENESS (#764)
+# ----------------------
+# The gates originally spoke only GitHub. A GitLab-forge project (`tracker.kind:
+# glab`) merges via `glab mr merge <iid>` — a shape neither the matcher nor this
+# helper recognised, so the gates silently did not fire (an ungated-merge hole,
+# the forge analog of the #47 `gh api` bypass). This helper now recognises both
+# forges' merge shapes and resolves MR/PR state via the matching CLI:
+#
+#   3. `glab mr merge 42 -R owner/repo`                           → MR is 42
+#
+# The gh path is unchanged byte-for-byte; glab is additive. Forge selection for
+# the CLI-calling resolvers goes through `tracker_kind` from `_lib-tracker.sh`
+# (gh + glab coincide with github + gitlab per #762); the shape detectors read
+# the command text directly.
+
+# Lazily source the tracker lib so `tracker_kind` is available for forge
+# resolution. Guarded: only source if not already defined and the lib is
+# present. tracker_kind defaults to "gh" with no config, preserving gh behaviour.
+if ! command -v tracker_kind >/dev/null 2>&1; then
+  _lib_extract_pr_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)"
+  if [ -n "$_lib_extract_pr_dir" ] && [ -f "$_lib_extract_pr_dir/_lib-tracker.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$_lib_extract_pr_dir/_lib-tracker.sh"
+  fi
+fi
+
+# Echoes the forge kind ('gh' | 'glab') for a repo, via tracker_kind. Any
+# non-glab kind (gh / none / jira / linear / unknown / unresolved) → 'gh', so
+# the GitHub CLI path stays the default. Used by the CLI-calling resolvers
+# (resolve_pr_head, resolve_pr_head_branch) which only have the repo, not the
+# command text.
+_forge_kind_for() {
+  local repo="${1:-}" kind="gh"
+  if command -v tracker_kind >/dev/null 2>&1; then
+    kind=$(tracker_kind "$repo" 2>/dev/null || echo gh)
+  fi
+  case "$kind" in glab) echo glab ;; *) echo gh ;; esac
+}
+
+# Echoes 'glab' if the command text is a GitLab (glab) invocation, else 'gh'.
+# Shape-based — used where the command string is in hand (the extractors), so
+# no config lookup is needed: the command literally says which CLI it drives.
+_forge_from_command() {
+  if echo "${1:-}" | grep -qE '\bglab\s+(mr|api)\b'; then echo glab; else echo gh; fi
+}
 
 # Returns 0 if $1 looks like a merge command this gate should fire on.
-# Matches EITHER:
+# Matches ANY of:
 #   - `gh pr merge ...`
 #   - `gh api ... repos/<owner>/<repo>/pulls/<N>/merge ...`
+#   - `glab mr merge ...`                                     (#764, GitLab)
 is_merge_command() {
   local cmd="$1"
   if echo "$cmd" | grep -qE '\bgh\s+pr\s+merge\b'; then
@@ -40,6 +87,10 @@ is_merge_command() {
   # `gh api` with a `/pulls/<N>/merge` path anywhere in the command. The path
   # may be quoted, slash-separated, and may include query params.
   if echo "$cmd" | grep -qE '\bgh\s+api\b.*repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge\b'; then
+    return 0
+  fi
+  # `glab mr merge ...` — GitLab merge-request merge (#764).
+  if echo "$cmd" | grep -qE '\bglab\s+mr\s+merge\b'; then
     return 0
   fi
   return 1
@@ -119,9 +170,32 @@ extract_pr_number() {
     fi
   fi
 
-  # 3. Last resort: ask gh which PR the current branch points at.
+  # 2b. glab mr merge positional arg (#764, GitLab). Same span-fencing and
+  #     redirection-stripping discipline as the gh path above.
   if [ -z "$pr" ]; then
-    pr=$(gh pr view --json number --jq '.number' 2>/dev/null)
+    local gspan gclean gtoken
+    gspan=$(echo "$cmd" | grep -oE '\bglab\s+mr\s+merge\b[^|;&]*')
+    if [ -n "$gspan" ]; then
+      gclean=$(echo "$gspan" | sed \
+        -e 's/[0-9]*>&[0-9]*/  /g' \
+        -e 's/&>[^[:space:]]*/  /g' \
+        -e 's/>>[^[:space:]]*/  /g' \
+        -e 's/>[^[:space:]]*/  /g')
+      gtoken=$(echo "$gclean" | grep -oE '\bmerge\b[[:space:]]+[^[:space:]]*' | awk 'NR==1 {print $NF}')
+      if echo "$gtoken" | grep -qE '^[0-9]+$'; then
+        pr="$gtoken"
+      fi
+    fi
+  fi
+
+  # 3. Last resort: ask the forge which PR/MR the current branch points at.
+  #    Forge-aware (#764): a glab command falls back to `glab mr view`.
+  if [ -z "$pr" ]; then
+    if [ "$(_forge_from_command "$cmd")" = glab ]; then
+      pr=$(glab mr view --output json 2>/dev/null | jq -r '.iid // empty' 2>/dev/null)
+    else
+      pr=$(gh pr view --json number --jq '.number' 2>/dev/null)
+    fi
   fi
 
   echo "$pr"
@@ -152,7 +226,8 @@ merge_command_uses_variable() {
   # redirection-stripping discipline as extract_pr_number so `2>&1` etc. don't
   # masquerade as the positional arg).
   local span clean_span first_token
-  span=$(echo "$cmd" | grep -oE '\bgh\s+pr\s+merge\b[^|;&]*')
+  # Match either forge's merge span: `gh pr merge …` or `glab mr merge …` (#764).
+  span=$(echo "$cmd" | grep -oE '\b(gh\s+pr|glab\s+mr)\s+merge\b[^|;&]*')
   clean_span=$(echo "$span" | sed \
     -e 's/[0-9]*>&[0-9]*/  /g' \
     -e 's/&>[^[:space:]]*/  /g' \
@@ -166,9 +241,10 @@ merge_command_uses_variable() {
     return 0
   fi
 
-  # --repo value (same quoted-or-bare variable forms).
+  # repo value (same quoted-or-bare variable forms). Covers gh/glab `--repo` and
+  # glab's short `-R` flag (#764).
   local repo_token
-  repo_token=$(echo "$cmd" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+  repo_token=$(echo "$cmd" | sed -nE 's/.*(--repo|-R)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
   if echo "$repo_token" | grep -qE '^["'"'"']?\$\{?[A-Za-z_]'; then
     return 0
   fi
@@ -210,13 +286,53 @@ resolve_pr_head() {
     return
   fi
 
-  if [ -n "$cmd_repo" ]; then
+  # Forge-aware (#764): glab projects resolve the MR HEAD SHA via `glab mr view`.
+  # glab's MR JSON exposes the head commit as `.sha` (fallback `.diff_refs.head_sha`
+  # on older glab). Any non-glab forge → the unchanged gh path.
+  if [ "$(_forge_kind_for "$cmd_repo")" = glab ]; then
+    if [ -n "$cmd_repo" ]; then
+      sha=$(glab mr view "$pr_number" -R "$cmd_repo" --output json 2>/dev/null | jq -r '.sha // .diff_refs.head_sha // empty' 2>/dev/null)
+    else
+      sha=$(glab mr view "$pr_number" --output json 2>/dev/null | jq -r '.sha // .diff_refs.head_sha // empty' 2>/dev/null)
+    fi
+  elif [ -n "$cmd_repo" ]; then
     sha=$(gh pr view "$pr_number" --repo "$cmd_repo" --json headRefOid --jq '.headRefOid' 2>/dev/null)
   else
     sha=$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid' 2>/dev/null)
   fi
 
   echo "$sha"
+}
+
+# Echoes the PR/MR's HEAD (source) branch name, or empty on failure.
+#
+# Extracted (#764) from block-unreviewed-merge.sh's inline `gh pr view
+# --json headRefName` so the sync-PR `--squash` guard is forge-aware. On glab
+# the source branch is `.source_branch`; on gh it is `.headRefName`. Same
+# repo-optional shape and silent-empty-on-failure contract as resolve_pr_head.
+resolve_pr_head_branch() {
+  local pr_number="$1"
+  local cmd_repo="$2"
+  local branch=""
+
+  if [ -z "$pr_number" ]; then
+    echo ""
+    return
+  fi
+
+  if [ "$(_forge_kind_for "$cmd_repo")" = glab ]; then
+    if [ -n "$cmd_repo" ]; then
+      branch=$(glab mr view "$pr_number" -R "$cmd_repo" --output json 2>/dev/null | jq -r '.source_branch // empty' 2>/dev/null)
+    else
+      branch=$(glab mr view "$pr_number" --output json 2>/dev/null | jq -r '.source_branch // empty' 2>/dev/null)
+    fi
+  elif [ -n "$cmd_repo" ]; then
+    branch=$(gh pr view "$pr_number" --repo "$cmd_repo" --json headRefName -q '.headRefName' 2>/dev/null)
+  else
+    branch=$(gh pr view "$pr_number" --json headRefName -q '.headRefName' 2>/dev/null)
+  fi
+
+  echo "$branch"
 }
 
 # Echoes the owner/repo extracted from the merge command, or empty if not found.
@@ -240,14 +356,19 @@ extract_repo_from_command() {
   repo=$(echo "$cmd" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' \
     | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
 
-  # 2. --repo flag on gh pr merge.
+  # 2. Repo flag on the merge command: gh/glab `--repo` or glab's short `-R` (#764).
   if [ -z "$repo" ]; then
-    repo=$(echo "$cmd" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+    repo=$(echo "$cmd" | sed -nE 's/.*(--repo|-R)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
   fi
 
-  # 3. Last resort: ask gh which repo the current branch's PR belongs to.
+  # 3. Last resort: ask the forge which repo the current branch's PR/MR belongs
+  #    to. Forge-aware (#764): a glab command falls back to `glab repo view`.
   if [ -z "$repo" ]; then
-    repo=$(gh pr view --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+    if [ "$(_forge_from_command "$cmd")" = glab ]; then
+      repo=$(glab repo view --output json 2>/dev/null | jq -r '.full_name // empty' 2>/dev/null)
+    else
+      repo=$(gh pr view --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+    fi
   fi
 
   echo "$repo"

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -37,6 +37,13 @@
 # forges' merge shapes and resolves MR/PR state via the matching CLI:
 #
 #   3. `glab mr merge 42 -R owner/repo`                           → MR is 42
+#   4. `glab api projects/owner%2Frepo/merge_requests/42/merge`   → MR is 42
+#
+# Shape 4 (#767) is the GitLab raw-API merge — the exact forge analog of the #47
+# `gh api …/pulls/<N>/merge` bypass. Gating only `glab mr merge` (shape 3) while
+# leaving the API passthrough open would re-create #47 on GitLab, so both glab
+# shapes are recognised (matched with `Bash(glab api *)` in settings.json, the
+# same way the gh CLI shape is paired with `Bash(gh api *)`).
 #
 # The gh path is unchanged byte-for-byte; glab is additive. Forge selection for
 # the CLI-calling resolvers goes through `tracker_kind` from `_lib-tracker.sh`
@@ -79,6 +86,7 @@ _forge_from_command() {
 #   - `gh pr merge ...`
 #   - `gh api ... repos/<owner>/<repo>/pulls/<N>/merge ...`
 #   - `glab mr merge ...`                                     (#764, GitLab)
+#   - `glab api ... merge_requests/<N>/merge ...`             (#767, GitLab raw-API)
 is_merge_command() {
   local cmd="$1"
   if echo "$cmd" | grep -qE '\bgh\s+pr\s+merge\b'; then
@@ -91,6 +99,16 @@ is_merge_command() {
   fi
   # `glab mr merge ...` — GitLab merge-request merge (#764).
   if echo "$cmd" | grep -qE '\bglab\s+mr\s+merge\b'; then
+    return 0
+  fi
+  # `glab api` with a `/merge_requests/<N>/merge` path — GitLab's raw-API merge
+  # passthrough (#767, the forge analog of the #47 `gh api …/pulls/<N>/merge`
+  # bypass). The project is a URL-encoded path (`projects/<owner>%2F<repo>`); the
+  # MR iid + `/merge` action is what we match. The trailing `\b` is load-bearing:
+  # it stops `/merge_ref`, `/merge_requests/<N>` (GET), and `/notes` from
+  # false-matching — a false match here would be fail-CLOSED (block), but a
+  # false NEGATIVE is fail-open, so the anchor is verified by negative tests.
+  if echo "$cmd" | grep -qE '\bglab\s+api\b.*merge_requests/[0-9]+/merge\b'; then
     return 0
   fi
   return 1
@@ -123,6 +141,14 @@ extract_pr_number() {
   # 1. gh api path extraction — greps the /pulls/<N>/merge segment directly.
   #    The PR number lives in the URL path, so redirections cannot affect it.
   pr=$(echo "$cmd" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | grep -oE '/pulls/[0-9]+/' | grep -oE '[0-9]+' | head -1)
+
+  # 1b. glab api path extraction — the /merge_requests/<N>/merge segment (#767).
+  #     Same URL-path discipline as step 1: the MR iid lives in the path, so
+  #     redirections cannot affect it. The `/merge` suffix keeps this from
+  #     grabbing an iid out of a non-merge URL (e.g. `/merge_requests/42/notes`).
+  if [ -z "$pr" ]; then
+    pr=$(echo "$cmd" | grep -oE 'merge_requests/[0-9]+/merge' | grep -oE '[0-9]+' | head -1)
+  fi
 
   # 2. gh pr merge positional arg.
   if [ -z "$pr" ]; then
@@ -346,6 +372,8 @@ resolve_pr_head_branch() {
 #
 # Recognises:
 #   1. `gh api repos/<owner>/<repo>/pulls/<N>/merge ...`  — repo from URL path
+#   1b. `glab api projects/<owner>%2F<repo>/merge_requests/<N>/merge ...` — repo
+#       from the URL-encoded project path (#767)
 #   2. `gh pr merge ... --repo <owner>/<repo> ...`        — repo from --repo flag
 #   3. Falls back to `gh pr view --json headRepository`   — current branch's PR
 #
@@ -357,6 +385,20 @@ extract_repo_from_command() {
   # 1. gh api path extraction.
   repo=$(echo "$cmd" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' \
     | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
+
+  # 1b. glab api path extraction (#767). GitLab's API takes the project as a
+  #     single URL-encoded path segment — `projects/<owner>%2F<repo>` (nested
+  #     subgroups become `<a>%2F<b>%2F<repo>`). There are no literal slashes in
+  #     the encoded segment, so [^/[:space:]]+ captures the whole project; then
+  #     decode %2F/%2f back to `/` so the result matches the owner/repo form the
+  #     markers and `glab mr view -R` expect.
+  if [ -z "$repo" ]; then
+    repo=$(echo "$cmd" | grep -oE 'projects/[^/[:space:]]+/merge_requests/[0-9]+/merge' \
+      | sed -nE 's|projects/([^/]+)/merge_requests/.*|\1|p' | head -1)
+    if [ -n "$repo" ]; then
+      repo=$(echo "$repo" | sed -e 's/%2[Ff]/\//g')
+    fi
+  fi
 
   # 2. Repo flag on the merge command: gh/glab `--repo` or the short `-R` alias
   #    (both gh and glab accept `-R`) (#764). Search ONLY within the merge-command

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -241,10 +241,12 @@ merge_command_uses_variable() {
     return 0
   fi
 
-  # repo value (same quoted-or-bare variable forms). Covers gh/glab `--repo` and
-  # glab's short `-R` flag (#764).
+  # repo value (same quoted-or-bare variable forms). Covers `--repo` and the
+  # short `-R` alias (#764). Searched within clean_span (the fenced merge span),
+  # not the whole command, so a trailing unrelated `-R` in a compound command
+  # can't be picked up.
   local repo_token
-  repo_token=$(echo "$cmd" | sed -nE 's/.*(--repo|-R)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
+  repo_token=$(echo "$clean_span" | sed -nE 's/.*(--repo|-R)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
   if echo "$repo_token" | grep -qE '^["'"'"']?\$\{?[A-Za-z_]'; then
     return 0
   fi
@@ -356,9 +358,15 @@ extract_repo_from_command() {
   repo=$(echo "$cmd" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' \
     | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
 
-  # 2. Repo flag on the merge command: gh/glab `--repo` or glab's short `-R` (#764).
+  # 2. Repo flag on the merge command: gh/glab `--repo` or the short `-R` alias
+  #    (both gh and glab accept `-R`) (#764). Search ONLY within the merge-command
+  #    span (fenced at the first shell separator, like extract_pr_number) so a
+  #    trailing unrelated `-R` in a compound command — e.g. `... && grep -R foo` —
+  #    cannot be mistaken for the merge target's repo.
   if [ -z "$repo" ]; then
-    repo=$(echo "$cmd" | sed -nE 's/.*(--repo|-R)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
+    local mspan
+    mspan=$(echo "$cmd" | grep -oE '\b(gh\s+pr|glab\s+mr)\s+merge\b[^|;&]*')
+    repo=$(echo "$mspan" | sed -nE 's/.*(--repo|-R)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
   fi
 
   # 3. Last resort: ask the forge which repo the current branch's PR/MR belongs

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -97,19 +97,13 @@ fi
 #   - `gh api .../pulls/<N>/merge -f merge_method=squash` (or rebase)
 # The `gh api` shape is the silent-bypass route that motivated #47, so the
 # guard must match `merge_method=squash|rebase` as well as the `--squash`
-# flag. (We make our own `gh pr view --json headRefName` call here — it is a
-# separate API call from the HEAD-SHA lookup further down, not the same one.)
+# flag. The head-branch lookup is delegated to resolve_pr_head_branch (#764) so
+# it is forge-aware (gh `.headRefName` / glab `.source_branch`) — a separate API
+# call from the HEAD-SHA lookup further down, not the same one.
 # On network failure we skip the guard and let the merge proceed — an
-# unavailable gh API is not a reason to permanently block all syncs.
+# unavailable forge API is not a reason to permanently block all syncs.
 if echo "$COMMAND" | grep -qE '(--squash|--rebase|merge_method=squash|merge_method=rebase)'; then
-  _SYNC_BRANCH=""
-  if [ -n "$CMD_REPO" ]; then
-    _SYNC_BRANCH=$(gh pr view "$PR_NUMBER" --repo "$CMD_REPO" \
-      --json headRefName -q '.headRefName' 2>/dev/null)
-  else
-    _SYNC_BRANCH=$(gh pr view "$PR_NUMBER" \
-      --json headRefName -q '.headRefName' 2>/dev/null)
-  fi
+  _SYNC_BRANCH=$(resolve_pr_head_branch "$PR_NUMBER" "$CMD_REPO")
   if echo "$_SYNC_BRANCH" | grep -qE '^sync/main-to-dev-after-'; then
     cat >&2 <<MSG
 BLOCKED: Sync PR #${PR_NUMBER} (branch: ${_SYNC_BRANCH}) cannot be squash-merged.

--- a/.claude/hooks/tests/test_forge_aware_extract_pr.sh
+++ b/.claude/hooks/tests/test_forge_aware_extract_pr.sh
@@ -118,6 +118,14 @@ assert_eq "extract_repo glab -R flag" "o/r" "$(extract_repo_from_command 'glab m
 assert_eq "extract_repo glab --repo flag" "o/r" "$(extract_repo_from_command 'glab mr merge 42 --repo o/r')"
 assert_eq "extract_repo glab fallback via glab repo view" "o/r" "$(PATH="$SB/bin:$PATH" extract_repo_from_command 'glab mr merge 42')"
 
+# --- repo-flag search is span-fenced: a trailing unrelated -R in a compound
+#     command must NOT be captured (Rex finding on PR #767). ---
+assert_eq "extract_repo gh compound: trailing 'grep -R' ignored" "o/r" \
+  "$(extract_repo_from_command 'gh pr merge 42 --repo o/r && grep -R foo .')"
+assert_eq "extract_repo glab compound: trailing 'grep -R' ignored" "o/r" \
+  "$(extract_repo_from_command 'glab mr merge 42 -R o/r && grep -R foo .')"
+assert_false merge_command_uses_variable 'gh pr merge 42 --repo o/r && grep -R $HOME .'
+
 # --- resolve_pr_head / resolve_pr_head_branch: glab path (kind=glab) ---
 tracker_clear_cache 2>/dev/null || true
 assert_eq "resolve_pr_head glab → .sha" "glabsha0000000000000000000000000000000042" \

--- a/.claude/hooks/tests/test_forge_aware_extract_pr.sh
+++ b/.claude/hooks/tests/test_forge_aware_extract_pr.sh
@@ -139,6 +139,37 @@ assert_true  merge_command_uses_variable 'glab mr merge $MR -R o/r'
 assert_true  merge_command_uses_variable 'glab mr merge 42 -R $REPO'
 assert_false merge_command_uses_variable 'glab mr merge 42 -R o/r --squash'
 
+# --- glab raw-API merge shape (#767) — the forge analog of the #47 `gh api`
+#     bypass. Gating only `glab mr merge` while leaving `glab api …/merge` open
+#     re-creates #47 on GitLab, so the raw-API shape must be detected + gated. ---
+# Positive: the canonical PUT-to-merge passthrough is recognised.
+assert_true  is_merge_command 'glab api projects/o%2Fr/merge_requests/42/merge -X PUT'
+# Positive: query-param form (the trailing \b matches before `?`).
+assert_true  is_merge_command 'glab api "projects/o%2Fr/merge_requests/42/merge?squash=true"'
+# NEGATIVE (fail-open is the danger, so prove the anchor rejects near-misses):
+#   - a GET on the MR (no /merge action) must NOT count as a merge
+assert_false is_merge_command 'glab api projects/o%2Fr/merge_requests/42'
+#   - a sibling sub-resource (/notes) must NOT count
+assert_false is_merge_command 'glab api projects/o%2Fr/merge_requests/42/notes'
+#   - `/merge_ref` — `merge` followed by `_` has no word boundary; the trailing
+#     \b in the detector is what makes this a non-match. This is THE case that
+#     justifies the anchor.
+assert_false is_merge_command 'glab api projects/o%2Fr/merge_requests/42/merge_ref'
+# extract_pr_number: the iid comes from the URL path (redirection-proof, like gh api).
+assert_eq "extract_pr_number glab api URL" "42" \
+  "$(extract_pr_number 'glab api projects/o%2Fr/merge_requests/42/merge -X PUT')"
+# extract_repo_from_command: the project path is URL-encoded; %2F must decode to /
+# so the repo matches the marker / `glab mr view -R` form. Use a value where the
+# decode is observable (not a bare o/r).
+assert_eq "extract_repo glab api %2F decode" "mygroup/myrepo" \
+  "$(extract_repo_from_command 'glab api projects/mygroup%2Fmyrepo/merge_requests/42/merge -X PUT')"
+# Lowercase %2f is equally valid URL-encoding — the decode covers both cases.
+assert_eq "extract_repo glab api %2f (lowercase) decode" "mygroup/myrepo" \
+  "$(extract_repo_from_command 'glab api projects/mygroup%2fmyrepo/merge_requests/42/merge -X PUT')"
+# Nested subgroup: two %2F separators decode to a two-slash project path.
+assert_eq "extract_repo glab api nested subgroup" "grp/sub/repo" \
+  "$(extract_repo_from_command 'glab api projects/grp%2Fsub%2Frepo/merge_requests/42/merge -X PUT')"
+
 # ---------------------------------------------------------------------------
 # Regression sandbox: kind=gh — the resolvers must take the UNCHANGED gh path.
 SB_GH=$(make_sandbox gh)
@@ -155,6 +186,11 @@ assert_eq "resolve_pr_head_branch gh path unchanged (regression)" "main" \
 assert_true  is_merge_command "gh pr merge 7 --repo o/r --squash"
 assert_eq "extract_pr_number gh positional (regression)" "7" "$(extract_pr_number 'gh pr merge 7 --repo o/r --squash')"
 assert_true  merge_command_uses_variable 'gh pr merge $PR --repo o/r'
+# gh raw-API merge shape (the #47 shape) still recognised + parsed — proves the
+# glab-api addition sits alongside the gh-api branch, not in place of it.
+assert_true  is_merge_command 'gh api repos/o/r/pulls/7/merge -X PUT'
+assert_eq "extract_pr_number gh api URL (regression)" "7" "$(extract_pr_number 'gh api repos/o/r/pulls/7/merge -X PUT')"
+assert_eq "extract_repo gh api URL (regression)" "o/r" "$(extract_repo_from_command 'gh api repos/o/r/pulls/7/merge -X PUT')"
 
 # ---------------------------------------------------------------------------
 echo

--- a/.claude/hooks/tests/test_forge_aware_extract_pr.sh
+++ b/.claude/hooks/tests/test_forge_aware_extract_pr.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# test_forge_aware_extract_pr.sh — the #764 forge-awareness of the merge-gate
+# PR/MR extraction lib (`_lib-extract-pr.sh`).
+#
+# The merge gates originally spoke only GitHub. A GitLab-forge project merges via
+# `glab mr merge <iid>` — a shape the matcher + extractor didn't recognise, so
+# the gates silently didn't fire (the forge analog of the #47 `gh api` bypass).
+# This suite proves the lib now recognises the glab merge shape and resolves MR
+# state via a mocked `glab`, WITHOUT disturbing the gh path (regression cases).
+#
+# Uses MOCK CLIs (fake gh/glab on PATH) — no real PR/MR is touched. Forge kind is
+# driven by the sandbox's project-config `.tracker.kind` (resolved via tracker_kind).
+#
+# Cases:
+#   is_merge_command:        glab mr merge recognised; non-merge glab rejected; gh unchanged
+#   extract_pr_number:       glab positional iid; glab fallback via `glab mr view`
+#   extract_repo_from_command: glab -R flag; glab fallback via `glab repo view`
+#   resolve_pr_head:         glab MR HEAD via `glab mr view .sha`; gh path unchanged (regression)
+#   resolve_pr_head_branch:  glab source_branch; gh headRefName (regression)
+#   merge_command_uses_variable: glab `$VAR` positional + `-R $VAR` detected
+#
+# Exit 0 = all pass. Exit 1 on first failure.
+
+set -u
+unset APEXYARD_OPS_PIN_DIR CLAUDE_CODE_SESSION_ID 2>/dev/null || true
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+EXTRACT_LIB="$HOOK_DIR/_lib-extract-pr.sh"
+TRACKER_LIB="$HOOK_DIR/_lib-tracker.sh"
+CONFIG_LIB="$HOOK_DIR/_lib-read-config.sh"
+PORTFOLIO_LIB="$HOOK_DIR/_lib-portfolio-paths.sh"
+OPSROOT_LIB="$HOOK_DIR/_lib-ops-root.sh"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS+1)); echo "PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "    expected: [$2]"; echo "    actual:   [$3]"; }
+assert_eq() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1" "$2" "$3"; fi; }
+assert_true()  { if "$@" >/dev/null 2>&1; then pass "${*}"; else fail "${*} (expected true)" "0" "1"; fi; }
+assert_false() { if "$@" >/dev/null 2>&1; then fail "${*} (expected false)" "1" "0"; else pass "${*} → false"; fi; }
+
+# Build a sandbox with a chosen tracker kind so tracker_kind (→ _forge_kind_for)
+# resolves gh or glab. Copies the extraction lib + tracker lib + config libs.
+make_sandbox() {
+  local kind="${1:-gh}" sb
+  sb=$(mktemp -d); sb=$(cd "$sb" && pwd -P)
+  mkdir -p "$sb/.claude/hooks" "$sb/bin"
+  touch "$sb/onboarding.yaml"
+  cp "$EXTRACT_LIB"   "$sb/.claude/hooks/_lib-extract-pr.sh"
+  cp "$TRACKER_LIB"   "$sb/.claude/hooks/_lib-tracker.sh"
+  cp "$CONFIG_LIB"    "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$PORTFOLIO_LIB" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  [ -f "$OPSROOT_LIB" ] && cp "$OPSROOT_LIB" "$sb/.claude/hooks/_lib-ops-root.sh"
+  printf '{ "tracker": { "kind": "%s" } }\n' "$kind" > "$sb/.claude/project-config.defaults.json"
+  printf 'version: 1\nprojects: []\n' > "$sb/apexyard.projects.yaml"
+  echo "$sb"
+}
+
+# Mock glab: capture argv, print MR/repo JSON for the view subcommands.
+install_glab_mock() {
+  local sb="$1"
+  cat > "$sb/bin/glab" <<'EOF'
+#!/bin/bash
+[ -n "${GLAB_CAPTURE:-}" ] && printf '%s\n' "$@" > "$GLAB_CAPTURE"
+if [ "$1" = "mr" ] && [ "$2" = "view" ]; then
+  echo '{"iid":42,"sha":"glabsha0000000000000000000000000000000042","source_branch":"feature/gl-x","diff_refs":{"head_sha":"glabsha0000000000000000000000000000000042"}}'
+elif [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  echo '{"full_name":"o/r"}'
+fi
+EOF
+  chmod +x "$sb/bin/glab"
+}
+
+# Mock gh: print the field the merge hooks ask for (headRefOid / headRefName / …).
+install_gh_mock() {
+  local sb="$1"
+  cat > "$sb/bin/gh" <<'EOF'
+#!/bin/bash
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  case "$*" in
+    *headRefOid*)     echo "ghsha00000000000000000000000000000000000007" ;;
+    *headRefName*)    echo "main" ;;
+    *headRepository*) echo "o/r" ;;
+    *number*)         echo "7" ;;
+  esac
+fi
+EOF
+  chmod +x "$sb/bin/gh"
+}
+
+# ---------------------------------------------------------------------------
+# Primary sandbox: kind=glab (drives _forge_kind_for → glab for the resolvers).
+SB=$(make_sandbox glab)
+install_glab_mock "$SB"
+install_gh_mock "$SB"
+cd "$SB" || { echo "FAIL: cd sandbox"; exit 1; }
+# shellcheck source=/dev/null
+. "$SB/.claude/hooks/_lib-extract-pr.sh"
+
+# --- is_merge_command: forge shapes ---
+assert_true  is_merge_command "glab mr merge 42 -R o/r --squash"
+assert_true  is_merge_command "gh pr merge 42 --squash"
+assert_true  is_merge_command "gh api repos/o/r/pulls/42/merge -X PUT"
+assert_false is_merge_command "glab mr view 42 -R o/r"
+assert_false is_merge_command "glab mr note 42"
+assert_false is_merge_command "echo not a merge"
+
+# --- extract_pr_number: glab positional iid (no CLI needed) ---
+assert_eq "extract_pr_number glab positional" "42" "$(extract_pr_number 'glab mr merge 42 -R o/r --squash')"
+# redirection must not leak digits (the #568 discipline, glab span)
+assert_eq "extract_pr_number glab positional w/ redirection" "42" "$(extract_pr_number 'glab mr merge 42 -R o/r 2>&1 | tail -5')"
+# glab fallback: no positional → `glab mr view` (mock returns iid 42)
+tracker_clear_cache 2>/dev/null || true
+assert_eq "extract_pr_number glab fallback via glab mr view" "42" "$(PATH="$SB/bin:$PATH" extract_pr_number 'glab mr merge --squash')"
+
+# --- extract_repo_from_command: glab -R flag; glab fallback ---
+assert_eq "extract_repo glab -R flag" "o/r" "$(extract_repo_from_command 'glab mr merge 42 -R o/r --squash')"
+assert_eq "extract_repo glab --repo flag" "o/r" "$(extract_repo_from_command 'glab mr merge 42 --repo o/r')"
+assert_eq "extract_repo glab fallback via glab repo view" "o/r" "$(PATH="$SB/bin:$PATH" extract_repo_from_command 'glab mr merge 42')"
+
+# --- resolve_pr_head / resolve_pr_head_branch: glab path (kind=glab) ---
+tracker_clear_cache 2>/dev/null || true
+assert_eq "resolve_pr_head glab → .sha" "glabsha0000000000000000000000000000000042" \
+  "$(PATH="$SB/bin:$PATH" resolve_pr_head 42 o/r)"
+tracker_clear_cache 2>/dev/null || true
+assert_eq "resolve_pr_head_branch glab → .source_branch" "feature/gl-x" \
+  "$(PATH="$SB/bin:$PATH" resolve_pr_head_branch 42 o/r)"
+
+# --- merge_command_uses_variable: glab $VAR forms (#643 parity) ---
+assert_true  merge_command_uses_variable 'glab mr merge $MR -R o/r'
+assert_true  merge_command_uses_variable 'glab mr merge 42 -R $REPO'
+assert_false merge_command_uses_variable 'glab mr merge 42 -R o/r --squash'
+
+# ---------------------------------------------------------------------------
+# Regression sandbox: kind=gh — the resolvers must take the UNCHANGED gh path.
+SB_GH=$(make_sandbox gh)
+install_glab_mock "$SB_GH"   # present but must NOT be used on the gh path
+install_gh_mock "$SB_GH"
+cd "$SB_GH" || { echo "FAIL: cd gh sandbox"; exit 1; }
+tracker_clear_cache 2>/dev/null || true
+assert_eq "resolve_pr_head gh path unchanged (regression)" "ghsha00000000000000000000000000000000000007" \
+  "$(PATH="$SB_GH/bin:$PATH" resolve_pr_head 7 o/r)"
+tracker_clear_cache 2>/dev/null || true
+assert_eq "resolve_pr_head_branch gh path unchanged (regression)" "main" \
+  "$(PATH="$SB_GH/bin:$PATH" resolve_pr_head_branch 7 o/r)"
+# gh merge shapes still recognised; gh $VAR still detected
+assert_true  is_merge_command "gh pr merge 7 --repo o/r --squash"
+assert_eq "extract_pr_number gh positional (regression)" "7" "$(extract_pr_number 'gh pr merge 7 --repo o/r --squash')"
+assert_true  merge_command_uses_variable 'gh pr merge $PR --repo o/r'
+
+# ---------------------------------------------------------------------------
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -212,6 +212,11 @@
           },
           {
             "type": "command",
+            "if": "Bash(glab api *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-unreviewed-merge.sh\"'"
+          },
+          {
+            "type": "command",
             "if": "Bash(gh pr merge *)",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
           },
@@ -227,6 +232,11 @@
           },
           {
             "type": "command",
+            "if": "Bash(glab api *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
+          },
+          {
+            "type": "command",
             "if": "Bash(gh pr merge *)",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
           },
@@ -238,6 +248,11 @@
           {
             "type": "command",
             "if": "Bash(glab mr merge *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(glab api *)",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
           },
           {
@@ -253,6 +268,11 @@
           {
             "type": "command",
             "if": "Bash(glab mr merge *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/require-architecture-review.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(glab api *)",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/require-architecture-review.sh\"'"
           },
           {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -207,12 +207,22 @@
           },
           {
             "type": "command",
+            "if": "Bash(glab mr merge *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-unreviewed-merge.sh\"'"
+          },
+          {
+            "type": "command",
             "if": "Bash(gh pr merge *)",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
           },
           {
             "type": "command",
             "if": "Bash(gh api *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(glab mr merge *)",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/require-design-review-for-ui.sh\"'"
           },
           {
@@ -223,6 +233,11 @@
           {
             "type": "command",
             "if": "Bash(gh api *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(glab mr merge *)",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-merge-on-red-ci.sh\"'"
           },
           {
@@ -233,6 +248,11 @@
           {
             "type": "command",
             "if": "Bash(gh api *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/require-architecture-review.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(glab mr merge *)",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/require-architecture-review.sh\"'"
           },
           {


### PR DESCRIPTION
## Summary

- **Closes the ungated-merge hole on GitLab forges — both merge shapes.** The merge gates matched only the GitHub merge shapes (`gh pr merge` / `gh api …/merge`) and resolved PR HEAD/branch via `gh pr view`. A `tracker.kind: glab` project merges via GitLab's CLI **and** raw-API — shapes neither the `settings.json` matchers nor `_lib-extract-pr.sh` recognised — so **every merge gate silently failed to fire** on GitLab. This is the exact forge analog of the #47 `gh api` bypass, and the merge-*gate* half of epic #711 (child #764). Both glab shapes are now gated: `glab mr merge <iid>` **and** `glab api projects/<owner>%2F<repo>/merge_requests/<N>/merge` (the raw-API passthrough — the #47 shape, added in the HIGH-1 fix below).
- **`_lib-extract-pr.sh` is now forge-aware.** `is_merge_command` matches both the GitLab CLI-merge and raw-API-merge shapes; `extract_pr_number` and `extract_repo_from_command` parse glab's positional iid, `-R`/`--repo` flag, **and** the raw-API URL (`merge_requests/<N>/merge` iid + the URL-encoded `projects/<owner>%2F<repo>` path, `%2F`/`%2f`-decoded, nested subgroups supported), reusing the same redirection-stripping discipline introduced in #568; `resolve_pr_head` resolves the MR HEAD SHA via `glab mr view --output json` (`.sha`, fallback `.diff_refs.head_sha`); and a new `resolve_pr_head_branch` centralises the head-branch lookup. Forge selection routes through `tracker_kind` (gh + glab coincide with github + gitlab, per #762) — **not** a new `_lib-forge.sh`, per #711's re-scope to extend the tracker lib. The GitHub `--repo` path is unchanged; the shared repo-flag parse additionally honours the `-R` alias (which gh itself accepts) and is **span-fenced** so a trailing unrelated `-R` in a compound command (`… && grep -R …`) can't be mistaken for the merge target — a fail-closed mis-parse would only ever *block*, never bypass. (Thanks Rex for catching the unfenced regex.)
- **The four merge gates now fire on both GitLab merge shapes.** `settings.json` gains `Bash(glab mr merge *)` **and** `Bash(glab api *)` matchers for `block-unreviewed-merge.sh`, `require-design-review-for-ui.sh`, `block-merge-on-red-ci.sh`, and `require-architecture-review.sh` — pairing the glab CLI shape with the glab API shape exactly as the gh side pairs `gh pr merge *` with `gh api *`. This matcher addition is what actually closes the bypass; the lib work makes the gates *correct* once they fire.
- **`block-unreviewed-merge.sh` sync-PR guard** routed through the new `resolve_pr_head_branch` (was an inline `gh pr view --json headRefName`), so the release-sync `--squash` guard is forge-aware too.
- **`merge_command_uses_variable` (#643)** extended to detect an unexpanded `$VAR` in the glab merge span and its `-R $VAR` flag, keeping the "refuse to guess the target" safety parity.

## Testing

```bash
bash .claude/hooks/tests/test_forge_aware_extract_pr.sh   # 37 PASS / 0 FAIL
bash bin/run-hook-tests.sh                                # PASS=77 FAIL=0
```

- `test_forge_aware_extract_pr.sh` (37 assertions) drives the glab paths with a **mocked `glab`** (no live MR): `is_merge_command` recognition of **both** the CLI and raw-API shapes, positional-iid + `-R` extraction, raw-API URL iid + `%2F`/`%2f`/nested-subgroup repo decode, `glab mr view`/`glab repo view` fallbacks, `resolve_pr_head`→`.sha`, `resolve_pr_head_branch`→`.source_branch`, and `$VAR` detection — plus **GitHub regression** cases proving the gh CLI *and* raw-API paths are unchanged. The raw-API detector is verified with three **negative** cases (`/merge_requests/<N>` GET, `/notes`, `/merge_ref`) that prove the trailing `\b` anchor rejects near-misses — a false negative here would be fail-open.
- End-to-end verified against the real `block-unreviewed-merge.sh`: a `glab api …/merge_requests/<N>/merge` command with no approval markers **blocks** (exit 2); a non-merge `glab api …/merge_requests/<N>` GET is a **no-op** (exit 0).
- Auto-discovered by `bin/run-hook-tests.sh` (76 → 77); no manifest edit.

## Scope / verification notes

- **First slice of #764** (the load-bearing gate + the shared primitive), now covering **both** GitLab merge shapes after the HIGH-1 fix. Deliberate follow-ups, each its own PR: glab **pipeline status** for `block-merge-on-red-ci.sh` (`gh pr checks` → `glab ci status`, the fuzziest mapping), and glab **changed-files** for the design + architecture gates (`gh pr diff --name-only` → `glab mr diff`).
- **Not in scope:** `validate-pr-create.sh` + `verify-commit-refs.sh` — those are *issue*-existence checks, already tracker-aware via `tracker_view`, and become glab-aware for free once #760 lands the `tracker_view` glab normaliser. They are the #755/#760/#761 tracker line, not this merge-gate ticket.
- **No new AgDR** — `.claude/hooks/**` + `settings.json` match none of the `require-agdr-for-arch-*` trigger paths; this fills the already-decided AgDR-0072 abstraction pattern (same as #762 / #760).
- **Known ceilings (both pre-existing and symmetric with the gh side, so not fixed here):**
  - **Variable iid inside the raw-API URL** (`glab api …/merge_requests/$MR/merge`): `is_merge_command` requires a literal `[0-9]+` iid, so a `$VAR` iid isn't detected → fail-open when the shell later expands it. This is **identical to the pre-existing gh-api gap** (`gh api …/pulls/$PR/merge` fails open the same way — `merge_command_uses_variable`'s span fences only the `merge` positional/repo-flag, never the api URL, on *either* forge). Fixing it here would break gh/glab parity and expand a gate-critical change beyond review scope; flagged for a symmetric follow-up covering both forges.
  - **Bare `glab mr merge` (no positional)** — same pre-existing gap as bare `gh pr merge` vs `Bash(gh pr merge *)`; worth a follow-up for both forges.
  - **glab verification ceiling** (same as #760 / #762): the glab read paths are verified by CLI-surface inspection + mocks, not a live MR. `glab mr view --output json` exposing `.sha` / `.source_branch` should be confirmed against a live GitLab MR before the follow-up PRs build on it.

## Glossary

| Term | Definition |
|------|------------|
| Forge | The code-hosting / PR-MR platform (GitHub `gh` / GitLab `glab`), distinct from the issue *tracker* though often the same vendor. |
| Merge request (MR) | GitLab's equivalent of a GitHub pull request; merged with the GitLab MR-merge command or the raw-API passthrough. |
| Raw-API merge | Merging via the platform's REST passthrough (`gh api …/pulls/<N>/merge` / `glab api …/merge_requests/<N>/merge`) instead of the CLI porcelain — the shape the #47 incident exploited to bypass the gates. |
| Merge-gate hook | A PreToolUse hook that blocks the merge command until reviews / CI / approvals are satisfied (`block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, `require-design-review-for-ui.sh`, `require-architecture-review.sh`). |
| HEAD-SHA resolution | Reading the PR/MR's current head commit (gh `headRefOid` / glab `.sha`) so approval markers can be matched against the commit being merged. |
| `resolve_pr_head_branch` | `_lib-extract-pr.sh` helper returning the PR/MR source-branch name (gh `.headRefName` / glab `.source_branch`) — used by the sync-PR `--squash` guard. |
| `tracker_kind` | Per-project resolver (`_lib-tracker.sh`) for the configured tool (gh/glab/…); reused here to select the forge CLI. |
| `%2F` decode | GitLab's REST API takes the project as a single URL-encoded path segment (`owner%2Frepo`); the repo extractor decodes `%2F`/`%2f` back to `/` so it matches the marker / `glab mr view -R` form. |

Closes #764
