### PR TITLE
chore(#819): least-privilege permissions + SHA-pin actions in CI

### DIFF
--- a/golden-paths/pipelines/ci.yml
+++ b/golden-paths/pipelines/ci.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -104,12 +104,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -119,7 +119,7 @@ jobs:
 
       - name: Semgrep SAST
         id: sast
-        uses: returntocorp/semgrep-action@v1
+        uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d  # v1
         with:
           config: >-
             p/security-audit
@@ -145,7 +145,7 @@ jobs:
 
       - name: Secrets Detection
         id: secrets
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@d7dcc6d3fe80206bc1bdcfb15db1dd8d890956fd  # main
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}
@@ -166,10 +166,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -220,7 +220,7 @@ jobs:
 
       - name: Post PR Comment
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const cq = '${{ needs.code-quality.result }}';

--- a/golden-paths/pipelines/code-quality.yml
+++ b/golden-paths/pipelines/code-quality.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0  # full history for proper diff
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -123,7 +123,7 @@ jobs:
       # Post PR comment
       - name: Post Review Comment
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const typeErrors = '${{ steps.typecheck.outputs.errors }}';

--- a/golden-paths/pipelines/dependency-audit.yml
+++ b/golden-paths/pipelines/dependency-audit.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -135,7 +135,7 @@ jobs:
       # Create issue for critical/high vulnerabilities
       - name: Create issue for vulnerabilities
         if: steps.npm-audit.outputs.critical > 0 || steps.npm-audit.outputs.high > 0
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const critical = ${{ steps.npm-audit.outputs.critical }};

--- a/golden-paths/pipelines/macos-release.yml
+++ b/golden-paths/pipelines/macos-release.yml
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: write       # create the GitHub Release + upload assets
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
@@ -187,7 +187,7 @@ jobs:
       # ── Publish the GitHub Release (tag pushes, or dispatch with publish=true) ─
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v') || inputs.publish
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           files: ${{ env.DMG_PATH }}
           generate_release_notes: true

--- a/golden-paths/pipelines/pr-title-check.yml
+++ b/golden-paths/pipelines/pr-title-check.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Check PR title for ticket ID
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -58,7 +58,7 @@ jobs:
 
       - name: Add ticket label
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const ticketId = '${{ steps.check.outputs.ticket_id }}';
@@ -82,7 +82,7 @@ jobs:
 
       - name: Post comment on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const title = context.payload.pull_request.title;

--- a/golden-paths/pipelines/review-check.yml
+++ b/golden-paths/pipelines/review-check.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check if Rex reviewed latest commit
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/golden-paths/pipelines/security.yml
+++ b/golden-paths/pipelines/security.yml
@@ -55,12 +55,12 @@ jobs:
 
     steps:
       - name: Checkout (full history for gitleaks git-log scan)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # GITLEAKS_LICENSE not required for public/OSS repos
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install Semgrep OSS
         run: pip install semgrep
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload Semgrep results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: semgrep-results
           path: semgrep-results.json
@@ -153,10 +153,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -195,10 +195,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Generate CycloneDX SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0
         with:
           format: cyclonedx-json
           output-file: sbom.cyclonedx.json
