### PR TITLE
fix(#791): pr-create validator — expand tilde before git -C + stop over-matching gh issue create

### DIFF
--- a/.claude/hooks/_lib-pr-repo.sh
+++ b/.claude/hooks/_lib-pr-repo.sh
@@ -74,6 +74,76 @@ _git_remote_to_slug() {
     's|.*[:/]([^/:]+/[^/]+)\.git$|\1|p; s|.*[:/]([^/:]+/[^/]+)$|\1|p' | head -1
 }
 
+# Internal: expand a leading `~` or `~user` in a path to an absolute path.
+#
+# WHY THIS EXISTS (me2resh/apexyard bug report, 2026-07)
+# -------------------------------------------------------
+# `pr_cmd_cd_target` extracts the literal path text from a `cd <path> && …`
+# prefix. When the operator's command reads `cd ~/Projects/foo && gh pr
+# create …`, the extracted path is the literal string `~/Projects/foo` — the
+# shell would expand that tilde when it actually runs the `cd`, but this hook
+# never runs a shell over the extracted string, it hands it straight to
+# `git -C`. `git -C` does NOT perform tilde-expansion (it treats `~` as a
+# literal directory-name character), so `git -C "~/Projects/foo"` fails
+# silently, every caller's cd-target resolution comes back empty, and each
+# hook falls back to its own cwd (typically the ops-fork root on `dev`) —
+# producing misleading errors like "Branch 'dev' missing ticket ID" for a
+# perfectly valid PR from a tilde-path worktree.
+#
+# This helper mirrors the shell's own tilde-expansion rules for the two forms
+# that matter:
+#   `~` / `~/...`       → the current user's $HOME
+#   `~user` / `~user/…` → that user's home directory, resolved via `eval echo`
+#                          ONLY after validating the extracted token looks
+#                          like a real username (alnum/dot/dash/underscore) —
+#                          refuses to eval anything that could smuggle shell
+#                          metacharacters through the path text.
+#
+# Graceful fallback: if expansion cannot be resolved (unknown user, `eval`
+# failure), the original string is returned unchanged rather than throwing —
+# callers already treat an unresolvable `git -C` target as "can't check from
+# here" and degrade non-misleadingly (skip/warn), so returning the original
+# text preserves that existing, safe behaviour rather than fabricating a path.
+_pr_repo_expand_tilde() {
+  local p="$1"
+  # shellcheck disable=SC2088  # intentional: matching a literal leading '~'
+  # in a case pattern, not asking the shell to expand it here.
+  case "$p" in
+    '~')
+      printf '%s' "$HOME"
+      ;;
+    '~/'*)
+      printf '%s' "$HOME/${p#\~/}"
+      ;;
+    '~'*)
+      local rest user tail_part home
+      rest="${p#\~}"
+      user="${rest%%/*}"
+      tail_part=""
+      case "$rest" in
+        */*) tail_part="/${rest#*/}" ;;
+      esac
+      if printf '%s' "$user" | grep -qE '^[A-Za-z0-9._-]+$'; then
+        home=$(eval echo "~${user}" 2>/dev/null)
+        case "$home" in
+          '~'*|'')
+            printf '%s' "$p"  # unresolved (no such user) — return unchanged
+            ;;
+          *)
+            printf '%s%s' "$home" "$tail_part"
+            ;;
+        esac
+      else
+        # Token doesn't look like a safe username — don't eval it.
+        printf '%s' "$p"
+      fi
+      ;;
+    *)
+      printf '%s' "$p"
+      ;;
+  esac
+}
+
 # Public: pr_cmd_target_repo <command>
 #   Echoes the owner/repo slug from the --repo / -R flag in the command.
 #   Handles all four CLI forms:
@@ -135,13 +205,18 @@ git_origin_repo() {
 #   `cd '../my repo' && …` resolves correctly.
 pr_cmd_cd_target() {
   local cmd="$1"
+  local raw
   # Strip leading whitespace, then match `cd ` followed by a quoted or bare
   # path up to the first `&&`, `;`, or `|` separator.
-  printf '%s' "$cmd" | sed -nE \
+  raw=$(printf '%s' "$cmd" | sed -nE \
     "s/^[[:space:]]*cd[[:space:]]+\"([^\"]+)\"[[:space:]]*(&&|;|\|).*/\1/p;
      s/^[[:space:]]*cd[[:space:]]+'([^']+)'[[:space:]]*(&&|;|\|).*/\1/p;
      s/^[[:space:]]*cd[[:space:]]+([^&;|[:space:]]+)[[:space:]]*(&&|;|\|).*/\1/p" \
-    | head -1
+    | head -1)
+  [ -z "$raw" ] && return 0
+  # Expand a leading ~ / ~user before handing the path to any caller — git -C
+  # does not shell-expand tilde itself (see _pr_repo_expand_tilde above).
+  _pr_repo_expand_tilde "$raw"
 }
 
 # Public: pr_repo_matches_cwd <command> [<git-dir>]

