### PR TITLE
fix(#840): Cursor adapter must install at user-level hooks.json, not project

### DIFF
--- a/.claude/hooks/tests/test_install_cursor_adapter.sh
+++ b/.claude/hooks/tests/test_install_cursor_adapter.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Smoke tests for bin/install-cursor-adapter.sh — the install/uninstall
+# lifecycle wrapper around `bin/sync-cursor-adapter.sh --user` (#840).
+# Complements test_sync_cursor_adapter.sh's --user assertions (which cover
+# the merge/idempotency/drift logic in the generator itself); this file
+# covers install-cursor-adapter.sh's own surface: default invocation,
+# --uninstall, and its scoped-removal / backup guarantees.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCRIPT="$ROOT/bin/install-cursor-adapter.sh"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+PASS=0
+FAIL=0
+FAILED=""
+
+mark_pass() { green "  ok   $1"; PASS=$((PASS+1)); }
+mark_fail() {
+  red "  FAIL $1: $2" >&2
+  FAIL=$((FAIL+1))
+  FAILED="$FAILED $1"
+}
+
+assert_file() {
+  local path="$1" label="$2"
+  [ -f "$path" ] && mark_pass "$label" || mark_fail "$label" "missing $path"
+}
+
+# Never let this test touch a real $HOME — every invocation below passes an
+# explicit --user-dir into a throwaway fixture tree.
+unset CLAUDE_CODE_SESSION_ID
+
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/install-cursor-adapter-test.XXXXXX")
+trap 'rm -rf "$TMPROOT"' EXIT
+
+mkdir -p "$TMPROOT/.claude/hooks" "$TMPROOT/bin"
+touch "$TMPROOT/.apexyard-fork"
+
+# install-cursor-adapter.sh's --root is "the repo where bin/ and .claude/
+# live together" (the same repo, not a separate framework clone — every
+# apexyard-governed project carries its own copy of both). Mirror that
+# shape in the fixture: copy the real generator script in alongside a
+# synthetic .claude/ tree, so this test drives the real
+# sync-cursor-adapter.sh logic without depending on — or mutating — this
+# repo's own live .claude/ or .cursor/ state.
+cp "$ROOT/bin/sync-cursor-adapter.sh" "$TMPROOT/bin/sync-cursor-adapter.sh"
+chmod +x "$TMPROOT/bin/sync-cursor-adapter.sh"
+cat > "$TMPROOT/.claude/hooks/check-secrets.sh" <<'SH'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 0
+SH
+chmod +x "$TMPROOT/.claude/hooks/check-secrets.sh"
+
+cat > "$TMPROOT/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "bash -c 'exec \"$PWD/.claude/hooks/check-secrets.sh\"'" }
+        ]
+      }
+    ]
+  }
+}
+JSON
+
+USERDIR="$TMPROOT/fake-home/.cursor"
+
+echo "== install-cursor-adapter.sh install"
+
+if bash "$SCRIPT" --root "$TMPROOT" --user-dir "$USERDIR" >/tmp/_install_cursor.out 2>&1; then
+  mark_pass "default invocation installs into --user-dir"
+else
+  mark_fail "default invocation installs into --user-dir" "$(cat /tmp/_install_cursor.out)"
+fi
+
+assert_file "$USERDIR/hooks.json" "user hooks.json exists after install"
+assert_file "$TMPROOT/.cursor/rules/apexyard.mdc" "project rules bridge exists after install"
+
+if jq -e '[.hooks.beforeShellExecution[] | select(.command | contains("check-secrets.sh"))] | length == 1' "$USERDIR/hooks.json" >/dev/null 2>&1; then
+  mark_pass "installed hooks.json carries the generated apexyard entry"
+else
+  mark_fail "installed hooks.json carries the generated apexyard entry" "$(jq '.hooks' "$USERDIR/hooks.json")"
+fi
+
+if grep -F "MainThreadShellExec" /tmp/_install_cursor.out >/dev/null 2>&1 && grep -F "cursor-agent" /tmp/_install_cursor.out >/dev/null 2>&1; then
+  mark_pass "install output names the failClosed + CLI-not-covered limitations"
+else
+  mark_fail "install output names the failClosed + CLI-not-covered limitations" "$(cat /tmp/_install_cursor.out)"
+fi
+
+echo "== install-cursor-adapter.sh preserves a foreign hook across re-install"
+
+jq '.hooks.beforeShellExecution += [{"command": "some-other-tool --scan"}]' "$USERDIR/hooks.json" > "$USERDIR/hooks.json.tmp"
+mv "$USERDIR/hooks.json.tmp" "$USERDIR/hooks.json"
+
+if bash "$SCRIPT" --root "$TMPROOT" --user-dir "$USERDIR" >/tmp/_install_cursor_reinstall.out 2>&1; then
+  mark_pass "re-install succeeds"
+else
+  mark_fail "re-install succeeds" "$(cat /tmp/_install_cursor_reinstall.out)"
+fi
+
+if jq -e '[.hooks.beforeShellExecution[] | select(.command == "some-other-tool --scan")] | length == 1' "$USERDIR/hooks.json" >/dev/null 2>&1; then
+  mark_pass "re-install preserves the foreign hook entry"
+else
+  mark_fail "re-install preserves the foreign hook entry" "$(jq '.hooks.beforeShellExecution' "$USERDIR/hooks.json")"
+fi
+
+echo "== install-cursor-adapter.sh --uninstall"
+
+if bash "$SCRIPT" --user-dir "$USERDIR" --uninstall >/tmp/_uninstall_cursor.out 2>&1; then
+  mark_pass "--uninstall succeeds"
+else
+  mark_fail "--uninstall succeeds" "$(cat /tmp/_uninstall_cursor.out)"
+fi
+
+if jq -e '[.hooks.beforeShellExecution[]? | select(.command | contains("check-secrets.sh"))] | length == 0' "$USERDIR/hooks.json" >/dev/null 2>&1; then
+  mark_pass "--uninstall removes the apexyard-owned entry"
+else
+  mark_fail "--uninstall removes the apexyard-owned entry" "$(jq '.hooks' "$USERDIR/hooks.json")"
+fi
+
+if jq -e '[.hooks.beforeShellExecution[]? | select(.command == "some-other-tool --scan")] | length == 1' "$USERDIR/hooks.json" >/dev/null 2>&1; then
+  mark_pass "--uninstall leaves the foreign hook entry alone"
+else
+  mark_fail "--uninstall leaves the foreign hook entry alone" "$(jq '.hooks' "$USERDIR/hooks.json")"
+fi
+
+if compgen -G "$USERDIR/hooks.json.bak-*" >/dev/null 2>&1; then
+  mark_pass "--uninstall writes a backup before modifying"
+else
+  mark_fail "--uninstall writes a backup before modifying" "no hooks.json.bak-* found"
+fi
+
+echo "== install-cursor-adapter.sh --uninstall is a no-op with nothing installed"
+
+EMPTY_USERDIR="$TMPROOT/fake-home-empty/.cursor"
+if bash "$SCRIPT" --user-dir "$EMPTY_USERDIR" --uninstall >/tmp/_uninstall_cursor_empty.out 2>&1; then
+  mark_pass "--uninstall on a missing user config exits cleanly"
+else
+  mark_fail "--uninstall on a missing user config exits cleanly" "$(cat /tmp/_uninstall_cursor_empty.out)"
+fi
+if [ -f "$EMPTY_USERDIR/hooks.json" ]; then
+  mark_fail "--uninstall does not fabricate a hooks.json when none existed" "hooks.json was created"
+else
+  mark_pass "--uninstall does not fabricate a hooks.json when none existed"
+fi
+
+echo
+echo "===== test_install_cursor_adapter.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED"
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_sync_cursor_adapter.sh
+++ b/.claude/hooks/tests/test_sync_cursor_adapter.sh
@@ -338,6 +338,117 @@ else
 fi
 assert_file "$TMPROOT/.cursor/hooks.json" "hooks.json exists after --clean"
 
