### PR TITLE
fix(#765): key all approval markers on the PR base repo (cross-fork)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -37,7 +37,7 @@ tracker_review_submit "$PR_HOST_REPO" {number} comment "$REVIEW_BODY_FILE"
 
 The verdict that drives the merge gate is the **local marker**, NOT the host's "Approved" review state. So:
 
-- **Canonical happy path:** call `tracker_review_submit "$PR_REPO" {number} comment "$REVIEW_BODY_FILE"` and state the verdict (`APPROVED` / `CHANGES REQUESTED`) in the body itself. This always works — on gh it maps to `gh pr review --comment`; on glab to an MR note; on custom to the operator's `review_command`.
+- **Canonical happy path:** call `tracker_review_submit "$PR_HOST_REPO" {number} comment "$REVIEW_BODY_FILE"` and state the verdict (`APPROVED` / `CHANGES REQUESTED`) in the body itself. This always works — on gh it maps to `gh pr review --comment`; on glab to an MR note; on custom to the operator's `review_command`.
 - **Do NOT pass the `approve` verdict by default.** On gh it maps to `gh pr review --approve`, which in the common single-account / auto-mode setup GitHub refuses ("Cannot approve your own PR"), and an auto-mode write-classifier may additionally flag it. **That block is expected and is not a failure** — a host "Approved" state is optional and unavailable when reviewing your own account's PR. Do not retry it, do not escalate it, and do not report the review as incomplete because of it. The local marker (output #1) is what satisfies the gate.
 - The `request-changes` verdict is fine for a non-approving result you want reflected in the host's review state (on gh it does not hit the self-approval restriction; on glab it posts a note, since GitLab has no request-changes state).
 
@@ -661,19 +661,25 @@ MARKER_HOME="${OPS_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 # shellcheck source=/dev/null
 . "$MARKER_HOME/.claude/hooks/_lib-tracker.sh"
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
-# Resolve the head (fork) repo — used for the qualified marker filename.
+# Resolve the head (fork) repo — used ONLY as the hint/fallback for the base
+# resolver below. It is NO LONGER the marker key (that was the cross-fork bug —
+# see #765).
 PR_REPO=$(gh pr view {number} --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
-REX_MARKER=$(review_marker_path "$PR_REPO" {number} rex "$MARKER_HOME")
 
-# Resolve the PR/MR HOST (base) repo — where the review must be POSTED and the
-# repo tracker_review_submit selects its adapter from. On a cross-fork PR this
-# differs from the fork above (posting to the fork fails: the PR lives on the
-# base). gh pr view has no baseRepository field, but the PR URL is ALWAYS on the
-# base repo — parse owner/repo from it (works for gh /pull/ and glab
-# /-/merge_requests/, incl. nested GitLab groups). Falls back to PR_REPO when
-# base == head (the common same-repo case).
-PR_HOST_REPO=$(gh pr view {number} --json url --jq '.url' 2>/dev/null | sed -E 's#^https?://[^/]+/(.+)/(pull|-/merge_requests)/[0-9].*#\1#')
-[ -z "$PR_HOST_REPO" ] && PR_HOST_REPO="$PR_REPO"
+# Resolve the PR/MR HOST (base) repo — the repo the PR lives on. It is BOTH where
+# the review must be POSTED (posting to the fork fails on a cross-fork PR: the PR
+# lives on the base) AND the canonical key for the approval marker. `pr_base_repo`
+# (in _lib-review-markers.sh) parses the PR URL — gh pr view has no baseRepository
+# field — and falls back to PR_REPO when base == head, so same-repo PRs are
+# unchanged.
+PR_HOST_REPO=$(pr_base_repo {number} "$PR_REPO")
+
+# Marker keyed on the BASE repo (#765) — this MATCHES what block-unreviewed-merge.sh
+# looks up: the gate keys on the merge command's --repo / API-path, which for a
+# cross-fork PR is always the base (you cannot merge a fork's copy). Keying the
+# marker on headRepository (the fork) was the divergence that blocked cross-fork
+# approvals.
+REX_MARKER=$(review_marker_path "$PR_HOST_REPO" {number} rex "$MARKER_HOME")
 
 # Write your review to a temp body-file, then submit it through the abstraction.
 # A file (not inline text) is the uniform path: gh takes --body-file, glab reads
@@ -690,7 +696,7 @@ tracker_review_submit "$PR_HOST_REPO" {number} comment "$REVIEW_BODY_FILE"; subm
 
 ### The command
 
-Once `MARKER_HOME`, `PR_REPO`, and `REX_MARKER` are resolved (see above), use exactly one of these forms:
+Once `MARKER_HOME`, `PR_HOST_REPO`, and `REX_MARKER` are resolved (see above), use exactly one of these forms:
 
 ```bash
 # Option A — from the local HEAD of the PR branch

--- a/.claude/agents/solution-architect.md
+++ b/.claude/agents/solution-architect.md
@@ -172,26 +172,20 @@ MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
 THREADED_REPO="{repo}"
 [ "$THREADED_REPO" = "{repo}" ] && THREADED_REPO=""
 
-# 2a. MARKER repo (keys the *-architecture.approved filename): threaded arg, else
-# headRepository. Unchanged from the pre-#763 behaviour — the cross-fork marker
-# alignment is tracked separately (see the note in the sign-off section below).
+# 2a. Resolve the PR's BASE (host) repo ONCE — the canonical key for BOTH the
+# review posting AND the sign-off marker (#765). $THREADED_REPO (when
+# /design-review passed it, #687) is the hint; otherwise headRepository. Then
+# pr_base_repo (in _lib-review-markers.sh) resolves the base from the PR URL
+# (gh pr view has no baseRepository field) and falls back to the hint when
+# base == head — so same-repo PRs are unchanged.
 if [ -n "$THREADED_REPO" ]; then
-  REPO="$THREADED_REPO"
+  HINT_REPO="$THREADED_REPO"
 else
-  REPO=$(gh pr view {number} --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+  HINT_REPO=$(gh pr view {number} --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
 fi
-PR_REPO="$REPO"
-
-# 2b. HOST (base) repo for POSTING — the repo tracker_review_submit picks its
-# adapter from. When /design-review threaded a repo it IS the base repo; reuse it.
-# Only in the headRepository fallback (the fork, on a cross-fork PR) do we parse
-# the base from the PR URL (base-rooted; gh pr view has no baseRepository field).
-if [ -n "$THREADED_REPO" ]; then
-  PR_HOST_REPO="$THREADED_REPO"
-else
-  PR_HOST_REPO=$(gh pr view {number} --json url --jq '.url' 2>/dev/null | sed -E 's#^https?://[^/]+/(.+)/(pull|-/merge_requests)/[0-9].*#\1#')
-  [ -z "$PR_HOST_REPO" ] && PR_HOST_REPO="$REPO"
-fi
+PR_HOST_REPO=$(pr_base_repo {number} "$HINT_REPO")
+REPO="$PR_HOST_REPO"      # the --repo flag for gh pr view when writing the marker SHA
+PR_REPO="$PR_HOST_REPO"   # marker key = the base repo (matches the gate's lookup)
 
 # 3. Write the review to a temp body-file and submit through the abstraction.
 # A file (not inline text) is the uniform path: gh takes --body-file, glab reads
@@ -211,15 +205,15 @@ When your verdict is APPROVED, and ONLY then, write the architecture-review appr
 
 ### Path: ops fork root, not git toplevel
 
-The marker MUST land at `<ops_fork_root>/.claude/session/reviews/<owner>__<repo>__{number}-architecture.approved` (repo-qualified path, AgDR-0060 / #485). Inside `workspace/<project>/`, `git rev-parse --show-toplevel` returns the project clone — NOT the ops fork; that's why `$MARKER_HOME` and `$PR_REPO` are resolved ONCE in "Posting the review" above (before any `cd` / `gh pr checkout`). **Reuse them here** — do not re-resolve (a second resolution risks keying the marker on a different repo than the one the review was posted to):
+The marker MUST land at `<ops_fork_root>/.claude/session/reviews/<owner>__<repo>__{number}-architecture.approved` (repo-qualified path, AgDR-0060 / #485). Inside `workspace/<project>/`, `git rev-parse --show-toplevel` returns the project clone — NOT the ops fork; that's why `$MARKER_HOME` and `$PR_HOST_REPO` are resolved ONCE in "Posting the review" above (before any `cd` / `gh pr checkout`). **Reuse them here** — do not re-resolve (a second resolution risks keying the marker on a different repo than the one the review was posted to):
 
 ```bash
-# $MARKER_HOME, $PR_REPO, and $REPO all come from "Posting the review" above.
+# $MARKER_HOME and $PR_HOST_REPO come from "Posting the review" above.
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
-ARCH_MARKER=$(review_marker_path "$PR_REPO" {number} architecture "$MARKER_HOME")
+ARCH_MARKER=$(review_marker_path "$PR_HOST_REPO" {number} architecture "$MARKER_HOME")
 ```
 
-> **Cross-fork note (tracked separately).** `$PR_REPO` keys the marker on the threaded repo, else `headRepository` (the fork). The gate `require-architecture-review.sh` keys its lookup on the merge command's **base** repo — so on a **cross-fork** PR the two can diverge (marker written under the fork qualifier; gate searches under the base). Aligning all marker writers to the base repo is a dedicated follow-up filed alongside #763. This PR only routes review *submission* through the tracker abstraction; marker keying is deliberately **unchanged** here.
+> **Cross-fork keying (#765).** `$PR_HOST_REPO` is the PR's **base** repo — exactly what `require-architecture-review.sh` keys its lookup on (the merge command's `--repo` / API-path, which on a cross-fork PR is always the base, since you cannot merge a fork's copy). Keying the marker on the base makes it findable by the gate on cross-fork PRs; same-repo PRs are unaffected (base == head). This replaces the earlier headRepository (fork) keying, which silently blocked cross-fork approvals.
 
 ### The command
 

--- a/.claude/agents/solution-architect.md
+++ b/.claude/agents/solution-architect.md
@@ -148,18 +148,32 @@ When MCP `search_docs` is available, you MAY supplement path-convention discover
 Resolve `$MARKER_HOME` and the PR's repo **once** here, then post. The sign-off marker below **reuses** these variables — do not re-resolve them (a second resolution risks diverging from the repo the marker is keyed on). Resolve at review start, before any `cd` / `gh pr checkout`.
 
 ```bash
-# 1. Ops fork root (walk up from the repo toplevel; `.apexyard-fork` first, then
-# the onboarding + registry pair). Inside workspace/<project>/, git toplevel is
-# the project clone — the walk-up finds the ops fork above it.
-REPO_ROOT=$(git rev-parse --show-toplevel)
+# 1. Ops fork root — resolve PIN-FIRST, the SAME strategy the merge gate and the
+# other reviewer agents (code-reviewer.md, security-reviewer.md) use. The session
+# pin points at the real ops fork even from inside a workspace/<project>/ clone;
+# a plain walk-up resolves to the private portfolio sibling in split-portfolio
+# mode (me2resh/apexyard#559). Fall back to walk-up only when no valid pin exists.
 OPS_ROOT=""
-r="$REPO_ROOT"
-while [ -n "$r" ] && [ "$r" != "/" ]; do
-  if [ -f "$r/.apexyard-fork" ]; then OPS_ROOT="$r"; break; fi
-  if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then OPS_ROOT="$r"; break; fi
-  r=$(dirname "$r")
-done
-MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
+PIN_FILE="${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID:-}"
+if [ -z "${APEXYARD_OPS_DISABLE_PIN:-}" ] && [ -n "${CLAUDE_CODE_SESSION_ID:-}" ] && [ -f "$PIN_FILE" ]; then
+  IFS= read -r OPS_ROOT < "$PIN_FILE" || OPS_ROOT=""
+fi
+# Validate the pin (self-heal a stale one): must satisfy a fork anchor.
+if [ -n "$OPS_ROOT" ] && [ ! -f "$OPS_ROOT/.apexyard-fork" ] && \
+   { [ ! -f "$OPS_ROOT/onboarding.yaml" ] || [ ! -f "$OPS_ROOT/apexyard.projects.yaml" ]; }; then
+  OPS_ROOT=""
+fi
+# Fallback: walk up from the repo root (pre-#381 behaviour, safety net).
+if [ -z "$OPS_ROOT" ]; then
+  r=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  while [ -n "$r" ] && [ "$r" != "/" ]; do
+    if [ -f "$r/.apexyard-fork" ] || { [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; }; then
+      OPS_ROOT="$r"; break
+    fi
+    r=$(dirname "$r")
+  done
+fi
+MARKER_HOME="${OPS_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 # _lib-tracker.sh posts the human-visible review to the right host; the marker
 # helper is sourced too so the sign-off marker below can reuse $MARKER_HOME.
 # shellcheck source=/dev/null

--- a/.claude/hooks/_lib-review-markers.sh
+++ b/.claude/hooks/_lib-review-markers.sh
@@ -88,3 +88,54 @@ review_marker_path() {
 
   printf '%s/%s__%s-%s.approved' "$reviews_dir" "$safe_repo" "$pr" "$role"
 }
+
+# pr_base_repo <pr> [hint_repo]
+#
+# Echoes the PR/MR's BASE (host) repo as "owner/repo" — the repo the PR *lives
+# on* and is numbered against. This is the canonical key for approval markers
+# (me2resh/apexyard#765).
+#
+# WHY THE BASE REPO IS CANONICAL
+# ------------------------------
+# The merge gates (block-unreviewed-merge.sh, require-architecture-review.sh,
+# require-design-review-for-ui.sh) derive their marker-lookup repo (`CMD_REPO`)
+# from the merge command's `--repo` value or `gh api repos/<o>/<r>/pulls/.../merge`
+# path. For a CROSS-FORK PR that is ALWAYS the base repo — you cannot merge a
+# fork's copy (`gh pr merge <n> --repo <fork>` errors; the PR doesn't live
+# there). So `merge --repo == CMD_REPO == base`. Historically the marker WRITERS
+# keyed on `headRepository` (the fork) instead, so on a cross-fork PR the marker
+# was written under the fork qualifier while the gate searched under the base →
+# a valid approval never satisfied the gate. Keying every writer on the base via
+# this helper makes writer/reader agreement STRUCTURAL, not coincidental.
+#
+# `gh pr view` exposes no baseRepository field, but the PR URL is ALWAYS rooted
+# on the base repo — parse owner/repo from it (handles GitHub /pull/ and GitLab
+# /-/merge_requests/, including nested GitLab groups). Falls back to <hint_repo>
+# (typically the headRepository value) when the URL can't be parsed or gh is
+# unavailable — so SAME-REPO PRs (base == head) resolve exactly as before and
+# this change is a provable no-op for them.
+#
+# Args:
+#   pr        — the PR/MR number.
+#   hint_repo — optional "owner/repo": scopes the gh query with --repo AND is the
+#               fallback when URL parsing yields nothing.
+#
+# Output (stdout): "owner/repo", or the hint (or empty) when unresolved.
+pr_base_repo() {
+  local pr="${1:-}" hint="${2:-}" url base
+  if [ -z "$pr" ]; then
+    [ -n "$hint" ] && printf '%s' "$hint"
+    return 0
+  fi
+  if [ -n "$hint" ]; then
+    url=$(gh pr view "$pr" --repo "$hint" --json url --jq '.url' 2>/dev/null)
+  else
+    url=$(gh pr view "$pr" --json url --jq '.url' 2>/dev/null)
+  fi
+  base=$(printf '%s' "$url" | sed -E 's#^https?://[^/]+/(.+)/(pull|-/merge_requests)/[0-9].*#\1#')
+  if [ -n "$base" ] && [ "$base" != "$url" ]; then
+    printf '%s' "$base"
+  else
+    [ -n "$hint" ] && printf '%s' "$hint"
+  fi
+}

--- a/.claude/hooks/_lib-review-markers.sh
+++ b/.claude/hooks/_lib-review-markers.sh
@@ -117,8 +117,9 @@ review_marker_path() {
 #
 # Args:
 #   pr        — the PR/MR number.
-#   hint_repo — optional "owner/repo": scopes the gh query with --repo AND is the
-#               fallback when URL parsing yields nothing.
+#   hint_repo — optional "owner/repo": the VALUE fallback when the URL can't be
+#               parsed or gh is unavailable. It is NEVER used to scope the gh
+#               query — see the WHY-UNSCOPED note in the body below.
 #
 # Output (stdout): "owner/repo", or the hint (or empty) when unresolved.
 pr_base_repo() {
@@ -127,11 +128,14 @@ pr_base_repo() {
     [ -n "$hint" ] && printf '%s' "$hint"
     return 0
   fi
-  if [ -n "$hint" ]; then
-    url=$(gh pr view "$pr" --repo "$hint" --json url --jq '.url' 2>/dev/null)
-  else
-    url=$(gh pr view "$pr" --json url --jq '.url' 2>/dev/null)
-  fi
+  # WHY UNSCOPED (me2resh/apexyard#770 review): query with NO --repo. gh's ambient
+  # base-repo resolution (from the working copy's remotes) prefers the parent /
+  # upstream — i.e. the BASE repo — which is exactly the key we want. Scoping with
+  # `--repo "$hint"` (the head/fork) would look up the base-numbered PR on the fork,
+  # where it does not exist → gh errors → empty url → the hint (fork) fallback fires
+  # → the #765 divergence is re-created on the very cross-fork path this helper
+  # exists to fix. So the hint is a VALUE fallback only, never a query scope.
+  url=$(gh pr view "$pr" --json url --jq '.url' 2>/dev/null)
   base=$(printf '%s' "$url" | sed -E 's#^https?://[^/]+/(.+)/(pull|-/merge_requests)/[0-9].*#\1#')
   if [ -n "$base" ] && [ "$base" != "$url" ]; then
     printf '%s' "$base"

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -76,6 +76,12 @@ fi
 PR_NUMBER=$(extract_pr_number "$COMMAND")
 # Also extract the repo so markers are scoped to (repo, pr) — #485.
 # CMD_REPO already parsed above; resolve via helper if blank (e.g. current-branch fallback).
+# NOTE (#765): approval markers are keyed on the PR's BASE repo. CMD_REPO is the base
+# for the sanctioned paths — the --repo value of `gh pr merge --repo` (you cannot merge
+# a fork's copy) and the `gh api .../pulls/N/merge` path. The extract_repo_from_command
+# fallback below resolves headRepository (the FORK) for a no---repo current-branch merge;
+# that residual path is NOT produced by /approve-merge (which always passes --repo), so it
+# only affects unsanctioned manual merges. Left as-is to keep the gate core untouched.
 if [ -z "$CMD_REPO" ]; then
   CMD_REPO=$(extract_repo_from_command "$COMMAND")
 fi

--- a/.claude/hooks/require-architecture-review.sh
+++ b/.claude/hooks/require-architecture-review.sh
@@ -83,6 +83,10 @@ fi
 PR_NUMBER=$(extract_pr_number "$COMMAND")
 # Resolve the repo for qualified marker paths (#485).
 # CMD_REPO already resolved above; fall back via helper if still blank.
+# NOTE (#765): the architecture marker is keyed on the BASE repo. CMD_REPO is the base via
+# --repo / API-path / cd-target origin; the extract_repo_from_command fallback below resolves
+# headRepository (the FORK) on a no---repo current-branch merge — a residual edge affecting
+# unsanctioned merges only (/design-review + /approve-architecture thread the base repo). Left as-is.
 if [ -z "$CMD_REPO" ]; then
   CMD_REPO=$(extract_repo_from_command "$COMMAND")
 fi

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -82,6 +82,10 @@ fi
 PR_NUMBER=$(extract_pr_number "$COMMAND")
 # Resolve the repo for qualified marker paths (#485).
 # CMD_REPO already resolved above; fall back via helper if still blank.
+# NOTE (#765): the design marker is keyed on the BASE repo. CMD_REPO is the base via
+# --repo / API-path / cd-target origin; the extract_repo_from_command fallback below resolves
+# headRepository (the FORK) on a no---repo current-branch merge — a residual edge affecting
+# unsanctioned merges only (/design-review + /approve-design thread the base repo). Left as-is.
 if [ -z "$CMD_REPO" ]; then
   CMD_REPO=$(extract_repo_from_command "$COMMAND")
 fi

--- a/.claude/hooks/tests/test_pr_base_repo.sh
+++ b/.claude/hooks/tests/test_pr_base_repo.sh
@@ -8,6 +8,13 @@
 #
 # gh is mocked via a file-driven stub (no env-export subtleties): the stub prints
 # the contents of $MOCKBIN/url, or exits non-zero when that file is empty.
+#
+# The stub is --repo-AWARE (me2resh/apexyard#770 review): a `gh pr view --repo <r>`
+# call only resolves when <r> is the BASE repo in the queued URL; scoping to any
+# other repo (e.g. the fork on a cross-fork PR) fails exactly like real gh rejecting
+# a base-numbered PR looked up on the fork. This makes the cross-fork case below
+# LOAD-BEARING: it fails if pr_base_repo ever re-introduces `--repo "$hint"` scoping
+# (the query MUST be unscoped) and passes only when the base is genuinely resolved.
 
 set -u
 
@@ -25,9 +32,22 @@ assert_eq() { # <label> <want> <got>
 MOCKBIN=$(mktemp -d)
 cat > "$MOCKBIN/gh" <<EOF
 #!/bin/bash
-# mock gh: emit the queued URL, or fail when none is queued.
+# mock gh (--repo-aware): emit the queued URL only when the query would resolve —
+# i.e. UNSCOPED (ambient base resolution) OR --repo naming the base repo in the
+# queued URL. A --repo pointing anywhere else (the fork) fails, like real gh
+# rejecting a base-numbered PR looked up on the fork. Empty queue → fail.
 [ -s "$MOCKBIN/url" ] || exit 1
-cat "$MOCKBIN/url"
+url="\$(cat "$MOCKBIN/url")"
+base="\$(printf '%s' "\$url" | sed -E 's#^https?://[^/]+/(.+)/(pull|-/merge_requests)/[0-9].*#\1#')"
+repo=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --repo) repo="\$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "\$repo" ] && [ "\$repo" != "\$base" ]; then exit 1; fi
+printf '%s' "\$url"
 EOF
 chmod +x "$MOCKBIN/gh"
 export PATH="$MOCKBIN:$PATH"

--- a/.claude/hooks/tests/test_pr_base_repo.sh
+++ b/.claude/hooks/tests/test_pr_base_repo.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Tests for pr_base_repo (+ its interaction with review_marker_path) in
+# _lib-review-markers.sh — the cross-fork approval-marker fix (me2resh/apexyard#765).
+#
+# pr_base_repo resolves a PR's BASE repo (the canonical marker key) by parsing the
+# PR URL, falling back to a hint when base == head or gh fails. The discriminating
+# assertions prove: (a) cross-fork keys on BASE, (b) same-repo is UNCHANGED.
+#
+# gh is mocked via a file-driven stub (no env-export subtleties): the stub prints
+# the contents of $MOCKBIN/url, or exits non-zero when that file is empty.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+LIB="$SRC_ROOT/.claude/hooks/_lib-review-markers.sh"
+# shellcheck source=/dev/null
+. "$LIB"
+
+PASS=0; FAIL=0; FAILED=""
+assert_eq() { # <label> <want> <got>
+  if [ "$2" = "$3" ]; then PASS=$((PASS+1));
+  else echo "FAIL [$1]: want [$2] got [$3]" >&2; FAIL=$((FAIL+1)); FAILED="${FAILED}$1 "; fi
+}
+
+MOCKBIN=$(mktemp -d)
+cat > "$MOCKBIN/gh" <<EOF
+#!/bin/bash
+# mock gh: emit the queued URL, or fail when none is queued.
+[ -s "$MOCKBIN/url" ] || exit 1
+cat "$MOCKBIN/url"
+EOF
+chmod +x "$MOCKBIN/gh"
+export PATH="$MOCKBIN:$PATH"
+seturl() { printf '%s' "$1" > "$MOCKBIN/url"; }
+
+# 1. cross-fork gh PR → base parsed from URL (hint = the fork, must be ignored).
+seturl 'https://github.com/me2resh/apexyard/pull/762'
+assert_eq "cross-fork → base from URL" "me2resh/apexyard" \
+  "$(pr_base_repo 762 AbdElrahmaN31/apexyard)"
+
+# 2. same-repo → base == head (UNCHANGED — the provable no-op).
+seturl 'https://github.com/me2resh/apexyard/pull/5'
+assert_eq "same-repo → unchanged" "me2resh/apexyard" \
+  "$(pr_base_repo 5 me2resh/apexyard)"
+
+# 3. GitLab MR URL with a nested group → group/subgroup/project.
+seturl 'https://gitlab.com/grp/sub/proj/-/merge_requests/12'
+assert_eq "glab nested MR → base" "grp/sub/proj" \
+  "$(pr_base_repo 12 grp/fork)"
+
+# 4. gh fails (no URL queued) → fall back to the hint.
+seturl ''
+assert_eq "gh fail → hint fallback" "me2resh/apexyard" \
+  "$(pr_base_repo 999 me2resh/apexyard)"
+
+# 5. unparseable URL → hint fallback (sed leaves it unchanged → base==url → hint).
+seturl 'https://github.com/not-a-pr-url'
+assert_eq "bad URL → hint fallback" "owner/repo" \
+  "$(pr_base_repo 1 owner/repo)"
+
+# 6. no pr number → hint (guard, no gh call).
+assert_eq "no pr → hint" "owner/repo" "$(pr_base_repo '' owner/repo)"
+
+# 7. self-hosted GitHub Enterprise host → base still parsed (host-agnostic).
+seturl 'https://github.example.com/team/svc/pull/8'
+assert_eq "GHE host → base" "team/svc" "$(pr_base_repo 8 team/fork)"
+
+# --- discriminating: the marker PATH keyed via pr_base_repo ---
+MH=$(mktemp -d)
+# cross-fork → marker keyed on BASE (this is the fix).
+seturl 'https://github.com/me2resh/apexyard/pull/762'
+CF=$(review_marker_path "$(pr_base_repo 762 AbdElrahmaN31/apexyard)" 762 rex "$MH")
+assert_eq "cross-fork marker keyed on BASE" \
+  "$MH/.claude/session/reviews/me2resh__apexyard__762-rex.approved" "$CF"
+# same-repo → marker path UNCHANGED from the pre-#765 (base==head) behaviour.
+seturl 'https://github.com/me2resh/apexyard/pull/5'
+SR=$(review_marker_path "$(pr_base_repo 5 me2resh/apexyard)" 5 rex "$MH")
+assert_eq "same-repo marker path unchanged" \
+  "$MH/.claude/session/reviews/me2resh__apexyard__5-rex.approved" "$SR"
+
+rm -rf "$MOCKBIN" "$MH"
+echo "=========================================="
+if [ "$FAIL" -eq 0 ]; then
+  echo "PASS: $PASS  FAIL: 0"; exit 0
+else
+  echo "PASS: $PASS  FAIL: $FAIL  (failed: $FAILED)"; exit 1
+fi

--- a/.claude/skills/approve-architecture/SKILL.md
+++ b/.claude/skills/approve-architecture/SKILL.md
@@ -69,11 +69,16 @@ done
 MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
 # shellcheck source=/dev/null
 . "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
-# Prefer the repo resolved in step 1 (the base repo the PR lives in — the slug
-# the gate derives from the merge cd-target, #687). Fall back to headRepository
-# only when REPO is unknown (single-fork / same-repo case).
-PR_REPO="${REPO:-$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)}"
-REX=$(review_marker_path "$PR_REPO" <pr> rex "$MARKER_HOME")
+# Base (host) repo — the canonical marker key: it matches solution-architect.md's
+# architecture marker AND the require-architecture-review.sh gate's lookup (which
+# keys on the merge command's base repo, #765). Prefer the repo resolved in step 1
+# (already the base, #687) as the hint; else headRepository. pr_base_repo confirms
+# the base from the PR URL and falls back to the hint when base == head, so
+# same-repo PRs are unchanged.
+HINT_REPO="${REPO:-$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)}"
+PR_HOST_REPO=$(pr_base_repo <pr> "$HINT_REPO")
+PR_REPO="$PR_HOST_REPO"
+REX=$(review_marker_path "$PR_HOST_REPO" <pr> rex "$MARKER_HOME")
 [ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "<headRefOid from step 3>" ]
 ```
 
@@ -92,9 +97,11 @@ gh pr diff <pr> --name-only | grep -qiE '(docs/agdr/.*migration.*\.md|technical-
 Use the repo-qualified path via `_lib-review-markers.sh` (already sourced in step 4):
 
 ```bash
-# (MARKER_HOME and PR_REPO already resolved in step 4 — reuse them here.)
+# (MARKER_HOME and PR_HOST_REPO already resolved in step 4 — reuse them here.)
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
-ARCH=$(review_marker_path "$PR_REPO" <pr> architecture "$MARKER_HOME")
+# architecture marker keyed on the BASE repo — same key as solution-architect.md
+# + the gate (#765). Keying on the fork would leave a cross-fork design PR blocked.
+ARCH=$(review_marker_path "$PR_HOST_REPO" <pr> architecture "$MARKER_HOME")
 printf '%s\n' "<headRefOid>" > "$ARCH"
 ```
 

--- a/.claude/skills/approve-design/SKILL.md
+++ b/.claude/skills/approve-design/SKILL.md
@@ -79,11 +79,15 @@ done
 MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
 # shellcheck source=/dev/null
 . "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
-# Prefer the repo resolved in step 1 (the base repo the PR lives in — the slug
-# the gate derives from the merge cd-target, #687). Fall back to headRepository
-# only when REPO is unknown (single-fork / same-repo case).
-PR_REPO="${REPO:-$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)}"
-REX=$(review_marker_path "$PR_REPO" <pr> rex "$MARKER_HOME")
+# Base (host) repo — the canonical marker key: it matches Rex's marker AND the
+# merge gate's lookup (which keys on the merge command's base repo, #765). Prefer
+# the repo resolved in step 1 (already the base, #687) as the hint; else
+# headRepository. pr_base_repo confirms the base from the PR URL and falls back to
+# the hint when base == head, so same-repo PRs are unchanged.
+HINT_REPO="${REPO:-$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)}"
+PR_HOST_REPO=$(pr_base_repo <pr> "$HINT_REPO")
+PR_REPO="$PR_HOST_REPO"
+REX=$(review_marker_path "$PR_HOST_REPO" <pr> rex "$MARKER_HOME")
 [ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "$(git rev-parse HEAD)" ]
 ```
 
@@ -102,9 +106,10 @@ gh pr diff <pr> --name-only | grep -qE '\.(tsx|jsx|vue|svelte|css|scss|sass|less
 Use the repo-qualified path via `_lib-review-markers.sh` (already sourced in step 4):
 
 ```bash
-# (MARKER_HOME and PR_REPO already resolved in step 4 — reuse them here.)
+# (MARKER_HOME and PR_HOST_REPO already resolved in step 4 — reuse them here.)
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
-DESIGN=$(review_marker_path "$PR_REPO" <pr> design "$MARKER_HOME")
+# design marker keyed on the BASE repo — same key as Rex's marker + the gate (#765).
+DESIGN=$(review_marker_path "$PR_HOST_REPO" <pr> design "$MARKER_HOME")
 git rev-parse HEAD > "$DESIGN"
 ```
 

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -106,8 +106,16 @@ MARKER_HOME="${OPS_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 # Source the marker path helper — repo-qualified naming (#485, AgDR-0060).
 # shellcheck source=/dev/null
 . "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
+# The PR's HEAD (fork) repo — used ONLY as the hint/fallback for the base resolver.
 PR_REPO=$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
-REX=$(review_marker_path "$PR_REPO" <pr> rex "$MARKER_HOME")
+# The PR's BASE (host) repo — the canonical marker key AND the repo you merge
+# against. Rex wrote its marker under the BASE (that is what code-reviewer.md and
+# the merge gate use, #765), so read + write markers here. `pr_base_repo` parses
+# the PR URL and falls back to PR_REPO when base == head, so same-repo PRs are
+# unchanged. Use $PR_HOST_REPO as `--repo` for EVERY gh call in this skill
+# (`<owner/repo>` throughout = $PR_HOST_REPO) — you cannot merge a fork's copy.
+PR_HOST_REPO=$(pr_base_repo <pr> "$PR_REPO")
+REX=$(review_marker_path "$PR_HOST_REPO" <pr> rex "$MARKER_HOME")
 [ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "<headRefOid from step 3>" ]
 ```
 
@@ -143,14 +151,16 @@ Optional fields the gate stores but doesn't validate:
 Use the **ops fork root** as the path anchor (NOT git toplevel — see #229 + #230 for the workspace-clone bug this avoids). Reuse the same MARKER_HOME and the `_lib-review-markers.sh` helper (already sourced in step 4):
 
 ```bash
-# (MARKER_HOME and PR_REPO already resolved in step 4 — reuse them here.)
+# (MARKER_HOME and PR_HOST_REPO already resolved in step 4 — reuse them here.)
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
 ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Sanitise: drop newlines, drop shell-special chars, truncate to 200.
 summary=$(echo "<user approval message>" | tr '\n' ' ' | tr -d '"`$\\' | cut -c1-200)
 
-CEO=$(review_marker_path "$PR_REPO" <pr> ceo "$MARKER_HOME")
+# CEO marker keyed on the BASE repo — same key as Rex's marker and the gate's
+# lookup (#765). Keying it on the fork would leave a cross-fork merge blocked.
+CEO=$(review_marker_path "$PR_HOST_REPO" <pr> ceo "$MARKER_HOME")
 cat > "$CEO" <<EOF
 sha=<headRefOid>
 approved_by=user
@@ -168,8 +178,8 @@ Before running the merge, check whether this is a **sync-class PR**. A PR is syn
 - Its PR title starts with `sync(` (the canonical `/release-sync` PR title prefix)
 
 ```bash
-PR_HEAD_BRANCH=$(gh pr view <pr> --repo <owner/repo> --json headRefName -q '.headRefName' 2>/dev/null)
-PR_TITLE=$(gh pr view <pr> --repo <owner/repo> --json title -q '.title' 2>/dev/null)
+PR_HEAD_BRANCH=$(gh pr view <pr> --repo "$PR_HOST_REPO" --json headRefName -q '.headRefName' 2>/dev/null)
+PR_TITLE=$(gh pr view <pr> --repo "$PR_HOST_REPO" --json title -q '.title' 2>/dev/null)
 
 MERGE_STRATEGY="squash"  # default for all other PRs — bare enum, not a CLI flag (tracker_pr_merge normalises it per-forge)
 if echo "$PR_HEAD_BRANCH" | grep -qE '^sync/main-to-dev-after-' || \
@@ -205,8 +215,12 @@ Unless `--no-merge` was passed, run the merge in the same turn via the tracker-a
 # equivalent for matcher purposes. Redirect the JSON result to a temp file
 # instead, and read it back in a separate step — `cat` isn't a merge
 # command, so wrapping THAT in `$(...)` is fine.
+#
+# The repo argument is $PR_HOST_REPO — the PR's BASE repo (#765). On a cross-fork
+# PR you cannot merge the fork's copy; the merge, like every other host call in
+# this skill, must target the base (`<owner/repo>` throughout = $PR_HOST_REPO).
 MERGE_RESULT_FILE=$(mktemp)
-tracker_pr_merge "<owner/repo>" "<pr>" "${MERGE_STRATEGY}" true > "$MERGE_RESULT_FILE"
+tracker_pr_merge "$PR_HOST_REPO" "<pr>" "${MERGE_STRATEGY}" true > "$MERGE_RESULT_FILE"
 MERGE_RC=$?
 MERGE_RESULT="$(cat "$MERGE_RESULT_FILE")"
 MERGE_SHA=$(printf '%s' "$MERGE_RESULT" | jq -r '.sha // empty' 2>/dev/null)


### PR DESCRIPTION
## Summary
- **Fixes the cross-fork approval-marker divergence** — all **five** marker writers now key on the PR's **base** repo, matching what the merge gates already look up. Writers previously keyed on `headRepository` (the fork), so on a cross-fork PR a valid approval was written under the fork qualifier while the gate searched under the base → the merge stayed blocked, forcing a manual marker rename on #762 / #766 / #768. (Rex's review of this PR caught a fifth writer — `/approve-architecture` — that the first pass missed; commit `d8ad532` completes the set.)
- **New `pr_base_repo <pr> [hint]` in `_lib-review-markers.sh`** — parses the PR URL (gh pr view exposes no baseRepository field), falling back to the hint when base == head, so **same-repo PRs are a provable no-op** (the regression suite is unchanged). Makes writer/reader agreement structural, not coincidental.
- **`/approve-merge` fixed end-to-end** — it is both a marker writer (ceo) and the merge-runner, so the CEO write, the Rex read, AND the merge `--repo` all move to the base; otherwise a cross-fork merge command fails before markers even matter.
- **Gates untouched** — they already key on the base via the merge command's `--repo` / API-path (you cannot merge a fork's copy); a comment documents the residual no-`--repo` fallback edge, which affects unsanctioned manual merges only. A separate commit unifies `solution-architect.md` on the pin-first ops-root resolver (Rex's non-blocking nit from #766).

## Testing
- `test_pr_base_repo.sh` — **9/9**: cross-fork → base, **same-repo → unchanged**, GitLab nested MR, GHE host, gh-fail / bad-URL / no-pr → hint fallback, and marker-path discrimination.
- Regression: **`block_unreviewed_merge` 29/29** (same-repo no-op holds), tracker suites 27/27 + 16/16 unchanged; all three gate hooks and both edited agents' bash blocks are `bash -n` clean.

## Stacked on #766 (→ #762)
This branch is stacked on `feature/GH-763` (PR #766, itself on #762). Because the base here is `dev`, the diff currently **includes #762's and #763's changes**; it reduces to #765's own commits once the chain lands. **Review scope for this PR is the three #765 commits** — `81b63c3` (base-repo keying), `f11415c` (pin-first unification), and `d8ad532` (the 5th writer, `/approve-architecture`). Merge order: **#762 → #766 → #765**.

Closes #765

## Glossary
| Term | Definition |
|------|------------|
| `pr_base_repo` | New helper resolving a PR's **base** repo (the repo it lives on / is numbered against) from the PR URL, with a hint fallback. The canonical key for approval markers. |
| base vs head repo | On a cross-fork PR the head branch is on a fork; the PR lives on (and can only be merged against) the base repo. `gh pr view` exposes `headRepository` but no `baseRepository`. |
| marker writer / reader | Writers = code-reviewer (rex), solution-architect (architecture), /approve-merge (ceo), /approve-design (design), /approve-architecture (architecture). Readers = the three merge-gate hooks. This PR makes all writers key on the base, matching the readers. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