--- a/.claude/hooks/_lib-pr-repo.sh
+++ b/.claude/hooks/_lib-pr-repo.sh
@@ -104,6 +104,19 @@ _git_remote_to_slug() {
 # callers already treat an unresolvable `git -C` target as "can't check from
 # here" and degrade non-misleadingly (skip/warn), so returning the original
 # text preserves that existing, safe behaviour rather than fabricating a path.
+#
+# Security note (Hakim / PR #792 review): the username allowlist check below
+# uses bash's `[[ =~ ]]` against the WHOLE string, anchored at both ends —
+# deliberately NOT `grep -qE '^…$'`, which matches per LINE. A multi-line
+# `$user` whose first line happens to look like a valid username would pass
+# a per-line grep check and reach `eval` with the remaining lines still
+# attached (a latent command-injection surface in a trust-chain hook). Not
+# reachable through today's sole caller (`pr_cmd_cd_target`'s `sed` output is
+# always single-line, further guaranteed by `head -1`), but this is a shared
+# lib function — a future caller that skips that sanitization would open the
+# hole `[[ =~ ]]` closes here for free (the whole-string anchor treats a
+# newline as just another character the charset must match, so ANY embedded
+# newline fails the check).
 _pr_repo_expand_tilde() {
   local p="$1"
   # shellcheck disable=SC2088  # intentional: matching a literal leading '~'
@@ -123,7 +136,7 @@ _pr_repo_expand_tilde() {
       case "$rest" in
         */*) tail_part="/${rest#*/}" ;;
       esac
-      if printf '%s' "$user" | grep -qE '^[A-Za-z0-9._-]+$'; then
+      if [[ "$user" =~ ^[A-Za-z0-9._-]+$ ]]; then
         home=$(eval echo "~${user}" 2>/dev/null)
         case "$home" in
           '~'*|'')

--- a/.claude/hooks/tests/test_lib_pr_repo_tilde_username_hardening.sh
+++ b/.claude/hooks/tests/test_lib_pr_repo_tilde_username_hardening.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Regression test — LOW hardening finding from Hakim's security review of
+# PR #792 (apexyard#791 fix): the `~user` username allowlist check in
+# `_pr_repo_expand_tilde` (_lib-pr-repo.sh) used to be a PER-LINE grep,
+# `grep -qE '^[A-Za-z0-9._-]+$'`, which matches per line rather than across
+# the whole string. A multi-line `$user` whose FIRST line looks like a valid
+# username passes that check even though later lines carry arbitrary text —
+# and the validated (but still multi-line) value was then handed straight to
+# `eval echo "~${user}"`.
+#
+# THE BUG (in isolation)
+# -----------------------
+# Not reachable through the current sole caller, `pr_cmd_cd_target`: its sed
+# extraction is single-line by construction and is further piped through
+# `head -1`, so `$user` can never carry an embedded newline when reached via
+# that path. But `_pr_repo_expand_tilde` is a shared, standalone lib
+# function — a future caller that skips that sanitization (or calls the
+# function directly with attacker-influenced input) would reach `eval` with
+# a multi-line, per-line-only-validated `$user`, which is a latent
+# command-injection surface in a trust-chain hook (`.claude/hooks/**`).
+#
+# THE FIX
+# -------
+# Swap the per-line `grep -qE '^…$'` for bash's `[[ "$user" =~ ^…$ ]]`, which
+# anchors against the WHOLE string (`^` / `$` bind to start/end of the full
+# value, not per line) — a multi-line value now fails the check outright
+# regardless of what its first line looks like, and `eval` is never reached.
+#
+# THIS TEST
+# ---------
+# Sources _lib-pr-repo.sh directly and calls the internal
+# `_pr_repo_expand_tilde` function with a hostile multi-line `~user` value
+# whose first line is a valid-looking username and whose second line is a
+# shell command that would create a sentinel file if it ever reached `eval`.
+# Asserts (a) the sentinel file is never created, and (b) the function
+# degrades gracefully — returns the original string unchanged, exactly as it
+# does for any other unresolvable/rejected `~user` form.
+#
+# Exit 0 if all cases pass; exit 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+LIB_PR_REPO="$SRC_ROOT/.claude/hooks/_lib-pr-repo.sh"
+
+if [ ! -f "$LIB_PR_REPO" ]; then
+  echo "FAIL: lib not found at $LIB_PR_REPO" >&2
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+. "$LIB_PR_REPO"
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# assert_no_eval_reach label path_value
+#   Calls _pr_repo_expand_tilde with a $1-shaped path whose embedded second
+#   line would touch a sentinel file if `eval` ever executed it. Asserts the
+#   sentinel is never created AND the function returns the input unchanged
+#   (the documented graceful-fallback behaviour for a rejected token).
+assert_no_eval_reach() {
+  local label="$1" path_value="$2"
+  local sentinel got
+  sentinel=$(mktemp -u /tmp/apexyard-test-tilde-hardening.XXXXXX)
+  rm -f "$sentinel"
+
+  # Rebuild path_value with the real sentinel path substituted in for the
+  # __SENTINEL__ placeholder (keeps callers readable).
+  path_value="${path_value//__SENTINEL__/$sentinel}"
+
+  got=$(_pr_repo_expand_tilde "$path_value")
+  local rc=$?
+
+  if [ -e "$sentinel" ]; then
+    echo "FAIL [$label]: sentinel file WAS created — eval executed injected content!" >&2
+    rm -f "$sentinel"
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  rm -f "$sentinel"
+
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]: function exited non-zero ($rc)" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+
+  if [ "$got" != "$path_value" ]; then
+    echo "FAIL [$label]: want unchanged passthrough, got: $got" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# ---------------------------------------------------------------------------
+# The reported hardening gap: first line of $user looks like a valid
+# username, second line is an injected shell command.
+# ---------------------------------------------------------------------------
+
+MULTILINE_USER=$'validuser\ntouch __SENTINEL__'
+assert_no_eval_reach \
+  "multi-line ~user (valid-looking first line + injected 2nd line) does NOT reach eval" \
+  "~${MULTILINE_USER}"
+
+MULTILINE_USER_WITH_TAIL=$'validuser\ntouch __SENTINEL__'
+assert_no_eval_reach \
+  "multi-line ~user/tail-path variant does NOT reach eval" \
+  "~${MULTILINE_USER_WITH_TAIL}/Projects/foo"
+
+# ---------------------------------------------------------------------------
+# Sanity: legitimate single-line ~user forms still behave as documented
+# (this is a behaviour-preservation check, not a new requirement — confirms
+# the hardening didn't regress the happy path).
+# ---------------------------------------------------------------------------
+
+result=$(_pr_repo_expand_tilde "~root")
+if [ -n "$result" ] && [ "$result" != "~root" ]; then
+  echo "PASS [~root (single-line, real user) still resolves via eval]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [~root (single-line, real user) still resolves via eval]: got '$result'" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}root-resolves "
+fi
+
+result=$(_pr_repo_expand_tilde "~zzznosuchuser999/x")
+if [ "$result" = "~zzznosuchuser999/x" ]; then
+  echo "PASS [~nosuchuser (single-line, unknown user) degrades unchanged]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [~nosuchuser (single-line, unknown user) degrades unchanged]: got '$result'" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}nosuchuser-passthrough "
+fi
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_pr_create_gate_anchor.sh
+++ b/.claude/hooks/tests/test_pr_create_gate_anchor.sh
@@ -209,6 +209,67 @@ run_case 'a --title value containing a literal && does NOT get misread as a chai
   "gh issue create --repo me2resh/apexyard --title 'build && deploy pipeline' --body 'desc'" \
   0 ""
 