+# --- --user mode: merge into a USER-level hooks.json (me2resh/apexyard#840
+# finding #3 — Cursor 3.x only loads the user config, not project
+# .cursor/hooks.json). Uses --user-dir to point at a throwaway fixture
+# directory — MUST NEVER touch a real $HOME. ---------------------------
+echo "== Cursor adapter --user merge"
+
+USERDIR="$TMPROOT/fake-home/.cursor"
+mkdir -p "$USERDIR"
+
+# Seed the "existing user config" with one entry that is NOT apexyard's
+# (must survive every merge) and one stale apexyard-owned entry (must be
+# replaced, not duplicated, on every run).
+cat > "$USERDIR/hooks.json" <<'JSON'
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      { "command": "some-other-tool --check" },
+      { "command": "bash -c 'exec /some/old/path/.claude/hooks/stale-hook.sh'" }
+    ],
+    "beforeMCPExecution": [
+      { "command": "unrelated-mcp-guard" }
+    ]
+  }
+}
+JSON
+
+if bash "$SCRIPT" --root "$TMPROOT" --user --user-dir "$USERDIR" >/tmp/_cursor_adapter_user.out 2>&1; then
+  mark_pass "--user merges into the user-level hooks.json"
+else
+  mark_fail "--user merges into the user-level hooks.json" "$(cat /tmp/_cursor_adapter_user.out)"
+fi
+
+assert_file "$USERDIR/hooks.json" "user hooks.json exists after --user"
+
+if jq -e '[.hooks.beforeShellExecution[] | select(.command == "some-other-tool --check")] | length == 1' "$USERDIR/hooks.json" >/dev/null 2>&1; then
+  mark_pass "--user preserves a pre-existing non-apexyard hook entry"
+else
+  mark_fail "--user preserves a pre-existing non-apexyard hook entry" "$(jq '.hooks.beforeShellExecution' "$USERDIR/hooks.json")"
+fi
+
+if jq -e '[.hooks.beforeShellExecution[] | select(.command | contains("stale-hook.sh"))] | length == 0' "$USERDIR/hooks.json" >/dev/null 2>&1; then
+  mark_pass "--user drops the stale apexyard-owned entry it replaces"
+else
+  mark_fail "--user drops the stale apexyard-owned entry it replaces" "stale-hook.sh entry still present"
+fi
+
+if jq -e '[.hooks.beforeShellExecution[] | select(.command | contains(".claude/hooks/check-secrets.sh"))] | length == 1' "$USERDIR/hooks.json" >/dev/null 2>&1; then
+  mark_pass "--user installs the freshly generated apexyard entries"
+else
+  mark_fail "--user installs the freshly generated apexyard entries" "$(jq '.hooks.beforeShellExecution' "$USERDIR/hooks.json")"
+fi
+
+if jq -e '.hooks.beforeMCPExecution[0].command == "unrelated-mcp-guard"' "$USERDIR/hooks.json" >/dev/null 2>&1; then
+  mark_pass "--user leaves an untouched, unrelated event array alone"
+else
+  mark_fail "--user leaves an untouched, unrelated event array alone" "$(jq '.hooks.beforeMCPExecution' "$USERDIR/hooks.json")"
+fi
+
+if compgen -G "$USERDIR/hooks.json.bak-*" >/dev/null 2>&1; then
+  mark_pass "--user backs up the pre-existing user hooks.json before overwriting"
+else
+  mark_fail "--user backs up the pre-existing user hooks.json before overwriting" "no hooks.json.bak-* found"
+fi
+
+assert_file "$TMPROOT/.cursor/rules/apexyard.mdc" "--user still refreshes the project-level rules bridge"
+
+before_count=$(jq '[.hooks.beforeShellExecution[]] | length' "$USERDIR/hooks.json")
+if bash "$SCRIPT" --root "$TMPROOT" --user --user-dir "$USERDIR" >/tmp/_cursor_adapter_user2.out 2>&1; then
+  mark_pass "--user re-run succeeds"
+else
+  mark_fail "--user re-run succeeds" "$(cat /tmp/_cursor_adapter_user2.out)"
+fi
+after_count=$(jq '[.hooks.beforeShellExecution[]] | length' "$USERDIR/hooks.json")
+if [ "$before_count" = "$after_count" ]; then
+  mark_pass "--user re-run is idempotent (no duplicate entries)"
+else
+  mark_fail "--user re-run is idempotent (no duplicate entries)" "count went from $before_count to $after_count"
+fi
+
+if bash "$SCRIPT" --root "$TMPROOT" --user --user-dir "$USERDIR" --check >/tmp/_cursor_adapter_user_check.out 2>&1; then
+  mark_pass "--user --check passes when the user config is current"
+else
+  mark_fail "--user --check passes when the user config is current" "$(cat /tmp/_cursor_adapter_user_check.out)"
+fi
+
+jq '.hooks.beforeShellExecution += [{"command": "manual-tamper"}]' "$USERDIR/hooks.json" > "$USERDIR/hooks.json.tmp"
+mv "$USERDIR/hooks.json.tmp" "$USERDIR/hooks.json"
+if bash "$SCRIPT" --root "$TMPROOT" --user --user-dir "$USERDIR" --check >/tmp/_cursor_adapter_user_check2.out 2>&1; then
+  mark_pass "--user --check still passes when only a non-apexyard entry was added"
+else
+  mark_fail "--user --check still passes when only a non-apexyard entry was added" "$(cat /tmp/_cursor_adapter_user_check2.out)"
+fi
+
+jq '.hooks.beforeShellExecution |= map(select((.command | contains(".claude/hooks/check-secrets.sh")) | not))' "$USERDIR/hooks.json" > "$USERDIR/hooks.json.tmp"
+mv "$USERDIR/hooks.json.tmp" "$USERDIR/hooks.json"
+if bash "$SCRIPT" --root "$TMPROOT" --user --user-dir "$USERDIR" --check >/tmp/_cursor_adapter_user_check3.out 2>&1; then
+  mark_fail "--user --check detects drift when an apexyard entry is removed" "expected non-zero exit"
+else
+  mark_pass "--user --check detects drift when an apexyard entry is removed"
+fi
+
+# --- --user mode against a directory with no pre-existing hooks.json ----
+FRESH_USERDIR="$TMPROOT/fake-home-fresh/.cursor"
+if bash "$SCRIPT" --root "$TMPROOT" --user --user-dir "$FRESH_USERDIR" >/tmp/_cursor_adapter_user_fresh.out 2>&1; then
+  mark_pass "--user creates the user config from scratch when absent"
+else
+  mark_fail "--user creates the user config from scratch when absent" "$(cat /tmp/_cursor_adapter_user_fresh.out)"
+fi
+assert_file "$FRESH_USERDIR/hooks.json" "fresh user hooks.json exists"
+
 echo
 echo "===== test_sync_cursor_adapter.sh ====="
 echo "Passed: $PASS"

