### PR TITLE
docs(#840): refresh harness matrices + cursor/opencode pages to merged reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ ApexYard is **built for Claude Code** — that's where the whole experience is n
 | **Claude Code** | Native — `CLAUDE.md` auto-loads; all rules, skills, agents are first-class | **Enforced live** — bash hooks fire on every tool call | **Native, full experience** |
 | **Codex** | Generated from `.claude/` into `.agents/` + `.codex/` | **Delegated** — generated `.codex/hooks.json` execs the unmodified bash hooks | Adapter **merged** (#730, [AgDR-0088](docs/agdr/AgDR-0088-codex-adapter-generation.md)); live conformance test pending |
 | **pi** (pi.dev) | `AGENTS.md` + `SYSTEM.md` advisory bridge | **Delegated** — one dispatcher extension over the unmodified bash hooks | Adapter **shipped**; live model-turn conformance pending (#815, [AgDR-0082](docs/agdr/AgDR-0082-pi-gate-dispatcher-adapter.md)) |
-| **opencode** | Planned | **Delegated** plugin over the bash hooks (planned) | **Planned** (#821) |
-| **Cursor** | Planned | Generated `.cursor/hooks.json` delegating to the bash hooks (planned) | **Planned** (#831) |
+| **opencode** | `AGENTS.md` bridge | **Delegated** — plugin derives its gate table from `settings.json` and execs the unmodified bash hooks | Adapter **merged** (PR #839, [AgDR-0092](docs/agdr/AgDR-0092-opencode-gate-adapter.md)); live conformance pending (#821) |
+| **Cursor** | Generated `.cursor/rules/` bridge | **Delegated** — generated `.cursor/hooks.json` execs the unmodified bash hooks; native `exit 2`, `failClosed` on security-critical gates | Adapter **merged** (PR #838, [AgDR-0091](docs/agdr/AgDR-0091-cursor-adapter-generation.md)); live conformance pending (#840) |
 
 The shared-core reason this works: gates stay portable bash ([AgDR-0086](docs/agdr/AgDR-0086-hooks-stay-bash-not-ported.md)), `.claude/` is the one canonical authoring surface, harnesses are transports (never a second copy of the gate logic), and model tiers resolve through one matrix ([`.claude/harness-models.json`](.claude/harness-models.json), [AgDR-0088](docs/agdr/AgDR-0088-codex-adapter-generation.md)). Full per-harness breakdown, the adapter-authoring pattern for new harnesses, and the rebrand trigger → **[`docs/harnesses/`](docs/harnesses/README.md)**.
 

--- a/docs/harnesses/README.md
+++ b/docs/harnesses/README.md
@@ -17,10 +17,10 @@ Three maturity tiers, so a column says exactly what it means:
 | **Claude Code** | Native — `CLAUDE.md` auto-loads at session start; all rules, 65 skills, and 25 agents are first-class | **Enforced live** — the bash hooks fire on `PreToolUse` / `PostToolUse` / `SessionStart` | **Native, full experience** |
 | **Codex** | Generated — `.claude/skills/` → `.agents/skills/`, `.claude/agents/*.md` → `.codex/agents/*.toml` | **Delegated** — generated `.codex/hooks.json` execs the *unmodified* `.claude/hooks/*.sh`; block-on-`exit 2` preserved | **Adapter merged** (#730, [AgDR-0088](../agdr/AgDR-0088-codex-adapter-generation.md)); live Codex-runtime conformance test pending |
 | **pi** (pi.dev) | `AGENTS.md` + `SYSTEM.md` advisory bridge, auto-loaded from cwd (#805) | **Delegated** — one dispatcher extension registers on pi's `tool_call` event and shells out to the *unmodified* bash hooks (#815, [AgDR-0082](../agdr/AgDR-0082-pi-gate-dispatcher-adapter.md)) | **Adapter shipped; live model-turn conformance pending** ([`pi.md`](pi.md)) |
-| **opencode** | Planned — `AGENTS.md` bridge | **Delegated** — plugin over the bash hooks (planned) | **Planned** (#821) |
-| **Cursor** | Planned — `AGENTS.md` / rules bridge | **Delegated** — generated `.cursor/hooks.json` delegating to the bash hooks, native `exit 2` / failClosed (planned) | **Planned** (#831) |
+| **opencode** | `AGENTS.md` bridge | **Delegated** — `harness-adapters/opencode/` plugin derives its gate table from `.claude/settings.json` at load and execs the *unmodified* bash hooks; throw = deny, fail-closed on execution failure (PR #839, [AgDR-0092](../agdr/AgDR-0092-opencode-gate-adapter.md)) | **Adapter merged; live model-turn conformance pending** (#821, [`opencode.md`](opencode.md)) |
+| **Cursor** | Generated `.cursor/rules/apexyard.mdc` bridge | **Delegated** — generated `.cursor/hooks.json` execs the *unmodified* bash hooks; native `exit 2` deny, `failClosed:true` on the 9 security-critical gates (PR #838, [AgDR-0091](../agdr/AgDR-0091-cursor-adapter-generation.md)) | **Adapter merged; live conformance pending** (#840, [`cursor.md`](cursor.md)) |
 
-The honest asterisk that applies to **every** non-Claude row: the adapters keep bash as the single source of truth for gate *decisions*, but whether a given harness's live internal event dispatch invokes the hook at the right moment during a real model turn is the last hop each adapter still has to prove with credentials. Codex and pi have the transport proven and tested; the credentialed live run is the open item for both.
+The honest asterisk that applies to **every** non-Claude row: the adapters keep bash as the single source of truth for gate *decisions*, but whether a given harness's live internal event dispatch invokes the hook at the right moment during a real model turn is the last hop each adapter still has to prove with credentials. All four adapters (Codex, pi, opencode, Cursor) have the transport proven and tested in-repo; the credentialed live run is the open item for each — consolidated in #840 (plus #815/#821 for pi/opencode).
 
 ## Shared-core architecture
 
@@ -40,8 +40,8 @@ Each harness has a dedicated page with a consistent skeleton — status, what's 
 - **[Claude Code](claude-code.md)** — Native, full experience. The reference harness: `CLAUDE.md` auto-load, hooks firing live, slash-command skills, sub-agents, session markers. Install pointer: [`docs/getting-started.md`](../getting-started.md).
 - **[Codex](codex.md)** — Adapter **merged** (#730). Generated from `.claude/`; gates delegate to the unmodified bash hooks, exit-2 fidelity proven in-repo; live Codex-runtime conformance pending. Full workflow in [`docs/codex-adapter.md`](../codex-adapter.md) (linked, not moved).
 - **[pi (pi.dev)](pi.md)** — Adapter **shipped** (`harness-adapters/pi/`, #815). A single dispatcher extension shells out to the bash hooks; the `AGENTS.md`/`SYSTEM.md` advisory bridge works today; live model-turn conformance is the open item.
-- **[opencode](opencode.md)** — **In progress** (#821). Intended shape: a TypeScript plugin over the unmodified bash hooks with `settings.json`-derived gates. Not shipped yet.
-- **[Cursor](cursor.md)** — **In progress** (#831). Intended shape: a generated `.cursor/hooks.json` delegating to the bash hooks, native `exit 2`, failClosed on security-critical gates. Not shipped yet.
+- **[opencode](opencode.md)** — Adapter **merged** (PR #839, AgDR-0092). A TypeScript plugin over the unmodified bash hooks with `settings.json`-derived gates (drift-proof by construction); live model-turn conformance is the open item (#821).
+- **[Cursor](cursor.md)** — Adapter **merged** (PR #838, AgDR-0091). Generated `.cursor/hooks.json` delegating to the bash hooks — native `exit 2`, `failClosed` on the security-critical gates; live conformance pending (#840). Full workflow in [`docs/cursor-adapter.md`](../cursor-adapter.md).
 
 ## Adapter-authoring pattern for future harnesses
 

--- a/docs/harnesses/cursor.md
+++ b/docs/harnesses/cursor.md
@@ -1,33 +1,44 @@
 # Harness support — Cursor
 
-**Status:** In progress — tracked by **#831**. Adapter being built now. Not shipped yet.
+**Status:** Adapter **merged** (#831 → PR #838, [AgDR-0091](../agdr/AgDR-0091-cursor-adapter-generation.md)); live Cursor-runtime conformance test pending ([#840](https://github.com/me2resh/apexyard/issues/840)).
 
-Cursor is an IDE-based agent harness that supports repo-local hooks with native `exit 2` blocking. That makes it a natural fit for the **declarative-generate** adapter shape (the same family as the Codex adapter): ApexYard generates a Cursor-native hook config that delegates every gate decision to the unmodified `.claude/hooks/*.sh`. This page describes the *intended* shape; nothing here is claimed as done.
+Cursor support follows the same declarative-generate pattern as Codex: `.cursor/hooks.json` is **generated** from the canonical `.claude/` runtime and every generated hook **delegates to the unmodified `.claude/hooks/*.sh`** — gate logic never forks. The full generate / drift-check workflow lives in **[`docs/cursor-adapter.md`](../cursor-adapter.md)** (linked here, not duplicated).
 
 ## What's enforced vs advisory today
 
-**Today:** nothing mechanical under Cursor yet — the generator isn't shipped. A Cursor user gets ApexYard's **advisory** governance now via the repo's `AGENTS.md` (which Cursor auto-loads) plus the rules and skills as plain markdown.
+**Delegated (blocking, by construction):** Cursor's hook contract natively treats **exit code 2 as deny**, so the bash hooks' block semantics pass through without translation. The generated `beforeShellExecution` entries carry every shell-command gate — the two-marker merge gate (both `gh pr merge` and `gh api …/merge` shapes), red-CI block, ticket-first, secrets/leak-protection — each deciding via the canonical bash hook. The in-repo smoke test (`.claude/hooks/tests/test_sync_cursor_adapter.sh`, 25 assertions) proves the stdin remap and exit-code preservation across the adapter boundary.
 
-**Intended (once #831 lands):** the delegated gate set the Codex and pi adapters already enforce — the two-marker merge gate, red-CI block, design/architecture review gates, secrets/leak-protection, and ticket-first / migration-ticket-first edit blocking — each decided by the canonical bash hook. Security-critical gates are intended to **failClosed** (block if the hook can't run), not fail open.
+**failClosed hardening:** the 9 security-critical gates (merge gates, red-CI, design/architecture review, secrets scan, trust-chain/leak hooks) are generated with Cursor's `"failClosed": true` — a crashed or timed-out gate hook **blocks** instead of failing open. This is a net hardening over Claude Code's own posture. Advisory/process hooks stay fail-open, matching their native behaviour.
+
+**Advisory:** a generated `.cursor/rules/apexyard.mdc` carries the advisory governance bridge (git conventions, ticket vocabulary, reporting rules) as Cursor rules content.
 
 ## How it works (transport)
 
-Intended shape: a generator emits a **`.cursor/hooks.json`** from `.claude/settings.json`, with each hook `command` exec'ing the unmodified `.claude/hooks/*.sh`. Cursor's native `exit 2` blocking maps directly to the hooks' existing block contract, so no exit-code translation layer is needed — the fidelity Codex's adapter proves in-repo carries over. This is the **declarative-generate** pattern from the [harness index](README.md#adapter-authoring-pattern-for-future-harnesses): the durable contribution is the generator + its tests, and the generated `.cursor/` tree is regenerable output.
+`bin/sync-cursor-adapter.sh` emits `.cursor/hooks.json` from `.claude/settings.json`:
 
-## How to install / generate
+- **Event mapping:** `Bash` → `beforeShellExecution` · `Edit|Write|MultiEdit` → `preToolUse` (matcher) · `SessionStart` → `sessionStart` · `UserPromptSubmit` → `beforeSubmitPrompt`, with post-tool events split the same way.
+- **Stdin remap:** Cursor delivers the shell command top-level (`{"command": …}`); the generated command re-wraps it into the Claude-Code shape (`{"tool_name":"Bash","tool_input":{"command":…}}`) before piping to the hook — so the hooks run byte-identical logic on both harnesses.
+- Claude Code's handler-level `if` predicates are compiled into the same `Bash(glob)` preflight filter the Codex adapter uses; unconditional hooks get glob `*` (remapped, never skipped).
+- No hook bodies are copied; every entry execs `$r/.claude/hooks/*.sh`.
 
-Not applicable yet. Generate instructions will ship with the adapter under **#831** (which will add `docs/cursor-adapter.md` and a dedicated AgDR). This page will link to those once merged.
+## How to generate
+
+```bash
+bin/sync-cursor-adapter.sh            # generate .cursor/hooks.json + rules
+bin/sync-cursor-adapter.sh --check    # verify generated files still match .claude/ (non-zero on drift)
+bin/sync-cursor-adapter.sh --clean    # remove generated .cursor tree before regenerating
+```
 
 ## Gaps + tracking
 
-- **The generator itself** — emitting `.cursor/hooks.json` and its drift-check — is unbuilt on `main`/`dev` today. Tracked as **#831**.
-- **Live model-turn conformance** — proving a real, credentialed Cursor turn is actually blocked by a gate (not just a generated-config test) will be an explicit AC on #831.
+- **Live Cursor-runtime conformance** — the in-repo smoke proves delegation by construction; a credentialed Cursor turn actually being blocked has not been recorded. The conformance test must explicitly assert the top-level-`.command` stdin contract (if Cursor's schema drifts from it, shell gates would fail open silently). Tracked in **#840**.
+- The `preToolUse`/`postToolUse` passthrough path (non-shell tools) carries only process/advisory hooks; its `tool_input` field names are unverified against a real Cursor session — every enforcement-critical gate rides the verified shell path. Also #840.
 
 ## Related AgDRs
 
-- [AgDR-0088](../agdr/AgDR-0088-codex-adapter-generation.md) — the Codex generator, the declarative-generate precedent this adapter follows
-- [AgDR-0086](../agdr/AgDR-0086-hooks-stay-bash-not-ported.md) — hooks stay bash; harnesses reach them via adapters
-- A dedicated Cursor-adapter AgDR will be added by **#831**.
+- [AgDR-0091](../agdr/AgDR-0091-cursor-adapter-generation.md) — Cursor adapter generation; delegate gates to the `.claude/` runtime
+- [AgDR-0088](../agdr/AgDR-0088-codex-adapter-generation.md) — the Codex precedent this adapter mirrors
+- [AgDR-0086](../agdr/AgDR-0086-hooks-stay-bash-not-ported.md) — hooks stay bash (the source of truth the adapter execs)
 
 ---
 

--- a/docs/harnesses/opencode.md
+++ b/docs/harnesses/opencode.md
@@ -1,33 +1,39 @@
 # Harness support — opencode
 
-**Status:** In progress — tracked by **#821**. Spike proved the adapter-over-bash pattern viable; the adapter is being built now. Not shipped yet.
+**Status:** Adapter **merged** (#821 → PR #839, [AgDR-0092](../agdr/AgDR-0092-opencode-gate-adapter.md)); live opencode model-turn conformance pending (#821 remains open for exactly that AC).
 
-opencode is a plugin-extensible agent harness. ApexYard's opencode support follows the same principle as every other adapter: **bash owns the gate decisions**, and a thin opencode-native layer carries each tool call into the unmodified `.claude/hooks/*.sh` scripts. This page describes the *intended* shape so adopters know what's coming; it deliberately claims nothing as done.
+opencode support is a **live TypeScript plugin** (opencode exposes an imperative plugin API rather than declarative hook config), but the governance stays single-source: the plugin is a thin transport that shells out to the **unmodified `.claude/hooks/*.sh`** and blocks the tool call when a hook exits `2`. Full install/usage in **[`docs/opencode-adapter.md`](../opencode-adapter.md)** (linked here, not duplicated).
 
 ## What's enforced vs advisory today
 
-**Today:** nothing mechanical under opencode yet — the plugin isn't shipped. An opencode user gets ApexYard's **advisory** governance now by reading the repo's `AGENTS.md` (the universal entry doc harnesses like Cursor/Aider/Cline/pi auto-load) plus the rules and skills as plain markdown.
+**Delegated (blocking, by construction):** on `tool.execute.before`, the plugin builds Claude-Code-shaped stdin, execs the matching bash hook, and **throws to deny** on exit 2 — the two-marker merge gate (all five wired merge-command shapes, including both #47 variants), red-CI block, ticket-first, secrets/leak-protection. Fail-closed is real: an execution-layer failure (spawn error, killed hook, no exit status) also denies. 43 hermetic unit tests plus a smoke script driving the real `block-unreviewed-merge.sh` to a genuine block back the transport.
 
-**Intended (once #821 lands):** the same delegated gate set the pi and Codex adapters enforce — the two-marker merge gate, red-CI block, design/architecture review gates, secrets/leak-protection, and ticket-first / migration-ticket-first edit blocking — with each decision made by the canonical bash hook, not re-implemented in the plugin.
+**Gate derivation is drift-proof:** the plugin **derives its gate table from `.claude/settings.json` at load time** — no hand-maintained gate list. A new gate wired in `settings.json` reaches opencode automatically with zero adapter changes. (This is the convergence pattern the pi adapter is slated to adopt — see #840.)
+
+**Advisory:** `AGENTS.md` carries the advisory governance bridge, per opencode's own convention.
 
 ## How it works (transport)
 
-Intended shape: a **TypeScript plugin** registered on opencode's tool-call hook that, for each matching tool call, reconstructs the stdin JSON the bash hook expects, spawns the unmodified hook, and maps its exit code (`2` = block, `0` = allow) to opencode's block/allow contract. The gate set is **derived from `.claude/settings.json`'s hook wiring** — the same "one config, two harnesses" property the pi dispatcher has — so adding a gate stays a one-place change rather than a per-harness edit. This is the **live-extension** adapter shape described in the [harness index](README.md#adapter-authoring-pattern-for-future-harnesses), mirroring the pi dispatcher.
+`harness-adapters/opencode/`:
 
-## How to install / generate
+- `src/derive-gates.ts` — parses `.claude/settings.json` PreToolUse wiring into the gate table at plugin init.
+- `src/resolve-ops-root.ts` — the same ops-fork anchor-walk the hooks use; loading outside an apexyard fork is a clean no-op.
+- `src/gate-dispatcher.ts` — builds `{"tool_name", "tool_input": {"command"|"filePath"}}` stdin, `execFile`s the hook (argv array, args via stdin only — no shell interpolation), throws on exit 2 or execution failure.
 
-Not applicable yet. Install instructions will ship with the adapter under **#821** (which will add `docs/opencode-adapter.md` and a dedicated AgDR). This page will link to those once merged.
+## How to install
+
+See [`docs/opencode-adapter.md`](../opencode-adapter.md) — opencode auto-discovers local plugins under `.opencode/plugin/`.
 
 ## Gaps + tracking
 
-- **The adapter itself** — the plugin, its gate table, and ops-root resolution — is unbuilt on `main`/`dev` today. Tracked as **#821**.
-- **Live model-turn conformance** — the same last-mile asterisk as every adapter: proving a real, credentialed opencode turn is actually blocked by a gate (not just a by-construction transport test) will be an explicit AC on #821.
+- **Live model-turn conformance** — the transport is proven against the real hooks in-repo; a credentialed opencode session invoking `tool.execute.before` against this shipped dispatcher has not been recorded (spike #816 proved the pattern live against a throwaway prototype, not this code). That closing AC is why **#821 stays open**.
+- Family hardening (bounded exec timeout, stdin for read-class tools, loud parse-failure warning): **#840**.
 
 ## Related AgDRs
 
-- [AgDR-0082](../agdr/AgDR-0082-pi-gate-dispatcher-adapter.md) — the pi gate-dispatcher, the live-extension precedent this adapter follows
-- [AgDR-0086](../agdr/AgDR-0086-hooks-stay-bash-not-ported.md) — hooks stay bash; harnesses reach them via adapters
-- A dedicated opencode-adapter AgDR will be added by **#821**.
+- [AgDR-0092](../agdr/AgDR-0092-opencode-gate-adapter.md) — opencode gate adapter; settings.json-derived gates over the bash hooks
+- [AgDR-0082](../agdr/AgDR-0082-pi-gate-dispatcher-adapter.md) — the pi dispatcher precedent
+- [AgDR-0086](../agdr/AgDR-0086-hooks-stay-bash-not-ported.md) — hooks stay bash (the source of truth the plugin execs)
 
 ---
 


### PR DESCRIPTION
## Summary
- **Fixes the docs-vs-reality drift from the merge train** — #836's harness pages shipped while the Cursor (#838) and opencode (#839) adapter PRs were still in flight, so the matrices said **Planned** and both pages said *not shipped yet* about adapters that merged the same hour. This closes #840's item D: both README matrices, the index bullets, the honest-asterisk paragraph, and full rewrites of `cursor.md` + `opencode.md` now state the merged truth — adapter **merged** (PR/AgDR cited), **live conformance pending** — the same asterisk shape Codex and pi carry.
- The rewritten pages document what actually shipped: Cursor's stdin remap + `failClosed` on the 9 security-critical gates; opencode's `settings.json`-derived gate table (drift-proof) + throw-to-deny fail-closed dispatcher.
- Every claim stays truthful: nothing asserts live-proven enforcement; the rebrand trigger and status key are untouched.

## Testing
- markdownlint clean; grep sweep confirms no stale 'Planned'/'not shipped' claims remain (the status-key definition line is the only legitimate 'Planned' left).

Refs #840 (item D — the rest of #840 stays open).

## Glossary
| Term | Definition |
|------|------------|
| Live conformance | A credentialed, real model turn actually blocked by a gate — the last-mile proof each adapter still owes. |
| failClosed | Cursor hook option: a crashed/timed-out gate hook blocks instead of failing open. |
| settings.json-derived gates | The opencode plugin builds its gate table from `.claude/settings.json` at load — no hand-maintained list to drift. |