+# ---------------------------------------------------------------------------
+# Hakim's SECOND security re-review of PR #792 found a new BLOCKING
+# regression: the round-1 loop applied shape 4 (a generic quote-free-segment
+# strip) unconditionally every iteration, so a genuine `gh pr create` with
+# quote-free trailing args followed by a top-level `&&` / `;` / `|`
+# separator got its OWN verb consumed as if it were a "chained prefix" —
+# the gate then silently skipped validation (exit 0) on a real invocation.
+# The fix (check-then-strip: verify the head before stripping, every
+# iteration) must make each of these fire and block a malformed title,
+# exactly like the true-positive/true-negative pairs above.
+#
+# NOTE 1: these cases deliberately use UNQUOTED --title values (or omit
+# --title entirely). Shape 4's whole point is stripping a QUOTE-FREE
+# segment — a quoted title (as used in every case above) contains a `'`
+# before any separator, which already keeps shape 4 from matching and would
+# make these cases pass trivially under the OLD buggy code too, defeating
+# the regression test. Hakim's literal reported bypass commands
+# (`--fill --head br && echo done`, `--title fixbug --head br; echo x`,
+# `--head br | cat`) are unquoted/title-free for exactly this reason —
+# faithfully reproducing them (rather than "equivalent" quoted variants) is
+# what makes these cases actually fail against the pre-fix code.
+#
+# NOTE 2: these cases also omit --body/--body-file. The gate-decision
+# preprocessing (near the top of the hook) strips everything from
+# --body-file/--body to end-of-string BEFORE the gate loop ever runs, which
+# would silently remove the trailing " && echo done" / "; echo x" / "| cat"
+# and — like quoting the title — would make the case pass regardless of
+# whether the gate fix works. Omitting --body/--body-file also means the
+# required-##-sections check no-ops (it only runs when the command carries
+# a body flag), so title-format + branch-ticket-ID are what prove the gate
+# fired for these cases specifically.
+#
+# Verified (see PR #792 discussion): each malformed-title case below FAILS
+# (wrongly returns rc=0) against the pre-fix commit and PASSES (rc=2)
+# against the check-then-strip fix.
+# ---------------------------------------------------------------------------
+
+run_case 'Hakim repro: gh pr create --fill --head br && echo done (no title) still validates' \
+  "gh pr create --repo me2resh/apexyard --fill --head fix/GH-900-test && echo done" \
+  0 ""
+
+run_case 'same shape with an unquoted malformed title still BLOCKS (proves the gate fired)' \
+  "gh pr create --repo me2resh/apexyard --fill --title fixbug --head fix/GH-900-test && echo done" \
+  2 "doesn't match format"
+
+run_case 'Hakim repro: gh pr create --title fixbug --head br; echo x — a well-formed unquoted title still validates' \
+  "gh pr create --repo me2resh/apexyard --title fix(#900):x --head fix/GH-900-test; echo x" \
+  0 ""
+
+run_case 'same shape (;) with the literal malformed "fixbug" title still BLOCKS' \
+  "gh pr create --repo me2resh/apexyard --title fixbug --head fix/GH-900-test; echo x" \
+  2 "doesn't match format"
+
+run_case 'Hakim repro: gh pr create --head br | cat (no title) still validates' \
+  "gh pr create --repo me2resh/apexyard --head fix/GH-900-test | cat" \
+  0 ""
+
+run_case 'same shape (|) with an unquoted malformed title still BLOCKS' \
+  "gh pr create --repo me2resh/apexyard --title fixbug --head fix/GH-900-test | cat" \
+  2 "doesn't match format"
+
 rm -f "$BF_OK"
 
 echo ""

--- a/.claude/hooks/tests/test_pr_create_gate_anchor.sh
+++ b/.claude/hooks/tests/test_pr_create_gate_anchor.sh
@@ -160,6 +160,55 @@ run_case 'a leading cd prefix before a genuine gh pr create still validates' \
   "cd /tmp && gh pr create --repo me2resh/apexyard --title 'fix(#900): gate anchor' --head fix/GH-900-test --body-file $BF_OK" \
   0 ""
 
+# ---------------------------------------------------------------------------
+# Hakim's security review of the anchor fix (PR #792) flagged a MEDIUM
+# completeness regression: the single-leading-`cd`-strip anchor missed
+# genuine `gh pr create` invocations behind OTHER prefix shapes that the old
+# (unanchored) gate used to catch. Each of Hakim's four named shapes gets a
+# true-positive case (still validates) below, plus one true-negative (still
+# BLOCKS a malformed title through the same prefix) so the fix isn't merely
+# "widen the no-op path".
+# ---------------------------------------------------------------------------
+
+run_case 'a leading env-var assignment before a genuine gh pr create still validates' \
+  "FOO=bar gh pr create --repo me2resh/apexyard --title 'fix(#900): gate anchor' --head fix/GH-900-test --body-file $BF_OK" \
+  0 ""
+
+run_case 'a leading env-var assignment with a malformed title still BLOCKS' \
+  "FOO=bar gh pr create --repo me2resh/apexyard --title 'no ticket id here' --head fix/GH-900-test --body-file $BF_OK" \
+  2 "doesn't match format"
+
+run_case 'a leading "time" wrapper before a genuine gh pr create still validates' \
+  "time gh pr create --repo me2resh/apexyard --title 'fix(#900): gate anchor' --head fix/GH-900-test --body-file $BF_OK" \
+  0 ""
+
+run_case 'a leading "time" wrapper with a malformed title still BLOCKS' \
+  "time gh pr create --repo me2resh/apexyard --title 'no ticket id here' --head fix/GH-900-test --body-file $BF_OK" \
+  2 "doesn't match format"
+
+run_case 'a double leading cd (cd a && cd b && …) before a genuine gh pr create still validates' \
+  "cd /tmp && cd /tmp && gh pr create --repo me2resh/apexyard --title 'fix(#900): gate anchor' --head fix/GH-900-test --body-file $BF_OK" \
+  0 ""
+
+run_case 'a double leading cd with a malformed title still BLOCKS' \
+  "cd /tmp && cd /tmp && gh pr create --repo me2resh/apexyard --title 'no ticket id here' --head fix/GH-900-test --body-file $BF_OK" \
+  2 "doesn't match format"
+
+run_case 'a generic non-cd prefix (X && gh pr create) still validates' \
+  "echo hi && gh pr create --repo me2resh/apexyard --title 'fix(#900): gate anchor' --head fix/GH-900-test --body-file $BF_OK" \
+  0 ""
+
+run_case 'a generic non-cd prefix (X && gh pr create) with a malformed title still BLOCKS' \
+  "echo hi && gh pr create --repo me2resh/apexyard --title 'no ticket id here' --head fix/GH-900-test --body-file $BF_OK" \
+  2 "doesn't match format"
+
+# The gate widening must not defeat the anchor itself — a --title value that
+# contains a literal "&&" stays inside its quotes and must NOT be misread as
+# a chained prefix ahead of a fabricated "gh pr create" segment.
+run_case 'a --title value containing a literal && does NOT get misread as a chained prefix (exit 0, no-op)' \
+  "gh issue create --repo me2resh/apexyard --title 'build && deploy pipeline' --body 'desc'" \
+  0 ""
+
 rm -f "$BF_OK"
 
 echo ""

