### PR TITLE
spike(#825): calibrate LLM-judge against real ship/reject outcomes

### DIFF
--- a/docs/spike-825/findings.md
+++ b/docs/spike-825/findings.md
@@ -1,0 +1,179 @@
+# Spike #825 — Does an LLM-judge's review score correlate with real ship/reject outcomes?
+
+**Groundwork for feature #824 (`/eval-agents`).** Throwaway, hypothesis-driven, time-boxed.
+
+## The question
+
+If we score the framework's review agents (Rex / Hakim / Tariq) with an LLM-judge
+against a rubric, do those judge scores **correlate with the real ship/reject
+outcomes that already happened in this repo's history**? A high judge score should
+predict "this review was good / the PR shipped clean"; a low score should predict
+"this review missed something / got reworked."
+
+## Verdict
+
+**PROVEN-WITH-CAVEATS — and the caveat is the finding, not a footnote.**
+
+A rubric applied to review *text* rank-orders reviews roughly in line with outcome
+in aggregate (Goodman-Kruskal **gamma = 0.83**, n = 19 review units). But that
+aggregate number is a mirage produced by the easy end of the distribution. On the
+one job `/eval-agents` actually exists to do — **decide whether an APPROVAL was
+justified** — the rubric is **at chance**. The mean judge score of a *correct*
+approval (14.00/16) is statistically indistinguishable from a *wrong* approval
+(13.67/16), and the single most fluent wrong-approval in the corpus scored 15/16,
+beating 7 of the 10 genuinely-correct approvals.
+
+**A surface LLM-judge cannot tell a thorough-and-right review from a
+thorough-looking-but-wrong one.** That is precisely the failure mode a weak review
+model produces, and precisely the thing `/eval-agents` is being built to catch.
+
+## Method
+
+Read-only over this repo's own merged-PR history (`me2resh/apexyard`). No agents
+spawned (sub-agents can't nest); I acted as the single judge.
+
+1. **Ground truth from history.** Pulled review + comment bodies for 15 merged PRs.
+   This repo posts full agent reviews (Rex = code, Hakim = security) as PR review
+   bodies, with explicit `Verdict: APPROVED / CHANGES REQUESTED / BLOCKING` lines and
+   re-review rounds — an unusually clean ground-truth source, because a **later or
+   parallel review of the same commit tells you whether an earlier review was right
+   or wrong.**
+
+2. **Labeled set = 19 "review units"** (one reviewer's assessment of one commit),
+   each with a ground-truth outcome:
+   - `GOOD_CATCH` (6) — verdict correct AND surfaced a real blocking/substantive
+     defect that was then fixed.
+   - `GOOD_CLEAN` (10) — verdict correct on genuinely clean code (no blocking
+     defect existed; no later fix contradicted the approval).
+   - `MISS` (3) — APPROVED a commit that a next-round / parallel review proved still
+     carried a **blocking** defect at that same commit. The approval was *wrong*.
+
+3. **Judge harness** (`judge_calibration.py`, alongside this file). A 4-dimension
+   rubric, 0-4 each (0-16 total), scored from the **review text only** — i.e. what
+   an LLM-judge that *reads the review but does not independently re-review the
+   diff* would produce:
+   - **Catch** — issues surfaced, with specific reasoning
+   - **Engagement** — load-bearing (fail-open / injection / regression), independent
+     verification present, not generic checklist-ticking
+   - **Calibration** — severity labels sane, verdict matches the stated evidence
+   - **False-positive discipline** — flagged issues are real, not noise
+
+   The MISS reviews were deliberately scored **high** where they read as fluent and
+   verification-heavy, because that is exactly what a blind surface judge would do.
+   Under-scoring them to "make the correlation work" would defeat the test.
+
+4. **Correlation.** Pairwise concordance (Goodman-Kruskal gamma) between judge score
+   and outcome rank, plus the discordant pairs, plus a dedicated **load-bearing
+   sub-test**: among APPROVED reviews only, can the rubric separate correct from
+   wrong?
+
+## Results
+
+| Outcome class | n | mean judge/16 | range |
+|---|---|---|---|
+| `GOOD_CATCH` (right + caught a blocker) | 6 | **16.00** | 16-16 |
+| `GOOD_CLEAN` (right, clean code) | 10 | 14.00 | 12-15 |
+| `MISS` (wrong approval) | 3 | **13.67** | 13-15 |
+
+- **Aggregate concordance:** 94 concordant / 9 discordant / 5 tied -> **gamma = 0.83**.
+- **All discrimination lives in `GOOD_CATCH`.** Every review that flagged a real
+  blocking issue scored 16/16 — but that is nearly circular: a review that says
+  `BLOCKING: ...` with evidence is *both* a max catch-score *and*, by construction, a
+  good outcome. The rubric isn't predicting the outcome there so much as restating it.
+- **Load-bearing sub-test collapses.** Restricting to APPROVED reviews (the case the
+  judge must actually grade), `GOOD_CLEAN` mean 14.00 vs `MISS` mean 13.67 — a 0.33
+  gap on a 16-point scale, i.e. noise. The rubric has **no usable signal** for
+  "was this approval justified?"
+
+### The interesting failure cases
+
+**False confidence (high score, bad outcome) — the load-bearing ones:**
+
+- **PR #792, Rex re-review @ `2ce6708` -> scored 15/16, outcome MISS.** A long,
+  table-filled, "traced + empirically confirmed", confidently-APPROVED review — of a
+  commit that Hakim, reviewing the *same* commit, caught a **BLOCKING** silent
+  gate-bypass in (a prefix-strip loop consumed the real create verb, so genuine
+  PR-create invocations skipped validation). Rex's review is indistinguishable *on
+  surface* from its correct approvals. It outscored 7 of 10 correct approvals.
+- **PR #770, initial reviews -> scored 13/16, outcome MISS.** Full checklist all-Pass,
+  "9/9 verified locally", APPROVED — missed a fork-scoped-query regression AND a
+  **vacuous test** (the mock never checked `--repo`, so 9/9 green proved nothing). A
+  later review caught both.
+- **PR #767, initial review -> scored 13/16, outcome MISS.** Correctly flagged one
+  non-blocking nit, radiating diligence — but missed the **blocking** GitLab-api
+  merge-shape gap (the exact #47 forge analog) that the re-review raised as
+  `CHANGES REQUESTED`.
+
+**False alarm (lower score, fine outcome):** PR #677 (docs-only marker clarification)
+scored 12/16 — the lowest correct approval — simply because a docs change gives a
+reviewer little to "catch." The rubric penalizes reviews of low-defect diffs, which
+is a property of the *diff*, not the *review*.
+
+## Why it fails (root cause)
+
+For an **APPROVED** review, three of the four rubric dimensions (engagement,
+calibration, FP-discipline) are high *regardless of whether the approval was
+correct* — a diligent-looking wrong review and a diligent right review present
+identically. Only the **Catch** dimension discriminates, and Catch is
+zero-information when the review (correctly or incorrectly) surfaced no blocking
+finding. So the rubric can rank "flagged a blocker" above "approved," but it cannot
+rank "correctly approved" above "wrongly approved" — which is the whole job.
+
+The corpus also *flatters* the method: this repo's Rex/Hakim reviews are uniformly
+high-craft (mean >= 13/16 across every class), so there is almost no genuine low end
+for the rubric to correctly reject. A real `/eval-agents` corpus containing a truly
+weak model would have more obvious duds the rubric *would* catch — but the weak
+model's dangerous output is the *fluent-but-wrong* review, and on that class this
+spike shows the surface rubric is blind.
+
+## Answer to the flagged caveat
+
+> Does this method catch a weak model's fluent-but-wrong reasoning, or only rank
+> obviously-good vs obviously-bad reviews?
+
+**Only the latter.** In this corpus, fluent-but-wrong is not hypothetical — PR #792
+Rex @ `2ce6708` and PR #770's initial reviews are real, in-repo instances, and the
+surface rubric scored them at or above the correct-approval median. A text-only
+LLM-judge would hand them a passing grade.
+
+## Recommendation for #824 (`/eval-agents`): PROCEED, but adjust the methodology
+
+Do **not** ship a judge that scores review *prose* against a rubric. It will
+rubber-stamp confident-but-wrong reviews — the exact failure mode the feature exists
+to detect — while penalizing good reviews of low-defect diffs.
+
+Instead:
+
+1. **Ground every score in an independent verification of the diff.** The judge must
+   itself be a *reviewer* (an oracle/reference review, or a stronger model actually
+   re-checking the code), and score the agent on **defects-found vs defects-missed
+   against ground truth**, not on rubric adherence of the text. Note that in this
+   very corpus, the mechanism that *did* reliably catch the misses was a **second
+   independent review of the same commit** (Hakim re-review, Rex re-review) — that is
+   the shape `/eval-agents` should emulate, not a prose rater.
+2. **Build the eval set from re-review disagreements + escaped bugs.** This repo hands
+   you labeled data almost for free: any APPROVED commit that a later round marked
+   `BLOCKING`/`CHANGES_REQUESTED`, and any merged PR followed by a `fix(#...)` on the
+   same file, is a ground-truth `MISS`. Harvest those as the gold set.
+3. **Report the load-bearing metric, not the aggregate.** "Can the judge separate
+   correct approvals from wrong approvals?" (approve-precision) — never a single
+   blended concordance number, which this spike shows hides the failure at 0.83.
+4. **Keep the rubric only as a secondary, advisory signal** for review *style/craft*,
+   explicitly not as the correctness oracle.
+
+If #824 can afford an independent-verification judge, proceed. If it can only afford
+a text-rubric judge, the honest call is **stop** — it would give false confidence.
+
+## Limitations (this is a spike)
+
+Single manual judge; n = 19; the judge was not fully blind to outcomes (mitigated by
+deliberately scoring the misses high); concordance is directional evidence, not a
+significance test; corpus is one repo's unusually strong review agents. Enough to
+answer the go/no-go question for #824's methodology; not a measured accuracy figure.
+
+## Reproduce
+
+`python3 docs/spike-825/judge_calibration.py`
+
+Raw review text was pulled with the tracker CLI (review JSON) for PRs:
+792, 770, 767, 762, 748, 747, 773, 778, 787, 789, 677, 686, 688, 689, 634.

--- a/docs/spike-825/judge_calibration.py
+++ b/docs/spike-825/judge_calibration.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Spike #825 — throwaway LLM-judge calibration harness.
+
+Question: if we score the framework's review agents (Rex / Hakim) against a
+rubric, do the judge scores correlate with the REAL ship/reject outcome that
+already happened in this repo's PR history?
+
+Method (see docs/spike-825/findings.md for the full write-up):
+  - Labeled set = 19 real "review units" (one reviewer's assessment of one
+    commit) pulled from 15 merged framework PRs.
+  - judge_score = a 4-dimension rubric (0-4 each, 0-16 total) scored from the
+    REVIEW TEXT ONLY -- i.e. what a surface LLM-judge that reads the review but
+    does NOT independently re-review the diff would produce. Scored blind-ish to
+    outcome, deliberately keeping fluent-but-wrong reviews HIGH (that is the
+    whole point of the test).
+  - outcome = ground truth from what actually happened next:
+        GOOD_CATCH  (2) : verdict correct AND surfaced a real blocking/substantive
+                          defect that was then fixed.
+        GOOD_CLEAN  (1) : verdict correct on genuinely clean code (no blocking
+                          defect existed; no later fix contradicted the approval).
+        MISS        (0) : review APPROVED a commit that a parallel/next-round
+                          review proved still carried a BLOCKING defect at (or at
+                          essentially) that same commit -- the review was wrong.
+
+We then measure rank concordance between judge_score and outcome, and call out
+the discordant pairs (a high-scored review with a bad outcome = false confidence).
+
+This is a spike: single manual judge, small N, judge not fully blind. Concordance
+(Goodman-Kruskal gamma style) is used, not a p-value. It is directional evidence,
+not a proof.
+"""
+
+from itertools import combinations
+from statistics import mean
+
+GOOD_CATCH, GOOD_CLEAN, MISS = 2, 1, 0
+OUTCOME_NAME = {2: "GOOD_CATCH", 1: "GOOD_CLEAN", 0: "MISS"}
+
+# (id, pr, reviewer, commit_short, [catch, engage, calib, fp], outcome, note)
+DATA = [
+    # ---- MISS: fluent, verification-heavy APPROVALS that were actually wrong ----
+    ("R1", 792, "Rex",   "2ce6708", [3, 4, 4, 4], MISS,
+     "APPROVED; missed BLOCKING shape-4 silent-bypass Hakim caught same commit"),
+    ("R2", 770, "Abd",   "init",    [2, 3, 4, 4], MISS,
+     "APPROVED (full checklist Pass, '9/9 verified'); missed fork-scope regression + vacuous test"),
+    ("R3", 767, "Abd",   "init",    [3, 3, 3, 4], MISS,
+     "APPROVED (flagged only a non-blocking nit); missed the BLOCKING glab-api half-fix (HIGH-1)"),
+
+    # ---- GOOD_CATCH: verdict correct AND caught a real blocking/substantive bug ----
+    ("R4", 792, "Hakim", "281da38", [4, 4, 4, 4], GOOD_CATCH,
+     "flagged LOW multiline + MEDIUM completeness -> both became the next-round fixes"),
+    ("R5", 792, "Hakim", "2ce6708", [4, 4, 4, 4], GOOD_CATCH,
+     "caught the BLOCKING shape-4 verb-eating bypass"),
+    ("R6", 770, "Rex",   "chg-req", [4, 4, 4, 4], GOOD_CATCH,
+     "CHANGES_REQUESTED: fork-scoped query regression + false-positive test mock"),
+    ("R7", 767, "RexHakim","chg-req",[4, 4, 4, 4], GOOD_CATCH,
+     "CHANGES_REQUESTED: glab-api merge shape left ungated (the #47 forge analog)"),
+    ("R8", 748, "Rex",   "chg-req", [4, 4, 4, 4], GOOD_CATCH,
+     "CHANGES_REQUESTED: Bug-2 fix is a no-op on bash 3.2 + the test is vacuous"),
+    ("R9", 762, "Abd",   "chg-req", [4, 4, 4, 4], GOOD_CATCH,
+     "CHANGES_REQUESTED: cross-fork review posts to wrong repo (silent regression)"),
+
+    # ---- GOOD_CLEAN: verdict correct on genuinely clean code ----
+    ("R10", 686, "Rex", "07dc21c", [2, 3, 4, 4], GOOD_CLEAN, "jq reserved-keyword rename; correct approve"),
+    ("R11", 688, "Rex", "0a54561", [2, 4, 4, 4], GOOD_CLEAN, "cd-target re-root; adversarial verify; correct"),
+    ("R12", 689, "Rex", "c00e644", [3, 4, 4, 4], GOOD_CLEAN, "merge-gate re-root; flagged latent follow-up; correct"),
+    ("R13", 634, "Rex", "10969b1", [3, 4, 4, 4], GOOD_CLEAN, "push-ref regex; full edge-case table; correct"),
+    ("R14", 789, "Rex", "bc429fb", [2, 4, 4, 4], GOOD_CLEAN, "agent-role rule; diff-scope verified; correct"),
+    ("R15", 677, "Rex", "c96238b", [1, 3, 4, 4], GOOD_CLEAN, "docs-only marker clarification; correct (little to catch)"),
+    ("R16", 747, "Rex", "chg?",    [3, 4, 4, 4], GOOD_CLEAN, "active-ticket re-root; proved regression by revert; correct"),
+    ("R17", 773, "Hakim","final",  [3, 3, 4, 4], GOOD_CLEAN, "agdr-arch-pr diff base; injection-clean; correct"),
+    ("R18", 778, "Rex", "final",   [2, 4, 4, 4], GOOD_CLEAN, "security-auditor trust-chain trigger; regression-free; correct"),
+    ("R19", 787, "Rex", "final",   [2, 4, 4, 4], GOOD_CLEAN, "isolated-builds rule; wiring guard passes; correct"),
+]
+
+
+def judge(row):
+    return sum(row[4])  # row = (id, pr, reviewer, commit, dims, outcome, note)
+
+
+def concordance(rows):
+    """Goodman-Kruskal style: over all pairs with DIFFERENT outcome ranks,
+    fraction where the higher-outcome review also has the higher judge score."""
+    conc = disc = tie = 0
+    inversions = []
+    for a, b in combinations(rows, 2):
+        oa, ob = a[5], b[5]
+        if oa == ob:
+            continue
+        ja, jb = judge(a), judge(b)
+        better = a if oa > ob else b       # the one that SHOULD score higher
+        worse = b if oa > ob else a
+        jb_better, jb_worse = judge(better), judge(worse)
+        if jb_better > jb_worse:
+            conc += 1
+        elif jb_better < jb_worse:
+            disc += 1
+            inversions.append((worse, better))  # worse-outcome outscored better-outcome
+        else:
+            tie += 1
+    gamma = (conc - disc) / (conc + disc) if (conc + disc) else 0.0
+    return conc, disc, tie, gamma, inversions
+
+
+def main():
+    rows = DATA
+    print(f"Labeled review units: {len(rows)}\n")
+    print(f"{'ID':<4}{'PR':<5}{'rev':<9}{'judge/16':<9}{'outcome':<12}note")
+    for r in sorted(rows, key=lambda x: (-judge(x), x[5])):
+        print(f"{r[0]:<4}{r[1]:<5}{r[2]:<9}{judge(r):<9}{OUTCOME_NAME[r[5]]:<12}{r[6][:60]}")
+
+    by = {2: [], 1: [], 0: []}
+    for r in rows:
+        by[r[5]].append(judge(r))
+    print("\nMean judge score by outcome class:")
+    for k in (2, 1, 0):
+        s = by[k]
+        print(f"  {OUTCOME_NAME[k]:<12} n={len(s):<3} mean={mean(s):.2f}  range={min(s)}-{max(s)}")
+
+    conc, disc, tie, gamma, inv = concordance(rows)
+    print(f"\nPairwise concordance (different-outcome pairs only):")
+    print(f"  concordant={conc}  discordant={disc}  tied={tie}")
+    print(f"  Goodman-Kruskal gamma = {gamma:.2f}   (1.0=perfect, 0=chance, -1=inverted)")
+
+    print(f"\nDiscordant pairs (worse OUTCOME scored >= better outcome by the judge) "
+          f"= false-confidence cases:")
+    for worse, better in inv:
+        print(f"  judge scored {worse[0]}({OUTCOME_NAME[worse[5]]},{judge(worse)}) "
+              f">= {better[0]}({OUTCOME_NAME[better[5]]},{judge(better)})")
+
+    # The specifically load-bearing test: can the judge separate CORRECT approvals
+    # from WRONG approvals? (i.e. among APPROVED reviews, GOOD_CLEAN vs MISS)
+    approvals = [r for r in rows if r[5] in (GOOD_CLEAN, MISS)]
+    clean = [judge(r) for r in approvals if r[5] == GOOD_CLEAN]
+    miss = [judge(r) for r in approvals if r[5] == MISS]
+    print("\nLOAD-BEARING SUB-TEST — among APPROVED reviews, can the rubric tell "
+          "correct from wrong?")
+    print(f"  GOOD_CLEAN (correct approve) mean={mean(clean):.2f} range={min(clean)}-{max(clean)}")
+    print(f"  MISS       (wrong approve)   mean={mean(miss):.2f} range={min(miss)}-{max(miss)}")
+    top_miss = max(miss)
+    beaten = [j for j in clean if j < top_miss]
+    print(f"  -> the single most-fluent MISS scored {top_miss}/16, HIGHER than "
+          f"{len(beaten)}/{len(clean)} genuinely-correct approvals.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Verdict up front: PROVEN-WITH-CAVEATS — and the caveat is the whole point for #824.** A rubric scored against review *text* rank-orders reviews roughly in line with real outcomes in aggregate (Goodman-Kruskal gamma = **0.83**, n = 19 real review units from 15 merged PRs), which *looks* like a green light. But that number is a mirage from the easy end of the distribution.
- **The load-bearing test collapses.** On the one job `/eval-agents` exists to do — decide whether an *approval* was justified — the rubric is at chance: a correct approval means **14.00/16**, a wrong approval **13.67/16**, indistinguishable. The single most fluent wrong-approval in the corpus (PR #792, Rex re-review @ `2ce6708`, which missed a BLOCKING gate-bypass Hakim caught at the same commit) scored **15/16**, beating 7 of 10 genuinely-correct approvals.
- **Why it matters for #824:** a text-only LLM-judge rubber-stamps *fluent-but-wrong* reviews — the exact failure mode a weak review model produces and the exact thing the feature is meant to catch. Root cause: for an APPROVED review, engagement/calibration/FP-discipline are high whether or not the approval was right; only the "catch" dimension discriminates, and it is zero-information when no blocking issue was flagged.
- **Recommendation: PROCEED, but adjust the methodology.** The judge must be an *independent reviewer of the diff* (oracle/reference review, or a stronger model actually re-checking the code), scored on defects-found-vs-missed against ground truth — not a prose-rater. In this corpus the only thing that reliably caught the misses was a *second independent review of the same commit*; that is the shape to emulate. Build the gold set from re-review disagreements + `fix(#...)`-on-same-file escapes; report approve-precision, never the blended concordance that hid the failure at 0.83. If only a text-rubric judge is affordable, the honest call is stop.
- Deliverable: `docs/spike-825/findings.md` (full write-up: labeled set, rubric, correlation, failure cases, recommendation) + `docs/spike-825/judge_calibration.py` (throwaway harness that encodes the 19 labeled units and computes the concordance).

## Testing

- Ran the harness: `python3 docs/spike-825/judge_calibration.py`. It reproduces gamma = 0.83, the per-class means (GOOD_CATCH 16.00 / GOOD_CLEAN 14.00 / MISS 13.67), the 9 discordant "false-confidence" pairs, and the load-bearing sub-test.
- Ground truth was validated against the repo's own review history: each `MISS` is a commit that a *later or parallel* review of the same commit proved still carried a blocking defect (#792 Rex vs Hakim; #770 initial vs re-review; #767 initial vs re-review), so the outcome labels are anchored to what demonstrably happened, not to my judge scores.
- Spike scope: read-only over merged-PR history; no code paths changed; no agents spawned.

Refs #825

## Glossary

| Term | Definition |
|------|------------|
| LLM-as-judge | Using a language model to score another model's output against a rubric instead of a human grader. Here: scoring review agents' reviews. |
| Ground truth | The real, already-happened outcome used as the answer key — here, whether a posted review's verdict proved correct once a later/parallel review of the same commit weighed in. |
| Load-bearing engagement | A review dimension: did it grapple with the actual risk (fail-open / injection / regression) with independent verification, versus ticking a generic checklist. |
| Concordance | Rank-agreement between two orderings (judge score vs outcome). Reported as Goodman-Kruskal gamma: 1.0 = perfect agreement, 0 = chance, -1 = inverted. |