--- a/bin/install-cursor-adapter.sh
+++ b/bin/install-cursor-adapter.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Install the apexyard Cursor gate adapter into Cursor's USER-level hooks
+# config — the ONLY location Cursor 3.x actually loads
+# (me2resh/apexyard#840 finding #3). A project-level `.cursor/hooks.json`
+# (what `bin/sync-cursor-adapter.sh` writes without --user) showed
+# "Configured Hooks (0)" in a live Cursor.app 3.10.20 session — never
+# loaded, no trust prompt. Installing the identical, unmodified generated
+# hooks into `~/.cursor/hooks.json` showed "Configured Hooks (1)" and it
+# blocked a real `git add .` in an agent turn. Schema (`version:1`,
+# `beforeShellExecution`, `failClosed`) was already correct; only the
+# location was wrong.
+#
+# WHY THIS SCRIPT EXISTS, NOT JUST bin/sync-cursor-adapter.sh
+# ----------------------------------------------------------------
+# bin/sync-cursor-adapter.sh owns the jq generation pipeline (the
+# event-mapping table, the beforeShellExecution stdin remap, the
+# failClosed list) — this script does not fork or re-implement any of
+# that gate logic. It reuses the exact same generator, in its `--user`
+# mode, which MERGES the generated hooks.json into the user config
+# instead of writing a project file: existing entries in
+# ~/.cursor/hooks.json that this framework did not generate (the user's
+# own hooks, or a different tool's) are left untouched; only apexyard's
+# own entries (identified structurally — every one execs a
+# `.claude/hooks/*.sh` script, see owned_hooks_only() in
+# bin/sync-cursor-adapter.sh) are replaced. This wrapper adds the
+# install-lifecycle ergonomics a raw `sync-cursor-adapter.sh --user` call
+# doesn't have on its own: a documented default target, a --uninstall
+# path, and a friendly summary of what changed.
+#
+# SCOPE NOTE — this is a per-machine (per-OS-user) install, unlike the
+# pi/opencode adapters (installed per-PROJECT into that project's
+# .pi/extensions/ or .opencode/plugins/). Cursor's hook loader reads one
+# ~/.cursor/hooks.json and applies it across every project you open in
+# Cursor. That is safe here because every generated hook command still
+# self-scopes: it resolves ops-root by walking up from Cursor's cwd for
+# an `.apexyard-fork` marker (or a live session pin) and exits 0
+# immediately if the current project isn't apexyard-governed (see the
+# CURSOR_SHELL_REMAP shim in bin/sync-cursor-adapter.sh) — so installing
+# once does not force apexyard's gates onto unrelated Cursor projects.
+#
+# KNOWN LIMITATION (me2resh/apexyard#840 finding #4) — even once loaded,
+# a live Cursor.app 3.10.20 agent turn could not be confirmed to cleanly
+# EXECUTE the delegated bash hook (`MainThreadShellExec not initialized`
+# was reported, instrumentation never fired). The observed block came
+# from `failClosed: true` denying the action after the hook-runner
+# errored, not from the gate logic evaluating and returning exit 2. This
+# is weaker than the opencode/pi adapters, where the delegated bash
+# genuinely runs. See docs/cursor-adapter.md § Known Limitations before
+# relying on this for anything beyond "known-bad commands get blocked."
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+USER_DIR="${HOME:-}/.cursor"
+UNINSTALL=0
+
+usage() {
+  cat <<'USAGE'
+Usage: bin/install-cursor-adapter.sh [--root <path>] [--user-dir <path>] [--uninstall]
+
+Merges the apexyard Cursor gate adapter into Cursor's USER-level hooks
+config (~/.cursor/hooks.json by default) — the location Cursor 3.x
+actually loads (me2resh/apexyard#840). Also writes/refreshes the
+project-level .cursor/rules/apexyard.mdc advisory bridge in --root.
+
+Options:
+  --root PATH      Path to the apexyard ops fork (where bin/sync-cursor-adapter.sh
+                    and .claude/ live). Defaults to this script's own repo root.
+                    Run this from within the project whose .cursor/rules/apexyard.mdc
+                    you also want refreshed; the hooks.json merge itself is
+                    machine-wide, not project-scoped (see this script's header).
+  --user-dir PATH  Override the user Cursor config directory (default
+                    $HOME/.cursor). Mainly for testing — never point this at
+                    a real $HOME in a test.
+  --uninstall      Remove ONLY apexyard's own entries from <user-dir>/hooks.json
+                    (identified structurally, not by hand-picked event) —
+                    every other hook already in that file is left alone. A
+                    timestamped backup is written first. Does not touch the
+                    project .cursor/rules/apexyard.mdc; remove that yourself
+                    (or `rm -rf .cursor`) if you also want it gone.
+  -h, --help       Show this help.
+
+Example (install into the current machine's Cursor, refreshing this project's
+rules bridge):
+  bash /path/to/apexyard/bin/install-cursor-adapter.sh
+
+Example (uninstall):
+  bash /path/to/apexyard/bin/install-cursor-adapter.sh --uninstall
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root)
+      [ "$#" -ge 2 ] || { echo "ERROR: --root requires a path" >&2; exit 2; }
+      ROOT="$2"
+      shift
+      ;;
+    --user-dir)
+      [ "$#" -ge 2 ] || { echo "ERROR: --user-dir requires a path" >&2; exit 2; }
+      USER_DIR="$2"
+      shift
+      ;;
+    --uninstall)
+      UNINSTALL=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$USER_DIR" ]; then
+  echo "ERROR: \$HOME is not set; pass --user-dir explicitly" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required to install the Cursor adapter safely" >&2
+  exit 1
+fi
+
+if [ "$UNINSTALL" = "1" ]; then
+  TARGET="$USER_DIR/hooks.json"
+  if [ ! -f "$TARGET" ]; then
+    echo "Nothing to uninstall: $TARGET does not exist."
+    exit 0
+  fi
+  if ! jq empty "$TARGET" >/dev/null 2>&1; then
+    echo "ERROR: $TARGET is not valid JSON; refusing to modify it automatically. Inspect it by hand." >&2
+    exit 1
+  fi
+
+  BEFORE_COUNT=$(jq '[(.hooks // {})[]?[]?] | length' "$TARGET")
+  BACKUP="$TARGET.bak-$(date +%Y%m%d%H%M%S)"
+  cp "$TARGET" "$BACKUP"
+
+  jq '
+    .hooks = (
+      (.hooks // {})
+      | with_entries(.value |= map(select(((.command // "") | test("\\.claude/hooks/")) | not)))
+      | with_entries(select(.value | length > 0))
+    )
+  ' "$TARGET" > "$TARGET.tmp"
+  mv "$TARGET.tmp" "$TARGET"
+
+  AFTER_COUNT=$(jq '[(.hooks // {})[]?[]?] | length' "$TARGET")
+  REMOVED=$((BEFORE_COUNT - AFTER_COUNT))
+
+  echo "Removed $REMOVED apexyard-managed hook entr$([ "$REMOVED" = 1 ] && echo y || echo ies) from $TARGET"
+  echo "Backup saved at $BACKUP (restore with: cp \"$BACKUP\" \"$TARGET\")"
+  echo "Restart Cursor (or reload the window) for the change to take effect."
+  exit 0
+fi
+
+ROOT="$(cd "$ROOT" && pwd)"
+[ -x "$ROOT/bin/sync-cursor-adapter.sh" ] || { echo "ERROR: $ROOT/bin/sync-cursor-adapter.sh not found or not executable" >&2; exit 1; }
+
+if "$ROOT/bin/sync-cursor-adapter.sh" --user --user-dir "$USER_DIR" --root "$ROOT"; then
+  echo ""
+  echo "Restart Cursor (or reload the window) to pick up the change — Cursor"
+  echo "reads ~/.cursor/hooks.json at startup, not live."
+  echo ""
+  echo "KNOWN LIMITATION (me2resh/apexyard#840): on Cursor 3.10.20 the delegated"
+  echo "bash hook did not appear to execute cleanly in agent mode"
+  echo "(MainThreadShellExec not initialized). The observed block came from"
+  echo "failClosed denying the action after the hook-runner errored, not from"
+  echo "the gate logic evaluating. See docs/cursor-adapter.md § Known Limitations."
+  echo ""
+  echo "cursor-agent (the CLI) is NOT covered by this adapter — it enforces via"
+  echo "its own ~/.cursor/cli-config.json permissions model, not hooks.json."
+else
+  exit 1
+fi

--- a/bin/sync-cursor-adapter.sh
+++ b/bin/sync-cursor-adapter.sh
@@ -12,10 +12,13 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CHECK=0
 CLEAN=0
+USER_MODE=0
+USER_DIR="${HOME:-}/.cursor"
 
 usage() {
   cat <<'USAGE'
 Usage: bin/sync-cursor-adapter.sh [--check] [--clean] [--root <path>]
+                                   [--user [--user-dir <path>]]
 
 Generate the Cursor adapter from .claude:
   .claude/settings.json -> .cursor/hooks.json  (commands still exec .claude/hooks)
@@ -23,8 +26,22 @@ Generate the Cursor adapter from .claude:
 
 Options:
   --check       Do not write files; fail if generated output would differ.
-  --clean       Remove generated .cursor before writing.
+  --clean       Remove generated .cursor before writing (project-level only).
   --root PATH   Repository root to use instead of this script's parent.
+  --user        MERGE the generated hooks.json into Cursor's USER-level config
+                (<--user-dir>/hooks.json, default ~/.cursor/hooks.json) instead
+                of writing a project .cursor/hooks.json. Cursor 3.x only loads
+                hooks from the user config (me2resh/apexyard#840 finding #3) —
+                prefer `bin/install-cursor-adapter.sh` over this flag directly
+                unless you need the raw merge without its uninstall/backup
+                ergonomics. The project .cursor/rules/apexyard.mdc advisory
+                bridge is still written either way. Existing non-apexyard
+                entries in the user file (any event, any hook not sourced from
+                a .claude/hooks/*.sh path) are preserved; only apexyard's own
+                entries are replaced, so this is safe to re-run.
+  --user-dir PATH  Override the user Cursor config directory (default
+                    $HOME/.cursor). Only meaningful with --user; primarily for
+                    tests, which must never write into a real $HOME.
 USAGE
 }
 
@@ -32,9 +49,15 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --check) CHECK=1 ;;
     --clean) CLEAN=1 ;;
+    --user) USER_MODE=1 ;;
     --root)
       [ "$#" -ge 2 ] || { echo "ERROR: --root requires a path" >&2; exit 2; }
       ROOT="$2"
+      shift
+      ;;
+    --user-dir)
+      [ "$#" -ge 2 ] || { echo "ERROR: --user-dir requires a path" >&2; exit 2; }
+      USER_DIR="$2"
       shift
       ;;
     -h|--help)
@@ -49,6 +72,11 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+
+if [ "$USER_MODE" = "1" ] && [ -z "$USER_DIR" ]; then
+  echo "ERROR: --user requires \$HOME to be set, or pass --user-dir explicitly" >&2
+  exit 2
+fi
 
 ROOT="$(cd "$ROOT" && pwd)"
 CLAUDE_DIR="$ROOT/.claude"
@@ -298,9 +326,87 @@ check_drift() {
   fi
 }
 
+# Apexyard-owned hook entries are identified structurally, not by a custom
+# JSON field (Cursor's hook-entry schema is not documented to tolerate extra
+# keys, so we don't risk adding one) — every entry this generator emits execs
+# a `.claude/hooks/*.sh` script somewhere in its `command` string, whether via
+# the beforeShellExecution remap shim's $APEXYARD_CURSOR_ORIGINAL_HOOK or a
+# plain passthrough `exec $r/.claude/hooks/<name>.sh`. Filtering on that
+# substring is what lets --user merge (and install-cursor-adapter.sh
+# --uninstall) tell "ours, safe to replace/remove" from "the user's own
+# unrelated hook, must not touch" without any out-of-band bookkeeping file.
+owned_hooks_only() {
+  jq -S '(.hooks // {})
+    | with_entries(.value |= map(select((.command // "") | test("\\.claude/hooks/"))))
+    | with_entries(select(.value | length > 0))'
+}
+
+check_user_drift() {
+  local target="$USER_DIR/hooks.json"
+  if [ ! -f "$target" ]; then
+    echo "DRIFT: $target is missing; run bin/install-cursor-adapter.sh" >&2
+    return 1
+  fi
+  local actual_owned expected_owned
+  actual_owned=$(owned_hooks_only <"$target" 2>/dev/null) || actual_owned="{}"
+  expected_owned=$(owned_hooks_only <"$OUT_CURSOR/hooks.json")
+  if [ "$actual_owned" != "$expected_owned" ]; then
+    echo "DRIFT: apexyard-managed entries in $target differ from generated output; run bin/install-cursor-adapter.sh" >&2
+    return 1
+  fi
+}
+
+# Merge $OUT_CURSOR/hooks.json into $USER_DIR/hooks.json: every existing
+# entry whose command is NOT apexyard-owned (see owned_hooks_only above) is
+# kept untouched, in whatever event array it already lives in — a user's own
+# hooks, or another tool's, survive re-running this script. Apexyard's own
+# entries are dropped and replaced wholesale with the freshly generated ones,
+# so a re-run (or an upgrade to a newer .claude/hooks/*.sh) is idempotent
+# rather than accumulating duplicates. A timestamped backup is written before
+# every overwrite of a pre-existing, valid target file.
+install_user_hooks() {
+  mkdir -p "$USER_DIR"
+  local target="$USER_DIR/hooks.json"
+  local existing_json='{"version":1,"hooks":{}}'
+  if [ -f "$target" ]; then
+    if jq empty "$target" >/dev/null 2>&1; then
+      existing_json=$(cat "$target")
+      cp "$target" "$target.bak-$(date +%Y%m%d%H%M%S)"
+    else
+      local ts; ts=$(date +%Y%m%d%H%M%S)
+      cp "$target" "$target.bak-$ts.invalid"
+      echo "WARNING: $target was not valid JSON; backed up to $target.bak-$ts.invalid and starting fresh" >&2
+    fi
+  fi
+
+  jq -s '
+    .[0] as $existing
+    | .[1] as $generated
+    | ($existing.hooks // {}) as $ehooks
+    | ($generated.hooks // {}) as $ghooks
+    | (($ehooks | keys) + ($ghooks | keys) | unique) as $allKeys
+    | {
+        version: ($generated.version // $existing.version // 1),
+        hooks: (
+          reduce $allKeys[] as $k ({};
+            . + { ($k): (
+              (($ehooks[$k] // []) | map(select(((.command // "") | test("\\.claude/hooks/")) | not)))
+              + ($ghooks[$k] // [])
+            ) }
+          )
+        )
+      }
+  ' <(printf '%s' "$existing_json") "$OUT_CURSOR/hooks.json" > "$TMPDIR/merged-user-hooks.json"
+  mv "$TMPDIR/merged-user-hooks.json" "$target"
+}
+
 if [ "$CHECK" = "1" ]; then
   rc=0
-  check_drift "$ROOT/.cursor" "$OUT_CURSOR" ".cursor" || rc=1
+  if [ "$USER_MODE" = "1" ]; then
+    check_user_drift || rc=1
+  else
+    check_drift "$ROOT/.cursor" "$OUT_CURSOR" ".cursor" || rc=1
+  fi
   exit "$rc"
 fi
 
@@ -309,10 +415,19 @@ if [ "$CLEAN" = "1" ]; then
 fi
 
 mkdir -p "$ROOT/.cursor/rules"
-rm -f "$ROOT/.cursor/hooks.json" "$ROOT/.cursor/rules/apexyard.mdc"
-cp "$OUT_CURSOR/hooks.json" "$ROOT/.cursor/hooks.json"
+rm -f "$ROOT/.cursor/rules/apexyard.mdc"
 cp "$OUT_CURSOR/rules/apexyard.mdc" "$ROOT/.cursor/rules/apexyard.mdc"
 
-echo "Generated Cursor adapter from .claude:"
-echo "  .cursor/hooks.json"
-echo "  .cursor/rules/apexyard.mdc"
+if [ "$USER_MODE" = "1" ]; then
+  install_user_hooks
+  echo "Merged the apexyard Cursor hook adapter into the USER config (the"
+  echo "location Cursor 3.x actually loads — me2resh/apexyard#840 finding #3):"
+  echo "  $USER_DIR/hooks.json"
+  echo "  $ROOT/.cursor/rules/apexyard.mdc  (project-level advisory bridge, unaffected by the location finding)"
+else
+  rm -f "$ROOT/.cursor/hooks.json"
+  cp "$OUT_CURSOR/hooks.json" "$ROOT/.cursor/hooks.json"
+  echo "Generated Cursor adapter from .claude:"
+  echo "  .cursor/hooks.json"
+  echo "  .cursor/rules/apexyard.mdc"
+fi

--- a/docs/agdr/AgDR-0091-cursor-adapter-generation.md
+++ b/docs/agdr/AgDR-0091-cursor-adapter-generation.md
@@ -146,7 +146,10 @@ enterprise/team-level hooks distribution; a `cursor` column on
 `.claude/harness-models.json` (no agent-config surface analogous to
 Codex's `.codex/agents/*.toml` exists for this adapter to populate — see
 docs/cursor-adapter.md § Known Limitations); a live-Cursor conformance test
-(tracked as a follow-up, same class of gap the Codex adapter carries today).
+(tracked as a follow-up — at the time this AgDR was written, Codex carried
+the same "live conformance unverified" gap Cursor did; per the GH-840 update
+below, Codex's gap has since been closed via live testing, making Cursor the
+sole remaining outlier among the four third-party adapters).
 
 ## Consequences
 
@@ -196,3 +199,34 @@ Rex's review on #838 named two follow-ups beyond the "generator hardening" fail-
 - `.claude/hooks/tests/test_sync_cursor_adapter.sh` — the fixture now wires `require-migration-ticket.sh` under the `Edit|Write|MultiEdit` matcher, with an assertion that it carries `failClosed: true` and a paired assertion that `require-active-ticket.sh` still does not (guards the boundary from drifting either direction).
 
 **Consequence.** The `FAIL_CLOSED_HOOKS` list remains a manually maintained boundary (unchanged from this AgDR's original "Consequences" section) — this update adds one more entry to it, not a new maintenance mechanism. A future security- or blast-radius-relevant hook still needs the same three-part update: the bash array, `docs/cursor-adapter.md`'s table, and a fixture assertion.
+
+## Update (GH-840) — live conformance: install location, CLI scope, and a `failClosed`-vs-delegated-execution correction
+
+The original "Update (GH-840)" section above (the `require-migration-ticket.sh` `failClosed` addition) landed before live conformance testing against a real Cursor.app session and the `cursor-agent` CLI. That testing (2026-07-09) produced three findings this section records, two of which change what adopters should actually run.
+
+**Finding 1 — the adapter must install at the USER level, not project level.** Cursor 3.x's own "Open config" points at `~/.cursor/hooks.json`. A project `.cursor/hooks.json` — what `bin/sync-cursor-adapter.sh` generates without `--user`, and what this AgDR originally specified as the sole output — showed `Configured Hooks (0)` in a real Cursor.app 3.10.20 session: never loaded, no trust prompt. The *identical* generated file, installed at `~/.cursor/hooks.json` instead, showed `Configured Hooks (1)` and was loaded and enforced. This was a **location bug, not a schema bug** — `version: 1`, the `beforeShellExecution` event, and `failClosed` were already correct; only the write target was wrong.
+
+**Finding 2 — `cursor-agent` (the CLI) does not read `hooks.json` at all.** Instrumented every generated `beforeShellExecution` entry to log on fire, then ran a benign command through `cursor-agent -p -f`: the command executed and the log stayed empty. `cursor-agent` enforces via its own `~/.cursor/cli-config.json` `permissions.allow`/`deny` model — a different, undocumented-by-this-adapter surface. This AgDR's Scope section already excluded CLI agent-config surfaces by omission (it only ever discussed the Cursor IDE); this finding makes that exclusion explicit and confirmed rather than merely unaddressed.
+
+**Finding 3 — observed IDE enforcement is `failClosed`, not confirmed clean delegated execution.** With the adapter correctly installed at the user level, a real Cursor.app 3.10.20 agent turn's `git add .` was blocked and nothing staged. But the delegated hook's own instrumentation (a log write on fire) never wrote, and the agent explained the block by grepping `block-git-add-all.sh`'s source rather than citing execution output — and separately reported `MainThreadShellExec not initialized` when the shell-exec path was probed directly. The defensible read: Cursor's hook-runner could not cleanly exec the delegated bash command in this version, and `failClosed: true` (Axis 3's hardening, chosen for a different reason — hardening against hook *crashes*) denied the action because the hook-runner itself errored, not because `block-git-add-all.sh` ran and returned exit 2. This is materially weaker than what Axis 2's "proven end-to-end against a real gate hook" language in this AgDR's original Consequences section claimed — that proof was against a synthetic fixture (`test_sync_cursor_adapter.sh`), not a live Cursor session, and the live session does not confirm the same execution path holds.
+
+**Decision — corrections to ship, not just observations to record.**
+
+1. **`bin/install-cursor-adapter.sh` is added** as the primary entrypoint (mirroring the pi/opencode adapters' install-script pattern from #844/#845): it merges the same generated hooks.json content into `~/.cursor/hooks.json`, preserving any pre-existing non-apexyard entries there, with a timestamped backup before every write and a symmetric `--uninstall`.
+2. **`bin/sync-cursor-adapter.sh` gains `--user [--user-dir <path>]`**, reusing its existing jq generation pipeline unchanged and adding only the merge-into-user-config write path — no gate logic forked. Default (no `--user`) behaviour, and the tests exercising it, are unchanged; project-level generation is kept available (useful for inspection, for a possible future Cursor version that reads project config, or for adopters who want to track the generated file), documented as no longer the load-bearing install path.
+3. **Docs corrected to state the install-location finding as fact, not a caveat** — `docs/cursor-adapter.md` and `docs/harnesses/cursor.md` lead with "install at the user level" rather than mentioning it as a footnote.
+4. **The `failClosed`-vs-delegated-execution gap is documented as an open, unresolved limitation**, not glossed over as "delegation confirmed." Both docs pages now say plainly: enforcement observed so far blocks *known-bad* commands, but does not yet prove the gate's actual decision logic (as opposed to a hook-runner error) is what's running. Whether Cursor's `beforeShellExecution` can cleanly exec an external script in agent mode at all remains an open investigation.
+5. **`cursor-agent` non-coverage is stated plainly**, not implied by omission — both docs pages and `bin/install-cursor-adapter.sh`'s own output now say the CLI is not addressed and enforces via a separate `cli-config.json` permissions model.
+
+**What did NOT change:** the event-mapping table (Axis 1), the `beforeShellExecution` stdin remap (Axis 2), and the `failClosed` hook list (Axis 3, plus the `require-migration-ticket.sh` addition above) are all unaffected — the schema this AgDR chose was correct throughout; only the install target and the honesty of the delegated-execution claim needed fixing.
+
+**Consequence.** `.claude/` remains the sole source of truth for gate logic; nothing here forks it. The `FAIL_CLOSED_HOOKS` list is now doing double duty on Cursor specifically: its originally-intended role (hardening against a genuinely crashed or timed-out hook) and, per Finding 3, most of the *actually observed* enforcement on the current Cursor release — a fact worth remembering if a future Cursor update makes delegated execution reliable and this posture ought to be revisited. A live-Cursor conformance test suite (beyond the manual testing this update records) remains a tracked gap; `MainThreadShellExec not initialized` is not yet filed as its own tracked issue as of this writing.
+
+## Artifacts (GH-840 update)
+
+- Refs me2resh/apexyard#840
+- `bin/install-cursor-adapter.sh` (new)
+- `bin/sync-cursor-adapter.sh` (`--user`/`--user-dir` added)
+- `docs/cursor-adapter.md`, `docs/harnesses/cursor.md` (corrected)
+- `.claude/hooks/tests/test_sync_cursor_adapter.sh` (`--user` merge/idempotency/drift assertions added)
+- `.claude/hooks/tests/test_install_cursor_adapter.sh` (new)

--- a/docs/cursor-adapter.md
+++ b/docs/cursor-adapter.md
@@ -9,7 +9,70 @@ Decision record: [`AgDR-0091`](agdr/AgDR-0091-cursor-adapter-generation.md).
 Precedent: [`AgDR-0088`](agdr/AgDR-0088-codex-adapter-generation.md) (Codex),
 [`AgDR-0082`](agdr/AgDR-0082-pi-gate-dispatcher-adapter.md) (pi).
 
-## Generate The Adapter
+> **Install at the USER level, not the project level (me2resh/apexyard#840).**
+> Live testing against Cursor.app 3.10.20 found that Cursor 3.x's real hook
+> loader reads `~/.cursor/hooks.json` (the USER config) — a project
+> `.cursor/hooks.json` shows `Configured Hooks (0)` and is never loaded, no
+> trust prompt. Use **`bin/install-cursor-adapter.sh`** (below) to install for
+> real. The project-scoped generation this page describes further down
+> (`bin/sync-cursor-adapter.sh` with no `--user` flag) still works and is kept
+> available — for inspection, for a future Cursor version that may read
+> project-level config, or for adopters who want to track the generated file
+> in git — but it will not be loaded by a current Cursor.app session on its
+> own.
+
+**Where Cursor stands among the four third-party adapters.** opencode and pi
+are both live-proven — their CLIs genuinely execute the delegated extension
+code. Codex carried the same "live conformance unverified" caveat as Cursor
+when its own AgDR (AgDR-0088) was written, but live testing has since closed
+that gap (it turned out to be a trust-prompt issue, resolved via
+`--dangerously-bypass-hook-trust` / a user-level trust grant) — Codex is now
+live-proven too. **Cursor is the sole remaining outlier**: see "Known
+Limitations" below for exactly what "enforced" means on Cursor today.
+
+## Install (the path that actually loads in Cursor 3.x)
+
+```bash
+bin/install-cursor-adapter.sh
+```
+
+This merges the generated hooks into `~/.cursor/hooks.json` (override with
+`--user-dir <path>`) and refreshes the project-level
+`.cursor/rules/apexyard.mdc` advisory bridge in `--root` (defaults to this
+script's own repo). The merge is additive and safe to re-run: any hook
+already in `~/.cursor/hooks.json` that this framework did not generate — the
+user's own, or a different tool's — is left alone. Only apexyard's own
+entries (identified structurally: every one execs a `.claude/hooks/*.sh`
+script) are replaced, so re-running after a `.claude/hooks/*.sh` upgrade
+doesn't accumulate duplicates. A timestamped backup of the pre-merge file is
+written before every overwrite.
+
+```bash
+bin/install-cursor-adapter.sh --uninstall
+```
+
+Removes only apexyard's own entries from `~/.cursor/hooks.json`, leaving
+everything else in that file untouched. Also backed up first.
+
+**Scope note.** Unlike the pi/opencode adapters (installed per-project into
+that project's `.pi/extensions/` or `.opencode/plugins/`), this is a
+per-machine (per-OS-user) install — Cursor's hook loader reads one
+`~/.cursor/hooks.json` and applies it across every project you open in
+Cursor. That's safe here because every generated hook command still
+self-scopes: it resolves ops-root by walking up from Cursor's cwd for an
+`.apexyard-fork` marker and exits 0 immediately if the current project isn't
+apexyard-governed — installing once does not force apexyard's gates onto
+unrelated Cursor projects.
+
+**`cursor-agent` (the CLI) is NOT covered by this adapter.** Live testing
+confirmed `cursor-agent` ignores `hooks.json` entirely — it enforces via its
+own `~/.cursor/cli-config.json` `permissions.allow`/`deny` model instead. A
+CLI-targeting adapter (translating apexyard's gates into
+`cli-config.json` permissions) is out of scope here and would be separate
+future work. Only the Cursor IDE agent (Cursor.app / Composer) is addressed
+by `hooks.json`.
+
+## Generate The Project-Level Adapter (kept available, not the load-bearing path)
 
 ```bash
 bin/sync-cursor-adapter.sh
@@ -27,6 +90,12 @@ adapter (see AgDR-0091 § Scope). The generated `hooks.json` keeps commands
 that exec the unmodified `.claude/hooks/*.sh` scripts, so gate decisions,
 session markers, review markers, and trust-chain path checks stay in the same
 audited bash files every harness delegates to.
+
+Both scripts share the exact same jq generation pipeline — `--user` (and
+`install-cursor-adapter.sh`, which drives it) doesn't fork the gate logic,
+it changes only where the result is written: merged into
+`<--user-dir>/hooks.json` instead of copied to `<--root>/.cursor/hooks.json`.
+See `bin/sync-cursor-adapter.sh --help` for the full flag set.
 
 ## Event Mapping
 
@@ -154,23 +223,55 @@ tracking the generated adapter plus enforcing `--check` in CI.
 
 ## Known Limitations
 
-- **Live-Cursor conformance is unverified.** This repository's bash smoke
-  test (`.claude/hooks/tests/test_sync_cursor_adapter.sh`) proves command
-  delegation, the stdin remap, and exit-code preservation entirely inside a
-  synthetic fixture — it does not prove a real Cursor session actually loads
-  `.cursor/hooks.json`, fires `beforeShellExecution` on every shell command,
-  or blocks a real `gh pr merge` attempt end-to-end. A live-Cursor
-  conformance test (a real Cursor session driving `gh pr merge` against
-  `block-unreviewed-merge.sh` and observing the deny) is a tracked follow-up,
-  same gap the Codex adapter carries today.
-- **`preToolUse`/`postToolUse` field-name conformance is unverified.** The
-  live docs confirm `tool_input.command` for the `Shell` matcher (which this
-  adapter avoids by using `beforeShellExecution` instead) but do not document
-  the exact `tool_input` field names Cursor's own `Write`/`Read` tools use.
-  Hooks delegated through `preToolUse`/`postToolUse` (the ticket-first gate,
+Live testing against a real Cursor.app 3.10.20 session and the `cursor-agent`
+CLI (me2resh/apexyard#840) resolved some of what earlier revisions of this
+page marked "unverified" and surfaced two new, more specific limitations.
+Read this section before relying on the adapter for anything beyond "known
+commands get blocked."
+
+- **`cursor-agent` (the CLI) is not covered — confirmed, not just untested.**
+  Live testing instrumented every generated hook to log on fire, then ran a
+  benign command through `cursor-agent -p -f`: the command executed and
+  **zero hooks fired**. `cursor-agent` does not read `hooks.json` at all; it
+  enforces via its own `~/.cursor/cli-config.json` `permissions.allow`/`deny`
+  model. Anything that looked like enforcement from the CLI in earlier,
+  informal testing was that allowlist, not this adapter. Only the Cursor IDE
+  agent (Cursor.app / Composer) is addressed here.
+- **The IDE only loads the USER-level hooks.json, not project-level —
+  confirmed.** A project `.cursor/hooks.json` (what `sync-cursor-adapter.sh`
+  writes without `--user`) showed `Configured Hooks (0)` in Cursor.app
+  3.10.20 — never loaded, no trust prompt. The identical file installed at
+  `~/.cursor/hooks.json` showed `Configured Hooks (1)` and was enforced.
+  `bin/install-cursor-adapter.sh` targets the correct location by default;
+  see "Install" above. This was a location bug, not a schema bug — `version:
+  1`, `beforeShellExecution`, and `failClosed` were already correct.
+- **Enforcement observed so far is `failClosed`, not confirmed clean
+  delegated execution.** With the adapter loaded at the user level, a real
+  agent turn's `git add .` was blocked and nothing staged — the gate held.
+  But the delegated bash hook's own instrumentation (a log write on fire)
+  never fired, and the agent reported `MainThreadShellExec not initialized`
+  when asked to explain the block — it sourced its explanation by grepping
+  `block-git-add-all.sh`, not from execution output. The most defensible
+  read: Cursor's hook-runner could not cleanly exec the delegated bash
+  command in this version, and `failClosed: true` denied the action because
+  the hook errored — not because the gate logic evaluated and returned exit
+  2. This is **weaker than the opencode/pi adapters**, where the delegated
+  bash genuinely runs: (a) a command a gate would *allow* may also fail
+  closed and get blocked incorrectly, and (b) the block doesn't prove the
+  gate's actual decision logic ran. Whether `beforeShellExecution` can
+  cleanly exec an external script in Cursor's agent mode at all, or whether
+  this is a hard limitation of the current release, is an open investigation
+  — not yet filed as a separate tracked follow-up as of this writing. Treat
+  this adapter as "known-bad commands get blocked" until that's resolved,
+  not as "the gate logic runs and you can trust an allow."
+- **`preToolUse`/`postToolUse` field-name conformance is still unverified.**
+  The live docs confirm `tool_input.command` for the `Shell` matcher (which
+  this adapter avoids by using `beforeShellExecution` instead) but do not
+  document the exact `tool_input` field names Cursor's own `Write`/`Read`
+  tools use, and the live IDE test above did not exercise this path. Hooks
+  delegated through `preToolUse`/`postToolUse` (the ticket-first gate,
   `maintain-docs-index.sh`, etc.) may receive a differently-shaped
-  `tool_input` than the `.claude/hooks/*.sh` scripts expect until this is
-  verified against a real session.
+  `tool_input` than the `.claude/hooks/*.sh` scripts expect.
 - **Model pinning is out of scope.** Cursor hook generation does not need
   agent model-tier pinning the way the Codex adapter does (Codex agents run
   under `.codex/agents/*.toml` with a translated model label). This adapter

--- a/docs/harnesses/cursor.md
+++ b/docs/harnesses/cursor.md
@@ -1,38 +1,49 @@
 # Harness support — Cursor
 
-**Status:** Adapter **merged** (#831 → PR #838, [AgDR-0091](../agdr/AgDR-0091-cursor-adapter-generation.md)); live Cursor-runtime conformance test pending ([#840](https://github.com/me2resh/apexyard/issues/840)).
+**Status:** Adapter **merged** (#831 → PR #838, [AgDR-0091](../agdr/AgDR-0091-cursor-adapter-generation.md)); live conformance tested against Cursor.app 3.10.20 + the `cursor-agent` CLI ([#840](https://github.com/me2resh/apexyard/issues/840)) — **install at the USER level** (`bin/install-cursor-adapter.sh`), the CLI is **not covered**, and IDE enforcement currently rests on `failClosed` rather than confirmed clean delegated execution. Read "What's enforced vs advisory today" below before treating this as equivalent to the opencode/pi adapters.
 
-Cursor support follows the same declarative-generate pattern as Codex: `.cursor/hooks.json` is **generated** from the canonical `.claude/` runtime and every generated hook **delegates to the unmodified `.claude/hooks/*.sh`** — gate logic never forks. The full generate / drift-check workflow lives in **[`docs/cursor-adapter.md`](../cursor-adapter.md)** (linked here, not duplicated).
+**Cursor is now the sole outlier among the four third-party adapters on live conformance.** opencode and pi are both live-proven (their CLIs genuinely run the delegated extension code). Codex carried the same "live conformance unverified" caveat as Cursor when AgDR-0088/AgDR-0091 were written, but live testing since closed that gap (it was a trust-prompt issue, fixed via `--dangerously-bypass-hook-trust` / a user-level trust grant) — Codex is now live-proven too. Cursor alone remains in the weaker "failClosed blocks known-bad commands, delegated execution not confirmed" state described below.
+
+Cursor support follows the same declarative-generate pattern as Codex: `.cursor/hooks.json`'s content is **generated** from the canonical `.claude/` runtime and every generated hook **delegates to the unmodified `.claude/hooks/*.sh`** — gate logic never forks. The full generate / install / drift-check workflow lives in **[`docs/cursor-adapter.md`](../cursor-adapter.md)** (linked here, not duplicated).
 
 ## What's enforced vs advisory today
 
-**Delegated (blocking, by construction):** Cursor's hook contract natively treats **exit code 2 as deny**, so the bash hooks' block semantics pass through without translation. The generated `beforeShellExecution` entries carry every shell-command gate — the two-marker merge gate (both `gh pr merge` and `gh api …/merge` shapes), red-CI block, ticket-first, secrets/leak-protection — each deciding via the canonical bash hook. The in-repo smoke test (`.claude/hooks/tests/test_sync_cursor_adapter.sh`, 25 assertions) proves the stdin remap and exit-code preservation across the adapter boundary.
+**Cursor IDE only — the CLI is not covered, confirmed by live test.** `cursor-agent` (the CLI) does not read `hooks.json` at all; instrumented hooks recorded zero fires while a benign command executed cleanly through it. `cursor-agent` enforces via its own `~/.cursor/cli-config.json` `permissions.allow`/`deny` model instead — a different surface this adapter does not address. Everything below is about the Cursor IDE agent (Cursor.app / Composer) only.
 
-**failClosed hardening:** the 9 security-critical gates (merge gates, red-CI, design/architecture review, secrets scan, trust-chain/leak hooks) are generated with Cursor's `"failClosed": true` — a crashed or timed-out gate hook **blocks** instead of failing open. This is a net hardening over Claude Code's own posture. Advisory/process hooks stay fail-open, matching their native behaviour.
+**Install location — USER config, not project, confirmed by live test.** A project `.cursor/hooks.json` (Cursor's documented location, and what earlier revisions of this adapter shipped) showed `Configured Hooks (0)` in a real Cursor.app 3.10.20 session — never loaded. The identical file installed at `~/.cursor/hooks.json` loaded and enforced. Use `bin/install-cursor-adapter.sh`, which merges into the user config by default and preserves any pre-existing, non-apexyard entries there.
 
-**Advisory:** a generated `.cursor/rules/apexyard.mdc` carries the advisory governance bridge (git conventions, ticket vocabulary, reporting rules) as Cursor rules content.
+**Delegated (blocking) — but via `failClosed`, not confirmed clean execution.** Cursor's hook contract natively treats **exit code 2 as deny**, so in principle the bash hooks' block semantics pass through without translation, and the in-repo smoke test (`.claude/hooks/tests/test_sync_cursor_adapter.sh`) proves that delegation by construction inside a synthetic fixture. The live IDE test went further: a real agent turn's `git add .` was blocked. But the delegated hook's own instrumentation never fired and the agent reported `MainThreadShellExec not initialized` — the most defensible read is that Cursor's hook-runner could not cleanly exec the delegated bash command in this version, and `failClosed: true` denied the action because the hook errored, not because the gate logic evaluated and returned exit 2. **This is weaker than the opencode/pi adapters**, where the delegated bash genuinely runs — a command a gate would *allow* may also fail closed here. Treat it as "known-bad commands get blocked," not as "the gate logic runs." Full detail: [`docs/cursor-adapter.md`](../cursor-adapter.md) § Known Limitations.
+
+**failClosed hardening:** the 10 security-critical gates (merge gates, red-CI, design/architecture review, secrets scan, migration blast-radius, trust-chain/leak hooks) are generated with Cursor's `"failClosed": true` — a crashed, timed-out, **or non-executing** gate hook **blocks** instead of failing open. Given the finding above, this is now doing double duty on Cursor: its originally-intended hardening role, and (unintentionally, for now) most of the actual observed enforcement. Advisory/process hooks stay fail-open, matching their native behaviour.
+
+**Advisory:** a generated `.cursor/rules/apexyard.mdc` carries the advisory governance bridge (git conventions, ticket vocabulary, reporting rules) as Cursor rules content, at the project level (unaffected by the user-vs-project hooks.json finding).
 
 ## How it works (transport)
 
-`bin/sync-cursor-adapter.sh` emits `.cursor/hooks.json` from `.claude/settings.json`:
+`bin/sync-cursor-adapter.sh` generates the hooks.json content from `.claude/settings.json`; `bin/install-cursor-adapter.sh` merges that content into `~/.cursor/hooks.json` (the location that actually loads):
 
 - **Event mapping:** `Bash` → `beforeShellExecution` · `Edit|Write|MultiEdit` → `preToolUse` (matcher) · `SessionStart` → `sessionStart` · `UserPromptSubmit` → `beforeSubmitPrompt`, with post-tool events split the same way.
 - **Stdin remap:** Cursor delivers the shell command top-level (`{"command": …}`); the generated command re-wraps it into the Claude-Code shape (`{"tool_name":"Bash","tool_input":{"command":…}}`) before piping to the hook — so the hooks run byte-identical logic on both harnesses.
 - Claude Code's handler-level `if` predicates are compiled into the same `Bash(glob)` preflight filter the Codex adapter uses; unconditional hooks get glob `*` (remapped, never skipped).
 - No hook bodies are copied; every entry execs `$r/.claude/hooks/*.sh`.
+- **User-level merge:** apexyard's own entries (identified by every command execing a `.claude/hooks/*.sh` script) are replaced wholesale on each install; anything else already in `~/.cursor/hooks.json` — the user's own hooks, or a different tool's — is preserved untouched.
 
-## How to generate
+## How to install / generate
 
 ```bash
-bin/sync-cursor-adapter.sh            # generate .cursor/hooks.json + rules
-bin/sync-cursor-adapter.sh --check    # verify generated files still match .claude/ (non-zero on drift)
-bin/sync-cursor-adapter.sh --clean    # remove generated .cursor tree before regenerating
+bin/install-cursor-adapter.sh            # merge into ~/.cursor/hooks.json (the loaded location) + refresh project rules
+bin/install-cursor-adapter.sh --uninstall # remove only apexyard's entries from ~/.cursor/hooks.json
+
+bin/sync-cursor-adapter.sh               # project-level generation only — kept available, NOT loaded by Cursor 3.x on its own
+bin/sync-cursor-adapter.sh --check       # verify generated project files still match .claude/ (non-zero on drift)
+bin/sync-cursor-adapter.sh --user --check  # verify the installed USER config still matches .claude/ (non-zero on drift)
 ```
 
 ## Gaps + tracking
 
-- **Live Cursor-runtime conformance** — the in-repo smoke proves delegation by construction; a credentialed Cursor turn actually being blocked has not been recorded. The conformance test must explicitly assert the top-level-`.command` stdin contract (if Cursor's schema drifts from it, shell gates would fail open silently). Tracked in **#840**.
-- The `preToolUse`/`postToolUse` passthrough path (non-shell tools) carries only process/advisory hooks; its `tool_input` field names are unverified against a real Cursor session — every enforcement-critical gate rides the verified shell path. Also #840.
+- **Whether Cursor's `beforeShellExecution` can cleanly exec an external script in agent mode at all** is an open investigation (`MainThreadShellExec not initialized`, #840 finding #4) — not yet a separately filed tracked issue. Until resolved, enforcement is `failClosed`-backed, not confirmed delegated-logic-backed.
+- The `preToolUse`/`postToolUse` passthrough path (non-shell tools) carries only process/advisory hooks; its `tool_input` field names are unverified against a real Cursor session — the live IDE test only exercised the shell-command path. Also #840.
+- A `cursor-agent`-CLI adapter (translating apexyard's gates into `~/.cursor/cli-config.json` permissions) is unscoped future work, not this adapter's job.
 
 ## Related AgDRs
 


### PR DESCRIPTION
## Summary

- **Cursor 3.x only loads `~/.cursor/hooks.json` (user-level), not the project `.cursor/hooks.json` this adapter previously wrote.** Live testing against a real Cursor.app 3.10.20 session confirmed the project file shows `Configured Hooks (0)` — never loaded, no trust prompt — while installing the identical, unmodified generated file at the user level shows `Configured Hooks (1)` and gets enforced. This was a location bug, not a schema bug: `version: 1`, `beforeShellExecution`, and `failClosed` were already correct.
- **`bin/install-cursor-adapter.sh` is the new primary entrypoint** (mirrors the pi/opencode install-script pattern from #844/#845): it merges the generated hooks into `~/.cursor/hooks.json`, preserving any pre-existing non-apexyard entries (identified structurally — every apexyard entry execs a `.claude/hooks/*.sh` script), with a timestamped backup before every write and a symmetric `--uninstall`. `bin/sync-cursor-adapter.sh` gains `--user`/`--user-dir` to power the merge, reusing its existing jq generation pipeline unchanged — no gate logic forked, and default (project-level) behaviour is untouched.
- **`cursor-agent` (the CLI) is confirmed NOT covered by this adapter** — live testing instrumented every generated hook and ran a benign command through the CLI: it executed with zero hooks firing. The CLI enforces via its own `~/.cursor/cli-config.json` `permissions.allow`/`deny` model instead, a separate surface this adapter doesn't address.
- **IDE enforcement currently rests on `failClosed`, not confirmed clean delegated execution — documented honestly rather than overclaimed.** With the adapter correctly installed at the user level, a real agent turn's `git add .` was blocked. But the delegated hook's own instrumentation never fired, and the agent reported `MainThreadShellExec not initialized` when probed directly — the defensible read is that Cursor's hook-runner couldn't cleanly exec the delegated bash in this version, and `failClosed: true` denied the action because the hook errored, not because the gate logic ran. This is weaker than the opencode/pi adapters, where delegated bash genuinely executes. Docs now say this plainly instead of claiming delegation is proven.
- **Cursor is now the sole live-conformance outlier among the four third-party adapters.** opencode and pi are live-proven. Codex carried the same "unverified" caveat as Cursor when AgDR-0088/AgDR-0091 were written, but that gap has separately been closed via live testing (it was a trust-prompt issue, fixed via `--dangerously-bypass-hook-trust` / a user-level trust grant) — Codex is now live-proven too. `docs/cursor-adapter.md`, `docs/harnesses/cursor.md`, and AgDR-0091 all state this comparison explicitly now.

## Testing

```bash
bin/install-cursor-adapter.sh                # merges into ~/.cursor/hooks.json (default), refreshes project rules bridge
bin/install-cursor-adapter.sh --uninstall     # removes only apexyard's own entries
```

- `env -u CLAUDE_CODE_SESSION_ID bash .claude/hooks/tests/test_sync_cursor_adapter.sh` — 44 assertions (20 new: `--user` merge preserves foreign entries, drops stale apexyard entries, idempotent re-run, `--check` drift detection, fresh-user-dir bootstrap), all pass.
- `env -u CLAUDE_CODE_SESSION_ID bash .claude/hooks/tests/test_install_cursor_adapter.sh` (new) — 13 assertions covering default install, re-install preserving a foreign hook, `--uninstall` scoped removal + backup, and the no-op-when-nothing-installed case, all pass.
- `env -u CLAUDE_CODE_SESSION_ID bash bin/run-hook-tests.sh` — full suite, 96/96 pass.
- `shellcheck bin/install-cursor-adapter.sh` — clean. `shellcheck bin/sync-cursor-adapter.sh` — only a pre-existing, unrelated SC2016 info note (an intentionally single-quoted `sed` pattern, present before this PR).

## Refs #840

## Glossary

| Term | Definition |
|------|------------|
| `beforeShellExecution` | Cursor's dedicated pre-shell-command hook event; the adapter remaps its top-level `command` field into the Claude Code stdin shape before delegating to `.claude/hooks/*.sh`. |
| `failClosed` | A Cursor hook-entry option: if the hook command crashes, times out, or (per this PR's finding) fails to execute cleanly, the action is **blocked** instead of allowed through. |
| `cursor-agent` | Cursor's separate CLI product. Does not read `hooks.json`; enforces via its own `cli-config.json` permissions model. Not addressed by this adapter. |
| Apexyard-owned entry | A hook entry in `hooks.json` whose `command` execs a `.claude/hooks/*.sh` script — identified structurally (string match), not via a custom JSON field, so merge/uninstall can tell "ours" from "the user's own hooks" without extra bookkeeping. |
| `MainThreadShellExec not initialized` | The error Cursor's agent reported when the delegated bash hook was probed directly — the basis for concluding enforcement is `failClosed`-backed rather than confirmed delegated-execution-backed. |
