### PR TITLE
fix(#769): agdr-arch-pr hook — origin-first diff base + raw-command marker haystack

### DIFF
--- a/.claude/hooks/require-agdr-for-arch-pr.sh
+++ b/.claude/hooks/require-agdr-for-arch-pr.sh
@@ -124,9 +124,21 @@ if [ -n "$BODY_FILE" ] && [ -f "$BODY_FILE" ]; then
   BODY_FILE_CONTENT=$(cat "$BODY_FILE" 2>/dev/null)
 fi
 
-# Build the body haystack. Title is included so an AgDR reference in the
-# title also satisfies the requirement (reviewers will see it either way).
-HAYSTACK=$(printf '%s\n%s\n%s\n' "$TITLE" "$BODY" "$BODY_FILE_CONTENT")
+# Build the body haystack. Title is included so an AgDR reference in the title
+# also satisfies the requirement (reviewers will see it either way).
+#
+# The RAW COMMAND is included too (#769 bug 2): the --body extractor cannot
+# reliably recover a value that spans newlines (a `--body "$(cat <<'EOF' … EOF)"`
+# heredoc — awk's `.` doesn't cross lines) or is followed by a shell operator
+# (`… )" 2>&1 | tail` — the closing-quote anchor doesn't match a trailing
+# redirect/pipe). In both shapes BODY comes back as a stub like `"$(cat`, so the
+# skip marker and any AgDR reference INSIDE the body were missed and the PR was
+# false-blocked. The inline body is always a substring of $COMMAND, so grepping
+# the command directly makes the marker + AgDR-ref checks robust to every
+# quoting shape. (--body-file bodies live in a file, handled above; the marker
+# there is a distinctive HTML comment, so a raw-command match is not a false
+# bypass risk.)
+HAYSTACK=$(printf '%s\n%s\n%s\n%s\n' "$TITLE" "$BODY" "$BODY_FILE_CONTENT" "$COMMAND")
 
 # ---------------------------------------------------------------------------
 # 2. Skip marker short-circuit.
@@ -333,8 +345,15 @@ resolve_ref() {
 }
 
 if [ -n "$BASE_ARG" ]; then
-  # Try upstream/<arg>, origin/<arg>, <arg> in that order.
-  for candidate in "upstream/$BASE_ARG" "origin/$BASE_ARG" "$BASE_ARG"; do
+  # Try origin/<arg>, upstream/<arg>, <arg> in that order (#769 bug 1).
+  # origin/<arg> FIRST: a same-repo `--base main` PR merges into the fork's OWN
+  # base (origin/main), so that is the correct diff base. Trying upstream/<arg>
+  # first meant that on a fork whose main is behind upstream (the normal state
+  # before /update), the merge-base was computed against upstream's newer tree,
+  # so every file upstream changed since the last sync surfaced as an
+  # "architecture change" in this PR — false-blocking docs-only PRs. upstream
+  # stays as a fallback for a fresh fork whose origin lacks the base ref.
+  for candidate in "origin/$BASE_ARG" "upstream/$BASE_ARG" "$BASE_ARG"; do
     r=$(resolve_ref "$candidate")
     if [ -n "$r" ]; then BASE_REF="$r"; break; fi
   done

--- a/.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
+++ b/.claude/hooks/tests/test_require_agdr_for_arch_pr.sh
@@ -434,6 +434,61 @@ run_case "cd-target arch PR with AgDR ref → PASS [#669]" \
 rm -rf "$TGT_ARCH2"
 
 # ---------------------------------------------------------------------------
+# #769 bug 1 — diff-base resolves origin/<base> before upstream/<base>.
+# On a fork DIVERGED-behind upstream (its own baseline arch customisations that
+# upstream lacks), diffing against upstream/<base>'s merge-base attributes the
+# fork's OWN baseline files to the PR → false arch-block on a docs-only PR.
+# ---------------------------------------------------------------------------
+setup_diverged_fork() {
+  local dir; dir=$(mktemp -d -t agdr-b1.XXXXXX)
+  (
+    cd "$dir" || exit 1
+    git init -q -b main
+    git config user.email t@t.test; git config user.name test
+    echo "company: test" > onboarding.yaml
+    git add onboarding.yaml; git commit -q -m init
+    local p; p=$(git rev-parse HEAD)
+    # Fork baseline: a CI workflow the fork carries but upstream does not.
+    mkdir -p .github/workflows; echo "on: push" > .github/workflows/fork-custom.yml
+    git add .github/workflows/fork-custom.yml; git commit -q -m "fork: baseline ci"
+    git update-ref refs/remotes/origin/main HEAD       # origin/main = fork main
+    # upstream/main diverged from p — does NOT have the fork's workflow.
+    git checkout -q "$p"
+    echo "# upstream" > UPSTREAM.md; git add UPSTREAM.md; git commit -q -m "upstream: unrelated"
+    git update-ref refs/remotes/upstream/main HEAD
+    # Feature branch off the fork's main: docs only.
+    git checkout -q main; git checkout -q -b feature
+    mkdir -p docs; echo "# new" > docs/new.md
+    git add docs/new.md; git commit -q -m "docs: add"
+  )
+  echo "$dir"
+}
+
+B1_DIR=$(setup_diverged_fork)
+run_case "docs-only PR on a fork diverged-behind upstream → PASS (diffs origin/main, not upstream/main) [#769 bug1]" \
+  "$B1_DIR" 0 "" \
+  "gh pr create --base main --title 'docs(#9): update guide' --body 'Docs only. No decisions.'"
+
+# ---------------------------------------------------------------------------
+# #769 bug 2 — the skip marker (and any AgDR ref) inside a heredoc --body with
+# a trailing pipe is honoured. The --body extractor cannot recover a value that
+# spans newlines or is followed by a shell operator; the raw command is now part
+# of the haystack, so the marker is seen regardless of --body quoting shape.
+# ---------------------------------------------------------------------------
+B2_DIR=$(setup_repo c1_base c1_feat)   # feature touches src/domain/ (arch), no AgDR
+B2_CMD=$'gh pr create --base main --title "feat(#10): domain" --body "$(cat <<\'EOF\'\nSome body text.\n<!-- agdr: not-applicable -->\nEOF\n)" 2>&1 | tail -3'
+run_case "arch PR, skip-marker in a heredoc --body with trailing pipe → PASS (bypassed) [#769 bug2]" \
+  "$B2_DIR" 0 "not-applicable marker present" \
+  "$B2_CMD"
+
+# And the AgDR-reference path through the same heredoc+pipe shape → PASS.
+B2b_DIR=$(setup_repo c1_base c1_feat)
+B2b_CMD=$'gh pr create --base main --title "feat(#11): domain" --body "$(cat <<\'EOF\'\nSee AgDR-0009-portfolio-domain for the rationale.\nEOF\n)" 2>&1 | tail -3'
+run_case "arch PR, AgDR ref in a heredoc --body with trailing pipe → PASS [#769 bug2]" \
+  "$B2b_DIR" 0 "" \
+  "$B2b_CMD"
+
+# ---------------------------------------------------------------------------
 # Result
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two independent bugs in `require-agdr-for-arch-pr.sh` (#769), both of which false-block legitimate PRs on a fork behind/diverged-from upstream — the normal state right before `/update`.

- **Bug 1 — diff-base preferred `upstream/<base>` over `origin/<base>`.** A same-repo `--base main` PR merges into the fork's **own** base (`origin/main`), so that's the correct diff base. Trying `upstream/<base>` first meant that on a fork carrying its own baseline customisations (custom hooks/CI upstream lacks), the merge-base was computed against upstream's **diverged** tree, and the fork's baseline arch files were attributed to *this* PR → docs-only PRs blocked. Reordered to `origin/<base>`, `upstream/<base>`, `<base>`.
- **Bug 2 — the `--body` extractor drops multi-line / trailing-operator bodies.** awk's `.` doesn't cross newlines, so a `--body "$(cat <<'EOF' … EOF)"` heredoc — or a `… )" 2>&1 | tail` trailing pipe — leaves `BODY` as a stub like `"$(cat`. The `<!-- agdr: not-applicable -->` escape-hatch marker and any AgDR reference **inside** the body were silently missed → PR blocked despite the marker. **Fix:** the inline body is always a substring of `$COMMAND`, so the raw command is now part of the marker/AgDR-ref haystack — robust to *every* quoting shape.
  - *Note:* the reporter's proposed fix (broaden the closing-quote anchor) only covers the single-line trailing-operator case. I verified with the real awk that a **multi-line heredoc** body fails regardless of the anchor (awk `.` is line-bound), so I fixed it at the haystack instead — bulletproof across both shapes.

## Testing

`bash .claude/hooks/tests/test_require_agdr_for_arch_pr.sh` → **20 pass**, 3 new:
- docs-only PR on a fork **diverged-behind** upstream → PASS (diffs `origin/main`, not `upstream/main`) — Bug 1.
- arch PR with the skip marker in a **heredoc `--body` + trailing pipe** → PASS (bypassed) — Bug 2.
- arch PR with an **AgDR ref** in a heredoc `--body + pipe` → PASS — Bug 2.

**1 pre-existing failure** (`spike active-ticket marker`) is unrelated — it's a **known in-sandbox ops-root limitation documented in the test file itself** (≈ line 311), red on clean `dev` before this change.

Closes #769

---

## Glossary
| Term | Definition |
|------|------------|
| diff-base | The ref the hook diffs HEAD against to compute a PR's changed files |
| diverged fork | A fork whose `main` carries its own commits (baseline customisations) that upstream lacks — so `merge-base(HEAD, upstream/main)` predates them |
| escape hatch | The `<!-- agdr: not-applicable -->` body marker that bypasses the AgDR requirement |
| haystack | The text the hook greps for the skip marker + AgDR references (title + body + body-file + now the raw command) |
