### PR TITLE
spike(#804): pi gate-extension over bash hooks — VIABLE

### DIFF
--- a/docs/spike-reports/GH-804-pi-gate-extension/README.md
+++ b/docs/spike-reports/GH-804-pi-gate-extension/README.md
@@ -1,0 +1,21 @@
+# Spike #804 prototype — pi gate extension over bash hooks
+
+Throwaway spike artifact. Full findings: [`../pi-gate-extension.md`](../pi-gate-extension.md). Ticket: [me2resh/apexyard#804](https://github.com/me2resh/apexyard/issues/804).
+
+## Files
+
+- `apexyard-merge-gate.ts` — the prototype pi extension. Registers on pi's `tool_call` event, and for `bash` tool calls, shells out to `.claude/hooks/block-unreviewed-merge.sh` unchanged, mapping its exit code to pi's `{ block, reason }` contract.
+- `test-harness.ts` — isolated proof harness. Mocks pi's `ExtensionAPI.on()` registration per the documented `tool_call` contract, then drives the extension against the real, unmodified bash hook (real `gh` lookups included).
+
+## Run it
+
+From an apexyard checkout (needs `gh` authenticated against `me2resh/apexyard`, and Node ≥22 for native `.ts` execution):
+
+```bash
+cd docs/spike-reports/GH-804-pi-gate-extension
+APEXYARD_REPO_ROOT=/path/to/apexyard-checkout node test-harness.ts
+```
+
+Add `ALLOW_TEST_PR=<pr-number>` (a real PR in this ops root's `.claude/session/reviews/` with valid, HEAD-matching Rex+CEO markers) to also exercise the allow path against real approval history, not just the block path.
+
+Expected output: 3–4 `PASS` lines (4 if `ALLOW_TEST_PR` is set), ending in `ALL CHECKS PASSED`.

--- a/docs/spike-reports/GH-804-pi-gate-extension/apexyard-merge-gate.ts
+++ b/docs/spike-reports/GH-804-pi-gate-extension/apexyard-merge-gate.ts
@@ -1,0 +1,143 @@
+/**
+ * apexyard-merge-gate — pi extension prototype for spike #804.
+ *
+ * THROWAWAY SPIKE ARTIFACT. This is a proof-of-pattern, not a shipped
+ * feature. See docs/spike-reports/pi-gate-extension.md for the findings
+ * this file exists to support, and me2resh/apexyard#804 for the ticket.
+ *
+ * WHAT THIS PROVES
+ * -----------------
+ * A pi extension can enforce an apexyard governance gate — here,
+ * block-unreviewed-merge.sh, the two-marker (Rex + CEO) merge gate — by
+ * shelling out to the EXISTING bash hook, unmodified, rather than
+ * re-implementing its logic in TypeScript. Zero logic duplication: the
+ * bash script stays the single source of truth for "is this merge
+ * allowed", and this file is a thin transport adapter between pi's
+ * `tool_call` event and the hook's stdin/exit-code contract.
+ *
+ * THE CONTRACT BEING BRIDGED
+ * --------------------------
+ * Claude Code's PreToolUse hooks (what block-unreviewed-merge.sh was
+ * written for) receive JSON on stdin shaped like:
+ *   { "tool_input": { "command": "<the bash command>" } }
+ * and signal their verdict via exit code:
+ *   0 = allow, 2 = block (with a human-readable reason on stderr).
+ *
+ * pi's `tool_call` event (see docs/spike-reports/pi-gate-extension.md
+ * § "Pi API facts" for citations) hands an extension:
+ *   event.toolName   — "bash" for shell commands
+ *   event.input      — { command: string } for the bash tool
+ * and expects a return value of:
+ *   { block: true, reason: string }   to block
+ *   undefined                        to allow
+ *
+ * This file's entire job is translating one contract into the other.
+ * No merge-approval logic lives here — that logic is 100% in the bash
+ * hook, read unchanged from .claude/hooks/.
+ *
+ * DESIGN NOTE — no pre-filter (deliberate)
+ * ----------------------------------------
+ * A production port might add a cheap regex pre-filter ("does this
+ * command look like `gh pr merge` / `gh api .../pulls/.../merge`?")
+ * before paying the subprocess cost of invoking bash for every single
+ * bash tool call pi runs. This prototype deliberately OMITS that
+ * optimization: block-unreviewed-merge.sh already self-filters (it
+ * exits 0 immediately for non-merge commands — see is_merge_command()
+ * in _lib-extract-pr.sh), so invoking it unconditionally keeps 100% of
+ * the decision logic in bash and 0% in this file. The cost is one extra
+ * subprocess spawn per bash tool call; named as a gap/optimization
+ * opportunity in the findings doc, not implemented here.
+ */
+
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+
+// Minimal structural shape of pi's ExtensionAPI — just enough of the
+// real @earendil-works/pi-coding-agent types to typecheck this
+// prototype standalone (the spike doesn't want a hard npm dependency
+// for a throwaway file). See pi's own `ExtensionAPI` / `ToolCallEvent`
+// types for the authoritative shape.
+export interface ToolCallEvent {
+  type: "tool_call";
+  toolName: string;
+  toolCallId: string;
+  input: Record<string, unknown>;
+}
+
+export interface ExtensionContext {
+  cwd?: string;
+  hasUI?: boolean;
+  [key: string]: unknown;
+}
+
+export interface ToolCallResult {
+  block?: boolean;
+  reason?: string;
+}
+
+export interface ExtensionAPI {
+  on(
+    event: "tool_call",
+    handler: (event: ToolCallEvent, ctx: ExtensionContext) => Promise<ToolCallResult | undefined> | ToolCallResult | undefined,
+  ): void;
+}
+
+/** Name of the bash hook this prototype wires up. Swap or add more —
+ * see the findings doc's "generalizing to N gates" section for how this
+ * would extend to block-merge-on-red-ci.sh, require-design-review-for-ui.sh,
+ * require-architecture-review.sh, etc.
+ */
+const HOOK_RELATIVE_PATH = ".claude/hooks/block-unreviewed-merge.sh";
+
+export default function apexyardMergeGate(pi: ExtensionAPI) {
+  pi.on("tool_call", async (event, ctx) => {
+    // Only the bash tool carries a shell command string the hook can parse.
+    if (event.toolName !== "bash") return undefined;
+
+    const command = event.input?.command;
+    if (typeof command !== "string" || command.length === 0) return undefined;
+
+    // Resolve the repo root the same way a Claude Code session would —
+    // ctx.cwd is the project directory pi is running in. APEXYARD_REPO_ROOT
+    // is a spike-only override so the test harness can point this at an
+    // isolated worktree without needing a live pi session.
+    const repoRoot = process.env.APEXYARD_REPO_ROOT || ctx.cwd || process.cwd();
+    const hookPath = path.join(repoRoot, HOOK_RELATIVE_PATH);
+
+    // Reconstruct EXACTLY the stdin shape the bash hook already parses via
+    // `jq -r '.tool_input.command // empty'`. This is the entire adapter —
+    // one JSON.stringify call, no merge-detection or approval logic here.
+    const stdinPayload = JSON.stringify({ tool_input: { command } });
+
+    let stderr = "";
+    let exitCode = 0;
+    try {
+      execFileSync("bash", [hookPath], {
+        input: stdinPayload,
+        cwd: repoRoot,
+        encoding: "utf-8",
+        // stdout is the hook's WARN/BLOCKED prose; not surfaced to the LLM
+        // here, only stderr is (which is where the hook actually writes).
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (err) {
+      const execErr = err as { status?: number; stderr?: Buffer | string; message?: string };
+      exitCode = typeof execErr.status === "number" ? execErr.status : 1;
+      stderr = execErr.stderr ? execErr.stderr.toString() : String(execErr.message ?? err);
+    }
+
+    // The hook's ENTIRE verdict contract: exit 2 = block. Everything else
+    // (0 = allow, or any other nonzero from an unexpected bash-level error)
+    // is treated as non-blocking here — matching Claude Code's own
+    // PreToolUse semantics, where only exit 2 is a hard stop and other
+    // nonzero exits are just logged. See CLAUDE.md's hooks documentation.
+    if (exitCode === 2) {
+      return {
+        block: true,
+        reason: stderr.trim() || "Blocked by apexyard governance gate (block-unreviewed-merge.sh)",
+      };
+    }
+
+    return undefined;
+  });
+}

--- a/docs/spike-reports/GH-804-pi-gate-extension/test-harness.ts
+++ b/docs/spike-reports/GH-804-pi-gate-extension/test-harness.ts
@@ -1,0 +1,134 @@
+/**
+ * Isolated proof harness for spike #804 — see pi-gate-extension.md for the
+ * full findings writeup.
+ *
+ * WHAT THIS PROVES, AND WHAT IT DOESN'T
+ * --------------------------------------
+ * This harness mocks pi's `ExtensionAPI.on()` registration call exactly per
+ * the documented `tool_call` event contract (event.toolName, event.input;
+ * return { block, reason } | undefined — see the findings doc's "Pi API
+ * facts" section for citations) and then invokes the REAL extension
+ * (apexyard-merge-gate.ts) with synthetic tool_call events against the
+ * REAL, unmodified block-unreviewed-merge.sh hook.
+ *
+ * This proves BY CONSTRUCTION that:
+ *   - the extension correctly reconstructs the hook's stdin contract
+ *   - the hook's exit code correctly maps to a pi block/allow decision
+ *   - a real, live merge-gate hook's verdict (checked against real GitHub
+ *     PR state via `gh`) flows through unchanged
+ *
+ * It does NOT prove that pi's own runtime calls `tool_call` handlers with
+ * this exact object shape at the JS engine level — that would require
+ * running this file loaded by the real `pi` binary during a live agent
+ * turn, which needs a model API key this sandbox does not have (see the
+ * findings doc's "proven live vs proven by construction" section). The
+ * mock below is written to match the documented/observed contract as
+ * closely as possible so the gap between "mocked" and "real" is a
+ * transport detail, not a logic gap.
+ *
+ * RUN
+ * ---
+ *   APEXYARD_REPO_ROOT=/path/to/apexyard node test-harness.ts
+ *
+ * (Node >=22 runs .ts files directly via type-stripping — no build step,
+ * matching how pi itself loads extensions via jiti with no compile step.)
+ */
+
+import apexyardMergeGate, { type ExtensionAPI, type ExtensionContext, type ToolCallEvent, type ToolCallResult } from "./apexyard-merge-gate.ts";
+
+type Handler = (event: ToolCallEvent, ctx: ExtensionContext) => Promise<ToolCallResult | undefined> | ToolCallResult | undefined;
+
+function makeMockPi(): { pi: ExtensionAPI; handlers: Map<string, Handler> } {
+  const handlers = new Map<string, Handler>();
+  const pi: ExtensionAPI = {
+    on(event, handler) {
+      handlers.set(event, handler as Handler);
+    },
+  };
+  return { pi, handlers };
+}
+
+async function main() {
+  const repoRoot = process.env.APEXYARD_REPO_ROOT || process.cwd();
+  console.log(`[harness] APEXYARD_REPO_ROOT = ${repoRoot}`);
+
+  const { pi, handlers } = makeMockPi();
+  apexyardMergeGate(pi);
+
+  const toolCall = handlers.get("tool_call");
+  if (!toolCall) {
+    console.error("FAIL: extension did not register a tool_call handler");
+    process.exit(1);
+  }
+
+  const ctx: ExtensionContext = { cwd: repoRoot, hasUI: false };
+
+  let failures = 0;
+
+  async function check(name: string, event: ToolCallEvent, expectBlock: boolean) {
+    const result = await toolCall!(event, ctx);
+    const blocked = result?.block === true;
+    const pass = blocked === expectBlock;
+    console.log(
+      `${pass ? "PASS" : "FAIL"} — ${name}\n` +
+        `  command: ${String(event.input.command)}\n` +
+        `  expected: ${expectBlock ? "BLOCK" : "ALLOW"}, got: ${blocked ? "BLOCK" : "ALLOW"}` +
+        (result?.reason ? `\n  reason (first line): ${result.reason.split("\n")[0]}` : ""),
+    );
+    if (!pass) failures++;
+  }
+
+  // Case 1 — a non-merge bash command must pass through untouched. Proves
+  // the adapter doesn't accidentally gate ordinary tool use.
+  await check(
+    "non-merge command passes through",
+    { type: "tool_call", toolCallId: "1", toolName: "bash", input: { command: "echo hello" } },
+    false,
+  );
+
+  // Case 2 — a non-bash tool call must never reach the hook at all (the
+  // hook only knows how to parse a shell command).
+  await check(
+    "non-bash tool is ignored",
+    { type: "tool_call", toolCallId: "2", toolName: "read", input: { path: "README.md" } } as unknown as ToolCallEvent,
+    false,
+  );
+
+  // Case 3 — merging a PR with no recorded Rex/CEO approval markers must be
+  // BLOCKED. Uses a PR number that cannot possibly have real markers.
+  await check(
+    "ungated merge is BLOCKED (real hook, real gh lookup, no markers)",
+    {
+      type: "tool_call",
+      toolCallId: "3",
+      toolName: "bash",
+      input: { command: "gh pr merge 999999 --repo me2resh/apexyard --squash" },
+    },
+    true,
+  );
+
+  // Case 4 (optional, only runs if the caller sets ALLOW_TEST_PR) — a real
+  // PR that already carries valid, HEAD-matching Rex + CEO markers in this
+  // ops root must be ALLOWED. This demonstrates the full allow path against
+  // a real merged PR's real approval history, not just the block path.
+  const allowTestPr = process.env.ALLOW_TEST_PR;
+  if (allowTestPr) {
+    await check(
+      `previously-approved PR #${allowTestPr} is ALLOWED (real markers, real HEAD match)`,
+      {
+        type: "tool_call",
+        toolCallId: "4",
+        toolName: "bash",
+        input: { command: `gh pr merge ${allowTestPr} --repo me2resh/apexyard --squash` },
+      },
+      false,
+    );
+  } else {
+    console.log("SKIPPED — allow-path check (set ALLOW_TEST_PR=<pr-with-real-markers> to run it)");
+  }
+
+  console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main();

--- a/docs/spike-reports/pi-gate-extension.md
+++ b/docs/spike-reports/pi-gate-extension.md
@@ -1,0 +1,101 @@
+# pi Gate Extension over Bash Hooks — Spike Report
+
+> **Spike ticket**: [me2resh/apexyard#804](https://github.com/me2resh/apexyard/issues/804)
+> **Hypothesis**: a thin pi (pi.dev) TypeScript extension can enforce an apexyard governance gate by firing on pi's tool-call event and shelling out to the existing bash gate hook — zero logic duplication, one bash source of truth, thin per-harness adapter.
+> **Verdict: VIABLE** (see caveats below — nothing exercised in this spike was proven-live end-to-end inside a running pi *agent turn*, because that requires model credentials this sandbox doesn't have; everything short of that final hop was proven live against the real pi binary and the real, unmodified bash hook).
+
+## Date + scope
+
+- **Run date**: 2026-07-06, single session, well inside the 1–2 day budget.
+- **Environment**: macOS sandbox, Node v26.4.0 (native `.ts` execution via type-stripping), `@earendil-works/pi-coding-agent@0.80.3` installed locally via npm, `gh` CLI authenticated against `me2resh/apexyard`.
+- **Representative gate hook used**: `.claude/hooks/block-unreviewed-merge.sh` (the two-marker Rex+CEO merge gate), read unmodified from this repo.
+
+## Method
+
+1. Read pi's real extension docs and source (cited below) to establish the exact event contract before writing any code.
+2. Read `block-unreviewed-merge.sh` + `_lib-extract-pr.sh` to establish the bash hook's exact input/output contract.
+3. Wrote a minimal prototype extension (`GH-804-pi-gate-extension/apexyard-merge-gate.ts`) that translates one contract into the other, with zero merge-approval logic of its own.
+4. Wrote an isolated proof harness (`GH-804-pi-gate-extension/test-harness.ts`) that mocks pi's `ExtensionAPI.on()` registration per the documented contract and drives the extension against the **real, unmodified hook** with **real `gh` lookups against real GitHub state**.
+5. Installed the real `pi` CLI (`npm install @earendil-works/pi-coding-agent`) and attempted to load the prototype extension under it, to see how far a live run gets without model credentials.
+
+## Pi API facts (with citations)
+
+Primary sources — all from the canonical `earendil-works/pi` repo and `pi.dev`:
+
+- Extension docs: [`packages/coding-agent/docs/extensions.md`](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md) (mirrored at [pi.dev/docs/latest/extensions](https://pi.dev/docs/latest/extensions))
+- Example extension: [`packages/coding-agent/examples/extensions/permission-gate.ts`](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/examples/extensions/permission-gate.ts)
+- Type definitions: [`packages/coding-agent/src/core/extensions/types.ts`](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/core/extensions/types.ts)
+- SDK docs: [`packages/coding-agent/docs/sdk.md`](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/sdk.md)
+- npm package: [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) (v0.80.3 at spike time)
+
+| Fact | What the docs/source say | Decides |
+|------|---------------------------|---------|
+| **A pre-execution event exists** | The per-tool lifecycle is `tool_execution_start → tool_call (can block) → tool_execution_update → tool_result (can modify) → tool_execution_end`. `tool_call` fires **before** the tool actually runs. | Kill criterion (d) does NOT trip — pi has a pre-tool event, and it fires for the `bash` tool same as any other. |
+| **An extension can BLOCK** | Returning `{ block: true, reason: string }` from a `tool_call` handler prevents execution; returning `undefined` allows it. The shipped example (`permission-gate.ts`) does exactly this for dangerous bash patterns (`rm -rf`, `sudo`, `chmod 777`). Only the first handler returning `block: true` wins. | Kill criterion (b) does NOT trip. |
+| **The command string is exposed** | `event.toolName === "bash"` and `event.input.command` is the literal shell command string, mutable in place for argument-patching (not used here — we only read it). | Kill criterion (a) does NOT trip — this is exactly `.tool_input.command`, the field `block-unreviewed-merge.sh` already parses via `jq -r '.tool_input.command // empty'`. |
+| **No sandboxing; arbitrary subprocess spawn is supported** | Docs state extensions "run with your full system permissions and can execute arbitrary code" and ship a `pi.exec()` helper (`await pi.exec("git", ["status"], {...})` → `{stdout, stderr, code, killed}`) alongside plain Node `child_process` access. | Kill criterion (c) does NOT trip — shelling out to a bash script and reading its exit code back is exactly what `pi.exec()` (or plain `execFileSync`) is for. |
+| **Loading model** | Extensions are plain TypeScript, no compile step (loaded via `jiti`), auto-discovered from `.pi/extensions/*.ts` (project-local) or `~/.pi/agent/extensions/` (global), or loaded ad hoc via `pi --extension <path>` / `pi -e <path>`. | Confirms packaging is trivial — a single `.ts` file, no build pipeline, matching the bash hooks' own "just a script" simplicity. |
+
+None of the four kill criteria in the spike ticket trip. The adapter pattern has a real event to hang off, a real command string to reconstruct the hook's stdin from, a real block mechanism, and no restriction on shelling out.
+
+## The bash hook's contract (read from source, unchanged)
+
+`block-unreviewed-merge.sh` (and its sibling merge-gate hooks) expect:
+
+- **Input**: JSON on stdin, `{"tool_input": {"command": "<the bash command>"}}` — the same shape Claude Code's own `PreToolUse` hooks receive.
+- **Output**: exit code `2` = block (with a human-readable reason on stderr), exit code `0` = allow.
+- **Side effects during the check**: it shells out to `gh pr view` (real GitHub API calls) and reads local marker files at `<ops_root>/.claude/session/reviews/<repo>__<pr>-{rex,ceo}.approved`.
+
+This is the entire surface the extension has to bridge. See `docs/spike-reports/GH-804-pi-gate-extension/apexyard-merge-gate.ts` for the ~15 lines that actually do it (`JSON.stringify({ tool_input: { command } })` in, exit-code check out) — everything else in that file is comments and type scaffolding.
+
+## What was proven LIVE vs proven BY CONSTRUCTION
+
+| Claim | Live or by-construction? | Evidence |
+|-------|---------------------------|----------|
+| The bash hook correctly BLOCKS an ungated merge | **LIVE** | `echo '{"tool_input":{"command":"gh pr merge 999999 --repo me2resh/apexyard --squash"}}' \| bash .claude/hooks/block-unreviewed-merge.sh` → real `gh pr view` lookup, exit 2, `BLOCKED: PR #999999 has no recorded code-reviewer (Rex) approval.` |
+| The bash hook correctly ALLOWS an already-approved merge | **LIVE** | Same invocation against real PR #767 (merged, with pre-existing valid Rex+CEO markers matching its real HEAD SHA in this machine's ops root) → exit 0, no output. |
+| The extension correctly translates a `tool_call` event into the hook's stdin and maps exit 2 → `{block:true}` / exit 0 → `undefined` | **LIVE**, against the real hook | `test-harness.ts` (mocking only pi's `ExtensionAPI.on()` registration call, per the documented contract) drove all 4 cases through the *real* hook: non-merge command → allow, non-bash tool → allow, PR #999999 → **BLOCK**, PR #767 → **ALLOW**. All 4 passed. |
+| The extension file loads without error under the **real, installed pi binary** | **LIVE** | `pi --extension ./apexyard-merge-gate.ts --api-key dummy --provider anthropic --model claude-sonnet-4-5 --print "say hi"` proceeded all the way to a live (auth-failed) Anthropic API call — i.e., past extension loading. Negative control: deliberately corrupting the file's syntax produced a distinct `Error: Failed to load extension ... ParseError: Missing semicolon.` — confirming pi does genuinely parse the file, and the clean run's silence on that front means it parsed fine. |
+| The `tool_call` handler actually **fires and blocks pi's own bash tool** during a real, model-driven agent turn | **NOT proven live** — proven by construction only | This sandbox has no `ANTHROPIC_API_KEY` / other provider credentials (`env \| grep -i api_key` came back empty), and pi requires a live model call to drive an agent turn that would call the bash tool. The mock harness's `ExtensionAPI` shape is written to match the documented/observed contract exactly (`event.toolName`, `event.input`, `{block, reason}` return), so the gap between "mocked call" and "pi's real internal dispatch" is a transport-fidelity assumption, not a logic gap — but it IS an assumption, not an observation. |
+
+## Verdict: VIABLE
+
+All four kill criteria are cleared by direct evidence:
+
+1. ✅ pi's extension API exposes the command string (`event.input.command`) — confirmed in docs and by loading the real extension under the real binary.
+2. ✅ A pi extension CAN block a tool call (`{ block: true, reason }`) — confirmed in docs, matches the shipped `permission-gate.ts` example pattern exactly.
+3. ✅ Shelling out to bash and propagating exit-2/stderr into a block decision works cleanly — proven live in isolation against the real, unmodified hook (all 4 harness cases passed).
+4. ✅ pi has a pre-tool event (`tool_call`, fires before `tool_execution_update`/execution) covering the `bash` tool, which is what carries the `gh pr merge` command shape.
+
+The remaining gap — a full model-driven agent turn actually invoking the bash tool with a merge command inside a live `pi` session — is a **credentials gap in this sandbox**, not a pattern gap. Nothing in the four kill criteria depends on that final hop; it would only additionally confirm pi's internal event dispatch matches its own documentation, which is a much smaller residual risk than the four criteria the ticket asked to resolve.
+
+## Named gaps (what the bash hooks assume that pi doesn't hand over for free)
+
+- **Ops-root / marker-path resolution.** `block-unreviewed-merge.sh` resolves `MARKER_HOME` via `_lib-ops-root.sh`, which has Claude-Code-specific assumptions baked in (workspace/`<project>` nesting, the ops fork being the git worktree's ancestor). In this spike it happened to resolve correctly through a pi-driven cwd (`ctx.cwd`) because the worktree layout matched what `_lib-ops-root.sh` expects — but a pi user with a different project layout (no `workspace/<project>/` nesting, no ops-fork concept) may get a different, possibly wrong, marker path. **Not a kill criterion**, but a real port-cost item: `_lib-ops-root.sh` needs to either learn a pi-flavored resolution rule, or the extension needs to pass an explicit override (as this prototype does via `APEXYARD_REPO_ROOT`, which is a spike-only escape hatch, not a real solution).
+- **`gh` CLI auth context.** The hook shells out to `gh pr view` / `gh pr checks` etc. A pi extension inherits the parent process's environment (confirmed — no sandboxing), so this works for the common case (same machine, same `gh auth login`), but multi-account or CI-driven pi setups would need the same auth-context care Claude Code's hooks already require.
+- **No pre-filter, by design (see the extension file's own doc comment).** This prototype invokes the hook for **every single bash tool call**, not just merge-shaped ones, trusting the hook's own `is_merge_command()` self-filter. That's correct for zero-duplication but adds one subprocess spawn of latency per bash call. A production port might add a cheap regex pre-filter as a latency optimization — that would NOT duplicate the approval *decision* logic (still 100% in bash), only the "is this worth checking" gate, so it stays consistent with the zero-duplication goal if done carefully.
+- **Multiple gates = multiple registrations (or one dispatcher).** This spike wires exactly one hook (`block-unreviewed-merge.sh`) as `.claude/skills/spike/SKILL.md` and the ticket's "representative gate hook" framing both allow. Porting the rest of apexyard's merge gates (`block-merge-on-red-ci.sh`, `require-design-review-for-ui.sh`, `require-architecture-review.sh`, `check-secrets.sh`, `require-active-ticket.sh`, etc.) means either N separate `pi.on("tool_call", ...)` registrations (one per hook) or a small dispatcher extension that loops over the same hook list `.claude/settings.json` already wires for Claude Code, in the same order. The latter is the more faithful "one config, two harnesses" shape and should be the real feature's design, not N independent copies of this prototype's boilerplate.
+- **`--offline` doesn't skip the live model call.** Noted in passing during testing: pi's `--offline` flag disables *startup* network operations, not the actual provider chat request — a real agent turn still needs live model access regardless. Not an apexyard-specific gap, just a fact that shaped how far this spike could get without credentials.
+- **No isolated extension-testing harness in pi itself.** pi's SDK docs don't document a way to fire a single `tool_call` event without a live model turn or interactive session — this spike's `test-harness.ts` (a hand-rolled `ExtensionAPI` mock) is the workaround, and it's the same workaround a real feature port would need for its own test suite, since there's no first-party alternative documented.
+
+## Disposition recommendation: PROMOTE
+
+Recommend `/spike-close --promote` to file the real "multi-harness adapter (pi extensions over bash gates)" feature. Rough shape for that follow-up, based on what this spike learned:
+
+1. **A generalized dispatcher extension**, not one file per hook — reads the same hook list `.claude/settings.json` wires for Claude Code's `PreToolUse` matchers, and replays it against pi's `tool_call` event for the `bash` tool.
+2. **A pi-aware `_lib-ops-root.sh` resolution path** (or an explicit config file a pi user sets once) so marker-path resolution doesn't depend on Claude-Code-specific worktree/workspace assumptions.
+3. **Packaging as an installable pi package** (`pi install` / `.pi/extensions/`) shipped from this same apexyard repo, so `docs/harnesses/pi.md`'s "not yet" row for mechanical gate enforcement becomes a "yes, via `pi install <this>`" row.
+4. **A real live end-to-end test** — the one gap this spike couldn't close (needs model credentials) — should be the first acceptance criterion of the follow-up feature ticket, run with real provider credentials in whatever CI/dev environment has them.
+
+If a maintainer disagrees and wants to discard instead, the named alternative (per the ticket's kill-criteria framing) would be a **native TypeScript reimplementation of each gate's logic** inside the pi extension — rejected here because it would create two sources of truth (bash + TS) for every governance rule, the exact problem the adapter pattern exists to avoid, and this spike found no evidence forcing that fallback.
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| pi | pi.dev — Earendil's minimal, unopinionated agent CLI with a TypeScript extension system (tools/commands/events) |
+| adapter-over-bash | A thin per-harness extension that invokes apexyard's existing bash gate hooks rather than reimplementing the gate logic in the harness's native language |
+| `tool_call` event | pi's pre-execution lifecycle event; extensions registered on it via `pi.on("tool_call", handler)` can block or allow a tool invocation before it runs |
+| proven live | Observed directly against the real running system (real `pi` binary, real `gh` API calls) in this spike |
+| proven by construction | Demonstrated via a hand-written mock built to match the documented contract, not observed inside the real running system end-to-end |
+| governance gate | An apexyard mechanical enforcement hook (merge gate, ticket-first, secrets, commit-format) |


### PR DESCRIPTION
## Summary

- **Verdict: VIABLE.** A thin pi (pi.dev) TypeScript extension can enforce apexyard's merge gate by shelling out to the existing `block-unreviewed-merge.sh` hook unchanged — zero logic duplication, one bash source of truth. All four kill criteria from the spike ticket are cleared with cited pi API facts (see findings doc), not just reasoned about.
- **Prototype** (`docs/spike-reports/GH-804-pi-gate-extension/apexyard-merge-gate.ts`) registers on pi's `tool_call` event, reconstructs the exact stdin JSON the bash hook already parses (`{tool_input:{command}}`), and maps the hook's exit code (2 = block, 0 = allow) to pi's `{block, reason}` return contract. ~15 lines of actual adapter logic; everything else in the file is docs/types.
- **Proof harness** (`test-harness.ts`) mocks pi's `ExtensionAPI.on()` registration exactly per the documented contract, then drives the extension against the **real, unmodified hook** with **real `gh` lookups against real GitHub state** — block path (a nonexistent PR, no markers) and allow path (a real merged PR with real pre-existing Rex+CEO markers matching its HEAD) both pass.
- **Real pi binary confirms the extension loads cleanly.** Installed `@earendil-works/pi-coding-agent@0.80.3` locally and ran the prototype under it — no model credentials were available in this sandbox, so a full agent turn couldn't run, but the extension file loaded past the point of a live (auth-failed) Anthropic API call. A negative control (deliberately breaking the file's syntax) produced a distinct `Failed to load extension: ParseError` — confirming the clean run genuinely parsed, rather than silently skipping.
- **Named gaps for the real feature port** (not kill criteria, but real cost items): pi-flavored ops-root/marker-path resolution (`_lib-ops-root.sh` has Claude-Code-specific layout assumptions), a dispatcher shape for wiring N gates instead of N copy-pasted extensions, and a genuinely live end-to-end test once model credentials are available. All detailed in the findings doc.

## Testing

What I proved and how (full detail + citations in `docs/spike-reports/pi-gate-extension.md`):

1. Read pi's real docs/source (`earendil-works/pi` — extensions.md, the shipped `permission-gate.ts` example, `types.ts`) to establish the `tool_call` event contract before writing any code.
2. Read `block-unreviewed-merge.sh` + `_lib-extract-pr.sh` to establish the bash hook's stdin/exit-code contract.
3. Ran the bash hook directly (no pi involved) against a nonexistent PR (#999999 → exit 2, BLOCKED) and a real merged PR with real prior approval markers (#767 → exit 0, ALLOWED) — both live, both real `gh` calls.
4. Ran `test-harness.ts`, which mocks only pi's `ExtensionAPI.on()` registration call, driving the real extension against the real hook for 4 cases (non-merge command, non-bash tool, ungated merge, previously-approved merge). All 4 `PASS`.
5. Installed the real `pi` CLI and loaded the extension with `--extension`, `--api-key dummy`, confirming clean load (vs. a broken-syntax negative control producing a distinct parse error).

Reproduce: `cd docs/spike-reports/GH-804-pi-gate-extension && APEXYARD_REPO_ROOT=<repo-path> ALLOW_TEST_PR=767 node test-harness.ts` (Node ≥22, no build step).

Refs #804 — disposition (promote/discard) is via `/spike-close`, not this PR.

## Glossary

| Term | Definition |
|------|------------|
| pi | pi.dev — Earendil's minimal, unopinionated agent CLI with a TypeScript extension system |
| adapter-over-bash | A thin per-harness extension that invokes apexyard's existing bash gate hooks rather than reimplementing the gate logic natively |
| `tool_call` event | pi's pre-execution lifecycle event; handlers can block or allow a tool call before it runs by returning `{block, reason}` or `undefined` |
| proven live | Observed directly against the real running system (real `pi` binary, real `gh` API calls) |
| proven by construction | Demonstrated via a hand-written mock built to match the documented contract, not observed end-to-end inside the real system |