--- a/.claude/hooks/tests/test_pr_create_gate_anchor.sh
+++ b/.claude/hooks/tests/test_pr_create_gate_anchor.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Regression test — validate-pr-create.sh's gate over-matched "gh pr create"
+# as an unanchored substring anywhere in the command (apexyard bug report,
+# 2026-07).
+#
+# THE BUG
+# -------
+# The gate that decides "should this hook validate at all" stripped only the
+# --body / --body-file / -F payload before testing for the command verb:
+#
+#     if ! printf '%s' "$_cmd_for_gate" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+create\b'; then
+#       exit 0
+#     fi
+#
+# That grep has NO position anchor — it matches "gh pr create" ANYWHERE in
+# what's left, including inside a --title value that was never stripped. A
+# `gh issue create --title '... gh pr create over-matches gh issue create ...'`
+# — e.g. exactly the kind of bug-report title you'd write about THIS hook —
+# got the full PR-only validation (title-format regex, missing ## Testing /
+# ## Glossary, branch-ticket-ID check) even though the invoked command was
+# `gh issue create`, not `gh pr create`. Reproduced live against the
+# installed hook before this fix.
+#
+# THE FIX
+# -------
+# The gate now strips one optional leading `cd <path> &&` / `cd <path>;`
+# prefix and then anchors the match to the command HEAD
+# (`^[[:space:]]*gh[[:space:]]+pr[[:space:]]+create\b`) — "gh pr create" must
+# be the actual verb being invoked, not merely present as a substring
+# anywhere in a flag's value.
+#
+# Exit 0 if all cases pass; exit 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/validate-pr-create.sh"
+LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+LIB_TRACKER="$SRC_ROOT/.claude/hooks/_lib-tracker.sh"
+LIB_PR_REPO="$SRC_ROOT/.claude/hooks/_lib-pr-repo.sh"
+DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+
+# shellcheck source=_lib-mock-gh.sh
+source "$(cd "$(dirname "$0")" && pwd)/_lib-mock-gh.sh"
+
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# make_sandbox [branch]
+#   Default branch carries a ticket ID so cases that aren't testing the
+#   branch check don't trip over it.
+make_sandbox() {
+  local branch="${1:-fix/GH-900-test}"
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    git remote add origin "git@github.com:me2resh/apexyard.git"
+    : > onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+    git checkout -q -B "$branch"
+  )
+  mkdir -p "$sb/.claude/hooks"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/validate-pr-create.sh"
+  chmod +x "$sb/.claude/hooks/validate-pr-create.sh"
+  [ -f "$LIB_CFG" ]     && cp "$LIB_CFG"     "$sb/.claude/hooks/_lib-read-config.sh"
+  [ -f "$LIB_TRACKER" ] && cp "$LIB_TRACKER" "$sb/.claude/hooks/_lib-tracker.sh"
+  [ -f "$LIB_PR_REPO" ] && cp "$LIB_PR_REPO" "$sb/.claude/hooks/_lib-pr-repo.sh"
+  [ -f "$DEFAULTS" ]    && cp "$DEFAULTS"    "$sb/.claude/project-config.defaults.json"
+  echo "$sb"
+}
+
+# run_case label command want_rc [want_stderr_regex]
+run_case() {
+  local label="$1" cmd="$2" want_rc="$3" want_stderr_regex="${4:-}"
+  local sb; sb=$(make_sandbox)
+  mock_gh_install "$sb"
+
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && printf '%s' "$input" | bash .claude/hooks/validate-pr-create.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:400})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! printf '%s' "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# ---------------------------------------------------------------------------
+# The reported bug: a real-world "issue create" whose TITLE discusses this
+# very hook, and therefore contains the literal words "gh pr create".
+# ---------------------------------------------------------------------------
+
+run_case 'issue create whose --title mentions the literal phrase does NOT trigger PR validation (exit 0)' \
+  "gh issue create --repo me2resh/apexyard --title 'fix validate-pr-create.sh: gh pr create over-matches gh issue create' --body 'the substring used to false-block this exact ticket'" \
+  0 ""
+
+# A second phrasing (word order varies) to make sure the anchor — not a
+# lucky specific string — is what fixed it.
+run_case 'issue create whose --title says "over-matches gh pr create" does NOT trigger PR validation (exit 0)' \
+  "gh issue create --repo me2resh/apexyard --title '[Bug] validator over-matches gh pr create pattern' --body 'desc'" \
+  0 ""
+
+# --title embedding the phrase via --body-file content (not just inline
+# --body) — the gate must not be fooled by title OR body-file content.
+BF=$(mktemp /tmp/test-gate-anchor-body.XXXXXX.md)
+printf 'Example: gh pr create --title "x" --body "y"\n' > "$BF"
+run_case 'issue create with --title mentioning it AND --body-file containing it → no-op (exit 0)' \
+  "gh issue create --repo me2resh/apexyard --title 'fix: gh pr create gate bug' --body-file $BF" \
+  0 ""
+rm -f "$BF"
+
+# ---------------------------------------------------------------------------
+# True positives must still fire — the anchor must not be so tight it misses
+# real invocations.
+# ---------------------------------------------------------------------------
+
+BODY_OK="## Summary
+test
+
+## Testing
+1. unit tests pass
+
+## Glossary
+| Term | Definition |
+|------|------------|
+| GH-900 | gate anchor fix |"
+BF_OK=$(mktemp /tmp/test-gate-anchor-ok.XXXXXX.md)
+printf '%s' "$BODY_OK" > "$BF_OK"
+
+run_case 'a genuine gh pr create still validates and PASSES with a conforming title/body/branch' \
+  "gh pr create --repo me2resh/apexyard --title 'fix(#900): gate anchor' --head fix/GH-900-test --body-file $BF_OK" \
+  0 ""
+
+run_case 'a genuine gh pr create with a malformed title still BLOCKS' \
+  "gh pr create --repo me2resh/apexyard --title 'no ticket id here' --head fix/GH-900-test --body-file $BF_OK" \
+  2 "doesn't match format"
+
+run_case 'a leading cd prefix before a genuine gh pr create still validates' \
+  "cd /tmp && gh pr create --repo me2resh/apexyard --title 'fix(#900): gate anchor' --head fix/GH-900-test --body-file $BF_OK" \
+  0 ""
+
+rm -f "$BF_OK"
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_pr_create_tilde_cd_target.sh
+++ b/.claude/hooks/tests/test_pr_create_tilde_cd_target.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Regression test — tilde-expansion bug in the PR-create cd-target resolution
+# (apexyard bug report, 2026-07).
+#
+# THE BUG
+# -------
+# `pr_cmd_cd_target` (in _lib-pr-repo.sh) extracts the literal path text from
+# a leading `cd <path> && …` prefix — e.g. for
+# `cd ~/Projects/foo && gh pr create …` it returned the literal string
+# `~/Projects/foo`. That string was then handed straight to `git -C`:
+#
+#     CD_TOPLEVEL=$(git -C "$CD_TARGET" rev-parse --show-toplevel ...)
+#
+# `git -C` does NOT perform shell tilde-expansion — it treats `~` as a
+# literal path-name character. So `git -C "~/Projects/foo"` failed silently,
+# CD_TOPLEVEL came back empty, and validate-pr-create.sh's branch-ticket-ID
+# fallback used the HOOK'S OWN cwd instead (typically the ops-fork root, on
+# `dev`) — producing a false "Branch 'dev' missing ticket ID" block for a
+# perfectly valid PR from a tilde-path worktree.
+#
+# THE FIX
+# -------
+# `_pr_repo_expand_tilde` (in _lib-pr-repo.sh) expands a leading `~` / `~user`
+# to an absolute path before `pr_cmd_cd_target` returns it, so `git -C`
+# receives a real path. This is a single fix point shared by every hook that
+# calls `pr_cmd_cd_target` (validate-pr-create.sh, validate-branch-name.sh,
+# require-agdr-for-arch-pr.sh, require-architecture-review.sh,
+# require-design-review-for-ui.sh).
+#
+# THIS TEST
+# ---------
+# Uses a per-case fake $HOME (via `HOME=<tmp> bash validate-pr-create.sh`) so
+# `~/Projects/tilde-target` resolves to a directory this test fully controls
+# — no dependency on, or pollution of, the real user's home directory.
+#
+# Exit 0 if all cases pass; exit 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/validate-pr-create.sh"
+LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+LIB_TRACKER="$SRC_ROOT/.claude/hooks/_lib-tracker.sh"
+LIB_PR_REPO="$SRC_ROOT/.claude/hooks/_lib-pr-repo.sh"
+DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+
+# shellcheck source=_lib-mock-gh.sh
+source "$(cd "$(dirname "$0")" && pwd)/_lib-mock-gh.sh"
+
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+BODY_OK="## Summary
+test
+
+## Testing
+1. unit tests pass
+
+## Glossary
+| Term | Definition |
+|------|------------|
+| tilde | home-directory shorthand |"
+
+# make_host_sandbox [local_branch]
+#   Host sandbox with the hook + libs installed, on an intentionally
+#   non-conforming local branch — proves the fix resolves the CD-TARGET's
+#   own branch, not the host sandbox's cwd branch.
+make_host_sandbox() {
+  local branch="${1:-totally-bogus-host-branch}"
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    : > onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+    git checkout -q -B "$branch"
+  )
+  mkdir -p "$sb/.claude/hooks"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/validate-pr-create.sh"
+  chmod +x "$sb/.claude/hooks/validate-pr-create.sh"
+  [ -f "$LIB_CFG" ]     && cp "$LIB_CFG"     "$sb/.claude/hooks/_lib-read-config.sh"
+  [ -f "$LIB_TRACKER" ] && cp "$LIB_TRACKER" "$sb/.claude/hooks/_lib-tracker.sh"
+  [ -f "$LIB_PR_REPO" ] && cp "$LIB_PR_REPO" "$sb/.claude/hooks/_lib-pr-repo.sh"
+  [ -f "$DEFAULTS" ]    && cp "$DEFAULTS"    "$sb/.claude/project-config.defaults.json"
+  echo "$sb"
+}
+
+# make_target_repo_under <fake_home> <subpath-under-home> <branch>
+#   Creates a git repo at $fake_home/<subpath>, checked out on <branch>.
+#   Echoes the absolute path.
+make_target_repo_under() {
+  local fake_home="$1" subpath="$2" branch="$3" tdir
+  tdir="$fake_home/$subpath"
+  mkdir -p "$tdir"
+  (
+    cd "$tdir" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    : > onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+    git checkout -q -B "$branch"
+  )
+  echo "$tdir"
+}
+
+# run_tilde_case label target_branch want_rc want_stderr_regex
+run_tilde_case() {
+  local label="$1" target_branch="$2" want_rc="$3" want_stderr_regex="$4"
+  local sb fake_home tgt
+  sb=$(make_host_sandbox)
+  mock_gh_install "$sb"
+  fake_home=$(mktemp -d)
+  tgt=$(make_target_repo_under "$fake_home" "Projects/tilde-target" "$target_branch")
+
+  local body_file="$sb/body.md"
+  printf '%s' "$BODY_OK" > "$body_file"
+
+  # NB: this whole assignment is double-quoted so the literal '~' is NOT
+  # expanded by THIS test script's own shell — it must reach the hook
+  # exactly as a real (un-executed) user command would contain it: a raw,
+  # un-expanded tilde in the cd-target path.
+  local cmd="cd ~/Projects/tilde-target && gh pr create --repo me2resh/apexyard --title 'fix(#900): test' --body-file $body_file"
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && printf '%s' "$input" | HOME="$fake_home" bash .claude/hooks/validate-pr-create.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb" "$fake_home" "$tgt"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc" >&2
+    echo "    stderr: ${got_stderr:0:300}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# (a) tilde cd-target on a CONFORMING branch, host cwd bogus, no --head →
+#     PASS. Pre-fix this BLOCKED on the host sandbox's bogus branch because
+#     `git -C "~/Projects/tilde-target"` failed silently and the fallback hit
+#     the (bogus-branch) host cwd instead.
+run_tilde_case "tilde cd-target on conforming branch resolves the TARGET, not host cwd → PASS" \
+  "feature/GH-900-tilde-target" 0 ""
+
+# (b) tilde cd-target on a genuinely non-conforming branch → still BLOCKS.
+#     Proves the fix re-roots to the RIGHT tree, not a blanket no-op that
+#     would silently pass everything.
+run_tilde_case "tilde cd-target on non-conforming branch still BLOCKS (true-negative)" \
+  "bogus-no-ticket-branch" 2 "missing ticket ID"
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -74,15 +74,39 @@ fi
 # Stripping the body payload (--body / --body-file / -F and everything after)
 # before the gate check means only the actual command verb is tested.
 # Fixes apexyard#743 Bug 3.
+#
+# apexyard bug report (2026-07): stripping --body/--body-file/-F is NOT
+# enough — the gate's match was an UNANCHORED substring grep
+# ('\bgh pr create\b' with no position anchor), so any text ANYWHERE else in
+# the command that happens to contain the words "gh pr create" also matched.
+# The most common trigger: a `gh issue create --title '... gh pr create ...'`
+# whose TITLE mentions the phrase (e.g. a bug report about this very hook) —
+# --title is never stripped by the body-only cleanup above, so its content
+# was fully exposed to the gate grep. Reproduced live: a `gh issue create`
+# whose --title read "...gh pr create over-matches gh issue create..." was
+# blocked with PR-only errors (title-format, missing ## Testing/## Glossary)
+# even though the invoked command was `gh issue create`, not `gh pr create`.
+#
+# Fix: anchor the match to the actual command HEAD — "gh pr create" must be
+# the verb actually being invoked (immediately at the start of the command,
+# or immediately after a leading `cd <path> &&` / `cd <path>;` prefix), not
+# merely present as a substring anywhere in a flag's value.
 _cmd_for_gate=$(printf '%s' "$COMMAND" \
   | sed -E 's/[[:space:]]--body-file[[:space:]].*//' \
   | sed -E 's/[[:space:]]--body[[:space:]].*//' \
   | sed -E 's/[[:space:]]-F[[:space:]].*//')
-if ! printf '%s' "$_cmd_for_gate" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+create\b'; then
-  unset _cmd_for_gate
+# Strip one optional leading `cd <path> &&` / `cd <path>;` / `cd <path>|`
+# prefix (quoted or bare path) so the head-anchor below checks the actual gh
+# invocation, not whatever directory the command cd's into first.
+_cmd_head=$(printf '%s' "$_cmd_for_gate" | sed -E \
+  "s/^[[:space:]]*cd[[:space:]]+\"[^\"]+\"[[:space:]]*(&&|;|\|)[[:space:]]*//;
+   s/^[[:space:]]*cd[[:space:]]+'[^']+'[[:space:]]*(&&|;|\|)[[:space:]]*//;
+   s/^[[:space:]]*cd[[:space:]]+[^&;|[:space:]]+[[:space:]]*(&&|;|\|)[[:space:]]*//")
+if ! printf '%s' "$_cmd_head" | grep -qE '^[[:space:]]*gh[[:space:]]+pr[[:space:]]+create\b'; then
+  unset _cmd_for_gate _cmd_head
   exit 0
 fi
-unset _cmd_for_gate
+unset _cmd_for_gate _cmd_head
 
 ERRORS=""
 

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -100,17 +100,41 @@ fi
 # (double cd), `X && gh pr create` (any non-cd prefix). That's a real
 # completeness regression, not just a hardening nice-to-have.
 #
-# Fix: loop the prefix-strip over four bounded, mutually-exclusive prefix
-# shapes until a fixed point (or a small iteration ceiling), THEN anchor:
+# Fix (round 1, since superseded — see below): loop the prefix-strip over
+# four bounded, mutually-exclusive prefix shapes until a fixed point (or a
+# small iteration ceiling), THEN anchor:
 #   1. `cd <path> (&&|;|\|)`               — quoted or bare path (as before)
 #   2. `VAR=value ` (one or more)          — leading env-var assignment(s)
 #   3. `time|command|nice|env `            — common command wrappers
 #   4. `<quote-free segment> (&&|;|\|)`    — a generic chained prefix
 #
-# Shape 4 is the one that needs care: naively scanning for "gh pr create" at
-# the head of ANY `&&`-delimited segment (rather than stripping bounded
-# prefixes) is exactly what reintroduces the original over-match — a
-# `--title '... && ...'` value containing a literal `&&` would get its
+# Hakim's SECOND security re-review of that fix (still PR #792) found a NEW
+# blocking regression in shape 4: applying all four shapes unconditionally
+# in every iteration, THEN checking the head only once the loop finished,
+# let shape 4 consume a genuine verb the moment it sat at the head followed
+# by a trailing separator — `gh pr create --fill --head br && echo done`,
+# `gh pr create --title fixbug --head br; echo x`, `gh pr create --head br
+# | cat` all got their own verb stripped as a "chained prefix" and the gate
+# silently skipped validation (exit 0). Confirmed live against the real
+# hook.
+#
+# Fix (round 2 — CHECK-THEN-STRIP): move the verb check to the TOP of every
+# loop iteration and evaluate it BEFORE any of the four strip shapes run
+# that iteration. The moment the current head already IS "gh pr create …",
+# the loop stops and the gate fires immediately — it never reaches shape 4
+# (or any shape) with the verb still sitting at the head, so the verb can
+# never be stripped as if it were a prefix. Only when the head is NOT yet
+# the verb do we attempt exactly ONE strip shape (in priority order 1-4)
+# and loop back to the top to re-check. This costs a few more iterations
+# for multi-prefix inputs (e.g. double `cd` now takes two passes instead of
+# one) but the 10-iteration ceiling comfortably covers realistic prefix
+# depths, and correctness — never eating the verb — matters more than
+# iteration-count elegance here.
+#
+# Shape 4 is still the one that needs care: naively scanning for "gh pr
+# create" at the head of ANY `&&`-delimited segment (rather than stripping
+# bounded prefixes) is exactly what reintroduces the original over-match —
+# a `--title '... && ...'` value containing a literal `&&` would get its
 # quoted content misread as a chain of commands. Shape 4 avoids that by
 # requiring the stripped segment to contain NO quote characters
 # (`[^"'&;|]+`) — a quoted flag value always contains a quote character
@@ -118,46 +142,75 @@ fi
 # eligible for this strip; it also naturally stops at the first real `&&`,
 # `;`, or `|` because those characters are excluded from the segment's own
 # character class. A bounded iteration ceiling (10) guards against any
-# pathological input looping unboundedly; in practice at most a couple of
-# prefixes ever precede a real invocation.
+# pathological input looping unboundedly; beyond the ceiling the gate fails
+# OPEN (skips validation) rather than hanging or false-blocking, which is
+# the safe direction for a completeness backstop like this one.
 _cmd_for_gate=$(printf '%s' "$COMMAND" \
   | sed -E 's/[[:space:]]--body-file[[:space:]].*//' \
   | sed -E 's/[[:space:]]--body[[:space:]].*//' \
   | sed -E 's/[[:space:]]-F[[:space:]].*//')
 _cmd_head="$_cmd_for_gate"
 _gate_iter=0
+_gate_fired=0
 while [ "$_gate_iter" -lt 10 ]; do
+  # CHECK before STRIP: if the current head already IS the pr-create verb,
+  # stop right here and fire — this must happen before ANY of the four
+  # strip shapes run this iteration. Checking only after a full pass of
+  # stripping (the round-1 structure) is what let shape 4 consume a verb
+  # that had just become the head as a side effect of an earlier shape in
+  # the SAME iteration (or was the head from the very start, for a
+  # prefix-free genuine invocation like `gh pr create ... && echo done`).
+  if printf '%s' "$_cmd_head" | grep -qE '^[[:space:]]*gh[[:space:]]+pr[[:space:]]+create\b'; then
+    _gate_fired=1
+    break
+  fi
+
   _cmd_head_prev="$_cmd_head"
 
+  # Try exactly ONE strip shape this iteration, in priority order, then
+  # loop back to the top so the verb-check above runs again before any
+  # later shape gets a chance at the newly-shortened head. This is the
+  # structural change from round 1 (which ran all four shapes every
+  # iteration, unconditionally) to round 2 (check-then-strip).
+
   # 1. cd <path> && / ; / | -- quoted or bare path.
-  _cmd_head=$(printf '%s' "$_cmd_head" | sed -E \
+  _stripped=$(printf '%s' "$_cmd_head" | sed -E \
     "s/^[[:space:]]*cd[[:space:]]+\"[^\"]+\"[[:space:]]*(&&|;|\|)[[:space:]]*//;
      s/^[[:space:]]*cd[[:space:]]+'[^']+'[[:space:]]*(&&|;|\|)[[:space:]]*//;
      s/^[[:space:]]*cd[[:space:]]+[^&;|[:space:]]+[[:space:]]*(&&|;|\|)[[:space:]]*//")
-
-  # 2. Leading env-var assignment(s): FOO=bar BAZ=qux <rest>.
-  _cmd_head=$(printf '%s' "$_cmd_head" | sed -E \
-    "s/^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+//")
-
-  # 3. Common command wrappers.
-  _cmd_head=$(printf '%s' "$_cmd_head" | sed -E \
-    "s/^[[:space:]]*(time|command|nice|env)[[:space:]]+//")
-
-  # 4. A quote-free arbitrary segment followed by a top-level separator.
-  #    Excluding quote characters from the segment means a quoted flag
-  #    value (which always contains a quote before any genuine separator)
-  #    can never be mistaken for a chained prefix here.
-  _cmd_head=$(printf '%s' "$_cmd_head" | sed -E \
-    "s/^[[:space:]]*[^\"'&;|]+(&&|;|\|)[[:space:]]*//")
+  if [ "$_stripped" != "$_cmd_head" ]; then
+    _cmd_head="$_stripped"
+  else
+    # 2. Leading env-var assignment(s): FOO=bar BAZ=qux <rest>.
+    _stripped=$(printf '%s' "$_cmd_head" | sed -E \
+      "s/^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+//")
+    if [ "$_stripped" != "$_cmd_head" ]; then
+      _cmd_head="$_stripped"
+    else
+      # 3. Common command wrappers.
+      _stripped=$(printf '%s' "$_cmd_head" | sed -E \
+        "s/^[[:space:]]*(time|command|nice|env)[[:space:]]+//")
+      if [ "$_stripped" != "$_cmd_head" ]; then
+        _cmd_head="$_stripped"
+      else
+        # 4. A quote-free arbitrary segment followed by a top-level
+        #    separator — last resort, only tried once shapes 1-3 (and the
+        #    verb-check above) have already failed to match this
+        #    iteration's head.
+        _cmd_head=$(printf '%s' "$_cmd_head" | sed -E \
+          "s/^[[:space:]]*[^\"'&;|]+(&&|;|\|)[[:space:]]*//")
+      fi
+    fi
+  fi
 
   [ "$_cmd_head" = "$_cmd_head_prev" ] && break
   _gate_iter=$((_gate_iter + 1))
 done
-if ! printf '%s' "$_cmd_head" | grep -qE '^[[:space:]]*gh[[:space:]]+pr[[:space:]]+create\b'; then
-  unset _cmd_for_gate _cmd_head _cmd_head_prev _gate_iter
+if [ "$_gate_fired" -ne 1 ]; then
+  unset _cmd_for_gate _cmd_head _cmd_head_prev _gate_iter _gate_fired _stripped
   exit 0
 fi
-unset _cmd_for_gate _cmd_head _cmd_head_prev _gate_iter
+unset _cmd_for_gate _cmd_head _cmd_head_prev _gate_iter _gate_fired _stripped
 
 ERRORS=""
 

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -91,22 +91,73 @@ fi
 # the verb actually being invoked (immediately at the start of the command,
 # or immediately after a leading `cd <path> &&` / `cd <path>;` prefix), not
 # merely present as a substring anywhere in a flag's value.
+#
+# Hakim's security review of the anchor fix (PR #792) flagged a MEDIUM
+# completeness regression: anchoring to the head after stripping only ONE
+# leading `cd … &&` prefix means a genuine `gh pr create` behind any OTHER
+# prefix now SKIPS validation where the old (unanchored) gate caught it —
+# `FOO=bar gh pr create`, `time gh pr create`, `cd a && cd b && gh pr create`
+# (double cd), `X && gh pr create` (any non-cd prefix). That's a real
+# completeness regression, not just a hardening nice-to-have.
+#
+# Fix: loop the prefix-strip over four bounded, mutually-exclusive prefix
+# shapes until a fixed point (or a small iteration ceiling), THEN anchor:
+#   1. `cd <path> (&&|;|\|)`               — quoted or bare path (as before)
+#   2. `VAR=value ` (one or more)          — leading env-var assignment(s)
+#   3. `time|command|nice|env `            — common command wrappers
+#   4. `<quote-free segment> (&&|;|\|)`    — a generic chained prefix
+#
+# Shape 4 is the one that needs care: naively scanning for "gh pr create" at
+# the head of ANY `&&`-delimited segment (rather than stripping bounded
+# prefixes) is exactly what reintroduces the original over-match — a
+# `--title '... && ...'` value containing a literal `&&` would get its
+# quoted content misread as a chain of commands. Shape 4 avoids that by
+# requiring the stripped segment to contain NO quote characters
+# (`[^"'&;|]+`) — a quoted flag value always contains a quote character
+# before the first genuine separator, so a segment carrying one is never
+# eligible for this strip; it also naturally stops at the first real `&&`,
+# `;`, or `|` because those characters are excluded from the segment's own
+# character class. A bounded iteration ceiling (10) guards against any
+# pathological input looping unboundedly; in practice at most a couple of
+# prefixes ever precede a real invocation.
 _cmd_for_gate=$(printf '%s' "$COMMAND" \
   | sed -E 's/[[:space:]]--body-file[[:space:]].*//' \
   | sed -E 's/[[:space:]]--body[[:space:]].*//' \
   | sed -E 's/[[:space:]]-F[[:space:]].*//')
-# Strip one optional leading `cd <path> &&` / `cd <path>;` / `cd <path>|`
-# prefix (quoted or bare path) so the head-anchor below checks the actual gh
-# invocation, not whatever directory the command cd's into first.
-_cmd_head=$(printf '%s' "$_cmd_for_gate" | sed -E \
-  "s/^[[:space:]]*cd[[:space:]]+\"[^\"]+\"[[:space:]]*(&&|;|\|)[[:space:]]*//;
-   s/^[[:space:]]*cd[[:space:]]+'[^']+'[[:space:]]*(&&|;|\|)[[:space:]]*//;
-   s/^[[:space:]]*cd[[:space:]]+[^&;|[:space:]]+[[:space:]]*(&&|;|\|)[[:space:]]*//")
+_cmd_head="$_cmd_for_gate"
+_gate_iter=0
+while [ "$_gate_iter" -lt 10 ]; do
+  _cmd_head_prev="$_cmd_head"
+
+  # 1. cd <path> && / ; / | -- quoted or bare path.
+  _cmd_head=$(printf '%s' "$_cmd_head" | sed -E \
+    "s/^[[:space:]]*cd[[:space:]]+\"[^\"]+\"[[:space:]]*(&&|;|\|)[[:space:]]*//;
+     s/^[[:space:]]*cd[[:space:]]+'[^']+'[[:space:]]*(&&|;|\|)[[:space:]]*//;
+     s/^[[:space:]]*cd[[:space:]]+[^&;|[:space:]]+[[:space:]]*(&&|;|\|)[[:space:]]*//")
+
+  # 2. Leading env-var assignment(s): FOO=bar BAZ=qux <rest>.
+  _cmd_head=$(printf '%s' "$_cmd_head" | sed -E \
+    "s/^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+//")
+
+  # 3. Common command wrappers.
+  _cmd_head=$(printf '%s' "$_cmd_head" | sed -E \
+    "s/^[[:space:]]*(time|command|nice|env)[[:space:]]+//")
+
+  # 4. A quote-free arbitrary segment followed by a top-level separator.
+  #    Excluding quote characters from the segment means a quoted flag
+  #    value (which always contains a quote before any genuine separator)
+  #    can never be mistaken for a chained prefix here.
+  _cmd_head=$(printf '%s' "$_cmd_head" | sed -E \
+    "s/^[[:space:]]*[^\"'&;|]+(&&|;|\|)[[:space:]]*//")
+
+  [ "$_cmd_head" = "$_cmd_head_prev" ] && break
+  _gate_iter=$((_gate_iter + 1))
+done
 if ! printf '%s' "$_cmd_head" | grep -qE '^[[:space:]]*gh[[:space:]]+pr[[:space:]]+create\b'; then
-  unset _cmd_for_gate _cmd_head
+  unset _cmd_for_gate _cmd_head _cmd_head_prev _gate_iter
   exit 0
 fi
-unset _cmd_for_gate _cmd_head
+unset _cmd_for_gate _cmd_head _cmd_head_prev _gate_iter
 
 ERRORS=""
 


### PR DESCRIPTION
## Summary

- **Tilde-expand the cd-target before `git -C`** — `pr_cmd_cd_target` (in `_lib-pr-repo.sh`) extracted the literal text of a leading `cd <path> && …` prefix, so a command like `cd ~/Projects/foo && gh pr create …` handed `git -C` the literal string `"~/Projects/foo"`. `git -C` never shell-expands tilde, so the lookup failed silently, the cd-target resolution came back empty, and every caller's branch-ticket-ID fallback used the hook's own cwd instead (typically the ops-fork root, on `dev`) — false-blocking a perfectly valid PR from a tilde-path worktree with "Branch 'dev' missing ticket ID". Fixed once, centrally, in the shared lib — all five callers (`validate-pr-create.sh`, `validate-branch-name.sh`, `require-agdr-for-arch-pr.sh`, `require-architecture-review.sh`, `require-design-review-for-ui.sh`) get the fix for free.
- **Anchor the PR-create gate to the command head, not an unanchored substring** — the gate that decides whether `validate-pr-create.sh` runs at all originally stripped only `--body`/`--body-file`/`-F` before testing for `gh pr create`, then ran a plain `grep -qE '\bgh[[:space:]]+pr[[:space:]]+create\b'` with no position anchor. That matched the phrase *anywhere* left in the command — including inside an untouched `--title` value. Reproduced live: filing a bug report about this exact bug (`gh issue create --title '...gh pr create over-matches gh issue create...'`) got full PR-only validation despite the invoked command being `gh issue create`, not `gh pr create`. Fixed by anchoring the match to the command head.
- **`~user` allowlist hardened against multi-line injection (Hakim's first review)** — `_pr_repo_expand_tilde`'s username check was a per-line `grep -qE '^[A-Za-z0-9._-]+$'`, which matches on the *first line* of a multi-line value and would let an embedded newline carry a smuggled command into the `eval` below it. Not reachable through the current sole caller (its output is always single-line), but a latent hole for any future caller. Swapped for bash's whole-string `[[ "$user" =~ ^[A-Za-z0-9._-]+$ ]]`, which anchors against the *entire* value and rejects any embedded newline outright.
- **Gate completeness restored WITHOUT reopening the anchor bug, via check-then-strip (Hakim's second review)** — anchoring to the head after stripping only one leading `cd <path> &&` prefix (the previous fix) missed genuine `gh pr create` invocations behind any *other* prefix shape: `FOO=bar gh pr create`, `time gh pr create`, `cd a && cd b && gh pr create` (double cd), `X && gh pr create` (any non-cd prefix) all silently skipped validation. A first attempt widened this by looping four bounded prefix-strip shapes (cd / env-assignment / wrapper / generic quote-free segment) before anchoring — but applying all four shapes *unconditionally* every iteration let the generic shape consume a genuine verb the moment it sat at the head followed by a trailing separator: `gh pr create --fill --head br && echo done`, `gh pr create --title fixbug --head br; echo x`, and `gh pr create --head br | cat` all silently bypassed validation on a real invocation — the same defect class the PR set out to fix, just triggered from the trailing side. Fixed by restructuring the loop to **check the head against the pr-create verb at the top of every iteration, before any stripping happens that iteration** — the moment the head already is the verb, the loop stops and fires immediately, so the verb can never be consumed as if it were a prefix. Only when the head isn't yet the verb does the loop attempt one strip shape and re-check.
- **Five new regression tests** — `test_pr_create_tilde_cd_target.sh` proves a `cd ~/...`-prefixed PR-create resolves the worktree's own branch; `test_lib_pr_repo_tilde_username_hardening.sh` proves a hostile multi-line `~user` value never reaches `eval`; `test_pr_create_gate_anchor.sh` proves a `gh issue create` (even one whose title/body mentions "gh pr create") stays a no-op, every prefix shape (cd / env-assignment / wrapper / double-cd / generic) still validates a genuine PR-create in both directions, and — the case that closes the second security finding — a genuine PR-create followed by an unquoted trailing `&&`/`;`/`|` chain still validates AND still blocks a malformed title, proving the verb is never eaten as a "prefix".

## Testing

1. `bash .claude/hooks/tests/test_pr_create_tilde_cd_target.sh` — 2/2 pass
2. `bash .claude/hooks/tests/test_lib_pr_repo_tilde_username_hardening.sh` — 4/4 pass
3. `bash .claude/hooks/tests/test_pr_create_gate_anchor.sh` — 21/21 pass (15 from the prior revision + 6 new trailing-separator cases proving the check-then-strip fix)
4. Re-ran the existing suites that exercise these two files — all still pass: `test_validate_pr_create_head.sh` (13/13), `test_validate_pr_create_structural_parse.sh` (7/7), `test_validate_pr_create_upstream.sh` (7/7), `test_validate_pr_required_sections.sh` (8/8), `test_pr_hooks_cross_repo.sh` (18/18), `test_validate_branch_name_pushref.sh` (34/34), `test_require_architecture_review.sh` (22/22), `test_require_design_review_for_ui.sh` (22/22)
5. Full `bash bin/run-hook-tests.sh` — 86/86 pass, including `test_require_agdr_for_arch_pr.sh` (its one known-flaky `spike active-ticket marker` case passes in the full-suite run; only fails standalone, reproduces identically on unmodified `upstream/dev`, unrelated to this PR)
6. `shellcheck --severity=warning` clean on both changed hook files
7. `jq empty .claude/settings.json` — valid (no settings.json changes; the fix is fully contained in the hook's own command-detection logic)
8. Regression-proved the trailing-separator fix both ways: the three new malformed-title cases in `test_pr_create_gate_anchor.sh` genuinely FAIL (wrongly return exit 0 instead of blocking) when run against the pre-check-then-strip code, and PASS against the fix — confirming the test cases catch the real bug rather than passing vacuously

Closes #791

## Glossary

| Term | Definition |
|------|------------|
| Gate (in a hook) | The early-exit check a PreToolUse hook runs to decide whether the rest of its validation logic applies to the current command at all |
| Anchored match | A regex match required to start at a specific position (here: the actual command head), as opposed to matching anywhere in the string |
| cd-target | The directory a `cd <path> && …`-prefixed command is about to run in — extracted by hooks because the PreToolUse hook fires *before* the real shell executes the `cd` |
| `pr_cmd_cd_target` | The shared `_lib-pr-repo.sh` function that parses the cd-target path out of a command string; used by five separate PreToolUse hooks |
| Check-then-strip | The loop structure where the verb-match check runs at the top of every iteration, before any prefix-stripping — as opposed to "strip-then-check" (strip everything possible, check once at the end), which is what let the generic strip shape consume a genuine verb |

### Note on `.claude/settings.json`

Confirmed again on this revision: the settings.json matcher for this hook (`"if": "Bash(gh pr create *)"`) is unchanged and was never the source of any of the three findings addressed across this PR's revisions — the over-match and both security-review findings are all internal to the hook's own command-text parsing, not the harness-level matcher. No `.claude/settings.json` changes in this PR.
