### PR TITLE
feat(#710): add tracker_list + cross-tracker query translation

### DIFF
--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -945,10 +945,13 @@ tracker_list() {
   fi
 
   # Client-side `since` for adapters that don't apply it server-side (glab /
-  # custom). gh already handled it via the search qualifier above.
+  # custom). gh already handled it via the search qualifier above. Items with no
+  # `updatedAt` are KEPT (not silently dropped) — recency is unknowable for them,
+  # and hiding an item the user can't date is worse than surfacing it. Only items
+  # with a known, older `updatedAt` are filtered out.
   if [ -n "$f_since" ] && [ "$kind" != "gh" ]; then
     normalised=$(printf '%s' "$normalised" | jq -c --arg since "$f_since" \
-      'map(select((.updatedAt // "") >= $since))' 2>/dev/null)
+      'map(select((.updatedAt // "") == "" or (.updatedAt >= $since)))' 2>/dev/null)
     [ -z "$normalised" ] && normalised='[]'
   fi
 

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -681,6 +681,281 @@ tracker_create() {
   echo "$result"
 }
 
+# ==============================================================================
+# Listing (tracker_list) — the #710 / AgDR-0082 read/triage abstraction.
+#
+# tracker_list is the listing analog of tracker_view: it lists a SET of issues
+# from a project's tracker via that tracker's CLI adapter. The read-side skills
+# (/inbox, /tasks, /stakeholder-update) call it instead of hardcoding
+# `gh issue list`, so they work on GitLab-tracked projects too.
+#
+# Design (AgDR-0082): callers express intent in a small GENERIC filter
+# vocabulary; each per-kind adapter renders those generic filters into its own
+# native CLI flags. We do NOT parse GitHub's search string and translate it —
+# that would couple the model to GitHub's DSL. Filters with no cross-tracker
+# equivalent (mentions:, commenter:) stay OUT of this model; skills that want
+# them keep a gh-only path (documented) or filter client-side.
+#
+# Contract: tracker_list <owner/repo> [key=value ...]
+#   Filter keys (all optional): state | assignee | author | labels | search |
+#                               since | limit
+#     state    = open (default) | closed | all
+#     assignee = @me | none | <user>   (none: gh via no:assignee; glab degrades)
+#     author   = @me | <user>
+#     labels   = comma-separated (AND semantics, per each CLI's native behaviour)
+#     search   = free text
+#     since    = ISO date (gh: search qualifier; others: client-side updatedAt)
+#     limit    = max items
+#   On success: emits a JSON ARRAY on stdout, exit 0. Each element:
+#     {"ref":str, "number":num, "state":str, "title":str, "url":str,
+#      "labels":[str], "updatedAt":str}
+#     - ref is the issue reference AS A STRING (callers must not do arithmetic —
+#       a future tracker may key LIN-42). number is the numeric convenience.
+#     - PR-only fields (mergeable/statusCheckRollup/reviewDecision) are excluded
+#       by design — those are the forge axis (#711), not the issue axis.
+#     - An empty result set is `[]` with exit 0 (success, nothing matched).
+#   On failure (CLI missing/errored, kind=none, unparseable): emits `[]` and
+#     exits 1 — callers treat empty output as "nothing / unavailable" uniformly.
+#
+# Filter args are parsed via a `case` statement into plain locals — bash 3.2-safe
+# (no `declare -A`), matching the POSIX-parameter-expansion constraint elsewhere
+# in this file. linear/jira/asana list adapters are a documented follow-up (the
+# #710 parent stack targets GitHub↔GitLab); they fall through to `[]`.
+# ------------------------------------------------------------------------------
+
+# Internal: resolve the list_command template for the `custom` kind — the
+# per-project override (registry) wins over a global .tracker.list_command.
+# Empty when neither is set (custom kind without a template can't list).
+_tracker_list_template() {
+  local repo="${1:-}"
+  if [ -n "$repo" ]; then
+    local pv
+    if pv=$(_tracker_project_value "$repo" list_command) && [ -n "$pv" ]; then
+      echo "$pv"
+      return 0
+    fi
+  fi
+  _tracker_load_config_lib
+  local tpl
+  tpl=$(config_get_or '.tracker.list_command' '' 2>/dev/null)
+  if [ -n "$tpl" ] && [ "$tpl" != "null" ]; then
+    echo "$tpl"
+  fi
+}
+
+# Internal adapter: gh → run `gh issue list --json …` with safe argv.
+# Structured filters map to gh's native flags; `assignee=none` and `since` have
+# no dedicated flag, so they append `no:assignee` / `closed:>=`|`updated:>=`
+# qualifiers to the --search string (gh merges --search with the other flags).
+_tracker_list_gh() {
+  local repo="$1" state="$2" assignee="$3" author="$4" labels="$5" search="$6" since="$7" limit="$8"
+  local -a args
+  args=(issue list --repo "$repo" --json number,title,url,labels,state,updatedAt)
+  case "$state" in
+    open|closed|all) args+=(--state "$state") ;;
+    *)               args+=(--state open) ;;
+  esac
+  if [ -n "$assignee" ]; then
+    case "$assignee" in
+      none) search="${search:+$search }no:assignee" ;;
+      *)    args+=(--assignee "$assignee") ;;
+    esac
+  fi
+  [ -n "$author" ] && args+=(--author "$author")
+  [ -n "$labels" ] && args+=(--label "$labels")
+  if [ -n "$since" ]; then
+    if [ "$state" = "closed" ]; then
+      search="${search:+$search }closed:>=$since"
+    else
+      search="${search:+$search }updated:>=$since"
+    fi
+  fi
+  [ -n "$search" ] && args+=(--search "$search")
+  [ -n "$limit" ]  && args+=(--limit "$limit")
+  gh "${args[@]}" 2>/dev/null
+}
+
+# Internal adapter: glab (GitLab) → `glab issue list -O json`. Flags verified
+# against `glab issue list --help`: --assignee/--author/--label(repeatable)/
+# --search+--in/--opened|--closed|--all/--per-page. `assignee=none` has no clean
+# glab flag → degrades (dropped); `since` is applied CLIENT-SIDE by tracker_list.
+_tracker_list_glab() {
+  local repo="$1" state="$2" assignee="$3" author="$4" labels="$5" search="$6" since="$7" limit="$8"
+  local -a args
+  args=(issue list -R "$repo" -O json)
+  case "$state" in
+    closed) args+=(--closed) ;;
+    all)    args+=(--all) ;;
+    *)      args+=(--opened) ;;
+  esac
+  if [ -n "$assignee" ]; then
+    case "$assignee" in
+      none) : ;;  # no clean glab flag — documented degradation (AgDR-0082)
+      *)    args+=(--assignee "$assignee") ;;
+    esac
+  fi
+  [ -n "$author" ] && args+=(--author "$author")
+  if [ -n "$labels" ]; then
+    local l
+    local IFS=','
+    for l in $labels; do
+      [ -n "$l" ] && args+=(--label "$l")
+    done
+  fi
+  if [ -n "$search" ]; then
+    args+=(--search "$search" --in "title,description")
+  fi
+  [ -n "$limit" ] && args+=(--per-page "$limit")
+  glab "${args[@]}" 2>/dev/null
+}
+
+# Internal adapter: custom → operator-supplied list_command template. Same trust
+# model as create: only {owner_repo} is substituted into the eval'd string; the
+# filter values pass via ENV ($TRACKER_STATE / $TRACKER_ASSIGNEE / … ) that the
+# operator references with quoted expansions — inert as command syntax. The
+# custom command is expected to emit a JSON array (normalised via identity, or a
+# configured .tracker.list_normalise_jq).
+_tracker_list_custom() {
+  local repo="$1" state="$2" assignee="$3" author="$4" labels="$5" search="$6" since="$7" limit="$8"
+  local tpl
+  tpl=$(_tracker_list_template "$repo")
+  if [ -z "$tpl" ]; then
+    return 1
+  fi
+  local cmd="$tpl"
+  cmd="${cmd//\{owner_repo\}/$repo}"
+  TRACKER_REPO="$repo" TRACKER_STATE="$state" TRACKER_ASSIGNEE="$assignee" TRACKER_AUTHOR="$author" \
+    TRACKER_LABELS="$labels" TRACKER_SEARCH="$search" TRACKER_SINCE="$since" TRACKER_LIMIT="$limit" \
+    eval "$cmd" 2>/dev/null
+}
+
+# Internal: normalise a gh `issue list --json` array → common array shape.
+_tracker_normalise_list_gh() {
+  local raw="$1"
+  [ -n "$raw" ] || return 1
+  printf '%s' "$raw" | jq -e . >/dev/null 2>&1 || return 1
+  printf '%s' "$raw" | jq -c 'map({
+    ref:       (.number | tostring),
+    number:    .number,
+    state:     (.state // ""),
+    title:     (.title // ""),
+    url:       (.url // ""),
+    labels:    ((.labels // []) | map(if type == "object" then .name else . end)),
+    updatedAt: (.updatedAt // "")
+  })' 2>/dev/null
+}
+
+# Internal: normalise a glab `issue list -O json` array → common array shape.
+# GitLab's REST JSON uses iid / web_url / updated_at, and labels as a string
+# array. state is "opened"/"closed" — normalised to that string verbatim.
+_tracker_normalise_list_glab() {
+  local raw="$1"
+  [ -n "$raw" ] || return 1
+  printf '%s' "$raw" | jq -e . >/dev/null 2>&1 || return 1
+  printf '%s' "$raw" | jq -c 'map({
+    ref:       ((.iid // .id) | tostring),
+    number:    (.iid // .id),
+    state:     (.state // ""),
+    title:     (.title // ""),
+    url:       (.web_url // .url // ""),
+    labels:    ((.labels // []) | map(if type == "object" then .name else . end)),
+    updatedAt: (.updated_at // .updatedAt // "")
+  })' 2>/dev/null
+}
+
+# Internal: normalise a custom list output. The operator's command is expected
+# to emit an already-shaped JSON array; an optional .tracker.list_normalise_jq
+# maps a different raw shape. Default is identity.
+_tracker_normalise_list_custom() {
+  local raw="$1"
+  [ -n "$raw" ] || return 1
+  printf '%s' "$raw" | jq -e . >/dev/null 2>&1 || return 1
+  _tracker_load_config_lib
+  local jq_expr
+  jq_expr=$(config_get_or '.tracker.list_normalise_jq' '.' 2>/dev/null)
+  if [ -z "$jq_expr" ] || [ "$jq_expr" = "null" ]; then
+    jq_expr='.'
+  fi
+  printf '%s' "$raw" | jq -c "$jq_expr" 2>/dev/null
+}
+
+# Public: tracker_list <owner/repo> [key=value ...]
+tracker_list() {
+  local repo="$1"
+  shift 2>/dev/null || true
+  if [ -z "$repo" ]; then
+    printf '[]\n'
+    return 1
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    printf '[]\n'
+    return 1
+  fi
+
+  # Parse key=value filter args into plain locals (bash 3.2-safe).
+  local f_state="" f_assignee="" f_author="" f_labels="" f_search="" f_since="" f_limit=""
+  local kv key val
+  for kv in "$@"; do
+    key="${kv%%=*}"
+    val="${kv#*=}"
+    case "$key" in
+      state)        f_state="$val" ;;
+      assignee)     f_assignee="$val" ;;
+      author)       f_author="$val" ;;
+      labels|label) f_labels="$val" ;;
+      search)       f_search="$val" ;;
+      since)        f_since="$val" ;;
+      limit)        f_limit="$val" ;;
+    esac
+  done
+
+  # Per-project resolution: the target repo selects the project's tracker
+  # override, else the global block (never cwd, never a session marker).
+  local kind
+  kind=$(tracker_kind "$repo")
+  case "$kind" in
+    none)
+      printf '[]\n'
+      return 1
+      ;;
+  esac
+
+  local raw rc
+  case "$kind" in
+    gh)     raw=$(_tracker_list_gh     "$repo" "$f_state" "$f_assignee" "$f_author" "$f_labels" "$f_search" "$f_since" "$f_limit"); rc=$? ;;
+    glab)   raw=$(_tracker_list_glab   "$repo" "$f_state" "$f_assignee" "$f_author" "$f_labels" "$f_search" "$f_since" "$f_limit"); rc=$? ;;
+    custom) raw=$(_tracker_list_custom "$repo" "$f_state" "$f_assignee" "$f_author" "$f_labels" "$f_search" "$f_since" "$f_limit"); rc=$? ;;
+    *)      raw=$(_tracker_list_gh     "$repo" "$f_state" "$f_assignee" "$f_author" "$f_labels" "$f_search" "$f_since" "$f_limit"); rc=$? ;;  # best-effort default
+  esac
+  if [ $rc -ne 0 ] || [ -z "$raw" ]; then
+    printf '[]\n'
+    return 1
+  fi
+
+  local normalised
+  case "$kind" in
+    gh)     normalised=$(_tracker_normalise_list_gh     "$raw") ;;
+    glab)   normalised=$(_tracker_normalise_list_glab   "$raw") ;;
+    custom) normalised=$(_tracker_normalise_list_custom "$raw") ;;
+    *)      normalised=$(_tracker_normalise_list_gh     "$raw") ;;
+  esac
+  if [ -z "$normalised" ] || [ "$normalised" = "null" ]; then
+    printf '[]\n'
+    return 1
+  fi
+
+  # Client-side `since` for adapters that don't apply it server-side (glab /
+  # custom). gh already handled it via the search qualifier above.
+  if [ -n "$f_since" ] && [ "$kind" != "gh" ]; then
+    normalised=$(printf '%s' "$normalised" | jq -c --arg since "$f_since" \
+      'map(select((.updatedAt // "") >= $since))' 2>/dev/null)
+    [ -z "$normalised" ] && normalised='[]'
+  fi
+
+  printf '%s\n' "$normalised"
+  return 0
+}
+
 # ------------------------------------------------------------------------------
 # Label ensure (tracker_label_ensure) — #709 creator-sweep companion to
 # tracker_create.

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -750,7 +750,9 @@ _tracker_list_template() {
 _tracker_list_gh() {
   local repo="$1" state="$2" assignee="$3" author="$4" labels="$5" search="$6" since="$7" limit="$8"
   local -a args
-  args=(issue list --repo "$repo" --json number,title,url,labels,state,updatedAt)
+  # Quote the comma-separated field list so shellcheck doesn't read the commas as
+  # array-element separators (SC2054); gh takes it as a single argument either way.
+  args=(issue list --repo "$repo" --json "number,title,url,labels,state,updatedAt")
   case "$state" in
     open|closed|all) args+=(--state "$state") ;;
     *)               args+=(--state open) ;;

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -682,14 +682,14 @@ tracker_create() {
 }
 
 # ==============================================================================
