### PR TITLE
fix(#790): make red-CI merge gate forge-aware (gh/glab), fail-closed

### DIFF
--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -387,11 +387,14 @@ resolve_pr_head_branch() {
 #   failure  — the pipeline failed, was cancelled, or was skipped
 #   none     — the MR has no pipeline configured (legitimate no-CI state,
 #              the glab analog of gh's "no checks reported")
-#   ""       — the status could not be determined (glab missing, network/auth
-#              failure, or an unparseable response). The caller MUST fail
-#              CLOSED on empty — an unresolvable status is never treated as
-#              green, exactly like red-or-unfetchable CI must never silently
-#              pass on the gh path.
+#   ""       — the status could not be determined: glab missing, a non-zero
+#              glab exit code, empty stdout, or a non-empty response that
+#              isn't a valid MR object (auth-error envelope, HTML error
+#              page, truncated/garbage JSON, a bare scalar or array — none
+#              of these carry an `.iid`). The caller MUST fail CLOSED on
+#              empty — an unresolvable status is never treated as green,
+#              exactly like red-or-unfetchable CI must never silently pass
+#              on the gh path.
 #
 # GitLab's MR API exposes the pipeline attached to the MR's HEAD SHA as
 # `head_pipeline` (current API); `pipeline` is the older/deprecated
@@ -402,7 +405,7 @@ resolve_pr_head_branch() {
 resolve_ci_status_glab() {
   local pr_number="$1"
   local cmd_repo="$2"
-  local json status
+  local json status rc has_iid
 
   if [ -z "$pr_number" ]; then
     echo ""
@@ -414,17 +417,42 @@ resolve_ci_status_glab() {
   else
     json=$(glab mr view "$pr_number" --output json 2>/dev/null)
   fi
+  rc=$?
 
-  if [ -z "$json" ]; then
+  # Fail closed on a non-zero glab exit code, mirroring the gh path's
+  # CHECKS_RC discipline — the exit code is the authoritative signal
+  # when glab supplies one, so don't rely on stdout emptiness alone (a
+  # non-zero exit can still print something to stdout).
+  if [ "$rc" -ne 0 ] || [ -z "$json" ]; then
     echo ""
     return
   fi
 
+  # Require the response to actually be a valid MR object (i.e. it has an
+  # `.iid`) before treating an absent pipeline as the legitimate no-CI
+  # `none` state. `jq -e` exits non-zero on a parse failure AND when the
+  # queried value is null/absent, so this single check rejects every
+  # non-MR shape in one place: garbage/non-JSON, truncated JSON, a bare
+  # scalar or array, and JSON error envelopes like
+  # `{"message":"401 Unauthorized"}` or an HTML error page glab passed
+  # through unparsed (none of these carry an `.iid`). A genuine MR
+  # response — with or without a pipeline — always has one.
+  if ! has_iid=$(echo "$json" | jq -e -r '.iid' 2>/dev/null) || [ -z "$has_iid" ]; then
+    echo ""
+    return
+  fi
+
+  # json is now confirmed to be a real MR object, so a missing/null
+  # pipeline field below is the legitimate "no CI configured" case, not
+  # an unparseable response — deliberately NOT using `jq -e` here: it
+  # would exit non-zero for the `empty`/`null` result this case is
+  # supposed to reach.
   status=$(echo "$json" | jq -r '.head_pipeline.status // .pipeline.status // empty' 2>/dev/null)
 
   case "$status" in
     "" | null)
-      # No pipeline object at all — MR genuinely has no CI configured.
+      # Valid MR object (iid confirmed above) with no pipeline object —
+      # MR genuinely has no CI configured.
       echo "none"
       ;;
     success)

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -49,6 +49,16 @@
 # the CLI-calling resolvers goes through `tracker_kind` from `_lib-tracker.sh`
 # (gh + glab coincide with github + gitlab per #762); the shape detectors read
 # the command text directly.
+#
+# CI-STATUS RESOLUTION (#790)
+# ----------------------------
+# #767 made block-unreviewed-merge.sh forge-aware but left its sibling
+# block-merge-on-red-ci.sh hardcoded to `gh pr checks` — the last
+# non-forge-aware merge gate. `resolve_ci_status_glab` closes that gap: it
+# resolves a GitLab MR's head-pipeline status via `glab mr view --output
+# json`, normalised to success | pending | failure | none | "" (unresolvable).
+# block-merge-on-red-ci.sh calls it only on the glab path; the gh path keeps
+# calling `gh pr checks` directly and is untouched.
 
 # Lazily source the tracker lib so `tracker_kind` is available for forge
 # resolution. Guarded: only source if not already defined and the lib is
@@ -361,6 +371,77 @@ resolve_pr_head_branch() {
   fi
 
   echo "$branch"
+}
+
+# Echoes a normalized CI/pipeline status for a PR/MR — the glab counterpart of
+# `gh pr checks`, used by block-merge-on-red-ci.sh (#790, the last merge gate
+# to gain forge-awareness after #767 covered block-unreviewed-merge.sh).
+#
+# GitHub's `gh pr checks` returns per-check text + an exit code the caller
+# parses directly — there is no equivalent normalization needed there, so this
+# function is glab-only; the gh path in block-merge-on-red-ci.sh is untouched.
+#
+# Returns one of:
+#   success  — the MR's head pipeline passed
+#   pending  — the pipeline is still running/queued/gated on a manual job
+#   failure  — the pipeline failed, was cancelled, or was skipped
+#   none     — the MR has no pipeline configured (legitimate no-CI state,
+#              the glab analog of gh's "no checks reported")
+#   ""       — the status could not be determined (glab missing, network/auth
+#              failure, or an unparseable response). The caller MUST fail
+#              CLOSED on empty — an unresolvable status is never treated as
+#              green, exactly like red-or-unfetchable CI must never silently
+#              pass on the gh path.
+#
+# GitLab's MR API exposes the pipeline attached to the MR's HEAD SHA as
+# `head_pipeline` (current API); `pipeline` is the older/deprecated
+# single-pipeline field some GitLab/glab versions still populate, kept as a
+# fallback. Status values per GitLab's Pipeline API: created,
+# waiting_for_resource, preparing, pending, running, success, failed,
+# canceled, skipped, manual, scheduled.
+resolve_ci_status_glab() {
+  local pr_number="$1"
+  local cmd_repo="$2"
+  local json status
+
+  if [ -z "$pr_number" ]; then
+    echo ""
+    return
+  fi
+
+  if [ -n "$cmd_repo" ]; then
+    json=$(glab mr view "$pr_number" -R "$cmd_repo" --output json 2>/dev/null)
+  else
+    json=$(glab mr view "$pr_number" --output json 2>/dev/null)
+  fi
+
+  if [ -z "$json" ]; then
+    echo ""
+    return
+  fi
+
+  status=$(echo "$json" | jq -r '.head_pipeline.status // .pipeline.status // empty' 2>/dev/null)
+
+  case "$status" in
+    "" | null)
+      # No pipeline object at all — MR genuinely has no CI configured.
+      echo "none"
+      ;;
+    success)
+      echo "success"
+      ;;
+    failed | canceled | cancelled | skipped)
+      echo "failure"
+      ;;
+    running | pending | created | waiting_for_resource | preparing | scheduled | manual)
+      echo "pending"
+      ;;
+    *)
+      # Unrecognised/future GitLab status value — fail closed (treat as
+      # blocking) rather than silently allow an unknown state through.
+      echo "pending"
+      ;;
+  esac
 }
 
 # Echoes the owner/repo extracted from the merge command, or empty if not found.

