### PR TITLE
docs(GH-812): credit community issue/idea contributors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Thanks to everyone who has helped forge ApexYard:
 
 <sub>External contributors' PRs are squash-merged, so GitHub's commit-author graph under-counts them — this list credits the humans directly. New contributor? Open a PR and you'll be added.</sub>
 
+**Community input** — thanks also to the people who've shaped ApexYard through issues and ideas rather than merged code, including [@nickyreinert](https://github.com/nickyreinert) ([#809](https://github.com/me2resh/apexyard/issues/809), repo-targeting safeguard).
+
 ## Star History
 
 <a href="https://star-history.com/#me2resh/apexyard&Date">


### PR DESCRIPTION
## Summary

- **Credits non-code community contributors** — the README `## Contributors` section credits merged-PR authors via the avatar table, so people who shape ApexYard through **issues and ideas** (rather than code) were invisible. Added a short, extensible "Community input" line to give them a home.
- **First entry: @nickyreinert** — filed [#809](https://github.com/me2resh/apexyard/issues/809) (repo-targeting safeguard), which prompted the repo-targeting convention shipped in #811. They contributed via an issue, not a PR, so they don't appear in the code-contributor table — hence the explicit mention.
- **Scope-limited** — one line added to the Contributors section; the existing avatar table and note are untouched. The line is phrased so future issue/idea contributors can be appended.

## Testing

1. Render `README.md` (GitHub preview or any Markdown renderer) and scroll to `## Contributors`.
2. Confirm the new **Community input** line appears below the existing squash-merge note.
3. Confirm both links resolve: [@nickyreinert](https://github.com/nickyreinert) → the GitHub profile, and [#809](https://github.com/me2resh/apexyard/issues/809) → the issue.
4. Confirm the avatar table above is unchanged.

## Glossary

| Term | Definition |
|------|------------|
| Code contributor | Someone credited via a merged PR; surfaced by GitHub's commit-author graph and the avatar table in the Contributors section. |
| Non-code / community contributor | Someone who shapes the project through issues, bug reports, or ideas rather than merged code — invisible to the commit-author graph, hence credited explicitly. |
| Repo-targeting safeguard | The convention (shipped in #811) that framework tracker-write commands always pass an explicit `--repo`, avoiding accidental writes to the wrong repository — the improvement #809 prompted. |

Closes #812