-# Listing (tracker_list) — the #710 / AgDR-0082 read/triage abstraction.
+# Listing (tracker_list) — the #710 / AgDR-0093 read/triage abstraction.
 #
 # tracker_list is the listing analog of tracker_view: it lists a SET of issues
 # from a project's tracker via that tracker's CLI adapter. The read-side skills
 # (/inbox, /tasks, /stakeholder-update) call it instead of hardcoding
 # `gh issue list`, so they work on GitLab-tracked projects too.
 #
-# Design (AgDR-0082): callers express intent in a small GENERIC filter
+# Design (AgDR-0093): callers express intent in a small GENERIC filter
 # vocabulary; each per-kind adapter renders those generic filters into its own
 # native CLI flags. We do NOT parse GitHub's search string and translate it —
 # that would couple the model to GitHub's DSL. Filters with no cross-tracker
@@ -720,7 +720,8 @@ tracker_create() {
 # Filter args are parsed via a `case` statement into plain locals — bash 3.2-safe
 # (no `declare -A`), matching the POSIX-parameter-expansion constraint elsewhere
 # in this file. linear/jira/asana list adapters are a documented follow-up (the
-# #710 parent stack targets GitHub↔GitLab); they fall through to `[]`.
+# #710 parent stack targets GitHub↔GitLab); until then they fall through to the
+# gh best-effort default (consistent with `tracker_view` / `tracker_create`).
 # ------------------------------------------------------------------------------
 
 # Internal: resolve the list_command template for the `custom` kind — the
@@ -792,7 +793,7 @@ _tracker_list_glab() {
   esac
   if [ -n "$assignee" ]; then
     case "$assignee" in
-      none) : ;;  # no clean glab flag — documented degradation (AgDR-0082)
+      none) : ;;  # no clean glab flag — documented degradation (AgDR-0093)
       *)    args+=(--assignee "$assignee") ;;
     esac
   fi

--- a/.claude/hooks/tests/test_tracker_list.sh
+++ b/.claude/hooks/tests/test_tracker_list.sh
@@ -129,6 +129,12 @@ tracker_clear_cache
 PATH="$SB/bin:$PATH" GH_CAPTURE="$SB/cap4" tracker_list "o/r" state=closed since=2026-06-01 >/dev/null
 assert_eq "gh since+closed → closed:>= qualifier" "closed:>=2026-06-01" "$(awk 'p{print;exit} $0=="--search"{p=1}' "$SB/cap4")"
 
+# Case 4b — since with DEFAULT state (open) → `updated:>=<date>` qualifier (the
+# non-closed branch of the since mapping).
+tracker_clear_cache
+PATH="$SB/bin:$PATH" GH_CAPTURE="$SB/cap4b" tracker_list "o/r" since=2026-06-01 >/dev/null
+assert_eq "gh since default(open) → updated:>= qualifier" "updated:>=2026-06-01" "$(awk 'p{print;exit} $0=="--search"{p=1}' "$SB/cap4b")"
+
 # Case 5 — empty result `[]` is SUCCESS (exit 0), not a failure.
 cat > "$SB/bin/gh" <<'EOF'
 #!/bin/bash
