### PR TITLE
chore(#833): eval-agents hardening follow-ups from the #828 reviews

### DIFF
--- a/.claude/skills/eval-agents/SKILL.md
+++ b/.claude/skills/eval-agents/SKILL.md
@@ -30,11 +30,23 @@ Full rationale: [AgDR-0089](../../../docs/agdr/AgDR-0089-eval-agents-methodology
 
 `<agent>` is one of `rex`, `hakim`, `tariq` — the three review agents that produce a verdict over a diff and share the `APPROVED / CHANGES REQUESTED / COMMENT` vocabulary. **Naqid is out of scope for v1** (it challenges premises, not diffs — no defect-set structure to score against; see AgDR-0089 § Decision point 7).
 
+**`--suggest-entries` is not implemented.** #833 scoped an optional corpus-growth-assist mode that would mine `gh` PR/review history for re-review disagreements and escaped-bug patterns (the same shape `docs/eval-agents/README.md` § "Growing the corpus" describes doing by hand) and propose candidate entries for human confirmation. Investigating this against #833's "keep it small or split it out" instruction: `docs/spike-825/judge_calibration.py` — the file #833 named as the source to lift mining logic from — turns out to hold a hand-curated data table of 19 review units the spike's author read and classified manually, not a reusable scan/detect routine; there is no existing mining logic to lift. Building a real one (walking PR review threads via `gh api`, correlating approve→later-CHANGES_REQUESTED and merge→next-commit-touches-same-files patterns, then shaping matches into draft `ground_truth_defects`) is a genuine new feature, not a hardening follow-up, so it's left for a separate ticket rather than folded in here.
+
 ## Safety — the agent-under-test never touches a live PR
 
 This is the load-bearing safety property of the whole skill. The real review agents are hard-wired (`.claude/agents/code-reviewer.md` § "HARD STOP" and the equivalent sections in `security-reviewer.md` / `solution-architect.md`) to fetch a live PR, post a real GitHub review comment, and write a real approval marker. An eval run that spawned one of these agents against a real historical PR number would spam an already-merged PR with an eval-only comment and pollute `.claude/session/reviews/`.
 
 **`/eval-agents` never gives the agent-under-test a PR number, a repo, or a tracker reference.** Every spawn is invoked with a bespoke eval prompt over sanitized, standalone diff text. See Step 3 below.
+
+> ## ⛔ MUST NOT be CI-gated until eval spawns can be tool-restricted
+>
+> **Harness-capability finding (#833, investigated per Hakim's security review of #828):** the strongest version of this mitigation would remove `Bash` from the agent-under-test's spawn entirely — the diff is handed inline in the prompt, so a re-review spawn has no legitimate need for shell access, and removing it converts every contamination vector in this file from "instructed not to" into "cannot." That requires **per-spawn tool subsetting**: the `Agent` tool call that `/eval-agents` issues would need to override the target `subagent_type`'s tool list for just this invocation.
+>
+> **The `Agent` tool does not expose this.** Its parameters are `description`, `isolation`, `model`, `prompt`, `run_in_background`, and `subagent_type` — there is no `tools` / `allowed_tools` override. Tool access is fixed per `subagent_type`, declared in that agent's own definition file (`.claude/agents/code-reviewer.md` etc. carry a `Tools:` frontmatter line), not overridable by the caller. This is the same shape of gap `.claude/rules/agent-role-selection.md` documents for the spawn boundary generally (AgDR-0056: "the current hook plumbing cannot reliably see into a sub-agent boundary") — here it's the tool *grant*, not a hook, that the spawn boundary can't touch.
+>
+> A heavier alternative exists — ship dedicated, Bash-free eval-mode agent definitions (`code-reviewer-eval.md` etc.) that `/eval-agents` spawns instead of the real `code-reviewer` / `security-reviewer` / `solution-architect` — but that means forking and hand-maintaining a second copy of each review checklist, which drifts from the real agent over time and is a materially bigger project than this hardening ticket's scope. Left as a follow-up if/when `/eval-agents` needs to move off manual/periodic use.
+>
+> Until per-spawn tool subsetting exists (or the dedicated-agent-definition alternative ships), the two-check contamination backstop in Step 3e (snapshot-diff + text-scan) is a **mitigation, not a hard sandbox** — the agent-under-test retains normal `Bash` access and could in principle still attempt a tracker call. **`/eval-agents` MUST NOT be wired into CI, a merge gate, a pre-commit hook, or any unattended/scheduled run until this gap closes.** Rule 6 below already scopes v1 to manual/periodic use for a different reason (#824's out-of-scope); this finding is an additional, independent reason the same restriction must hold.
 
 ## Process
 
@@ -68,7 +80,7 @@ bash .claude/skills/eval-agents/lib/validate-corpus.sh "$AGENT" "$CORPUS_PATH"
 
 Abort on any schema violation — do not spend a real agent spawn scoring against a malformed corpus. `--check-only` stops here: print the validator's entry-count summary and exit 0.
 
-### Step 3 — Per-entry: resolve diff, sanitize, spawn, score
+### Step 3 — Per-entry: resolve diff, sanitize, snapshot, spawn, score
 
 For each entry in the corpus:
 
@@ -89,7 +101,7 @@ if [ -z "$DIFF_TEXT" ]; then
 fi
 ```
 
-Also capture the changed-file list (`git diff --name-only "$DIFF_RANGE"` or the API equivalent) — needed for the diff-engagement mechanical check in 3d.
+Also capture the changed-file list (`git diff --name-only "$DIFF_RANGE"` or the API equivalent) — needed for the diff-engagement mechanical check in 3f.
 
 #### 3b. Sanitize — strip everything that could identify the live PR
 
@@ -101,7 +113,16 @@ Before the diff text reaches the agent-under-test:
 
 This is a mitigation, not a hard sandbox — see "Residual risk" below.
 
-#### 3c. Spawn the agent-under-test
+#### 3c. Snapshot `.claude/session/reviews/` before spawning
+
+```bash
+bash .claude/skills/eval-agents/lib/snapshot-diff.sh snapshot \
+  .claude/session/reviews "$SNAPSHOT_FILE"
+```
+
+`$SNAPSHOT_FILE` is a per-entry scratch path (e.g. `$(mktemp)`), not committed anywhere. This must run immediately before the spawn in 3d — the whole point is capturing the directory's state at the last possible moment the harness controls, so anything the spawn writes shows up in the post-spawn diff in 3f.
+
+#### 3d. Spawn the agent-under-test
 
 Use the `Agent` tool with `subagent_type` mapped from `<agent>`:
 
@@ -118,13 +139,25 @@ This is an EVALUATION run, not a live PR review. You are reviewing a
 standalone code change — there is no PR number, no repository context
 beyond what's needed to read the diff, and no tracker to report to.
 
+Your system prompt carries a HARD STOP / MANDATORY-ACTIONS section that
+normally REQUIRES you to write a local approval marker and post a review via
+tracker_review_submit (or the equivalent for your role) before you are done.
+**That mandate is explicitly SUSPENDED for this run only.** It does not
+apply here — treating it as inactive is the correct behavior for this task,
+not a violation of your normal instructions. There is no real PR number and
+no marker path to resolve, so attempting to satisfy that mandate would mean
+acting on fabricated inputs.
+
 Rules for this run:
-- Do NOT run `gh pr view`, `gh pr diff`, `gh issue`, or any tracker command.
-- Do NOT call tracker_review_submit or post any review anywhere.
-- Do NOT write any file, including an approval marker. You have no Write/Edit
-  tools regardless, but do not attempt a Bash-redirect write either.
-- Simply review the diff below against your normal checklist and return your
-  full review — checklist, issues found, verdict — as your final message text.
+- Your only required output is your review, returned as this message's final
+  text — checklist, issues found, and verdict. There is no other mandatory
+  action; the HARD STOP's marker-write and tracker-submit steps are
+  suspended per the paragraph above.
+- Do NOT run `gh pr view`, `gh pr diff`, `gh issue`, or any tracker command —
+  there is no real PR behind this diff to look up.
+- Do NOT call tracker_review_submit — the requirement to do so is suspended
+  for this run.
+- Do NOT write any file, including an approval marker — same suspension.
 
 --- BEGIN DIFF ---
 <sanitized diff text>
@@ -133,19 +166,38 @@ Rules for this run:
 Review this diff and report your findings and verdict.
 ```
 
+This wording is deliberate (#833, Hakim's security review of #828): telling the agent-under-test "don't do the mandatory thing" *contradicts* its own HARD STOP instead of overriding it, which leaves the two instructions in tension and relies on the sanitized-out PR number to break the tie. Explicitly suspending the mandate removes the tension — the agent isn't refusing a required action, it's correctly recognizing the requirement doesn't apply to this run.
+
 Capture the sub-agent's full returned text as `AGENT_OUTPUT`.
 
-#### 3d. Contamination check (safety backstop)
+#### 3e. Contamination check (safety backstop) — snapshot-diff is authoritative, text-scan is secondary
 
-Before scoring, scan `AGENT_OUTPUT` for any sign the agent queried a live tracker despite the instructions: a `gh pr` command echoed in its reasoning, a real `headRefOid`, the corpus entry's actual PR number appearing verbatim, or a posted-review confirmation phrase. If found, **discard this run** — mark the entry `CONTAMINATED` in the report and do not fold it into the aggregate scores. This is the backstop for the residual risk noted above: sanitization in 3b is not a hard sandbox (the agent-under-test retains normal `Bash` access), so the harness must be able to notice and discard a leak rather than silently score a compromised run.
+Two independent checks, both run before scoring. Either one flagging is sufficient to discard the run.
 
-#### 3e. Mechanical checks (rule-based, not judgment)
+**Primary — filesystem snapshot-diff (mechanical, cannot be talked around):**
+
+```bash
+if ! bash .claude/skills/eval-agents/lib/snapshot-diff.sh check \
+       .claude/session/reviews "$SNAPSHOT_FILE" > "$DIFF_REPORT"; then
+  # any new / changed / deleted file under .claude/session/reviews/ since 3c
+  # => CONTAMINATED, regardless of what AGENT_OUTPUT narrates
+  ...
+fi
+```
+
+This is the load-bearing fix from #833 (Hakim's security review of #828): the original design scanned `AGENT_OUTPUT`'s *narrated* text for signs of a marker write, which a silent `Bash`-redirect write (`echo ... > .claude/session/reviews/<pr>-rex.approved`) never appears in — the agent doesn't have to say anything about a write it performed for the check to miss it. Snapshot-diff instead asks a question the agent's narration cannot influence: **did any file under `.claude/session/reviews/` actually change on disk between 3c and now?** A write that never gets mentioned in `AGENT_OUTPUT` still shows up as a `NEW` or `CHANGED` line in the diff.
+
+**Secondary — text-scan (catches read-only tracker calls the snapshot can't see):** scan `AGENT_OUTPUT` for any sign the agent queried a live tracker despite the instructions: a `gh pr` command echoed in its reasoning, a real `headRefOid`, the corpus entry's actual PR number appearing verbatim, or a posted-review confirmation phrase. This check still matters because a `gh pr view` (a *read*, not a write) leaves no trace in `.claude/session/reviews/` for the snapshot-diff to catch — the two checks cover disjoint failure modes, not overlapping ones.
+
+If either check flags, **discard this run** — mark the entry `CONTAMINATED` in the report (cite which check fired and, for a snapshot-diff hit, the exact path(s) changed) and do not fold it into the aggregate scores. This is the backstop for the residual risk noted in "Safety" above: sanitization in 3b is not a hard sandbox (the agent-under-test retains normal `Bash` access — see the "MUST NOT be CI-gated" callout in "Safety" for the harness-capability finding on why that access can't currently be removed at spawn time), so the harness must be able to notice and discard a leak rather than silently score a compromised run.
+
+#### 3f. Mechanical checks (rule-based, not judgment)
 
 - `produced_output` — `AGENT_OUTPUT` is non-empty
 - `valid_verdict` — regex-extracts one of `APPROVED`, `CHANGES REQUESTED`, `COMMENT` from a `### Verdict` (or equivalent) section
 - `engaged_diff` — at least one file path mentioned in `AGENT_OUTPUT`'s findings appears in the entry's changed-file list (guards against a generic "looks fine" non-engaged response)
 
-#### 3f. Defect-overlap scoring (the orchestrator's judgment, against a FROZEN key)
+#### 3g. Defect-overlap scoring (the orchestrator's judgment, against a FROZEN key)
 
 For each `ground_truth_defects[]` entry, decide **caught** or **missed**: does `AGENT_OUTPUT`'s findings describe the same substantive problem at (or near) the same location? This is a semantic match performed by whichever model is running `/eval-agents` — it is comparing a candidate answer to an already-fixed answer key, not establishing truth, so it does not trip the self-grading concern AgDR-0089 addresses (that concern is about *who freezes the ground truth*, never about *who checks a candidate against it*).
 
@@ -299,7 +351,7 @@ Override per-project in `.claude/project-config.json` (shallow-merge — overrid
 ## Rules
 
 1. **Ground truth is frozen at corpus-authoring time.** The skill never spawns an "oracle" agent at run time to re-derive truth — see AgDR-0089 for why (no model is credibly stronger than the opus-pinned agents being measured; a dynamic oracle is also non-reproducible, which breaks the regression-detection use case).
-2. **The agent-under-test never sees a live PR number, repo, or tracker reference.** Sanitize before every spawn (Step 3b); run the contamination check after every spawn (Step 3d). No supported invocation path skips this.
+2. **The agent-under-test never sees a live PR number, repo, or tracker reference.** Sanitize before every spawn (Step 3b); snapshot `.claude/session/reviews/` immediately before every spawn (Step 3c); run the two-check contamination gate — snapshot-diff primary, text-scan secondary — after every spawn (Step 3e). No supported invocation path skips this.
 3. **Approve-precision is the headline pass/fail metric.** Never report a single blended score as the verdict.
 4. **Any missed BLOCKING/HIGH ground-truth defect forces WARN**, independent of the aggregate score.
 5. **The 0-4 rubric dimensions are advisory only.** They never gate pass/fail on their own — this is the load-bearing methodology correction from AgDR-0089; do not let a future edit slide the rubric back into being the correctness oracle.
@@ -308,6 +360,7 @@ Override per-project in `.claude/project-config.json` (shallow-merge — overrid
 8. **No ticket creation without explicit operator yes** (Step 9).
 9. **`tariq` requires an explicit `--corpus`** — no starter corpus is seeded for it in v1.
 10. **`naqid` is not a supported `<agent>` value in v1** — see "Usage" above.
+11. **Every score is the output of non-deterministic LLM steps, not a fixed measurement.** Both the candidate spawn (Step 3d) and the defect-overlap match against the frozen key (Step 3g) are judgment calls made by an LLM — the frozen `ground_truth_defects` are fixed, but *matching a fresh run's findings against them* is not a byte-for-byte comparison, and re-running the exact same corpus against the exact same agent can produce a different verdict_justified call on a borderline entry. A score delta between two runs (this week's approve-precision vs. last month's) is **not automatically a real regression** — it can just as easily be run-to-run noise in the matching step. Treat a delta as a prompt to look at *which specific entries* flipped and re-read the agent's actual output for that entry, never as a number to trend-line on its own. This is the same caveat AgDR-0089 and spike #825 already carry for the starter corpus's small N — non-determinism compounds it, it doesn't replace it.
 
 ## Implementation notes
 
@@ -315,7 +368,9 @@ Override per-project in `.claude/project-config.json` (shallow-merge — overrid
 |---|---|
 | `.claude/skills/eval-agents/SKILL.md` | This file — the skill spec |
 | `.claude/skills/eval-agents/lib/validate-corpus.sh` | Schema validator (Step 2 / `--check-only`) |
+| `.claude/skills/eval-agents/lib/snapshot-diff.sh` | Filesystem snapshot/check pair — the Step 3c/3e contamination backstop (#833) |
 | `.claude/skills/eval-agents/tests/smoke.sh` | Validator smoke tests |
+| `.claude/skills/eval-agents/tests/test-snapshot-diff.sh` | Snapshot-diff smoke tests (#833) |
 | `docs/eval-agents/README.md` | Corpus directory overview, what's seeded, how to grow it |
 | `docs/eval-agents/SCHEMA.md` | Field-by-field corpus format |
 | `docs/eval-agents/corpus/rex.json` | Starter corpus — 6 entries |

--- a/.claude/skills/eval-agents/lib/snapshot-diff.sh
+++ b/.claude/skills/eval-agents/lib/snapshot-diff.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# snapshot-diff.sh — filesystem contamination detector for /eval-agents.
+#
+# Snapshots a directory's file set before an agent-under-test spawn, then
+# checks it after. Any new, changed, or deleted file is flagged. This is the
+# authoritative contamination check (SKILL.md Step 3c/3e, #833) — a stronger
+# backstop than scanning the agent's returned text for a marker-write
+# confession, because a silent Bash-redirect write never has to appear in
+# narrated output for this check to catch it.
+#
+# Usage:
+#   snapshot-diff.sh snapshot <dir> <snapshot-file>
+#   snapshot-diff.sh check    <dir> <snapshot-file>
+#
+# `snapshot` records a manifest of <dir>'s current file set (relative path +
+# sha256, one per line, sorted) to <snapshot-file>. `check` re-scans <dir>
+# and reports any file that's NEW, CHANGED (different hash), or DELETED
+# since the snapshot was taken.
+#
+# Exit codes:
+#   0 — no contamination (dir unchanged since snapshot)
+#   1 — contamination detected (each affected path + reason printed to stdout)
+#   2 — usage error (bad args, or `check` with no prior `snapshot`)
+
+set -euo pipefail
+export LC_ALL=C   # deterministic sort/comm collation regardless of locale
+
+MODE="${1:-}"
+DIR="${2:-}"
+SNAPSHOT_FILE="${3:-}"
+
+usage() {
+  echo "usage: snapshot-diff.sh <snapshot|check> <dir> <snapshot-file>" >&2
+  exit 2
+}
+
+[ -n "$MODE" ] && [ -n "$DIR" ] && [ -n "$SNAPSHOT_FILE" ] || usage
+
+sha_of() {
+  # Portable sha256: shasum on macOS, sha256sum on Linux.
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    sha256sum "$1" | awk '{print $1}'
+  fi
+}
+
+manifest_of() {
+  # Emits "<relpath>  <sha256>" for every regular file under $DIR, sorted.
+  # Creates $DIR if missing — a fresh session may have no reviews/ dir yet,
+  # and "the directory doesn't exist" is not itself contamination.
+  mkdir -p "$DIR"
+  find "$DIR" -type f 2>/dev/null | sort | while IFS= read -r f; do
+    rel="${f#"$DIR"/}"
+    echo "$rel  $(sha_of "$f")"
+  done
+}
+
+case "$MODE" in
+  snapshot)
+    manifest_of > "$SNAPSHOT_FILE"
+    ;;
+  check)
+    if [ ! -f "$SNAPSHOT_FILE" ]; then
+      echo "snapshot-diff.sh: no snapshot at $SNAPSHOT_FILE — run 'snapshot' first" >&2
+      exit 2
+    fi
+    CURRENT="$(mktemp)"
+    trap 'rm -f "$CURRENT"' EXIT
+    manifest_of > "$CURRENT"
+
+    if diff -q "$SNAPSHOT_FILE" "$CURRENT" >/dev/null 2>&1; then
+      echo "OK — no changes to $DIR since snapshot"
+      exit 0
+    fi
+
+    echo "CONTAMINATION — $DIR changed since snapshot:"
+    path_in() {
+      # $1 = path, $2 = manifest file — fixed-string match on the "path  " prefix
+      grep -qF "$1  " "$2" 2>/dev/null
+    }
+
+    # Lines only in CURRENT (new content, or a path whose hash changed).
+    comm -13 "$SNAPSHOT_FILE" "$CURRENT" | while IFS= read -r line; do
+      path="${line%%  *}"
+      if path_in "$path" "$SNAPSHOT_FILE"; then
+        echo "  CHANGED: $path"
+      else
+        echo "  NEW:     $path"
+      fi
+    done
+
+    # Lines only in SNAPSHOT and whose path is genuinely gone from CURRENT
+    # (not just hash-changed — that case was already reported as CHANGED above).
+    comm -23 "$SNAPSHOT_FILE" "$CURRENT" | while IFS= read -r line; do
+      path="${line%%  *}"
+      if ! path_in "$path" "$CURRENT"; then
+        echo "  DELETED: $path"
+      fi
+    done
+
+    exit 1
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/.claude/skills/eval-agents/tests/test-snapshot-diff.sh
+++ b/.claude/skills/eval-agents/tests/test-snapshot-diff.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# test-snapshot-diff.sh — smoke tests for the /eval-agents contamination
+# backstop (snapshot-diff.sh, #833).
+# Run: .claude/skills/eval-agents/tests/test-snapshot-diff.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SNAPSHOT_DIFF="$SCRIPT_DIR/../lib/snapshot-diff.sh"
+
+pass=0
+fail=0
+
+check() {
+  local desc="$1" expect_rc="$2"; shift 2
+  "$@" >/tmp/snapshot-diff-test.out 2>&1
+  local rc=$?
+  if [ "$rc" -eq "$expect_rc" ]; then
+    echo "✓ $desc"
+    pass=$((pass + 1))
+  else
+    echo "✗ $desc (expected exit $expect_rc, got $rc)"
+    cat /tmp/snapshot-diff-test.out
+    fail=$((fail + 1))
+  fi
+}
+
+check_output_contains() {
+  local desc="$1" needle="$2"
+  if grep -qF "$needle" /tmp/snapshot-diff-test.out; then
+    echo "✓ $desc"
+    pass=$((pass + 1))
+  else
+    echo "✗ $desc (output did not contain: $needle)"
+    cat /tmp/snapshot-diff-test.out
+    fail=$((fail + 1))
+  fi
+}
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+TARGET="$WORKDIR/reviews"
+SNAP="$WORKDIR/snap.manifest"
+
+mkdir -p "$TARGET"
+echo "existing content" > "$TARGET/keep.txt"
+
+# 1. check with no prior snapshot is a usage error, not a false negative.
+check "check without a prior snapshot fails cleanly" 2 bash "$SNAPSHOT_DIFF" check "$TARGET" "$SNAP"
+
+# 2. snapshot succeeds and check right after reports no contamination.
+check "snapshot succeeds" 0 bash "$SNAPSHOT_DIFF" snapshot "$TARGET" "$SNAP"
+check "check immediately after snapshot is clean" 0 bash "$SNAPSHOT_DIFF" check "$TARGET" "$SNAP"
+
+# 3. a new file (simulating a silent marker write) is flagged NEW.
+echo "contamination" > "$TARGET/pr-99-rex.approved"
+check "new file is flagged as contamination" 1 bash "$SNAPSHOT_DIFF" check "$TARGET" "$SNAP"
+check_output_contains "new-file report names the path" "NEW:     pr-99-rex.approved"
+rm -f "$TARGET/pr-99-rex.approved"
+
+# 4. back to clean after the extra file is removed (re-snapshot first).
+check "re-snapshot after cleanup" 0 bash "$SNAPSHOT_DIFF" snapshot "$TARGET" "$SNAP"
+check "check is clean again" 0 bash "$SNAPSHOT_DIFF" check "$TARGET" "$SNAP"
+
+# 5. a changed file (same path, different content) is flagged CHANGED, not NEW.
+echo "mutated content" > "$TARGET/keep.txt"
+check "changed file is flagged as contamination" 1 bash "$SNAPSHOT_DIFF" check "$TARGET" "$SNAP"
+check_output_contains "changed-file report names the path" "CHANGED: keep.txt"
+
+# 6. a deleted file is flagged DELETED.
+check "re-snapshot before delete test" 0 bash "$SNAPSHOT_DIFF" snapshot "$TARGET" "$SNAP"
+rm -f "$TARGET/keep.txt"
+check "deleted file is flagged as contamination" 1 bash "$SNAPSHOT_DIFF" check "$TARGET" "$SNAP"
+check_output_contains "deleted-file report names the path" "DELETED: keep.txt"
+
+# 7. snapshotting a directory that doesn't exist yet is not itself an error
+#    (a fresh session may have no .claude/session/reviews/ at all).
+FRESH="$WORKDIR/does-not-exist-yet"
+FRESH_SNAP="$WORKDIR/fresh.manifest"
+check "snapshot of a missing dir creates it and succeeds" 0 bash "$SNAPSHOT_DIFF" snapshot "$FRESH" "$FRESH_SNAP"
+check "check of an untouched fresh dir is clean" 0 bash "$SNAPSHOT_DIFF" check "$FRESH" "$FRESH_SNAP"
+
+echo
+echo "snapshot-diff test: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/docs/eval-agents/README.md
+++ b/docs/eval-agents/README.md
@@ -18,7 +18,7 @@ docs/eval-agents/
 
 ## What's seeded, and what isn't
 
-- **Rex (`corpus/rex.json`)** — 6 entries mined from this repo's own review history: two confirmed MISSes (wrong approvals — one caught by Hakim reviewing the identical commit, the other by a subsequent fix), two GOOD_CATCH (correctly required changes), and two GOOD_CLEAN (correctly approved a genuinely clean diff).
+- **Rex (`corpus/rex.json`)** — 6 entries mined from this repo's own review history: two confirmed MISSes (wrong approvals — both caught by Hakim's independent review of the identical commit; both entries carry `oracle.source: independent_review`, not `confirmed_fix` — the fix that landed afterward corroborates the defect but isn't the oracle basis), two GOOD_CATCH (correctly required changes), and two GOOD_CLEAN (correctly approved a genuinely clean diff).
 - **Hakim (`corpus/hakim.json`)** — 4 entries: three GOOD_CATCH, one GOOD_CLEAN. **No confirmed Hakim MISS is seeded yet** — the spike's sample didn't surface a clean Hakim-authored wrong approval. This is a real, documented gap. Approve-precision on the Hakim starter run will trivially read 1.0 until a genuine miss is harvested and added; treat that number as "no counter-evidence yet," not "Hakim is perfect."
 - **Two entries are same-diff cross-agent pairs** (`rex-792-2ce6708` / `hakim-792-2ce6708`, and `rex-767-a99f1009` / `hakim-767-a99f1009`) — the identical commit, reviewed by both agents the same day, with different outcomes (Rex approved, Hakim caught a real defect). These are the cleanest possible corpus entries: the diff is held constant, only the reviewing agent varies.
 - **Tariq — no starter corpus.** No Tariq-reviewed PRs were in the spike's sample. `/eval-agents tariq` requires an operator-supplied `--corpus <path>` until one exists.
@@ -33,6 +33,10 @@ Every entry traces back to a real, merged `me2resh/apexyard` PR. Ground truth wa
 - `no_contradiction` — a clean approval that no later review or fix ever contradicted.
 
 This is the same mining method spike #825 used for its own labeled set (`docs/spike-825/judge_calibration.py`), reshaped from rubric-scores into defect-sets.
+
+## Non-determinism caveat
+
+Every score `/eval-agents` reports is downstream of two LLM steps, not a fixed measurement: the candidate spawn re-reviewing the diff, and the defect-overlap match against the frozen `ground_truth_defects` key. The key itself is frozen — that's the whole point of AgDR-0089 — but *comparing a fresh run's findings to that key* is a semantic judgment call, not a byte-for-byte diff, and can land differently on a borderline entry from one run to the next. A score delta between two runs of the same corpus against the same agent is **not automatically a real regression**; it can be run-to-run noise in the matching step. Read a delta by checking which specific entries flipped and re-reading the agent's actual output for those entries — never by trend-lining the raw percentage alone.
 
 ## Growing the corpus
 


### PR DESCRIPTION
## Summary

Hardening follow-ups for `/eval-agents` from Hakim's security review and Tariq's design review of #828 (tracked in #833) — v1 shipped with an explicitly-accepted "mitigated, not hard-sandboxed" posture, and this PR closes or documents each item so they don't evaporate.

- **Suspend the HARD STOP instead of contradicting it** — the eval prompt used to tell the agent-under-test "don't write a marker, don't post a review," which directly contradicts that same agent's own system-prompt mandate to do exactly that. The only thing breaking the tie was the sanitized-out PR number. The prompt now explicitly **suspends** the mandate for the eval run ("that mandate is explicitly SUSPENDED for this run only") instead of issuing a competing instruction — this matters because a suspended requirement and a contradicted one are different reliability postures for an agent following its own hard-wired rules.
- **Snapshot-diff replaces "hope the agent narrates its own leak"** — the old contamination check only scanned the agent's *returned text* for signs of a tracker call. A silent `Bash`-redirect write to `.claude/session/reviews/<pr>-rex.approved` never has to appear in that text to escape it. `lib/snapshot-diff.sh` now snapshots `.claude/session/reviews/` immediately before every spawn and diffs it after — any new/changed/deleted file is a mechanical CONTAMINATED flag, regardless of what the agent says about it. The old text-scan is kept as a secondary check (it still catches read-only `gh pr view` calls, which leave no file trace).
- **Investigated removing `Bash` from the eval spawn — found a real harness-capability gap.** The `Agent` tool has no per-spawn tool-restriction parameter (its params are `description`, `isolation`, `model`, `prompt`, `run_in_background`, `subagent_type` — no `tools`/`allowed_tools` override); tool access is fixed per `subagent_type` in that agent's own definition file. Per the ticket's fallback AC, SKILL.md now carries a hard **"MUST NOT be CI-gated until eval spawns can be tool-restricted"** banner in the Safety section, documenting the gap and the heavier alternative (dedicated Bash-free eval-mode agent definitions) as a future option, not something this PR builds.
- **README data fix** — both Rex MISS corpus entries carry `oracle.source: independent_review` (Hakim's independent review of the identical commit), not "one caught by Hakim, the other by a subsequent fix" as the README previously said. Verified against `docs/eval-agents/corpus/rex.json` directly.
- **Non-determinism caveat added** (SKILL.md Rule 11 + a new README section) — the candidate spawn and the defect-overlap match against the frozen key are both LLM steps, so a score delta between two runs of the same corpus isn't automatically a real regression; it can be run-to-run noise in the matching step.
- **`--suggest-entries` — investigated, left out of this PR.** The ticket named `docs/spike-825/judge_calibration.py` as the source to lift mining logic from; it turns out to be a hand-curated data table of 19 manually-classified review units, not a reusable scan/detect routine. Building a real gh-api-driven miner is a genuine new feature, not a hardening follow-up, so it's out of scope here — flagged in SKILL.md's Usage section as a candidate for its own ticket rather than silently dropped.

No new AgDR — this is hardening of the existing AgDR-0089 design, not a new decision.

## Testing

```
bash .claude/skills/eval-agents/tests/smoke.sh              # 6/6 passed (pre-existing, unchanged)
bash .claude/skills/eval-agents/tests/test-snapshot-diff.sh  # 14/14 passed (new — snapshot/new/changed/deleted/missing-snapshot/missing-dir cases)
shellcheck .claude/skills/eval-agents/lib/snapshot-diff.sh .claude/skills/eval-agents/tests/test-snapshot-diff.sh   # clean
```

`docs/eval-agents/corpus/{rex,hakim}.json` still validate clean against the schema validator (unchanged by this PR).

## Glossary

| Term | Definition |
|------|------------|
| Contamination (in this skill) | A sign the agent-under-test interacted with a real, live PR/tracker during an eval run — a tracker command, a marker write, a posted review — despite being sandboxed to a sanitized standalone diff. A contaminated run is discarded, not scored. |
| Snapshot-diff | Record a directory's file set (path + sha256) before an action, re-scan after, and report anything new/changed/deleted. Used here as a filesystem-level contamination check that doesn't depend on the agent narrating its own actions. |
| HARD STOP (Rex/Hakim/Tariq's own) | The mandatory-actions section in each review agent's own system prompt requiring it to write a local approval marker and post a review before finishing a real PR review. Eval runs must suspend this, not fight it, since there's no real PR to satisfy it against. |
| Per-spawn tool subsetting | Restricting which tools a specific `Agent` tool invocation grants to the spawned sub-agent, overriding that sub-agent type's normal tool list for just this one call. Not currently supported by the `Agent` tool. |

Closes #833
