### PR TITLE
chore(#819): least-privilege workflow permissions + SHA-pin actions

### DIFF
--- a/.github/workflows/auto-tag-on-release-pr-merge.yml
+++ b/.github/workflows/auto-tag-on-release-pr-merge.yml
@@ -17,7 +17,11 @@ name: auto-tag-on-release-pr-merge
 #   - Manual dispatch (operator can re-run if something fails post-merge)
 #
 # Permissions:
-#   - contents: write (create tag + GitHub Release)
+#   - contents: write (create tag + GitHub Release) — granted at job level
+#     only (#819 / Scorecard Token-Permissions #58): the top-level block
+#     stays read-only because Scorecard's topLevelPermissions probe flags
+#     any write scope declared at workflow level, even when only one job
+#     exists and even when a job also scopes down.
 #
 # No new secrets required — uses the default GITHUB_TOKEN.
 
@@ -35,12 +39,14 @@ on:
         required: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   auto-tag:
     name: tag release + create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create tag (git push --tags) + gh release create
     # Only run on merged release PRs (not just any closed PR, and not on forks)
     if: |
       (

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,8 +21,11 @@ on:
   schedule:
     - cron: '27 3 * * 1'   # weekly, Monday 03:27 UTC
 
+# Least-privilege (#819 / Scorecard Token-Permissions #59): keep the
+# top-level block read-only. security-events:write is only granted at job
+# level below — Scorecard's topLevelPermissions probe flags any write scope
+# declared at workflow level, regardless of job-level scoping.
 permissions:
-  security-events: write
   actions: read
   contents: read
 

--- a/.github/workflows/extract-subpacks-on-release.yml
+++ b/.github/workflows/extract-subpacks-on-release.yml
@@ -50,8 +50,13 @@ on:
       - 'templates/audits/**'
   workflow_dispatch:
 
+# Least-privilege (#819 / Scorecard Token-Permissions #60): this job only
+# checks out the repo, runs a local script, and uploads a build artefact —
+# none of that needs contents:write (upload-artifact authenticates via its
+# own internal API, not the contents scope). `contents: write` was over-
+# granted; the job never pushes a commit, tag, or PR.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   extract-subpacks:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -11,13 +11,19 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  pull-requests: write
+# Least-privilege sweep (#819): top-level stays empty — this workflow never
+# checks out code, so it needs no `contents` scope either. pull-requests:write
+# (label + comment on failure) is granted at job level only, since a
+# top-level write scope is flagged by Scorecard's Token-Permissions check
+# regardless of job-level scoping.
+permissions: {}
 
 jobs:
   check-title:
     name: Verify Ticket ID
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write   # add ticket label + post comment on failure
 
     steps:
       - name: Check PR title for ticket ID

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,9 +12,13 @@ on:
   push:
     branches: [main]
 
+# Least-privilege (#819 / Scorecard Token-Permissions #61): the top-level
+# block must stay read-only — Scorecard's topLevelPermissions probe flags
+# ANY write scope declared at workflow level, even when a job scopes back
+# down. Elevated scopes belong at job level only (below). id-token isn't
+# granted here or at job level because publish_results is false (#679) —
+# the OSSF-API publish step that needed it is disabled, so the scope is dead.
 permissions:
-  security-events: write
-  id-token: write
   contents: read
 
 jobs:
@@ -23,7 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write   # upload results to code-scanning
-      id-token: write          # publish results to the OSSF API (badge)
       contents: read
 
     steps:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -87,14 +87,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install Semgrep OSS
-        run: pip install semgrep
-
+      # Run Semgrep via its official pinned Docker image rather than
+      # `pip install semgrep` (#819 / Scorecard Pinned-Dependencies #32:
+      # a bare `pip install <pkg>` is always reported unpinned by Scorecard —
+      # its check only accepts `--require-hashes`, which for a package with
+      # semgrep's transitive dependency tree means maintaining a hash-locked
+      # requirements file. Pinning the Docker image by digest gets the same
+      # supply-chain guarantee — reproducible, verifiable artefact — with a
+      # one-line bump on upgrade, matching how every `uses:` action in this
+      # repo is already SHA-pinned.
       - name: Run Semgrep — bash security rules
         id: semgrep
         run: |
           set +e
-          semgrep scan \
+          docker run --rm -v "$PWD:/src" -w /src \
+            semgrep/semgrep@sha256:59fbed6127ea7c5dde3ba6a85142733bb20ea9aaa36120c953904f1539aaf66e `# 1.168.0` \
+            semgrep scan \
             --config=r/bash \
             --metrics=off \
             --no-autofix \

--- a/docs/agdr/AgDR-0084-workflow-least-privilege-and-pip-pin.md
+++ b/docs/agdr/AgDR-0084-workflow-least-privilege-and-pip-pin.md
@@ -1,0 +1,56 @@
+# AgDR-0084 — Job-scoped write permissions + Docker-digest pin over pip hash-locking
+
+> In the context of OpenSSF Scorecard flagging 5 High/Medium alerts on the framework's own CI (4 Token-Permissions, 1 Pinned-Dependencies), facing a choice between two independent hardening questions — where write scopes should live in a workflow, and how to pin a `pip install` that Scorecard's pinning check can only ever see as unpinned — I decided to (1) **move every top-level write scope down to job level, leaving all workflow-level `permissions:` blocks read-only**, and (2) **replace `pip install semgrep` with Semgrep's official Docker image pinned by digest** rather than hash-lock the pip install, to achieve a clean Scorecard pass without changing what any pipeline does, accepting that the Semgrep step's supply-chain guarantee now rests on a digest bump discipline instead of pip's native hash-checking mode.
+
+## Context
+
+`me2resh/apexyard#819` tracked 5 Scorecard alerts:
+
+- Token-Permissions (High) #58 `auto-tag-on-release-pr-merge.yml`, #59 `codeql.yml`, #60 `extract-subpacks-on-release.yml`, #61 `scorecard.yml`
+- Pinned-Dependencies (Medium) #32 `security-scan.yml`
+
+All five workflows already declared a `permissions:` block — the framework had already been through one hardening pass (#636, dc588e1). That ruled out the obvious diagnosis ("no permissions declared") and required reading Scorecard's actual probe source (`probes/topLevelPermissions/impl.go`, `checks/raw/shell_download_validate.go`) plus the live GitHub code-scanning alerts (`gh api repos/me2resh/apexyard/code-scanning/alerts`) to find the real trigger:
+
+1. **`topLevelPermissions` flags ANY write scope declared at workflow level** — regardless of whether a job also declares its own (more restrictive or identical) permissions block. Four workflows granted a write scope (`security-events`, `contents`, or both) at the top level; three of the four already had matching job-level blocks, which didn't matter to this probe.
+2. **`isUnpinnedPipInstall` only accepts one thing as "pinned": the literal `--require-hashes` flag.** Adding `--hash=sha256:...` to a normal `pip install pkg==ver` command does NOT satisfy it — the function's control flow treats any non-flag, non-wheel, non-`--require-hashes` argument as "additional args" and returns "unpinned" unconditionally. There is no version-pin-only path that passes.
+
+Verified with `gh api` against the live alert list before writing any fix — see the alert JSON quoted in the PR description for the exact file:line:message triples.
+
+## Options Considered
+
+### Axis 1 — Where do write permissions live
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Keep top-level `permissions: <write-scope>`, rely on job-level re-declaration to "already be minimal" | No edit needed | This is the exact shape Scorecard flags; job-level scoping doesn't offset a top-level grant in this probe's logic |
+| **Top-level `permissions: contents: read` (or `{}` when no checkout happens) on every workflow; any write scope moves to the one job that needs it** | Matches the probe's actual pass condition; matches the convention already used by `tests.yml`/`markdown-lint.yml`/`shellcheck.yml` in this repo; self-documenting (the write grant sits next to the job that uses it) | One more block to add per job that previously relied on a workflow-level grant (`auto-tag`, `pr-title-check`) |
+| Set top-level to `permissions: write-all` equivalent and scope down everywhere | — | Strictly worse on every axis; not seriously considered |
+
+Chosen: **top-level read-only, job-level write-where-needed**, applied to `scorecard.yml`, `codeql.yml`, `auto-tag-on-release-pr-merge.yml`, `extract-subpacks-on-release.yml`, and (defence-in-depth sweep) `pr-title-check.yml`. `extract-subpacks-on-release.yml` additionally lost `contents: write` entirely — re-reading the job (checkout → run script → run smoke test → content guard → upload-artifact → summary) found no push, tag, or PR-creation step; the write grant was simply excess, not misplaced. `scorecard.yml` also dropped `id-token: write` at both levels — dead since `publish_results: false` (#679) removed the only step that used Sigstore/OIDC.
+
+### Axis 2 — How to pin the Semgrep install
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Add `--hash=sha256:...` per package to the `pip install` line | Smallest textual diff | Confirmed by reading Scorecard's source: does NOT satisfy the check. Ships a diff that looks like a fix and isn't. |
+| `pip install --require-hashes -r <hash-locked requirements file>` | The literal condition Scorecard checks for; textbook-correct pip hardening | Requires generating and maintaining hashes for semgrep's full transitive dependency tree (many packages), refreshed on every version bump — meaningfully more ongoing maintenance than any other pin in this repo, for a tool that isn't itself part of the shipped product |
+| Switch to `pipx install semgrep==<ver>` | Escapes Scorecard's pip-specific regex (`isPipInstall` checks literal `pip`/`pip3` argv[0]) with a one-line change | Passes the *heuristic*, not the underlying concern — pipx still resolves the same unpinned transitive tree under the hood; this is gaming the metric rather than closing the gap it's a proxy for |
+| **Run Semgrep via its official Docker image (`semgrep/semgrep`), pinned by digest** | Real reproducibility guarantee (a digest is content-addressed, same guarantee as SHA-pinning an action) with a one-line bump on upgrade, matching every `uses:` action already pinned in this repo; Scorecard's pinned-dependency check does not inspect `docker run` invocations inside `run:` scripts (confirmed: the pre-existing `docker run ghcr.io/gitleaks/gitleaks:v8.18.4` in `extract-subpacks-on-release.yml`, tag-pinned not digest-pinned, isn't flagged either) | Adds a `docker run` dependency to a job that previously only needed Python; output file ownership inside the mounted volume may be root-owned on the runner (harmless — the following `python3` parsing step and `upload-artifact` both only need read access, verified empirically: pulled `semgrep/semgrep@sha256:59fbed61...` locally, ran the exact scan invocation against a test file, confirmed valid JSON output at the expected path, exit 0) |
+
+Chosen: **Docker image pinned by digest**, `semgrep/semgrep@sha256:59fbed6127ea7c5dde3ba6a85142733bb20ea9aaa36120c953904f1539aaf66e` (tag `1.168.0` at time of writing, verified against Docker Hub's tags API and `docker manifest inspect` — confirms a multi-arch manifest list including `linux/amd64`, what GitHub-hosted `ubuntu-latest` runners use). Rejected the hash-lock path because the maintenance cost (regenerating a hashes file across semgrep's full dependency closure on every bump) is disproportionate for a scan tool with no runtime footprint in the shipped product, and rejected `pipx` because it satisfies the letter of Scorecard's regex without closing the actual unpinned-supply-chain gap the check exists to catch.
+
+## Decision
+
+Chosen: **least-privilege top-level permissions + Docker-digest pin for Semgrep**, because both close the real Scorecard-flagged gap (verified against Scorecard's own probe source and the live alert JSON, not just against the alert's plain-English title) while keeping every pipeline's actual behaviour — what gets scanned, what gets uploaded, what triggers what — unchanged.
+
+## Consequences
+
+- Four Token-Permissions alerts (#58, #59, #60, #61) and one Pinned-Dependencies alert (#32) should clear on the next Scorecard run against `main` after this PR merges and releases.
+- Bumping Semgrep going forward is a one-line digest change (same discipline as bumping any SHA-pinned action in this repo), not a `pip install semgrep` version bump — slightly more friction, in exchange for a verifiable artefact.
+- The `extract-subpacks-on-release.yml` header comment still describes a future "opens a sync PR" step (deferred to v2 per AgDR-0049) that would need its own `contents: write` (or `pull-requests: write`) grant *at that job* when it's built — this AgDR's `contents: read` reflects the workflow's current, actual behaviour only.
+- No pipeline's inputs, outputs, or trigger conditions changed — this is a permissions/pinning-only PR per the driving ticket's explicit scope.
+
+## Artifacts
+
+- me2resh/apexyard#819 (driving ticket)
+- PR: (see accompanying pull request, branch `chore/819-least-priv-workflow-perms`)


### PR DESCRIPTION
## Summary

- **Top-level write permissions moved to job level, or dropped entirely, across 5 workflows** — OpenSSF Scorecard's Token-Permissions probe flags any write scope declared at *workflow* level regardless of whether a job also scopes down (confirmed by reading the probe's source, `probes/topLevelPermissions/impl.go`). `scorecard.yml`, `codeql.yml`, and `auto-tag-on-release-pr-merge.yml` had a matching job-level block already — that didn't help; the top-level grant was still the thing flagged. `extract-subpacks-on-release.yml` had `contents: write` with no job-level override at all, and — after re-reading the job's actual steps (checkout → run script → smoke test → content guard → upload-artifact → summary, no push/tag/PR anywhere) — didn't need write at any level, so it's now `contents: read` throughout.
- **Dropped the dead `id-token: write` from `scorecard.yml`** — it was only ever needed to publish results to the OSSF badge API over OIDC, and that step (`publish_results`) was already set to `false` in an earlier PR (#679) after it started failing the run. The scope had nobody using it.
- **Swept `pr-title-check.yml` too** (not in the original alert list, but same shape) — top-level `pull-requests: write` moved to job level; the workflow never checks out code, so top-level is now `permissions: {}`.
- **Replaced `pip install semgrep` with Semgrep's official Docker image pinned by digest** in `security-scan.yml`. I initially assumed a version-pin or `--hash=` flag would satisfy Scorecard's Pinned-Dependencies check, but reading its actual Go source (`checks/raw/shell_download_validate.go` → `isUnpinnedPipInstall`) showed the check only ever accepts the literal `--require-hashes` flag — nothing else counts as "pinned" for a plain `pip install <pkg>`. Hash-locking semgrep's full transitive dependency tree is real, ongoing maintenance for a tool with no runtime footprint in the shipped product, so I pinned the official `semgrep/semgrep` Docker image by digest instead — same reproducible-artefact guarantee as every SHA-pinned `uses:` action already in this repo, with a one-line bump on upgrade. Verified end-to-end locally: pulled the pinned digest, ran the exact scan invocation from the workflow against a test file, confirmed valid JSON output and exit 0.
- **AgDR-0084** records both hardening decisions (permission placement, Docker-digest vs. pip hash-lock) and the alternatives that were considered and rejected (and why "add `--hash=`" and "switch to `pipx`" don't actually close the gap Scorecard is checking for).

## Verified against real alerts, not just the plain-English alert titles

Before touching any file, I pulled the actual GitHub code-scanning alerts (`gh api repos/me2resh/apexyard/code-scanning/alerts`) to get real file:line:message triples, since a prior hardening pass (#636) had already added `permissions:` blocks to every workflow and I needed to know what was actually still being flagged rather than re-doing already-done work.

| Alert | File:line | Real cause (from the alert message + probe source) | Fix |
|---|---|---|---|
| Token-Permissions #61 | `scorecard.yml:16` | `topLevel 'security-events' permission set to 'write'` | top-level → `contents: read`; also dropped dead `id-token: write` |
| Token-Permissions #60 | `extract-subpacks-on-release.yml:54` | `topLevel 'contents' permission set to 'write'` | top-level → `contents: read` (job never writes) |
| Token-Permissions #59 | `codeql.yml:25` | `topLevel 'security-events' permission set to 'write'` | top-level → `actions: read` + `contents: read` |
| Token-Permissions #58 | `auto-tag-on-release-pr-merge.yml:38` | `topLevel 'contents' permission set to 'write'` | top-level → `contents: read`; `contents: write` added at job level (the job genuinely tags + creates a release) |
| Pinned-Dependencies #32 | `security-scan.yml:92` | `pipCommand not pinned by hash` (`isUnpinnedPipInstall` only accepts `--require-hashes`) | `pip install semgrep` → digest-pinned `semgrep/semgrep` Docker image |

## Verification

- `actionlint` clean on every changed workflow, relative to a pre-existing baseline: the same 7 shellcheck style/warning nits (SC2129, SC2034, SC2166) exist unchanged on `upstream/dev` before this PR — none are new, and none relate to permissions or pinning.
- Every `yaml.safe_load` parses cleanly.
- The new Docker-pinned Semgrep invocation was run for real: `docker manifest inspect semgrep/semgrep@sha256:59fbed61...` confirmed a multi-arch manifest list (including `linux/amd64`, what `ubuntu-latest` runners use), then a live `docker run` against a test shell script reproduced the exact command from the workflow — valid JSON output, exit 0, no `ENTRYPOINT` double-invocation issue (the official image sets no `ENTRYPOINT`, only a default `CMD`).
- No pipeline's triggers, steps, or outputs changed — this is a permissions + pinning-only PR, per the driving ticket's explicit scope.

## Testing

1. Merge to `dev`, then to `main` on the next release — Scorecard's `push: branches: [main]` trigger will re-scan and should clear all 5 alerts.
2. In the meantime, `gh api repos/me2resh/apexyard/code-scanning/alerts` can be re-run after the workflows execute on a push to confirm no *new* Token-Permissions or Pinned-Dependencies findings were introduced.

Refs #819

---

## Glossary

| Term | Definition |
|------|------------|
| OpenSSF Scorecard | Automated supply-chain security scanner that scores a repo on checks like Token-Permissions, Pinned-Dependencies, and Branch-Protection; publishes findings to the repo's Security → Code scanning tab |
| Token-Permissions (Scorecard check) | Flags GitHub Actions workflows that grant the `GITHUB_TOKEN` more scope than needed — specifically, this PR's fix addresses the sub-check that any *write* scope declared at the workflow (top) level is flagged, independent of job-level scoping |
| Pinned-Dependencies (Scorecard check) | Flags dependencies fetched by a mutable reference (a tag, a version string, `latest`) instead of an immutable one (a commit SHA, a Docker digest, a `--require-hashes` pip lock) |
| Digest-pinning (Docker) | Referencing a container image by its content-addressed `sha256:` digest instead of a mutable tag — the same reproducibility guarantee SHA-pinning gives GitHub Actions `uses:` steps |
| `--require-hashes` (pip) | A pip install mode that refuses to install anything without an explicit cryptographic hash for every package in the resolved dependency tree, including transitive dependencies |
| Job-level vs. top-level `permissions:` | GitHub Actions lets a workflow declare a `permissions:` block at the top (applies to every job by default) and/or per-job (overrides the top-level default for that job only) — this PR's core change is moving write grants from the former to the latter |