### PR TITLE
feat(#777): auto-invoke the Security Auditor on trust-chain changes (.claude/hooks/**, settings.json)

### DIFF
--- a/.claude/hooks/detect-role-trigger.sh
+++ b/.claude/hooks/detect-role-trigger.sh
@@ -184,6 +184,25 @@ detect_path_triggers() {
       ;;
   esac
 
+  # Security Auditor — the TRUST CHAIN (me2resh/apexyard#777).
+  # The framework's most security-critical code is its own enforcement layer:
+  # the hooks that decide whether an action (esp. a merge) is permitted, and the
+  # settings.json matcher wiring that decides whether a gate fires at all. These
+  # are NOT auth/crypto/secrets paths, so the trigger above misses them — yet a
+  # subtle bug here (a path-traversal write, a fail-open gate, an injection in
+  # the tracker/broker lib) is exactly what the adversarial security lens is for.
+  # Over-triggering is cheap (the auditor no-ops on a false positive); leaving
+  # trust-chain edits to the generalist review alone is the gap #777 closes.
+  case "$rel" in
+    .claude/hooks/*|*/.claude/hooks/*|\
+    .claude/settings.json|*/.claude/settings.json)
+      emit_banner \
+        "Security Auditor" \
+        "roles/security/security-auditor.md" \
+        "edit touches the security-critical trust chain ($rel) — run /security-review"
+      ;;
+  esac
+
   # Platform Engineer — CI/CD pipelines + golden-path templates
   case "$rel" in
     .github/workflows/*|*/.github/workflows/*|\

--- a/.claude/hooks/tests/test_detect_role_trigger.sh
+++ b/.claude/hooks/tests/test_detect_role_trigger.sh
@@ -133,6 +133,33 @@ in=$(jq -nc \
   '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
 run_case "path trigger: ordinary path is silent" 0 "" "$in"
 
+# 2e-i. Trust chain (#777): a merge-gate hook fires Security Auditor.
+in=$(jq -nc \
+  --arg p ".claude/hooks/block-unreviewed-merge.sh" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "trust chain: .claude/hooks/* fires Security Auditor [#777]" 0 \
+  "ROLE TRIGGER: Security Auditor.*roles/security/security-auditor\\.md" "$in"
+
+# 2e-ii. Trust chain (#777): settings.json (the matcher wiring) fires Security Auditor.
+in=$(jq -nc \
+  --arg p ".claude/settings.json" \
+  '{hook_event_name:"PreToolUse", tool_name:"Write", tool_input:{file_path:$p}}')
+run_case "trust chain: .claude/settings.json fires Security Auditor [#777]" 0 \
+  "ROLE TRIGGER: Security Auditor" "$in"
+
+# 2e-iii. Trust chain (#777): a nested hooks path (e.g. a managed-project fork) fires too.
+in=$(jq -nc \
+  --arg p "workspace/proj/.claude/hooks/_lib-tracker.sh" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "trust chain: */.claude/hooks/* fires Security Auditor [#777]" 0 \
+  "ROLE TRIGGER: Security Auditor" "$in"
+
+# 2e-iv. A .claude path that is NOT trust-chain (a skill doc) stays silent.
+in=$(jq -nc \
+  --arg p ".claude/skills/roadmap/SKILL.md" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "trust chain: non-hook .claude path is silent [#777]" 0 "" "$in"
+
 # 2f. Edit on .github/workflows/ci.yml → Platform Engineer banner.
 in=$(jq -nc \
   --arg p ".github/workflows/ci.yml" \

--- a/.claude/rules/role-triggers.md
+++ b/.claude/rules/role-triggers.md
@@ -21,7 +21,7 @@ ApexYard ships **20 role definitions** in `roles/{department}/`. They are not al
 | **UI Designer** | `roles/design/ui-designer.md` | Visual design · component specifications · design tokens · pixel-level work |
 | **UX Designer** | `roles/design/ux-designer.md` | User flows · information architecture · usability review · wireframing |
 | **Head of Security** | `roles/security/head-of-security.md` | Security strategy · threat model · compliance call · cross-project security architecture |
-| **Security Auditor** | `roles/security/security-auditor.md` | **PR touches auth / crypto / user data / secrets** · SAST findings · OWASP review · dependency vulnerability |
+| **Security Auditor** | `roles/security/security-auditor.md` | **PR touches auth / crypto / user data / secrets** · **the security-critical trust chain (`.claude/hooks/**`, `.claude/settings.json`) — #777** · SAST findings · OWASP review · dependency vulnerability |
 | **Penetration Tester** | `roles/security/penetration-tester.md` | Active testing · exploit discovery · API security review · pre-release security sign-off |
 | **Head of Data** | `roles/data/head-of-data.md` | Analytics strategy · data governance · reporting architecture · cross-project data modelling |
 | **Data Analyst** | `roles/data/data-analyst.md` | SQL queries · dashboards · A/B-test analysis · metric investigation |
@@ -81,6 +81,7 @@ This is a **prose convention**, not a mechanically-enforced format. The sibling 
 |--------|----------|
 | Ticket moved to `qa` label | QA Engineer |
 | PR diff touches `**/auth/**`, `**/crypto/**`, `**/secrets/**`, `.env*` | Security Auditor |
+| Edit/PR touches the trust chain — `.claude/hooks/**` (merge gates, tracker/forge lib, review-marker lib, credential-broker scripts) or `.claude/settings.json` (the matcher wiring that decides whether a gate fires) | Security Auditor (#777) |
 | PR diff touches `.github/workflows/**`, `golden-paths/pipelines/**` | Platform Engineer |
 | PR diff touches `docs/agdr/**` or adds a new dependency | Tech Lead |
 | Edit/PR touches a design artifact (technical design, migration AgDR, feature spec / PRD) | Solution Architect |
@@ -159,6 +160,7 @@ Triggers wired in v1 (me2resh/apexyard#206):
 |----------------|------------|-----------|------|
 | Label-based  | `PreToolUse` on `Bash` (matcher: `gh issue edit *`) | `--add-label qa` (single or comma list) | QA Engineer |
 | Diff/path    | `PreToolUse` on `Edit` / `Write` / `MultiEdit` | path contains `auth/`, `crypto/`, `secrets/`, `.env*` | Security Auditor |
+| Diff/path    | same | path under `.claude/hooks/` or matches `.claude/settings.json` (the trust chain — #777) | Security Auditor |
 | Diff/path    | same | path under `.github/workflows/` or `golden-paths/pipelines/` | Platform Engineer |
 | Diff/path    | same | path under `docs/agdr/` | Tech Lead |
 | Diff/path    | same | path matches a design artifact (`*technical-design*.md`, `*tech-design*.md`, `**/designs/**`, `**/prds/**`, `*prd*.md`, `*feature-spec*.md`, `docs/agdr/*migration*.md`) | Solution Architect |


### PR DESCRIPTION
## Summary

- **The adversarial Security Auditor now auto-fires on trust-chain changes.** It previously auto-fired only on `auth` / `crypto` / `secrets` / `.env*` diffs — but the framework's most security-critical code is its **own enforcement layer**: the hooks under `.claude/hooks/` (merge gates, the tracker/forge lib that shells out + `eval`s, the review-marker lib, credential-broker scripts) and `.claude/settings.json` (the matcher wiring that decides *whether a gate fires at all*). None of those matched the trigger, so trust-chain changes got only the **generalist** code review by default — never the specialist's adversarial lens.
- **This isn't hypothetical.** A recent review sweep found a **path-traversal write** and a **fail-open merge gate** that the generalist reviewer *approved* and only a *manually-invoked* security review caught. Extending the trigger would have surfaced the specialist automatically on the contributor's own governed run — before the PR ever reached a human.
- **`detect-role-trigger.sh`** — a new trust-chain `case` fires the Security Auditor banner on `.claude/hooks/**` + `.claude/settings.json`. Advisory (exit 0), same shape as the existing path triggers — **over-triggering is cheap** (the auditor no-ops on a false positive); *under*-triggering is what let the two bugs through.
- **`role-triggers.md`** — trust-chain paths added to the Security Auditor rows (activation table, auto-activation signals, wired-triggers table).

## Testing

`bash .claude/hooks/tests/test_detect_role_trigger.sh` → **42/0**. Four new cases: `.claude/hooks/*`, `.claude/settings.json`, and a nested `*/.claude/hooks/*` (managed-project fork) each fire the Security Auditor; a non-hook `.claude/skills/*/SKILL.md` path stays **silent** (no over-broad `.claude/**` match). `bash -n` clean.

## Design notes
- **Advisory, not a hard gate** — consistent with how the Security Auditor works today. The goal is that the specialist *always gets a look* at trust-chain changes, not to block them.
- **Scope: the trust chain, not all of `.claude/`** — skills/docs/agents don't fire it; only the hooks + the settings matcher wiring do.
- **Fittingly self-dogfooding:** this PR itself edits `.claude/hooks/detect-role-trigger.sh`, so once merged the rule would flag *its own kind* of change for a security look — which is exactly why this PR is going through a security review.
- **Follow-up (out of scope):** an adopter-configurable `security_review_paths` key so teams can add their own trust-chain paths — noted in #777, deferred.

Closes #777

---

## Glossary
| Term | Definition |
|------|------------|
| trust chain | The hooks + settings that decide whether an action (esp. a merge) is permitted — the code an attacker most wants to weaken |
| generalist vs specialist review | The always-on code reviewer (code quality) vs the path-triggered security auditor (adversarial security) |
| advisory trigger | Emits a banner/nudge to run the specialist; never blocks the tool call |
