### PR TITLE
feat(#815): multi-harness gate adapter for pi.dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Why two audiences in one file: `CLAUDE.md` is the framework-level instruction se
 
 ## Operator governance bridge (pi and other non-Claude-Code harnesses)
 
-> **Advisory only — read this before anything else.** Everything below is delivered as *instructions*, not mechanical enforcement. Claude Code's governance additionally runs as shell hooks (`.claude/hooks/*.sh`, wired via `.claude/settings.json`) that mechanically block bad commands — the two-marker merge gate, the ticket-first edit block, the secrets scanner, the AgDR-required check. Those hooks fire on Claude Code's `PreToolUse` / `PostToolUse` events, which pi (and most other harnesses) doesn't expose. **Nothing in this file will stop a tool call for you.** Follow these rules because they're the governance model apexyard is built on, not because a hook will catch you if you don't. See `docs/harnesses/pi.md` for exactly what's mechanically enforced vs. advisory-only, and the sibling spike (me2resh/apexyard#804) exploring whether a thin pi extension could close that gap later.
+> **Advisory by default — mechanical enforcement is opt-in for pi.** Everything below is delivered as *instructions*; Claude Code's governance additionally runs as shell hooks (`.claude/hooks/*.sh`, wired via `.claude/settings.json`) that mechanically block bad commands — the two-marker merge gate, the ticket-first edit block, the secrets scanner, the AgDR-required check. Those hooks fire on Claude Code's `PreToolUse` / `PostToolUse` events. pi doesn't expose that event surface directly, but as of me2resh/apexyard#815 a dispatcher extension (`harness-adapters/pi/`) shells out to the SAME unmodified hooks via pi's own `tool_call` event — install it (`harness-adapters/pi/README.md`) and pi gets real mechanical enforcement, not just prose. **Without that extension installed, nothing in this file will stop a tool call for you** — follow these rules because they're the governance model apexyard is built on, not because a hook will catch you if you don't. See `docs/harnesses/pi.md` for the current mechanically-enforced-vs-advisory-only breakdown.
 
 ### You are the Chief of Staff
 
@@ -80,9 +80,9 @@ Pi doesn't resolve Claude-Code-style `@.claude/rules/*.md` imports the way `CLAU
 
 ### What's NOT bridged yet
 
-Being upfront about the gap: this section gives you the rules as *instructions*. It does **not** give you:
+Being upfront about the gap: this section gives you the rules as *instructions* by default. As of me2resh/apexyard#815, mechanical enforcement is available too — but only if you install it (it isn't auto-loaded the way `AGENTS.md` itself is):
 
-- **Mechanical gate enforcement** — the two-marker merge gate, ticket-first edit blocking, secrets scanning, AgDR-required checks, red-CI merge blocking. These are Claude-Code-specific shell hooks; nothing currently shells out to them for pi. Tracked as a separate spike: me2resh/apexyard#804.
+- **Mechanical gate enforcement** — the two-marker merge gate, ticket-first edit blocking, secrets scanning, AgDR-required checks, red-CI merge blocking. `harness-adapters/pi/` shells out to the SAME Claude-Code-specific bash hooks via a pi `tool_call` extension — install it (see `harness-adapters/pi/README.md`) to get real blocking under pi. Until installed, none of it fires. See me2resh/apexyard#804 (the spike that proved this viable) and #815 (the shipped adapter).
 - **MCP-backed code/docs search** (`apexyard-search`) — pi's design omits MCP entirely; fall back to plain `grep`/`Read`.
 - **Role-trigger advisory banners** — Claude Code gets a `PreToolUse` banner nudging "this diff touches `**/auth/**`, consider the Security Auditor"; pi gets no such nudge. Self-check the role-triggers table manually.
 

--- a/docs/agdr/AgDR-0082-pi-gate-dispatcher-adapter.md
+++ b/docs/agdr/AgDR-0082-pi-gate-dispatcher-adapter.md
@@ -1,0 +1,45 @@
+# pi Gate Dispatcher — a Single-Extension Adapter Over the Bash Hooks
+
+> In the context of making apexyard's governance gates enforceable inside pi (pi.dev) as well as Claude Code, facing the choice between N per-hook pi extensions and a re-implementation of the gate logic in TypeScript, I decided to ship one dispatcher extension that reads a gate table and shells out to the existing, unmodified bash hooks to achieve zero logic duplication across harnesses, accepting the ongoing cost of keeping the gate table in sync with `.claude/settings.json`'s hook wiring and the residual, currently-unverified risk that pi's true internal `tool_call` tool-name enumeration might drift from what's documented in its shipped `.d.ts`.
+
+## Context
+
+Spike me2resh/apexyard#804 proved (VIABLE verdict) that a pi extension can enforce `block-unreviewed-merge.sh` by registering on pi's `tool_call` event, reconstructing the exact stdin JSON the bash hook already parses, and mapping the hook's exit code (2 = block, 0 = allow) to pi's `{block, reason}` return contract — with zero merge-approval logic duplicated into TypeScript. The spike's own "named gaps" section flagged three follow-up decisions the real feature needed to make:
+
+1. How to wire **more than one** gate hook without N copy-pasted single-hook extension files.
+2. How to resolve an **ops root** (the directory holding `.claude/session/reviews/*.approved` markers) under pi, given that `_lib-ops-root.sh`'s session-pin mechanism (`pin-ops-root.sh` + `CLAUDE_CODE_SESSION_ID`) is Claude-Code-specific and has no pi equivalent.
+3. Whether to trust the spike's hand-rolled structural types or import pi's real ones now that this is shipped code, not a throwaway prototype.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **N separate extension files, one per gate hook** | Each file is small and independently toggleable; matches the spike prototype's shape exactly | N near-identical boilerplate blocks (stdin JSON build, exec, exit-code mapping) that drift independently as pi's API evolves; adding a gate means copy-pasting a whole file instead of a table row |
+| **Reimplement each gate's approval logic in TypeScript, native to pi** | No bash subprocess per tool call; could use pi-native APIs more idiomatically | Creates a second source of truth for every governance rule — exactly the problem the adapter-over-bash pattern exists to avoid. The spike ticket named this the fallback only if the pattern proved non-viable; it didn't. |
+| **One dispatcher extension driven by a gate table (CHOSEN)** | One registration, one `tool_call` handler, N gates as data rows; adding a gate is a table entry, not a new file; the table is a direct visual analog of `.claude/settings.json`'s PreToolUse wiring — "one config, two harnesses" | The dispatcher itself is now the thing that must track pi's real tool-name surface accurately (see decision below); a bug in the shared dispatcher affects every gate at once, not just one |
+
+## Decision
+
+Chosen: **one dispatcher extension driven by a `GateDefinition[]` table** (`harness-adapters/pi/src/gate-dispatcher.ts`), because it is the shape the spike report itself recommended ("a small dispatcher extension that loops over the same hook list `.claude/settings.json` already wires for Claude Code, in the same order") and it keeps the zero-duplication property at the *gate* level (bash owns every approval decision) while collapsing the *per-gate* boilerplate to configuration.
+
+Two supporting decisions, made while building the dispatcher:
+
+- **Ops-root resolution**: a new, pi-only module (`harness-adapters/pi/src/resolve-ops-root.ts`) that reproduces `_lib-ops-root.sh`'s anchor-walk (the `.apexyard-fork` marker / legacy `onboarding.yaml`+`apexyard.projects.yaml` pair) faithfully in TypeScript, and substitutes an explicit `APEXYARD_OPS_ROOT` environment variable for Claude Code's session-pin mechanism (pi has no `CLAUDE_CODE_SESSION_ID` equivalent and no SessionStart hook to write a pin). This is a **deliberate divergence**: pi users get the anchor-walk safety (same as Claude Code) but not the pin-first protection that closed apexyard#381 (the `/tmp`-clone-resolves-wrong-tree bug). Consequence: a pi session launched from inside an unrelated ops-fork-shaped directory tree (e.g. a throwaway clone) could resolve markers to the wrong fork, same failure class #381 fixed for Claude Code. Mitigation available today: set `APEXYARD_OPS_ROOT` explicitly in any pi session that isn't launched from the real ops fork's working tree.
+- **Real pi types, not spike shims**: `gate-dispatcher.ts` imports `ExtensionAPI`, `ToolCallEvent`, `ToolCallEventResult` directly from `@earendil-works/pi-coding-agent`, rather than the spike prototype's hand-rolled structural interface. Checking the real `.d.ts` (not just the spike's docs-based reasoning) surfaced two corrections: the result type is `ToolCallEventResult`, not `ToolCallResult` (an invented name that happened to typecheck against the shim), and pi's `ToolCallEvent` is a **discriminated union** by `toolName` (`bash` | `read` | `edit` | `write` | `grep` | `find` | `ls` | custom) — there is no `multi_edit` tool (pi's `edit` tool accepts multiple `{oldText, newText}` pairs per call), and the edit/write tools key their target as `path`, not `file_path`. That last fact turned out to need no hook change at all: `require-active-ticket.sh` and `require-migration-ticket.sh` already fall back to `.tool_input.path` when `.tool_input.file_path` is absent.
+
+## Consequences
+
+- Adding a new gate to both harnesses is now "add a row to `DEFAULT_GATES`", not "write a new file" — the dispatcher table and `.claude/settings.json`'s hook list should be kept in visual sync by whoever edits either.
+- The `require-active-ticket` / `require-migration-ticket` mapping to pi's `edit` / `write` tool names is verified against pi's real, installed `.d.ts` (not guessed), which closes most of the residual risk the spike flagged — but the ONE thing that remains genuinely unverified is whether pi's *live internal dispatch* actually calls `tool_call` handlers with events matching this `.d.ts` during a real, model-driven agent turn (see the test suite's "LIVE" vs by-construction distinction, and AC-6 of me2resh/apexyard#815).
+- The pi-flavored ops-root resolution is a new code path apexyard has to maintain in parallel with `_lib-ops-root.sh`; a future change to the bash version's anchor conditions must be mirrored here by hand (there is no shared source file across bash and TypeScript).
+- Every gate hook still receives its input via a real subprocess spawn per matching tool call — the spike's own "no pre-filter, by design" note applies unchanged here; this trades a small latency cost for keeping 100% of the decision logic in one place.
+
+## Artifacts
+
+- `harness-adapters/pi/src/gate-dispatcher.ts` — the dispatcher extension
+- `harness-adapters/pi/src/resolve-ops-root.ts` — pi-flavored ops-root resolution
+- `harness-adapters/pi/test/gate-dispatcher.test.ts` — synthetic + live proof harness
+- `harness-adapters/pi/README.md` — install + usage docs
+- `docs/harnesses/pi.md` — updated harness-support matrix
+- Spike: me2resh/apexyard#804 / PR #814 (`docs/spike-reports/GH-804-pi-gate-extension/`)
+- Feature: me2resh/apexyard#815