@@ -216,7 +216,7 @@ jobs:
 
     steps:
       - name: Evaluate gate
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const jobs = {

--- a/golden-paths/pipelines/seo-check.yml
+++ b/golden-paths/pipelines/seo-check.yml
@@ -35,13 +35,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@ac21d93904fb48e7f76ce4bd2a4d197f67e34abe  # v42
         with:
           files: |
             content/**
@@ -52,7 +52,7 @@ jobs:
             **/*.md
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
 
@@ -212,7 +212,7 @@ jobs:
 
       - name: Post SEO Review Comment
         if: github.event_name == 'pull_request' && steps.seo-analysis.outputs.file_count > 0
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const avgScore = '${{ steps.seo-analysis.outputs.avg_score }}';

--- a/golden-paths/pipelines/swift-ci.yml
+++ b/golden-paths/pipelines/swift-ci.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1
         with:
           # Pin a concrete version (e.g. '16.2') if you need reproducible builds.
           xcode-version: latest-stable

--- a/golden-paths/pipelines/terraform-ci.yml
+++ b/golden-paths/pipelines/terraform-ci.yml
@@ -49,11 +49,11 @@ jobs:
     name: 🔍 Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       - name: Terraform Format Check
@@ -63,11 +63,11 @@ jobs:
     name: ✅ Validate Configuration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       - name: Setup Terramate
@@ -89,11 +89,11 @@ jobs:
     name: 🧹 Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       - name: Setup Terramate
@@ -113,11 +113,11 @@ jobs:
     name: 🔒 Security Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       - name: Setup Terramate
@@ -144,7 +144,7 @@ jobs:
       stacks: ${{ steps.detect.outputs.stacks }}
       has-changes: ${{ steps.detect.outputs.has-changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
       - name: Setup Terramate
@@ -214,15 +214,15 @@ jobs:
       contents: read
       pull-requests: write  # comment the plan on the PR
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       - name: Configure AWS OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
           role-to-assume: ${{ env.AWS_CI_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -232,7 +232,7 @@ jobs:
       # it on a path match so it only runs for the stacks that need it.
       # - name: Setup Node.js (for artifact builds)
       #   if: contains(matrix.path, 'my-app')
-      #   uses: actions/setup-node@v4
+      #   uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
       #   with:
       #     node-version: '22'
       # - name: Build artifacts
@@ -289,7 +289,7 @@ jobs:
 
       - name: Comment plan on PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const planOutput = `${{ steps.plan.outputs.PLAN_OUTPUT }}`;
@@ -342,15 +342,15 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
       - name: Configure AWS OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
           role-to-assume: ${{ env.AWS_CI_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Summary

- **SHA-pins every third-party action in the `golden-paths/pipelines/**` reusable CI templates** — these are the workflow files adopters copy into their own `.github/workflows/`, and until now they still referenced actions by mutable tag (`@v4`, `@main`). An adopter copying `security.yml` or `terraform-ci.yml` today would inherit an OpenSSF Scorecard Pinned-Dependencies failure on day one. Now every `uses:` resolves to a 40-char commit SHA with the tag kept as a trailing comment (so Dependabot can still open version-bump PRs).
- **Closes the remaining scope from #819** — the framework's own `.github/workflows/**` was already fully least-privilege + SHA-pinned in #820 (merged). Issue #819's acceptance criteria explicitly called out sweeping the golden-paths templates for the same gap ("while in there"); this PR is that sweep. `golden-paths/pipelines/**` already carried top-level `permissions:` blocks on every file, so no permissions changes were needed — pinning was the only outstanding gap.
- **No behaviour change** — same actions, same versions, same job/step order. Only the action-reference format changed (tag → SHA + comment).

## Testing

- `actionlint golden-paths/pipelines/*.yml .github/workflows/*.yml` — same 189 findings before and after this change (all pre-existing shellcheck `SC2086` quoting notices and one untrusted-expression note in `auto-tag-on-release-pr-merge.yml`, unrelated to this diff). Zero new findings, and none of the pre-existing findings reference `permissions:` or `uses:`.
- `python3 -c "import yaml,sys; yaml.safe_load(open(f))"` on every changed file — all parse cleanly.
- Diffed against a fresh clone of `me2resh/apexyard:dev` to confirm `.github/workflows/**` already had 100% SHA-pinned actions + permissions blocks (from #820), and that `golden-paths/pipelines/**` permissions blocks were already present — isolating the diff to exactly the pinning gap.

Refs #819

---

## Glossary

| Term | Definition |
|------|------------|
| **Token-Permissions** | An OpenSSF Scorecard check that flags workflows relying on the default (broad, often read-write) `GITHUB_TOKEN` instead of declaring an explicit least-privilege `permissions:` block. |
| **Pinned-Dependencies** | An OpenSSF Scorecard check that flags third-party GitHub Actions referenced by a mutable tag (e.g. `@v4`) or branch (e.g. `@main`) instead of an immutable commit SHA — a mutable ref can be repointed by the action's maintainer (or an attacker who compromises their account) to ship different code without the pin ever changing. |
| **Least-privilege GITHUB_TOKEN** | The practice of scoping the automatically-issued `GITHUB_TOKEN` down to only the permissions a workflow's jobs actually use (e.g. `contents: read` for a job that only builds/tests), rather than accepting the broad default scope. |
