### PR TITLE
feat(#831): Cursor gate adapter — generate .cursor/hooks.json delegating to the bash hooks

### DIFF
--- a/.claude/hooks/tests/test_sync_cursor_adapter.sh
+++ b/.claude/hooks/tests/test_sync_cursor_adapter.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# Smoke tests for bin/sync-cursor-adapter.sh.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCRIPT="$ROOT/bin/sync-cursor-adapter.sh"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+PASS=0
+FAIL=0
+FAILED=""
+
+mark_pass() { green "  ok   $1"; PASS=$((PASS+1)); }
+mark_fail() {
+  red "  FAIL $1: $2" >&2
+  FAIL=$((FAIL+1))
+  FAILED="$FAILED $1"
+}
+
+assert_file() {
+  local path="$1" label="$2"
+  [ -f "$path" ] && mark_pass "$label" || mark_fail "$label" "missing $path"
+}
+
+assert_contains() {
+  local path="$1" pattern="$2" label="$3"
+  grep -F "$pattern" "$path" >/dev/null 2>&1 && mark_pass "$label" || mark_fail "$label" "missing pattern [$pattern] in $path"
+}
+
+assert_not_contains() {
+  local path="$1" pattern="$2" label="$3"
+  if grep -F "$pattern" "$path" >/dev/null 2>&1; then
+    mark_fail "$label" "unexpected pattern [$pattern] in $path"
+  else
+    mark_pass "$label"
+  fi
+}
+
+# Neutralize the Claude Code session-pin artifact so the generated wrapper's
+# ops-root resolution falls through to the directory-walk branch, same as it
+# would under a real Cursor session (which never sets this var).
+unset CLAUDE_CODE_SESSION_ID
+
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/cursor-adapter-test.XXXXXX")
+trap 'rm -rf "$TMPROOT"' EXIT
+
+mkdir -p "$TMPROOT/.claude/hooks"
+touch "$TMPROOT/.apexyard-fork"
+
+cat > "$TMPROOT/.claude/hooks/block-test.sh" <<'SH'
+#!/usr/bin/env bash
+input=$(cat)
+case "$input" in
+  *deny*) exit 2 ;;
+  *) exit 0 ;;
+esac
+SH
+chmod +x "$TMPROOT/.claude/hooks/block-test.sh"
+
+cat > "$TMPROOT/.claude/hooks/unconditional-test.sh" <<'SH'
+#!/usr/bin/env bash
+input=$(cat)
+case "$input" in
+  *unconditional-deny*) exit 2 ;;
+  *) exit 0 ;;
+esac
+SH
+chmod +x "$TMPROOT/.claude/hooks/unconditional-test.sh"
+
+cat > "$TMPROOT/.claude/hooks/check-secrets.sh" <<'SH'
+#!/usr/bin/env bash
+input=$(cat)
+case "$input" in
+  *secret*) exit 2 ;;
+  *) exit 0 ;;
+esac
+SH
+chmod +x "$TMPROOT/.claude/hooks/check-secrets.sh"
+
+cat > "$TMPROOT/.claude/hooks/require-active-ticket.sh" <<'SH'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 0
+SH
+chmod +x "$TMPROOT/.claude/hooks/require-active-ticket.sh"
+
+cat > "$TMPROOT/.claude/hooks/pin-ops-root.sh" <<'SH'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 0
+SH
+chmod +x "$TMPROOT/.claude/hooks/pin-ops-root.sh"
+
+# Fixture settings.json exercises: a Bash(glob) predicate hook, an
+# unconditional Bash hook (no `if`), a fail-closed-eligible hook
+# (check-secrets.sh), an Edit|Write|MultiEdit hook, and a SessionStart hook —
+# covering every branch the generator's event-mapping table has to handle.
+cat > "$TMPROOT/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/pin-ops-root.sh\"'" }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(policy *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-test.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/unconditional-test.sh\"'"
+          },
+          {
+            "type": "command",
+            "if": "Bash(git commit *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/check-secrets.sh\"'"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/require-active-ticket.sh\"'"
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
+
+echo "== Cursor adapter sync smoke"
+
+if bash "$SCRIPT" --root "$TMPROOT" >/tmp/_cursor_adapter_sync.out 2>&1; then
+  mark_pass "generator writes adapter output"
+else
+  mark_fail "generator writes adapter output" "$(cat /tmp/_cursor_adapter_sync.out)"
+fi
+
+assert_file "$TMPROOT/.cursor/hooks.json" "hooks.json exists"
+assert_file "$TMPROOT/.cursor/rules/apexyard.mdc" "rules bridge exists"
+
+# --- config shape -----------------------------------------------------
+if jq -e '.version == 1' "$TMPROOT/.cursor/hooks.json" >/dev/null 2>&1; then
+  mark_pass "hooks.json has version 1"
+else
+  mark_fail "hooks.json has version 1" "wrong or missing .version"
+fi
+
+if jq -e '.hooks.beforeShellExecution | length == 3' "$TMPROOT/.cursor/hooks.json" >/dev/null 2>&1; then
+  mark_pass "beforeShellExecution has one entry per Bash-matcher hook"
+else
+  mark_fail "beforeShellExecution has one entry per Bash-matcher hook" "$(jq '.hooks.beforeShellExecution | length' "$TMPROOT/.cursor/hooks.json")"
+fi
+
+if jq -e '.hooks.preToolUse[0].matcher == "Write"' "$TMPROOT/.cursor/hooks.json" >/dev/null 2>&1; then
+  mark_pass "Edit|Write|MultiEdit maps to preToolUse matcher Write"
+else
+  mark_fail "Edit|Write|MultiEdit maps to preToolUse matcher Write" "unexpected preToolUse[0]"
+fi
+
+if jq -e '.hooks.sessionStart | length == 1' "$TMPROOT/.cursor/hooks.json" >/dev/null 2>&1; then
+  mark_pass "SessionStart maps to sessionStart"
+else
+  mark_fail "SessionStart maps to sessionStart" "$(jq '.hooks.sessionStart' "$TMPROOT/.cursor/hooks.json")"
+fi
+
+assert_not_contains "$TMPROOT/.cursor/hooks.json" "$TMPROOT" "hooks.json has no absolute fixture path"
+assert_not_contains "$TMPROOT/.cursor/rules/apexyard.mdc" "$TMPROOT" "rules bridge has no absolute fixture path"
+
+if jq -e '.. | objects | select(has("if"))' "$TMPROOT/.cursor/hooks.json" >/dev/null 2>&1; then
+  mark_fail "hooks.json omits unsupported if fields" "found handler-level if metadata"
+else
+  mark_pass "hooks.json omits unsupported if fields"
+fi
+
+# --- failClosed on the security-critical gate, not on the ticket gate -
+if jq -e '[.hooks.beforeShellExecution[] | select(.command | contains("check-secrets.sh")) | .failClosed] == [true]' "$TMPROOT/.cursor/hooks.json" >/dev/null 2>&1; then
+  mark_pass "failClosed is set on the security-critical gate (check-secrets.sh)"
+else
+  mark_fail "failClosed is set on the security-critical gate (check-secrets.sh)" "missing failClosed:true"
+fi
+
+if jq -e '[.hooks.beforeShellExecution[] | select(.command | contains("block-test.sh")) | .failClosed] == [null]' "$TMPROOT/.cursor/hooks.json" >/dev/null 2>&1; then
+  mark_pass "failClosed is absent on a non-security-critical gate (block-test.sh)"
+else
+  mark_fail "failClosed is absent on a non-security-critical gate (block-test.sh)" "unexpected failClosed"
+fi
+
+# --- delegation exec: block / allow / skip across the remap boundary --
+predicate_cmd=$(jq -r '.hooks.beforeShellExecution[] | select(.command | contains("block-test.sh")) | .command' "$TMPROOT/.cursor/hooks.json")
+
+printf '{"command":"policy deny","cwd":"/tmp"}' | (cd "$TMPROOT" && bash -c "$predicate_cmd") >/tmp/_cursor_adapter_block.out 2>&1
+block_rc=$?
+if [ "$block_rc" -eq 2 ]; then
+  mark_pass "generated hook command preserves blocking exit (predicate match)"
+else
+  mark_fail "generated hook command preserves blocking exit (predicate match)" "expected exit 2, got $block_rc: $(cat /tmp/_cursor_adapter_block.out)"
+fi
+
+printf '{"command":"policy allow","cwd":"/tmp"}' | (cd "$TMPROOT" && bash -c "$predicate_cmd") >/tmp/_cursor_adapter_allow.out 2>&1
+allow_rc=$?
+if [ "$allow_rc" -eq 0 ]; then
+  mark_pass "generated hook command preserves allowing exit (predicate match)"
+else
+  mark_fail "generated hook command preserves allowing exit (predicate match)" "expected exit 0, got $allow_rc: $(cat /tmp/_cursor_adapter_allow.out)"
+fi
+
+printf '{"command":"other deny","cwd":"/tmp"}' | (cd "$TMPROOT" && bash -c "$predicate_cmd") >/tmp/_cursor_adapter_skip.out 2>&1
+skip_rc=$?
+if [ "$skip_rc" -eq 0 ]; then
+  mark_pass "generated hook command skips nonmatching predicates"
+else
+  mark_fail "generated hook command skips nonmatching predicates" "expected exit 0, got $skip_rc: $(cat /tmp/_cursor_adapter_skip.out)"
+fi
+
+# --- unconditional Bash hook (no `if`) still gets remapped ------------
+unconditional_cmd=$(jq -r '.hooks.beforeShellExecution[] | select(.command | contains("unconditional-test.sh")) | .command' "$TMPROOT/.cursor/hooks.json")
+
+printf '{"command":"anything unconditional-deny here","cwd":"/tmp"}' | (cd "$TMPROOT" && bash -c "$unconditional_cmd") >/tmp/_cursor_adapter_uncond_block.out 2>&1
+uncond_block_rc=$?
+if [ "$uncond_block_rc" -eq 2 ]; then
+  mark_pass "unconditional Bash hook still blocks via the remap"
+else
+  mark_fail "unconditional Bash hook still blocks via the remap" "expected exit 2, got $uncond_block_rc: $(cat /tmp/_cursor_adapter_uncond_block.out)"
+fi
+
+printf '{"command":"anything else","cwd":"/tmp"}' | (cd "$TMPROOT" && bash -c "$unconditional_cmd") >/tmp/_cursor_adapter_uncond_allow.out 2>&1
+uncond_allow_rc=$?
+if [ "$uncond_allow_rc" -eq 0 ]; then
+  mark_pass "unconditional Bash hook allows on no match"
+else
+  mark_fail "unconditional Bash hook allows on no match" "expected exit 0, got $uncond_allow_rc: $(cat /tmp/_cursor_adapter_uncond_allow.out)"
+fi
+
+# --- preToolUse (Edit|Write|MultiEdit) passthrough exit-code preservation
+write_cmd=$(jq -r '.hooks.preToolUse[0].command' "$TMPROOT/.cursor/hooks.json")
+printf '{"tool_name":"Write","tool_input":{"file_path":"foo.txt"}}' | (cd "$TMPROOT" && bash -c "$write_cmd") >/tmp/_cursor_adapter_write.out 2>&1
+write_rc=$?
+if [ "$write_rc" -eq 0 ]; then
+  mark_pass "preToolUse passthrough delegates and preserves exit code"
+else
+  mark_fail "preToolUse passthrough delegates and preserves exit code" "expected exit 0, got $write_rc: $(cat /tmp/_cursor_adapter_write.out)"
+fi
+
+# --- rules bridge sanity -----------------------------------------------
+assert_contains "$TMPROOT/.cursor/rules/apexyard.mdc" "alwaysApply: true" "rules bridge sets alwaysApply"
+assert_contains "$TMPROOT/.cursor/rules/apexyard.mdc" "CLAUDE.md" "rules bridge points at CLAUDE.md"
+assert_contains "$TMPROOT/.cursor/rules/apexyard.mdc" "sync-cursor-adapter.sh" "rules bridge documents regeneration"
+
+# --- drift check ---------------------------------------------------------
+if bash "$SCRIPT" --root "$TMPROOT" --check >/tmp/_cursor_adapter_check.out 2>&1; then
+  mark_pass "--check passes when generated output is current"
+else
+  mark_fail "--check passes when generated output is current" "$(cat /tmp/_cursor_adapter_check.out)"
+fi
+
+cp "$TMPROOT/.claude/settings.json" "$TMPROOT/.claude/settings.json.bak"
+jq '.hooks.PreToolUse[0].hooks[0].if = "Bash(drift *)"' "$TMPROOT/.claude/settings.json" > "$TMPROOT/.claude/settings.json.new"
+mv "$TMPROOT/.claude/settings.json.new" "$TMPROOT/.claude/settings.json"
+if bash "$SCRIPT" --root "$TMPROOT" --check >/tmp/_cursor_adapter_check_drift.out 2>&1; then
+  mark_fail "--check detects drift" "expected non-zero exit"
+else
+  mark_pass "--check detects drift"
+fi
+mv "$TMPROOT/.claude/settings.json.bak" "$TMPROOT/.claude/settings.json"
+
+# --- --clean removes then regenerates .cursor --------------------------
+if bash "$SCRIPT" --root "$TMPROOT" --clean >/tmp/_cursor_adapter_clean.out 2>&1; then
+  mark_pass "--clean regenerates .cursor"
+else
+  mark_fail "--clean regenerates .cursor" "$(cat /tmp/_cursor_adapter_clean.out)"
+fi
+assert_file "$TMPROOT/.cursor/hooks.json" "hooks.json exists after --clean"
+
+echo
+echo "===== test_sync_cursor_adapter.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED"
+  exit 1
+fi
+exit 0

--- a/bin/sync-cursor-adapter.sh
+++ b/bin/sync-cursor-adapter.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Generate Cursor-facing adapter files from the canonical .claude runtime.
+#
+# .claude remains the source of truth. This script emits .cursor/hooks.json
+# (Cursor's native hook config) plus a minimal .cursor/rules/apexyard.mdc
+# advisory bridge, while delegating every gate to the unmodified
+# .claude/hooks/*.sh scripts — same declarative-generate pattern as
+# bin/sync-codex-adapter.sh (AgDR-0088). See docs/agdr/AgDR-0091.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CHECK=0
+CLEAN=0
+
+usage() {
+  cat <<'USAGE'
+Usage: bin/sync-cursor-adapter.sh [--check] [--clean] [--root <path>]
+
+Generate the Cursor adapter from .claude:
+  .claude/settings.json -> .cursor/hooks.json  (commands still exec .claude/hooks)
+  (static)               -> .cursor/rules/apexyard.mdc  (advisory bridge)
+
+Options:
+  --check       Do not write files; fail if generated output would differ.
+  --clean       Remove generated .cursor before writing.
+  --root PATH   Repository root to use instead of this script's parent.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --check) CHECK=1 ;;
+    --clean) CLEAN=1 ;;
+    --root)
+      [ "$#" -ge 2 ] || { echo "ERROR: --root requires a path" >&2; exit 2; }
+      ROOT="$2"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+ROOT="$(cd "$ROOT" && pwd)"
+CLAUDE_DIR="$ROOT/.claude"
+
+[ -d "$CLAUDE_DIR" ] || { echo "ERROR: .claude not found under $ROOT" >&2; exit 1; }
+[ -f "$CLAUDE_DIR/settings.json" ] || { echo "ERROR: .claude/settings.json not found" >&2; exit 1; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required to generate the Cursor adapter safely" >&2
+  exit 1
+fi
+
+TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/cursor-adapter.XXXXXX")
+trap 'rm -rf "$TMPDIR"' EXIT
+
+OUT_CURSOR="$TMPDIR/.cursor"
+mkdir -p "$OUT_CURSOR/rules"
+
+# Security-critical gates get failClosed:true (a hook crash/timeout BLOCKS
+# instead of failing open) — Cursor hardening Codex doesn't offer. The list
+# is derived from hook class, not hand-picked per-PR: merge gates (the four
+# hooks that guard `gh pr merge` / `gh api .../merge`), the secrets scanner,
+# and the trust/leak-protection class (no-direct-main, no-git-add-all, the
+# leak-protection scrubber, and the onboarding-config leak guard). Every
+# other hook (ticket-vocabulary format checks, ticket-first gates, advisory
+# banners) stays fail-open — same default Cursor ships and the same posture
+# those hooks already have under Claude Code (they exit 0 on error today).
+FAIL_CLOSED_HOOKS=(
+  block-unreviewed-merge.sh
+  block-merge-on-red-ci.sh
+  require-design-review-for-ui.sh
+  require-architecture-review.sh
+  check-secrets.sh
+  block-git-add-all.sh
+  block-main-push.sh
+  block-private-refs-in-public-repos.sh
+  block-onboarding-in-git.sh
+)
+fail_closed_json=$(printf '%s\n' "${FAIL_CLOSED_HOOKS[@]}" | jq -R . | jq -s .)
+
+# Cursor's beforeShellExecution event puts the command at the TOP LEVEL
+# ({"command": "...", "cwd": "...", "sandbox": ...}), while every .claude
+# hook parses Claude Code's stdin shape (.tool_name / .tool_input.command).
+# This is the stdin remap shim called out in #831: read the top-level
+# `command`, apply the same Bash(glob) preflight filter Claude's handler-
+# level `if` predicate encodes (glob "*" when no `if` was present, so
+# unconditional Bash hooks still get remapped even though they have no
+# predicate to check), then re-wrap into the canonical shape before
+# delegating to the unmodified hook script. Built as a real (unexpanded)
+# heredoc and passed through jq's --arg + @sh so quoting is handled by jq
+# instead of by hand — the previous adapter (Codex) had to hand-escape a
+# shell script embedded in a jq string literal; passing it as an argument
+# avoids that entirely.
+CURSOR_SHELL_REMAP=$(cat <<'SH'
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.command // empty')
+[[ "$cmd" == $APEXYARD_CURSOR_HOOK_GLOB ]] || exit 0
+cmdjson=$(printf '%s' "$input" | jq -c '.command // null')
+printf '{"tool_name":"Bash","tool_input":{"command":%s}}' "$cmdjson" | bash -c "$APEXYARD_CURSOR_ORIGINAL_HOOK"
+SH
+)
+
+generate_hooks_json() {
+  jq --argjson failClosedList "$fail_closed_json" \
+     --arg shellRemap "$CURSOR_SHELL_REMAP" '
+    def hook_basename:
+      if (.command | test("[a-zA-Z0-9_-]+\\.sh")) then
+        (.command | capture("(?<f>[a-zA-Z0-9_-]+\\.sh)")).f
+      else
+        ""
+      end;
+
+    def is_fail_closed:
+      (hook_basename) as $b | ($failClosedList | index($b)) != null;
+
+    # Bash(glob) -> glob. Absent `if` means the hook is unconditional under
+    # Claude Code (runs on every Bash call) — represented here as glob "*"
+    # so the remapped command still applies to every shell invocation.
+    def if_glob:
+      if has("if") then
+        (.if | capture("^(?<tool>[^()]+)\\((?<glob>.*)\\)$")).glob
+      else
+        "*"
+      end;
+
+    def to_shell_entry:
+      . as $orig
+      | ($orig | if_glob) as $glob
+      | { command: (
+            "APEXYARD_CURSOR_HOOK_GLOB=" + ($glob | @sh) +
+            " APEXYARD_CURSOR_ORIGINAL_HOOK=" + ($orig.command | @sh) +
+            " bash -c " + ($shellRemap | @sh)
+          ) }
+        + (if ($orig | is_fail_closed) then { failClosed: true } else {} end);
+
+    def to_passthrough_entry(cursorMatcher):
+      { command: .command }
+      + (if cursorMatcher != null then { matcher: cursorMatcher } else {} end)
+      + (if is_fail_closed then { failClosed: true } else {} end);
+
+    (.hooks.PreToolUse // [])       as $pre
+    | (.hooks.PostToolUse // [])      as $post
+    | (.hooks.SessionStart // [])     as $session
+    | (.hooks.UserPromptSubmit // []) as $prompt
+
+    # PreToolUse/Bash -> beforeShellExecution (remapped; the dedicated
+    # pre-shell-command block point, closest analog to our per-command
+    # PreToolUse:Bash matcher).
+    | ([$pre[] | select(.matcher == "Bash") | .hooks[] | to_shell_entry]) as $beforeShell
+
+    # PreToolUse/{Edit|Write|MultiEdit, Write} -> preToolUse (generic event;
+    # its tool_name/tool_input shape is the closest match to what the bash
+    # hooks already parse, so no remap — passthrough). Cursor tool-type
+    # matcher values are Shell/Read/Write/Grep/Delete/Task, so Edit and
+    # MultiEdit both fold into "Write" (a known conformance gap: Cursor
+    # does not distinguish Edit vs MultiEdit vs Write the way Claude Code
+    # does — see docs/cursor-adapter.md).
+    | ([$pre[] | select(.matcher == "Edit|Write|MultiEdit" or .matcher == "Write")
+       | .hooks[] | to_passthrough_entry("Write")]) as $preWrite
+    | ([$pre[] | select(.matcher == "Read|Glob|Grep")
+       | .hooks[] | to_passthrough_entry("Read|Grep")]) as $preRead
+    | ($preWrite + $preRead) as $preToolUse
+
+    | ([$post[] | select(.matcher == "Bash")
+       | .hooks[] | to_passthrough_entry("Shell")]) as $postShell
+    | ([$post[] | select(.matcher == "Write|Edit|MultiEdit")
+       | .hooks[] | to_passthrough_entry("Write")]) as $postWrite
+    | ($postShell + $postWrite) as $postToolUse
+
+    | ([$session[] | .hooks[] | to_passthrough_entry(null)]) as $sessionStart
+    | ([$prompt[] | .hooks[] | to_passthrough_entry(null)]) as $beforeSubmitPrompt
+
+    | { version: 1,
+        hooks: (
+          { beforeShellExecution: $beforeShell,
+            preToolUse: $preToolUse,
+            postToolUse: $postToolUse,
+            sessionStart: $sessionStart,
+            beforeSubmitPrompt: $beforeSubmitPrompt
+          } | with_entries(select(.value | length > 0))
+        )
+      }
+  ' "$CLAUDE_DIR/settings.json"
+}
+
+write_rules_mdc() {
+  cat <<'MDC'
+---
+description: ApexYard governance bridge for Cursor — the mechanical gates run via .cursor/hooks.json; this file is the advisory pointer.
+alwaysApply: true
+---
+
+# ApexYard governance (Cursor)
+
+This repo is governed by ApexYard's SDLC framework. The gates are
+**mechanical, not this file** — `.cursor/hooks.json` (generated by
+`bin/sync-cursor-adapter.sh`) delegates every hook to the same audited
+`.claude/hooks/*.sh` scripts Claude Code enforces: ticket-first edits,
+merge gates (Rex + CEO + design + architecture review), the red-CI block,
+secrets scanning, branch/PR/commit format, and the trust-chain / leak-
+protection checks. A blocked action here means one of those scripts
+exited 2 — read its message, it names the fix.
+
+For the full rules (why a gate exists, how to satisfy it, the escape
+hatches) read `CLAUDE.md` at the repo root and the modular rule files
+under `.claude/rules/*.md`. Load-bearing ones to know before you start:
+
+- One ticket at a time — `/start-ticket <N>` before editing (`.claude/rules/workflow-gates.md`)
+- Branch `{type}/{TICKET-ID}-{description}`, PR title `type(TICKET): description` (`.claude/rules/git-conventions.md`)
+- Every PR needs a Glossary + narrative Summary bullets (`.claude/rules/pr-quality.md`)
+- Merges need an explicit per-PR human nod — no plan-level "go" (`.claude/rules/pr-workflow.md`)
+- Technical decisions get an AgDR before Build (`.claude/rules/agdr-decisions.md`)
+
+Regenerate this adapter after any `.claude/settings.json` or
+`.claude/hooks/*.sh` change: `bin/sync-cursor-adapter.sh`. Drift check:
+`bin/sync-cursor-adapter.sh --check`.
+MDC
+}
+
+generate_hooks_json > "$OUT_CURSOR/hooks.json"
+write_rules_mdc > "$OUT_CURSOR/rules/apexyard.mdc"
+
+if grep -R "$(printf '%s' "$ROOT" | sed 's/[.[\*^$()+?{}|]/\\&/g')" "$OUT_CURSOR" >/dev/null 2>&1; then
+  echo "ERROR: generated adapter contains an absolute path to $ROOT" >&2
+  exit 1
+fi
+
+check_drift() {
+  local actual="$1" expected="$2" label="$3"
+  if [ ! -e "$actual" ]; then
+    echo "DRIFT: $label is missing; run bin/sync-cursor-adapter.sh" >&2
+    return 1
+  fi
+  if ! diff -qr "$expected" "$actual" >/dev/null; then
+    echo "DRIFT: $label differs from generated output; run bin/sync-cursor-adapter.sh" >&2
+    diff -qr "$expected" "$actual" >&2 || true
+    return 1
+  fi
+}
+
+if [ "$CHECK" = "1" ]; then
+  rc=0
+  check_drift "$ROOT/.cursor" "$OUT_CURSOR" ".cursor" || rc=1
+  exit "$rc"
+fi
+
+if [ "$CLEAN" = "1" ]; then
+  rm -rf "$ROOT/.cursor"
+fi
+
+mkdir -p "$ROOT/.cursor/rules"
+rm -f "$ROOT/.cursor/hooks.json" "$ROOT/.cursor/rules/apexyard.mdc"
+cp "$OUT_CURSOR/hooks.json" "$ROOT/.cursor/hooks.json"
+cp "$OUT_CURSOR/rules/apexyard.mdc" "$ROOT/.cursor/rules/apexyard.mdc"
+
+echo "Generated Cursor adapter from .claude:"
+echo "  .cursor/hooks.json"
+echo "  .cursor/rules/apexyard.mdc"

--- a/docs/agdr/AgDR-0091-cursor-adapter-generation.md
+++ b/docs/agdr/AgDR-0091-cursor-adapter-generation.md
@@ -1,0 +1,182 @@
+# AgDR-0091 — Cursor adapter: event-mapped delegation with a stdin remap, fail-closed on the security-critical gates
+
+> In the context of extending the multiharness family (Claude Code · Codex ·
+> pi · opencode planned) to Cursor — the largest third-party agent-IDE user
+> base, per #831 — facing a hook vocabulary that does not name-match Claude
+> Code's (`beforeShellExecution` / `preToolUse` / `postToolUse` /
+> `sessionStart` / `beforeSubmitPrompt` vs. `PreToolUse` / `PostToolUse` /
+> `SessionStart` / `UserPromptSubmit`) and a shell-command stdin shape that
+> puts `command` at the top level instead of nested under
+> `tool_input.command`, I decided to generate `.cursor/hooks.json` with an
+> explicit event-mapping table, a stdin remap shim scoped to the
+> `beforeShellExecution` path, and `failClosed: true` on a fixed list of
+> security-critical gates, delegating every hook to the unmodified
+> `.claude/hooks/*.sh` scripts exactly as the Codex and pi adapters do, to
+> achieve Cursor-native governance without a second gate-logic
+> implementation, accepting that field-name conformance for the
+> `preToolUse`/`postToolUse` (Edit/Write/Read) path and live-Cursor
+> conformance overall remain unverified until a real Cursor session is
+> exercised.
+
+## Context
+
+- AgDR-0088 (Codex) and AgDR-0082 (pi) both established the pattern this
+  repeats: generate the harness-native hook config from `.claude/settings.json`,
+  delegate execution to the existing, unmodified `.claude/hooks/*.sh` scripts,
+  never fork gate logic into a second file tree.
+- Cursor's hooks system (verified against the live docs,
+  <https://cursor.com/docs/hooks>, 2026-07-09) differs from both Codex and pi
+  in two structural ways that neither prior adapter had to solve:
+  1. **Its event names don't match Claude Code's at all.** Codex's generator
+     could keep `PreToolUse`/`PostToolUse`/etc. as literal JSON keys in
+     `.codex/hooks.json` because Codex's own hook config uses the same
+     top-level event vocabulary. Cursor's events are a different, camelCase,
+     more granular set (`beforeShellExecution`, `beforeMCPExecution`,
+     `beforeReadFile`, `afterFileEdit`, `preToolUse`, `postToolUse`,
+     `sessionStart`, `beforeSubmitPrompt`, …) — a straight key rename does
+     not work; an explicit mapping table does.
+  2. **Its dedicated shell-command hook (`beforeShellExecution`) puts the
+     command at the top level of stdin**, not nested under
+     `tool_input.command` the way every `.claude/hooks/*.sh` script parses
+     it. This is the literal stdin-remap shim #831 called out by name.
+- Cursor's `preToolUse` event, by contrast, *does* carry a `tool_name` /
+  `tool_input` envelope close to Claude Code's shape, and for its `Shell`
+  matcher the live docs confirm `tool_input.command` is present — genuinely
+  no remap needed on that specific path. But Cursor's own tool-type matcher
+  vocabulary (`Shell`, `Read`, `Write`, `Grep`, `Delete`, `Task`) is coarser
+  than Claude Code's (`Edit`, `Write`, `MultiEdit` are three distinct
+  matchers in `.claude/settings.json`), and the live docs do not enumerate
+  `tool_input`'s field names for `Write`/`Read` beyond the base envelope —
+  so passthrough on that path carries an explicit, documented conformance
+  risk (see docs/cursor-adapter.md § Known Limitations).
+- Cursor's docs confirm exit code `2` is a **native deny**
+  ("equivalent to returning `permission: "deny"`") with no JSON translation
+  required — simpler than Codex, which needed a JSON `permission` payload
+  translation layer. This removed an entire class of complexity Codex's
+  adapter had to solve.
+- Cursor is the only adapter target so far that documents a per-hook
+  `failClosed` option — a crashed or timed-out hook script BLOCKS instead of
+  fails open. Neither Claude Code nor Codex expose this. It is a genuine
+  hardening opportunity worth using selectively, not uniformly (uniform
+  fail-closed would turn every advisory banner into a potential hard block
+  on a transient script failure).
+
+## Options Considered
+
+### Axis 1 — Event mapping strategy
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Keep Claude Code's literal event names as JSON keys (Codex's approach) | Reuses the exact generator shape, minimal new code | Cursor does not recognize `PreToolUse`/`PostToolUse`/etc. as hook-config keys at all — the config would be silently inert |
+| **Explicit per-matcher mapping table (`Bash`→`beforeShellExecution`, `Edit\|Write\|MultiEdit`/`Write`→`preToolUse`+matcher `Write`, `Read\|Glob\|Grep`→`preToolUse`+matcher `Read\|Grep`, `PostToolUse` split the same way, `SessionStart`→`sessionStart`, `UserPromptSubmit`→`beforeSubmitPrompt`)** | Every existing `.claude/settings.json` matcher group lands on the Cursor event closest to its actual semantics; deterministic and testable | Requires maintaining the mapping table by hand if Cursor's event vocabulary changes; coarser Cursor matcher values (no Edit/MultiEdit distinction) is a documented, accepted gap |
+| Drop non-Bash/non-shell hooks from the Cursor adapter entirely (ship only merge/secrets/ticket gates that fire on shell commands) | Avoids the field-name conformance risk on the Edit/Write path entirely | Silently drops governance coverage (ticket-first, docs-index maintenance, MCP-reindex suggestions) that Cursor users would reasonably expect parity on; the risk is better documented than hidden |
+
+### Axis 2 — Shell-command stdin shape
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Target `preToolUse` with matcher `Shell` (its `tool_input.command` field matches ours 1:1 per the live docs — zero remap) | Simplest possible implementation; no remap code at all | `preToolUse` is the generic multi-tool-call event; `beforeShellExecution` is Cursor's dedicated, purpose-built pre-execution block point for shell commands specifically — the semantically closer analog to our per-command `PreToolUse:Bash` matcher, and the one #831 explicitly asked the remap to target |
+| **Target `beforeShellExecution`, remap its top-level `command` into `{"tool_name":"Bash","tool_input":{"command":…}}` before delegating** | Matches the ticket's explicit design note; uses Cursor's dedicated shell gate; the remap is one deterministic three-line shell script, testable directly | The remap adds a moving part `preToolUse`+`Shell` wouldn't have needed |
+
+Chosen: `beforeShellExecution` with the remap, per #831's explicit design
+note. The three-line shim is a bounded, unit-testable risk; using the
+purpose-built shell-execution hook is the more defensible choice for the
+governance-critical majority of our gates (merge gates, secrets scan,
+ticket-vocabulary validators — all matched on `Bash`).
+
+### Axis 3 — `failClosed` scope
+
+| Option | Pros | Cons |
+|--------|------|------|
+| `failClosed: true` on every generated hook | Maximum hardening; a crashed script never silently passes | Turns every advisory banner (role-trigger detection, MCP-reindex suggestions) into a potential hard block on a transient jq/bash failure — disproportionate; also diverges from how those same hooks behave under Claude Code today (exit 0 on internal error) |
+| `failClosed: false` (Cursor's own default) everywhere, i.e. don't use the option | Zero risk of a new failure mode | Forfeits the one piece of hardening Cursor offers that neither Claude Code nor Codex do; the ticket explicitly calls this out as worth using |
+| **`failClosed: true` on a fixed, named list — the four merge gates, the secrets scanner, and the trust-chain/leak-protection class (no-git-add-all, no-direct-main-push, leak-protection scrubber, onboarding-config leak guard)** | Matches the ticket's framing ("mark the security-critical gates … fail-CLOSED") with a defensible, documented boundary; everything else keeps its existing fail-open posture | The boundary is a judgment call — a future security-relevant hook must be added to the list by hand; documented in both this AgDR and `docs/cursor-adapter.md` as the place to extend it |
+
+## Decision
+
+Chosen: **event-mapped delegation with a scoped stdin remap, `failClosed`
+on a named security-critical list**, implemented in
+`bin/sync-cursor-adapter.sh`:
+
+- `PreToolUse`/`Bash` → `beforeShellExecution`, remapped (Axis 2).
+- `PreToolUse`/`{Edit|Write|MultiEdit, Write}` → `preToolUse` + matcher
+  `Write`, passthrough. `PreToolUse`/`Read|Glob|Grep` → `preToolUse` +
+  matcher `Read|Grep`, passthrough.
+- `PostToolUse`/`Bash` → `postToolUse` + matcher `Shell`, passthrough.
+  `PostToolUse`/`Write|Edit|MultiEdit` → `postToolUse` + matcher `Write`,
+  passthrough.
+- `SessionStart` → `sessionStart`, passthrough. `UserPromptSubmit` →
+  `beforeSubmitPrompt`, passthrough.
+- Handler-level `if: "Bash(glob)"` predicates are compiled into the
+  remap shim as a `[[ "$cmd" == $GLOB ]]` preflight filter — the same
+  technique Codex's adapter uses for its own `if`-predicate conversion, with
+  glob `*` substituted when no `if` was present (so unconditional Bash
+  hooks are still remapped, not skipped).
+- `failClosed: true` is set on exactly nine hooks:
+  `block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`,
+  `require-design-review-for-ui.sh`, `require-architecture-review.sh`
+  (merge gates); `check-secrets.sh` (secrets scan); `block-git-add-all.sh`,
+  `block-main-push.sh`, `block-private-refs-in-public-repos.sh`,
+  `block-onboarding-in-git.sh` (trust-chain / leak protection). The list is
+  a bash array (`FAIL_CLOSED_HOOKS`) near the top of the generator, matched
+  against the hook script's basename — extend it there when a future hook
+  earns the same posture.
+- A minimal `.cursor/rules/apexyard.mdc` (`alwaysApply: true`) is generated
+  alongside `hooks.json` as the advisory bridge: it states the gates are
+  mechanical, lists the five load-bearing rules, and points at `CLAUDE.md` /
+  `.claude/rules/*.md` for the rest. It does not inline the framework's SDLC
+  content — the gates carry the enforcement; this file is a pointer, per
+  #831's "keep it minimal."
+- No `.codex/agents/*.toml`-equivalent generation and no `cursor` column on
+  `.claude/harness-models.json` — out of scope (see Scope below).
+
+## Scope
+
+**In**: `.cursor/hooks.json` generation with the event-mapping table above,
+the `beforeShellExecution` stdin remap, `failClosed` on the named
+security-critical list, the `.cursor/rules/apexyard.mdc` advisory bridge,
+`--check` drift detection, `--clean` regeneration, and a smoke test that
+exercises the delegation boundary (block/allow/skip across the remap,
+`failClosed` present/absent by hook class, exit-code preservation on the
+`preToolUse` passthrough path, no absolute paths, drift detection).
+
+**Out** (per #831 and consistent with AgDR-0086, "hooks stay bash"):
+porting hook logic to TS/JS; Cursor Tab/completions behaviour;
+enterprise/team-level hooks distribution; a `cursor` column on
+`.claude/harness-models.json` (no agent-config surface analogous to
+Codex's `.codex/agents/*.toml` exists for this adapter to populate — see
+docs/cursor-adapter.md § Known Limitations); a live-Cursor conformance test
+(tracked as a follow-up, same class of gap the Codex adapter carries today).
+
+## Consequences
+
+- `.claude/` remains the sole source of truth for gate logic across all
+  three adapters (Claude Code native, Codex, Cursor).
+- A Cursor user running `bin/sync-cursor-adapter.sh` gets the same audited
+  merge gates, secrets scan, ticket-vocabulary checks, and trust-chain
+  protections Claude Code enforces, with the security-critical subset hardened
+  fail-closed — a strictly stronger default posture than Codex's adapter
+  offers today (Codex has no `failClosed` equivalent to set).
+- The `preToolUse`/`postToolUse` (Edit/Write/Read) passthrough path carries
+  an accepted, documented conformance risk: Cursor's exact `tool_input`
+  field names for those tool types are not verified against a real session.
+  If a live-Cursor conformance test later reveals a field mismatch, the fix
+  is scoped to that passthrough path — the `beforeShellExecution` remap
+  (proven end-to-end against a real gate hook, `block-git-add-all.sh`,
+  during generator development) is unaffected.
+- The `FAIL_CLOSED_HOOKS` list is a manually maintained boundary, not derived
+  automatically from hook content. A future PR that adds a new
+  security-critical hook must also add it to this list and to the
+  corresponding table in `docs/cursor-adapter.md`, or it silently inherits
+  Cursor's fail-open default.
+- Regenerating after any `.claude/settings.json` or `.claude/hooks/*.sh`
+  change is manual (`bin/sync-cursor-adapter.sh`); `--check` catches drift
+  but nothing currently runs it automatically in CI.
+
+## Artifacts
+
+- Refs me2resh/apexyard#831
+- `bin/sync-cursor-adapter.sh`
+- `docs/cursor-adapter.md`
+- `.claude/hooks/tests/test_sync_cursor_adapter.sh`
+- Precedent: AgDR-0088 (Codex adapter), AgDR-0082 (pi gate dispatcher adapter), AgDR-0086 (hooks stay bash), AgDR-0087 (frontier-model floor — not applicable here, no model pinning added)

--- a/docs/cursor-adapter.md
+++ b/docs/cursor-adapter.md
@@ -1,0 +1,185 @@
+# Cursor Adapter
+
+ApexYard's canonical runtime still lives in `.claude/`: skills, agents, hooks,
+rules, and hook wiring are authored there first. Cursor support is generated
+from that source of truth so the two agent surfaces do not drift by hand —
+the same declarative-generate pattern as the [Codex adapter](codex-adapter.md).
+
+Decision record: [`AgDR-0091`](agdr/AgDR-0091-cursor-adapter-generation.md).
+Precedent: [`AgDR-0088`](agdr/AgDR-0088-codex-adapter-generation.md) (Codex),
+[`AgDR-0082`](agdr/AgDR-0082-pi-gate-dispatcher-adapter.md) (pi).
+
+## Generate The Adapter
+
+```bash
+bin/sync-cursor-adapter.sh
+```
+
+The command emits:
+
+- `.claude/settings.json` → `.cursor/hooks.json`
+- a static `.cursor/rules/apexyard.mdc` advisory bridge
+
+It does **not** copy `.claude/hooks/` into `.cursor/`, and it does not mirror
+`.claude/skills/` or `.claude/agents/` the way the Codex adapter does — Cursor
+has no equivalent slash-command or agent-config surface in scope for this
+adapter (see AgDR-0091 § Scope). The generated `hooks.json` keeps commands
+that exec the unmodified `.claude/hooks/*.sh` scripts, so gate decisions,
+session markers, review markers, and trust-chain path checks stay in the same
+audited bash files every harness delegates to.
+
+## Event Mapping
+
+Cursor's hook vocabulary (`beforeShellExecution`, `preToolUse`,
+`postToolUse`, `sessionStart`, `beforeSubmitPrompt`, …) does not name-match
+Claude Code's (`PreToolUse`, `PostToolUse`, `SessionStart`,
+`UserPromptSubmit`). The generator maps each `.claude/settings.json` matcher
+group to the closest Cursor event:
+
+| `.claude/settings.json` | Cursor event | Matcher | Notes |
+|---|---|---|---|
+| `PreToolUse` / `Bash` | `beforeShellExecution` | — | stdin remap (below) |
+| `PreToolUse` / `Edit\|Write\|MultiEdit`, `Write` | `preToolUse` | `Write` | passthrough |
+| `PreToolUse` / `Read\|Glob\|Grep` | `preToolUse` | `Read\|Grep` | passthrough |
+| `PostToolUse` / `Bash` | `postToolUse` | `Shell` | passthrough |
+| `PostToolUse` / `Write\|Edit\|MultiEdit` | `postToolUse` | `Write` | passthrough |
+| `SessionStart` | `sessionStart` | — | passthrough |
+| `UserPromptSubmit` | `beforeSubmitPrompt` | — | passthrough |
+
+Cursor's tool-type matcher values are `Shell`, `Read`, `Write`, `Grep`,
+`Delete`, `Task` — coarser than Claude Code's `Edit` / `Write` / `MultiEdit`
+split. Both `Edit` and `MultiEdit` fold into Cursor's `Write` matcher. This is
+a known conformance gap, not a bug: a hook that behaves differently for an
+`Edit` vs. a `MultiEdit` call cannot be reproduced 1:1 under Cursor's coarser
+taxonomy. None of the current `Edit|Write|MultiEdit`-matched hooks branch on
+which specific tool fired, so the gap is latent today.
+
+## Stdin Remap — `beforeShellExecution`
+
+Cursor's `beforeShellExecution` event puts the shell command at the
+**top level** of its stdin payload (`{"command": "...", "cwd": "...",
+"sandbox": ...}`). Every `.claude/hooks/*.sh` script parses Claude Code's
+stdin shape instead (`{"tool_name": "Bash", "tool_input": {"command": "..."}}`).
+The generator closes that gap with a thin remap shim embedded in each
+generated `beforeShellExecution` command:
+
+1. Read the top-level `command` field from Cursor's stdin.
+2. If the original Claude Code hook had a handler-level `if: "Bash(glob)"`
+   predicate, apply the same glob as a shell `[[ == ]]` preflight filter
+   (absent `if` — an unconditional Bash hook — is treated as glob `*`, so
+   unconditional hooks are still remapped and still run on every shell call).
+3. Re-wrap the command into `{"tool_name":"Bash","tool_input":{"command":…}}`
+   and pipe it into the unmodified `.claude/hooks/<name>.sh`.
+4. The hook's exit code propagates unchanged.
+
+Unlike the Codex adapter (which needed a JSON `permission` translation),
+Cursor treats **exit code 2 as a native deny** — "Exit code 2 blocks the
+action (equivalent to returning `permission: "deny"`)" per the [Cursor hooks
+docs](https://cursor.com/docs/hooks) — so the remap is the only shape
+translation required; no exit-code translation is needed.
+
+`preToolUse` / `postToolUse`-mapped hooks (Edit/Write/Read family) get no
+remap: Cursor's own `tool_name`/`tool_input` shape for those events is
+already the closest match to what the bash hooks parse, so those entries are
+passed through unchanged. The Cursor-native field names inside `tool_input`
+for non-Shell tools are not publicly documented beyond the base
+`tool_name`/`tool_input` envelope, so live-Cursor conformance for that path
+is unverified — see "Known Limitations" below.
+
+## `failClosed` — Security-Critical Gates
+
+Cursor hooks default to **fail-open**: `"failClosed": false` (or omitted)
+means a crashed or timed-out hook lets the action through. The generator
+marks a fixed set of security-critical gates `"failClosed": true` so a hook
+crash blocks instead of silently passing:
+
+| Class | Hooks |
+|---|---|
+| Merge gates | `block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, `require-design-review-for-ui.sh`, `require-architecture-review.sh` |
+| Secrets scan | `check-secrets.sh` |
+| Trust-chain / leak protection | `block-git-add-all.sh`, `block-main-push.sh`, `block-private-refs-in-public-repos.sh`, `block-onboarding-in-git.sh` |
+
+Every other hook (ticket-vocabulary format validators, ticket-first gates,
+advisory banners) stays fail-open — same default Cursor ships and the same
+posture those hooks already have under Claude Code today (they exit 0 on
+their own internal errors). The list is defined as `FAIL_CLOSED_HOOKS` near
+the top of `bin/sync-cursor-adapter.sh`; extend it there if a future hook
+joins the security-critical class.
+
+## Advisory Bridge — `.cursor/rules/apexyard.mdc`
+
+The generator also writes a minimal Cursor project rule
+(`.cursor/rules/apexyard.mdc`, `alwaysApply: true`) that tells the agent the
+gates are mechanical (enforced by `.cursor/hooks.json`, not by this file),
+lists the five load-bearing rules to know before starting work, and points
+at `CLAUDE.md` and `.claude/rules/*.md` for the full detail. It intentionally
+does not inline the framework's SDLC content — see AgDR-0091 for why the
+gates carry the substance and the rule file stays a pointer.
+
+## Drift Check
+
+```bash
+bin/sync-cursor-adapter.sh --check
+```
+
+Use `--check` when generated adapter files are present and you want to
+verify they still match `.claude/`. It exits non-zero on drift and prints
+the files that need regeneration.
+
+## Clean Regeneration
+
+```bash
+bin/sync-cursor-adapter.sh --clean
+```
+
+Removes the existing generated `.cursor/` tree before regenerating it.
+Useful after generator changes.
+
+## Tracking Policy
+
+Same as the Codex adapter: the generator and its tests are the durable
+upstream contribution. The generated `.cursor/` output should not be
+committed directly from a local run (it can contain no absolute paths by
+construction, but treat it the same as any generated artifact). For local
+exploration, add it to `.git/info/exclude`:
+
+```gitignore
+.cursor/
+```
+
+If an adopter wants to treat Cursor as an enforced governance surface,
+review and trust the generated `.cursor/hooks.json` explicitly and consider
+tracking the generated adapter plus enforcing `--check` in CI.
+
+## Known Limitations
+
+- **Live-Cursor conformance is unverified.** This repository's bash smoke
+  test (`.claude/hooks/tests/test_sync_cursor_adapter.sh`) proves command
+  delegation, the stdin remap, and exit-code preservation entirely inside a
+  synthetic fixture — it does not prove a real Cursor session actually loads
+  `.cursor/hooks.json`, fires `beforeShellExecution` on every shell command,
+  or blocks a real `gh pr merge` attempt end-to-end. A live-Cursor
+  conformance test (a real Cursor session driving `gh pr merge` against
+  `block-unreviewed-merge.sh` and observing the deny) is a tracked follow-up,
+  same gap the Codex adapter carries today.
+- **`preToolUse`/`postToolUse` field-name conformance is unverified.** The
+  live docs confirm `tool_input.command` for the `Shell` matcher (which this
+  adapter avoids by using `beforeShellExecution` instead) but do not document
+  the exact `tool_input` field names Cursor's own `Write`/`Read` tools use.
+  Hooks delegated through `preToolUse`/`postToolUse` (the ticket-first gate,
+  `maintain-docs-index.sh`, etc.) may receive a differently-shaped
+  `tool_input` than the `.claude/hooks/*.sh` scripts expect until this is
+  verified against a real session.
+- **Model pinning is out of scope.** Cursor hook generation does not need
+  agent model-tier pinning the way the Codex adapter does (Codex agents run
+  under `.codex/agents/*.toml` with a translated model label). This adapter
+  does not add a `cursor` column to `.claude/harness-models.json`.
+
+## Design Notes
+
+- `.claude/` remains the source of truth.
+- Generated files must not contain absolute paths to the local clone.
+- Hook, rule, session, and review-marker references stay pointed at
+  `.claude/...` because those files remain canonical and audited.
+- The generator is intentionally plain Bash plus `jq`, matching the rest of
+  the framework's hook/test toolchain and the Codex adapter's own approach.


### PR DESCRIPTION
## Summary

- **New `bin/sync-cursor-adapter.sh`** generates `.cursor/hooks.json` from `.claude/settings.json`, following the AgDR-0088 declarative-generate pattern already proven by the Codex adapter (#730): every generated hook command still execs the unmodified `.claude/hooks/*.sh` scripts, so gate logic is never forked or duplicated. Cursor's hook vocabulary doesn't name-match Claude Code's (`beforeShellExecution`/`preToolUse`/`postToolUse`/`sessionStart`/`beforeSubmitPrompt` vs. `PreToolUse`/`PostToolUse`/`SessionStart`/`UserPromptSubmit`), so the generator carries an explicit per-matcher mapping table instead of a straight key rename.
- **Stdin remap for shell commands** — Cursor's `beforeShellExecution` event puts the command at the top level of stdin (`{"command": "...", "cwd": ...}`), while every `.claude/hooks/*.sh` script parses Claude Code's shape (`tool_input.command`). The generated command reads the top-level field, applies the same `Bash(glob)` preflight filter Claude's handler-level `if` predicate encodes (unconditional hooks get glob `*` so they're still remapped), re-wraps into the canonical shape, and delegates. Verified end-to-end during development against a real gate (`block-git-add-all.sh` correctly blocked `git add -A` and allowed `git add file.txt` through the full remap path).
- **`failClosed: true` on nine security-critical hooks** — the four merge gates (`block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, `require-design-review-for-ui.sh`, `require-architecture-review.sh`), the secrets scanner (`check-secrets.sh`), and the trust-chain/leak-protection class (`block-git-add-all.sh`, `block-main-push.sh`, `block-private-refs-in-public-repos.sh`, `block-onboarding-in-git.sh`). A crash or timeout on one of these blocks the action instead of silently passing — a hardening option Cursor exposes that neither Claude Code nor Codex do. Everything else stays fail-open, matching its existing posture under Claude Code.
- **`--check` drift detection and `--clean` regeneration**, mirroring the Codex generator's flags exactly.
- **`.cursor/rules/apexyard.mdc`** — a minimal, `alwaysApply: true` advisory bridge that states the gates are mechanical (not this file), lists the five load-bearing rules, and points at `CLAUDE.md`/`.claude/rules/*.md` for the rest. Kept deliberately thin — the gates carry the substance.
- **`docs/cursor-adapter.md`** (mirrors `docs/codex-adapter.md`) and **AgDR-0091** record the event-mapping table, the remap design, the `failClosed` boundary and its rationale, and the accepted conformance gaps — documented rather than silently hidden, matching how AgDR-0088 handled the equivalent Codex-runtime-conformance risk.

## Design decisions worth flagging for review

- **Event mapping**: `PreToolUse`/`Bash` → `beforeShellExecution` (remapped); `PreToolUse`/`{Edit|Write|MultiEdit, Write}` and `Read|Glob|Grep` → `preToolUse` (passthrough, matcher `Write` / `Read|Grep`); `PostToolUse` splits the same way onto `postToolUse`; `SessionStart` → `sessionStart`; `UserPromptSubmit` → `beforeSubmitPrompt`. Full table in `docs/cursor-adapter.md`.
- **Known, documented conformance gaps** (not blocking, called out explicitly): (1) Cursor's own `tool_input` field names for `Write`/`Read` tool types beyond the base envelope aren't published in the docs I could verify, so the `preToolUse`/`postToolUse` passthrough path is unverified against a real session; (2) Cursor's tool-type matcher values (`Shell`/`Read`/`Write`/`Grep`/`Delete`/`Task`) are coarser than Claude Code's `Edit`/`Write`/`MultiEdit` split — both fold into `Write`; (3) a real live-Cursor conformance test (a Cursor session actually blocking `gh pr merge`) is a tracked follow-up, same gap class the Codex adapter carries today.
- **No `.codex/agents/*.toml` equivalent and no `cursor` column on `.claude/harness-models.json`** — Cursor hook generation doesn't need agent model-tier pinning (there's no agent-config surface analogous to Codex's for this adapter to populate). Noted rather than silently added, in case a future PR needs it.
- Did **not** touch `README.md` (owned by the #834 doc-index PR) or `.claude/harness-models.json`.

## Testing

- `bash .claude/hooks/tests/test_sync_cursor_adapter.sh` — new smoke test, 25/25 assertions pass: config shape (`version: 1`), the event-mapping table (Bash-matcher count under `beforeShellExecution`, `Edit|Write|MultiEdit` → `preToolUse` matcher `Write`, `SessionStart` → `sessionStart`), no absolute fixture paths, no leaked `if` metadata, `failClosed` present on the security-critical fixture hook and absent on a non-critical one, delegation exec across the remap boundary (block / allow / skip, including the unconditional-Bash-hook case), `preToolUse` passthrough exit-code preservation, rules-bridge content, `--check` drift detection (clean + dirty), `--clean` regeneration.
- `bash bin/run-hook-tests.sh` (session pin neutralized) — full suite green: **95/95 PASS, 0 FAIL, 0 SKIP**, including the new test alongside the existing 94.
- Ran `bin/sync-cursor-adapter.sh` against this repo's real `.claude/settings.json` (not committed — same untracked-generated-output policy as the Codex adapter) and manually exercised the generated `beforeShellExecution` command for `block-git-add-all.sh` with `git add -A` (blocked, exit 2, full error message rendered), `git add file.txt` (allowed, exit 0), and a non-matching command (skipped, exit 0).
- `shellcheck` on both new files: only pre-existing-pattern info-level notices (SC2015, SC2016) matching the Codex adapter's own style — no new warnings.

Closes #831

---

## Glossary

| Term | Definition |
|------|------------|
| `failClosed` | Cursor hook option: a crashed/timed-out hook BLOCKS the action instead of failing open — used here for merge gates, secrets scan, and trust-chain hooks. |
| `beforeShellExecution` | Cursor's dedicated pre-execution hook for shell commands; stdin carries `command` at the top level (not nested under `tool_input`), which is why the remap shim exists. |
| `preToolUse` (Cursor) | Cursor's generic pre-tool hook event; carries `tool_name`/`tool_input`, closest to Claude Code's stdin contract for non-shell tool calls. |
| Declarative-generate adapter | The AgDR-0088 pattern: generate the harness's native hook config from `.claude/settings.json`, delegating execution to the unmodified bash gates — used by the Codex, pi, and now Cursor adapters. |
| Stdin remap shim | The three-line shell script embedded in each generated `beforeShellExecution` command that reshapes Cursor's top-level `command` field into Claude Code's `{"tool_name":"Bash","tool_input":{"command":...}}` envelope before delegating. |