--- a/.claude/hooks/block-merge-on-red-ci.sh
+++ b/.claude/hooks/block-merge-on-red-ci.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-# PreToolUse hook on `gh pr merge` AND `gh api .../pulls/<N>/merge`: blocks the
-# merge if any required CI check is failing, pending, or cancelled.
+# PreToolUse hook on `gh pr merge` / `gh api .../pulls/<N>/merge` AND their
+# GitLab counterparts `glab mr merge` / `glab api .../merge_requests/<N>/merge`:
+# blocks the merge if CI is failing, pending, or unresolvable.
 #
-# Both merge shapes are covered — see _lib-extract-pr.sh for the parser and
-# #47 for why the API-shape bypass was a gap worth closing.
+# All four merge shapes are covered — see _lib-extract-pr.sh for the parser.
+# #47 is why the gh-api-shape bypass was worth closing; #764/#767 added the
+# glab shapes to the OTHER three merge gates; this hook was the one sibling
+# still hardcoded to `gh pr checks` (#790 — the last non-forge-aware gate).
 #
 # Enforces .claude/rules/pr-quality.md § "No Red CI Before Merge" —
 # "Never merge with red CI - even if the failure is pre-existing or
@@ -11,6 +14,8 @@
 # the PR so all checks are green, and only then merge." Was prose-only
 # until this hook shipped.
 #
