### PR TITLE
docs(#859): remove broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,16 +240,6 @@ Thanks to everyone who has helped forge ApexYard:
 
 <sub>External contributors' PRs are squash-merged, so GitHub's commit-author graph under-counts them — this list credits the humans directly. New contributor? Open a PR and you'll be added.</sub>
 
-## Star History
-
-<a href="https://star-history.com/#me2resh/apexyard&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=me2resh/apexyard&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=me2resh/apexyard&type=Date" />
-    <img alt="ApexYard Star History Chart" src="https://api.star-history.com/svg?repos=me2resh/apexyard&type=Date" width="600" />
-  </picture>
-</a>
-
 ## License
 
 MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

- **Removes the broken Star History chart from the README.** The embedded `api.star-history.com` SVG renders as a broken image on every load. Root cause is not transient: the API returns `HTTP 404 — "GitHub restricted starred-data access for me2resh/apexyard."` The repo is under an EMU-managed org, and GitHub blocks starred-data access for EMU repos, so star-history can never fetch the history — no URL/theme tweak can fix it.
- **No replacement needed** — the header `Stars` shields.io badge already shows the count and works fine. The interactive star-history link was dead for the same reason, so the whole section went.

## Testing

1. Render `README.md` — confirm no broken image where Star History was, and the Contributors section flows straight into License.
2. Confirm the header `Stars` badge is untouched.
3. (Diagnosis reference) `curl -s "https://api.star-history.com/svg?repos=me2resh/apexyard&type=Date"` returns a 404 with the EMU restriction message.

Closes #859

---

## Glossary

| Term | Definition |
|------|------------|
| EMU | Enterprise Managed User — a GitHub identity managed by an enterprise; certain data (including starred-data) is access-restricted for repos under EMU orgs. |
| star-history embed | An SVG image served by star-history.com that charts a repo's stars over time; requires read access to the repo's starred-data. |
| Shields badge | The static `Stars` badge (shields.io) in the README header — a count, not a chart, and not subject to the starred-data restriction. |
