### PR TITLE
feat(#805): pi.dev AGENTS.md bridge (advisory rules for pi)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,102 @@
 # AGENTS.md
 
-Entry point for AI coding agents (Cursor, Claude Code, Aider, Cline, etc.) working inside this repository.
+Entry point for AI coding agents (Cursor, Claude Code, Aider, Cline, **pi**, etc.) working inside this repository. This file now serves **two audiences** — read the section that matches what you're doing:
 
-This file is **distinct from `CLAUDE.md`** — `CLAUDE.md` is the framework-level instruction set the apexyard framework loads when an adopter runs Claude Code inside their ops fork. `AGENTS.md` is the universal coding-agent convention (one entry doc per repo, regardless of which agent is driving) that points a visiting agent at structure, key files, and constraints.
+| You are… | Read |
+|----------|------|
+| An agent operating *inside an apexyard ops fork* on behalf of an adopter — governing a portfolio, working a ticket, opening a PR — **and you don't auto-load `CLAUDE.md`** (this is the normal case for **pi** and most non-Claude-Code harnesses) | **"Operator governance bridge"** below, first |
+| An agent extending apexyard's *own* source (hooks, skills, rules, agents) — i.e. contributing to the framework itself | **"Framework repo orientation"** further down |
+| Claude Code | Neither — `CLAUDE.md` is auto-loaded at session start and already covers the governance bridge in full; skim "Framework repo orientation" only if you're also touching the framework's own internals |
 
-## Project structure
+Why two audiences in one file: `CLAUDE.md` is the framework-level instruction set Claude Code auto-loads inside an ops fork. Harnesses that don't recognise `CLAUDE.md` — pi chief among them — auto-load `AGENTS.md` instead (from cwd, or `~/.pi/agent/`). Before this section existed, a pi user landing in an apexyard ops fork got only the framework-contributor orientation below — useful if you're hacking on apexyard's hooks, useless if you're trying to run the SDLC it governs. This section closes that gap.
+
+---
+
+## Operator governance bridge (pi and other non-Claude-Code harnesses)
+
+> **Advisory only — read this before anything else.** Everything below is delivered as *instructions*, not mechanical enforcement. Claude Code's governance additionally runs as shell hooks (`.claude/hooks/*.sh`, wired via `.claude/settings.json`) that mechanically block bad commands — the two-marker merge gate, the ticket-first edit block, the secrets scanner, the AgDR-required check. Those hooks fire on Claude Code's `PreToolUse` / `PostToolUse` events, which pi (and most other harnesses) doesn't expose. **Nothing in this file will stop a tool call for you.** Follow these rules because they're the governance model apexyard is built on, not because a hook will catch you if you don't. See `docs/harnesses/pi.md` for exactly what's mechanically enforced vs. advisory-only, and the sibling spike (me2resh/apexyard#804) exploring whether a thin pi extension could close that gap later.
+
+### You are the Chief of Staff
+
+If you're operating inside an apexyard ops fork, you're running a portfolio of projects under a strict SDLC — not just editing files. Read `onboarding.yaml` (company config) and `apexyard.projects.yaml` (the registry of every repo under management) before doing anything else. Every project ships production-ready MVPs; processes are followed; work moves from idea to production through defined gates.
+
+### The SDLC, in brief
+
+```
+Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
+```
+
+Four hard gates — full detail in `.claude/rules/workflow-gates.md`:
+
+| Gate | Before | Verify |
+|------|--------|--------|
+| 1 | Design → Build | PRD approved, tickets exist |
+| 2 | Build → Review | Tests pass, checks pass, >80% coverage |
+| 3 | Review → Merge | Code review approved, CI green |
+| 4 | Merge → Done | QA verified all acceptance criteria |
+
+**If a gate fails, stop.** Complete the missing step first — there's no hook here to stop you, so this is on you.
+
+### Roles
+
+`roles/{department}/*.md` define 20 role identities (Backend/Frontend/Platform Engineer, Tech Lead, QA, Product Manager, Security Auditor, etc.) with CAN/CANNOT boundaries. They activate on specific triggers (a diff touching `**/auth/**` → Security Auditor; a PR carrying a technical design → Solution Architect review), not on every session. Full trigger table: `.claude/rules/role-triggers.md`. When you adopt a role, read its file and stay in it until the task completes.
+
+### Load-bearing conventions (inlined — see `.claude/rules/` for the full text of each)
+
+- **Branch / PR / commit format** — branch `{type}/{TICKET-ID}-{description}` (e.g. `feature/GH-42-csv-export`); PR title `type(TICKET): description` (e.g. `feat(#42): add CSV export`), one ticket ID per title; commit `type: subject` body with `Closes #N` / `Refs #N`. Never `git add -A` — stage specific files. Never push directly to `main` — every change through a PR.
+- **Ticket vocabulary is reserved** — `Ticket`, `#N`, and dependency notation (`blocked by #N`, `depends on #N`) refer ONLY to real tracker issues you can fetch with `gh issue view`. Decomposing work in conversation without a tracker ticket yet? Use `Step N` / `Item N` / plain bullets — never tracker notation for something that doesn't exist as an issue.
+- **One ticket at a time** — work one ticket fully (start → PR → review → QA → done) before starting the next. Each PR = one ticket.
+- **Plan before multi-step or risky work** — favor an explicit plan-then-execute shape when a task is ≥4 dependent steps, the path is unclear, or you're about to do something hard-to-reverse (force push, schema migration, batch ticket/PR creation). Pi has no built-in plan-mode primitive — approximate it by writing the plan out and pausing for confirmation before executing.
+- **Report like a colleague** — lead with the outcome in plain language, say why it matters, match structure to content (a table for genuinely tabular data, short prose for one point). Don't dump hook names, marker SHAs, or full CI logs unless something failed or was asked for.
+- **AgDR required for technical decisions** — before choosing a library, framework, architecture pattern, or implementation approach with real trade-offs, write an Agent Decision Record at `docs/agdr/AgDR-NNNN-{slug}.md` (template: `templates/agdr.md`). No hook enforces this for pi — it's self-discipline.
+- **No hardcoded secrets** — API keys, passwords, tokens, connection strings go in environment variables, never in code.
+- **PR quality** — every PR body needs a `## Glossary` table and narrative (not label-only) summary bullets — what changed AND why it matters. See `.claude/rules/pr-quality.md`.
+- **Explicit per-PR approval before merge** — a plan-level "go"/"continue" does not authorize `gh pr merge`. Stop and get an explicit per-PR nod first. See `.claude/rules/pr-workflow.md`.
+
+### Full detail — read on demand
+
+Pi doesn't resolve Claude-Code-style `@.claude/rules/*.md` imports the way `CLAUDE.md` does, but you *can* `Read` any file on request — so treat these as the source of truth when you need the exact wording, an edge case, or the rationale behind a rule:
+
+| File | Covers |
+|------|--------|
+| `.claude/rules/git-conventions.md` | Branch naming, PR titles, commit format, no `git add -A`, no direct `main` |
+| `.claude/rules/ticket-vocabulary.md` | Reserved tracker terms, safe planning vocabulary |
+| `.claude/rules/workflow-gates.md` | The 6 gates (PRD→Done), pre-build gate, migration gate, architecture-review gate, spike exemptions |
+| `.claude/rules/pr-workflow.md` | Pre-push checklist, merge-gate mechanics, build-agents-cannot-self-review |
+| `.claude/rules/pr-quality.md` | Glossary requirement, narrative summary bullets, QA checklist, no red CI |
+| `.claude/rules/agdr-decisions.md` | When an AgDR is required, trigger patterns |
+| `.claude/rules/plan-mode.md` | When to plan before executing |
+| `.claude/rules/loop-mode.md` | When a repetitive build→verify cycle should be looped, with guardrails |
+| `.claude/rules/parallel-work.md` | When to split independent work across parallel agents |
+| `.claude/rules/isolated-builds.md` | Safe multi-repo git (worktrees, not `/tmp`; guarded `cd`) |
+| `.claude/rules/agent-role-selection.md` | Picking the role-appropriate sub-agent when spawning build work |
+| `.claude/rules/reporting-style.md` | How to narrate status back to the operator |
+| `.claude/rules/leak-protection.md` | Never leak private project names/repos into public framework issues |
+| `.claude/rules/role-triggers.md` | Full role-activation table + handoff artefacts |
+
+### Skills, without the slash-command runner
+
+`.claude/skills/<name>/SKILL.md` are markdown prompts — 62 of them, covering everything from filing a ticket (`/feature`, `/bug`, `/task`) to running an audit (`/launch-check`, `/threat-model`) to cutting a release. Claude Code turns these into typed slash commands; pi has no slash-command mechanism, so invoke one by `Read`-ing its `SKILL.md` and following the process it describes step by step (e.g. read `.claude/skills/feature/SKILL.md`, then do what it says). The skill's content is the same either way — only the invocation mechanism differs.
+
+### What's NOT bridged yet
+
+Being upfront about the gap: this section gives you the rules as *instructions*. It does **not** give you:
+
+- **Mechanical gate enforcement** — the two-marker merge gate, ticket-first edit blocking, secrets scanning, AgDR-required checks, red-CI merge blocking. These are Claude-Code-specific shell hooks; nothing currently shells out to them for pi. Tracked as a separate spike: me2resh/apexyard#804.
+- **MCP-backed code/docs search** (`apexyard-search`) — pi's design omits MCP entirely; fall back to plain `grep`/`Read`.
+- **Role-trigger advisory banners** — Claude Code gets a `PreToolUse` banner nudging "this diff touches `**/auth/**`, consider the Security Auditor"; pi gets no such nudge. Self-check the role-triggers table manually.
+
+See `docs/harnesses/pi.md` for the full today-vs-not-yet breakdown and the install shape.
+
+---
+
+## Framework repo orientation (contributing to apexyard's own source)
+
+The rest of this file is for an agent extending **apexyard itself** — its hooks, skills, rules, agents, or docs — as opposed to an agent operating an ops fork built from it (see above).
+
+`AGENTS.md` is **distinct from `CLAUDE.md`** — `CLAUDE.md` is the framework-level instruction set the apexyard framework loads when an adopter runs Claude Code inside their ops fork. This section of `AGENTS.md` is the universal coding-agent convention (one entry doc per repo, regardless of which agent is driving) that points a visiting agent at structure, key files, and constraints for hacking on the framework's own codebase.
+
+### Project structure
 
 - `.claude/` — framework hooks, agents, rules, skills, settings.json
   - `.claude/hooks/` — 31 shell scripts (PreToolUse / PostToolUse / SessionStart)
@@ -16,17 +108,17 @@ This file is **distinct from `CLAUDE.md`** — `CLAUDE.md` is the framework-leve
 - `workflows/` — SDLC, code-review, deployment workflow docs
 - `templates/` — PRD, ADR, AgDR (Agent Decision Record), migration AgDR, C4 L1/L2, vision, sequence, DFD, audit templates, ticket templates
 - `handbooks/` — adopter-authored Rex-consumed standards (architecture / general / language buckets, path-convention discovery)
-- `docs/` — adopter docs (`getting-started.md`, `multi-project.md`, `release-process.md`, `agdr/`)
+- `docs/` — adopter docs (`getting-started.md`, `multi-project.md`, `release-process.md`, `agdr/`, `harnesses/`)
 - `projects/<name>/` — per-managed-project docs (committed to the ops fork)
 - `workspace/<name>/` — managed-project clones (gitignored — each project has its own remote)
 - `site/` — **moved** to [me2resh/apexyard-site](https://github.com/me2resh/apexyard-site); live at yard.apexscript.com
 - `golden-paths/pipelines/` — reusable GitHub Actions workflows for adopter projects
 - `bin/` — small CLI shims (e.g. `bin/apexyard` for the `apexyard status` briefing)
 
-## Key files
+### Key files
 
 - `CLAUDE.md` — framework-level instructions for Claude Code adopters (always loaded by Claude Code at session start)
-- `AGENTS.md` — this file (universal coding-agent entry doc; AI-agent-agnostic)
+- `AGENTS.md` — this file (universal coding-agent entry doc; AI-agent-agnostic; see "Operator governance bridge" above for the pi-facing half)
 - `onboarding.yaml` — company / team / tech-stack config (adopter customises)
 - `apexyard.projects.yaml` — portfolio registry listing every repo under management
 - `.claude/settings.json` — hook wiring (which scripts fire on which tool events)
@@ -34,19 +126,19 @@ This file is **distinct from `CLAUDE.md`** — `CLAUDE.md` is the framework-leve
 - `README.md` — public-facing project description + Quick Start
 - `LICENSE` — MIT
 
-## Sandbox & test environments
+### Sandbox & test environments
 
 - `.claude/hooks/tests/` — hook test suite (~30+ bash test files; run via `bash .claude/hooks/tests/test_<name>.sh`)
 - `.claude/skills/<name>/tests/` — per-skill smoke tests where applicable
 - Test runner: plain bash test scripts. No JS / npm dependency required to run the hook tests.
 - No CI/CD smoke env in this repo — the framework itself ships CI templates under `golden-paths/pipelines/` for adopter projects, but the framework's own CI is light (markdownlint, link-check, shellcheck where available)
 
-## MCP servers
+### MCP servers
 
 - **None ships with the framework by default.** Custom MCP servers can be wired into adopter forks via `.claude/settings.json` and per-agent configuration.
 - No required external services. The framework runs offline once the fork is cloned; `gh` CLI is the only mandatory external dependency for ticket / PR operations.
 
-## Rate limits / constraints
+### Rate limits / constraints
 
 - **Two-marker merge gate** — every merge requires Rex (code-reviewer agent) AND explicit per-PR CEO approval. Plan-level "go" does NOT authorize a merge. Mechanically enforced by `block-unreviewed-merge.sh`.
 - **Ticket-first hook** — code edits are blocked without an active ticket marker at `.claude/session/current-ticket`. Bootstrap-class skills (`/setup`, `/handover`, `/update`, `/split-portfolio`) are exempt.
@@ -56,8 +148,9 @@ This file is **distinct from `CLAUDE.md`** — `CLAUDE.md` is the framework-leve
 - **Secrets scanning** — `check-secrets.sh` runs on commit; blocks API keys, passwords, tokens.
 - **Workflow gates** — documented in `.claude/rules/workflow-gates.md`. Six gates from PRD → Done; each gate has a mechanical check or an advisory reminder.
 - **Branch model (framework only)** — daily PRs merge to `dev`; releases cut to `main` via `/release`. Managed projects under apexyard governance stay trunk-based on `main`.
+- **The above mechanical enforcement is Claude-Code-specific.** It doesn't fire for pi or other harnesses without equivalent hook plumbing — see "Operator governance bridge" above and `docs/harnesses/pi.md`.
 
-## Conventions
+### Conventions
 
 - **Branch naming**: `{type}/{TICKET-ID}-{description}` (e.g. `feature/GH-42-csv-export`, `fix/#58-login-bug`)
 - **PR title**: `type(TICKET): description` (e.g. `feat(#42): add CSV export`). Enforced by `validate-pr-create.sh`.
@@ -68,11 +161,11 @@ This file is **distinct from `CLAUDE.md`** — `CLAUDE.md` is the framework-leve
 - **Plan mode for ≥ 4 dependent steps** — see `.claude/rules/plan-mode.md`.
 - **Fan-out for ≥ 2 independent items** — see `.claude/rules/parallel-work.md`.
 
-## Quick orientation for visiting agents
+### Quick orientation for visiting agents
 
 If you're an AI agent landing in this repo for the first time:
 
-1. Read `CLAUDE.md` (framework spec — even if you're not Claude Code, the rules transfer)
+1. If you're operating an ops fork on an adopter's behalf (not Claude Code), read "Operator governance bridge" above first. Otherwise, read `CLAUDE.md` (framework spec — even if you're not Claude Code, the rules transfer)
 2. Skim `docs/multi-project.md` (full setup guide, directory layout, daily workflow)
 3. Browse `.claude/skills/` for the 53 slash commands (each `SKILL.md` is one capability)
 4. Browse `roles/` to understand the role-activation model
@@ -81,9 +174,11 @@ If you're an AI agent landing in this repo for the first time:
 
 The framework is plain markdown + shell — no build step, no SaaS, no lock-in. MIT licensed.
 
-## Related entry-point conventions
+### Related entry-point conventions
 
 - **[yard.apexscript.com/skill.md](https://yard.apexscript.com/skill.md)** — capability manifest for AI coding agents (served from me2resh/apexyard-site)
 - **[yard.apexscript.com/llms.txt](https://yard.apexscript.com/llms.txt)** — llmstxt.org manifest; index for AI crawlers (served from me2resh/apexyard-site)
 - **[yard.apexscript.com/llms-full.txt](https://yard.apexscript.com/llms-full.txt)** — full content concatenation for one-shot LLM consumption (served from me2resh/apexyard-site)
 - **`README.md`** — public-facing intro (humans + agents)
+- **`SYSTEM.md`** — optional custom system prompt pi reads alongside `AGENTS.md`; a short operating-posture primer, not a duplicate of this file
+- **`docs/harnesses/pi.md`** — what works / doesn't yet for pi specifically

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Pi doesn't resolve Claude-Code-style `@.claude/rules/*.md` imports the way `CLAU
 
 ### Skills, without the slash-command runner
 
-`.claude/skills/<name>/SKILL.md` are markdown prompts — 62 of them, covering everything from filing a ticket (`/feature`, `/bug`, `/task`) to running an audit (`/launch-check`, `/threat-model`) to cutting a release. Claude Code turns these into typed slash commands; pi has no slash-command mechanism, so invoke one by `Read`-ing its `SKILL.md` and following the process it describes step by step (e.g. read `.claude/skills/feature/SKILL.md`, then do what it says). The skill's content is the same either way — only the invocation mechanism differs.
+`.claude/skills/<name>/SKILL.md` are markdown prompts — 64 of them, covering everything from filing a ticket (`/feature`, `/bug`, `/task`) to running an audit (`/launch-check`, `/threat-model`) to cutting a release. Claude Code turns these into typed slash commands; pi has no slash-command mechanism, so invoke one by `Read`-ing its `SKILL.md` and following the process it describes step by step (e.g. read `.claude/skills/feature/SKILL.md`, then do what it says). The skill's content is the same either way — only the invocation mechanism differs.
 
 ### What's NOT bridged yet
 
@@ -99,9 +99,9 @@ The rest of this file is for an agent extending **apexyard itself** — its hook
 ### Project structure
 
 - `.claude/` — framework hooks, agents, rules, skills, settings.json
-  - `.claude/hooks/` — 31 shell scripts (PreToolUse / PostToolUse / SessionStart)
-  - `.claude/skills/` — 53 slash commands (one dir per skill, each with `SKILL.md`)
-  - `.claude/agents/` — 23 sub-agents: 5 utility (Rex code-reviewer, Hakim security-reviewer/auditor, Munir dep-auditor, Tariq PR-manager, Idris ticket-manager) + 18 dept-aligned agents across engineering / product / design / security / data
+  - `.claude/hooks/` — 42 shell scripts (PreToolUse / PostToolUse / SessionStart)
+  - `.claude/skills/` — 64 slash commands (one dir per skill, each with `SKILL.md`)
+  - `.claude/agents/` — 25 sub-agents: 5 utility (Rex code-reviewer, Hakim security-reviewer/auditor, Munir dep-auditor, Tariq PR-manager, Idris ticket-manager) + 20 dept-aligned agents across engineering / product / design / security / data
   - `.claude/rules/` — 11 modular rule files imported via `@.claude/rules/*.md` from `CLAUDE.md`
   - `.claude/settings.json` — hook wiring
 - `roles/` — 19 role definitions across Engineering, Product, Design, Security, Data
@@ -167,7 +167,7 @@ If you're an AI agent landing in this repo for the first time:
 
 1. If you're operating an ops fork on an adopter's behalf (not Claude Code), read "Operator governance bridge" above first. Otherwise, read `CLAUDE.md` (framework spec — even if you're not Claude Code, the rules transfer)
 2. Skim `docs/multi-project.md` (full setup guide, directory layout, daily workflow)
-3. Browse `.claude/skills/` for the 53 slash commands (each `SKILL.md` is one capability)
+3. Browse `.claude/skills/` for the 64 slash commands (each `SKILL.md` is one capability)
 4. Browse `roles/` to understand the role-activation model
 5. Browse `templates/` for the standard document shapes
 6. Check `.claude/rules/` for the mechanical rules (ticket vocabulary, PR workflow, plan mode, parallel work, leak protection, etc.)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ApexYard is a set of plain-text primitives Claude Code reads automatically — n
 
 > **Marketing site:** the site that was previously bundled here has moved to its own repo ([me2resh/apexyard-site](https://github.com/me2resh/apexyard-site)) and is deployed independently at [yard.apexscript.com](https://yard.apexscript.com).
 >
-> **For AI coding agents:** the repo root carries `AGENTS.md` — universal entry doc for Cursor / Claude Code / Aider / Cline.
+> **For AI coding agents:** the repo root carries `AGENTS.md` — universal entry doc for Cursor / Claude Code / Aider / Cline / **pi**. For harnesses that don't auto-load `CLAUDE.md` (pi chief among them), `AGENTS.md`'s "Operator governance bridge" section carries the same advisory SDLC governance `CLAUDE.md` gives Claude Code — see [`docs/harnesses/pi.md`](docs/harnesses/pi.md) for what's bridged today vs. not yet.
 
 ## Quick Start — fork and go
 

--- a/SYSTEM.md
+++ b/SYSTEM.md
@@ -1,0 +1,7 @@
+# SYSTEM.md — apexyard operating posture for pi
+
+You are operating inside an apexyard-governed ops fork — a portfolio-governance framework, not just a folder of files. Before touching anything outside `.claude/`, `docs/`, `projects/*/docs/`, or `*.md`, read `AGENTS.md` at the repo root. Its "Operator governance bridge" section carries the SDLC, the ticket-first discipline, and the load-bearing conventions (branch/PR/commit format, ticket vocabulary, one-ticket-at-a-time, plan-before-risky-work, reporting style, no secrets, no direct pushes to `main`) you're expected to follow.
+
+Nothing here is mechanically enforced for you the way it is for Claude Code — no hook blocks a bad commit, an unreviewed merge, or an edit made without an active ticket. Follow the rules because they're the governance model apexyard is built on, not because anything will stop you if you skip them. When a rule's exact wording matters, `Read` the relevant file under `.claude/rules/` rather than guessing — `AGENTS.md` points to each one.
+
+Default posture: one ticket at a time, plan before multi-step or hard-to-reverse work, report status like a colleague (outcome first, plain language), and never merge on a plan-level "go" — always get an explicit per-PR nod first.

--- a/docs/agdr/AgDR-0083-pi-agents-md-advisory-bridge.md
+++ b/docs/agdr/AgDR-0083-pi-agents-md-advisory-bridge.md
@@ -1,0 +1,59 @@
+# AgDR-0083 — `AGENTS.md` becomes the dual-purpose pi advisory bridge, not a new file
+
+> In the context of pi (pi.dev) auto-loading `AGENTS.md` from cwd instead of `CLAUDE.md`, and apexyard's root `AGENTS.md` already serving a different, established audience (framework-repo orientation for contributors, per AgDR-0073), facing the need to deliver the same advisory SDLC governance to pi operators that `CLAUDE.md` delivers to Claude Code, I decided to **extend the existing `AGENTS.md` in place with a new "Operator governance bridge" section** (Chief-of-Staff framing + SDLC + inlined load-bearing rules + pointers to `.claude/rules/*.md`) rather than create a separate file or replace `AGENTS.md`'s contents, to achieve pi-compatible governance delivery through the one file pi actually auto-loads, accepting that `AGENTS.md` now serves two audiences in a single file and that mechanical enforcement for pi remains explicitly out of scope (deferred to the sibling spike, me2resh/apexyard#804).
+
+## Context
+
+Two prior decisions collide here:
+
+1. **`CLAUDE.md` is the governance-delivery mechanism.** Claude Code auto-loads it every session; it imports `.claude/rules/*.md` and carries the full Chief-of-Staff/SDLC framing. This is the load-bearing content an apexyard operator needs, regardless of harness.
+2. **`AGENTS.md` already exists and already has a job** (AgDR-0073): a tool-agnostic, in-repo orientation doc — project structure, key files, sandbox/test info, rate limits, conventions — aimed at an agent *contributing to apexyard's own source* (or, via `/handover`, aimed at whoever later works inside an *adopted* repo). It explicitly frames itself as "distinct from `CLAUDE.md`."
+
+pi (pi.dev) doesn't resolve `CLAUDE.md` at all. It auto-loads `AGENTS.md` (cwd, or `~/.pi/agent/`) and an optional `SYSTEM.md`. So a pi user landing in an apexyard ops fork today gets whatever `AGENTS.md` says — which, before this decision, was framework-contributor orientation, not governance. The two files' audiences (Claude-Code operators via `CLAUDE.md`, non-Claude-Code operators via whatever they auto-load) were never reconciled, because until pi, "AI agent working in this repo" and "Claude Code" were effectively the same population.
+
+## Options Considered
+
+### Axis 1 — Where does pi-facing governance content live?
+
+| Option | Pros | Cons |
+|--------|------|------|
+| New file (e.g. `PI.md`, `AGENTS_PI.md`) | Keeps `AGENTS.md`'s existing single-purpose framing intact | pi doesn't auto-load anything except `AGENTS.md` / `~/.pi/agent/` — a new file is invisible unless the operator manually points pi at it, which defeats "the same way `CLAUDE.md` delivers them to Claude Code" |
+| Overwrite `AGENTS.md` with governance content only | Simplest possible file; single clear purpose | Destroys the existing framework-contributor orientation content that README, `docs/multi-project.md`, and AgDR-0073's `/handover` generation flow all reference and build on |
+| **Extend `AGENTS.md` in place — add an "Operator governance bridge" section, retain the existing content under "Framework repo orientation"** | The one file pi actually loads now carries both; no new load convention to teach; existing callers (README, `/handover`) still resolve correctly since the file still exists at the same path with its prior content intact | The file now serves two audiences and is longer; a reader has to route themselves via the intro table |
+
+### Axis 2 — How much of `CLAUDE.md`'s content to inline vs. reference
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Duplicate every rule file's full text into `AGENTS.md` | Zero extra reads for a pi agent | Massive duplication; the two copies drift the moment one is edited; defeats the point of `.claude/rules/*.md` being modular |
+| **Inline only the load-bearing rule statements concisely; point to `.claude/rules/*.md` for full text/rationale/edge cases** | No duplication of the actual rule prose; pi *can* `Read` files on request, so the reference is cheap; matches how `CLAUDE.md` itself works (imports, doesn't inline, the rule files) | A pi agent that never reads the referenced files gets the condensed version only — acceptable, since the condensed version already states the actionable rule |
+
+### Axis 3 — Mechanical enforcement scope
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Attempt to wire real enforcement now (e.g. a pi extension shelling out to the bash hooks) | Would close the advisory/mechanical gap in one pass | Unproven — pi's extension API surface for blocking tool calls, propagating exit codes, and exposing the tool/command string is unverified; conflating a documentation change with an unproven mechanical integration risks shipping neither cleanly |
+| **Advisory only in this change; mechanical enforcement is the explicit, separately-tracked next step** | Ships the cheap, high-value slice (governance-as-instructions) now; keeps the two concerns — "can pi read the rules" vs. "can pi's tool calls be blocked" — decoupled and independently reviewable | Pi operators get no gate enforcement until the follow-up spike lands (or proves the pattern non-viable) |
+
+## Decision
+
+Chosen on all three axes:
+
+- **Axis 1 — extend `AGENTS.md` in place.** A new top-of-file routing table tells a reader which of the two sections applies to them; the existing framework-contributor content is retained verbatim under "Framework repo orientation," just retitled and cross-referenced. No new load-order convention for pi to learn — it already auto-loads this file.
+- **Axis 2 — inline the load-bearing rule *statements*, reference the rule *files*.** `AGENTS.md`'s new section states each rule's actionable content in one or two sentences (branch/PR/commit format, ticket vocabulary, one-ticket-at-a-time, plan-mode heuristic, reporting style, no secrets, no direct-`main`, AgDR requirement, PR quality, per-PR merge approval) and links to the corresponding `.claude/rules/*.md` file for full text.
+- **Axis 3 — advisory only, explicitly.** `AGENTS.md`'s new section opens with a boundary callout: nothing here mechanically blocks a tool call for pi. Mechanical enforcement is out of scope for this change and is the subject of the sibling spike me2resh/apexyard#804 ("prove the governance-gate-as-pi-extension-over-bash pattern").
+
+A short `SYSTEM.md` was added alongside `AGENTS.md` — pi's optional custom-system-prompt file — as a brief operating-posture primer that points back at `AGENTS.md` rather than duplicating its content, since the two files serve different layers (identity/behaviour priming vs. reference manual). A new `docs/harnesses/pi.md` documents the full today/not-yet breakdown and the install shape, so operators (and future contributors extending harness support further) have one place to check what's real.
+
+## Consequences
+
+- `AGENTS.md` is no longer single-purpose. Future edits to either section must keep the intro routing table accurate — a contributor adding framework-orientation content should not accidentally land it in the operator-governance section, and vice versa.
+- The existing `/handover`-generated in-repo `AGENTS.md` convention (AgDR-0073) is unaffected: that flow generates a project-specific `AGENTS.md` for an *adopted* repo, a different file in a different repo. This AgDR only concerns apexyard's own root `AGENTS.md`.
+- Mechanical enforcement for pi remains a known, explicitly-scoped gap until me2resh/apexyard#804 resolves (promote to a real feature, or disposition-discard with a documented alternative).
+- If pi's own conventions evolve (e.g. it adds native project-instruction imports), this bridge should be revisited — the inline-vs-reference balance in Axis 2 was chosen against pi's *current* lack of an import mechanism.
+
+## Artifacts
+
+- PR: feat(#805): pi.dev AGENTS.md bridge (advisory rules for pi)
+- Sibling spike: me2resh/apexyard#804
+- Related: AgDR-0073 (`/handover`-generated in-repo `AGENTS.md`)

--- a/docs/harnesses/pi.md
+++ b/docs/harnesses/pi.md
@@ -1,0 +1,41 @@
+# Harness support — pi (pi.dev)
+
+apexyard's governance was built for Claude Code first: `CLAUDE.md` is auto-loaded at session start, `.claude/hooks/*.sh` mechanically enforce the merge gate / ticket-first / secrets-scan rules, and `.claude/skills/*.md` become typed slash commands. **pi** (pi.dev — Earendil's minimal, unopinionated agent CLI) is a deliberately different shape: no `CLAUDE.md`-style auto-load, no hook plumbing, no MCP, no slash-command runner, no plan mode, no background bash, no permission popups. Pi pushes that governance layer to user-installed packages instead of building it in. **apexyard is exactly that layer for a pi user.**
+
+This doc is the honest today-vs-not-yet breakdown for running apexyard-governed work under pi. It's the first slice of multi-harness support — see me2resh/apexyard#805 (this bridge) and the sibling me2resh/apexyard#804 (a spike on whether mechanical enforcement can be ported).
+
+## What works today
+
+| Capability | How it reaches pi |
+|------------|--------------------|
+| Chief-of-Staff framing + SDLC | `AGENTS.md` § "Operator governance bridge" — pi auto-loads `AGENTS.md` from cwd (or `~/.pi/agent/`), the same convention Cursor/Aider/Cline use |
+| Load-bearing conventions (branch/PR/commit format, ticket vocabulary, one-ticket-at-a-time, plan-before-risky-work, reporting style, no secrets, no direct-`main`) | Inlined concisely in `AGENTS.md`, with the full text of each rule at `.claude/rules/*.md` — pi can `Read` those on request |
+| Role definitions + activation triggers | `roles/*.md` + `.claude/rules/role-triggers.md` — readable, no auto-fire banner (see "not yet" below) |
+| Skills (ticket filing, audits, releases, …) | `.claude/skills/<name>/SKILL.md` are plain markdown processes — invoke by reading the file and following it step by step; there's no slash-command mechanism to trigger them automatically |
+| Operating-posture priming | `SYSTEM.md` — a short custom system prompt pi reads alongside `AGENTS.md`, pointing back at it rather than duplicating it |
+| AgDR / templates / workflows docs | All plain markdown under `docs/agdr/`, `templates/`, `workflows/` — readable exactly as they are for any harness |
+
+## What does NOT work yet
+
+| Gap | Why | Tracked as |
+|-----|-----|-----------|
+| **Mechanical gate enforcement** — the two-marker merge gate, ticket-first edit blocking, secrets scanning, AgDR-required checks, red-CI merge blocking | These are shell hooks wired to Claude Code's `PreToolUse`/`PostToolUse` events via `.claude/settings.json`. Pi has no equivalent hook-registration surface documented yet, so nothing shells out to `.claude/hooks/*.sh` on pi's behalf | me2resh/apexyard#804 (spike: can a thin pi extension shell out to the existing bash hooks?) |
+| **MCP-backed code/docs search** (`apexyard-search`) | Pi's design omits MCP entirely | No dedicated ticket — falls back to plain `grep`/`Read`, which is slower but functionally equivalent |
+| **Role-trigger advisory banners** | Claude Code's `detect-role-trigger.sh` posts a `PreToolUse` reminder banner when a diff matches a role trigger (e.g. touching `**/auth/**`). Pi has no hook to run that check | Self-check `.claude/rules/role-triggers.md` manually |
+| **Slash-command UX** for skills | Pi has no command-registration mechanism; skills are invoked by reading their `SKILL.md` and following the process by hand | Not tracked — an ergonomics gap, not a governance one |
+| **Plan mode, background bash, permission popups** | Deliberately absent from pi's design, not apexyard-specific gaps | N/A — approximate with an explicit "here's my plan, confirming before I execute" pause where `.claude/rules/plan-mode.md` would otherwise apply |
+
+## The honest summary
+
+Today, a pi user gets apexyard's rules **as instructions to follow**, not **as gates that stop them**. That's a real step — it's the difference between a pi session that has no idea apexyard's conventions exist and one that opens with the same Chief-of-Staff framing, SDLC, and ticket discipline a Claude Code session gets from `CLAUDE.md`. It is not parity with Claude Code's mechanical enforcement, and this doc — and `AGENTS.md`'s own "What's NOT bridged yet" section — say so explicitly rather than imply otherwise.
+
+## Install shape
+
+1. Fork [`me2resh/apexyard`](https://github.com/me2resh/apexyard) (or your existing ops fork) as usual — no pi-specific setup step.
+2. `cd` into the fork.
+3. Run `pi`. It auto-loads `AGENTS.md` (governance + orientation) and `SYSTEM.md` (operating posture) from the current directory.
+4. Work as normal — start tickets, open PRs, run skills by reading their `SKILL.md` — with the understanding from "What does NOT work yet" above that nothing here blocks you the way Claude Code's hooks would.
+
+## Roadmap
+
+The natural next step is the spike already filed at me2resh/apexyard#804: prove whether a thin pi extension can fire on pi's tool-call event and shell out to the existing bash gate hooks (e.g. `block-unreviewed-merge.sh`), giving apexyard real mechanical enforcement under pi with a single bash source of truth and a thin per-harness adapter — rather than a from-scratch TypeScript reimplementation of every gate. If that pattern holds, this doc's "not yet" column becomes the next feature ticket; if it doesn't, the spike's disposition memo will say why and name the alternative.


### PR DESCRIPTION
## Summary

- **`AGENTS.md` now bridges apexyard's advisory SDLC governance to pi (pi.dev)** — pi auto-loads `AGENTS.md` from cwd instead of `CLAUDE.md`, but the root `AGENTS.md` here already had a different, established job (framework-repo orientation for contributors, AgDR-0073). A pi user landing in an apexyard ops fork today would get that orientation content, not the Chief-of-Staff/SDLC governance a Claude Code session gets automatically. This PR extends `AGENTS.md` in place with a new "Operator governance bridge" section — the SDLC in brief, the four workflow gates, the role model, and the load-bearing conventions (branch/PR/commit format, ticket vocabulary, one-ticket-at-a-time, plan-before-risky-work, reporting style, no secrets, no direct-`main`, AgDR requirement, PR quality, per-PR merge approval) — stated concisely inline, with pointers to the full `.claude/rules/*.md` files for detail. The existing framework-contributor content is retained, unchanged, under its own "Framework repo orientation" heading.
- **The advisory-vs-mechanical boundary is explicit, not implied.** A boundary callout opens the new section: nothing here mechanically blocks a tool call the way Claude Code's `PreToolUse`/`PostToolUse` hooks do (merge gate, ticket-first, secrets scan, AgDR-required). Those hooks are Claude-Code-specific plumbing pi doesn't run. A "What's NOT bridged yet" list in `AGENTS.md` and the full breakdown in `docs/harnesses/pi.md` both name the gap rather than paper over it. Mechanical enforcement is tracked as the sibling spike #804 ("prove the governance-gate-as-pi-extension-over-bash pattern"), filed the same day and cross-linked from both docs.
- **`SYSTEM.md`** — a short custom system prompt pi reads alongside `AGENTS.md`. Kept deliberately brief and non-duplicative: it primes the operating posture (one ticket at a time, plan before risky work, report like a colleague, no unauthorized merges) and points back at `AGENTS.md` for the actual rule text, rather than repeating it.
- **`docs/harnesses/pi.md`** — the honest today-vs-not-yet table (what pi gets via the bridge, what still needs the mechanical-gate spike or isn't planned at all) plus the install shape (fork → `cd` → run `pi`, no pi-specific setup step).
- **`docs/agdr/AgDR-0083`** — records the coexistence decision across three axes: where pi-facing content lives (extend `AGENTS.md` in place vs. a new file vs. overwriting it), how much to inline vs. reference (rule statements inlined, full text/rationale left in `.claude/rules/*.md`), and scope (advisory now, mechanical enforcement explicitly deferred).
- **`README.md`** — the existing "For AI coding agents" callout now names pi and links to the harness doc.

## Testing

- `npx markdownlint-cli2` on all five touched/added files — 0 errors.
- Manually verified every `.claude/rules/*.md` path referenced from the new `AGENTS.md` section exists (`git-conventions.md`, `ticket-vocabulary.md`, `workflow-gates.md`, `pr-workflow.md`, `pr-quality.md`, `agdr-decisions.md`, `plan-mode.md`, `loop-mode.md`, `parallel-work.md`, `isolated-builds.md`, `agent-role-selection.md`, `reporting-style.md`, `leak-protection.md`, `role-triggers.md`).
- Cross-checked the new `AgDR-0083` filename/number against `docs/agdr/` for collisions (caught and fixed one against an already-merged `AgDR-0082-handover-badge-offer.md` from `upstream/dev`).
- Read-through of `AGENTS.md` end to end to confirm the new "Operator governance bridge" section doesn't contradict `CLAUDE.md` (same SDLC phases, same four gates, same rule set) and that the existing "Framework repo orientation" section is preserved verbatim aside from its new heading and two small cross-references to the new section.

Closes #805

## Glossary

| Term | Definition |
|------|------------|
| pi | pi.dev — Earendil's minimal, unopinionated agent CLI; auto-loads `AGENTS.md` (cwd or `~/.pi/agent/`) and an optional `SYSTEM.md`; omits MCP, plan mode, background bash, and permission popups by design |
| Advisory rule | A governance rule delivered as instructions/context an agent is expected to follow by convention, with no mechanical (hook-level) enforcement behind it |
| Mechanical gate | A shell-hook-enforced apexyard rule (e.g. the two-marker merge gate, ticket-first edit block) wired via `.claude/settings.json` — Claude-Code-specific plumbing pi doesn't have |
| Multi-harness support | apexyard's governance model working across more than one agent CLI (Claude Code today; pi via this PR; Codex/Cursor/Aider tracked separately, e.g. #261) |
| `AGENTS.md` dual audience | This PR's core move: one file, routed by an intro table, serving both framework contributors (existing content) and ops-fork operators on non-Claude-Code harnesses (new content) |