+# GH PATH (unchanged, byte-identical to pre-#790 behaviour)
+# -----------------------------------------------------------
 # Uses `gh pr checks <pr>` which returns one line per check with status.
 # Exit codes:
 #   0 = all checks passed (and none required are missing)
@@ -26,6 +31,18 @@
 #
 # Pending checks (IN_PROGRESS | QUEUED): BLOCKED. The rule says all checks
 # must be green; pending is not green. Wait for CI to finish, then retry.
+#
+# GLAB PATH (new, #790)
+# ----------------------
+# `resolve_ci_status_glab` (see _lib-extract-pr.sh) resolves the GitLab MR's
+# head-pipeline status via `glab mr view <iid> --output json`, normalised to
+# one of: success | pending | failure | none | "" (unresolvable).
+#   Allows: "success"; "none" (MR has no pipeline configured — the glab
+#   analog of gh's "no checks reported").
+#   Blocks: "pending"; "failure"; "" — an EMPTY status means the pipeline
+#   state could not be determined (glab missing, network/auth failure,
+#   unparseable response). Fail CLOSED: an unresolvable status is never
+#   treated as green, exactly like a red-or-unfetchable gh CI check.
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -35,7 +52,8 @@ if [ -z "$COMMAND" ]; then
 fi
 
 # Shared merge-shape detector + PR-number parser (see _lib-extract-pr.sh).
-# Handles `gh pr merge <N>` and `gh api repos/<owner>/<repo>/pulls/<N>/merge`.
+# Handles `gh pr merge <N>`, `gh api repos/<owner>/<repo>/pulls/<N>/merge`,
+# `glab mr merge <N>`, and `glab api .../merge_requests/<N>/merge` (#764/#767).
 . "$(dirname "$0")/_lib-extract-pr.sh"
 
 if ! is_merge_command "$COMMAND"; then
@@ -52,19 +70,22 @@ if merge_command_uses_variable "$COMMAND"; then
 BLOCKED: cannot verify CI on a variable-substituted merge command.
 
 This gate reads the literal command text and can't resolve shell variables
-(e.g. `gh pr merge $PR --repo $REPO`) to the real PR / repo, so it cannot
-check the correct PR's CI status. Re-run with literal values:
+(e.g. `gh pr merge $PR --repo $REPO` or `glab mr merge $MR -R $REPO`) to the
+real PR/MR or repo, so it cannot check the correct one's CI status. Re-run
+with literal values:
 
   gh pr merge <number> --repo <owner>/<repo> --squash
+  glab mr merge <iid> -R <owner>/<repo>
 
-(Use the actual PR number and owner/repo — not shell variables.)
+(Use the actual PR/MR number and owner/repo — not shell variables.)
 EOF
   exit 2
 fi
 
