### PR TITLE
feat(#709): route remaining creator skills + label helper through tracker abstraction

### DIFF
--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -624,11 +624,12 @@ tracker_create() {
 #   Color is accepted as a bare hex ("FBCA04", the gh convention); the glab
 #   adapter normalises it to "#FBCA04" (GitLab wants the leading #).
 #
-# Adapters: gh + glab do a real create. jira / linear / asana / custom / none
-#   are no-ops — tracker_create has no create adapter for them (the dispatch
-#   defaults to gh), so a label step for those trackers is out of scope. (GitLab
-#   additionally auto-creates a label when it is first applied on issue-create,
-#   so the glab path is a convenience, not a correctness requirement.)
+# Adapters: gh + glab do a real create. jira / linear / asana / none have no
+#   built-in gh/glab label CLI here, and `custom` files issues via the operator's
+#   own create_command (which handles labels its own way) — so all of them are
+#   no-ops; a generic label-ensure step doesn't apply. (GitLab additionally
+#   auto-creates a label when it is first applied on issue-create, so even the
+#   glab path is a convenience, not a correctness requirement.)
 # ------------------------------------------------------------------------------
 
 # Internal adapter: gh → `gh label create <name>` (name is positional).

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -608,6 +608,71 @@ tracker_create() {
 }
 
 # ------------------------------------------------------------------------------
+# Label ensure (tracker_label_ensure) — #709 creator-sweep companion to
+# tracker_create.
+#
+# A few creator skills (/spike, /prototype, /investigation) depend on a trigger
+# label (spike / prototype / investigation) existing on the target repo so
+# downstream hooks can read it and apply their workflow exemptions. On GitHub
+# that label must be created explicitly; tracker_label_ensure is the
+# tracker-agnostic analog of that inline `gh label create` step.
+#
+# Contract: tracker_label_ensure <owner/repo> <name> [<color>] [<description>]
+#   BEST-EFFORT by design — ALWAYS returns 0. A missing/duplicate/errored label
+#   must never abort the subsequent tracker_create (the same "swallow the
+#   duplicate" semantics the inline `gh label create … || true` calls had).
+#   Color is accepted as a bare hex ("FBCA04", the gh convention); the glab
+#   adapter normalises it to "#FBCA04" (GitLab wants the leading #).
+#
+# Adapters: gh + glab do a real create. jira / linear / asana / custom / none
+#   are no-ops — tracker_create has no create adapter for them (the dispatch
+#   defaults to gh), so a label step for those trackers is out of scope. (GitLab
+#   additionally auto-creates a label when it is first applied on issue-create,
+#   so the glab path is a convenience, not a correctness requirement.)
+# ------------------------------------------------------------------------------
+
+# Internal adapter: gh → `gh label create <name>` (name is positional).
+_tracker_label_ensure_gh() {
+  local repo="$1" name="$2" color="$3" desc="$4"
+  local -a args
+  args=(label create "$name" --repo "$repo")
+  [ -n "$color" ] && args+=(--color "$color")
+  [ -n "$desc" ]  && args+=(--description "$desc")
+  gh "${args[@]}" >/dev/null 2>&1 || true
+}
+
+# Internal adapter: glab → `glab label create --name <name>`. GitLab wants the
+# colour as "#RRGGBB"; normalise a bare-hex input by prepending '#'.
+_tracker_label_ensure_glab() {
+  local repo="$1" name="$2" color="$3" desc="$4"
+  local -a args
+  args=(label create --name "$name" -R "$repo")
+  if [ -n "$color" ]; then
+    case "$color" in \#*) : ;; *) color="#$color" ;; esac
+    args+=(--color "$color")
+  fi
+  [ -n "$desc" ] && args+=(--description "$desc")
+  glab "${args[@]}" >/dev/null 2>&1 || true
+}
+
+# Public: tracker_label_ensure <owner/repo> <name> [<color>] [<description>]
+tracker_label_ensure() {
+  local repo="$1" name="${2:-}" color="${3:-}" desc="${4:-}"
+  # Nothing actionable without a repo + name — never abort the caller.
+  if [ -z "$repo" ] || [ -z "$name" ]; then
+    return 0
+  fi
+  local kind
+  kind=$(tracker_kind "$repo")
+  case "$kind" in
+    gh)   _tracker_label_ensure_gh   "$repo" "$name" "$color" "$desc" ;;
+    glab) _tracker_label_ensure_glab "$repo" "$name" "$color" "$desc" ;;
+    *)    : ;;  # jira / linear / asana / custom / none — no-op
+  esac
+  return 0
+}
+
+# ------------------------------------------------------------------------------
 # GitHub-Issues-enabled detection (#653, AgDR-0071)
 #
 # GitHub disables Issues on forks by default, so a fresh github-kind fork will

--- a/.claude/hooks/tests/test_tracker_create.sh
+++ b/.claude/hooks/tests/test_tracker_create.sh
@@ -214,6 +214,117 @@ else
   echo "SKIP: tracker_create custom per-project case (no yq / python3+PyYAML)"
 fi
 
