### PR TITLE
docs(#795): README pain-story hook + technical detail to sub-doc + adopter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 <h1 align="center">ApexYard</h1>
 
 <p align="center">
-  <strong>Ship AI-built software like a real engineering team.</strong><br>
-  <em>Where projects get forged.</em>
+  <strong>Take agent-built code the last mile — safely to production.</strong>
 </p>
 
 <p align="center">
@@ -17,60 +16,29 @@
   <a href="https://github.com/me2resh/apexyard/stargazers"><img src="https://img.shields.io/github/stars/me2resh/apexyard?style=social" alt="Stars"></a>
 </p>
 
-A multi-project ops repo where your projects reference each other, learn from shared experience, and ship production-ready under a strict SDLC. Built for founders who ship alone, or companies standing up AI-enabled squads.
+## You built something real with AI. Then it fell apart.
 
-You don't *add* ApexYard to a project — projects get forged *inside* it. One ops repo. Every product. Shared memory. Strict gates. Production-ready MVPs.
+The first 80% flew — a working prototype in a weekend, features landing faster than you could test them. Then the context slipped. The codebase turned into a pile nobody could review, decisions vanished into chat history, and the thing you were *so close* to shipping never actually made it to production.
+
+**ApexYard is the machinery that takes agent-built code the last mile.** It wraps your AI coding agent in the discipline a real engineering team runs on: every change moves through a ticket, gets an independent review, and hits a merge gate that stays shut until a *named human* says "ship it." So the code your agent writes is actually safe to put in front of users.
+
+Concretely, it's a multi-project **ops repo**: you fork it, register your projects, and govern them all as one organisation — shared memory across the portfolio, a strict SDLC, and **42 shell hooks** that enforce the rules mechanically instead of hoping everyone remembers them. Built for founders who ship alone, and for teams standing up AI-enabled squads.
 
 Claude Code is the default driver, but the rules, hooks, and templates are plain markdown and shell. Swap the AI. Keep the forge. No SaaS. No lock-in.
 
 **Proven shipping** TypeScript + AWS Lambda backends, Next.js web apps, Chrome extensions, and native **Swift** macOS desktop apps. The stack is process and guardrails — not a language or framework lock-in.
 
-## What's Inside
+## What's inside
 
-```
-apexyard/
-├── CLAUDE.md              # Stack entry point -- Claude Code reads this first
-├── onboarding.yaml        # Your company config -- fill this in to adopt the stack
-│
-├── roles/                 # AI agent role definitions (20 across 6 departments)
-│   ├── engineering/       # Backend, Frontend, QA, Platform, SRE, Tech Lead, Head of Eng
-│   ├── architecture/      # Solution Architect (Tariq)
-│   ├── product/           # Product Manager, Product Analyst, Head of Product
-│   ├── design/            # UI Designer, UX Designer, Head of Design
-│   ├── security/          # Security Auditor, Penetration Tester, Head of Security
-│   └── data/              # Data Analyst, Data Engineer, Head of Data
-│
-├── workflows/             # Development lifecycle processes
-│   ├── sdlc.md            # Full SDLC including the database-migration sub-workflow
-│   ├── code-review.md     # Code review process and standards
-│   └── deployment.md      # Environment promotion, rollback, IaC patterns
-│
-├── templates/             # Reusable document templates
-│   ├── prd.md             # Product Requirements Document
-│   ├── technical-design.md # Technical design document
-│   ├── adr.md             # Architecture Decision Record
-│   ├── agdr.md            # Agent Decision Record (AI-specific)
-│   ├── agdr-migration.md  # Migration-specific AgDR (rollback, downtime, consumers)
-│   └── architecture/      # C4 diagram templates — Context (L1) + Container (L2), Mermaid
-│
-├── .claude/               # Claude Code primitives (the runnable layer)
-│   ├── settings.json      # Hook wiring (PreToolUse, PostToolUse, SessionStart)
-│   ├── hooks/             # 40 shell scripts — ticket-first, migration gate, two-marker merge gate, red-CI block, secrets scan, branch/PR validation, leak protection, MCP-reindex advisories, upstream-drift banner
-│   ├── rules/             # 12 modular rule files imported via @.claude/rules/* (agdr-decisions, code-standards, git-conventions, leak-protection, loop-mode, parallel-work, plan-mode, pr-quality, pr-workflow, role-triggers, ticket-vocabulary, workflow-gates)
-│   ├── agents/            # 24 sub-agents — Rex (Code Reviewer), Hakim (Security Auditor), Tariq (Solution Architect), the engineering / product / design / data / security personas, plus utility agents (PR & ticket managers, dependency auditor)
-│   └── skills/            # 62 slash commands — see CLAUDE.md for the full list
-│
-├── workspace/             # Live local clones of managed projects — gitignored
-├── projects/              # Per-project committed docs (README, roadmap, AgDRs, updates)
-├── apexyard.projects.yaml.example  # Portfolio registry template
-│
-├── golden-paths/          # Reusable infra & ops templates
-│   └── pipelines/         # Drop-in GitHub Actions workflows (CI, code quality, Swift CI, security, dependency audit, PR title check, review check, SEO check)
-│
-└── docs/                  # Documentation
-    ├── getting-started.md # Setup guide
-    └── multi-project.md   # Full setup guide (fork flow, directory layout, daily workflow, FAQ)
-```
+ApexYard is a set of plain-text primitives Claude Code reads automatically — no runtime, no service:
+
+- **20 roles** across 6 departments (engineering, product, design, security, data, architecture) that activate on triggers
+- **42 shell hooks** that mechanically enforce the SDLC — ticket-first edits, a two-marker merge gate, migration gates, secrets scanning, and more
+- **64 slash-command skills** — from `/setup` and `/handover` to `/decide`, `/code-review`, `/migration`, and `/launch-check`
+- **25 sub-agents** — Rex (code review), Hakim (security), Tariq (design review), plus the department personas
+- **15 rule files**, workflow docs, and document templates (PRD, tech design, ADR, AgDR, C4 diagrams)
+
+**Full directory tree and the complete role / hook / skill / agent breakdown → [`docs/whats-inside.md`](docs/whats-inside.md).**
 
 > **Marketing site:** the site that was previously bundled here has moved to its own repo ([me2resh/apexyard-site](https://github.com/me2resh/apexyard-site)) and is deployed independently at [yard.apexscript.com](https://yard.apexscript.com).
 >
@@ -158,7 +126,7 @@ Keeping a fork current — upgrade in place, when to re-fork instead, and how to
 
 **The problem**: Claude Code is powerful, but without structure it produces inconsistent results. Every team reinvents the same processes -- role definitions, review checklists, document templates, workflow gates.
 
-**The solution**: ApexYard provides that structure as a reusable, open-source stack. One config file to customize, 20 role definitions to use, battle-tested workflows to follow, and 40 shell hooks that enforce the rules mechanically.
+**The solution**: ApexYard provides that structure as a reusable, open-source stack. One config file to customize, 20 role definitions to use, battle-tested workflows to follow, and 42 shell hooks that enforce the rules mechanically.
 
 ### What makes it different
 
@@ -166,7 +134,7 @@ Keeping a fork current — upgrade in place, when to re-fork instead, and how to
 |---------|-------------------|----------------|
 | Code reviews | Ad-hoc prompts | Rex agent on every PR, SHA-bound approval marker |
 | Technical decisions | Lost in chat history | Documented as Agent Decision Records |
-| Quality gates | Hope and pray | 40 shell hooks block bad commits, forged markers, unreviewed merges |
+| Quality gates | Hope and pray | 42 shell hooks block bad commits, forged markers, unreviewed merges |
 | Merge approval | Informal "LGTM" | Two-marker gate — Rex (code) + CEO (per-PR explicit) |
 | Database migrations | Drop-column-on-Friday | Dedicated gate: labelled ticket + migration AgDR (rollback, downtime, consumers) required before schema edits |
 | Architecture docs | Nobody draws them | C4 L1 + L2 Mermaid templates + `/c4` skill generates stubs from a codebase |
@@ -175,97 +143,31 @@ Keeping a fork current — upgrade in place, when to re-fork instead, and how to
 | Role consistency | Re-explain every session | Persistent role definitions, activation-triggered |
 | Onboarding | Days of context-setting | `/setup` three-exchange config |
 
-## Roles
+## Roles, workflows & templates
 
-ApexYard includes 20 software development roles across 6 departments:
+ApexYard ships **20 roles** across 6 departments that activate on triggers, a full **SDLC** (Planning → Design → Build → Review → QA → Deploy → Monitor) with a dedicated migration sub-workflow, and reusable **document templates** (PRD, technical design, ADR, AgDR, migration AgDR, C4 diagrams).
 
-### Engineering (7 roles)
+The full role roster, workflow detail, and template catalogue live in **[`docs/whats-inside.md`](docs/whats-inside.md)**. The canonical entry point Claude Code reads is [`CLAUDE.md`](CLAUDE.md).
 
-- **Head of Engineering** -- Technical strategy, architecture standards, quality
-- **Tech Lead** -- Feature design, code review, team coordination
-- **Backend Engineer** -- Domain logic, APIs, infrastructure
-- **Frontend Engineer** -- UI components, design system, accessibility
-- **QA Engineer** -- Test strategy, automation, quality gates
-- **Platform Engineer** -- CI/CD, infrastructure as code, developer tooling
-- **Site Reliability Engineer** -- Monitoring, incidents, SLOs
+## Show you're governed by ApexYard
 
-### Architecture (1 role)
+Running your repo under ApexYard? Add a badge to its README. Every adopter repo that carries one is a backlink and a bit of social proof — and `/handover` will offer to drop it into the repos it onboards.
 
-- **Solution Architect** (Tariq) -- Independent design review before Build: NFRs, patterns, tech-debt, risk, traceability — the non-code analog of the Code Reviewer
+**Governed by** — for a repo managed under an ApexYard ops fork:
 
-### Product (3 roles)
-
-- **Head of Product** -- Roadmap, prioritization, feasibility
-- **Product Manager** -- PRDs, user stories, acceptance criteria
-- **Product Analyst** -- Market research, metrics, competitive analysis
-
-### Design (3 roles)
-
-- **Head of Design** -- Design system, UX principles, visual standards
-- **UI Designer** -- Visual design tokens, component specifications
-- **UX Designer** -- User flows, information architecture, usability
-
-### Security (3 roles)
-
-- **Head of Security** -- Security strategy, threat modeling, compliance
-- **Security Auditor** -- Static analysis, vulnerability detection, OWASP
-- **Penetration Tester** -- Active testing, exploit discovery, API security
-
-### Data (3 roles)
-
-- **Head of Data** -- Analytics strategy, data governance, reporting
-- **Data Analyst** -- SQL, dashboards, A/B testing, metrics
-- **Data Engineer** -- ETL pipelines, data modeling, data quality
-
-## Workflows
-
-### Software Development Lifecycle (SDLC)
-
-```
-Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
+```markdown
+[![Governed by ApexYard](https://img.shields.io/badge/governed_by-ApexYard-2F6DF6?style=flat-square)](https://github.com/me2resh/apexyard)
 ```
 
-Each phase has entry criteria, activities, exit criteria, and quality gates. See [`workflows/sdlc.md`](workflows/sdlc.md) for the full flow.
+[![Governed by ApexYard](https://img.shields.io/badge/governed_by-ApexYard-2F6DF6?style=flat-square)](https://github.com/me2resh/apexyard)
 
-### Code Review Process
+**Built with** — for a project built out through the ApexYard workflow:
 
-Structured review with:
+```markdown
+[![Built with ApexYard](https://img.shields.io/badge/built_with-ApexYard-2F6DF6?style=flat-square)](https://github.com/me2resh/apexyard)
+```
 
-- Author responsibilities and PR description format
-- Reviewer checklist (architecture, security, testing, performance)
-- Feedback severity levels (blocking, suggestion, question)
-- Response time targets
-- Rex (code-reviewer agent) auto-runs on every PR; human reviewer activates per role triggers
-
-### Deployment Process
-
-- Infrastructure as Code patterns
-- CI/CD pipeline stages
-- Environment promotion (staging → production)
-- Rollback procedures
-
-See [`workflows/deployment.md`](workflows/deployment.md) for the full flow.
-
-### Database Migration Sub-Workflow
-
-Migrations are high-blast-radius work and get their own gate (workflow gate 3a). Any edit to `migrate-*.{ts,js,py,sql}`, `**/migrations/**`, `prisma/schema.prisma`, `alembic/versions/*`, or similar requires:
-
-1. A labelled `migration` ticket
-2. A matching migration AgDR that documents rollback, estimated downtime, cross-service consumers, data volume, testing plan, observability
-
-The `/migration` skill creates both artefacts in one guided flow; the `require-migration-ticket.sh` hook blocks edits to migration paths until they exist.
-
-## Templates
-
-| Template | Purpose |
-|----------|---------|
-| PRD | Product Requirements Document with user stories, acceptance criteria |
-| Technical Design | Architecture, domain model, API design, implementation plan |
-| ADR | Architecture Decision Record for significant technical decisions |
-| AgDR | Agent Decision Record — AI-specific decision tracking |
-| Migration AgDR | Migration-specific AgDR — rollback plan, downtime estimate, consumers, observability |
-| C4 Context (L1) | System context Mermaid diagram — external actors + system boundary |
-| C4 Container (L2) | Container Mermaid diagram — deployable units inside the system |
+[![Built with ApexYard](https://img.shields.io/badge/built_with-ApexYard-2F6DF6?style=flat-square)](https://github.com/me2resh/apexyard)
 
 ## Customization
 

--- a/docs/whats-inside.md
+++ b/docs/whats-inside.md
@@ -1,0 +1,199 @@
+# What's Inside ApexYard
+
+The full component breakdown — directory layout, every role, the workflow docs, the templates, and the runnable `.claude/` layer (hooks, rules, agents, skills). The [README](../README.md) keeps a lean summary; this is the exhaustive reference.
+
+All of it is plain markdown and shell. There is no runtime and no service — Claude Code reads these files directly, and the hooks fire on your `git` / `gh` commands.
+
+## Directory layout
+
+```
+apexyard/
+├── CLAUDE.md              # Stack entry point -- Claude Code reads this first
+├── onboarding.yaml        # Your company config -- fill this in to adopt the stack
+│
+├── roles/                 # AI agent role definitions (20 across 6 departments)
+│   ├── engineering/       # Backend, Frontend, QA, Platform, SRE, Tech Lead, Head of Eng
+│   ├── architecture/      # Solution Architect (Tariq)
+│   ├── product/           # Product Manager, Product Analyst, Head of Product
+│   ├── design/            # UI Designer, UX Designer, Head of Design
+│   ├── security/          # Security Auditor, Penetration Tester, Head of Security
+│   └── data/              # Data Analyst, Data Engineer, Head of Data
+│
+├── workflows/             # Development lifecycle processes
+│   ├── sdlc.md            # Full SDLC including the database-migration sub-workflow
+│   ├── code-review.md     # Code review process and standards
+│   └── deployment.md      # Environment promotion, rollback, IaC patterns
+│
+├── templates/             # Reusable document templates
+│   ├── prd.md             # Product Requirements Document
+│   ├── technical-design.md # Technical design document
+│   ├── adr.md             # Architecture Decision Record
+│   ├── agdr.md            # Agent Decision Record (AI-specific)
+│   ├── agdr-migration.md  # Migration-specific AgDR (rollback, downtime, consumers)
+│   └── architecture/      # C4 diagram templates — Context (L1) + Container (L2), Mermaid
+│
+├── .claude/               # Claude Code primitives (the runnable layer)
+│   ├── settings.json      # Hook wiring (PreToolUse, PostToolUse, SessionStart)
+│   ├── hooks/             # 42 shell scripts — ticket-first, migration gate, two-marker merge gate, red-CI block, secrets scan, branch/PR validation, leak protection, MCP-reindex advisories, upstream-drift banner
+│   ├── rules/             # 15 modular rule files imported via @.claude/rules/*
+│   ├── agents/            # 25 sub-agents — Rex (Code Reviewer), Hakim (Security Auditor), Tariq (Solution Architect), the engineering / product / design / data / security personas, plus utility agents (PR & ticket managers, dependency auditor, The Contrarian)
+│   └── skills/            # 64 slash commands — see CLAUDE.md for the full list
+│
+├── workspace/             # Live local clones of managed projects — gitignored
+├── projects/              # Per-project committed docs (README, roadmap, AgDRs, updates)
+├── apexyard.projects.yaml.example  # Portfolio registry template
+│
+├── golden-paths/          # Reusable infra & ops templates
+│   └── pipelines/         # Drop-in GitHub Actions workflows (CI, code quality, Swift CI, security, dependency audit, PR title check, review check, SEO check)
+│
+└── docs/                  # Documentation
+    ├── getting-started.md # Setup guide
+    ├── multi-project.md   # Full setup guide (fork flow, directory layout, daily workflow, FAQ)
+    └── whats-inside.md    # This file — the full component breakdown
+```
+
+## Roles
+
+ApexYard includes 20 software-development roles across 6 departments. Roles are not passive docs — they **activate on triggers** (a PR touching `**/auth/**` fires the Security Auditor; a ticket labelled `qa` fires the QA Engineer). See [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md) for the full activation table.
+
+### Engineering (7 roles)
+
+- **Head of Engineering** -- Technical strategy, architecture standards, quality
+- **Tech Lead** -- Feature design, code review, team coordination
+- **Backend Engineer** -- Domain logic, APIs, infrastructure
+- **Frontend Engineer** -- UI components, design system, accessibility
+- **QA Engineer** -- Test strategy, automation, quality gates
+- **Platform Engineer** -- CI/CD, infrastructure as code, developer tooling
+- **Site Reliability Engineer** -- Monitoring, incidents, SLOs
+
+### Architecture (1 role)
+
+- **Solution Architect** (Tariq) -- Independent design review before Build: NFRs, patterns, tech-debt, risk, traceability — the non-code analog of the Code Reviewer
+
+### Product (3 roles)
+
+- **Head of Product** -- Roadmap, prioritization, feasibility
+- **Product Manager** -- PRDs, user stories, acceptance criteria
+- **Product Analyst** -- Market research, metrics, competitive analysis
+
+### Design (3 roles)
+
+- **Head of Design** -- Design system, UX principles, visual standards
+- **UI Designer** -- Visual design tokens, component specifications
+- **UX Designer** -- User flows, information architecture, usability
+
+### Security (3 roles)
+
+- **Head of Security** -- Security strategy, threat modeling, compliance
+- **Security Auditor** -- Static analysis, vulnerability detection, OWASP
+- **Penetration Tester** -- Active testing, exploit discovery, API security
+
+### Data (3 roles)
+
+- **Head of Data** -- Analytics strategy, data governance, reporting
+- **Data Analyst** -- SQL, dashboards, A/B testing, metrics
+- **Data Engineer** -- ETL pipelines, data modeling, data quality
+
+## Workflows
+
+### Software Development Lifecycle (SDLC)
+
+```
+Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
+```
+
+Each phase has entry criteria, activities, exit criteria, and quality gates. See [`workflows/sdlc.md`](../workflows/sdlc.md) for the full flow.
+
+### Code Review Process
+
+Structured review with:
+
+- Author responsibilities and PR description format
+- Reviewer checklist (architecture, security, testing, performance)
+- Feedback severity levels (blocking, suggestion, question)
+- Response time targets
+- Rex (code-reviewer agent) auto-runs on every PR; human reviewer activates per role triggers
+
+See [`workflows/code-review.md`](../workflows/code-review.md).
+
+### Deployment Process
+
+- Infrastructure as Code patterns
+- CI/CD pipeline stages
+- Environment promotion (staging → production)
+- Rollback procedures
+
+See [`workflows/deployment.md`](../workflows/deployment.md) for the full flow.
+
+### Database Migration Sub-Workflow
+
+Migrations are high-blast-radius work and get their own gate (workflow gate 3a). Any edit to `migrate-*.{ts,js,py,sql}`, `**/migrations/**`, `prisma/schema.prisma`, `alembic/versions/*`, or similar requires:
+
+1. A labelled `migration` ticket
+2. A matching migration AgDR that documents rollback, estimated downtime, cross-service consumers, data volume, testing plan, observability
+
+The `/migration` skill creates both artefacts in one guided flow; the `require-migration-ticket.sh` hook blocks edits to migration paths until they exist.
+
+## Templates
+
+| Template | Purpose |
+|----------|---------|
+| PRD | Product Requirements Document with user stories, acceptance criteria |
+| Technical Design | Architecture, domain model, API design, implementation plan |
+| ADR | Architecture Decision Record for significant technical decisions |
+| AgDR | Agent Decision Record — AI-specific decision tracking |
+| Migration AgDR | Migration-specific AgDR — rollback plan, downtime estimate, consumers, observability |
+| C4 Context (L1) | System context Mermaid diagram — external actors + system boundary |
+| C4 Container (L2) | Container Mermaid diagram — deployable units inside the system |
+
+## The `.claude/` layer — the runnable primitives
+
+This is what turns the markdown above into an enforced workflow. Claude Code picks it up automatically when the `.claude/` directory lives at the repo root.
+
+| Layer | Path | What it is |
+|-------|------|------------|
+| **Hooks** | `.claude/hooks/` | 42 shell scripts that mechanically enforce SDLC rules — ticket-first edits (Edit/Write/Bash), migration-ticket-first, auto code review, merge gates (Rex + CEO + design + architecture review), red-CI block, commit-format, AgDR-for-arch-changes, branch/PR-title validation, secrets scanning, private-ref leak protection, upstream-drift banner, MCP-reindex advisories |
+| **Rules** | `.claude/rules/` | 15 modular rule files imported via `@.claude/rules/*` from `CLAUDE.md` |
+| **Agents** | `.claude/agents/` | 25 sub-agents — the department personas plus utility agents |
+| **Skills** | `.claude/skills/` | 64 slash commands |
+| **Settings** | `.claude/settings.json` | Wires hooks to `PreToolUse`, `PostToolUse`, and `SessionStart` events |
+
+### The 15 rule files
+
+`agdr-decisions`, `agent-role-selection`, `code-standards`, `git-conventions`, `isolated-builds`, `leak-protection`, `loop-mode`, `parallel-work`, `plan-mode`, `pr-quality`, `pr-workflow`, `reporting-style`, `role-triggers`, `ticket-vocabulary`, `workflow-gates`.
+
+### The 25 sub-agents
+
+Utility agents: **Rex** (`code-reviewer`), **Hakim** (`security-reviewer`), **Tariq** (`solution-architect`), **Naqid** (`contrarian`), plus `pr-manager`, `ticket-manager`, and `dependency-auditor`. The remaining 18 are the department-role agents (engineering, product, design, security, data — one per role file).
+
+### The 64 skills
+
+The full, one-line-per-skill list lives in [`CLAUDE.md`](../CLAUDE.md) under "Available skills". Highlights by category:
+
+- **Bootstrap & sync** — `/setup`, `/handover`, `/update`, `/split-portfolio`
+- **Planning & tickets** — `/write-spec`, `/plan-initiative`, `/feature`, `/bug`, `/task`, `/tickets-batch`, `/spike`, `/prototype`, `/walking-skeleton`, `/migration`, `/investigation`, `/idea`
+- **Review & decisions** — `/decide`, `/agdr`, `/code-review`, `/security-review`, `/design-review`, `/challenge`, `/approve-merge`, `/approve-design`, `/approve-architecture`
+- **Audits** — `/launch-check`, `/threat-model`, `/accessibility-audit`, `/compliance-check`, `/analytics-audit`, `/seo-audit`, `/geo-audit`, `/performance-audit`, `/monitoring-audit`, `/docs-audit`, `/mutation-test`, `/audit-deps`
+- **Architecture & diagrams** — `/c4`, `/dfd`, `/tech-vision`, `/journey`, `/feature-diagram`, `/extract-features`, `/process`
+- **Portfolio** — `/projects`, `/inbox`, `/status`, `/tasks`, `/roadmap`, `/stakeholder-update`, `/fan-out`
+
+## CI/CD pipelines
+
+Reusable GitHub Actions workflows live at `golden-paths/pipelines/`:
+
+| Pipeline | Purpose |
+|----------|---------|
+| `ci.yml` | Combined pipeline (code quality + security + dependencies) |
+| `code-quality.yml` | TypeScript, ESLint, tests, build |
+| `swift-ci.yml` | Swift Package Manager build + guarded test (macOS) |
+| `security.yml` | Semgrep SAST + npm audit + secrets detection |
+| `dependency-audit.yml` | Weekly vulnerability + license scan |
+| `pr-title-check.yml` | Enforce ticket ID in PR titles |
+| `review-check.yml` | Block merge if Code Reviewer hasn't reviewed the latest commit |
+| `seo-check.yml` | SEO analysis for content files |
+
+Copy whichever you need into your project's `.github/workflows/`. Full details in `golden-paths/pipelines/README.md`.
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*


### PR DESCRIPTION
## Summary

- **New pain-story opener** — the README used to lead with a category ("A multi-project ops repo where…"). It now opens with the founder's real wound: *you built something real with AI, hit ~80% fast, then it fell apart — context lost, unreviewable pile, never shipped.* Then it lands the what-it-is: ApexYard takes agent-built code the last mile through tickets, independent review, and a merge gate that stays shut until a named human approves. This is the single biggest GTM lever from the viral-competitor study — a relatable moment beats a taxonomy for a cold reader deciding whether to star.
- **Heavy technical detail moved to a new `docs/whats-inside.md`** — the full `apexyard/` directory tree, the complete 20-role roster, the workflow detail (SDLC + code-review + deployment + migration sub-workflow), the templates catalogue, and the exhaustive `.claude/` layer breakdown (hooks/rules/agents/skills lists) all left the README. The README keeps a 6-line "What's inside" summary plus a "Roles, workflows & templates" pointer, each linking to the sub-doc. Result: a README you can scan top-to-bottom in a minute instead of scrolling past three enumerations.
- **New adopter-badge section** ("Show you're governed by ApexYard") — copy-paste markdown for two shields.io variants ("Governed by" and "Built with", brand blue `2F6DF6`, flat-square), matching the site's existing badge exactly, with a one-line why: every adopter repo that carries one is a backlink and social proof, and `/handover` will offer to add it to onboarded repos.
- **Corrected stale component counts** to the real file counts on this branch — hooks 40 → **42**, rule files 12 → **15**, sub-agents 24 → **25**, skills 62 → **64**. Roles stay at **20** (verified — the growth department is uncommitted upstream). The "40 shell hooks" figure appeared in three places (What's Inside tree, Why-ApexYard prose, the comparison table); all now read 42.

## Testing

1. Render `README.md` on GitHub (or any markdown previewer) — confirm the pain-story opener reads first, the "What's inside" summary is 6 bullets + a link, the badge section shows both rendered badges, and no directory tree / role enumeration remains inline.
2. Follow every internal link — `docs/whats-inside.md`, `docs/multi-project.md`, `docs/upgrading.md`, `CLAUDE.md`, `CONTRIBUTING.md`, etc. all resolve (verified: all present on the branch).
3. From `docs/whats-inside.md`, follow the `../` links back to README, CLAUDE.md, the rule file, and the workflow docs — all resolve.
4. Hit both badge URLs — `https://img.shields.io/badge/governed_by-ApexYard-2F6DF6?style=flat-square` and the `built_with` variant both return HTTP 200.
5. Grep confirms none of the old counts (40/24/62/12/59) remain and the new counts (42/15/25/64/20) are used consistently across both files.

Refs #795

---

## Glossary

| Term | Definition |
|------|------------|
| Pain-story hook | An opener that leads with a relatable problem the reader feels (the founder's wound) before describing what the product is — the GTM pattern that outperformed category-first copy in the competitor study. |
| Ops repo | The forked apexyard repo itself, treated as the single governance repo for a whole portfolio of managed projects — you don't add apexyard *to* a project; projects are forged *inside* it. |
| Two-marker merge gate | The merge is blocked until two approval markers exist: Rex's code-review approval and an explicit per-PR CEO approval — neither can be a plan-level "go". |
| Adopter badge | A shields.io badge an adopter repo adds to its README to signal it's governed by / built with ApexYard — doubles as a backlink and social proof. |
| Harnessability | The `/handover` score (across five codebase dimensions) for how ready an external repo is to be governed under the ApexYard workflow. |
| AgDR | Agent Decision Record — the AI-specific decision log (options considered, choice, rationale) ApexYard writes for significant technical calls. |
