### PR TITLE
docs(#466): discard spikes #466/#660 (memos) + state Git Bash as Windows prereq

### DIFF
--- a/docs/agdr/AgDR-0086-hooks-stay-bash-not-ported.md
+++ b/docs/agdr/AgDR-0086-hooks-stay-bash-not-ported.md
@@ -1,0 +1,44 @@
+# AgDR-0086 — Keep `.claude/hooks` in bash; support other OSes via adapter-over-bash + Git Bash, not a language port
+
+> In the context of bash being the runtime of the framework's entire hook layer with no native Windows execution outside Git Bash/WSL, facing spike #466's question of whether porting `.claude/hooks/**` to a cross-platform runtime (Node/Python/Go) is the highest-leverage move for Windows-native support, I decided **to keep bash as the single source of truth and reach other OSes/harnesses through thin adapters that shell out to the unmodified hooks, plus a documented Git Bash prerequisite on Windows**, to achieve cross-platform coverage without rewriting the security-critical trust chain, accepting that fully native Git-Bash/WSL-free Windows support remains unaddressed until (if ever) it becomes an explicit business requirement.
+
+## Context
+
+The `.claude/hooks/*.sh` scripts are the mechanical enforcement layer of the ApexYard SDLC — merge gates, red-CI blocking, ticket-first, secrets/leak-protection. They run natively on macOS/Linux; on Windows they need WSL or Git Bash. Spike #466 hypothesised that the bash hooks (not the git-fork/pipx distribution mechanism) were the real blocker to Windows-native support, and that porting them to a cross-platform language would be feasible without losing the PreToolUse/PostToolUse gating semantics.
+
+The spike found a port is **technically viable but not worth doing now**. Decision-relevant facts it surfaced:
+
+- The hooks directory is far larger than the ticket assumed: 58 files (44 hooks + 14 shared `_lib-*.sh` libraries), ~13,142 lines, plus a **19,019-line bash test suite** larger than the code it tests.
+- The 14 `_lib-*.sh` files (4,201 lines, ~32% of the total) are the real cost — each encodes dozens of previously-debugged edge cases (multi-tracker dispatch, split-portfolio path resolution, the `gh api` vs `gh pr merge` bypass fix from #47) that a naive port would silently regress unless re-verified against the also-bash test suite.
+- The hook **wiring** in `.claude/settings.json` is an inline bash bootstrap duplicated across ~40 hook registrations; porting the hook bodies alone doesn't remove it, so any real port also means rewriting ~40 `command` entries.
+- Because `.claude/hooks/**` is the framework's explicit security-critical trust chain, every ported file re-triggers a mandatory Security Auditor review — dozens of security-reviewed PRs, not one refactor.
+- The framework validated the **opposite** direction the same week: spike #804 (pi.dev) promoted to #815 and a matching opencode spike promoted to #821 — both prove a thin per-harness adapter shelling out to the *unmodified* bash hooks, keeping bash as the single source of truth. A language port would replace that source of truth and strand the in-flight adapter work.
+- Windows-via-Git-Bash already works today: the one concrete blocker (an ancestor-directory-walk that never terminated on `C:`-drive paths) was fixed in #691.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| (a) Port hooks to **Node.js** | Matches the stack already used by premium/admin/pi-adapter tooling; enables native Windows | Multi-week (T-shirt L): ~4.2k lines of `_lib-*.sh`, the 19k-line parallel bash test suite, the `settings.json` ~40-entry rewrite, and per-file Security Auditor review; replaces and strands the adapter-over-bash direction #815/#821 depend on |
+| (b) Port hooks to **Python** | Cross-platform; readable | Same multi-week cost as (a); additionally carries Python's flagged startup-latency cost (AgDR-0038) on hooks that fire on every tool call |
+| (c) Port hooks to **Go** | Single static binary, fast | Largest effort (T-shirt XL); conflicts with the fork-and-clone distribution model (AgDR-0047); same strand-the-adapters problem |
+| (d) **Stay bash** — single source of truth; reach other OSes/harnesses via adapter-over-bash (#815/#821) and document Git Bash/WSL as a stated Windows prerequisite | Zero change to the trust chain (no re-review churn); complements rather than replaces the live multi-harness adapter work; closes the actual Windows gap cheaply, same shape as the existing `jq` hard-dependency precedent (AgDR-0038); Windows already works via Git Bash after #691 | Does not deliver *native*, Git-Bash/WSL-free Windows execution — an adopter on Windows must install Git Bash |
+
+## Decision
+
+Chosen: **(d) — keep `.claude/hooks` in bash as the single source of truth**, do **not** port to a cross-platform runtime, and support other OSes/harnesses through the adapter-over-bash pattern (#815/#821) plus a documented Git Bash/WSL prerequisite on Windows.
+
+The port is disqualified against spike #466's own kill criteria on cost (multi-week for the shared libs + parallel bash test suite + `settings.json` rewrite + per-file security review), and — more decisively — it would replace the exact source of truth the validated multi-harness direction shells out to. The cheap fix that closes the real gap (documenting Git Bash/WSL as a Windows prerequisite, mirroring the `jq` hard dependency in AgDR-0038) ships in the same PR as this decision, without touching the trust chain.
+
+## Consequences
+
+- Windows adopters run the hooks today via Git Bash/WSL (documented prerequisite, the `C:`-path hang fixed in #691); there is no native, Git-Bash-free Windows path, and that is an accepted, stated limitation — not a silent failure.
+- Cross-OS and cross-harness coverage is delivered by thin adapters over the unmodified bash hooks (#815 pi.dev, #821 opencode), keeping one behavioural source of truth and avoiding a fork of the trust chain.
+- If native, Git-Bash/WSL-free Windows support ever becomes an explicit business requirement (not just "works via a documented prerequisite"), **Node.js** is the best of the three language options — it matches existing tooling, avoids Python's startup-latency cost (AgDR-0038) and Go's distribution-model conflict (AgDR-0047). Revisiting is a dedicated multi-week initiative that must carry **its own AgDR**, not an add-on to this decision.
+
+## Artifacts
+
+- Spike disposition memo: [`docs/spike-memos/GH-466-cross-platform-hooks.md`](../spike-memos/GH-466-cross-platform-hooks.md)
+- Spike ticket: me2resh/apexyard#466 (DISCARD); PR #823
+- Multi-harness adapter direction this defers to: #804 → #815 (pi.dev gate adapter), opencode gate adapter spike → #821
+- Precedent — explicit prerequisite beats silent failure: [AgDR-0038](AgDR-0038-jq-as-hard-dependency.md); Windows Git-Bash hang fix: #690/#691

--- a/docs/agdr/AgDR-0087-reasoning-agents-require-frontier-model.md
+++ b/docs/agdr/AgDR-0087-reasoning-agents-require-frontier-model.md
@@ -1,0 +1,42 @@
+# AgDR-0087 — Reasoning-layer agents require a frontier model; local/open LLMs are a harness concern, not a framework change
+
+> In the context of spike #660 asking whether the full ApexYard loop can run on open-weights/local LLMs with no proprietary-API dependency, facing a split between a governance layer that is already model-agnostic and a reasoning layer that is not, I decided **that the mechanical/gate layer stays model-agnostic and self-hostable via the harness adapters while the reasoning-layer agents (Rex/Hakim/Tariq/Naqid + the orchestrator) require a frontier model — and that local/open-LLM support is a harness+model choice, not a framework change**, to achieve run-anywhere mechanical governance without lowering the merge-gate review floor, accepting that a fully self-hosted zero-Claude configuration cannot meet the framework's review-depth bar today.
+
+## Context
+
+Spike #660 hypothesised (building on #348, cited as having "validated local routing for 3 low-stakes agents") that the whole loop — code review (Rex), build engineers, design/security review, core skills — could run on strong open-weights models via `agent-routing.yaml` → Ollama/LiteLLM at a usable governance bar, giving adopters a fully self-hostable, no-Claude configuration.
+
+The spike found the question splits into two layers, only one viable:
+
+- **Mechanical/gate layer** — the bash hooks enforcing merge gates, red-CI blocking, design review, ticket-first, secrets/leak-protection — is already harness-agnostic and proven portable: the pi.dev (#815) and opencode (#821) adapters shell out to the unmodified hooks with no dependency on which model drives the session. No new framework work needed.
+- **Reasoning layer** — Rex, Hakim, Tariq, Naqid, and the orchestrating main thread — is **not** viable at a usable governance bar on any open-weights model tested or evidenced. AgDR-0050's 24-agent model matrix already pins these depth-bound reviewer roles to `opus` (its stated capability floor), independent of this spike.
+
+New live evidence the spike added: a real merged security-relevant PR (#793, a fail-closed CI-gate fix) was fed to the strongest locally-available coding model (`qwen3-coder`, ~20B) through Rex's actual review checklist. The review completed (424.5s wall-clock, ~111s pure compute — roughly **300x** a synchronous Claude-driven Rex pass) but **never engaged the one question the prompt told it to check** — whether the gate fails closed or open on an unresolvable status, the load-bearing security decision in that PR — raising five generic SUGGESTION-level nitpicks instead. A fluent-but-incomplete review that looks thorough while missing the actual risk is a worse failure mode for a merge-gate reviewer than a visible timeout. A parallel `mistral` call timed out under contention, confirming the single-endpoint constraint. The spike also corrected the ticket's premise: #348 was closed unrun; #195 (the spike that did measure) landed a narrow partial-GO limited to prose-synthesis, explicitly rejecting local routing for anything that must count, classify precisely, or reason about a diff.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| (a) **Full local** — route all agents, including Rex/Hakim/Tariq/Naqid + orchestrator, to open-weights/local models | Zero proprietary-API dependency; fully self-hostable | Live evidence shows the reasoning layer misses the load-bearing risk at ~300x latency; a fluent-but-incomplete merge-gate review is worse than a timeout; contradicts AgDR-0050's `opus` pin reached independently |
+| (b) **Hybrid** — mechanical/gate layer model-agnostic (local-OK), reasoning layer pinned to a frontier model | Governance runs anywhere; keeps the review-depth floor where the evidence and AgDR-0050 both put it; low-stakes sub-tasks (triage, SQL sketches, AC checklists, prose synthesis) can still route local per #195 | Not "zero-Claude" — the reasoning floor still needs a frontier model |
+| (c) **No framework change** — treat local-LLM support as a harness+model choice (BYOK harness + a capable model), shipped via the existing adapters, not a framework feature | Nothing to build; self-hosted mechanical gates already work via #815/#821; matches how the framework already ships the *pattern*, not a recommendation | Adopters wanting local reasoning get the same frontier-floor answer; no new self-hostable reasoning tier is delivered |
+
+## Decision
+
+Chosen: **(b)/(c) — the reasoning layer stays frontier; local/open-LLM support is a harness concern, not a framework change.** The mechanical governance layer is already model-agnostic and self-hostable through the harness adapters (#815/#821); the depth-bound reviewer roles keep a frontier-model floor.
+
+"Self-hosted, zero-Claude, full governance bar" — the ticket's actual ask — is not viable today at any open-weights tier this spike could test or find evidence for, and the framework's own designers reached the same conclusion independently by pinning Rex/Hakim/Tariq/Naqid/SRE/Pen-Tester to `opus` in AgDR-0050. Re-opening the full-loop question now would be asking, for the third time, something already answered twice (#348 closed unrun, #195 partial-GO for prose only).
+
+## Consequences
+
+- Mechanical governance (merge gates, red-CI, ticket-first, secrets/leak-protection) runs anywhere via the harness adapters — self-hosted mechanical enforcement needs no proprietary API.
+- Review quality has a **frontier-model floor**: the reasoning-layer agents are not routed to open-weights models; low-stakes sub-tasks (ticket triage, SQL sketches, AC checklists, prose synthesis) may still route local per `agent-routing.yaml` and #195's narrow recommendation.
+- This is a "not yet", not a permanent no. Revisit only via the **narrower re-test the memo proposes**: does a specific coding-tuned open model (e.g. `qwen2.5-coder:14b`, matching typical adopter hardware) clear Rex's real review checklist across 10–15 real merged PRs with known outcomes — turning "this happened once" into a measured rate. That ~2–3 day measurement, not framework rework, is the missing evidence.
+
+## Artifacts
+
+- Spike disposition memo: [`docs/spike-memos/GH-660-local-open-llms.md`](../spike-memos/GH-660-local-open-llms.md)
+- Spike ticket: me2resh/apexyard#660 (DISCARD); PR #823
+- Model matrix pinning the depth-bound reviewer roles to `opus`: [AgDR-0050](AgDR-0050-agent-runtime-overhaul.md)
+- Prior local-routing history: me2resh/apexyard#348 (closed unrun), #195 (`docs/spikes/local-model-routing.md`, live-measured partial-GO)
+- Multi-harness adapters delivering self-hosted mechanical gates: #804 → #815 (pi.dev), opencode gate adapter spike → #821

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,6 +10,7 @@ Short version of the setup flow. For the full walkthrough (directory layout, dai
 - [Claude Code](https://claude.com/claude-code) installed
 - [GitHub CLI (`gh`)](https://cli.github.com) installed (optional but recommended)
 - [`jq`](https://jqlang.org/download/) installed — required. Framework hooks use jq to read `.claude/project-config.json` overrides; without it your overrides silently no-op. `brew install jq` / `apt-get install jq` / `dnf install jq` depending on platform. `/setup` refuses to run without it, and a SessionStart banner surfaces the gap if jq disappears later. See [AgDR-0038](agdr/AgDR-0038-jq-as-hard-dependency.md) for the rationale.
+- **Windows**: [Git for Windows](https://gitforwindows.org) (which bundles Git Bash) or WSL — required. `.claude/hooks/*.sh` are bash scripts; native `cmd.exe`/PowerShell can't run them. This already works today (the ancestor-directory-walk hang some Windows users hit on `C:`-drive paths was fixed in [#691](https://github.com/me2resh/apexyard/issues/691)) — this is just making the requirement explicit, same shape as the `jq` line above.
 - Basic familiarity with Claude Code's `CLAUDE.md` system
 
 ---

--- a/docs/spike-memos/GH-466-cross-platform-hooks.md
+++ b/docs/spike-memos/GH-466-cross-platform-hooks.md
@@ -24,6 +24,7 @@ If native, Git-Bash/WSL-free Windows support ever becomes an explicit business r
 
 ## Artefacts
 
+- Decision record: [AgDR-0086](../agdr/AgDR-0086-hooks-stay-bash-not-ported.md) — the "keep hooks in bash; adapter-over-bash + Git Bash" decision this memo records
 - Original spike ticket: me2resh/apexyard#466
 - Spike branch: `spike/GH-466-cross-platform-hooks` (delete after merge of this memo)
 - Full findings: `docs/spike-reports/GH-466-cross-platform-hooks.md` on the spike branch

--- a/docs/spike-memos/GH-466-cross-platform-hooks.md
+++ b/docs/spike-memos/GH-466-cross-platform-hooks.md
@@ -1,0 +1,30 @@
+# Spike memo: Evaluate porting .claude/hooks off bash to a cross-platform runtime for Windows-native support
+
+> **Disposition: DISCARD** — hypothesis rejected (viable, but not worth doing); not pursuing further.
+
+- **Spike ticket**: me2resh/apexyard#466
+- **Author**: me2resh
+- **Closed**: 2026-07-08
+
+## Hypothesis (from the spike ticket)
+
+apexyard's `.claude/hooks/*.sh` bash scripts are the real blocker to Windows-native support — not the distribution mechanism (git fork / pipx both work cross-platform). On Windows the hooks need WSL or Git Bash; to be truly native they'd need a cross-platform runtime. Porting the hooks to a cross-platform language (Python or Node) was hypothesized to be feasible without losing the PreToolUse/PostToolUse gating semantics, and the highest-leverage move for Windows support.
+
+## Findings
+
+A port is technically **viable** — nothing in the hook logic resists translation to Node or Python — but it is not worth doing now. The hooks directory has grown well past the ticket's original estimate: 58 files (44 hooks + 14 shared `_lib-*.sh` libraries), 13,142 lines, plus a 19,019-line bash test suite that is itself larger than the code it tests. The 14 `_lib-*.sh` files (4,201 lines, ~32% of the total) are the real cost — not because the logic is conceptually bash-only, but because each one encodes dozens of previously-debugged edge cases (multi-tracker dispatch, split-portfolio path resolution, the `gh api` vs `gh pr merge` bypass fix from #47) that a naive port would silently regress unless re-verified against the also-bash test suite. A further wrinkle: the hook *wiring* itself, in `.claude/settings.json`, is an inline bash bootstrap duplicated across roughly 40 hook registrations — porting the hook bodies alone doesn't remove it, so any real port also means rewriting `settings.json`'s ~40 `command` entries. Because `.claude/hooks/**` is the framework's explicit security-critical trust chain, every ported file would also re-trigger a mandatory Security Auditor review — dozens of security-reviewed PRs, not one refactor PR.
+
+## Why we're not pursuing
+
+The port cost (multi-week — the shared libs plus the parallel bash test suite plus the settings.json rewrite plus per-file security review, T-shirt-sized L for Node/Python and XL for Go) is disqualifying against the spike's own kill criteria. More decisively, the framework validated the *opposite* direction the same week this spike ran: spike #804 (pi.dev support) closed VIABLE and promoted to #815, and a matching opencode spike promoted to #821 — both prove a thin per-harness adapter that shells out to the **unmodified** bash hooks, keeping bash as the single source of truth. A language port would replace that source of truth and strand the in-flight adapter work rather than complement it. On top of that, Windows-via-Git-Bash already works today: the one concrete blocker (an ancestor-directory-walk that never terminated on `C:`-drive paths) was fixed in #691. The cheap fix — document Git Bash/WSL as a stated Windows prerequisite, same shape as the existing `jq` hard dependency (AgDR-0038) — closes the actual gap without touching the trust chain at all, and has been made as part of this same PR.
+
+## What would change the answer
+
+If native, Git-Bash/WSL-free Windows support ever becomes an explicit business requirement (not just "it works via a documented prerequisite"), Node.js is the best of the three real language options — it matches the stack already used by the premium/admin/pi-adapter tooling, avoids Python's flagged startup-latency cost (AgDR-0038), and avoids Go's conflict with the fork-and-clone distribution model (AgDR-0047). That would need its own multi-week initiative and its own AgDR — not an add-on to this spike.
+
+## Artefacts
+
+- Original spike ticket: me2resh/apexyard#466
+- Spike branch: `spike/GH-466-cross-platform-hooks` (delete after merge of this memo)
+- Full findings: `docs/spike-reports/GH-466-cross-platform-hooks.md` on the spike branch
+- Related: [AgDR-0038](../agdr/AgDR-0038-jq-as-hard-dependency.md) (explicit-prereq-beats-silent-failure precedent), #690/#691 (Windows Git-Bash hang bug + fix), #804 → #815 (pi.dev gate adapter), opencode gate adapter spike → #821 — the live multi-harness direction this memo defers to

--- a/docs/spike-memos/GH-660-local-open-llms.md
+++ b/docs/spike-memos/GH-660-local-open-llms.md
@@ -1,0 +1,34 @@
+# Spike memo: Run the full yard on open / local LLMs (Ollama / open-weights) — no proprietary-API dependency
+
+> **Disposition: DISCARD** — hypothesis rejected at the ticket's stated bar; not pursuing further.
+
+- **Spike ticket**: me2resh/apexyard#660
+- **Author**: me2resh
+- **Closed**: 2026-07-08
+
+## Hypothesis (from the spike ticket)
+
+Building on #348 (cited as having "validated local routing for 3 low-stakes agents"), the hypothesis was that the full apexyard loop — code review (Rex), build engineers, design/security review, the core skills — could run on strong open-weights/local models via `agent-routing.yaml` → Ollama/LiteLLM at a usable governance bar, giving adopters a fully self-hostable configuration with no Claude/proprietary-API dependency.
+
+## Findings
+
+The question splits into two layers, and only one of them is viable. The **mechanical/gate layer** — the bash hooks that enforce merge gates, red-CI blocking, design review, ticket-first, secrets/leak-protection — is already harness-agnostic and proven portable: two independent spikes (pi.dev → #815, opencode → #821) showed a thin per-harness adapter shelling out to the unmodified bash hooks, with no dependency on which model drives the session. This part needs no new framework work.
+
+The **reasoning layer** — Rex, Hakim, Tariq, Naqid, and the orchestrating main thread itself — is not viable at a usable governance bar on any open-weights model tested or evidenced. The framework's own model matrix (AgDR-0050) already pins these roles to `opus`, its own stated capability floor, independent of this spike. This spike added new live evidence: a real merged security-relevant PR (#793, a fail-closed CI-gate fix) was fed to the strongest locally-available coding model (`qwen3-coder`, ~20B) through Rex's actual review checklist. The review completed (424.5s wall-clock, ~111s of that pure compute — roughly 300x a synchronous Claude-driven Rex pass) but never engaged with the one question the prompt explicitly told it to check: whether the gate fails closed or open on an unresolvable status, the load-bearing security decision in that PR. It raised five generic, SUGGESTION-level defensive-programming nitpicks instead. A fluent-but-incomplete review — one that looks thorough while missing the actual risk — is a worse failure mode for a merge-gate reviewer than a visible timeout would have been. A parallel call to a smaller model (`mistral`) timed out under resource contention, confirming the single-endpoint constraint the framework's own local-model docs already document.
+
+The ticket's premise also overstated prior evidence: #348 (cited as having "validated local routing") was actually closed unrun — the design pivoted to "framework ships the pattern, not a recommendation" without ever measuring anything. #195, the spike that did run live measurements, landed a narrow partial-GO limited to prose-synthesis tasks (inbox summaries via a regex-extracts/LLM-narrates hybrid) — explicitly rejecting local routing for anything that needs to count, classify precisely, or reason about a diff.
+
+## Why we're not pursuing
+
+"Self-hosted, zero-Claude, full governance bar" — the ticket's actual ask — is not viable today at any open-weights tier this spike could test or find evidence for, and the framework's own designers already reached the same conclusion independently by pinning the depth-bound reviewer roles to `opus`. What *is* already shipped and requires no further work: self-hosted mechanical gates via the harness adapters (#815/#821), plus local/open routing for genuinely low-stakes sub-tasks (ticket triage, SQL sketches, AC checklists, prose synthesis) per `agent-routing.yaml` and #195's narrow recommendation. Re-opening the full-loop question would be asking, for the third time, something already answered twice.
+
+## What would change the answer
+
+A future open-weights release that closes the review-depth gap at a size that runs comfortably on typical adopter hardware — worth periodic re-testing, not a permanent no. Restructuring the review gate to be async-tolerant (accepting a multi-minute local-model review as normal instead of expecting Rex-in-seconds) would remove the latency objection independently of the quality one, but that's an SDLC-shape change, out of this spike's scope. Most concretely: a narrower, sharper follow-up spike — does a specific coding-tuned open model (e.g. `qwen2.5-coder:14b`, matching more typical adopter hardware than the 20B model this spike hit a wall with) clear Rex's real review checklist across 10-15 real merged PRs with known outcomes — would turn "this happened once" into an actual measured rate. That measurement, not framework rework, is the one piece of real evidence still missing; it's roughly a 2-3 day effort, matching #348's own original unfulfilled budget.
+
+## Artefacts
+
+- Original spike ticket: me2resh/apexyard#660
+- Spike branch: `spike/GH-660-local-open-llms` (delete after merge of this memo)
+- Full findings: `docs/spike-reports/GH-660-local-open-llms.md` on the spike branch
+- Related: me2resh/apexyard#348 (closed unrun, local-routing feasibility), `docs/spikes/local-model-routing.md` (spike #195, live-measured partial-GO), [AgDR-0050](../agdr/AgDR-0050-agent-runtime-overhaul.md) (the 24-agent model matrix pinning Rex/Hakim/Tariq/Naqid to `opus`), `docs/local-model-setup.md`, #804 → #815 (pi.dev gate adapter), opencode gate adapter spike → #821

--- a/docs/spike-memos/GH-660-local-open-llms.md
+++ b/docs/spike-memos/GH-660-local-open-llms.md
@@ -28,6 +28,7 @@ A future open-weights release that closes the review-depth gap at a size that ru
 
 ## Artefacts
 
+- Decision record: [AgDR-0087](../agdr/AgDR-0087-reasoning-agents-require-frontier-model.md) — the "reasoning layer needs a frontier model; local LLMs are a harness concern" decision this memo records
 - Original spike ticket: me2resh/apexyard#660
 - Spike branch: `spike/GH-660-local-open-llms` (delete after merge of this memo)
 - Full findings: `docs/spike-reports/GH-660-local-open-llms.md` on the spike branch


### PR DESCRIPTION
## Summary
- **Spike #466 (cross-platform hooks) disposed DISCARD** — a port to Node/Python is technically viable but not worth it now: the hooks directory has grown to 58 files / 13k lines plus 4.2k lines of shared `_lib-*.sh` libraries encoding dozens of previously-debugged edge cases, plus a 19k-line bash test suite with no free port, plus the `settings.json` wiring itself is bash (~40 duplicated entries). The framework validated the opposite direction the same week — thin per-harness adapters that shell out to the *unmodified* bash hooks (pi.dev #804→#815, opencode →#821) — and Windows-via-Git-Bash already works today (#691). Memo: `docs/spike-memos/GH-466-cross-platform-hooks.md`.
- **Spike #660 (local/open LLMs) disposed DISCARD** — the mechanical gate layer is already harness-agnostic and solved by #815/#821 (no new work needed). The reasoning layer (Rex/Hakim/Tariq/Naqid, all pinned to `opus` per AgDR-0050) is not viable on open-weights at a usable governance bar: this spike live-tested `qwen3-coder` (~20B, the strongest local model available) against a real merged security PR using Rex's actual review checklist — it produced a fluent, well-formed review that never engaged with the one load-bearing question it was explicitly told to check (fail-open vs fail-closed on a security gate), at roughly 300x Claude-driven Rex's latency. Memo: `docs/spike-memos/GH-660-local-open-llms.md`.
- **Cheap docs fix surfaced by #466** — `docs/getting-started.md` never stated Git Bash/WSL as a Windows prerequisite, even though the hooks require it and it already works (the one blocking bug was fixed in #691). Added one bullet in the Prerequisites section, same shape as the existing `jq` requirement (AgDR-0038).

Neither spike's code is being merged or promoted — both branches (`spike/GH-466-cross-platform-hooks`, `spike/GH-660-local-open-llms`) stay as throwaway artifacts and can be deleted once this memo PR lands. The full findings for each live in `docs/spike-reports/` on those branches (referenced from each memo).

## Testing
1. `npx markdownlint-cli2 docs/spike-memos/*.md docs/getting-started.md` — 0 errors
2. Manually confirmed every internal doc link referenced by the memos and the getting-started bullet resolves (AgDR-0038, AgDR-0050, `docs/spikes/local-model-routing.md`)

Refs #466
Refs #660

---

## Glossary
| Term | Definition |
|------|------------|
| Spike disposition | The mandatory close-out decision for a `[Spike]` ticket — either `--promote` (file a production `[Feature]`) or `--discard` (write a memo). No third path. See `.claude/skills/spike-close/SKILL.md`. |
| Adapter-over-bash | A thin per-harness extension/plugin (pi.dev, opencode) that shells out to an apexyard bash gate hook unmodified, rather than reimplementing its logic — the pattern this memo's recommendation defers to for #466 and #660 alike |
| Capability floor | The minimum model reasoning depth below which a role's output is unacceptable regardless of cost savings — AgDR-0050 sets this at `opus` for Rex/Hakim/Tech Lead/SRE/Pen Tester |