+# ---------------------------------------------------------------------------
+# tracker_label_ensure (#709) — the tracker-agnostic analog of the inline
+# `gh label create` steps used by /spike, /prototype, /investigation.
+#
+# Contract: best-effort, ALWAYS exit 0. gh + glab do a real create; every other
+# kind (jira/linear/asana/custom/none) is a no-op. gh takes a BARE-hex colour
+# ("FBCA04"); glab normalises it to "#FBCA04".
+# ---------------------------------------------------------------------------
+
+# Case 6 — gh: `label create <name> --repo <repo>` with a BARE-hex colour.
+SBL=$(make_sandbox)
+cat > "$SBL/bin/gh" <<'EOF'
+#!/bin/bash
+[ -n "${GH_CAPTURE:-}" ] && printf '%s\n' "$@" > "$GH_CAPTURE"
+EOF
+chmod +x "$SBL/bin/gh"
+(
+  cd "$SBL" || exit 1
+  # shellcheck source=/dev/null
+  . "$SBL/.claude/hooks/_lib-tracker.sh"
+  tracker_clear_cache
+  PATH="$SBL/bin:$PATH" GH_CAPTURE="$SBL/cap" tracker_label_ensure "o/r" "spike" "FBCA04" "Throw-away exploration"
+  echo "rc=$?"
+) > "$SBL/rc"
+gh_cap="$SBL/cap"
+assert_eq "tracker_label_ensure gh → exit 0"                 "0"    "$(sed -n 's/^rc=//p' "$SBL/rc")"
+assert_eq "tracker_label_ensure gh → 'label create' subcmd"  "spike" "$(awk 'p{print;exit} /^create$/{p=1}' "$gh_cap")"
+assert_eq "tracker_label_ensure gh → --repo passed"          "o/r"  "$(awk 'p{print;exit} /^--repo$/{p=1}' "$gh_cap")"
+assert_eq "tracker_label_ensure gh → colour is BARE hex (no #)" "FBCA04" "$(awk 'p{print;exit} /^--color$/{p=1}' "$gh_cap")"
+
+# A gh that errors (e.g. duplicate label) must STILL leave tracker_label_ensure at exit 0.
+cat > "$SBL/bin/gh" <<'EOF'
+#!/bin/bash
+exit 22
+EOF
+chmod +x "$SBL/bin/gh"
+(
+  cd "$SBL" || exit 1
+  # shellcheck source=/dev/null
+  . "$SBL/.claude/hooks/_lib-tracker.sh"; tracker_clear_cache
+  PATH="$SBL/bin:$PATH" tracker_label_ensure "o/r" "spike" "FBCA04" "d"; echo "rc=$?"
+) > "$SBL/rc2"
+assert_eq "tracker_label_ensure gh error (dup) → still exit 0" "0" "$(sed -n 's/^rc=//p' "$SBL/rc2")"
+
+# Empty repo / name → no-op, exit 0, no CLI call.
+(
+  cd "$SBL" || exit 1
+  # shellcheck source=/dev/null
+  . "$SBL/.claude/hooks/_lib-tracker.sh"; tracker_clear_cache
+  tracker_label_ensure "" "spike"; echo "rc_norepo=$?"
+  tracker_label_ensure "o/r" "";     echo "rc_noname=$?"
+) > "$SBL/rc3"
+assert_eq "tracker_label_ensure empty repo → exit 0 (no-op)" "0" "$(sed -n 's/^rc_norepo=//p' "$SBL/rc3")"
+assert_eq "tracker_label_ensure empty name → exit 0 (no-op)" "0" "$(sed -n 's/^rc_noname=//p' "$SBL/rc3")"
+rm -rf "$SBL"
+
+# Case 7 — glab: `label create --name <name> -R <repo>` with a #-prefixed colour.
+if [ "$HAVE_YAML" = yes ]; then
+  SBLG=$(make_sandbox "version: 1
+projects:
+  - name: gl
+    repo: g/p
+    tracker:
+      kind: glab")
+  cat > "$SBLG/bin/glab" <<'EOF'
+#!/bin/bash
+[ -n "${GLAB_CAPTURE:-}" ] && printf '%s\n' "$@" > "$GLAB_CAPTURE"
+EOF
+  chmod +x "$SBLG/bin/glab"
+  (
+    cd "$SBLG" || exit 1
+    # shellcheck source=/dev/null
+    . "$SBLG/.claude/hooks/_lib-tracker.sh"; tracker_clear_cache
+    PATH="$SBLG/bin:$PATH" GLAB_CAPTURE="$SBLG/cap" tracker_label_ensure "g/p" "spike" "FBCA04" "d"; echo "rc=$?"
+  ) > "$SBLG/rc"
+  glab_cap="$SBLG/cap"
+  assert_eq "tracker_label_ensure glab → exit 0"                  "0"      "$(sed -n 's/^rc=//p' "$SBLG/rc")"
+  assert_eq "tracker_label_ensure glab → --name passed"           "spike"  "$(awk 'p{print;exit} /^--name$/{p=1}' "$glab_cap")"
+  assert_eq "tracker_label_ensure glab → -R (repo) passed"        "g/p"    "$(awk 'p{print;exit} /^-R$/{p=1}' "$glab_cap")"
+  assert_eq "tracker_label_ensure glab → colour normalised to #hex" "#FBCA04" "$(awk 'p{print;exit} /^--color$/{p=1}' "$glab_cap")"
+  rm -rf "$SBLG"
+
+  # Case 8 — a non-gh/glab tracker (jira) → no-op, exit 0, NO CLI on PATH is called.
+  SBLJ=$(make_sandbox "version: 1
+projects:
+  - name: jr
+    repo: j/r
+    tracker:
+      kind: jira")
+  # Put a booby-trapped gh/glab on PATH; a no-op must not invoke either.
+  for c in gh glab; do
+    cat > "$SBLJ/bin/$c" <<EOF
+#!/bin/bash
+touch "$SBLJ/CALLED_$c"
+EOF
+    chmod +x "$SBLJ/bin/$c"
+  done
+  (
+    cd "$SBLJ" || exit 1
+    # shellcheck source=/dev/null
+    . "$SBLJ/.claude/hooks/_lib-tracker.sh"; tracker_clear_cache
+    PATH="$SBLJ/bin:$PATH" tracker_label_ensure "j/r" "spike" "FBCA04" "d"; echo "rc=$?"
+  ) > "$SBLJ/rc"
+  called=no; { [ -e "$SBLJ/CALLED_gh" ] || [ -e "$SBLJ/CALLED_glab" ]; } && called=yes
+  assert_eq "tracker_label_ensure jira → exit 0 (no-op)"        "0"  "$(sed -n 's/^rc=//p' "$SBLJ/rc")"
+  assert_eq "tracker_label_ensure jira → no gh/glab invoked"    "no" "$called"
+  rm -rf "$SBLJ"
+else
+  echo "SKIP: tracker_label_ensure glab + jira per-project cases (no yq / python3+PyYAML)"
+fi
+
 echo "=========================================="
 echo "PASS: $PASS  FAIL: $FAIL"
 if [ "$FAIL" -gt 0 ]; then printf "Failed:%b\n" "$FAILED"; exit 1; fi

--- a/.claude/skills/investigation/SKILL.md
+++ b/.claude/skills/investigation/SKILL.md
@@ -232,31 +232,59 @@ livedoc_path="$livedoc_dir/${date_prefix}-${slug}.md"
 
 Substitute the gathered values into the resolved template and write the file via the `Write` tool. The Metadata block at the bottom of the file references the GitHub issue number — leave it as `#{NNN}` until step 8, then patch it.
 
-### 8. Create the GitHub Issue
+### 8. Create the issue (via the tracker abstraction)
+
+Dispatch creation through `tracker_create` (#670 / AgDR-0072, extended by the
+#709 creator sweep) so the investigation lands in **this project's** tracker —
+GitHub, GitLab, or a `custom` CLI — per its `tracker:` block in
+`apexyard.projects.yaml`. For a GitHub adopter this runs `gh issue create`
+exactly as before.
 
 ```bash
-gh issue create --repo {owner/repo} \
-  --title "[Investigation] {slug}" \
-  --label "investigation" \
-  --body "{rendered template body, with the Metadata block pointing at the live-doc path}"
+# Resolve the tracker lib (it lives in the ops fork's hooks dir) by walking up
+# from the cwd; source it.
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
+# Ensure the `investigation` trigger label exists on the target tracker.
+# Best-effort (tracker_label_ensure always exits 0).
+tracker_label_ensure "{owner/repo}" "investigation" "5319E7" "Sustained root-cause work — closes when Follow-up actions land, not on PR merge"
+
+# Pass the body via a file (arbitrary markdown — never inline-interpolated).
+body_file="$(mktemp)"
+cat > "$body_file" <<'BODY'
+{rendered template body, with the Metadata block pointing at the live-doc path}
+BODY
+
+# tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
+result="$(tracker_create "{owner/repo}" "[Investigation] {slug}" "$body_file" "investigation")"
+rc=$?
+rm -f "$body_file"
+if [ "$rc" -eq 3 ]; then
+  echo "Tracker is 'none' (shape-only) — nothing was created in a tracker." >&2
+  echo "File this in your external system (e.g. Jira/Linear via MCP):" >&2
+  printf '%s\n' "$result"
+  exit 0
+elif [ "$rc" -ne 0 ] || [ -z "$result" ]; then
+  echo "Investigation creation failed — check the tracker CLI / auth. Nothing was created." >&2
+  exit 1
+fi
+
+ref="$(printf '%s' "$result" | jq -r '.ref')"
+url="$(printf '%s' "$result" | jq -r '.url')"
 ```
 
-Capture the issue number from the URL `gh` returns; patch the live-doc's Metadata block to replace `#{NNN}` with the real number.
-
-If the `investigation` label doesn't exist on the target repo, create it idempotently:
-
-```bash
-gh label create investigation \
-  --color "5319E7" \
-  --description "Sustained root-cause work — closes when Follow-up actions land, not on PR merge" \
-  --repo {owner/repo} 2>/dev/null || true
-```
+Use `$ref` to patch the live-doc's Metadata block — replace the `#{NNN}`
+placeholder with the real reference.
 
 ### 9. Return paths + next steps
 
 ```
-Created: {owner/repo}#{number} — [Investigation] {slug}
-{url}
+Created: {owner/repo}#${ref} — [Investigation] {slug}
+${url}
 
 Live-doc: {livedoc_path}
 

--- a/.claude/skills/investigation/SKILL.md
+++ b/.claude/skills/investigation/SKILL.md
@@ -234,8 +234,8 @@ Substitute the gathered values into the resolved template and write the file via
 
 ### 8. Create the issue (via the tracker abstraction)
 
-Dispatch creation through `tracker_create` (#670 / AgDR-0072, extended by the
-#709 creator sweep) so the investigation lands in **this project's** tracker —
+Dispatch creation through `tracker_create` (#670 / AgDR-0072, extended by
+the #709 creator sweep) so the investigation lands in **this project's** tracker —
 GitHub, GitLab, or a `custom` CLI — per its `tracker:` block in
 `apexyard.projects.yaml`. For a GitHub adopter this runs `gh issue create`
 exactly as before.

--- a/.claude/skills/migration/SKILL.md
+++ b/.claude/skills/migration/SKILL.md
@@ -215,36 +215,67 @@ migration-gate hook (`require-migration-ticket.sh`) verifies the
 `migration` label is present before allowing edits to migration files.
 ```
 
-Create via:
+Create via the tracker abstraction (`tracker_create`, #670 / AgDR-0072, extended
+by the #709 creator sweep) so the ticket lands in **this project's** tracker —
+GitHub, GitLab, or a `custom` CLI — per its `tracker:` block in
+`apexyard.projects.yaml`. For a GitHub adopter this runs `gh issue create`
+exactly as before.
 
 ```bash
-gh issue create \
-  --repo "<owner/repo>" \
-  --title "[Migration] <type>: <summary>" \
-  --label "migration" \
-  --label "<priority>" \
-  --body "$BODY"
+# Resolve the tracker lib (it lives in the ops fork's hooks dir) by walking up
+# from the cwd; source it.
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
+# $BODY was assembled above; hand it to tracker_create via a file (arbitrary
+# markdown — never inline-interpolated). Labels pass as a comma-separated list.
+body_file="$(mktemp)"
+printf '%s\n' "$BODY" > "$body_file"
+
+# tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
+result="$(tracker_create "<owner/repo>" "[Migration] <type>: <summary>" "$body_file" "migration,<priority>")"
+rc=$?
+rm -f "$body_file"
+if [ "$rc" -eq 3 ]; then
+  echo "Tracker is 'none' (shape-only) — nothing was created in a tracker." >&2
+  echo "File this in your external system (e.g. Jira/Linear via MCP):" >&2
+  printf '%s\n' "$result"
+  exit 0
+elif [ "$rc" -ne 0 ] || [ -z "$result" ]; then
+  echo "Migration ticket creation failed — check the tracker CLI / auth. Nothing was created." >&2
+  exit 1
+fi
+
+# Capture the reference + URL for the AgDR back-fill below.
+ref="$(printf '%s' "$result" | jq -r '.ref')"
+url="$(printf '%s' "$result" | jq -r '.url')"
 ```
 
-Capture the returned URL and issue number.
+The `migration` label is what `require-migration-ticket.sh` reads to gate edits
+to migration files (Gate 3a). On GitHub it must already exist on the repo; on
+GitLab it is auto-created when first applied.
 
 ### 6. Back-fill the AgDR with the issue reference
 
-Open the AgDR written in step 4 and update:
+Open the AgDR written in step 4 and update (using the `ref` / `url` captured
+above):
 
-- Frontmatter `ticket: <owner/repo>#<number>`
-- The Artifacts section: add the ticket URL
+- Frontmatter `ticket: <owner/repo>#${ref}`
+- The Artifacts section: add the ticket `${url}`
 
 This lets a future reader land on the AgDR and find the ticket, and land on the ticket and find the AgDR.
 
 ### 7. Return a summary
 
-Single-line output:
+Single-line output (using the `ref` / `url` captured above):
 
 ```
-Migration ticket: <ticket-url>
+Migration ticket: ${url}
 Migration AgDR:   <relative-path-to-AgDR>
-Next step:        run /start-ticket <owner/repo>#<number>, then begin editing the migration files
+Next step:        run /start-ticket <owner/repo>#${ref}, then begin editing the migration files
 ```
 
 **Do NOT automatically run `/start-ticket`** — the user may have other context to set first, and the explicit handoff makes the workflow legible. The migration gate will block edits until the marker points at this ticket.

--- a/.claude/skills/plan-initiative/SKILL.md
+++ b/.claude/skills/plan-initiative/SKILL.md
@@ -366,7 +366,7 @@ Accept:
 
 #### Pass 1 — file each accepted milestone
 
-Write the active-issue-skill marker so `require-skill-for-issue-create.sh` lets the `gh issue create` calls through (per AgDR-0030):
+Write the active-issue-skill marker so `require-skill-for-issue-create.sh` lets the `tracker_create` calls (a `gh issue create` on a GitHub adopter) through (per AgDR-0030):
 
 ```bash
 # Resolve the ops-fork root the SAME way the hooks do (_lib-ops-root.sh):
@@ -407,22 +407,50 @@ _Source: /plan-initiative on YYYY-MM-DD — see `projects/<name>/initiatives/<sl
 
 Same source-link shape as `/handover` step 7.5 — plain prose path, no markdown link. The initiative doc lives in the ops fork (or private sibling), not in the target repo's URL space; a relative markdown link would be dead-on-render. See AgDR-0051 § Axis 3.
 
-File each via `gh issue create`:
+File each via `tracker_create` (#670 / AgDR-0072, extended by the #709 creator
+sweep) so milestones land in **this project's** tracker — GitHub, GitLab, or a
+`custom` CLI. For a GitHub adopter this runs `gh issue create` exactly as before.
 
 ```bash
-gh issue create --repo "$repo" \
-  --title "[Feature] {milestone-name}" \
-  --label "enhancement,${priority:-P2}" \
-  --body "$body"
+# Resolve + source the tracker lib ONCE, before the pass-1 loop, by walking up from cwd.
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
+# ── per milestone ────────────────────────────────────────────────────────────
+body_file="$(mktemp)"
+printf '%s\n' "$body" > "$body_file"
+# tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
+result="$(tracker_create "$repo" "[Feature] {milestone-name}" "$body_file" "enhancement,${priority:-P2}")"
+rc=$?
+rm -f "$body_file"
+if [ "$rc" -ne 0 ] || [ -z "$result" ]; then
+  : # stop pass 1 — see failure handling below (rc=3 = tracker.kind=none: nothing filed)
+fi
+ref="$(printf '%s' "$result" | jq -r '.ref // empty')"
 ```
 
-Capture the returned issue number from `gh issue create`'s output (the URL contains it, or use `--json url -q '.url'`). Record `milestone_name → issue_number` in an in-memory map for pass 2.
+Capture the returned `ref` (from `tracker_create`'s normalised `{ref,url}` — no
+more URL-parsing). Record `milestone_name → ref` in an in-memory map for pass 2
+(the map now holds tracker references, so a non-numeric tracker key like `LIN-42`
+works unchanged — do not do arithmetic on it).
 
 On non-zero exit, stop pass 1 immediately. Use the same failure-handling shape as `/tickets-batch` § "Failure handling" (4 options: Retry, Skip, Edit, Abort; don't roll back filed tickets on abort).
 
 #### Pass 2 — add cross-references to each filed ticket
 
-Iterate over the just-filed set. For each filed milestone:
+Iterate over the just-filed set. For each filed milestone (`$issue_number` below
+is the tracker `ref` recorded in pass 1's map):
+
+> **Scope note (#709):** the pass-2 cross-ref edit uses `gh issue view` /
+> `gh issue edit` — issue *reads* and *body updates*, which are the read/update
+> axis, **not** creation. The #709 creator sweep converts only the creation call
+> (pass 1); the body-edit here stays on `gh` and is tracker-agnosticised
+> separately (read-side + update axis, tracked in #710 and the forge work). On a
+> non-GitHub project pass 1 files the milestones fine, but this cross-ref pass is
+> a no-op until that follow-up lands.
 
 1. Compute its inbound + outbound DAG edges restricted to the also-filed set.
 2. Build the cross-ref lines:
@@ -505,7 +533,7 @@ Next:
 8. **Idempotence via filed-marker presence.** Re-runs partition milestones into "already filed" (silently skipped at filing step) vs "unfiled" (offered). Step 6's regeneration MUST preserve prior `Filed as [#N](url)` markers — match milestones across runs by name (case-insensitive, normalised whitespace). NOT byte-equivalence on the section (which would break under the post-filing rewrite). Same rule as `/handover` Rule 18.
 9. **Two-pass filing handles cross-refs.** Pass 1 files all accepted milestones (no cross-refs yet — issue numbers not yet known). Pass 2 iterates over the filed set, computes per-milestone cross-refs restricted to the also-filed subset, and rewrites each ticket's body via `gh issue edit`. Pass-2 failures don't abort — partial cross-refs are more useful than zero.
 10. **Source-link every filed ticket back to the initiative doc.** Each filed Feature ticket carries a `_Source: /plan-initiative on YYYY-MM-DD — see projects/<name>/initiatives/<slug>.md in the ops fork (...)_` footer in the body. Plain prose path, no markdown link — the initiative doc isn't in the target repo's URL space. Same shape as `/handover` step 7.5's source-link convention.
-11. **Active-issue-skill marker handling.** Write `plan-initiative` to `<ops_root>/.claude/session/active-issue-skill` before the first `gh issue create` in pass 1; remove on EVERY exit path (success, abort, error). Per AgDR-0030.
+11. **Active-issue-skill marker handling.** Write `plan-initiative` to `<ops_root>/.claude/session/active-issue-skill` before the first `tracker_create` (a `gh issue create` on a GitHub adopter) in pass 1; remove on EVERY exit path (success, abort, error). Per AgDR-0030.
 12. **No bootstrap exemption needed.** The skill writes `*.md` (exempt from `require-active-ticket.sh`) and dispatches `gh` calls (gated separately by `require-skill-for-issue-create.sh`, satisfied by the active-issue-skill marker in step 8 pass 1). Don't add `plan-initiative` to `ticket.bootstrap_skills`.
 13. **Re-run history is append-only.** Each invocation adds one row to the table at the bottom of the doc. Don't truncate; long histories are evidence the initiative is being actively re-planned.
 14. **Out-of-scope items belong in the Anti-scope section.** When the operator names something during the interview as "we considered this but no", capture it in the doc's `## Anti-scope` block. Mirrors `templates/architecture/vision.md` § Anti-scope.

--- a/.claude/skills/prototype-close/SKILL.md
+++ b/.claude/skills/prototype-close/SKILL.md
@@ -126,28 +126,58 @@ What is NOT being carried over from the prototype artifact:
 {or "—"}
 ```
 
-After confirmation, create the issue:
+After confirmation, create the follow-up feature via the tracker abstraction
+(`tracker_create`, #670 / AgDR-0072, extended by the #709 creator sweep) so it
+lands in **this project's** tracker. For a GitHub adopter this runs
+`gh issue create` exactly as before.
 
 ```bash
-gh issue create --repo {owner/repo} \
-  --title "[Feature] {title}" \
-  --label "enhancement" \
-  --body "{body}"
+# Resolve the tracker lib (it lives in the ops fork's hooks dir) by walking up
+# from the cwd; source it.
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
+body_file="$(mktemp)"
+cat > "$body_file" <<'BODY'
+{body}
+BODY
+
+# tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
+result="$(tracker_create "{owner/repo}" "[Feature] {title}" "$body_file" "enhancement")"
+rc=$?
+rm -f "$body_file"
+if [ "$rc" -eq 3 ]; then
+  echo "Tracker is 'none' (shape-only) — nothing was created in a tracker." >&2
+  printf '%s\n' "$result"
+  exit 0
+elif [ "$rc" -ne 0 ] || [ -z "$result" ]; then
+  echo "Follow-up creation failed — check the tracker CLI / auth. Nothing was created." >&2
+  exit 1
+fi
+
+ref="$(printf '%s' "$result" | jq -r '.ref')"   # the new feature's reference
+url="$(printf '%s' "$result" | jq -r '.url')"
 ```
 
-Capture the new issue number, then close the prototype with a cross-ref comment:
+Then close the prototype with a cross-ref comment. (Closing stays on `gh` here —
+issue *state transitions* are out of scope for the #709 creation sweep; a
+tracker-agnostic close/state primitive is separate follow-up work. On a
+non-GitHub project, close the prototype manually.)
 
 ```bash
 gh issue close {prototype-number} --repo {owner/repo} \
-  --comment "Prototype disposition: PROMOTE. Follow-up filed as #{new-number} — {feature-title}. Prototype artifact is NOT being lifted into production; the new feature work re-implements the chosen direction recorded above."
+  --comment "Prototype disposition: PROMOTE. Follow-up filed as #${ref} — {feature-title}. Prototype artifact is NOT being lifted into production; the new feature work re-implements the chosen direction recorded above."
 ```
 
 Return both URLs:
 
 ```
 Prototype closed: {owner/repo}#{prototype-number}
-Follow-up:        {owner/repo}#{new-number} — {feature-title}
-                  {url}
+Follow-up:        {owner/repo}#${ref} — {feature-title}
+                  ${url}
 ```
 
 #### 3b. DISCARD — one question, then write a memo

--- a/.claude/skills/prototype/SKILL.md
+++ b/.claude/skills/prototype/SKILL.md
@@ -221,26 +221,67 @@ Create this ticket? (yes / edit / cancel)
 - **edit** / **change X** → ask what to change, update, re-show
 - **cancel** / **no** → abort
 
-### 7. Create the GitHub Issue
+### 7. Create the issue (via the tracker abstraction)
+
+Dispatch creation through `tracker_create` (#670 / AgDR-0072, extended by the
+#709 creator sweep) so the prototype lands in **this project's** tracker —
+GitHub, GitLab, or a `custom` CLI — per its `tracker:` block in
+`apexyard.projects.yaml`. For a GitHub adopter this runs `gh issue create`
+exactly as before.
 
 ```bash
-gh issue create --repo {owner/repo} \
-  --title "[Prototype] {title}" \
-  --label "prototype" \
-  --body "{formatted body}"
+# Resolve the tracker lib (it lives in the ops fork's hooks dir) by walking up
+# from the cwd; source it.
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
+# Ensure the `prototype` trigger label exists on the target tracker. Best-effort
+# (tracker_label_ensure always exits 0). Same mechanism `/spike` uses with the
+# `spike` label — downstream hooks read it to apply the workflow exemptions.
+tracker_label_ensure "{owner/repo}" "prototype" "C5DEF5" "Throw-away UX/demo prototype; exempt from AgDR + coverage gates"
+
+# Pass the body via a file (arbitrary markdown — never inline-interpolated).
+body_file="$(mktemp)"
+cat > "$body_file" <<'BODY'
+{formatted body}
+BODY
+
+# tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
+result="$(tracker_create "{owner/repo}" "[Prototype] {title}" "$body_file" "prototype")"
+rc=$?
+rm -f "$body_file"
+if [ "$rc" -eq 3 ]; then
+  echo "Tracker is 'none' (shape-only) — nothing was created in a tracker." >&2
+  echo "File this in your external system (e.g. Jira/Linear via MCP):" >&2
+  printf '%s\n' "$result"
+  exit 0
+elif [ "$rc" -ne 0 ] || [ -z "$result" ]; then
+  echo "Prototype creation failed — check the tracker CLI / auth. Nothing was created." >&2
+  exit 1
+fi
+
+ref="$(printf '%s' "$result" | jq -r '.ref')"
+url="$(printf '%s' "$result" | jq -r '.url')"
 ```
 
-The `prototype` label is the trigger that downstream hooks (AgDR-required hooks, coverage gates) read to apply the workflow exemptions — the same mechanism `/spike` uses with the `spike` label. If the label doesn't exist on the target repo, the skill will create it via `gh label create prototype --color "C5DEF5" --description "Throw-away UX/demo prototype; exempt from AgDR + coverage gates"` (idempotent — `gh label create` errors on duplicate, the skill swallows that).
+The `prototype` label is the trigger that downstream hooks (AgDR-required hooks,
+coverage gates) read to apply the workflow exemptions — the same mechanism
+`/spike` uses with the `spike` label.
 
 ### 8. Return the URL + branch suggestion
 
+Use the `ref` / `url` parsed from `tracker_create` in step 7:
+
 ```
-Created: {owner/repo}#{number} — {title}
-{url}
+Created: {owner/repo}#${ref} — {title}
+${url}
 
 When you start work:
-  /start-ticket {owner/repo}#{number}
-  git checkout -b prototype/GH-{number}-{slug}
+  /start-ticket {owner/repo}#${ref}
+  git checkout -b prototype/GH-${ref}-{slug}
 ```
 
 ### 9. Remind the operator about the disposition gate

--- a/.claude/skills/prototype/SKILL.md
+++ b/.claude/skills/prototype/SKILL.md
@@ -223,8 +223,8 @@ Create this ticket? (yes / edit / cancel)
 
 ### 7. Create the issue (via the tracker abstraction)
 
-Dispatch creation through `tracker_create` (#670 / AgDR-0072, extended by the
-#709 creator sweep) so the prototype lands in **this project's** tracker —
+Dispatch creation through `tracker_create` (#670 / AgDR-0072, extended by
+the #709 creator sweep) so the prototype lands in **this project's** tracker —
 GitHub, GitLab, or a `custom` CLI — per its `tracker:` block in
 `apexyard.projects.yaml`. For a GitHub adopter this runs `gh issue create`
 exactly as before.

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -138,17 +138,35 @@ The default milestones are **Now / Next / Later / Done** (Now-Next-Later format)
 
 ## Linking to GitHub Issues
 
-If the user passes `--with-issues`, also create or update GitHub Issues to mirror the roadmap:
+If the user passes `--with-issues`, also create or update tracker issues to
+mirror the roadmap. Dispatch through `tracker_create` (#670 / AgDR-0072,
+extended by the #709 creator sweep) so the issues land in **this project's**
+tracker — GitHub, GitLab, or a `custom` CLI. For a GitHub adopter this runs
+`gh issue create` exactly as before.
 
 ```bash
+# Resolve + source the tracker lib once (before the loop) by walking up from cwd.
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
 # For each item in Now and Next without a GH link in Notes:
-gh issue create \
-  --title "[Roadmap] {item}" \
-  --body "Tracking issue for roadmap item {RM-NNN}" \
-  --label "roadmap,{priority}"
+body_file="$(mktemp)"
+printf 'Tracking issue for roadmap item %s\n' "{RM-NNN}" > "$body_file"
+result="$(tracker_create "{owner/repo}" "[Roadmap] {item}" "$body_file" "roadmap,{priority}")"
+rc=$?
+rm -f "$body_file"
+if [ "$rc" -eq 0 ] && [ -n "$result" ]; then
+  ref="$(printf '%s' "$result" | jq -r '.ref')"
+  # write ${ref} back into the item's Notes column
+fi
 ```
 
-Then write the issue number back into the Notes column.
+Then write the issue reference (`${ref}`) back into the Notes column. (When
+`tracker.kind=none`, `tracker_create` exits 3 and prints the body for external
+filing — skip the Notes back-write in that case.)
 
 ## Output format (show)
 

--- a/.claude/skills/spike-close/SKILL.md
+++ b/.claude/skills/spike-close/SKILL.md
@@ -122,28 +122,58 @@ What is NOT being carried over from the spike branch:
 {or "—"}
 ```
 
-After confirmation, create the issue:
+After confirmation, create the follow-up feature via the tracker abstraction
+(`tracker_create`, #670 / AgDR-0072, extended by the #709 creator sweep) so it
+lands in **this project's** tracker. For a GitHub adopter this runs
+`gh issue create` exactly as before.
 
 ```bash
-gh issue create --repo {owner/repo} \
-  --title "[Feature] {title}" \
-  --label "enhancement" \
-  --body "{body}"
+# Resolve the tracker lib (it lives in the ops fork's hooks dir) by walking up
+# from the cwd; source it.
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
+body_file="$(mktemp)"
+cat > "$body_file" <<'BODY'
+{body}
+BODY
+
+# tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
+result="$(tracker_create "{owner/repo}" "[Feature] {title}" "$body_file" "enhancement")"
+rc=$?
+rm -f "$body_file"
+if [ "$rc" -eq 3 ]; then
+  echo "Tracker is 'none' (shape-only) — nothing was created in a tracker." >&2
+  printf '%s\n' "$result"
+  exit 0
+elif [ "$rc" -ne 0 ] || [ -z "$result" ]; then
+  echo "Follow-up creation failed — check the tracker CLI / auth. Nothing was created." >&2
+  exit 1
+fi
+
+ref="$(printf '%s' "$result" | jq -r '.ref')"   # the new feature's reference
+url="$(printf '%s' "$result" | jq -r '.url')"
 ```
 
-Capture the new issue number, then close the spike with a cross-ref comment:
+Then close the spike with a cross-ref comment. (Closing stays on `gh` here —
+issue *state transitions* are out of scope for the #709 creation sweep; a
+tracker-agnostic close/state primitive is separate follow-up work. On a
+non-GitHub project, close the spike manually.)
 
 ```bash
 gh issue close {spike-number} --repo {owner/repo} \
-  --comment "Spike disposition: PROMOTE. Follow-up filed as #{new-number} — {feature-title}. Spike branch is NOT being lifted into production; the new feature work re-implements based on the findings recorded above."
+  --comment "Spike disposition: PROMOTE. Follow-up filed as #${ref} — {feature-title}. Spike branch is NOT being lifted into production; the new feature work re-implements based on the findings recorded above."
 ```
 
 Return both URLs:
 
 ```
 Spike closed: {owner/repo}#{spike-number}
-Follow-up:    {owner/repo}#{new-number} — {feature-title}
-              {url}
+Follow-up:    {owner/repo}#${ref} — {feature-title}
+              ${url}
 ```
 
 #### 3b. DISCARD — one question, then write a memo

--- a/.claude/skills/spike/SKILL.md
+++ b/.claude/skills/spike/SKILL.md
@@ -210,26 +210,71 @@ Create this ticket? (yes / edit / cancel)
 - **edit** / **change X** → ask what to change, update, re-show
 - **cancel** / **no** → abort
 
-### 7. Create the GitHub Issue
+### 7. Create the issue (via the tracker abstraction)
+
+Dispatch creation through `tracker_create` (#670 / AgDR-0072, extended by the
+#709 creator sweep) so the spike lands in **this project's** tracker — GitHub,
+GitLab, or a `custom` CLI — per its `tracker:` block in `apexyard.projects.yaml`.
+For a GitHub adopter this runs `gh issue create` exactly as before.
 
 ```bash
-gh issue create --repo {owner/repo} \
-  --title "[Spike] {title}" \
-  --label "spike" \
-  --body "{formatted body}"
+# Resolve the tracker lib (it lives in the ops fork's hooks dir) by walking up
+# from the cwd; source it.
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
+# Ensure the `spike` trigger label exists on the target tracker. Best-effort
+# (tracker_label_ensure always exits 0) — a duplicate/missing label never aborts
+# the create. The label is what downstream hooks (AgDR-required hooks, coverage
+# gates) read to apply the spike workflow exemptions.
+tracker_label_ensure "{owner/repo}" "spike" "FBCA04" "Throw-away exploration; exempt from AgDR + coverage gates"
+
+# Pass the body via a file (arbitrary markdown — never inline-interpolated).
+body_file="$(mktemp)"
+cat > "$body_file" <<'BODY'
+{formatted body}
+BODY
+
+# tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
+# It is gated by require-skill-for-issue-create.sh; the active-issue-skill marker
+# written at skill entry keeps this call allowed.
+result="$(tracker_create "{owner/repo}" "[Spike] {title}" "$body_file" "spike")"
+rc=$?
+rm -f "$body_file"
+if [ "$rc" -eq 3 ]; then
+  # tracker.kind=none (shape-only): no tracker to create in. tracker_create
+  # printed the rendered ticket body to stdout — surface it for manual /
+  # external filing instead of a non-existent CLI/auth failure.
+  echo "Tracker is 'none' (shape-only) — nothing was created in a tracker." >&2
+  echo "File this in your external system (e.g. Jira/Linear via MCP):" >&2
+  printf '%s\n' "$result"
+  exit 0
+elif [ "$rc" -ne 0 ] || [ -z "$result" ]; then
+  echo "Spike creation failed — check the tracker CLI / auth. Nothing was created." >&2
+  exit 1
+fi
+
+ref="$(printf '%s' "$result" | jq -r '.ref')"
+url="$(printf '%s' "$result" | jq -r '.url')"
 ```
 
-The `spike` label is the trigger that downstream hooks (AgDR-required hooks, coverage gates) read to apply the workflow exemptions. If the label doesn't exist on the target repo, the skill will create it via `gh label create spike --color "FBCA04" --description "Throw-away exploration; exempt from AgDR + coverage gates"` (idempotent — `gh label create` errors on duplicate, the skill swallows that).
+The `spike` label is the trigger that downstream hooks (AgDR-required hooks,
+coverage gates) read to apply the workflow exemptions.
 
 ### 8. Return the URL + branch suggestion
 
+Use the `ref` / `url` parsed from `tracker_create` in step 7:
+
 ```
-Created: {owner/repo}#{number} — {title}
-{url}
+Created: {owner/repo}#${ref} — {title}
+${url}
 
 When you start work:
-  /start-ticket {owner/repo}#{number}
-  git checkout -b spike/GH-{number}-{slug}
+  /start-ticket {owner/repo}#${ref}
+  git checkout -b spike/GH-${ref}-{slug}
 ```
 
 ### 9. Remind the operator about the disposition gate

--- a/.claude/skills/spike/SKILL.md
+++ b/.claude/skills/spike/SKILL.md
@@ -212,8 +212,8 @@ Create this ticket? (yes / edit / cancel)
 
 ### 7. Create the issue (via the tracker abstraction)
 
-Dispatch creation through `tracker_create` (#670 / AgDR-0072, extended by the
-#709 creator sweep) so the spike lands in **this project's** tracker — GitHub,
+Dispatch creation through `tracker_create` (#670 / AgDR-0072, extended by
+the #709 creator sweep) so the spike lands in **this project's** tracker — GitHub,
 GitLab, or a `custom` CLI — per its `tracker:` block in `apexyard.projects.yaml`.
 For a GitHub adopter this runs `gh issue create` exactly as before.
 

--- a/.claude/skills/tickets-batch/SKILL.md
+++ b/.claude/skills/tickets-batch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tickets-batch
-description: File 5–20 structured tickets in one flow — shared-context Qs once, 3-Q micro-interview per ticket, then per-ticket `gh issue create`.
+description: File 5–20 structured tickets in one flow — shared-context Qs once, 3-Q micro-interview per ticket, then per-ticket `tracker_create` (gh/glab/custom).
 argument-hint: "<optional bulk description>"
 allowed-tools: Bash, Read, Write
 ---
@@ -18,7 +18,7 @@ Flow shape:
   → 1 shared-context Q batch (priority, epic, area-labels, repo)
   → N micro-interviews (≤ 3 Qs each: type, one-line purpose, optional clarification)
   → 1 confirmation
-  → N `gh issue create` calls (one per ticket — never a single batch dump)
+  → N `tracker_create` calls (one per ticket — never a single batch dump)
 ```
 
 ## Path resolution
@@ -231,15 +231,29 @@ Handle the response:
 
 ### 6. File the batch
 
-For each ticket in order, run a **specific `gh issue create`** — one call per ticket, NEVER a single bulk JSON dump. The validator runs per-issue, so per-issue calls are the only conformant shape.
+For each ticket in order, run a **specific `tracker_create` call** — one call per ticket, NEVER a single bulk JSON dump. The validator runs per-issue, so per-issue calls are the only conformant shape. Dispatch through `tracker_create` (#670 / AgDR-0072, extended by the #709 creator sweep) so the tickets land in **this project's** tracker — GitHub, GitLab, or a `custom` CLI. For a GitHub adopter each call runs `gh issue create` exactly as before.
 
 Build the title as `[<Type>] <title>`. Build the body from the inferred sections, ending with the optional `Refs <epic>` line if a parent was set.
 
 ```bash
-gh issue create --repo {owner/repo} \
-  --title "[{Type}] {title}" \
-  --label "{type-label},{priority},{area-labels}" \
-  --body "{formatted body}"
+# Resolve + source the tracker lib ONCE, before the loop, by walking up from cwd.
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
+# ── per ticket ──────────────────────────────────────────────────────────────
+body_file="$(mktemp)"
+cat > "$body_file" <<'BODY'
+{formatted body}
+BODY
+# tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
+result="$(tracker_create "{owner/repo}" "[{Type}] {title}" "$body_file" "{type-label},{priority},{area-labels}")"
+rc=$?
+rm -f "$body_file"
+# rc=3 → tracker.kind=none (shape-only); rc!=0/empty → hard failure (see step 7).
+ref="$(printf '%s' "$result" | jq -r '.ref // empty')"   # e.g. 451 — used in the progress line
 ```
 
 Type-label mapping:
@@ -250,7 +264,7 @@ Type-label mapping:
 | Bug | `bug` |
 | Chore / Refactor / Testing / CI / Docs | (none — type is in title prefix; labels stay area + priority) |
 
-Show progress per call:
+Show progress per call, using the `${ref}` parsed from each `tracker_create`:
 
 ```
 [1/12] Filing "Wire OIDC discovery endpoint"… → owner/repo#451 ✓
@@ -259,19 +273,19 @@ Show progress per call:
 
 ### 7. Failure handling
 
-On the first `gh issue create` non-zero exit, **stop the batch immediately**. Do not silently skip. Show:
+On the first `tracker_create` failure (`rc` non-zero **or** empty `result`), **stop the batch immediately**. Do not silently skip. (A `tracker.kind=none` project returns `rc=3` with the rendered body on stdout — treat that as "shape-only, nothing filed" and stop the batch the same way, telling the operator to file the set in their external system.) Show:
 
 ```
 [5/12] Filing "Migrate user table to new auth schema"… ✗
 
-Error from gh / validator:
+Error from the tracker CLI / validator:
 {stderr — usually the validator's "missing section: Driver" line}
 
 Filed so far: 4 tickets ({owner/repo}#451, #452, #453, #454).
 Remaining: 8 tickets (not filed).
 
 What now?
-1. Retry — re-run the same gh call (use this if the failure was transient)
+1. Retry — re-run the same tracker_create call (use this if the failure was transient)
 2. Skip — drop this ticket, continue with the next 7
 3. Edit — re-interview this ticket and retry
 4. Abort — stop here; the 4 already-filed tickets stay (no rollback)
@@ -362,7 +376,7 @@ As a {persona}, I want {goal} so that {benefit}.
 1. **ASK shared-context questions ONCE** at the start (priority, epic, area-labels, repo). NEVER re-ask them per ticket.
 2. **Per-ticket interview is at most THREE questions**: type, one-line purpose, optional clarification. If the type + purpose yield a confident inference, skip the third question.
 3. **Output conforms to `.ticket.required_sections` by construction.** Never produce a body that the `validate-issue-structure.sh` hook would reject. Every required section is present and non-empty (placeholders allowed); section headers match the schema spelling exactly.
-4. **One `gh issue create` per ticket.** NEVER a single batch-mode JSON dump — the validator runs per-issue and a bulk shape silently bypasses it.
+4. **One `tracker_create` per ticket.** NEVER a single batch-mode JSON dump — the validator runs per-issue and a bulk shape silently bypasses it. (For a GitHub adopter each call is a `gh issue create`.)
 5. **Confirm the full batch BEFORE filing any ticket.** No partial commits-before-confirm. A `cancel` at the summary leaves the tracker untouched.
 6. **On failure mid-batch: stop, surface the validator error, ask the user.** Don't silently skip. Don't roll back. Tell them exactly which tickets did file.
 7. **Cap at 20 tickets per invocation.** Above that, ask the user to split into batches.

--- a/.claude/skills/walking-skeleton/SKILL.md
+++ b/.claude/skills/walking-skeleton/SKILL.md
@@ -243,26 +243,66 @@ Create this ticket? (yes / edit / cancel)
 - **edit** / **change X** → ask what to change, update, re-show
 - **cancel** / **no** → abort
 
-### 7. Create the GitHub Issue
+### 7. Create the issue (via the tracker abstraction)
+
+Dispatch creation through `tracker_create` (#670 / AgDR-0072, extended by the
+#709 creator sweep) so the skeleton lands in **this project's** tracker —
+GitHub, GitLab, or a `custom` CLI — per its `tracker:` block in
+`apexyard.projects.yaml`. For a GitHub adopter this runs `gh issue create`
+exactly as before.
 
 ```bash
-gh issue create --repo {owner/repo} \
-  --title "[Feature] Walking skeleton — {title}" \
-  --label "enhancement" \
-  --body "{formatted body}"
+# Resolve the tracker lib (it lives in the ops fork's hooks dir) by walking up
+# from the cwd; source it.
+tracker_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-tracker.sh" ] && { echo "$r/.claude/hooks/_lib-tracker.sh"; break; }; \
+  r="${r%/*}"; done)"
+# shellcheck source=/dev/null
+. "$tracker_lib"
+
+# Pass the body via a file (arbitrary markdown — never inline-interpolated).
+body_file="$(mktemp)"
+cat > "$body_file" <<'BODY'
+{formatted body}
+BODY
+
+# tracker_create <owner/repo> <title> <body_file> [<labels_csv>] → {"ref","url"}.
+result="$(tracker_create "{owner/repo}" "[Feature] Walking skeleton — {title}" "$body_file" "enhancement")"
+rc=$?
+rm -f "$body_file"
+if [ "$rc" -eq 3 ]; then
+  echo "Tracker is 'none' (shape-only) — nothing was created in a tracker." >&2
+  echo "File this in your external system (e.g. Jira/Linear via MCP):" >&2
+  printf '%s\n' "$result"
+  exit 0
+elif [ "$rc" -ne 0 ] || [ -z "$result" ]; then
+  echo "Walking-skeleton creation failed — check the tracker CLI / auth. Nothing was created." >&2
+  exit 1
+fi
+
+ref="$(printf '%s' "$result" | jq -r '.ref')"
+url="$(printf '%s' "$result" | jq -r '.url')"
 ```
 
-Note: a walking skeleton is filed under the normal feature label (`enhancement` by default) — **NOT** under `spike`. The label matters: there is **no** `walking-skeleton` exemption label, because the skeleton is held to the full SDLC. If your fork uses a different feature label, use that.
+Note: a walking skeleton is filed under the normal feature label (`enhancement`
+by default) — **NOT** under `spike`. The label matters: there is **no**
+`walking-skeleton` exemption label, because the skeleton is held to the full
+SDLC. If your fork uses a different feature label, pass that instead. (No
+`tracker_label_ensure` step here — `enhancement` is a default tracker label, so
+unlike the `spike` / `prototype` / `investigation` trigger labels it does not
+need to be created.)
 
 ### 8. Return the URL + branch suggestion
 
+Use the `ref` / `url` parsed from `tracker_create` in step 7:
+
 ```
-Created: {owner/repo}#{number} — Walking skeleton — {title}
-{url}
+Created: {owner/repo}#${ref} — Walking skeleton — {title}
+${url}
 
 When you start work:
-  /start-ticket {owner/repo}#{number}
-  git checkout -b feature/GH-{number}-{slug}-skeleton
+  /start-ticket {owner/repo}#${ref}
+  git checkout -b feature/GH-${ref}-{slug}-skeleton
 ```
 
 ### 9. Remind the operator this is KEPT — full SDLC

--- a/.claude/skills/walking-skeleton/SKILL.md
+++ b/.claude/skills/walking-skeleton/SKILL.md
@@ -245,8 +245,8 @@ Create this ticket? (yes / edit / cancel)
 
 ### 7. Create the issue (via the tracker abstraction)
 
-Dispatch creation through `tracker_create` (#670 / AgDR-0072, extended by the
-#709 creator sweep) so the skeleton lands in **this project's** tracker —
+Dispatch creation through `tracker_create` (#670 / AgDR-0072, extended by
+the #709 creator sweep) so the skeleton lands in **this project's** tracker —
 GitHub, GitLab, or a `custom` CLI — per its `tracker:` block in
 `apexyard.projects.yaml`. For a GitHub adopter this runs `gh issue create`
 exactly as before.

--- a/docs/agdr/AgDR-0072-per-project-tracker-config-and-creation-abstraction.md
+++ b/docs/agdr/AgDR-0072-per-project-tracker-config-and-creation-abstraction.md
@@ -62,3 +62,22 @@ Shipped as **two stacked PRs against `dev`**, to stay under the <400-line review
 - #310 — the fork-global tracker-resolution invariant this relaxes
 - #268 — the create guard / `ticket.create_command_patterns`
 - #670 — the feature request this implements (closed by PR-B)
+
+## Follow-up — #709 creator sweep
+
+PR-B wired `tracker_create` into only the three core creators (`/task`,
+`/feature`, `/bug`). **#709** extends the same pattern to the remaining
+issue-creating skills — `/spike`, `/prototype`, `/investigation`,
+`/walking-skeleton`, `/migration`, `/tickets-batch`, `/plan-initiative`,
+`/spike-close`, `/prototype-close`, `/roadmap` (`/mutation-test` needs no change:
+it routes through `/task`). It also adds a sibling best-effort helper,
+`tracker_label_ensure <owner/repo> <name> [<color>] [<description>]`, as the
+tracker-agnostic analog of the inline `gh label create` steps for the
+`spike` / `prototype` / `investigation` trigger labels (gh + glab adapters;
+jira/linear/asana/custom/none are no-ops; always exits 0 so a duplicate/missing
+label never aborts the create). Kept a **separate** public function rather than
+folding label-ensure into `tracker_create`, to preserve PR-B's already-shipped
+create contract. Issue-state transitions (`gh issue close` in the `-close`
+skills) and body updates (`gh issue edit` in `/plan-initiative` pass 2) stay on
+`gh` — those are the read/update + forge axes, tracked separately (#710 and the
+forge work), out of #709's creation-only scope.


### PR DESCRIPTION
## Summary

- **Completes the tracker-agnostic issue-creation surface** — #670 / AgDR-0072 (PR-B) wired `tracker_create` into only `/task`, `/feature`, `/bug`. This routes the remaining **10** creator skills through the same abstraction, so a GitLab- or `custom`-tracker project can file spikes, migrations, investigations, batches, etc. instead of erroring on a hardcoded `gh issue create`. For a GitHub adopter every call still runs `gh issue create` — zero behaviour change.
- **New best-effort helper `tracker_label_ensure`** in `_lib-tracker.sh` — the tracker-agnostic analog of the inline `gh label create` steps for the `spike` / `prototype` / `investigation` trigger labels. gh + glab adapters (gh takes bare-hex `FBCA04`, glab normalises to `#FBCA04`); jira/linear/asana/custom/none are no-ops. Always exits 0, so a duplicate/missing label never aborts the subsequent create. Kept a **separate** public function rather than folding it into `tracker_create` — folding would change PR-B's already-shipped create contract.
- **`/mutation-test` intentionally unchanged** — it files through `/task`, so it inherits the abstraction and needs no edit. Called out so the omission isn't read as a miss.
- **Scope discipline: creation only.** Issue *state transitions* (`gh issue close` in `/spike-close` + `/prototype-close`) and *body updates* (`gh issue view`/`edit` in `/plan-initiative` pass 2) stay on `gh`, each with an inline scope note. Those are the read/update + forge axes, tracked separately (#710 and the forge line), out of #709's remit.

## Per-skill checklist

| Skill | Create → `tracker_create` | Label → `tracker_label_ensure` | Notes |
|-------|:--:|:--:|-------|
| `/spike` | ✅ | ✅ (`spike`) | Exemplar / locked template |
| `/prototype` | ✅ | ✅ (`prototype`) | |
| `/investigation` | ✅ | ✅ (`investigation`) | `.ref` patches the live-doc metadata |
| `/walking-skeleton` | ✅ | — | Uses default `enhancement` label (never created) |
| `/migration` | ✅ | — | Two labels via CSV (`migration,<priority>`); `.ref`/`.url` back-fill the AgDR |
| `/tickets-batch` | ✅ (loop) | — | Per-ticket `.ref` in progress line; rc=3 handled |
| `/plan-initiative` | ✅ (pass 1) | — | Map stores `.ref` (non-numeric keys OK); pass-2 edit stays gh (scoped) |
| `/spike-close` | ✅ | — | Follow-up create; `gh issue close` stays gh (scoped) |
| `/prototype-close` | ✅ | — | Mirror of spike-close |
| `/roadmap` | ✅ (`--with-issues`) | — | `.ref` written back into Notes |
| `/mutation-test` | n/a | n/a | Routes through `/task` — no change |

## Testing

- `bash .claude/hooks/tests/test_tracker_create.sh` → **29 pass / 0 fail** (16 existing + 13 new `tracker_label_ensure` cases: gh bare-hex colour, glab `#`-prefixed colour, `label create`/`--name`+`-R` argv, duplicate-error-still-exit-0, empty repo/name no-op, jira no-op invokes no CLI).
- `bash .claude/hooks/tests/test_tracker_aware_hooks.sh` and `test_per_project_tracker.sh` → green (no regression).
- `bash -n` clean on `_lib-tracker.sh` + the test; `markdownlint-cli2` clean on all changed markdown.

## Glossary

| Term | Definition |
|------|------------|
| `tracker_create` | `_lib-tracker.sh` function (AgDR-0072) that creates an issue via the per-project CLI adapter and returns normalised `{ref,url}`. |
| `tracker_label_ensure` | New sibling helper: best-effort, tracker-agnostic label creation (`<owner/repo> <name> [color] [description]`); always exits 0. |
| `{ref, url}` | Tracker-agnostic return value: `ref` is the issue reference as a **string** (`123`, `LIN-42` — no arithmetic), `url` the web link. |
| `rc=3` | `tracker_create`'s documented "shape-only" code when `tracker.kind=none` — it prints the rendered body for external filing instead of erroring. |
| Creator skill | A skill whose job is to file a structured ticket (spike, migration, investigation, …). |

Closes #709
