### PR TITLE
chore(#807): combine codeql-action init+analyze bump (4.36.3) + group github-actions in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,14 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Group the codeql-action family so init/analyze/upload-sarif version
+    # bumps land as ONE PR instead of splitting. codeql.yml pins init and
+    # analyze to the same version — CodeQL fails CI if they mismatch, which
+    # is exactly what split PRs (#800 init, #801 analyze) produced. #807.
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
     commit-message:
       prefix: "chore"
     labels:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,12 +44,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- **Combines the split codeql-action bump** — Dependabot opened #800 (`codeql-action/init`) and #801 (`codeql-action/analyze`) as two separate 4.36.2→4.36.3 PRs, but `.github/workflows/codeql.yml` pins both actions to the same SHA and CodeQL fails CI unless they match. Merging either PR alone would have produced a red `Analyze (actions)` check on `dev`. This PR bumps **both** pins together to v4.36.3 (SHA `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a`), so it lands as a single green change. **Supersedes #800 and #801** — those two should be closed once this merges (each has a comment pointing here).
- **Adds a Dependabot `groups:` entry** for the `codeql-action` family (`github/codeql-action*`) in `.github/dependabot.yml` — the durable fix. Future version bumps to `init`/`analyze`/`upload-sarif` will now land as one grouped PR instead of splitting across independent PRs, so this exact CI-breaking scenario can't recur.

## Testing

1. `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — confirms the new `groups:` block is valid YAML.
2. Diff review: only the two `codeql-action` pin lines in `.github/workflows/codeql.yml` changed (both to the same SHA), and only an additive `groups:` block was added to `.github/dependabot.yml` — no other files touched.
3. Once merged, the `Analyze (actions)` job in the CodeQL workflow will run `init` and `analyze` at the same version (v4.36.3) and should pass.

Closes #807

---

## Glossary

| Term | Definition |
|------|------------|
| CodeQL | GitHub's semantic code-scanning tool for finding security vulnerabilities; the `init` and `analyze` actions in a workflow must run the same version to interoperate correctly |
| Dependabot group | A `dependabot.yml` config block (`groups:`) that bundles matching dependency updates into a single PR instead of opening one PR per dependency — the fix for this class of paired-bump mismatch |
| Paired-bump split | The failure mode this PR fixes: two dependencies that must move in lockstep (here, `codeql-action/init` and `codeql-action/analyze`) get bumped in separate, independently-mergeable PRs, so merging only one breaks CI |
