### PR TITLE
docs(GH-809): repo-targeting convention — always pass an explicit repo flag, and document existing write guards

### DIFF
--- a/.claude/rules/ticket-vocabulary.md
+++ b/.claude/rules/ticket-vocabulary.md
@@ -123,6 +123,42 @@ When you're working in a fork (e.g. `your-org/apexyard`) with `origin` = the for
 
 Earlier versions of these hooks were origin-only, which forced the cross-repo workaround for fork → upstream PRs and silently broke GitHub's auto-close — leaving every cross-fork PR's issue OPEN forever. After #207, bare `#N` is the supported pattern and the cross-repo workaround is no longer needed (it still passes the hook for backwards compat, but you lose auto-close).
 
+## Repo targeting — always pass an explicit `--repo` (me2resh/apexyard#809)
+
+The reserved-vocabulary rule above assumes you already know **which repo** a `#N` lives in. Across a portfolio that assumption is dangerous: numeric issue IDs collide freely across repos — `me2resh/apexyard#92`, a managed project's `#92`, and any other repo's `#92` are three unrelated issues. If you run a tracker command that omits the target repo, `gh` (and the equivalent Linear / Jira / Asana CLIs) resolves it against the **ambient (cwd) repo** — whichever repo the current directory happens to belong to. When the working directory isn't the one you meant, that silently reads or writes the *wrong* `#92`.
+
+**The rule: always pass an explicit `--repo <owner/repo>` on `gh issue` / `gh pr` (and equivalent tracker) commands. Never rely on ambient cwd resolution across a portfolio.** This matters most on bare **reads** — `gh issue view <N>`, `gh issue view <N> --json state` — where nothing downstream flags the mistake: the command succeeds, returns a real issue's state, and quietly feeds the wrong data into your reasoning. A wrong read is worse than a wrong write, because the write path has a human approval step in front of it and the read path does not.
+
+```bash
+# WRONG — resolves against whatever repo the cwd belongs to
+gh issue view 92 --json state,title
+
+# RIGHT — the target repo is stated, not inferred
+gh issue view 92 --repo me2resh/apexyard --json state,title
+```
+
+The same discipline is what `/start-ticket` already bakes in: it records the ticket's fully-qualified `owner/repo` in the session marker (see `.claude/skills/start-ticket/SKILL.md` § "Cross-repo note"), so pass the qualified form (`me2resh/flat-mate#128`) whenever you're in one repo but the ticket lives in another.
+
+### The write side is already mechanically guarded
+
+Two shipped hooks already close the *write* half of this gap — you don't need to remember them, but knowing they're there tells you where the residual risk actually is (reads):
+
+| Hook | Guards | How it helps repo-targeting |
+|------|--------|-----------------------------|
+| `require-skill-for-issue-create.sh` (#268) | Issue **creation** | Blocks a bare `gh issue create` / `gh api repos/.../issues` POST unless a structured skill (`/task`, `/feature`, `/bug`, `/spike`, `/migration`, `/investigation`, `/idea`) is in flight. Those skills resolve the target from the registry and pass an explicit `--repo` — so ambient-repo creation is already off the table. See [`leak-protection.md`](leak-protection.md) for the sibling concern. |
+| `block-private-refs-in-public-repos.sh` | Public-repo **writes** (issue / PR / comment) | Scrubs registered private-project names, repo slugs, and workspace paths out of anything written to a public framework repo — the privacy-boundary half of "wrong repo". Full rule: [`leak-protection.md`](leak-protection.md). |
+
+So the genuine residual gap is narrow: a bare `gh issue view <N>` with no `--repo`, when IDs collide **and** the working directory isn't the intended repo **and** `--repo` was omitted. Real, but read-only — and closed by the discipline above, not by a gate.
+
+### Why a convention, not a hook
+
+A `PreToolUse` hook sees a **number, not intent**. When the command is `gh issue view 92`, the hook cannot tell a *wrong-repo* access from a *legitimate cross-repo* one — and the framework reads and writes `me2resh/apexyard` **by design** (`/report-apexyard-bug`, `/request-apexyard-feature`, upstream framework PRs, reading issues like #809 itself). So:
+
+- A **blocking** hook that allowed only registered private projects would break every one of those legitimate upstream paths.
+- An **advisory** hook that fired on every bare read would be almost all noise — the bare-read pattern is overwhelmingly correct in a single-repo cwd.
+
+That's why this is self-discipline plus the two write-side backstops above, not a new gate. Same shape as the "why not lint Claude's prose output?" reasoning below: the shell can't infer the intended repo any more than it can lint prose. This section encodes the maintainer resolution posted on me2resh/apexyard#809.
+
 ## Why not lint Claude's prose output?
 
 Considered and rejected. Hooks run on tool calls, not on assistant text output. The only way to catch a fabricated `#N` in prose would be a self-discipline check Claude runs at the end of every response — which is exactly the failure mode this rule is trying to prevent. If Claude could reliably remember to check itself, the vocabulary collision wouldn't happen in the first place.


### PR DESCRIPTION
## Summary

- **Encodes the maintainer resolution on #809 as a convention, not a gate.** The bug report asked for a *blocking hook* that only lets the agent touch registered private projects. That design isn't safe — the framework reads and writes `me2resh/apexyard` by design (`/report-apexyard-bug`, `/request-apexyard-feature`, upstream framework PRs, reading issues like #809 itself), and a `PreToolUse` hook sees a *number, not intent*, so it can't tell a wrong-repo access from a legitimate cross-repo one. A blocking hook breaks upstream; an advisory one fires on every legitimate bare read (pure noise). The right shape is a self-discipline rule plus documenting the guards that already exist.
- **Adds a "Repo targeting — always pass an explicit `--repo`" section to `ticket-vocabulary.md`** (the rule that already owns tracker/repo discipline — so no 16th rule file, and no rule-count references to update across CLAUDE.md / README / AGENTS.md). It states the rule (always `--repo <owner/repo>`, never ambient cwd resolution), and explains *why it matters most on bare reads*: numeric IDs collide across a portfolio, and `gh issue view <N>` with no `--repo` silently returns the wrong repo's issue with nothing downstream to flag it — worse than a wrong write, which has a human approval step in front of it.
- **Documents the two shipped write-side backstops so readers know the residual gap is read-only:** `require-skill-for-issue-create.sh` forces issue creation through the structured skills (which resolve + pass explicit `--repo` from the registry, so ambient-repo creation is already blocked), and `block-private-refs-in-public-repos.sh` scrubs private-project names/slugs/paths out of public-repo writes (the privacy-boundary half of "wrong repo"). Both are cross-linked to `leak-protection.md`.

## Testing

- Verified the two named hooks exist and do what the rule claims:
  - `require-skill-for-issue-create.sh` — blocks raw `gh issue create` / `gh api repos/.../issues` **POST** (it downgrades read-only `gh api` GETs to a no-op, and only fires on `/issues` + a write signal) unless a structured ticket-skill marker is in flight; the structured skills pass an explicit `--repo` from the registry.
  - `block-private-refs-in-public-repos.sh` — documented in `leak-protection.md` as scrubbing registered private-project `name` / `repo` slug / `workspace` path out of public-repo issue/PR/comment writes.
- Confirmed the relative link `leak-protection.md` resolves (same `.claude/rules/` directory).
- Docs-only change; extends an existing rule, so the "15 modular rule files" counts in CLAUDE.md / `docs/whats-inside.md` / AGENTS.md are untouched and remain truthful.

## Glossary

| Term | Definition |
|------|------------|
| Ambient (cwd) repo resolution | `gh`/`glab`/etc. resolving a bare `<N>` against whichever repo the current working directory belongs to, when no `--repo` is passed |
| Bare read | A tracker read with no explicit target, e.g. `gh issue view 92` — the highest-risk case because nothing downstream flags a wrong-repo result |
| Write-side backstop | A shipped `PreToolUse` hook that mechanically guards the *write* path (create / public-repo write); reads are left to the convention |
| Residual gap | The narrow read-only case the convention closes: colliding IDs + wrong cwd + omitted `--repo` on a bare read |

Implements the maintainer resolution posted on #809 (convention + documenting existing write guards, not a blocking hook).

Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAQ1mgxusECbQaRAdiBwRj
