### PR TITLE
chore(#829): add hossam-96 to the Contributors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Thanks to everyone who has helped forge ApexYard:
     <td align="center"><a href="https://github.com/AbdElrahmaN31"><img src="https://github.com/AbdElrahmaN31.png?size=100" width="64" alt="AbdElrahmaN31"><br><sub>AbdElrahmaN31</sub></a></td>
     <td align="center"><a href="https://github.com/HishamM1"><img src="https://github.com/HishamM1.png?size=100" width="64" alt="HishamM1"><br><sub>HishamM1</sub></a></td>
     <td align="center"><a href="https://github.com/tifa64"><img src="https://github.com/tifa64.png?size=100" width="64" alt="tifa64"><br><sub>tifa64</sub></a></td>
+    <td align="center"><a href="https://github.com/hossam-96"><img src="https://github.com/hossam-96.png?size=100" width="64" alt="hossam-96"><br><sub>hossam-96</sub></a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Summary
- Adds @hossam-96 to the README `## Contributors` table — credit for the Codex adapter generator (PR #730, AgDR-0088). Per the table's own note, external contributors are added by PR because squash-merges under-count them in GitHub's commit-author graph.

## Testing
- Docs-only change; the new `<td>` mirrors the existing cells (avatar + profile link).

Closes #829.

## Glossary
| Term | Definition |
|------|------------|
| Contributors table | The README's hand-maintained credit list for humans whose work is otherwise hidden by squash-merges. |