-# Parse --repo (for `gh pr merge --repo owner/repo`). Uses the shared extractor,
-# which also recovers the repo from a `gh api .../pulls/<N>/merge` URL path so
-# `gh pr checks` below is still scoped correctly.
+# Parse --repo / -R (for `gh pr merge --repo owner/repo` or `glab mr merge -R
+# owner/repo`). Uses the shared extractor, which also recovers the repo from a
+# `gh api .../pulls/<N>/merge` or `glab api .../merge_requests/<N>/merge` URL
+# path so the CI-status check below is still scoped correctly.
 CMD_REPO=$(extract_repo_from_command "$COMMAND")
 REPO_FLAG=""
 if [ -n "$CMD_REPO" ]; then
@@ -78,6 +99,59 @@ if [ -z "$PR_NUMBER" ]; then
   exit 0
 fi
 
+# Forge dispatch (#790): the command text says which CLI it drives — the same
+# detector _lib-extract-pr.sh's own resolvers use internally.
+if [ "$(_forge_from_command "$COMMAND")" = "glab" ]; then
+  # --- GitLab path ---
+  PIPELINE_STATUS=$(resolve_ci_status_glab "$PR_NUMBER" "$CMD_REPO")
+
+  case "$PIPELINE_STATUS" in
+    success)
+      exit 0
+      ;;
+    none)
+      echo "NOTE: MR !${PR_NUMBER} has no pipeline configured. Merge-on-red-CI gate is a no-op for this MR." >&2
+      exit 0
+      ;;
+    *)
+      # pending | failure | "" (unresolvable) — all three BLOCK. An empty
+      # status must never be treated as green: if glab is missing, the
+      # network/auth failed, or the response was unparseable, that is a
+      # reason to block, not a reason to guess "probably fine".
+      STATUS_DESC="${PIPELINE_STATUS:-unresolvable (glab CLI missing, network/auth failure, or unparseable response)}"
+      cat >&2 <<MSG
+BLOCKED: MR !${PR_NUMBER} has red or unresolvable CI. Cannot merge.
+
+\`glab mr view ${PR_NUMBER}\` reports pipeline status: ${STATUS_DESC}
+
+ApexYard rule (.claude/rules/pr-quality.md § "No Red CI Before Merge"):
+
+  "Never merge with red CI — even if the failure is pre-existing or
+  unrelated. Fix the pre-existing issue first (separate commit), rebase
+  the PR so all checks are green, and only then merge."
+
+To unblock:
+
+  1. Look at the pipeline: \`glab mr view ${PR_NUMBER} --web\` or
+     \`glab ci status\` on the MR's source branch
+  2. If the failure is in YOUR change, fix it and push
+  3. If the failure is PRE-EXISTING (pipeline was already red on the target
+     branch), fix the pre-existing issue in a separate commit, then retry
+  4. If the pipeline is PENDING, wait for it to finish, then retry
+  5. If the status could not be fetched at all, check glab auth/network and
+     retry — this gate fails CLOSED on an unresolvable status
+  6. Re-invoke Rex after any new commit (re-review required)
+  7. Retry \`glab mr merge ${PR_NUMBER}\`
+
+No exceptions. Not even for "unrelated" failures. Red or unresolvable CI
+stays blocking until someone fixes it — that's the whole point of the rule.
+MSG
+      exit 2
+      ;;
+  esac
+fi
+
+# --- GitHub path (unchanged, byte-identical to pre-#790 behaviour) ---
 # Query checks. gh pr checks returns text output; we check both the exit code
 # and a "no checks reported" substring — the latter is how gh reports the
 # genuinely-unchecked case regardless of exit code version.

--- a/.claude/hooks/tests/test_block_merge_on_red_ci.sh
+++ b/.claude/hooks/tests/test_block_merge_on_red_ci.sh
@@ -43,10 +43,19 @@ TEST_REPO="me2resh/apexyard"
 
 # make_sandbox <gh_mode> <glab_mode>
 #   gh_mode:   green | red | none | ""  (mock `gh pr checks` behaviour)
-#   glab_mode: success | pending | failure | none | unresolvable | ""
+#   glab_mode: success | pending | failure | none | unresolvable |
+#              nonzero_exit | auth_error | http_error | truncated |
+#              scalar | array | ""
 #              (mock `glab mr view --output json` behaviour)
 # Empty mode = mock exits 0 with no output (only relevant CLI is installed
 # per test; the other is left as a stub that should never be called).
+#
+# The "success" / "pending" / "failure" / "none" bodies all include an
+# `.iid` field, matching a real `glab mr view --output json` response —
+# this is what `resolve_ci_status_glab`'s MR-object validity check keys
+# off (#793 fail-open fix). The new failure-shape modes below deliberately
+# omit `.iid` (or aren't a JSON object at all), the way a broken/hostile
+# response would be.
 make_sandbox() {
   local gh_mode="$1" glab_mode="$2"
   local sb
@@ -77,11 +86,28 @@ EOF
 case "\$*" in
   *"mr view"*)
     case "$glab_mode" in
-      success)      echo '{"head_pipeline":{"status":"success"}}' ;;
-      pending)      echo '{"head_pipeline":{"status":"running"}}' ;;
-      failure)      echo '{"head_pipeline":{"status":"failed"}}' ;;
-      none)         echo '{"head_pipeline":null}' ;;
+      success)      echo '{"iid":1,"head_pipeline":{"status":"success"}}' ;;
+      pending)      echo '{"iid":1,"head_pipeline":{"status":"running"}}' ;;
+      failure)      echo '{"iid":1,"head_pipeline":{"status":"failed"}}' ;;
+      none)         echo '{"iid":1,"head_pipeline":null}' ;;
       unresolvable) exit 1 ;;
+      # --- fail-open regression cases (#793) ---
+      # glab exits non-zero but still prints something on stdout (a
+      # content-only emptiness check would miss this; the exit code
+      # must be honored).
+      nonzero_exit) echo '{"iid":1,"head_pipeline":{"status":"success"}}'; exit 1 ;;
+      # GitLab REST error envelopes — valid JSON, exit 0, but NOT an MR
+      # object (no .iid). Previously mapped to "none" -> ALLOW.
+      auth_error)   echo '{"message":"401 Unauthorized"}' ;;
+      # An intermediary (proxy / captive portal / SSO gateway) returning
+      # an HTML error page on stdout instead of JSON.
+      http_error)   echo '<html><body>502 Bad Gateway</body></html>' ;;
+      # Truncated/partial JSON body.
+      truncated)    echo '{"head_pipeline":' ;;
+      # A bare JSON scalar (not an object).
+      scalar)       echo '"unexpected"' ;;
+      # A JSON array (not an object).
+      array)        echo '[1,2,3]' ;;
       *)            exit 0 ;;
     esac
     ;;
@@ -167,6 +193,38 @@ run_case "glab: no pipeline configured -> allows (no-op note)" 0 "" "$sb" \
 sb=$(make_sandbox "" unresolvable)
 run_case "glab: unresolvable status -> blocks (fail closed)" 2 "unresolvable" "$sb" \
   "glab mr merge 404 -R $TEST_REPO --squash"
+
+# ----------------------------------------------------------------------
+# Fail-OPEN regression suite (#793 / Hakim HIGH finding): a non-empty
+# glab response that ISN'T a valid MR object must still BLOCK, not fall
+# through to the "none" allow-arm. The pre-fix implementation only
+# checked stdout emptiness, so every case below used to resolve to
+# "none" -> exit 0 (ALLOW) despite being an error/garbage response.
+# ----------------------------------------------------------------------
+
+sb=$(make_sandbox "" nonzero_exit)
+run_case "glab: non-zero exit (even with stdout output) -> blocks (fail closed)" 2 "unresolvable" "$sb" \
+  "glab mr merge 408 -R $TEST_REPO --squash"
+
+sb=$(make_sandbox "" auth_error)
+run_case "glab: JSON auth-error envelope (401) -> blocks (fail closed)" 2 "unresolvable" "$sb" \
+  "glab mr merge 409 -R $TEST_REPO --squash"
+
+sb=$(make_sandbox "" http_error)
+run_case "glab: HTML error page on stdout -> blocks (fail closed)" 2 "unresolvable" "$sb" \
+  "glab mr merge 410 -R $TEST_REPO --squash"
+
+sb=$(make_sandbox "" truncated)
+run_case "glab: truncated/garbage JSON -> blocks (fail closed)" 2 "unresolvable" "$sb" \
+  "glab mr merge 411 -R $TEST_REPO --squash"
+
+sb=$(make_sandbox "" scalar)
+run_case "glab: bare JSON scalar response -> blocks (fail closed)" 2 "unresolvable" "$sb" \
+  "glab mr merge 412 -R $TEST_REPO --squash"
+
+sb=$(make_sandbox "" array)
+run_case "glab: JSON array response -> blocks (fail closed)" 2 "unresolvable" "$sb" \
+  "glab mr merge 413 -R $TEST_REPO --squash"
 
 sb=$(make_sandbox "" pending)
 run_case "glab: variable-substituted merge -> blocks" 2 "variable-substituted" "$sb" \

--- a/.claude/hooks/tests/test_block_merge_on_red_ci.sh
+++ b/.claude/hooks/tests/test_block_merge_on_red_ci.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# Tests for block-merge-on-red-ci.sh — forge-aware CI-status gate (#790).
+#
+# #767 made block-unreviewed-merge.sh forge-aware (gh/glab); this hook was
+# the one sibling merge gate still hardcoded to `gh pr checks`, so a GitLab
+# project's `glab mr merge` sailed through with no CI-status check at all.
+# This suite proves:
+#
+#   - the gh path is byte-identical to pre-#790 behaviour (green/red/no-CI/
+#     variable-substituted/non-merge cases, mirroring the hook's own header
+#     comment contract)
+#   - the new glab path resolves the MR's head-pipeline status via a mocked
+#     `glab mr view --output json` and maps it to the same allow/block shape
+#   - the glab path FAILS CLOSED when the pipeline status can't be resolved
+#     at all (glab missing / network-auth failure / unparseable response) —
+#     an unresolvable status must never be treated as green
+#
+# Each case builds an isolated sandbox with the hook + _lib-extract-pr.sh,
+# mocks `gh` and/or `glab` to return a deterministic status without hitting
+# any real forge, pipes a synthetic PreToolUse JSON for the merge command,
+# and asserts exit code (0 = pass-through, 2 = blocked) + a stderr regex.
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/block-merge-on-red-ci.sh"
+LIB_PR="$SRC_ROOT/.claude/hooks/_lib-extract-pr.sh"
+
+for f in "$HOOK_SRC" "$LIB_PR"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: required source missing: $f" >&2
+    exit 1
+  fi
+done
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+TEST_REPO="me2resh/apexyard"
+
+# make_sandbox <gh_mode> <glab_mode>
+#   gh_mode:   green | red | none | ""  (mock `gh pr checks` behaviour)
+#   glab_mode: success | pending | failure | none | unresolvable | ""
+#              (mock `glab mr view --output json` behaviour)
+# Empty mode = mock exits 0 with no output (only relevant CLI is installed
+# per test; the other is left as a stub that should never be called).
+make_sandbox() {
+  local gh_mode="$1" glab_mode="$2"
+  local sb
+  sb=$(mktemp -d)
+  mkdir -p "$sb/.claude/hooks" "$sb/bin"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/block-merge-on-red-ci.sh"
+  cp "$LIB_PR"   "$sb/.claude/hooks/_lib-extract-pr.sh"
+  chmod +x "$sb/.claude/hooks/block-merge-on-red-ci.sh"
+
+  cat > "$sb/bin/gh" <<EOF
+#!/bin/bash
+case "\$*" in
+  *"pr checks"*)
+    case "$gh_mode" in
+      green) printf 'build\tpass\t1m\thttps://x\n'; exit 0 ;;
+      red)   printf 'build\tfail\t1m\thttps://x\n'; exit 1 ;;
+      none)  echo "no checks reported on the 'feature' branch"; exit 8 ;;
+      *)     exit 0 ;;
+    esac
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$sb/bin/gh"
+
+  cat > "$sb/bin/glab" <<EOF
+#!/bin/bash
+case "\$*" in
+  *"mr view"*)
+    case "$glab_mode" in
+      success)      echo '{"head_pipeline":{"status":"success"}}' ;;
+      pending)      echo '{"head_pipeline":{"status":"running"}}' ;;
+      failure)      echo '{"head_pipeline":{"status":"failed"}}' ;;
+      none)         echo '{"head_pipeline":null}' ;;
+      unresolvable) exit 1 ;;
+      *)            exit 0 ;;
+    esac
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$sb/bin/glab"
+
+  echo "$sb"
+}
+
+run_case() {
+  local label="$1" want_rc="$2" want_stderr_regex="$3" sb="$4" cmd="$5"
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-merge-on-red-ci.sh" 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:300})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# ======================================================================
+# GH PATH — regression (must stay byte-identical to pre-#790 behaviour)
+# ======================================================================
+
+sb=$(make_sandbox green "")
+run_case "gh: green CI -> allows" 0 "" "$sb" \
+  "gh pr merge 300 --repo $TEST_REPO --squash"
+
+sb=$(make_sandbox red "")
+run_case "gh: red CI -> blocks" 2 "red CI" "$sb" \
+  "gh pr merge 301 --repo $TEST_REPO --squash"
+
+sb=$(make_sandbox none "")
+run_case "gh: no checks configured -> allows (no-op note)" 0 "" "$sb" \
+  "gh pr merge 302 --repo $TEST_REPO --squash"
+
+sb=$(make_sandbox red "")
+run_case "gh: variable-substituted merge -> blocks" 2 "variable-substituted" "$sb" \
+  'gh pr merge $PR --repo me2resh/apexyard --squash'
+
+sb=$(make_sandbox red "")
+run_case "gh: non-merge command -> no-op" 0 "" "$sb" \
+  "gh pr view 303 --repo $TEST_REPO"
+
+sb=$(make_sandbox red "")
+run_case "gh: gh-api merge shape, red CI -> blocks" 2 "red CI" "$sb" \
+  "gh api repos/me2resh/apexyard/pulls/304/merge -X PUT"
+
+# ======================================================================
+# GLAB PATH — new (#790)
+# ======================================================================
+
+sb=$(make_sandbox "" success)
+run_case "glab: pipeline success -> allows" 0 "" "$sb" \
+  "glab mr merge 400 -R $TEST_REPO --squash"
+
+sb=$(make_sandbox "" pending)
+run_case "glab: pipeline pending -> blocks" 2 "red or unresolvable" "$sb" \
+  "glab mr merge 401 -R $TEST_REPO --squash"
+
+sb=$(make_sandbox "" failure)
+run_case "glab: pipeline failed -> blocks" 2 "red or unresolvable" "$sb" \
+  "glab mr merge 402 -R $TEST_REPO --squash"
+
+sb=$(make_sandbox "" none)
+run_case "glab: no pipeline configured -> allows (no-op note)" 0 "" "$sb" \
+  "glab mr merge 403 -R $TEST_REPO --squash"
+
+# Fail-closed: glab CLI failure / unparseable response -> BLOCK, never allow.
+sb=$(make_sandbox "" unresolvable)
+run_case "glab: unresolvable status -> blocks (fail closed)" 2 "unresolvable" "$sb" \
+  "glab mr merge 404 -R $TEST_REPO --squash"
+
+sb=$(make_sandbox "" pending)
+run_case "glab: variable-substituted merge -> blocks" 2 "variable-substituted" "$sb" \
+  'glab mr merge $MR -R me2resh/apexyard --squash'
+
+sb=$(make_sandbox "" pending)
+run_case "glab: non-merge command -> no-op" 0 "" "$sb" \
+  "glab mr view 405 -R $TEST_REPO"
+
+sb=$(make_sandbox "" success)
+run_case "glab: raw-API merge shape, pipeline success -> allows" 0 "" "$sb" \
+  "glab api projects/me6resh%2Fapexyard/merge_requests/406/merge -X PUT"
+
+sb=$(make_sandbox "" failure)
+run_case "glab: raw-API merge shape, pipeline failed -> blocks" 2 "red or unresolvable" "$sb" \
+  "glab api projects/me6resh%2Fapexyard/merge_requests/407/merge -X PUT"
+
+# ======================================================================
+
+echo ""
+echo "=== test_block_merge_on_red_ci: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **`block-merge-on-red-ci.sh` is now forge-aware** — it was the last of the four merge gates still hardcoded to `gh pr checks`. #767 made `block-unreviewed-merge.sh` forge-aware (gh/glab); a GitLab project's `glab mr merge` sailed through this sibling gate with no CI-status check at all until now.
- **New `resolve_ci_status_glab` in `_lib-extract-pr.sh`** resolves a GitLab MR's head-pipeline status via `glab mr view <iid> --output json` (`.head_pipeline.status`, falling back to the older `.pipeline.status`), normalised to `success | pending | failure | none | ""` (unresolvable).
- **The gh path is untouched** — same `gh pr checks` call, same exit-code handling, same BLOCKED message. The glab path allows on `success` and `none` (no pipeline configured — the glab analog of gh's "no checks reported"), blocks on `pending`/`failure`, and **BLOCKS on an unresolvable status** (glab missing, network/auth failure, unparseable response) — a CI gate must fail closed, never guess "probably fine."
- **No `settings.json` changes needed** — the glab matchers for this hook (`Bash(glab mr merge *)`, `Bash(glab api *)`) were already wired in #767's matcher pass.

## Testing

1. `shellcheck .claude/hooks/block-merge-on-red-ci.sh .claude/hooks/_lib-extract-pr.sh .claude/hooks/tests/test_block_merge_on_red_ci.sh` — clean (the two pre-existing info-level findings on the untouched gh line/source line are unchanged from before this PR).
2. `jq empty .claude/settings.json` — valid.
3. New `.claude/hooks/tests/test_block_merge_on_red_ci.sh` (15 cases): gh regression (green/red/no-CI/variable-substituted/non-merge/`gh api` shape) + glab (success/pending/failure/none/unresolvable/variable-substituted/non-merge/`glab api` raw shape) — all pass.
4. Full hook suite: `bin/run-hook-tests.sh` → **84/84 pass** (83 pre-existing + 1 new test file), zero regressions.

Closes #790

---

## Glossary

| Term | Definition |
|------|------------|
| Forge | The Git hosting platform a project's PRs live on — GitHub (`gh` CLI) or GitLab (`glab` CLI). ApexYard's merge gates need to speak both. |
| MR | Merge Request — GitLab's term for what GitHub calls a Pull Request. |
| Head pipeline | GitLab's field on an MR representing the CI pipeline run against the MR's current HEAD commit — the GitLab analog of GitHub's per-PR "checks". |
| Fail closed | When a gate can't determine a status with confidence, it blocks rather than allows — the opposite of "fail open," where an error would silently let the risky action through. |
