### PR TITLE
docs(#834): harness support matrix + docs/harnesses/ index

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ Claude Code is the default driver, but the rules, hooks, and templates are plain
 
 **Proven shipping** TypeScript + AWS Lambda backends, Next.js web apps, Chrome extensions, and native **Swift** macOS desktop apps. The stack is process and guardrails — not a language or framework lock-in.
 
+## Harness support
+
+ApexYard is **built for Claude Code** — that's where the whole experience is native. But its mechanical enforcement layer is **portable bash**, not Claude-Code-specific, so other agent harnesses reach the *same* gates through thin adapters that shell out to the unmodified `.claude/hooks/*.sh` scripts. This is the honest, per-harness "what works where, today" view — no over-claiming an enforcement path that hasn't been live-proven.
+
+| Harness | Advisory governance | Mechanical gates | Status |
+|---------|---------------------|------------------|--------|
+| **Claude Code** | Native — `CLAUDE.md` auto-loads; all rules, skills, agents are first-class | **Enforced live** — bash hooks fire on every tool call | **Native, full experience** |
+| **Codex** | Generated from `.claude/` into `.agents/` + `.codex/` | **Delegated** — generated `.codex/hooks.json` execs the unmodified bash hooks | Adapter **merged** (#730, [AgDR-0088](docs/agdr/AgDR-0088-codex-adapter-generation.md)); live conformance test pending |
+| **pi** (pi.dev) | `AGENTS.md` + `SYSTEM.md` advisory bridge | **Delegated** — one dispatcher extension over the unmodified bash hooks | Adapter **shipped**; live model-turn conformance pending (#815, [AgDR-0082](docs/agdr/AgDR-0082-pi-gate-dispatcher-adapter.md)) |
+| **opencode** | Planned | **Delegated** plugin over the bash hooks (planned) | **Planned** (#821) |
+| **Cursor** | Planned | Generated `.cursor/hooks.json` delegating to the bash hooks (planned) | **Planned** (#831) |
+
+The shared-core reason this works: gates stay portable bash ([AgDR-0086](docs/agdr/AgDR-0086-hooks-stay-bash-not-ported.md)), `.claude/` is the one canonical authoring surface, harnesses are transports (never a second copy of the gate logic), and model tiers resolve through one matrix ([`.claude/harness-models.json`](.claude/harness-models.json), [AgDR-0088](docs/agdr/AgDR-0088-codex-adapter-generation.md)). Full per-harness breakdown, the adapter-authoring pattern for new harnesses, and the rebrand trigger → **[`docs/harnesses/`](docs/harnesses/README.md)**.
+
 ## Codex Adapter
 
 ApexYard can generate a Codex-facing adapter from the canonical `.claude/` runtime:

--- a/docs/codex-adapter.md
+++ b/docs/codex-adapter.md
@@ -4,7 +4,7 @@ ApexYard's canonical runtime still lives in `.claude/`: skills, agents, hooks,
 rules, and hook wiring are authored there first. Codex support is generated from
 that source of truth so the two agent surfaces do not drift by hand.
 
-Decision record: [`AgDR-0088`](agdr/AgDR-0088-codex-adapter-generation.md).
+Decision record: [`AgDR-0088`](agdr/AgDR-0088-codex-adapter-generation.md). For where Codex sits among all supported harnesses (and the shared-core architecture behind every adapter), see the [harness support index](harnesses/README.md).
 
 ## Generate The Adapter
 

--- a/docs/harnesses/README.md
+++ b/docs/harnesses/README.md
@@ -1,0 +1,77 @@
+# Harness support
+
+An **agent harness** is the CLI/IDE runtime that actually drives an ApexYard session — Claude Code, Codex, pi, opencode, Cursor. ApexYard was built for Claude Code first, and Claude Code is still the only harness where the whole experience is native. But the framework's mechanical enforcement layer — the merge gate, ticket-first edits, secrets scanning, red-CI blocking — is **portable bash**, not Claude-Code-specific, so it can be reached from other harnesses through thin adapters. This directory is the honest, per-harness "what works where, today" breakdown.
+
+> **Not a rebrand.** The primary tagline is still **"for Claude Code."** These pages document the engineering reality (a Codex adapter is merged; pi/opencode/Cursor adapters are in flight) without claiming a multi-harness experience the framework hasn't live-proven yet. See [Rebrand trigger](#rebrand-trigger) below for the exact condition that flips the headline.
+
+## Support matrix
+
+Three maturity tiers, so a column says exactly what it means:
+
+- **Native** — the harness runs the full framework as-is, gates enforced live on every tool call.
+- **Adapter — live conformance pending** — an adapter exists and delegates gate decisions to the unmodified bash hooks; the transport is proven by construction/tests, but a live, credentialed end-to-end run (a real model turn actually blocked by a gate) hasn't been recorded yet.
+- **Planned** — scoped in a tracking ticket, adapter not yet shipped.
+
+| Harness | Advisory governance (framing, conventions, roles) | Mechanical gates (merge / ticket-first / secrets / red-CI) | Status |
+|---------|----------------------------------------------------|------------------------------------------------------------|--------|
+| **Claude Code** | Native — `CLAUDE.md` auto-loads at session start; all rules, 65 skills, and 25 agents are first-class | **Enforced live** — the bash hooks fire on `PreToolUse` / `PostToolUse` / `SessionStart` | **Native, full experience** |
+| **Codex** | Generated — `.claude/skills/` → `.agents/skills/`, `.claude/agents/*.md` → `.codex/agents/*.toml` | **Delegated** — generated `.codex/hooks.json` execs the *unmodified* `.claude/hooks/*.sh`; block-on-`exit 2` preserved | **Adapter merged** (#730, [AgDR-0088](../agdr/AgDR-0088-codex-adapter-generation.md)); live Codex-runtime conformance test pending |
+| **pi** (pi.dev) | `AGENTS.md` + `SYSTEM.md` advisory bridge, auto-loaded from cwd (#805) | **Delegated** — one dispatcher extension registers on pi's `tool_call` event and shells out to the *unmodified* bash hooks (#815, [AgDR-0082](../agdr/AgDR-0082-pi-gate-dispatcher-adapter.md)) | **Adapter shipped; live model-turn conformance pending** ([`pi.md`](pi.md)) |
+| **opencode** | Planned — `AGENTS.md` bridge | **Delegated** — plugin over the bash hooks (planned) | **Planned** (#821) |
+| **Cursor** | Planned — `AGENTS.md` / rules bridge | **Delegated** — generated `.cursor/hooks.json` delegating to the bash hooks, native `exit 2` / failClosed (planned) | **Planned** (#831) |
+
+The honest asterisk that applies to **every** non-Claude row: the adapters keep bash as the single source of truth for gate *decisions*, but whether a given harness's live internal event dispatch invokes the hook at the right moment during a real model turn is the last hop each adapter still has to prove with credentials. Codex and pi have the transport proven and tested; the credentialed live run is the open item for both.
+
+## Shared-core architecture
+
+Everything above rests on four load-bearing decisions:
+
+1. **Gates stay portable bash — they are not ported per harness.** The `.claude/hooks/*.sh` scripts (merge gates, red-CI block, ticket-first, secrets/leak-protection) are the framework's security-critical trust chain. Rewriting them in a per-harness language would fork the gate logic and re-trigger a full security review per file. Instead, every harness reaches the *same* unmodified scripts. Rationale and the rejected language-port options: [AgDR-0086](../agdr/AgDR-0086-hooks-stay-bash-not-ported.md).
+2. **`.claude/` is the canonical authoring surface.** Skills, agents, hooks, settings, rules, and templates are authored under `.claude/` first. Adapter surfaces (`.agents/`, `.codex/`, `harness-adapters/pi/`, a future `.cursor/`) are *generated from* or *shell out to* `.claude/` — never a second hand-maintained copy. This is why adding a gate is a one-place change.
+3. **Harnesses are transports, not forks.** An adapter's job is to carry a tool call from the harness's event model into the bash hook's stdin/exit-code contract and back. It carries no governance logic of its own. A bug in an adapter can fail to *invoke* a gate; it cannot silently *change* a gate's decision, because the decision lives in bash.
+4. **Model tiers resolve through one matrix.** Framework agent frontmatter uses Claude model-tier labels (`opus` / `sonnet` / `haiku`). Each harness maps those to its own concrete models via a single file, [`.claude/harness-models.json`](../../.claude/harness-models.json) — the Codex adapter reads the `codex` column; a pi/opencode adapter adds its own column rather than hardcoding a second mapping. Per [AgDR-0087](../agdr/AgDR-0087-reasoning-agents-require-frontier-model.md), each harness's `opus` row must stay on that harness's strongest available model — the reasoning-layer reviewers (Rex, Hakim, Tariq, Naqid) have a frontier-model floor and are never downgraded when a harness is added. See [AgDR-0088](../agdr/AgDR-0088-codex-adapter-generation.md) for how the Codex generator consumes the matrix.
+
+The upshot: mechanical governance is model- and harness-agnostic and self-hostable, while review *depth* keeps a frontier-model floor. Those two facts are decided in AgDR-0086/0087/0088 and 0082, not asserted here.
+
+## Per-harness pages
+
+### Claude Code
+
+The default and reference harness. No adapter page — the whole repo is its documentation. `CLAUDE.md` is the entry point; the [`.claude/` integration model](../getting-started.md) explains how hooks, agents, and skills wire together.
+
+### Codex
+
+Adapter **merged**. The generator (`bin/sync-codex-adapter.sh`) emits Codex-facing skills, agents, and hook wiring from `.claude/`, with the generated `hooks.json` delegating gate execution to the unmodified bash hooks. Full generate / drift-check / tracking-policy workflow: **[`docs/codex-adapter.md`](../codex-adapter.md)** (kept at its existing path; linked, not moved). Decision record: [AgDR-0088](../agdr/AgDR-0088-codex-adapter-generation.md).
+
+### pi (pi.dev)
+
+Adapter **shipped**; live model-turn conformance is the open item. pi is a deliberately minimal harness — no `CLAUDE.md` auto-load, no hook plumbing, no slash-command runner — so ApexYard supplies both halves of governance: the *instructions* via the `AGENTS.md` / `SYSTEM.md` advisory bridge, and the *mechanical gates* via a single dispatcher extension (`harness-adapters/pi/`) that shells out to the same bash hooks. Full today-vs-not-yet breakdown, install shape, and the one remaining verification gap: **[`pi.md`](pi.md)**. Decision record: [AgDR-0082](../agdr/AgDR-0082-pi-gate-dispatcher-adapter.md).
+
+### opencode
+
+**Planned** — tracked by **#821**. A spike proved the adapter-over-bash pattern viable for opencode; the shipped adapter will be a plugin that maps opencode's tool-call events to the bash hooks' stdin/exit-code contract, same shape as the pi dispatcher. No adapter code in-repo yet.
+
+### Cursor
+
+**Planned** — tracked by **#831**. Cursor supports repo-local hooks with native `exit 2` blocking, so the adapter will *generate* a `.cursor/hooks.json` (the declarative shape, like Codex) that delegates to the bash hooks with failClosed semantics. No adapter code in-repo yet.
+
+## Adapter-authoring pattern for future harnesses
+
+Every adapter answers the same question — *how does this harness let a pre-tool gate block an action, and how do I route that to the bash hooks without duplicating their logic?* Two shapes have emerged, chosen by how the target harness consumes hook configuration:
+
+- **Declarative-generate** — for harnesses that read a static hook-config file (Codex's `.codex/hooks.json`, Cursor's `.cursor/hooks.json`). Write a generator that reads `.claude/settings.json` + `.claude/agents/*` and emits the harness's native config, with each `command` still exec'ing the unmodified `.claude/hooks/*.sh`. Compile any Claude-Code-specific handler metadata (e.g. handler-level `if` predicates) into a shell-side preflight in the generated command. Ship the *generator and its tests* as the durable contribution; treat the generated tree as regenerable output. Reference: the Codex generator (`bin/sync-codex-adapter.sh`, [AgDR-0088](../agdr/AgDR-0088-codex-adapter-generation.md)).
+- **Live extension** — for harnesses with an imperative plugin/extension API (pi's `tool_call` event; opencode's plugin hooks). Write one dispatcher extension driven by a gate table: on each tool call, reconstruct the exact stdin JSON the bash hook expects, spawn the hook, and map its exit code (`2` = block, `0` = allow) to the harness's block/allow return contract. One dispatcher, N gates as data rows — adding a gate is a table entry, not a new file. Reference: the pi dispatcher (`harness-adapters/pi/src/gate-dispatcher.ts`, [AgDR-0082](../agdr/AgDR-0082-pi-gate-dispatcher-adapter.md)).
+
+In both shapes the non-negotiable is the same: **bash owns every gate decision.** The adapter is the wire, never the judge. And both shapes carry the same last-mile obligation — a live, credentialed end-to-end run proving the harness invokes the gate at the right moment during a real model turn, not just a by-construction test of the transport.
+
+## Rebrand trigger
+
+The headline stays **"for Claude Code"** until this condition is met, verbatim:
+
+> The headline flips to harness-neutral only when **≥2 adapters have live end-to-end conformance proof** (then the site + channel positioning follow in a coordinated pass).
+
+"Live end-to-end conformance proof" means the credentialed run described above: a real model turn under that harness actually blocked by a gate (e.g. an unreviewed merge refused), not a mock or a by-construction test. Today zero adapters have cleared that bar — Codex and pi have the transport proven but the credentialed live run pending — so the framework describes itself as multi-harness *in engineering terms* while keeping the Claude-Code tagline. When the second adapter records that proof, the site (yard.apexscript.com) and channel positioning move in one coordinated pass, not piecemeal.
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/docs/harnesses/README.md
+++ b/docs/harnesses/README.md
@@ -35,25 +35,13 @@ The upshot: mechanical governance is model- and harness-agnostic and self-hostab
 
 ## Per-harness pages
 
-### Claude Code
+Each harness has a dedicated page with a consistent skeleton — status, what's enforced vs advisory today, how the transport works, how to install/generate, gaps + tracking, and related AgDRs.
 
-The default and reference harness. No adapter page — the whole repo is its documentation. `CLAUDE.md` is the entry point; the [`.claude/` integration model](../getting-started.md) explains how hooks, agents, and skills wire together.
-
-### Codex
-
-Adapter **merged**. The generator (`bin/sync-codex-adapter.sh`) emits Codex-facing skills, agents, and hook wiring from `.claude/`, with the generated `hooks.json` delegating gate execution to the unmodified bash hooks. Full generate / drift-check / tracking-policy workflow: **[`docs/codex-adapter.md`](../codex-adapter.md)** (kept at its existing path; linked, not moved). Decision record: [AgDR-0088](../agdr/AgDR-0088-codex-adapter-generation.md).
-
-### pi (pi.dev)
-
-Adapter **shipped**; live model-turn conformance is the open item. pi is a deliberately minimal harness — no `CLAUDE.md` auto-load, no hook plumbing, no slash-command runner — so ApexYard supplies both halves of governance: the *instructions* via the `AGENTS.md` / `SYSTEM.md` advisory bridge, and the *mechanical gates* via a single dispatcher extension (`harness-adapters/pi/`) that shells out to the same bash hooks. Full today-vs-not-yet breakdown, install shape, and the one remaining verification gap: **[`pi.md`](pi.md)**. Decision record: [AgDR-0082](../agdr/AgDR-0082-pi-gate-dispatcher-adapter.md).
-
-### opencode
-
-**Planned** — tracked by **#821**. A spike proved the adapter-over-bash pattern viable for opencode; the shipped adapter will be a plugin that maps opencode's tool-call events to the bash hooks' stdin/exit-code contract, same shape as the pi dispatcher. No adapter code in-repo yet.
-
-### Cursor
-
-**Planned** — tracked by **#831**. Cursor supports repo-local hooks with native `exit 2` blocking, so the adapter will *generate* a `.cursor/hooks.json` (the declarative shape, like Codex) that delegates to the bash hooks with failClosed semantics. No adapter code in-repo yet.
+- **[Claude Code](claude-code.md)** — Native, full experience. The reference harness: `CLAUDE.md` auto-load, hooks firing live, slash-command skills, sub-agents, session markers. Install pointer: [`docs/getting-started.md`](../getting-started.md).
+- **[Codex](codex.md)** — Adapter **merged** (#730). Generated from `.claude/`; gates delegate to the unmodified bash hooks, exit-2 fidelity proven in-repo; live Codex-runtime conformance pending. Full workflow in [`docs/codex-adapter.md`](../codex-adapter.md) (linked, not moved).
+- **[pi (pi.dev)](pi.md)** — Adapter **shipped** (`harness-adapters/pi/`, #815). A single dispatcher extension shells out to the bash hooks; the `AGENTS.md`/`SYSTEM.md` advisory bridge works today; live model-turn conformance is the open item.
+- **[opencode](opencode.md)** — **In progress** (#821). Intended shape: a TypeScript plugin over the unmodified bash hooks with `settings.json`-derived gates. Not shipped yet.
+- **[Cursor](cursor.md)** — **In progress** (#831). Intended shape: a generated `.cursor/hooks.json` delegating to the bash hooks, native `exit 2`, failClosed on security-critical gates. Not shipped yet.
 
 ## Adapter-authoring pattern for future harnesses
 

--- a/docs/harnesses/claude-code.md
+++ b/docs/harnesses/claude-code.md
@@ -1,0 +1,40 @@
+# Harness support — Claude Code
+
+**Status:** Native — the reference harness. Full experience, gates enforced live.
+
+Claude Code is the harness ApexYard was built for, and the only one where nothing is adapted: `CLAUDE.md` auto-loads at session start, the bash hooks fire on real tool calls, skills are typed slash commands, and agents spawn with their own tool restrictions. Everything the other harness pages describe as "delegated" or "planned" is simply *native* here.
+
+## What "full experience" concretely means
+
+- **`CLAUDE.md` auto-load** — the Chief-of-Staff framing, SDLC, workflow gates, and the `@.claude/rules/*.md` imports are loaded into every session without any manual step.
+- **Mechanical gates fire on every tool call** — the `.claude/hooks/*.sh` scripts wire to `PreToolUse` / `PostToolUse` / `SessionStart` via `.claude/settings.json` and block (exit 2) or advise (exit 0) in real time.
+- **Slash-command skills** — each `.claude/skills/<name>/SKILL.md` is a typed `/command` (e.g. `/start-ticket`, `/decide`, `/code-review`, `/approve-merge`).
+- **Sub-agents** — Rex (code review), Hakim (security), Tariq (design review), Naqid (the contrarian), plus the department personas, each spawned via the `Agent` tool with role-scoped tools.
+- **Session markers + memory** — review approvals live under `.claude/session/reviews/*.approved`; the ops-root session pin (`~/.claude/apexyard/ops-root-<session>`) protects against wrong-fork resolution (apexyard#381); per-project auto-memory persists across sessions.
+
+## What's enforced vs advisory today
+
+**Mechanically enforced (blocking):** the two-marker merge gate (Rex + CEO), red-CI merge block, ticket-first edits, migration-ticket-first edits, design-review gate for UI PRs, architecture-review gate for design-artifact PRs, secrets scanning, private-ref leak protection, branch-name and PR-title validation, and AgDR-for-architecture-change prompts.
+
+**Advisory (non-blocking reminders):** role-trigger banners (`detect-role-trigger.sh`), upstream-drift notices, MCP-reindex-after-clone/-pull nudges, and the self-discipline rules (plan mode, parallel-work/fan-out offers, loop mode, reporting style).
+
+## How it works (transport)
+
+There is no transport layer — Claude Code *is* the runtime the other adapters shell out to. The hooks read tool-call JSON on stdin, decide, and return an exit code Claude Code honors directly. `.claude/` is the canonical authoring surface for every other harness precisely because it is executed natively here.
+
+## How to install
+
+Fork `me2resh/apexyard`, clone it, run `/setup`, and register projects with `/handover`. The `.claude/` directory is picked up automatically. Full walkthrough: [`docs/getting-started.md`](../getting-started.md); portfolio model: [`docs/multi-project.md`](../multi-project.md).
+
+## Gaps + tracking
+
+None specific to Claude Code — it is the feature-complete baseline. The one cross-cutting limitation is OS-level: on Windows the hooks require Git Bash / WSL (a documented prerequisite, not a silent failure — see [AgDR-0086](../agdr/AgDR-0086-hooks-stay-bash-not-ported.md)).
+
+## Related AgDRs
+
+- [AgDR-0086](../agdr/AgDR-0086-hooks-stay-bash-not-ported.md) — hooks stay bash; other OSes/harnesses reach them via adapters
+- [AgDR-0087](../agdr/AgDR-0087-reasoning-agents-require-frontier-model.md) — reasoning-layer reviewers keep a frontier-model floor
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/docs/harnesses/codex.md
+++ b/docs/harnesses/codex.md
@@ -1,0 +1,45 @@
+# Harness support — Codex
+
+**Status:** Adapter **merged** (#730, [AgDR-0088](../agdr/AgDR-0088-codex-adapter-generation.md)); live Codex-runtime conformance test pending.
+
+Codex support is **generated** from the canonical `.claude/` runtime rather than hand-maintained, so the two agent surfaces can't drift by hand. This page is the short orientation; the full generate / drift-check / tracking-policy workflow lives in **[`docs/codex-adapter.md`](../codex-adapter.md)** (kept at its existing path — linked here, not duplicated or moved).
+
+## What's enforced vs advisory today
+
+**Delegated (blocking, by construction):** the generated `.codex/hooks.json` keeps the commands that exec the *unmodified* `.claude/hooks/*.sh`. A `PreToolUse` gate that exits `2` blocks the action under Codex the same way it does under Claude Code — the merge gate, red-CI block, ticket-first, secrets/leak-protection, and the review gates all run the same audited bash. The adapter's in-repo test (`.claude/hooks/tests/test_sync_codex_adapter.sh`) proves the generated command path preserves the hook stdin and exit-code contract across the adapter boundary (block on `exit 2`, allow on `exit 0`, skip on a non-matching predicate).
+
+**Advisory:** the generated skills/agents carry the same guidance content as Claude Code's, but Claude-Code-specific advisory banners (role triggers, drift notices) are not part of Codex's documented hook shape.
+
+## How it works (transport)
+
+`bin/sync-codex-adapter.sh` emits:
+
+- `.claude/skills/` → `.agents/skills/` (rewriting only the skill path references)
+- `.claude/agents/*.md` → `.codex/agents/*.toml`, translating model-tier labels via the shared [`.claude/harness-models.json`](../../.claude/harness-models.json) matrix (`opus`→`gpt-5.5`, `sonnet`→`gpt-5.4`, `haiku`→`gpt-5.4-mini`)
+- `.claude/settings.json` → `.codex/hooks.json`, preserving the commands that exec `$r/.claude/hooks/*.sh`
+
+It deliberately does **not** copy the hooks, rules, migrations, or registries into `.codex/` — those stay canonical under `.claude/`. Claude Code's handler-level `if` predicates (not part of Codex's documented hook shape) are compiled into the generated shell command as a preflight filter.
+
+## How to generate
+
+```bash
+bin/sync-codex-adapter.sh            # generate the adapter
+bin/sync-codex-adapter.sh --check    # verify generated files still match .claude/ (non-zero on drift)
+bin/sync-codex-adapter.sh --clean    # remove generated .agents/ and .codex/ trees before regenerating
+```
+
+Tracking policy, gitignore guidance, and CI `--check` enforcement: [`docs/codex-adapter.md`](../codex-adapter.md).
+
+## Gaps + tracking
+
+The one honest gap is **live Codex-runtime conformance**: the in-repo bash test proves command delegation and exit-code preservation, but a credentialed, model-driven Codex turn *actually* being blocked by a gate has not been recorded yet — that depends on Codex loading trusted project hooks and invoking matching hook events as documented. This is the same last-mile asterisk every non-Claude adapter carries, and it is exactly the bar the [rebrand trigger](README.md#rebrand-trigger) requires ≥2 adapters to clear.
+
+## Related AgDRs
+
+- [AgDR-0088](../agdr/AgDR-0088-codex-adapter-generation.md) — Codex adapter generation; delegate gates to the `.claude/` runtime
+- [AgDR-0086](../agdr/AgDR-0086-hooks-stay-bash-not-ported.md) — hooks stay bash (the source of truth the adapter execs)
+- [AgDR-0087](../agdr/AgDR-0087-reasoning-agents-require-frontier-model.md) — frontier-model floor for reviewer roles (why the label mapping keeps `opus` on Codex's strongest model)
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/docs/harnesses/cursor.md
+++ b/docs/harnesses/cursor.md
@@ -1,0 +1,34 @@
+# Harness support — Cursor
+
+**Status:** In progress — tracked by **#831**. Adapter being built now. Not shipped yet.
+
+Cursor is an IDE-based agent harness that supports repo-local hooks with native `exit 2` blocking. That makes it a natural fit for the **declarative-generate** adapter shape (the same family as the Codex adapter): ApexYard generates a Cursor-native hook config that delegates every gate decision to the unmodified `.claude/hooks/*.sh`. This page describes the *intended* shape; nothing here is claimed as done.
+
+## What's enforced vs advisory today
+
+**Today:** nothing mechanical under Cursor yet — the generator isn't shipped. A Cursor user gets ApexYard's **advisory** governance now via the repo's `AGENTS.md` (which Cursor auto-loads) plus the rules and skills as plain markdown.
+
+**Intended (once #831 lands):** the delegated gate set the Codex and pi adapters already enforce — the two-marker merge gate, red-CI block, design/architecture review gates, secrets/leak-protection, and ticket-first / migration-ticket-first edit blocking — each decided by the canonical bash hook. Security-critical gates are intended to **failClosed** (block if the hook can't run), not fail open.
+
+## How it works (transport)
+
+Intended shape: a generator emits a **`.cursor/hooks.json`** from `.claude/settings.json`, with each hook `command` exec'ing the unmodified `.claude/hooks/*.sh`. Cursor's native `exit 2` blocking maps directly to the hooks' existing block contract, so no exit-code translation layer is needed — the fidelity Codex's adapter proves in-repo carries over. This is the **declarative-generate** pattern from the [harness index](README.md#adapter-authoring-pattern-for-future-harnesses): the durable contribution is the generator + its tests, and the generated `.cursor/` tree is regenerable output.
+
+## How to install / generate
+
+Not applicable yet. Generate instructions will ship with the adapter under **#831** (which will add `docs/cursor-adapter.md` and a dedicated AgDR). This page will link to those once merged.
+
+## Gaps + tracking
+
+- **The generator itself** — emitting `.cursor/hooks.json` and its drift-check — is unbuilt on `main`/`dev` today. Tracked as **#831**.
+- **Live model-turn conformance** — proving a real, credentialed Cursor turn is actually blocked by a gate (not just a generated-config test) will be an explicit AC on #831.
+
+## Related AgDRs
+
+- [AgDR-0088](../agdr/AgDR-0088-codex-adapter-generation.md) — the Codex generator, the declarative-generate precedent this adapter follows
+- [AgDR-0086](../agdr/AgDR-0086-hooks-stay-bash-not-ported.md) — hooks stay bash; harnesses reach them via adapters
+- A dedicated Cursor-adapter AgDR will be added by **#831**.
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/docs/harnesses/opencode.md
+++ b/docs/harnesses/opencode.md
@@ -1,0 +1,34 @@
+# Harness support — opencode
+
+**Status:** In progress — tracked by **#821**. Spike proved the adapter-over-bash pattern viable; the adapter is being built now. Not shipped yet.
+
+opencode is a plugin-extensible agent harness. ApexYard's opencode support follows the same principle as every other adapter: **bash owns the gate decisions**, and a thin opencode-native layer carries each tool call into the unmodified `.claude/hooks/*.sh` scripts. This page describes the *intended* shape so adopters know what's coming; it deliberately claims nothing as done.
+
+## What's enforced vs advisory today
+
+**Today:** nothing mechanical under opencode yet — the plugin isn't shipped. An opencode user gets ApexYard's **advisory** governance now by reading the repo's `AGENTS.md` (the universal entry doc harnesses like Cursor/Aider/Cline/pi auto-load) plus the rules and skills as plain markdown.
+
+**Intended (once #821 lands):** the same delegated gate set the pi and Codex adapters enforce — the two-marker merge gate, red-CI block, design/architecture review gates, secrets/leak-protection, and ticket-first / migration-ticket-first edit blocking — with each decision made by the canonical bash hook, not re-implemented in the plugin.
+
+## How it works (transport)
+
+Intended shape: a **TypeScript plugin** registered on opencode's tool-call hook that, for each matching tool call, reconstructs the stdin JSON the bash hook expects, spawns the unmodified hook, and maps its exit code (`2` = block, `0` = allow) to opencode's block/allow contract. The gate set is **derived from `.claude/settings.json`'s hook wiring** — the same "one config, two harnesses" property the pi dispatcher has — so adding a gate stays a one-place change rather than a per-harness edit. This is the **live-extension** adapter shape described in the [harness index](README.md#adapter-authoring-pattern-for-future-harnesses), mirroring the pi dispatcher.
+
+## How to install / generate
+
+Not applicable yet. Install instructions will ship with the adapter under **#821** (which will add `docs/opencode-adapter.md` and a dedicated AgDR). This page will link to those once merged.
+
+## Gaps + tracking
+
+- **The adapter itself** — the plugin, its gate table, and ops-root resolution — is unbuilt on `main`/`dev` today. Tracked as **#821**.
+- **Live model-turn conformance** — the same last-mile asterisk as every adapter: proving a real, credentialed opencode turn is actually blocked by a gate (not just a by-construction transport test) will be an explicit AC on #821.
+
+## Related AgDRs
+
+- [AgDR-0082](../agdr/AgDR-0082-pi-gate-dispatcher-adapter.md) — the pi gate-dispatcher, the live-extension precedent this adapter follows
+- [AgDR-0086](../agdr/AgDR-0086-hooks-stay-bash-not-ported.md) — hooks stay bash; harnesses reach them via adapters
+- A dedicated opencode-adapter AgDR will be added by **#821**.
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/docs/harnesses/pi.md
+++ b/docs/harnesses/pi.md
@@ -1,5 +1,7 @@
 # Harness support — pi (pi.dev)
 
+**Status:** Adapter **shipped** (`harness-adapters/pi/`, #815, [AgDR-0082](../agdr/AgDR-0082-pi-gate-dispatcher-adapter.md)); the one open item is a live, credentialed model-turn actually triggering the gate adapter (#815 § "Known gaps").
+
 apexyard's governance was built for Claude Code first: `CLAUDE.md` is auto-loaded at session start, `.claude/hooks/*.sh` mechanically enforce the merge gate / ticket-first / secrets-scan rules, and `.claude/skills/*.md` become typed slash commands. **pi** (pi.dev — Earendil's minimal, unopinionated agent CLI) is a deliberately different shape: no `CLAUDE.md`-style auto-load, no hook plumbing, no MCP, no slash-command runner, no plan mode, no background bash, no permission popups. Pi pushes that governance layer to user-installed packages instead of building it in. **apexyard is exactly that layer for a pi user.**
 
 This doc is the honest today-vs-not-yet breakdown for running apexyard-governed work under pi — updated as of me2resh/apexyard#815, which closes the mechanical-enforcement gap this doc used to list under "not yet". See me2resh/apexyard#805 (the `AGENTS.md` advisory bridge), me2resh/apexyard#804 (the spike that proved the enforcement pattern viable), and me2resh/apexyard#815 (the shipped adapter).


### PR DESCRIPTION
## Summary

- **README harness support matrix** — a new "Harness support" section right after the pitch gives non-Claude users an honest, at-a-glance read on whether the framework reaches them, without over-claiming. Claude Code is native (gates enforced live); Codex is an adapter merged (#730, generated from `.claude/`, live conformance pending); pi has a shipped dispatcher extension (live model-turn conformance pending); opencode (#821) and Cursor (#831) are planned. **"for Claude Code" stays the primary tagline** — this is a docs pass, not a rebrand.
- **New `docs/harnesses/README.md` index** — the shared-core architecture note that makes multi-harness possible: gates stay portable bash (AgDR-0086), `.claude/` is the one canonical authoring surface, harnesses are transports (never a second copy of gate logic), and model tiers resolve through one matrix (`.claude/harness-models.json`, AgDR-0088). Includes per-harness pages (Codex links to the existing `docs/codex-adapter.md`, which stays put; pi links to `pi.md`; opencode/Cursor are stub paragraphs pointing at their tickets) and the **adapter-authoring pattern** for future harnesses — declarative-generate for harnesses that read a static hook config (Codex, Cursor) vs. live extension for imperative plugin APIs (pi, opencode).
- **Rebrand trigger recorded verbatim** — the headline flips to harness-neutral only when ≥2 adapters have live end-to-end conformance proof, then the site + channel positioning follow in a coordinated pass. Every enforcement claim is grounded in AgDR-0082/0086/0087/0088 — nothing asserts a gate is live-proven that isn't.
- **Reciprocal cross-link** added from `docs/codex-adapter.md` back to the harness index so the two adapter docs point at each other.

Docs-only; no code, no AgDR needed. Does **not** touch `.claude/harness-models.json`.

## Testing

1. `npx markdownlint-cli2 README.md docs/harnesses/README.md docs/codex-adapter.md` → 0 errors (also enforced by the pre-push gate).
2. Read the README "Harness support" section — matrix renders, links resolve to the four AgDRs and the harness index.
3. Read `docs/harnesses/README.md` — every AgDR/ticket reference resolves; the rebrand trigger is quoted verbatim.

Closes #834

---

## Glossary

| Term | Definition |
|------|------------|
| Harness | The agent CLI/IDE runtime that drives an ApexYard session — Claude Code, Codex, pi, opencode, Cursor. |
| Adapter | A thin transport layer that carries a harness's tool call into the bash hooks' stdin/exit-code contract and back — it carries no gate logic of its own. |
| Delegated gate | A gate whose *decision* runs in the unmodified `.claude/hooks/*.sh`; the harness adapter only invokes it, never re-implements it. |
| Declarative-generate | Adapter shape for harnesses that read a static hook-config file (Codex `.codex/hooks.json`, Cursor `.cursor/hooks.json`) — a generator emits that config from `.claude/`. |
| Live extension | Adapter shape for harnesses with an imperative plugin API (pi's `tool_call` event) — one dispatcher extension shells out to the bash hooks. |
| Live conformance proof | A credentialed, real model turn under a harness actually blocked by a gate — the bar the rebrand trigger requires (not a by-construction test). |
| Rebrand trigger | The documented condition (≥2 live-proven adapters) for flipping the headline from "for Claude Code" to harness-neutral. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAQ1mgxusECbQaRAdiBwRj