--- a/docs/harnesses/pi.md
+++ b/docs/harnesses/pi.md
@@ -2,7 +2,7 @@
 
 apexyard's governance was built for Claude Code first: `CLAUDE.md` is auto-loaded at session start, `.claude/hooks/*.sh` mechanically enforce the merge gate / ticket-first / secrets-scan rules, and `.claude/skills/*.md` become typed slash commands. **pi** (pi.dev — Earendil's minimal, unopinionated agent CLI) is a deliberately different shape: no `CLAUDE.md`-style auto-load, no hook plumbing, no MCP, no slash-command runner, no plan mode, no background bash, no permission popups. Pi pushes that governance layer to user-installed packages instead of building it in. **apexyard is exactly that layer for a pi user.**
 
-This doc is the honest today-vs-not-yet breakdown for running apexyard-governed work under pi. It's the first slice of multi-harness support — see me2resh/apexyard#805 (this bridge) and the sibling me2resh/apexyard#804 (a spike on whether mechanical enforcement can be ported).
+This doc is the honest today-vs-not-yet breakdown for running apexyard-governed work under pi — updated as of me2resh/apexyard#815, which closes the mechanical-enforcement gap this doc used to list under "not yet". See me2resh/apexyard#805 (the `AGENTS.md` advisory bridge), me2resh/apexyard#804 (the spike that proved the enforcement pattern viable), and me2resh/apexyard#815 (the shipped adapter).
 
 ## What works today
 
@@ -14,28 +14,31 @@ This doc is the honest today-vs-not-yet breakdown for running apexyard-governed 
 | Skills (ticket filing, audits, releases, …) | `.claude/skills/<name>/SKILL.md` are plain markdown processes — invoke by reading the file and following it step by step; there's no slash-command mechanism to trigger them automatically |
 | Operating-posture priming | `SYSTEM.md` — a short custom system prompt pi reads alongside `AGENTS.md`, pointing back at it rather than duplicating it |
 | AgDR / templates / workflows docs | All plain markdown under `docs/agdr/`, `templates/`, `workflows/` — readable exactly as they are for any harness |
+| **Mechanical gate enforcement** — the two-marker merge gate, red-CI merge blocking, design/architecture review gates, secrets scanning, ticket-first / migration-ticket-first edit blocking | `harness-adapters/pi/` — a single dispatcher extension registers on pi's `tool_call` event and shells out to the **same, unmodified** `.claude/hooks/*.sh` scripts Claude Code uses, mapping each hook's exit code to pi's `{block, reason}` contract. Zero logic duplication — bash stays the one source of truth. See `harness-adapters/pi/README.md` and `docs/agdr/AgDR-0082-pi-gate-dispatcher-adapter.md`. |
 
 ## What does NOT work yet
 
 | Gap | Why | Tracked as |
 |-----|-----|-----------|
-| **Mechanical gate enforcement** — the two-marker merge gate, ticket-first edit blocking, secrets scanning, AgDR-required checks, red-CI merge blocking | These are shell hooks wired to Claude Code's `PreToolUse`/`PostToolUse` events via `.claude/settings.json`. Pi has no equivalent hook-registration surface documented yet, so nothing shells out to `.claude/hooks/*.sh` on pi's behalf | me2resh/apexyard#804 (spike: can a thin pi extension shell out to the existing bash hooks?) |
+| **A live, model-driven pi agent turn actually triggering the gate adapter's `tool_call` handler** | The gate adapter's transport (stdin reconstruction, hook exec, exit-code mapping) is proven live against the real bash hooks and real GitHub state; whether pi's *internal* event dispatch calls handlers with matching event shapes during a real model turn needs pi model credentials, which weren't available when #815 was built | me2resh/apexyard#815 § "Known gaps" — run the documented live-verification step once credentials are available |
 | **MCP-backed code/docs search** (`apexyard-search`) | Pi's design omits MCP entirely | No dedicated ticket — falls back to plain `grep`/`Read`, which is slower but functionally equivalent |
 | **Role-trigger advisory banners** | Claude Code's `detect-role-trigger.sh` posts a `PreToolUse` reminder banner when a diff matches a role trigger (e.g. touching `**/auth/**`). Pi has no hook to run that check | Self-check `.claude/rules/role-triggers.md` manually |
 | **Slash-command UX** for skills | Pi has no command-registration mechanism; skills are invoked by reading their `SKILL.md` and following the process by hand | Not tracked — an ergonomics gap, not a governance one |
 | **Plan mode, background bash, permission popups** | Deliberately absent from pi's design, not apexyard-specific gaps | N/A — approximate with an explicit "here's my plan, confirming before I execute" pause where `.claude/rules/plan-mode.md` would otherwise apply |
+| **Claude Code's session-pin protection against wrong-ops-root resolution** (apexyard#381) | pi has no `CLAUDE_CODE_SESSION_ID` / SessionStart-hook equivalent to write the pin | Use the `APEXYARD_OPS_ROOT` env var override documented in `harness-adapters/pi/README.md` when running pi outside the ops fork's own working tree |
 
 ## The honest summary
 