@@ -230,6 +236,37 @@ EOF
   IFS=$'\t' read -r s_len s_ref < "$SB2/result2"
   assert_eq "tracker_list glab since → client-side filter keeps 1" "1"  "$s_len"
   assert_eq "tracker_list glab since → kept the recent item"       "45" "$s_ref"
+
+  # Case 9c: an item MISSING updated_at must be KEPT by the client-side `since`
+  # filter (recency unknowable → surface it, don't silently drop). Mock returns
+  # one recent, one old, one with a null updated_at.
+  cat > "$SB2/bin/glab" <<'EOF'
+#!/bin/bash
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  cat <<'JSON'
+[
+  {"iid":45,"title":"recent","web_url":"https://gitlab.com/g/p/-/issues/45","labels":[],"state":"opened","updated_at":"2026-07-02T08:00:00Z"},
+  {"iid":9,"title":"old","web_url":"https://gitlab.com/g/p/-/issues/9","labels":[],"state":"opened","updated_at":"2026-05-01T08:00:00Z"},
+  {"iid":3,"title":"undated","web_url":"https://gitlab.com/g/p/-/issues/3","labels":[],"state":"opened","updated_at":null}
+]
+JSON
+fi
+EOF
+  chmod +x "$SB2/bin/glab"
+  (
+    cd "$SB2" || exit 1
+    # shellcheck source=/dev/null
+    . "$SB2/.claude/hooks/_lib-tracker.sh"
+    tracker_clear_cache
+    out=$(PATH="$SB2/bin:$PATH" tracker_list "g/p" since=2026-06-01)
+    # Expect the recent (45) AND the undated (3) kept; the old (9) dropped.
+    len=$(printf '%s' "$out" | jq -r 'length')
+    refs=$(printf '%s' "$out" | jq -r '[.[].ref] | sort | join(",")')
+    printf '%s\t%s\n' "$len" "$refs"
+  ) > "$SB2/result3"
+  IFS=$'\t' read -r u_len u_refs < "$SB2/result3"
+  assert_eq "tracker_list glab since → keeps recent + undated, drops old (count)" "2"    "$u_len"
+  assert_eq "tracker_list glab since → undated item (3) NOT dropped"              "3,45" "$u_refs"
   rm -rf "$SB2"
 else
   echo "SKIP: tracker_list glab per-project cases (no yq / python3+PyYAML)"