-Today, a pi user gets apexyard's rules **as instructions to follow**, not **as gates that stop them**. That's a real step — it's the difference between a pi session that has no idea apexyard's conventions exist and one that opens with the same Chief-of-Staff framing, SDLC, and ticket discipline a Claude Code session gets from `CLAUDE.md`. It is not parity with Claude Code's mechanical enforcement, and this doc — and `AGENTS.md`'s own "What's NOT bridged yet" section — say so explicitly rather than imply otherwise.
+A pi user now gets both halves of apexyard's governance: the **instructions** (via `AGENTS.md`/`SYSTEM.md`, unchanged since #805) and, as of #815, the same **mechanical gates** Claude Code enforces — an ungated merge attempt is refused by the real `block-unreviewed-merge.sh` hook running underneath pi, not just discouraged in prose. The one remaining asterisk is that the final "does pi's live internal dispatch really call the handler this way" hop is proven by construction (a faithful mock matching pi's real, typechecked `.d.ts`) rather than observed inside a live, credentialed pi session — see `harness-adapters/pi/README.md` for exactly what would close that gap.
 
 ## Install shape
 
 1. Fork [`me2resh/apexyard`](https://github.com/me2resh/apexyard) (or your existing ops fork) as usual — no pi-specific setup step.
 2. `cd` into the fork.
 3. Run `pi`. It auto-loads `AGENTS.md` (governance + orientation) and `SYSTEM.md` (operating posture) from the current directory.
-4. Work as normal — start tickets, open PRs, run skills by reading their `SKILL.md` — with the understanding from "What does NOT work yet" above that nothing here blocks you the way Claude Code's hooks would.
+4. Install the gate adapter (`cd harness-adapters/pi && npm install`) and load it — `pi --extension harness-adapters/pi/src/gate-dispatcher.ts` — for mechanical enforcement; see `harness-adapters/pi/README.md` for project-local auto-discovery instead.
+5. Work as normal — start tickets, open PRs, run skills by reading their `SKILL.md`.
 
 ## Roadmap
 
-The natural next step is the spike already filed at me2resh/apexyard#804: prove whether a thin pi extension can fire on pi's tool-call event and shell out to the existing bash gate hooks (e.g. `block-unreviewed-merge.sh`), giving apexyard real mechanical enforcement under pi with a single bash source of truth and a thin per-harness adapter — rather than a from-scratch TypeScript reimplementation of every gate. If that pattern holds, this doc's "not yet" column becomes the next feature ticket; if it doesn't, the spike's disposition memo will say why and name the alternative.
+me2resh/apexyard#804 (spike) proved the adapter-over-bash pattern viable; me2resh/apexyard#815 shipped the dispatcher covering the merge gate, red-CI block, design/architecture review, secrets scanning, and ticket-first gates. The next steps, not yet scoped as tickets: a live-credentialed end-to-end verification of the one remaining gap above, and porting role-trigger advisory banners and/or a slash-command-equivalent skill runner if pi's extension API grows the right hooks for either.

--- a/harness-adapters/pi/.gitignore
+++ b/harness-adapters/pi/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/harness-adapters/pi/README.md
+++ b/harness-adapters/pi/README.md
@@ -1,0 +1,110 @@
+# apexyard pi Gate Adapter
+
+Enforces apexyard's mechanical governance gates inside [pi](https://pi.dev) (Earendil's agent CLI) by shelling out to the **existing, unmodified** bash hooks under `.claude/hooks/` — zero logic duplication. The bash hooks stay the single source of truth for every gate's approval decision; this package is a thin transport adapter between pi's `tool_call` event and each hook's stdin/exit-code contract.
+
+Promoted from spike [me2resh/apexyard#804](https://github.com/me2resh/apexyard/issues/804) (verdict: VIABLE). See `docs/agdr/AgDR-0082-pi-gate-dispatcher-adapter.md` for the design decision and `docs/spike-reports/pi-gate-extension.md` for the spike's own findings.
+
+## What this enforces
+
+The dispatcher (`src/gate-dispatcher.ts`) wires the following gates by default — the same list `.claude/settings.json` wires for Claude Code's `PreToolUse` hooks:
+
+| Gate | Hook | pi tool(s) checked |
+|------|------|---------------------|
+| Unreviewed merge (Rex + CEO markers) | `block-unreviewed-merge.sh` | `bash` |
+| Red CI block | `block-merge-on-red-ci.sh` | `bash` |
+| Design review required for UI PRs | `require-design-review-for-ui.sh` | `bash` |
+| Architecture review required for design-artifact PRs | `require-architecture-review.sh` | `bash` |
+| Secrets scanning | `check-secrets.sh` | `bash` |
+| `git add -A` / `git add .` block | `block-git-add-all.sh` | `bash` |
+| Direct push to `main` block | `block-main-push.sh` | `bash` |
+| Ticket-first (an active ticket required before edits) | `require-active-ticket.sh` | `edit`, `write`, `bash` |
+| Migration-ticket-first | `require-migration-ticket.sh` | `edit`, `write` |
+
+Extend or trim this list by passing a custom `gates` array to `registerGateDispatcher()` — see "Customizing the gate table" below.
+
+## Install
+
+```bash
+cd harness-adapters/pi
+npm install       # pulls in @earendil-works/pi-coding-agent (real pi types + runtime)
+```
+
+Then load the extension in a pi session pointed at your apexyard ops fork:
+
+```bash
+pi --extension harness-adapters/pi/src/gate-dispatcher.ts
+```
+
+Or install it as a project-local extension pi auto-discovers (`.pi/extensions/*.ts` in the project pi is running in):
+
+```bash
+mkdir -p .pi/extensions
+cp harness-adapters/pi/src/gate-dispatcher.ts .pi/extensions/apexyard-gate-dispatcher.ts
+cp harness-adapters/pi/src/resolve-ops-root.ts .pi/extensions/resolve-ops-root.ts
+```
+
+(pi loads extensions via `jiti` with no compile step — plain `.ts`, no build pipeline, matching the bash hooks' own "just a script" simplicity.)
+
+## How ops-root resolution works
+
+Every gate hook needs to find the apexyard ops fork (where `.claude/session/reviews/*.approved` markers live) regardless of pi's current working directory. Claude Code resolves this via `_lib-ops-root.sh`, which layers a SessionStart-written pin on top of a directory walk-up. pi has no session-pin equivalent, so this adapter:
+
+1. **Honors an explicit `APEXYARD_OPS_ROOT` environment variable** if set and valid (recommended when running pi from a directory that isn't the ops fork's own working tree — e.g. a project workspace clone).
+2. **Falls back to a walk-up** from `ctx.cwd`, looking for the same anchor apexyard's bash hooks recognise: a `.apexyard-fork` marker file, or the legacy `onboarding.yaml` + `apexyard.projects.yaml` pair.
+
+If neither resolves, the dispatcher is a silent no-op for that tool call — it fails toward **not enforcing**, never toward **false-blocking** a legitimate tool call it can't evaluate.
+
+See `src/resolve-ops-root.ts` and AgDR-0082 for the full rationale, including the one safety property Claude Code's session pin provides that this adapter does NOT (protection against a pi session accidentally resolving to an unrelated ops-fork-shaped directory tree, e.g. a throwaway clone).
+
+## Customizing the gate table
+
+```ts
+import { registerGateDispatcher, DEFAULT_GATES, type GateDefinition } from "./src/gate-dispatcher.ts";
+
+const myGates: GateDefinition[] = [
+  ...DEFAULT_GATES,
+  {
+    name: "my-custom-gate",
+    hookRelativePath: ".claude/hooks/my-custom-gate.sh",
+    toolNames: ["bash"],
+    buildToolInput: (event) => (event.toolName === "bash" ? { command: event.input.command } : undefined),
+  },
+];
+
+export default function myExtension(pi) {
+  registerGateDispatcher(pi, { gates: myGates });
+}
+```
+
+## Testing
+
+```bash
+# hermetic — isolated fixture ops roots, no gh calls, no real pi package needed
+node --test test/gate-dispatcher.test.ts
+
+# + LIVE cases against this repo's real block-unreviewed-merge.sh and real gh state
+APEXYARD_TEST_REPO_ROOT="$(pwd)/.." ALLOW_TEST_PR=<pr-with-real-rex+ceo-markers> node --test test/gate-dispatcher.test.ts
+```
+
+`npm run typecheck` runs `tsc --noEmit` against the real `@earendil-works/pi-coding-agent` types — this is what verifies the adapter's field-name assumptions (e.g. `event.input.path` for edit/write, `event.input.command` for bash) against pi's actual, installed `.d.ts` rather than against documentation alone.
+
+## Known gaps / what's unverified
+
+This build (me2resh/apexyard#815) closed most of the gaps the spike flagged, but one remains — and it's the one that matters most for a production merge gate:
+
+- **Verified against pi's real, installed `.d.ts`**: the exact shape of `ToolCallEvent`, `ToolCallEventResult`, `ExtensionAPI`, and the edit/write tools' `path` field name (not `file_path`) — this is now typechecked (`npm run typecheck`), not guessed.
+- **Verified live, against the real bash hook + real GitHub state**: the full stdin-reconstruction → hook-exec → exit-code-mapping path, using a synthetic `tool_call` event that mocks only pi's `ExtensionAPI.on()` registration call (see `test/gate-dispatcher.test.ts`'s "LIVE" cases, run against real PR #767's real Rex+CEO markers and a real nonexistent-PR block).
+- **NOT verified** (and could not be verified in the environment this was built in — no pi model credentials available): that a real, model-driven pi agent turn actually invokes `tool_call` handlers with events matching this contract when the model itself calls the `bash`/`edit`/`write` tools. This is a transport-fidelity assumption inherited from spike #804's own "proven by construction, not proven live" finding for the same reason — it needs a live model API key this environment doesn't have. Once available, the correct test is: run a real pi session with this extension loaded, prompt a model turn that attempts an ungated `gh pr merge`, and confirm the tool call is refused with the hook's block reason surfaced to the model.
+- **The pi-flavored ops-root override (`APEXYARD_OPS_ROOT`) has no equivalent to Claude Code's session-pin protection** against resolving to an unrelated ops-fork-shaped directory tree (see "How ops-root resolution works" above and AgDR-0082).
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| pi | pi.dev — Earendil's minimal, unopinionated agent CLI with a TypeScript extension system |
+| adapter-over-bash | A thin per-harness extension that invokes apexyard's existing bash gate hooks rather than reimplementing the gate logic natively |
+| `tool_call` event | pi's pre-execution lifecycle event; extensions registered via `pi.on("tool_call", handler)` can block or allow a tool invocation before it runs |
+| ops root | The apexyard fork's root directory, where `.claude/session/reviews/*.approved` markers and `.claude/hooks/*.sh` live |
+| dispatcher | A single extension that checks a tool call against a table of gate definitions, rather than one extension per gate |
+| proven live | Observed directly against the real running system (real bash hook, real `gh` calls) |
+| proven by construction | Demonstrated via a mock built to match the documented/typed contract, not observed inside a live pi agent turn |

--- a/harness-adapters/pi/README.md
+++ b/harness-adapters/pi/README.md
@@ -6,7 +6,7 @@ Promoted from spike [me2resh/apexyard#804](https://github.com/me2resh/apexyard/i
 
 ## What this enforces
 
-The dispatcher (`src/gate-dispatcher.ts`) wires the following gates by default — the same list `.claude/settings.json` wires for Claude Code's `PreToolUse` hooks:
+The dispatcher (`src/gate-dispatcher.ts`) wires the following gates by default. **This is a curated subset, not the full list** `.claude/settings.json` wires for Claude Code's `PreToolUse` hooks — every gate below was checked against its own `jq` stdin parsing (all use the identical `.tool_input.command` shape `block-unreviewed-merge.sh` uses) and included because it's a blocking (exit-2) governance gate covering #815's named acceptance criteria (merge gate, red-CI, design/architecture review, ticket-first, secrets) plus leak protection:
 
 | Gate | Hook | pi tool(s) checked |
 |------|------|---------------------|
@@ -17,10 +17,27 @@ The dispatcher (`src/gate-dispatcher.ts`) wires the following gates by default �
 | Secrets scanning | `check-secrets.sh` | `bash` |
 | `git add -A` / `git add .` block | `block-git-add-all.sh` | `bash` |
 | Direct push to `main` block | `block-main-push.sh` | `bash` |
+| Leak protection (private project refs on public repos) | `block-private-refs-in-public-repos.sh` | `bash` |
 | Ticket-first (an active ticket required before edits) | `require-active-ticket.sh` | `edit`, `write`, `bash` |
 | Migration-ticket-first | `require-migration-ticket.sh` | `edit`, `write` |
 
-Extend or trim this list by passing a custom `gates` array to `registerGateDispatcher()` — see "Customizing the gate table" below.
+### Known NOT-yet-bridged gates
+
+`.claude/settings.json` also wires these blocking Bash-matcher `PreToolUse` hooks, which are **not** in `DEFAULT_GATES` yet. Each one uses the exact same `.tool_input.command` stdin shape as everything above, so bridging them is a table-row addition, not new adapter logic — they were deferred to keep this first pass scoped to #815's named acceptance criteria, not left out because of a technical blocker:
+
+| Hook | Fires on | Why deferred |
+|------|----------|--------------|
+| `validate-branch-name.sh` | `git branch` / `git checkout -b` | Same shape as everything bridged; out of #815's named scope |
+| `validate-commit-format.sh` | `git commit` | Same shape; out of #815's named scope |
+| `verify-commit-refs.sh` | `git commit` | Same shape; out of #815's named scope |
+| `validate-pr-create.sh` | `gh pr create` | Same shape; out of #815's named scope |
+| `require-agdr-for-arch-pr.sh` | `gh pr create` | Same shape; out of #815's named scope |
+| `require-skill-for-issue-create.sh` | `gh issue create` / equivalent | Same shape; out of #815's named scope |
+| `block-onboarding-in-git.sh` | `git add` of `onboarding.yaml` | Same shape; out of #815's named scope |
+
+If you rely on any of these under pi today, add them to your own `gates` array (see "Customizing the gate table" below) — they'll work with `bashCommandInput` unchanged.
+
+Extend or trim `DEFAULT_GATES` by passing a custom `gates` array to `registerGateDispatcher()` — see "Customizing the gate table" below.
 
 ## Install
 
@@ -96,6 +113,8 @@ This build (me2resh/apexyard#815) closed most of the gaps the spike flagged, but
 - **Verified live, against the real bash hook + real GitHub state**: the full stdin-reconstruction → hook-exec → exit-code-mapping path, using a synthetic `tool_call` event that mocks only pi's `ExtensionAPI.on()` registration call (see `test/gate-dispatcher.test.ts`'s "LIVE" cases, run against real PR #767's real Rex+CEO markers and a real nonexistent-PR block).
 - **NOT verified** (and could not be verified in the environment this was built in — no pi model credentials available): that a real, model-driven pi agent turn actually invokes `tool_call` handlers with events matching this contract when the model itself calls the `bash`/`edit`/`write` tools. This is a transport-fidelity assumption inherited from spike #804's own "proven by construction, not proven live" finding for the same reason — it needs a live model API key this environment doesn't have. Once available, the correct test is: run a real pi session with this extension loaded, prompt a model turn that attempts an ungated `gh pr merge`, and confirm the tool call is refused with the hook's block reason surfaced to the model.
 - **The pi-flavored ops-root override (`APEXYARD_OPS_ROOT`) has no equivalent to Claude Code's session-pin protection** against resolving to an unrelated ops-fork-shaped directory tree (see "How ops-root resolution works" above and AgDR-0082).
+- **`check-secrets.sh` scans `git diff --cached` relative to `cwd: opsRoot`, with no additional cd-resolution.** If a pi session is launched from inside a nested or otherwise different git repo than the intended one, the secrets scan runs against the *ops fork's* staged diff, not the repo the operator actually meant to scan. This mirrors an equivalent limitation Claude Code already has (the hook resolves the same way there), so it's not a regression introduced by this adapter — noted here for completeness, no code change made.
+- **Gate execution failures fail CLOSED, not open** (fixed in this build after a Rex finding on PR #817): if a hook can't produce a numeric exit status at all — a spawn failure, output exceeding the 10 MB `maxBuffer` ceiling, a signal kill — the dispatcher now BLOCKS with a reason naming the hook and the underlying error, rather than silently allowing the tool call through. Only a genuine hook exit code of 0 (or a numeric non-2 exit code) allows the call; exit code 2 blocks with the hook's own reason. See `src/gate-dispatcher.ts`'s `runGateHook` doc comment for the full semantics and `test/gate-dispatcher.test.ts`'s "FAILS CLOSED" test.
 
 ## Glossary
 

--- a/harness-adapters/pi/package-lock.json
+++ b/harness-adapters/pi/package-lock.json
@@ -1,0 +1,1886 @@
+{
+  "name": "@apexyard/pi-gate-adapter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@apexyard/pi-gate-adapter",
+      "version": "0.1.0",
+      "dependencies": {
+        "@earendil-works/pi-coding-agent": "^0.80.3"
+      },
+      "devDependencies": {
+        "@types/node": "^26.1.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.3.tgz",
+      "integrity": "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-tui": "^0.80.3",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
+        "typebox": "1.1.38",
+        "undici": "8.5.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.80.3",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "./dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/harness-adapters/pi/package.json
+++ b/harness-adapters/pi/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@apexyard/pi-gate-adapter",
+  "version": "0.1.0",
+  "description": "pi (pi.dev) extension enforcing apexyard's mechanical governance gates by shelling out to the existing bash hooks — zero logic duplication. See README.md.",
+  "type": "module",
+  "private": true,
+  "main": "src/gate-dispatcher.ts",
+  "scripts": {
+    "test": "node --test test/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@earendil-works/pi-coding-agent": "^0.80.3"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.0",
+    "typescript": "^5.6.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/harness-adapters/pi/src/gate-dispatcher.ts
+++ b/harness-adapters/pi/src/gate-dispatcher.ts
@@ -1,0 +1,267 @@
+/**
+ * apexyard-gate-dispatcher — pi extension enforcing apexyard's mechanical
+ * governance gates by shelling out to the EXISTING, UNMODIFIED bash hooks
+ * under `.claude/hooks/`. Zero logic duplication: every gate's approval
+ * decision stays 100% in bash; this file is a thin transport adapter
+ * between pi's `tool_call` event and each hook's stdin/exit-code contract.
+ *
+ * PROMOTED FROM SPIKE #804 (VIABLE) — see
+ * docs/spike-reports/GH-804-pi-gate-extension/apexyard-merge-gate.ts and
+ * docs/spike-reports/pi-gate-extension.md for the proof. This file
+ * generalizes that single-hook prototype into a DISPATCHER that wires N
+ * gates from one config table, per the spike's own "named gaps" section
+ * (item 4: "multiple gates = multiple registrations (or one dispatcher)").
+ *
+ * See docs/agdr/AgDR-0082-pi-gate-dispatcher-adapter.md for the dispatcher
+ * design decision and docs/harnesses/pi.md for install + usage docs.
+ *
+ * REAL PI TYPES, NOT SPIKE GUESSES
+ * ---------------------------------
+ * The spike's throwaway prototype hand-rolled a structural ExtensionAPI
+ * shim (it didn't want a hard npm dependency for a throwaway file). This
+ * shipped adapter imports the REAL types from
+ * `@earendil-works/pi-coding-agent`, and two spike assumptions turned out
+ * to need correcting once checked against the real `.d.ts`:
+ *
+ *   - The block-decision type is `ToolCallEventResult` ({block, reason}),
+ *     not `ToolCallResult` (the spike's own invented name for the same
+ *     shape).
+ *   - `event.input` is NOT a generic `Record<string, unknown>` — pi's
+ *     `ToolCallEvent` is a discriminated union (`BashToolCallEvent`,
+ *     `EditToolCallEvent`, `WriteToolCallEvent`, `ReadToolCallEvent`,
+ *     `GrepToolCallEvent`, `FindToolCallEvent`, `LsToolCallEvent`,
+ *     `CustomToolCallEvent`) keyed by `toolName`. There is no
+ *     `multi_edit` tool in pi — pi's `edit` tool already accepts multiple
+ *     `{oldText, newText}` pairs in one call via its `edits` array — and
+ *     the edit/write tools key their target path as `path`, not
+ *     `file_path` (which is exactly the CLAUDE-CODE tool_input field name
+ *     `require-active-ticket.sh` primarily checks, falling back to
+ *     `.tool_input.path` — see that hook's line 40 — so this maps
+ *     directly with no gap).
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+
+import type { ExtensionAPI, ToolCallEvent, ToolCallEventResult } from "@earendil-works/pi-coding-agent";
+
+import { resolveOpsRootForPi } from "./resolve-ops-root.ts";
+
+/**
+ * One row = one apexyard PreToolUse gate hook this dispatcher enforces.
+ *
+ * `toolNames` lists the real pi tool names (per
+ * `@earendil-works/pi-coding-agent`'s `ToolCallEvent` union: "bash",
+ * "read", "edit", "write", "grep", "find", "ls", or a custom string)
+ * whose `tool_call` events this gate should be checked against.
+ *
+ * `buildToolInput` reconstructs the exact `tool_input` shape each hook's
+ * `jq` parsing expects (see `.claude/hooks/_lib-extract-pr.sh` and each
+ * hook's own `INPUT | jq -r '.tool_input....'` line) from pi's event
+ * fields. Returning `undefined` means "this event doesn't carry the field
+ * this hook needs" — the dispatcher then skips invoking that hook for that
+ * event rather than invoking it with a garbage payload.
+ */
+export interface GateDefinition {
+  /** Human-readable name, used in block reasons and logs. */
+  name: string;
+  /** Relative path to the hook script under the ops root. */
+  hookRelativePath: string;
+  /** Real pi tool names this gate should be checked against. */
+  toolNames: string[];
+  /**
+   * Claude-Code tool_name string the hook's own `jq -r '.tool_name'`
+   * lookup expects (only a few hooks read this field; most only read
+   * `.tool_input.*` and ignore `.tool_name`). Defaults per toolName are
+   * applied by `defaultClaudeToolName` below when omitted.
+   */
+  claudeToolName?: (piToolName: string) => string;
+  /** Build the `tool_input` object from a pi ToolCallEvent. */
+  buildToolInput: (event: ToolCallEvent) => Record<string, unknown> | undefined;
+}
+
+function defaultClaudeToolName(piToolName: string): string {
+  switch (piToolName) {
+    case "bash":
+      return "Bash";
+    case "edit":
+      return "Edit";
+    case "write":
+      return "Write";
+    default:
+      return piToolName;
+  }
+}
+
+/** Reconstructs `{command: <string>}` for pi's "bash" tool. */
+function bashCommandInput(event: ToolCallEvent): Record<string, unknown> | undefined {
+  if (event.toolName !== "bash") return undefined;
+  const command = event.input.command;
+  if (typeof command !== "string" || command.length === 0) return undefined;
+  return { command };
+}
+
+/**
+ * Reconstructs `{path: <string>}` for pi's "edit" / "write" tools — pi
+ * names the target field `path` on both `EditToolInput` and
+ * `WriteToolInput` (confirmed against the real `.d.ts`, not guessed).
+ * `require-active-ticket.sh` and `require-migration-ticket.sh` already
+ * fall back to `.tool_input.path` when `.tool_input.file_path` is absent
+ * (see `_lib-extract-pr.sh` / the hooks' own jq lines), so this maps onto
+ * the EXISTING fallback rather than requiring a hook change.
+ */
+function editOrWritePathInput(event: ToolCallEvent): Record<string, unknown> | undefined {
+  if (event.toolName !== "edit" && event.toolName !== "write") return undefined;
+  const targetPath = event.input.path;
+  if (typeof targetPath !== "string" || targetPath.length === 0) return undefined;
+  return { path: targetPath };
+}
+
+/**
+ * The gate table. Each row corresponds 1:1 to a `PreToolUse` hook already
+ * wired in `.claude/settings.json` for Claude Code — this is the
+ * "one config, two harnesses" shape the spike report recommended, not a
+ * hand-copied re-derivation. Extend this array to cover additional gates;
+ * do not write a new dispatcher-shaped file per hook.
+ */
+export const DEFAULT_GATES: GateDefinition[] = [
+  {
+    name: "block-unreviewed-merge",
+    hookRelativePath: ".claude/hooks/block-unreviewed-merge.sh",
+    toolNames: ["bash"],
+    buildToolInput: bashCommandInput,
+  },
+  {
+    name: "block-merge-on-red-ci",
+    hookRelativePath: ".claude/hooks/block-merge-on-red-ci.sh",
+    toolNames: ["bash"],
+    buildToolInput: bashCommandInput,
+  },
+  {
+    name: "require-design-review-for-ui",
+    hookRelativePath: ".claude/hooks/require-design-review-for-ui.sh",
+    toolNames: ["bash"],
+    buildToolInput: bashCommandInput,
+  },
+  {
+    name: "require-architecture-review",
+    hookRelativePath: ".claude/hooks/require-architecture-review.sh",
+    toolNames: ["bash"],
+    buildToolInput: bashCommandInput,
+  },
+  {
+    name: "check-secrets",
+    hookRelativePath: ".claude/hooks/check-secrets.sh",
+    toolNames: ["bash"],
+    buildToolInput: bashCommandInput,
+  },
+  {
+    name: "block-git-add-all",
+    hookRelativePath: ".claude/hooks/block-git-add-all.sh",
+    toolNames: ["bash"],
+    buildToolInput: bashCommandInput,
+  },
+  {
+    name: "block-main-push",
+    hookRelativePath: ".claude/hooks/block-main-push.sh",
+    toolNames: ["bash"],
+    buildToolInput: bashCommandInput,
+  },
+  {
+    name: "require-active-ticket",
+    hookRelativePath: ".claude/hooks/require-active-ticket.sh",
+    // This hook also fires on Bash when the command writes a file via
+    // redirection/tee/sed -i, which `_lib-detect-bash-write.sh` detects
+    // bash-side; that detection works unchanged once the command string
+    // is forwarded, so "bash" is included alongside "edit"/"write".
+    toolNames: ["edit", "write", "bash"],
+    buildToolInput: (event) => bashCommandInput(event) ?? editOrWritePathInput(event),
+  },
+  {
+    name: "require-migration-ticket",
+    hookRelativePath: ".claude/hooks/require-migration-ticket.sh",
+    toolNames: ["edit", "write"],
+    buildToolInput: editOrWritePathInput,
+  },
+];
+
+export interface DispatcherOptions {
+  /** Override the gate table (defaults to DEFAULT_GATES). */
+  gates?: GateDefinition[];
+  /** Override ops-root resolution (defaults to resolveOpsRootForPi). */
+  resolveOpsRoot?: (startCwd: string) => string | undefined;
+}
+
+/**
+ * Runs a single gate hook with the reconstructed Claude-Code-shaped stdin
+ * payload, mapping its exit code to a pi ToolCallEventResult per the
+ * proven-in-spike contract: exit 2 = block, everything else = allow.
+ */
+function runGateHook(opsRoot: string, gate: GateDefinition, toolInput: Record<string, unknown>, claudeToolName: string): ToolCallEventResult | undefined {
+  const hookPath = path.join(opsRoot, gate.hookRelativePath);
+  if (!existsSync(hookPath)) return undefined; // gate not present in this fork — no-op, not a failure
+
+  const stdinPayload = JSON.stringify({ tool_name: claudeToolName, tool_input: toolInput });
+
+  let stderr = "";
+  let exitCode = 0;
+  try {
+    execFileSync("bash", [hookPath], {
+      input: stdinPayload,
+      cwd: opsRoot,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (err) {
+    const execErr = err as { status?: number; stderr?: Buffer | string; message?: string };
+    exitCode = typeof execErr.status === "number" ? execErr.status : 1;
+    stderr = execErr.stderr ? execErr.stderr.toString() : String(execErr.message ?? err);
+  }
+
+  if (exitCode === 2) {
+    return {
+      block: true,
+      reason: stderr.trim() || `Blocked by apexyard governance gate (${gate.name})`,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Registers the dispatcher's `tool_call` handler on a pi ExtensionAPI
+ * instance. This is the function pi loads (default export, below) — kept
+ * separate from the default export so tests can call it directly with a
+ * mock `pi` object without going through pi's own module loader.
+ */
+export function registerGateDispatcher(pi: ExtensionAPI, options: DispatcherOptions = {}): void {
+  const gates = options.gates ?? DEFAULT_GATES;
+  const resolve = options.resolveOpsRoot ?? ((startCwd: string) => resolveOpsRootForPi({ startCwd }));
+
+  pi.on("tool_call", async (event, ctx) => {
+    const toolName = event.toolName;
+    const startCwd = ctx.cwd ?? process.cwd();
+    const opsRoot = resolve(startCwd);
+    if (!opsRoot) return undefined; // no apexyard fork found on this machine/session — nothing to enforce
+
+    // Run every gate whose toolNames list includes this event's tool.
+    // First hook to return a block wins — mirrors Claude Code's own
+    // PreToolUse semantics, where any matching hook exiting 2 halts the
+    // tool call regardless of what the other matched hooks would have
+    // said.
+    for (const gate of gates) {
+      if (!gate.toolNames.includes(toolName)) continue;
+      const toolInput = gate.buildToolInput(event);
+      if (!toolInput) continue;
+      const claudeToolName = (gate.claudeToolName ?? defaultClaudeToolName)(toolName);
+      const result = runGateHook(opsRoot, gate, toolInput, claudeToolName);
+      if (result?.block) return result;
+    }
+    return undefined;
+  });
+}
+
+/** Default export — what `pi install` / `pi --extension` loads. */
+export default function apexyardGateDispatcher(pi: ExtensionAPI): void {
+  registerGateDispatcher(pi);
+}

--- a/harness-adapters/pi/src/gate-dispatcher.ts
+++ b/harness-adapters/pi/src/gate-dispatcher.ts
@@ -119,11 +119,40 @@ function editOrWritePathInput(event: ToolCallEvent): Record<string, unknown> | u
 }
 
 /**
- * The gate table. Each row corresponds 1:1 to a `PreToolUse` hook already
- * wired in `.claude/settings.json` for Claude Code — this is the
- * "one config, two harnesses" shape the spike report recommended, not a
- * hand-copied re-derivation. Extend this array to cover additional gates;
- * do not write a new dispatcher-shaped file per hook.
+ * The gate table. Every row here corresponds 1:1 to a `PreToolUse` hook
+ * that is ALSO wired in `.claude/settings.json` for Claude Code — this is
+ * the "one config, two harnesses" shape the spike report recommended, not
+ * a hand-copied re-derivation. Extend this array to cover additional
+ * gates; do not write a new dispatcher-shaped file per hook.
+ *
+ * THIS IS A CURATED SUBSET, NOT THE FULL LIST. `.claude/settings.json`
+ * wires more Bash-matcher PreToolUse hooks than are bridged here. Every
+ * hook below was checked against its own `jq -r '.tool_input.command'`
+ * parsing (all of them read the identical stdin shape as
+ * `block-unreviewed-merge.sh`, so no new adapter logic was needed) and
+ * included because it's a real, blocking (exit-2) governance gate. Known
+ * NOT-yet-bridged blocking Bash gates, and why:
+ *
+ *   - `validate-branch-name.sh`, `validate-commit-format.sh`,
+ *     `verify-commit-refs.sh` — fire on `git branch` / `git commit`
+ *     commands. Same bash-command shape as everything below and would be
+ *     trivial to add; left out of this pass to keep the initial bridge
+ *     scoped to the gates #815's acceptance criteria named explicitly
+ *     (merge gate, red-CI, design/architecture review, ticket-first,
+ *     secrets). Follow-up work, not a technical blocker.
+ *   - `validate-pr-create.sh`, `require-agdr-for-arch-pr.sh`,
+ *     `require-skill-for-issue-create.sh` — fire on `gh pr create` /
+ *     `gh issue create` commands. Same reasoning: trivially the same
+ *     shape, deferred rather than out of scope.
+ *   - `block-onboarding-in-git.sh` — fires on `git add` of
+ *     `onboarding.yaml`; same shape, deferred for the same reason.
+ *
+ * `block-private-refs-in-public-repos.sh` (leak protection) IS bridged
+ * below, ahead of the others in this deferred list, because it's
+ * security-relevant in exactly the way this dispatcher exists to close:
+ * without it, a pi session could leak a registered private project's
+ * name/repo/workspace path into a public framework issue with nothing
+ * underneath to stop it.
  */
 export const DEFAULT_GATES: GateDefinition[] = [
   {
@@ -169,6 +198,12 @@ export const DEFAULT_GATES: GateDefinition[] = [
     buildToolInput: bashCommandInput,
   },
   {
+    name: "block-private-refs-in-public-repos",
+    hookRelativePath: ".claude/hooks/block-private-refs-in-public-repos.sh",
+    toolNames: ["bash"],
+    buildToolInput: bashCommandInput,
+  },
+  {
     name: "require-active-ticket",
     hookRelativePath: ".claude/hooks/require-active-ticket.sh",
     // This hook also fires on Bash when the command writes a file via
@@ -194,38 +229,94 @@ export interface DispatcherOptions {
 }
 
 /**
+ * Ceiling for the hook subprocess's stdout+stderr buffers. Normal gate
+ * hook output (a block reason, a jq error) is a few KB at most; 10 MB is
+ * generous headroom so no legitimate hook run ever trips this, while
+ * still bounding memory if something goes very wrong.
+ */
+const MAX_HOOK_OUTPUT_BYTES = 10 * 1024 * 1024;
+
+/**
  * Runs a single gate hook with the reconstructed Claude-Code-shaped stdin
  * payload, mapping its exit code to a pi ToolCallEventResult per the
  * proven-in-spike contract: exit 2 = block, everything else = allow.
+ *
+ * FAIL CLOSED, NOT OPEN (security — Rex finding on #817).
+ * ---------------------------------------------------------
+ * `execFileSync` throwing does not always mean "the hook exited nonzero".
+ * It can also mean the hook never produced a numeric exit status at all —
+ * `ENOBUFS` when a hook emits more than `maxBuffer`, a spawn failure
+ * (missing `bash`, permission denied), a signal kill, or any other
+ * execution-layer error. The earlier version of this function treated
+ * every one of those cases the same as "exit 0" (allow), which is a
+ * fail-OPEN on a security gate: a hook that couldn't even run its check
+ * silently permitted the tool call it was supposed to be gating.
+ *
+ * The corrected semantics:
+ *   - exit code 2                  → BLOCK (the hook's own verdict)
+ *   - exit code 0 (or any other
+ *     *numeric* non-2 exit code)   → ALLOW (matches Claude Code's own
+ *                                     PreToolUse semantics: only exit 2
+ *                                     is a hard stop)
+ *   - NO numeric exit status at
+ *     all (spawn failure, ENOBUFS,
+ *     signal kill, etc.)           → BLOCK, fail closed, with a reason
+ *                                     naming the hook and the underlying
+ *                                     error, so the operator can see
+ *                                     WHY a gate refused to evaluate
+ *                                     rather than silently letting the
+ *                                     tool call through.
  */
-function runGateHook(opsRoot: string, gate: GateDefinition, toolInput: Record<string, unknown>, claudeToolName: string): ToolCallEventResult | undefined {
+export function runGateHook(
+  opsRoot: string,
+  gate: GateDefinition,
+  toolInput: Record<string, unknown>,
+  claudeToolName: string,
+  maxBufferBytes: number = MAX_HOOK_OUTPUT_BYTES,
+): ToolCallEventResult | undefined {
   const hookPath = path.join(opsRoot, gate.hookRelativePath);
   if (!existsSync(hookPath)) return undefined; // gate not present in this fork — no-op, not a failure
 
   const stdinPayload = JSON.stringify({ tool_name: claudeToolName, tool_input: toolInput });
 
-  let stderr = "";
-  let exitCode = 0;
   try {
     execFileSync("bash", [hookPath], {
       input: stdinPayload,
       cwd: opsRoot,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      maxBuffer: maxBufferBytes,
     });
+    // No throw => exit code 0 => allow.
+    return undefined;
   } catch (err) {
-    const execErr = err as { status?: number; stderr?: Buffer | string; message?: string };
-    exitCode = typeof execErr.status === "number" ? execErr.status : 1;
-    stderr = execErr.stderr ? execErr.stderr.toString() : String(execErr.message ?? err);
-  }
+    const execErr = err as { status?: number | null; stderr?: Buffer | string; message?: string };
+    const stderr = execErr.stderr ? execErr.stderr.toString() : String(execErr.message ?? err);
 
-  if (exitCode === 2) {
+    if (execErr.status === 2) {
+      return {
+        block: true,
+        reason: stderr.trim() || `Blocked by apexyard governance gate (${gate.name})`,
+      };
+    }
+    if (typeof execErr.status === "number") {
+      // A numeric, non-2 exit code (e.g. 1 from an unrelated bash-level
+      // error inside the hook script itself). Claude Code's own
+      // PreToolUse contract only treats exit 2 as blocking; mirror that
+      // here rather than fail closed on every nonzero exit, which would
+      // make an unrelated warning inside a hook block unrelated tool
+      // calls.
+      return undefined;
+    }
+    // No numeric exit status at all — execution-layer failure (spawn
+    // error, ENOBUFS from output exceeding maxBuffer, killed by signal,
+    // etc.). Fail CLOSED: a gate that could not run its check must deny,
+    // not permit.
     return {
       block: true,
-      reason: stderr.trim() || `Blocked by apexyard governance gate (${gate.name})`,
+      reason: `apexyard governance gate "${gate.name}" could not be evaluated (${hookPath}) — failing closed. Underlying error: ${stderr.trim() || "unknown execution failure"}`,
     };
   }
-  return undefined;
 }
 
 /**

--- a/harness-adapters/pi/src/resolve-ops-root.ts
+++ b/harness-adapters/pi/src/resolve-ops-root.ts
@@ -1,0 +1,114 @@
+/**
+ * resolve-ops-root — pi-flavored port of `.claude/hooks/_lib-ops-root.sh`.
+ *
+ * WHY THIS EXISTS
+ * ----------------
+ * The bash gate hooks (block-unreviewed-merge.sh and siblings) resolve an
+ * "ops root" — the directory holding `.claude/session/reviews/*.approved`
+ * markers — via `_lib-ops-root.sh`. That resolution has Claude-Code-specific
+ * assumptions baked in:
+ *
+ *   1. A SessionStart hook (`pin-ops-root.sh`) writes a pin file at
+ *      `${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-<SESSION_ID>`,
+ *      keyed by `CLAUDE_CODE_SESSION_ID`. pi has no equivalent session-id
+ *      env var and no SessionStart hook to write the pin in the first
+ *      place, so the pin branch of `_lib-ops-root.sh` is dead code under pi
+ *      — it silently falls through to the walk-up, which is fine, but it's
+ *      worth being explicit that pi gets NONE of the pin-first safety net
+ *      that closed apexyard#381 (the /tmp-clone-resolves-wrong-tree bug).
+ *   2. The walk-up anchor conditions themselves (`.apexyard-fork` marker,
+ *      or the legacy `onboarding.yaml` + `apexyard.projects.yaml` pair) are
+ *      harness-agnostic — they're just files on disk — so THAT part of the
+ *      contract ports cleanly.
+ *
+ * This module reproduces the anchor-walk (condition 2) faithfully in
+ * TypeScript, and layers a pi-specific override on top instead of the
+ * Claude-Code-specific session pin (condition 1): an explicit
+ * `APEXYARD_OPS_ROOT` environment variable, or an explicit `opsRoot` field
+ * a pi user can set once in their own extension config. This is a
+ * DELIBERATE divergence, not an oversight — see
+ * docs/agdr/AgDR-0082-pi-gate-dispatcher-adapter.md for the decision and
+ * its consequences.
+ *
+ * WHAT THIS DOES NOT DO
+ * ----------------------
+ * It does not touch `_lib-ops-root.sh` — that file remains the single
+ * source of truth for Claude Code sessions. This module is a parallel,
+ * pi-only resolution path that the dispatcher extension consults before
+ * shelling out to a gate hook, so the hook's own bash-side resolution
+ * (which re-derives the same answer from $PWD when invoked directly) stays
+ * consistent with what the dispatcher already decided.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, resolve as resolvePath } from "node:path";
+
+export interface ResolveOpsRootOptions {
+  /** Directory to start the walk-up from. Defaults to process.cwd(). */
+  startCwd?: string;
+  /** Explicit override — highest priority, skips the walk when set and valid. */
+  explicitOpsRoot?: string;
+  /** Environment lookup, injectable for tests. Defaults to `process.env`. */
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * Returns true if `dir` satisfies one of the two ops-root anchor
+ * conditions apexyard recognises (mirrors `_ops_root_anchor_valid` in
+ * `_lib-ops-root.sh`):
+ *   - v2: a `.apexyard-fork` marker file is present, OR
+ *   - v1 (legacy): both `onboarding.yaml` AND `apexyard.projects.yaml` are present.
+ */
+export function isOpsRootAnchor(dir: string): boolean {
+  if (existsSync(`${dir}/.apexyard-fork`)) return true;
+  if (existsSync(`${dir}/onboarding.yaml`) && existsSync(`${dir}/apexyard.projects.yaml`)) return true;
+  return false;
+}
+
+/**
+ * Pure walk-up from `startDir` toward `/`, looking for the first directory
+ * that satisfies an ops-root anchor condition. Mirrors
+ * `resolve_ops_root_walk` in `_lib-ops-root.sh` line for line.
+ *
+ * Returns the resolved path, or `undefined` if no ancestor directory
+ * satisfies an anchor (the hook's bash equivalent falls back to the
+ * caller's own default in that case — same contract here).
+ */
+export function walkUpOpsRoot(startDir: string): string | undefined {
+  let dir = resolvePath(startDir);
+  // Cap the walk at a sane depth so a pathological filesystem (symlink
+  // loop, extremely deep nesting) can't spin forever — the bash version
+  // is bounded by reaching "/", which this loop also respects via the
+  // dirname(dir) === dir fixed-point check below.
+  for (let i = 0; i < 128; i++) {
+    if (isOpsRootAnchor(dir)) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return undefined;
+}
+
+/**
+ * pi-flavored ops-root resolver. Priority order:
+ *
+ *   1. `options.explicitOpsRoot` (or `APEXYARD_OPS_ROOT` env var) — the
+ *      pi-specific override this module introduces in place of the
+ *      Claude-Code session pin. Validated against the anchor conditions
+ *      before being trusted; an invalid override falls through rather
+ *      than silently pointing the merge gate at the wrong directory.
+ *   2. Walk-up from `options.startCwd` (or `process.cwd()`), identical
+ *      logic to `_lib-ops-root.sh`'s `resolve_ops_root_walk`.
+ *   3. `undefined` if neither resolves — callers should treat this the
+ *      same way the bash hooks do: fall back to the tool-call's own cwd
+ *      and accept that markers may not be found (fail toward re-review,
+ *      never toward silently allowing).
+ */
+export function resolveOpsRootForPi(options: ResolveOpsRootOptions = {}): string | undefined {
+  const env = options.env ?? process.env;
+  const explicit = options.explicitOpsRoot ?? env.APEXYARD_OPS_ROOT;
+  if (explicit && isOpsRootAnchor(resolvePath(explicit))) {
+    return resolvePath(explicit);
+  }
+  return walkUpOpsRoot(options.startCwd ?? process.cwd());
+}

--- a/harness-adapters/pi/test/gate-dispatcher.test.ts
+++ b/harness-adapters/pi/test/gate-dispatcher.test.ts
@@ -1,0 +1,203 @@
+/**
+ * gate-dispatcher.test.ts — synthetic tool_call harness for the dispatcher.
+ *
+ * WHAT THIS PROVES (and doesn't)
+ * -------------------------------
+ * Same shape as spike #804's test-harness.ts: mocks pi's `ExtensionAPI.on()`
+ * registration call per the DOCUMENTED contract (see
+ * docs/spike-reports/pi-gate-extension.md "Pi API facts"), then drives the
+ * real dispatcher against the REAL, unmodified bash hooks in this repo,
+ * with real `gh` lookups against real GitHub state for the merge-gate
+ * cases. This is "proven by construction" for the pi-transport boundary
+ * (mock matches the documented event shape) and "proven live" for
+ * everything downstream of that boundary (the actual hook, the actual gh
+ * calls, the actual exit-code mapping).
+ *
+ * It does NOT prove pi's real internal event dispatch calls handlers with
+ * this exact object shape during a live, model-driven agent turn — that
+ * is AC-6 from #815 and remains the one gap this build could not close in
+ * this environment (no pi package / model credentials available here).
+ * See harness-adapters/pi/README.md "Known gaps / what's unverified".
+ *
+ * RUN
+ * ---
+ *   node --test harness-adapters/pi/test/gate-dispatcher.test.ts
+ *
+ * (Node >=22, no build step — native TS type-stripping, matching how pi
+ * itself loads extensions with no compile step.)
+ */
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, cpSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { registerGateDispatcher, DEFAULT_GATES, type GateDefinition } from "../src/gate-dispatcher.ts";
+
+// ---------------------------------------------------------------------
+// Minimal structural mock of pi's ExtensionAPI. Typed loosely (no import
+// of the real pi types here) because this test suite must run WITHOUT
+// the @earendil-works/pi-coding-agent package installed — the whole
+// point of a CI-runnable proof harness is that it doesn't require model
+// credentials or a live pi install. gate-dispatcher.ts itself imports the
+// real types (type-only; erased at runtime by Node's type stripping), so
+// production code still tracks pi's real contract even though this test
+// double does not import it.
+// ---------------------------------------------------------------------
+type Handler = (event: any, ctx: any) => Promise<any>;
+
+function makeMockPi(): { pi: { on: (event: string, handler: Handler) => void }; handlers: Map<string, Handler> } {
+  const handlers = new Map<string, Handler>();
+  return {
+    pi: {
+      on(event: string, handler: Handler) {
+        handlers.set(event, handler);
+      },
+    },
+    handlers,
+  };
+}
+
+/**
+ * Builds an isolated fake "ops root" — a temp dir containing a real,
+ * unmodified copy of .claude/hooks/ plus a .apexyard-fork marker — so
+ * these tests don't require a real GitHub PR to exist and don't touch the
+ * repo's own session markers. Only used for the non-merge / non-bash /
+ * hook-missing cases; the two live-gh cases below intentionally run
+ * against the REAL repo root (passed via APEXYARD_TEST_REPO_ROOT) because
+ * they need the real block-unreviewed-merge.sh + real `gh` state.
+ */
+function makeIsolatedOpsRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "apexyard-pi-gate-test-"));
+  writeFileSync(join(dir, ".apexyard-fork"), "test fixture\n");
+  mkdirSync(join(dir, ".claude", "hooks"), { recursive: true });
+  // A trivial "always allow" hook standing in for a gate we don't want to
+  // exercise for real in this isolated case.
+  writeFileSync(join(dir, ".claude", "hooks", "noop-allow.sh"), "#!/bin/bash\nexit 0\n", { mode: 0o755 });
+  writeFileSync(join(dir, ".claude", "hooks", "always-block.sh"), "#!/bin/bash\necho 'blocked for test' >&2\nexit 2\n", { mode: 0o755 });
+  return dir;
+}
+
+test("non-merge bash command passes through untouched", async () => {
+  const opsRoot = makeIsolatedOpsRoot();
+  const { pi, handlers } = makeMockPi();
+  registerGateDispatcher(pi as any, { resolveOpsRoot: () => opsRoot });
+  const toolCall = handlers.get("tool_call")!;
+
+  const result = await toolCall({ type: "tool_call", toolCallId: "1", toolName: "bash", input: { command: "echo hello" } }, { cwd: opsRoot });
+  assert.equal(result, undefined);
+});
+
+test("non-bash, non-edit tool is ignored entirely", async () => {
+  const opsRoot = makeIsolatedOpsRoot();
+  const { pi, handlers } = makeMockPi();
+  registerGateDispatcher(pi as any, { resolveOpsRoot: () => opsRoot });
+  const toolCall = handlers.get("tool_call")!;
+
+  const result = await toolCall({ type: "tool_call", toolCallId: "2", toolName: "read", input: { path: "README.md" } }, { cwd: opsRoot });
+  assert.equal(result, undefined);
+});
+
+test("a gate whose hook file doesn't exist in this ops root is a silent no-op", async () => {
+  const opsRoot = makeIsolatedOpsRoot();
+  const { pi, handlers } = makeMockPi();
+  registerGateDispatcher(pi as any, { resolveOpsRoot: () => opsRoot }); // DEFAULT_GATES reference real hook paths that don't exist in this fixture dir
+  const toolCall = handlers.get("tool_call")!;
+
+  const result = await toolCall({ type: "tool_call", toolCallId: "3", toolName: "bash", input: { command: "gh pr merge 1 --squash" } }, { cwd: opsRoot });
+  assert.equal(result, undefined, "missing hook files must not crash or falsely block");
+});
+
+test("a custom gate hook that exits 2 is surfaced as a block with the stderr reason", async () => {
+  const opsRoot = makeIsolatedOpsRoot();
+  const customGates: GateDefinition[] = [
+    {
+      name: "always-block",
+      hookRelativePath: ".claude/hooks/always-block.sh",
+      toolNames: ["bash"],
+      buildToolInput: (event) => ({ command: (event.input as any).command }),
+    },
+  ];
+  const { pi, handlers } = makeMockPi();
+  registerGateDispatcher(pi as any, { gates: customGates, resolveOpsRoot: () => opsRoot });
+  const toolCall = handlers.get("tool_call")!;
+
+  const result = await toolCall({ type: "tool_call", toolCallId: "4", toolName: "bash", input: { command: "anything" } }, { cwd: opsRoot });
+  assert.equal(result?.block, true);
+  assert.match(result?.reason ?? "", /blocked for test/);
+});
+
+test("a custom gate hook that exits 0 allows the call", async () => {
+  const opsRoot = makeIsolatedOpsRoot();
+  const customGates: GateDefinition[] = [
+    {
+      name: "noop-allow",
+      hookRelativePath: ".claude/hooks/noop-allow.sh",
+      toolNames: ["bash"],
+      buildToolInput: (event) => ({ command: (event.input as any).command }),
+    },
+  ];
+  const { pi, handlers } = makeMockPi();
+  registerGateDispatcher(pi as any, { gates: customGates, resolveOpsRoot: () => opsRoot });
+  const toolCall = handlers.get("tool_call")!;
+
+  const result = await toolCall({ type: "tool_call", toolCallId: "5", toolName: "bash", input: { command: "anything" } }, { cwd: opsRoot });
+  assert.equal(result, undefined);
+});
+
+test("no ops root resolved => dispatcher is a silent no-op (fails toward not-enforcing, never toward false-blocking)", async () => {
+  const { pi, handlers } = makeMockPi();
+  registerGateDispatcher(pi as any, { resolveOpsRoot: () => undefined });
+  const toolCall = handlers.get("tool_call")!;
+
+  const result = await toolCall({ type: "tool_call", toolCallId: "6", toolName: "bash", input: { command: "gh pr merge 1 --squash" } }, { cwd: "/nonexistent" });
+  assert.equal(result, undefined);
+});
+
+// ---------------------------------------------------------------------
+// LIVE cases against the real repo's real block-unreviewed-merge.sh and
+// real `gh` state — same two cases the spike #804 harness proved. These
+// only run when APEXYARD_TEST_REPO_ROOT points at a real apexyard ops
+// root (the checkout these tests live in), keeping the default `node
+// --test` run fully offline/hermetic via the fixtures above.
+// ---------------------------------------------------------------------
+
+const realRepoRoot = process.env.APEXYARD_TEST_REPO_ROOT;
+
+test("LIVE: ungated merge of a nonexistent PR is BLOCKED by the real hook", { skip: !realRepoRoot }, async () => {
+  const { pi, handlers } = makeMockPi();
+  registerGateDispatcher(pi as any, { resolveOpsRoot: () => realRepoRoot });
+  const toolCall = handlers.get("tool_call")!;
+
+  const result = await toolCall(
+    { type: "tool_call", toolCallId: "7", toolName: "bash", input: { command: "gh pr merge 999999 --repo me2resh/apexyard --squash" } },
+    { cwd: realRepoRoot },
+  );
+  assert.equal(result?.block, true);
+});
+
+const allowTestPr = process.env.ALLOW_TEST_PR;
+
+test(
+  "LIVE: a previously-approved PR is ALLOWED by the real hook (real markers, real HEAD match)",
+  { skip: !realRepoRoot || !allowTestPr },
+  async () => {
+    const { pi, handlers } = makeMockPi();
+    registerGateDispatcher(pi as any, { resolveOpsRoot: () => realRepoRoot });
+    const toolCall = handlers.get("tool_call")!;
+
+    const result = await toolCall(
+      { type: "tool_call", toolCallId: "8", toolName: "bash", input: { command: `gh pr merge ${allowTestPr} --repo me2resh/apexyard --squash` } },
+      { cwd: realRepoRoot },
+    );
+    assert.equal(result, undefined);
+  },
+);
+
+// Reference DEFAULT_GATES so the import isn't flagged unused if the LIVE
+// cases above are both skipped in a given run.
+void DEFAULT_GATES;
+void execFileSync;
+void cpSync;

--- a/harness-adapters/pi/test/gate-dispatcher.test.ts
+++ b/harness-adapters/pi/test/gate-dispatcher.test.ts
@@ -34,7 +34,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { registerGateDispatcher, DEFAULT_GATES, type GateDefinition } from "../src/gate-dispatcher.ts";
+import { registerGateDispatcher, runGateHook, DEFAULT_GATES, type GateDefinition } from "../src/gate-dispatcher.ts";
 
 // ---------------------------------------------------------------------
 // Minimal structural mock of pi's ExtensionAPI. Typed loosely (no import
@@ -145,6 +145,51 @@ test("a custom gate hook that exits 0 allows the call", async () => {
 
   const result = await toolCall({ type: "tool_call", toolCallId: "5", toolName: "bash", input: { command: "anything" } }, { cwd: opsRoot });
   assert.equal(result, undefined);
+});
+
+test("FAILS CLOSED: a hook whose output exceeds maxBuffer (execution-layer error, no numeric exit status) is BLOCKED, not silently allowed", () => {
+  const opsRoot = makeIsolatedOpsRoot();
+  // A hook that emits well more output than a deliberately tiny maxBuffer,
+  // simulating the ENOBUFS class of failure Rex flagged: execFileSync
+  // throws with no `status` field at all (not exit code 0, not exit code
+  // 2 — an execution-layer failure). Fixed semantics must BLOCK this,
+  // not treat the "no status" case as an implicit allow.
+  writeFileSync(join(opsRoot, ".claude", "hooks", "noisy.sh"), "#!/bin/bash\nyes | head -c 100000\nexit 0\n", { mode: 0o755 });
+  const gate: GateDefinition = {
+    name: "noisy",
+    hookRelativePath: ".claude/hooks/noisy.sh",
+    toolNames: ["bash"],
+    buildToolInput: (event) => ({ command: (event.input as any).command }),
+  };
+
+  const result = runGateHook(opsRoot, gate, { command: "anything" }, "Bash", /* maxBufferBytes */ 1024);
+  assert.equal(result?.block, true, "an execution-layer failure (ENOBUFS) must fail CLOSED, not open");
+  assert.match(result?.reason ?? "", /could not be evaluated/);
+  assert.match(result?.reason ?? "", /noisy/);
+});
+
+test("a hook exiting 1 (an unrelated, non-blocking bash-level error) is allowed, not blocked — only exit 2 blocks", async () => {
+  const opsRoot = makeIsolatedOpsRoot();
+  writeFileSync(join(opsRoot, ".claude", "hooks", "exit-one.sh"), "#!/bin/bash\nexit 1\n", { mode: 0o755 });
+  const customGates: GateDefinition[] = [
+    {
+      name: "exit-one",
+      hookRelativePath: ".claude/hooks/exit-one.sh",
+      toolNames: ["bash"],
+      buildToolInput: (event) => ({ command: (event.input as any).command }),
+    },
+  ];
+  const { pi, handlers } = makeMockPi();
+  registerGateDispatcher(pi as any, { gates: customGates, resolveOpsRoot: () => opsRoot });
+  const toolCall = handlers.get("tool_call")!;
+
+  const result = await toolCall({ type: "tool_call", toolCallId: "9", toolName: "bash", input: { command: "anything" } }, { cwd: opsRoot });
+  assert.equal(result, undefined, "exit code 1 is not exit code 2 — must not block, matching Claude Code's own PreToolUse semantics");
+});
+
+test("DEFAULT_GATES includes the leak-protection gate (block-private-refs-in-public-repos)", () => {
+  const names = DEFAULT_GATES.map((g) => g.name);
+  assert.ok(names.includes("block-private-refs-in-public-repos"), "leak protection must be bridged by default — it's security-relevant");
 });
 
 test("no ops root resolved => dispatcher is a silent no-op (fails toward not-enforcing, never toward false-blocking)", async () => {

--- a/harness-adapters/pi/tsconfig.json
+++ b/harness-adapters/pi/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- **Promotes spike #804 (VIABLE) into a shipped dispatcher extension.** `harness-adapters/pi/src/gate-dispatcher.ts` registers on pi's `tool_call` event and enforces apexyard's merge gate, red-CI block, design/architecture review, secrets scanning, and ticket-first gates by shelling out to the **same, unmodified** `.claude/hooks/*.sh` scripts — zero logic duplication, bash stays the single source of truth. Adding a gate is now a table row (`DEFAULT_GATES`), not a new file.
- **Pi-flavored ops-root resolution.** `harness-adapters/pi/src/resolve-ops-root.ts` reproduces `_lib-ops-root.sh`'s anchor-walk (`.apexyard-fork` marker / legacy `onboarding.yaml`+`apexyard.projects.yaml` pair) in TypeScript, substituting an explicit `APEXYARD_OPS_ROOT` override for Claude Code's session-pin mechanism, which pi has no equivalent for. This is a deliberate, documented divergence — see AgDR-0082 and the README's "Known gaps" for the exact safety property pi doesn't get.
- **Real pi types, not the spike's hand-rolled shim.** The adapter imports `ExtensionAPI`, `ToolCallEvent`, `ToolCallEventResult` directly from `@earendil-works/pi-coding-agent` (declared dependency, installs cleanly). Checking the real, installed `.d.ts` (not just docs) surfaced two corrections to the spike's assumptions: the block-result type is `ToolCallEventResult`, not the spike's invented `ToolCallResult`, and pi's edit/write tools key their target path as `path` (not `file_path`) with no `multi_edit` tool at all — `require-active-ticket.sh` already falls back to `.tool_input.path`, so no hook changes were needed.
- **Test suite proves the transport live**, not just by construction: 8/8 tests pass, including two LIVE cases run against this repo's real, unmodified `block-unreviewed-merge.sh` and real GitHub state (a real block against a nonexistent PR, a real allow against PR #767's real pre-existing Rex+CEO markers). The one gap this build could not close — a live, model-driven pi agent turn actually invoking the extension's handler — is documented explicitly as unverified in the README rather than claimed as proven; it needs pi model credentials this environment doesn't have.
- **Docs + AgDR.** `docs/agdr/AgDR-0082-pi-gate-dispatcher-adapter.md` records the dispatcher-vs-N-extensions and ops-root-resolution decisions; `docs/harnesses/pi.md` and `AGENTS.md` are updated to move "mechanical gate enforcement" from the "not yet" column to "available (opt-in install)".

## Testing

```bash
cd harness-adapters/pi
npm install
npx tsc --noEmit                                  # typechecks clean against the real pi package
node --test test/gate-dispatcher.test.ts          # 6/6 hermetic tests, no gh/network required

# + 2 LIVE tests against this repo's real hook and real gh state:
cd ../..
APEXYARD_TEST_REPO_ROOT="$(pwd)" ALLOW_TEST_PR=767 node --test harness-adapters/pi/test/gate-dispatcher.test.ts
# => 8/8 pass, including "LIVE: ungated merge ... BLOCKED" and "LIVE: previously-approved PR ... ALLOWED"
```

AC-6 status (from #815): the live-hook / real-gh-state path (5 of 6 named test cases) **was actually run and passed**, as shown above. The remaining sub-case — a real, model-driven pi agent turn triggering the extension inside a live pi session — was **not run**; no pi model credentials were available in this environment. This matches exactly what the spike itself could not close, for the same reason. Documented as an open item in `harness-adapters/pi/README.md` § "Known gaps / what's unverified", with the exact verification steps to run once credentials exist.

Refs #815

## Glossary

| Term | Definition |
|------|------------|
| pi | pi.dev — Earendil's minimal, unopinionated agent CLI with a TypeScript extension system |
| adapter-over-bash | A thin per-harness extension that invokes apexyard's existing bash gate hooks rather than reimplementing the gate logic natively |
| `tool_call` event | pi's pre-execution lifecycle event; extensions registered via `pi.on("tool_call", handler)` can block or allow a tool invocation before it runs |
| dispatcher | A single extension that checks a tool call against a table of gate definitions, rather than one extension per gate |
| ops root | The apexyard fork's root directory, where `.claude/session/reviews/*.approved` markers and `.claude/hooks/*.sh` live |
| proven live | Observed directly against the real running system (real bash hook, real `gh` calls) |
| proven by construction | Demonstrated via a mock built to match the documented/typed contract, not observed inside a live pi agent turn |