--- a/.claude/hooks/tests/test_tracker_list.sh
+++ b/.claude/hooks/tests/test_tracker_list.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+# test_tracker_list.sh — the #710 / AgDR-0082 listing abstraction.
+#
+# tracker_list lists a SET of issues from a project's tracker, mirroring
+# tracker_view/tracker_create. Callers express intent in a generic filter
+# vocabulary (state/assignee/author/labels/search/since/limit); each per-kind
+# adapter renders those into native CLI flags. Returns a normalised JSON ARRAY
+# on stdout, exit 0; `[]` + exit 1 on failure. GitHub's search DSL is NOT parsed.
+#
+# Tests use MOCK CLIs (a fake gh/glab/custom on PATH) — no real API calls.
+#
+# Cases:
+#   1.  gh happy path → array normalised {ref,number,state,title,url,labels,updatedAt}
+#   2.  gh filter render → state/assignee/author/labels/search/limit reach gh as flags
+#   3.  gh assignee=none → appended as `no:assignee` search qualifier (no --assignee)
+#   4.  gh since + state=closed → `closed:>=<date>` search qualifier
+#   5.  gh empty result `[]` → exit 0 (empty set is success, not failure)
+#   6.  gh CLI failure → `[]` + exit 1
+#   7.  kind=none → `[]` + exit 1 (no CLI to call)
+#   8.  per-project glab override → dispatches glab, normalises iid/web_url/updated_at
+#           [needs YAML parser]
+#   9.  glab labels csv → repeated --label flags; glab since → client-side filter
+#           [needs YAML parser]
+#   10. per-project custom list_command → filters via ENV, NO shell injection
+#           [needs YAML parser]
+#
+# Exit 0 = all pass. Exit 1 on first failure.
+
+set -u
+unset APEXYARD_OPS_PIN_DIR CLAUDE_CODE_SESSION_ID 2>/dev/null || true
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TRACKER_LIB="$HOOK_DIR/_lib-tracker.sh"
+CONFIG_LIB="$HOOK_DIR/_lib-read-config.sh"
+PORTFOLIO_LIB="$HOOK_DIR/_lib-portfolio-paths.sh"
+OPSROOT_LIB="$HOOK_DIR/_lib-ops-root.sh"
+
+PASS=0
+FAIL=0
+FAILED=""
+pass() { PASS=$((PASS+1)); echo "PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); FAILED="$FAILED\n  - $1"; echo "FAIL: $1"; echo "    expected: [$2]"; echo "    actual:   [$3]"; }
+assert_eq() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1" "$2" "$3"; fi; }
+
+HAVE_YAML=no
+if command -v yq >/dev/null 2>&1 || python3 -c 'import yaml' >/dev/null 2>&1; then HAVE_YAML=yes; fi
+
+# Build a single-fork sandbox; $1 optional registry body (per-project trackers).
+make_sandbox() {
+  local sb registry_body="${1:-}"
+  sb=$(mktemp -d); sb=$(cd "$sb" && pwd -P)
+  mkdir -p "$sb/.claude/hooks" "$sb/bin"
+  touch "$sb/onboarding.yaml"
+  cp "$TRACKER_LIB"   "$sb/.claude/hooks/_lib-tracker.sh"
+  cp "$CONFIG_LIB"    "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$PORTFOLIO_LIB" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  [ -f "$OPSROOT_LIB" ] && cp "$OPSROOT_LIB" "$sb/.claude/hooks/_lib-ops-root.sh"
+  cat > "$sb/.claude/project-config.defaults.json" <<'JSON'
+{ "tracker": { "kind": "gh" } }
+JSON
+  if [ -n "$registry_body" ]; then
+    printf '%s\n' "$registry_body" > "$sb/apexyard.projects.yaml"
+  else
+    printf 'version: 1\nprojects: []\n' > "$sb/apexyard.projects.yaml"
+  fi
+  echo "$sb"
+}
+
+# Mock gh: capture argv (one per line) to $GH_CAPTURE, print a JSON array for
+# `issue list`. The array uses gh's --json shape (labels as {name} objects,
+# state UPPERCASE, updatedAt camelCase).
+install_gh_mock() {
+  local sb="$1"
+  cat > "$sb/bin/gh" <<'EOF'
+#!/bin/bash
+[ -n "${GH_CAPTURE:-}" ] && printf '%s\n' "$@" > "$GH_CAPTURE"
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  cat <<'JSON'
+[
+  {"number":42,"title":"Fix login","url":"https://github.com/o/r/issues/42","labels":[{"name":"blocked"}],"state":"OPEN","updatedAt":"2026-07-01T10:00:00Z"},
+  {"number":7,"title":"Add export","url":"https://github.com/o/r/issues/7","labels":[],"state":"OPEN","updatedAt":"2026-06-20T09:00:00Z"}
+]
+JSON
+fi
+EOF
+  chmod +x "$sb/bin/gh"
+}
+
+# ---------------------------------------------------------------------------
+SB=$(make_sandbox)
+install_gh_mock "$SB"
+cd "$SB" || { echo "FAIL: cd sandbox"; exit 1; }
+# shellcheck source=/dev/null
+. "$SB/.claude/hooks/_lib-tracker.sh"
+
+# Case 1 — gh happy path: normalised array.
+tracker_clear_cache
+out=$(PATH="$SB/bin:$PATH" tracker_list "o/r"); rc=$?
+assert_eq "tracker_list gh → exit 0"                  "0"          "$rc"
+assert_eq "tracker_list gh → 2 items"                 "2"          "$(printf '%s' "$out" | jq -r 'length' 2>/dev/null)"
+assert_eq "tracker_list gh → ref is a STRING"         "42"         "$(printf '%s' "$out" | jq -r '.[0].ref' 2>/dev/null)"
+assert_eq "tracker_list gh → number is numeric"       "42"         "$(printf '%s' "$out" | jq -r '.[0].number' 2>/dev/null)"
+assert_eq "tracker_list gh → title normalised"        "Fix login"  "$(printf '%s' "$out" | jq -r '.[0].title' 2>/dev/null)"
+assert_eq "tracker_list gh → url normalised"          "https://github.com/o/r/issues/42" "$(printf '%s' "$out" | jq -r '.[0].url' 2>/dev/null)"
+assert_eq "tracker_list gh → labels flattened"        "blocked"    "$(printf '%s' "$out" | jq -r '.[0].labels[0]' 2>/dev/null)"
+assert_eq "tracker_list gh → updatedAt carried"       "2026-07-01T10:00:00Z" "$(printf '%s' "$out" | jq -r '.[0].updatedAt' 2>/dev/null)"
+
+# Case 2 — filter render: state/assignee/author/labels/search/limit → gh flags.
+tracker_clear_cache
+PATH="$SB/bin:$PATH" GH_CAPTURE="$SB/cap2" \
+  tracker_list "o/r" state=closed assignee=@me author=octocat labels=bug,ci search="oauth flow" limit=50 >/dev/null
+CAP=$(cat "$SB/cap2")
+assert_eq "gh render → --state closed"     "1" "$(printf '%s\n' "$CAP" | grep -cx -- 'closed' )"
+val_after() { awk -v f="$1" 'p{print;exit} $0==f{p=1}' "$SB/cap2"; }
+assert_eq "gh render → --assignee value"   "@me"        "$(val_after '--assignee')"
+assert_eq "gh render → --author value"     "octocat"    "$(val_after '--author')"
+assert_eq "gh render → --label value"      "bug,ci"     "$(val_after '--label')"
+assert_eq "gh render → --search value"     "oauth flow" "$(val_after '--search')"
+assert_eq "gh render → --limit value"      "50"         "$(val_after '--limit')"
+
+# Case 3 — assignee=none appends `no:assignee` to --search, no --assignee flag.
+tracker_clear_cache
+PATH="$SB/bin:$PATH" GH_CAPTURE="$SB/cap3" tracker_list "o/r" assignee=none >/dev/null
+assert_eq "gh assignee=none → no --assignee flag"       "0" "$(grep -cx -- '--assignee' "$SB/cap3")"
+assert_eq "gh assignee=none → no:assignee in --search"  "no:assignee" "$(awk 'p{print;exit} $0=="--search"{p=1}' "$SB/cap3")"
+
+# Case 4 — since + state=closed → `closed:>=<date>` search qualifier.
+tracker_clear_cache
+PATH="$SB/bin:$PATH" GH_CAPTURE="$SB/cap4" tracker_list "o/r" state=closed since=2026-06-01 >/dev/null
+assert_eq "gh since+closed → closed:>= qualifier" "closed:>=2026-06-01" "$(awk 'p{print;exit} $0=="--search"{p=1}' "$SB/cap4")"
+
+# Case 5 — empty result `[]` is SUCCESS (exit 0), not a failure.
+cat > "$SB/bin/gh" <<'EOF'
+#!/bin/bash
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then echo "[]"; fi
+EOF
+chmod +x "$SB/bin/gh"
+tracker_clear_cache
+out=$(PATH="$SB/bin:$PATH" tracker_list "o/r"); rc=$?
+assert_eq "tracker_list gh empty set → exit 0" "0"  "$rc"
+assert_eq "tracker_list gh empty set → []"     "[]" "$out"
+
+# Case 6 — CLI failure → `[]` + exit 1.
+cat > "$SB/bin/gh" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x "$SB/bin/gh"
+tracker_clear_cache
+out=$(PATH="$SB/bin:$PATH" tracker_list "o/r"); rc=$?
+assert_eq "tracker_list gh failure → exit 1" "1"  "$rc"
+assert_eq "tracker_list gh failure → []"     "[]" "$out"
+rm -rf "$SB"
+
+# Case 7 — kind=none → `[]` + exit 1 (no CLI to call).
+SBN=$(make_sandbox)
+cat > "$SBN/.claude/project-config.defaults.json" <<'JSON'
+{ "tracker": { "kind": "none" } }
+JSON
+(
+  cd "$SBN" || exit 1
+  # shellcheck source=/dev/null
+  . "$SBN/.claude/hooks/_lib-tracker.sh"
+  tracker_clear_cache
+  out=$(tracker_list "o/r"); rc=$?
+  printf '%s|%s\n' "$rc" "$out"
+) > "$SBN/r"
+IFS="|" read -r n_rc n_out < "$SBN/r"
+assert_eq "tracker_list kind=none → exit 1" "1"  "$n_rc"
+assert_eq "tracker_list kind=none → []"     "[]" "$n_out"
+rm -rf "$SBN"
+
+# Case 8 & 9 — per-project glab override (needs a YAML parser).
+if [ "$HAVE_YAML" = yes ]; then
+  SB2=$(make_sandbox "version: 1
+projects:
+  - name: gl
+    repo: g/p
+    tracker:
+      kind: glab")
+  # Mock glab: capture argv, print GitLab REST-shaped JSON array.
+  cat > "$SB2/bin/glab" <<'EOF'
+#!/bin/bash
+[ -n "${GLAB_CAPTURE:-}" ] && printf '%s\n' "$@" > "$GLAB_CAPTURE"
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  cat <<'JSON'
+[
+  {"iid":45,"title":"GL bug","web_url":"https://gitlab.com/g/p/-/issues/45","labels":["blocked","ci"],"state":"opened","updated_at":"2026-07-02T08:00:00Z"},
+  {"iid":9,"title":"GL old","web_url":"https://gitlab.com/g/p/-/issues/9","labels":[],"state":"opened","updated_at":"2026-05-01T08:00:00Z"}
+]
+JSON
+fi
+EOF
+  chmod +x "$SB2/bin/glab"
+  (
+    cd "$SB2" || exit 1
+    # shellcheck source=/dev/null
+    . "$SB2/.claude/hooks/_lib-tracker.sh"
+    tracker_clear_cache
+    # Case 8: normalisation of GitLab shape.
+    out=$(PATH="$SB2/bin:$PATH" GLAB_CAPTURE="$SB2/cap" tracker_list "g/p" labels=blocked,ci)
+    len=$(printf '%s' "$out" | jq -r 'length' 2>/dev/null)
+    ref=$(printf '%s' "$out" | jq -r '.[0].ref' 2>/dev/null)
+    url=$(printf '%s' "$out" | jq -r '.[0].url' 2>/dev/null)
+    state=$(printf '%s' "$out" | jq -r '.[0].state' 2>/dev/null)
+    upd=$(printf '%s' "$out" | jq -r '.[0].updatedAt' 2>/dev/null)
+    # Case 9a: labels csv → repeated --label flags.
+    label_count=$(grep -cx -- '--label' "$SB2/cap")
+    opened=$(grep -cx -- '--opened' "$SB2/cap")
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$len" "$ref" "$url" "$state" "$upd" "$label_count" "$opened"
+  ) > "$SB2/result"
+  IFS=$'\t' read -r g_len g_ref g_url g_state g_upd g_labelc g_opened < "$SB2/result"
+  assert_eq "tracker_list glab → normalised count"        "2"       "$g_len"
+  assert_eq "tracker_list glab → ref from iid"            "45"      "$g_ref"
+  assert_eq "tracker_list glab → url from web_url"        "https://gitlab.com/g/p/-/issues/45" "$g_url"
+  assert_eq "tracker_list glab → state opened verbatim"   "opened"  "$g_state"
+  assert_eq "tracker_list glab → updatedAt from updated_at" "2026-07-02T08:00:00Z" "$g_upd"
+  assert_eq "tracker_list glab → labels csv → repeated --label" "2" "$g_labelc"
+  assert_eq "tracker_list glab → default state --opened"  "1"       "$g_opened"
+
+  # Case 9b: glab since → CLIENT-SIDE filter (drops the 2026-05 item).
+  (
+    cd "$SB2" || exit 1
+    # shellcheck source=/dev/null
+    . "$SB2/.claude/hooks/_lib-tracker.sh"
+    tracker_clear_cache
+    out=$(PATH="$SB2/bin:$PATH" tracker_list "g/p" since=2026-06-01)
+    printf '%s\t%s\n' "$(printf '%s' "$out" | jq -r 'length')" "$(printf '%s' "$out" | jq -r '.[0].ref')"
+  ) > "$SB2/result2"
+  IFS=$'\t' read -r s_len s_ref < "$SB2/result2"
+  assert_eq "tracker_list glab since → client-side filter keeps 1" "1"  "$s_len"
+  assert_eq "tracker_list glab since → kept the recent item"       "45" "$s_ref"
+  rm -rf "$SB2"
+else
+  echo "SKIP: tracker_list glab per-project cases (no yq / python3+PyYAML)"
+fi
+
+# Case 10 — per-project custom list_command. Filters pass via ENV
+# ($TRACKER_STATE / $TRACKER_LABELS / …), never string-substituted — so a
+# filter value full of shell metacharacters cannot inject. (needs YAML parser.)
+if [ "$HAVE_YAML" = yes ]; then
+  SB3=$(make_sandbox "version: 1
+projects:
+  - name: cu
+    repo: c/u
+    tracker:
+      kind: custom
+      list_command: 'mycli list -R {owner_repo} --state \"\$TRACKER_STATE\" --search \"\$TRACKER_SEARCH\"'")
+  cat > "$SB3/bin/mycli" <<'EOF'
+#!/bin/bash
+[ -n "${MYCLI_CAPTURE:-}" ] && printf '%s\n' "$@" > "$MYCLI_CAPTURE"
+# Emit an already-normalised array (custom contract: identity normalise).
+echo '[{"ref":"77","number":77,"state":"open","title":"custom","url":"https://example.com/c/u/issues/77","labels":[],"updatedAt":"2026-07-01T00:00:00Z"}]'
+EOF
+  chmod +x "$SB3/bin/mycli"
+  (
+    cd "$SB3" || exit 1
+    # shellcheck source=/dev/null
+    . "$SB3/.claude/hooks/_lib-tracker.sh"
+    tracker_clear_cache
+    EVIL='hi"; touch PWNED; echo "'
+    out=$(PATH="$SB3/bin:$PATH" MYCLI_CAPTURE="$SB3/cap" tracker_list "c/u" state=open search="$EVIL")
+    ref=$(printf '%s' "$out" | jq -r '.[0].ref' 2>/dev/null)
+    search_seen=$(awk 'p{print;exit} $0=="--search"{p=1}' "$SB3/cap")
+    pwned=no; [ -e "$SB3/PWNED" ] && pwned=yes
+    printf '%s\t%s\t%s\n' "$ref" "$search_seen" "$pwned"
+  ) > "$SB3/result"
+  IFS=$'\t' read -r c_ref c_search c_pwned < "$SB3/result"
+  assert_eq "tracker_list custom → ref parsed"                      "77" "$c_ref"
+  assert_eq "tracker_list custom → search passed verbatim (env)"    'hi"; touch PWNED; echo "' "$c_search"
+  assert_eq "tracker_list custom → NO shell injection (no PWNED)"   "no" "$c_pwned"
+  rm -rf "$SB3"
+else
+  echo "SKIP: tracker_list custom per-project case (no yq / python3+PyYAML)"
+fi
+
+echo "=========================================="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then printf "Failed:%b\n" "$FAILED"; exit 1; fi
+exit 0

--- a/.claude/hooks/tests/test_tracker_list.sh
+++ b/.claude/hooks/tests/test_tracker_list.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# test_tracker_list.sh — the #710 / AgDR-0082 listing abstraction.
+# test_tracker_list.sh — the #710 / AgDR-0093 listing abstraction.
 #
 # tracker_list lists a SET of issues from a project's tracker, mirroring
 # tracker_view/tracker_create. Callers express intent in a generic filter

--- a/.claude/skills/inbox/SKILL.md
+++ b/.claude/skills/inbox/SKILL.md
@@ -15,10 +15,23 @@ Read the registry path via `portfolio_registry`, the per-project docs dir via `p
 ```bash
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-tracker.sh"
 registry=$(portfolio_registry)
 ```
 
 Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
+## Tracker-agnostic issue listing (#710 / AgDR-0082)
+
+The **issue** sections below (assigned to you, your issues with new comments, blocked items) call `tracker_list` from `_lib-tracker.sh` instead of hardcoding `gh issue list`, so they work on a project whose `tracker.kind` is `glab` (GitLab) too. Pass the project's `repo:` (from the registry) as the first argument — the tracker is resolved per-project — plus generic filters:
+
+```bash
+# tracker_list <owner/repo> [state=…] [assignee=@me|none|<user>] [author=…] [labels=csv] [search=…] [since=ISO] [limit=N]
+# → emits a JSON array: [{ref,number,state,title,url,labels,updatedAt}, …]  ([] on empty/unavailable)
+tracker_list "$repo" state=open assignee=@me limit=50 2>/dev/null
+```
+
+> **Scope caveat (forge axis, #711).** The **PR** sections still call `gh pr list` directly. The PR/MR forge abstraction is a separate ticket (#711); until it lands, `/inbox`'s PR sections are GitHub-only. `/inbox` is therefore *issue-axis* tracker-agnostic, not fully tracker-agnostic. Filters GitHub expresses but GitLab can't (`mentions:`, `commenter:`) stay on a gh-only path, documented at the section that uses them.
 
 ## Usage
 
@@ -37,6 +50,8 @@ Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projec
 The inbox is grouped by section. Empty sections are omitted.
 
 ### 1. PRs awaiting your review
+
+> Forge axis (#711) — GitHub-only until the PR/MR abstraction lands.
 
 ```bash
 gh pr list \
@@ -69,30 +84,38 @@ Filter to ones where `mergeStateStatus` is `CLEAN` — those are ready to merge 
 
 ### 4. Issues assigned to you
 
+Issue axis — tracker-agnostic via `tracker_list` (run per `repo:` from the registry):
+
 ```bash
-gh issue list \
-  --search "is:open is:issue assignee:@me" \
-  --json number,title,url,labels,updatedAt
+tracker_list "$repo" state=open assignee=@me limit=50
+# → [{ref,number,state,title,url,labels,updatedAt}, …]
 ```
 
 ### 5. Issues you opened that have new comments since you last looked
 
-```bash
-gh issue list \
-  --search "is:open is:issue author:@me commenter:>@me" \
-  --json number,title,url,comments,updatedAt
-```
+The "new comments since last looked" part is a GitHub-only search qualifier (`commenter:>@me`) with no GitLab equivalent, so `tracker_list` fetches your open-authored issues and the comment recency is filtered **client-side** (the established degradation for no-equivalent filters):
 
-(GitHub's search syntax doesn't perfectly express "new comments since you last looked", so use `updatedAt` and filter client-side against a stored "last seen" timestamp if available, otherwise show everything from the last 7 days.)
+```bash
+tracker_list "$repo" state=open author=@me
+# Then filter client-side on `updatedAt` against a stored "last seen" timestamp
+# if available, otherwise show everything from the last 7 days.
+```
 
 ### 6. Mentions in comments
 
+`mentions:@me` is a cross-repo GitHub-search capability (a *different operation* than a repo-scoped list) with no GitLab CLI equivalent, so this section stays on a **gh-only path** — it returns nothing on non-GitHub trackers, and `--no-mentions` hides it entirely:
+
 ```bash
-gh search issues "mentions:@me is:open" \
-  --json number,title,url,repository,updatedAt
+# gh-only (degrades to empty on glab / other trackers):
+if [ "$(tracker_kind "$repo")" = "gh" ]; then
+  gh search issues "mentions:@me is:open" \
+    --json number,title,url,repository,updatedAt
+fi
 ```
 
 ### 7. PRs failing CI on a branch you authored
+
+> Forge axis (#711) — GitHub-only until the PR/MR abstraction lands.
 
 ```bash
 gh pr list \
@@ -104,12 +127,11 @@ Filter client-side to those where any check is `FAILURE`.
 
 ### 8. Blocking labels across managed projects
 
-```bash
-gh issue list --label blocked --state open \
-  --json number,title,url,labels
-```
+Issue axis — tracker-agnostic via `tracker_list` (run per project from the registry):
 
-(Run per project from the registry.)
+```bash
+tracker_list "$repo" state=open labels=blocked
+```
 
 ## Output format
 

--- a/.claude/skills/inbox/SKILL.md
+++ b/.claude/skills/inbox/SKILL.md
@@ -21,7 +21,7 @@ registry=$(portfolio_registry)
 
 Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
 
-## Tracker-agnostic issue listing (#710 / AgDR-0082)
+## Tracker-agnostic issue listing (#710 / AgDR-0093)
 
 The **issue** sections below (assigned to you, your issues with new comments, blocked items) call `tracker_list` from `_lib-tracker.sh` instead of hardcoding `gh issue list`, so they work on a project whose `tracker.kind` is `glab` (GitLab) too. Pass the project's `repo:` (from the registry) as the first argument — the tracker is resolved per-project — plus generic filters:
 

--- a/.claude/skills/stakeholder-update/SKILL.md
+++ b/.claude/skills/stakeholder-update/SKILL.md
@@ -16,6 +16,7 @@ Read the registry path via `portfolio_registry`, the per-project docs dir via `p
 ```bash
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-tracker.sh"
 projects_dir=$(portfolio_projects_dir)
 registry=$(portfolio_registry)
 ```
@@ -52,15 +53,17 @@ Aggregated across every project in `apexyard.projects.yaml` (the registry at the
 
 The skill pulls from:
 
-| Source | What it gives |
-|--------|---------------|
-| `gh pr list --state merged --search "merged:>=<since>"` | What shipped |
-| `gh issue list --state closed --search "closed:>=<since>"` | What got resolved |
-| `git log --since=<since> --oneline` | Commit volume / themes |
-| `docs/agdr/AgDR-*.md` (in this period, inside each project) | Decisions made |
-| `projects/<name>/roadmap.md` | Strategic direction |
-| `gh pr list --state open` | What's in flight |
-| `projects/ideas-backlog.md` | Ideas captured |
+| Source | What it gives | Axis |
+|--------|---------------|------|
+| `gh pr list --state merged --search "merged:>=<since>"` | What shipped | forge (#711) |
+| `tracker_list "$repo" state=closed since=<since>` | What got resolved | issue ✓ |
+| `git log --since=<since> --oneline` | Commit volume / themes | — |
+| `docs/agdr/AgDR-*.md` (in this period, inside each project) | Decisions made | — |
+| `projects/<name>/roadmap.md` | Strategic direction | — |
+| `gh pr list --state open` | What's in flight | forge (#711) |
+| `projects/ideas-backlog.md` | Ideas captured | — |
+
+> **Scope caveat (forge axis, #711).** The **PR** rows still call `gh pr list` (the PR/MR forge abstraction is a separate ticket), so `/stakeholder-update` is *issue-axis* tracker-agnostic — the "resolved issues" row works on GitLab-tracked projects; the "shipped / in-flight PRs" rows are GitHub-only until #711. The `since` filter on non-GitHub trackers is applied client-side on `updatedAt` (gh applies it server-side via the `closed:>=` search qualifier).
 
 `<since>` is computed from the update type:
 

--- a/.claude/skills/tasks/SKILL.md
+++ b/.claude/skills/tasks/SKILL.md
@@ -21,7 +21,7 @@ registry=$(portfolio_registry)
 
 Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
 
-## Tracker-agnostic issue listing (#710 / AgDR-0082)
+## Tracker-agnostic issue listing (#710 / AgDR-0093)
 
 The **issue** sources below call `tracker_list` from `_lib-tracker.sh` (per `repo:` from the registry) instead of hardcoding `gh issue list`, so `/tasks` works on GitLab-tracked projects too:
 

--- a/.claude/skills/tasks/SKILL.md
+++ b/.claude/skills/tasks/SKILL.md
@@ -15,10 +15,22 @@ Read the registry path via `portfolio_registry`, the per-project docs dir via `p
 ```bash
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
 source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-tracker.sh"
 registry=$(portfolio_registry)
 ```
 
 Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projects`, `./projects/ideas-backlog.md`). Adopters in split-portfolio mode override the `portfolio.{registry, projects_dir, ideas_backlog}` keys in `.claude/project-config.json`. Don't hardcode literal `apexyard.projects.yaml` or `projects/` paths in bash blocks — the helper resolves whichever mode the adopter is in. See `docs/multi-project.md`.
+
+## Tracker-agnostic issue listing (#710 / AgDR-0082)
+
+The **issue** sources below call `tracker_list` from `_lib-tracker.sh` (per `repo:` from the registry) instead of hardcoding `gh issue list`, so `/tasks` works on GitLab-tracked projects too:
+
+```bash
+# tracker_list <owner/repo> [state=…] [assignee=@me|none|<user>] [author=…] [labels=csv] [search=…] [since=ISO] [limit=N]
+# → JSON array [{ref,number,state,title,url,labels,updatedAt}, …]  ([] on empty/unavailable)
+```
+
+> **Scope caveat (forge axis, #711).** The **PR** sources still call `gh pr list` / `gh api …/pulls`. The PR/MR forge abstraction is #711; until it lands, those sources are GitHub-only, so `/tasks` is *issue-axis* tracker-agnostic, not fully tracker-agnostic. Filters GitHub expresses but GitLab can't (`mentions:`, `commenter:`, `assignee=none` on glab) degrade to a gh-only path or empty, noted per source.
 
 ## Usage
 
@@ -37,16 +49,18 @@ Iterates every project in `apexyard.projects.yaml` (the registry at the root of 
 
 The task list is the union of:
 
-| Source | Tool |
-|--------|------|
-| PRs awaiting your review | `gh pr list --search "review-requested:@me is:open"` |
-| PRs you authored that are blocked on you (changes requested, conflicts, failing CI) | `gh pr list --search "author:@me is:open review:changes_requested"` |
-| Issues assigned to you with high priority | `gh issue list --assignee @me --label priority-high,priority-critical` |
-| Issues you opened with new comments | `gh issue list --search "author:@me commenter:>@me is:open"` |
-| Mentions in unresolved threads | `gh search issues "mentions:@me is:open"` |
-| PR comments awaiting your response | `gh api repos/{repo}/pulls/{n}/comments` filtered to threads where you were mentioned and the last reply isn't yours |
-| Open Critical/High issues with no assignee in projects you own | `gh issue list --label priority-critical --assignee none` |
-| Failing CI on your authored open PRs | from `statusCheckRollup` |
+| Source | Tool | Axis |
+|--------|------|------|
+| PRs awaiting your review | `gh pr list --search "review-requested:@me is:open"` | forge (#711) |
+| PRs you authored that are blocked on you (changes requested, conflicts, failing CI) | `gh pr list --search "author:@me is:open review:changes_requested"` | forge (#711) |
+| Issues assigned to you with high priority | `tracker_list "$repo" assignee=@me labels=priority-high,priority-critical` | issue ✓ |
+| Issues you opened with new comments | `tracker_list "$repo" state=open author=@me` + client-side comment-recency filter (`commenter:` is gh-only) | issue ✓ |
+| Mentions in unresolved threads | gh-only: `gh search issues "mentions:@me is:open"` (empty on non-gh trackers) | issue (gh-only) |
+| PR comments awaiting your response | `gh api repos/{repo}/pulls/{n}/comments` filtered to threads where you were mentioned and the last reply isn't yours | forge (#711) |
+| Open Critical/High issues with no assignee in projects you own | `tracker_list "$repo" labels=priority-critical assignee=none` (`assignee=none` degrades on glab) | issue ✓ |
+| Failing CI on your authored open PRs | from `statusCheckRollup` | forge (#711) |
+
+Label semantics note: `labels=priority-high,priority-critical` is passed to each CLI's native `--label` handling, which is **AND** on both gh and glab. The intent here (high **OR** critical) is a pre-existing GitHub-search limitation carried over unchanged — call the two labels in separate `tracker_list` passes and union the results if strict OR is needed.
 
 ## Prioritisation
 

--- a/docs/agdr/AgDR-0082-tracker-list-query-translation.md
+++ b/docs/agdr/AgDR-0082-tracker-list-query-translation.md
@@ -79,7 +79,7 @@ Because Option A points the design the wrong way (parsing GitHub's DSL) and Opti
 
 - **Backward-compatible.** A github-kind fork sees byte-for-byte the same `gh issue list` results (the gh adapter renders the same flags). The default-config regression suite locks this in.
 - **Skills are partially converted by design.** Issue-axis tracker-agnostic; forge-axis (`gh pr list`) still `gh`-coupled until #711. Stated in every #710 PR body to prevent a false "it's fully abstracted" read.
-- **Some filters degrade on non-GitHub trackers** (`assignee=none`, `since`, `mentions:`, `commenter:`) — documented per-filter. Degradation is "empty / client-side," never a crash.
+- **Some filters degrade on non-GitHub trackers** (`assignee=none`, `since`, `mentions:`, `commenter:`) — documented per-filter. Degradation is "empty / client-side," never a crash. The client-side `since` filter (glab / custom) **keeps** items with no `updatedAt` rather than dropping them — recency is unknowable for such items, and silently hiding one is worse than surfacing it.
 - **`tracker_list` is a read, not a create** — it is **not** added to `ticket.create_command_patterns` (that guard is for creation). Listing needs no skill gate.
 - **glab list adapter is written against the real CLI**, not recall — `glab issue list --help` confirms `--assignee=@me`, `--author`, `--label` (repeatable), `--search`+`--in`, `-O json`, `--opened`/`--closed`/`--all`. The one gap (`assignee=none`) is a known degradation.
 - **Per-project resolution needs a YAML parser** (`yq` / `python3`+PyYAML), inheriting AgDR-0072's known edge: with no parser, a per-project `tracker:` block is silently ignored and the global tracker is used. Tests SKIP (not fail) when no parser is present, mirroring the `jq` guard.

--- a/docs/agdr/AgDR-0082-tracker-list-query-translation.md
+++ b/docs/agdr/AgDR-0082-tracker-list-query-translation.md
@@ -1,0 +1,102 @@
+---
+id: AgDR-0082
+timestamp: 2026-07-03T09:00:00Z
+agent: claude
+model: claude-opus-4-8[1m]
+trigger: user-prompt
+status: proposed
+---
+
+# `tracker_list` + cross-tracker query-translation model
+
+> In the context of read-side skills (`/inbox`, `/tasks`, `/stakeholder-update`) that hardcode `gh issue list` with GitHub-native search syntax and therefore return **nothing** on a GitLab-tracked project, facing the fact that the `_lib-tracker.sh` abstraction exposes `tracker_view` / `tracker_create` but **no list primitive at all** and that several GitHub search qualifiers (`commenter:>@me`, `mentions:@me`) have no 1:1 GitLab equivalent, I decided to add a **`tracker_list`** primitive driven by a small **generic filter vocabulary** (`state` / `assignee` / `author` / `labels` / `search` / `since`) that each per-kind adapter renders into its own CLI flags — **not** by parsing GitHub's search string — with no-equivalent qualifiers handled **client-side** (the precedent `/inbox` already sets), to achieve tracker-agnostic triage/listing for the issue axis, accepting that the forge axis (`gh pr list` → #711) stays `gh`-coupled and that a few exotic filters degrade to empty on non-GitHub trackers.
+
+## Context
+
+- **Read-side skills are blind on non-GitHub trackers.** `/inbox`, `/tasks`, `/stakeholder-update` call `gh issue list --search "…"` / `gh search issues "…"` directly. On a project whose `tracker.kind` is `glab` (GitLab), these silently return nothing — the exact failure #710's parent stack (#670) exists to close for the issue axis.
+- **The tracker abstraction has no `list`.** `_lib-tracker.sh` (AgDR-0033, AgDR-0072) dispatches `tracker_view` (one issue) and `tracker_create` (create) by `tracker.kind` with per-kind adapters (gh / glab / linear / jira / asana / custom). There is nothing to list a *set* of issues. Unlike the creators — which were wired to an existing `tracker_create` — the read-side conversion must build a new primitive first.
+- **The query filters don't map 1:1.** GitHub search is a rich string DSL (`author:@me commenter:>@me is:open`); GitLab's `glab issue list` is flag-based (`--assignee`, `--author`, `--label`, `--search`, `--opened`/`--closed`). Some GitHub qualifiers (`commenter:`, `mentions:`) have no GitLab CLI equivalent. So a design call is required — what is the cross-tracker query model? — which is why #710 is AgDR-worthy and asymmetric in effort with the creator sweep (#709).
+- **Not all seven "read-side" skills are the same work.** Auditing the actual calls:
+
+  | Tier | Skills | Issue-axis calls today | #710 disposition |
+  |------|--------|------------------------|------------------|
+  | **A — need `tracker_list`** | `/inbox`, `/tasks`, `/stakeholder-update` | `gh issue list` / `gh search issues` with search filters | **Converted** |
+  | **B — single `gh issue view`** | `/status`, `/plan-initiative`, `/spike-close`, `/prototype-close` | a single `gh issue view` (NOT `gh issue list`) | **Deferred** — see below |
+
+  **Issue-statement discrepancy (found during scoping).** #710's Problem statement lists the four Tier-B skills as hardcoding `gh issue list`. They don't — they each make a single **`gh issue view`** call, which is the *view* primitive (`tracker_view`, #671), not the *list* primitive this ticket adds. So #710's stated scope (`gh issue list` → `tracker_list`) does not, strictly, touch them.
+
+  **Why Tier B can't be a clean `tracker_view` swap.** `tracker_view` returns exactly `{state,title,url,labels}`. The Tier-B call sites need more: `/status` reads `assignees` (+ `number`, already derived from the branch); `/plan-initiative` reads `body` (a race-safe re-fetch before splicing cross-refs); `/spike-close` + `/prototype-close` read `body` (consumed for the DISCARD memo's hypothesis/direction text). The discriminating test — *after converting, does the skill still hard-depend on a gh-only call?* — is **yes for all four** (`assignees` / `body` are not in `tracker_view`'s schema). A partial conversion would add a round-trip and still break on GitLab. Extending `tracker_view`'s schema (`body`/`assignees`) is a **separate design call** — it changes a shipped contract, every view consumer, and every adopter `view_command` template — so it is **deferred to a follow-up** (`/task`), not silently expanded here. Tier B is therefore out of #710's shippable scope.
+
+- **The forge axis is out of scope (#711).** `/inbox`, `/tasks`, `/status`, `/stakeholder-update` are *dominated* by `gh pr list` calls (PRs awaiting review, approved-and-ready, failing CI, merged-since). Those are the PR/MR forge axis handled by #711. #710 therefore leaves these skills **partially converted** — issue-axis tracker-agnostic, forge-axis still `gh`-coupled. This must be stated in the PR body so the next reader does not assume `/inbox` became fully tracker-agnostic.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Translate GitHub's search string** — parse `author:@me is:open …` and rewrite per tracker | Callers keep writing familiar GH syntax | Brittle DSL parsing pointed the wrong way; every new qualifier is a parser change; no-equivalent qualifiers (`commenter:`) have nowhere to go; couples the model to GitHub's syntax forever |
+| **B. Generic filter vocabulary → adapters render native** — callers pass `state`/`assignee`/`author`/`labels`/`search`; each kind renders its own flags; no-equivalent qualifiers handled client-side | Tractable, closed model; mirrors `tracker_create`'s function-with-args shape; new tracker = one adapter; GH-only qualifiers isolated to the skills that want them | A small filter vocabulary can't express every GH qualifier natively; some filters degrade (documented) |
+| **C. Per-skill glab special-casing** — add `if kind == glab` branches inside each skill | No new primitive | Duplicates dispatch logic across 3+ skills; every new tracker touches every skill; abandons the abstraction the rest of the lib established |
+
+## Decision
+
+Chosen: **Option B — a `tracker_list` primitive over a generic filter vocabulary, adapters render generic → native.**
+
+Concrete shape:
+
+1. **`tracker_list <owner/repo> [key=value …]`** added to `_lib-tracker.sh`, mirroring `tracker_view`'s per-project resolution (the target repo selects the project's `tracker:` override, else the global block — never cwd, never a session marker; AgDR-0072 §3). Filters are passed as `key=value` positional args parsed via a `case` statement into plain locals — **bash 3.2-safe** (no `declare -A`, matching the lib's existing POSIX-param-expansion constraint).
+
+2. **Generic filter vocabulary** (the source of truth; every filter optional):
+
+   | Filter | Values | gh render | glab render |
+   |--------|--------|-----------|-------------|
+   | `state` | `open` (default) / `closed` / `all` | `--state open\|closed\|all` | `--opened` / `--closed` / `--all` |
+   | `assignee` | `@me` / `none` / `<user>` | `--assignee @me\|<user>` (`none` → `--search "no:assignee"`) | `--assignee=@me\|<user>` (`none` → **client-side / degrade** — no clean glab flag) |
+   | `author` | `@me` / `<user>` | `--author <user>` (`@me` resolved) | `--author <user>` |
+   | `labels` | csv | `--label a,b` | `--label a --label b` (repeated) |
+   | `search` | free text | `--search "<text>"` | `--search "<text>" --in title,description` |
+   | `since` | ISO date | `--search "closed:>=<date>"` (or `updated:>=`) | **client-side** filter on `updatedAt` |
+
+   Label semantics are preserved per-adapter as-is (GitHub `--label a,b` and GitLab repeated `--label` are both **AND**); the pre-existing `/tasks` intent of "high OR critical" is a GitHub-search limitation carried over unchanged, not introduced here — noted, not fixed in #710.
+
+3. **No-equivalent GitHub qualifiers stay out of the generic model.** `commenter:>@me` and `mentions:@me` (cross-repo) have no GitLab CLI equivalent and must not force `tracker_list`'s shape. They are handled by the **existing client-side precedent**: `/inbox` already filters "new comments since last seen" client-side on `updatedAt`. Skills that want `mentions:` keep a **gh-only** path that returns empty on non-gh trackers, documented inline. Cross-repo `gh search issues` is a *different operation* than a repo-scoped list — it is **not** part of `tracker_list`.
+
+4. **Normalised list-item schema** — a JSON **array**, each element mirroring `tracker_view`'s `{state,title,url,labels}` plus the two fields listing needs:
+
+   ```json
+   [{ "ref": "42", "number": 42, "state": "open", "title": "…",
+      "url": "https://…", "labels": ["blocked"], "updatedAt": "2026-07-01T…" }]
+   ```
+
+   `ref` is the tracker reference **as a string** (callers must not do arithmetic — a future tracker may key `LIN-42`); `number` is the numeric convenience for gh/glab. PR-only fields (`mergeable`, `statusCheckRollup`, `reviewDecision`) are **explicitly excluded** — forge axis, #711. On failure (CLI missing/errored, `kind=none`) `tracker_list` emits `[]` and exits non-zero, so callers treat empty output as "nothing / unavailable" without special-casing.
+
+5. **Built-in adapters `gh` + `glab`; `custom` reserved for the trusted template.** Same trust model as `tracker_create`: built-in adapters build `--flag "$val"` argv arrays (never string-eval untrusted filter values); the `list_command` template is reserved for the operator-authored `custom` kind. `linear`/`jira`/`asana` list adapters are **out of scope** for #710 (parent stack targets GitHub↔GitLab); they fall through to a documented empty result until a follow-up adds them — the same phasing `tracker_create` used.
+
+6. **Tier B is deferred, not done here.** The four `gh issue view` single-reads (`/status`, `/plan-initiative`, `/spike-close`, `/prototype-close`) need fields `tracker_view` doesn't return (`assignees` / `body`), so converting them requires a `tracker_view` **schema extension** — a separate design call filed as a follow-up `/task`. #710 ships the `tracker_list` primitive + Tier A only.
+
+Because Option A points the design the wrong way (parsing GitHub's DSL) and Option C abandons the abstraction, only B gives a closed, extensible model consistent with the `tracker_view` / `tracker_create` pattern the lib already validated.
+
+## Consequences
+
+- **Backward-compatible.** A github-kind fork sees byte-for-byte the same `gh issue list` results (the gh adapter renders the same flags). The default-config regression suite locks this in.
+- **Skills are partially converted by design.** Issue-axis tracker-agnostic; forge-axis (`gh pr list`) still `gh`-coupled until #711. Stated in every #710 PR body to prevent a false "it's fully abstracted" read.
+- **Some filters degrade on non-GitHub trackers** (`assignee=none`, `since`, `mentions:`, `commenter:`) — documented per-filter. Degradation is "empty / client-side," never a crash.
+- **`tracker_list` is a read, not a create** — it is **not** added to `ticket.create_command_patterns` (that guard is for creation). Listing needs no skill gate.
+- **glab list adapter is written against the real CLI**, not recall — `glab issue list --help` confirms `--assignee=@me`, `--author`, `--label` (repeatable), `--search`+`--in`, `-O json`, `--opened`/`--closed`/`--all`. The one gap (`assignee=none`) is a known degradation.
+- **Per-project resolution needs a YAML parser** (`yq` / `python3`+PyYAML), inheriting AgDR-0072's known edge: with no parser, a per-project `tracker:` block is silently ignored and the global tracker is used. Tests SKIP (not fail) when no parser is present, mirroring the `jq` guard.
+- **Follow-up surface** — linear/jira/asana list adapters and the forge axis (#711) are explicitly deferred, not forgotten.
+
+## Delivery
+
+Single PR against `dev`: the `tracker_list` primitive + `test_tracker_list.sh` + this AgDR + Tier A conversions (`/inbox`, `/tasks`, `/stakeholder-update`). Tier B is **not** in this PR (deferred — see Decision §6). PR body: `Closes #710`, with two caveats called out — (a) the forge axis (`gh pr list`) stays gh-coupled until #711, and (b) the four `gh issue view` skills are deferred to a `tracker_view`-schema-extension follow-up — plus `Refs #670` for the parent stack.
+
+**Follow-up to file:** a `/task` to extend `tracker_view`'s schema (`body` + `assignees`) and route the four single-view reads through it, so the skills #710's Problem statement named are not silently dropped.
+
+## Artifacts
+
+- #710 — the feature request this implements
+- #670 / AgDR-0072 — per-project tracker config + `tracker_create` (the pattern this mirrors)
+- AgDR-0033 — the original verification-abstraction pattern
+- #709 — the creator-conversion sweep (sibling, issue-creation axis)
+- #711 — PR/MR forge abstraction (the out-of-scope forge axis)
+- `.claude/hooks/_lib-tracker.sh` — where `tracker_list` lands
+- `.claude/hooks/tests/test_tracker_list.sh` — new test surface

--- a/docs/agdr/AgDR-0093-tracker-list-query-translation.md
+++ b/docs/agdr/AgDR-0093-tracker-list-query-translation.md
@@ -1,5 +1,5 @@
 ---
-id: AgDR-0082
+id: AgDR-0093
 timestamp: 2026-07-03T09:00:00Z
 agent: claude
 model: claude-opus-4-8[1m]
@@ -69,7 +69,7 @@ Concrete shape:
 
    `ref` is the tracker reference **as a string** (callers must not do arithmetic — a future tracker may key `LIN-42`); `number` is the numeric convenience for gh/glab. PR-only fields (`mergeable`, `statusCheckRollup`, `reviewDecision`) are **explicitly excluded** — forge axis, #711. On failure (CLI missing/errored, `kind=none`) `tracker_list` emits `[]` and exits non-zero, so callers treat empty output as "nothing / unavailable" without special-casing.
 
-5. **Built-in adapters `gh` + `glab`; `custom` reserved for the trusted template.** Same trust model as `tracker_create`: built-in adapters build `--flag "$val"` argv arrays (never string-eval untrusted filter values); the `list_command` template is reserved for the operator-authored `custom` kind. `linear`/`jira`/`asana` list adapters are **out of scope** for #710 (parent stack targets GitHub↔GitLab); they fall through to a documented empty result until a follow-up adds them — the same phasing `tracker_create` used.
+5. **Built-in adapters `gh` + `glab`; `custom` reserved for the trusted template.** Same trust model as `tracker_create`: built-in adapters build `--flag "$val"` argv arrays (never string-eval untrusted filter values); the `list_command` template is reserved for the operator-authored `custom` kind. `linear`/`jira`/`asana` list adapters are **out of scope** for #710 (parent stack targets GitHub↔GitLab); until a follow-up adds them, unknown kinds fall through to the **gh best-effort default** — the same phasing `tracker_create` / `tracker_view` use for unrecognised kinds (a project on one of those trackers gets gh-shaped results, not silently `[]`).
 
 6. **Tier B is deferred, not done here.** The four `gh issue view` single-reads (`/status`, `/plan-initiative`, `/spike-close`, `/prototype-close`) need fields `tracker_view` doesn't return (`assignees` / `body`), so converting them requires a `tracker_view` **schema extension** — a separate design call filed as a follow-up `/task`. #710 ships the `tracker_list` primitive + Tier A only.
 


### PR DESCRIPTION
## Summary
- **New `tracker_list` primitive in `_lib-tracker.sh`** — the listing analog of `tracker_view`. Callers express intent in a small generic filter vocabulary (`state` / `assignee` / `author` / `labels` / `search` / `since` / `limit`) and each per-kind adapter (`gh` / `glab` / `custom`) renders it into that CLI's native flags. We deliberately do **not** parse GitHub's search DSL — that would couple the model to GitHub forever. Output is a normalised JSON array `{ref,number,state,title,url,labels,updatedAt}`; empty result is `[]` + exit 0, failure is `[]` + exit 1, so callers treat "empty" uniformly.
- **Read-side skills converted** — `/inbox`, `/tasks`, and `/stakeholder-update` now call `tracker_list` for their **issue** sources instead of hardcoding `gh issue list`, so they return real results on a project whose `tracker.kind` is `glab`. This is the triage/listing half of issue-axis tracker support (#670 stack).
- **38-case test suite** (`test_tracker_list.sh`) — covers filter-render (state/assignee/author/labels/search/limit → correct flags), the `assignee=none` / `since` degradations, the empty-set-vs-CLI-failure contract, `kind=none`, the glab adapter (iid/web_url/updated_at normalisation, repeated `--label`, client-side `since`), and **shell-injection safety** on the `custom` template. Uses mock CLIs — no real API calls.
- **AgDR-0093** records the design: generic-filters-not-string-translation, the normalised list schema, and the two scope boundaries below.

## Scope boundaries (read before assuming full tracker-agnosticism)
- **Forge axis is out of scope (#711).** `/inbox`, `/tasks`, `/status`, `/stakeholder-update` are dominated by `gh pr list` calls (PRs to review, ready-to-merge, failing CI, shipped-since). Those are the PR/MR forge axis handled by #711. This PR makes the skills **issue-axis** tracker-agnostic, **not** fully tracker-agnostic — every `gh pr list` call is annotated `forge (#711)` inline.
- **Four `gh issue view` skills deferred.** #710's Problem statement names `/status`, `/plan-initiative`, `/spike-close`, `/prototype-close`, but these use `gh issue view` (single-issue), not `gh issue list`. Routing them through the existing `tracker_view` fails because they read `assignees` (`/status`) and `body` (`/plan-initiative`, `/spike-close`, `/prototype-close`) — fields `tracker_view`'s `{state,title,url,labels}` schema doesn't return. Extending that schema is a separate design call, filed as a follow-up (extend `tracker_view` → `body`+`assignees`, then route the single-view reads). See AgDR-0093 §"Why Tier B can't be a clean `tracker_view` swap".
- **GitHub-only filters degrade, don't crash.** `mentions:` (cross-repo) and `commenter:>@me` have no GitLab equivalent, so they stay on a guarded gh-only path (empty on other trackers) or are filtered client-side — the precedent `/inbox` already set for "new comments since last seen".

## Testing
1. `bash .claude/hooks/tests/test_tracker_list.sh` → 38 pass / 0 fail.
2. Regression: `test_tracker_create` (29), `test_per_project_tracker` (6), `test_tracker_aware_hooks` (26), `test_tracker_issues_detection` (18) all green; the diff to `_lib-tracker.sh` is purely additive (no existing function touched).
3. `bash -n` clean on the lib and the test.
4. glab adapter flags verified against `glab issue list --help` (not written from recall).

## Glossary
| Term | Definition |
|------|------------|
| `tracker_list` | New `_lib-tracker.sh` primitive that lists a set of issues from a project's tracker via its CLI adapter — the listing analog of `tracker_view`. |
| Generic filter vocabulary | The framework's tracker-neutral filter set (`state`/`assignee`/`author`/`labels`/`search`/`since`/`limit`) that each adapter renders into native CLI flags. |
| Issue axis vs forge axis | Issue axis = issues/tickets (this PR + #709, the creator sweep — landed as #771); forge axis = pull/merge requests (#711). The two are converted separately. |
| Adapter | A per-`tracker.kind` renderer (`gh`/`glab`/`custom`) that turns generic filters into one CLI's flags and normalises its output. |
| Degradation | A filter with no cross-tracker equivalent handled by falling back to client-side filtering or a gh-only path, never a crash. |

Closes #710
Refs #670
