### PR TITLE
fix(#861): repoint rex-770, add defect-in-diff validator guard, propose corpus growth

### DIFF
--- a/.claude/skills/eval-agents/lib/validate-corpus.sh
+++ b/.claude/skills/eval-agents/lib/validate-corpus.sh
@@ -3,7 +3,16 @@
 #
 # Usage: validate-corpus.sh <agent> <corpus-path>
 #
-# Checks structure and required fields only — NOT ground-truth accuracy.
+# Checks structure and required fields, PLUS one ground-truth-adjacent check:
+# every ground_truth_defects[].location must appear in the entry's diff_range
+# changed-file set (git-resolved). This is NOT re-deriving ground truth (still
+# forbidden — see SKILL.md rule 1) — it's a structural guard against the
+# rex-770 class of mislabel (me2resh/apexyard#861), where the corpus pointed
+# at a diff that never contained the defect it claimed to carry, making the
+# entry unscoreable. A location the validator can't resolve locally (commit
+# not fetched) is a best-effort SKIP with a warning, not a hard failure — CI
+# checkouts don't always have every historical commit's full ancestry.
+#
 # Exit 0 + prints entry count on success. Exit 1 on any schema violation,
 # with every violation listed (not just the first) so a corpus author fixes
 # everything in one pass.
@@ -26,11 +35,41 @@ if [ ! -f "$CORPUS_PATH" ]; then
   exit 1
 fi
 
-python3 - "$AGENT" "$CORPUS_PATH" <<'PYEOF'
-import json, sys
+# Repo root for git diff resolution — derive from the corpus file's own
+# location so this works regardless of the caller's cwd.
+REPO_ROOT="$(git -C "$(dirname "$CORPUS_PATH")" rev-parse --show-toplevel 2>/dev/null || pwd)"
 
-agent, path = sys.argv[1], sys.argv[2]
+python3 - "$AGENT" "$CORPUS_PATH" "$REPO_ROOT" <<'PYEOF'
+import json, subprocess, sys
+
+agent, path, repo_root = sys.argv[1], sys.argv[2], sys.argv[3]
 errors = []
+unresolvable = 0
+
+
+def changed_files(diff_range):
+    """git diff --name-only over diff_range, resolved against repo_root.
+    Returns a set of changed paths, or None if the range can't be resolved
+    locally (unfetched commit, malformed range, etc.) — caller treats None
+    as best-effort SKIP, not a failure."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", repo_root, "diff", "--name-only", diff_range],
+            capture_output=True, text=True, timeout=15,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+
+def location_file(location):
+    """Extract the leading file path from a location string that may carry
+    a trailing ':line' or ' (note)' annotation (per SCHEMA.md: 'File path
+    (± line)')."""
+    token = location.split()[0] if location else ""
+    return token.split(":")[0]
 
 try:
     with open(path) as f:
@@ -103,6 +142,37 @@ else:
                 if "severity" in d and d["severity"] not in VALID_SEVERITY:
                     errors.append(f"{dwhere}: severity {d['severity']!r} not in {sorted(VALID_SEVERITY)}")
 
+            # Defect-in-diff guard (me2resh/apexyard#861): every defect's
+            # location must actually appear in the reviewed diff — otherwise
+            # the agent-under-test could never have caught it, and scoring
+            # the entry is meaningless (the rex-770 corpus mislabel).
+            diff_range = e.get("diff_range")
+            valid_locations = [
+                (j, d.get("location")) for j, d in enumerate(defects)
+                if isinstance(d, dict) and d.get("location")
+            ]
+            if valid_locations and isinstance(diff_range, str) and diff_range:
+                files = changed_files(diff_range)
+                if files is None:
+                    unresolvable += 1
+                    print(
+                        f"⚠ {where}: diff_range {diff_range!r} not resolvable locally "
+                        f"(commit not fetched, or malformed range) — skipping "
+                        f"defect-in-diff check for this entry",
+                        file=sys.stderr,
+                    )
+                else:
+                    for j, loc in valid_locations:
+                        lf = location_file(loc)
+                        if lf not in files and not any(lf in f or f in lf for f in files):
+                            errors.append(
+                                f"{where} defect[{j}]: location {loc!r} does not appear in "
+                                f"diff_range {diff_range!r}'s changed files "
+                                f"({sorted(files) or '[]'}) — the ground-truth defect must "
+                                f"live inside the reviewed diff, or the entry is unscoreable "
+                                f"(the rex-770 class of mislabel, me2resh/apexyard#861)"
+                            )
+
         rv = e.get("recorded_verdict")
         if not isinstance(rv, dict):
             errors.append(f"{where}: missing/invalid 'recorded_verdict' object")
@@ -124,5 +194,6 @@ blocking_defects = sum(
     if d.get("severity") in ("BLOCKING", "HIGH")
 )
 misses = sum(1 for e in data.get("entries", []) if e.get("recorded_verdict", {}).get("was_justified") is False)
-print(f"✓ {path}: schema valid — {n} entries, {blocking_defects} BLOCKING/HIGH ground-truth defects, {misses} recorded MISS(es)")
+skip_note = f", {unresolvable} defect-in-diff check(s) skipped (unresolvable locally)" if unresolvable else ""
+print(f"✓ {path}: schema valid — {n} entries, {blocking_defects} BLOCKING/HIGH ground-truth defects, {misses} recorded MISS(es){skip_note}")
 PYEOF

--- a/.claude/skills/eval-agents/tests/smoke.sh
+++ b/.claude/skills/eval-agents/tests/smoke.sh
@@ -48,6 +48,38 @@ EOF
 check "missing required fields are caught" 1 bash "$VALIDATE" rex "$tmpbad2"
 rm -f "$tmpbad2"
 
+# 6-7. Defect-in-diff guard (me2resh/apexyard#861 — the rex-770 mislabel
+# class): a ground_truth_defects[].location must appear in diff_range's
+# changed-file set. Built on a throwaway fixture git repo (not this repo's
+# own history) so the test is deterministic regardless of checkout depth —
+# it doesn't depend on any real apexyard commit being locally fetchable.
+fixture="$(mktemp -d)"
+git -C "$fixture" init -q
+git -C "$fixture" config user.email "test@example.com"
+git -C "$fixture" config user.name "Eval Agents Smoke Test"
+printf 'one\n' > "$fixture/present.sh"
+printf 'two\n' > "$fixture/absent.sh"
+git -C "$fixture" add present.sh absent.sh
+git -C "$fixture" commit -q -m "base"
+printf 'one changed\n' > "$fixture/present.sh"
+git -C "$fixture" add present.sh
+git -C "$fixture" commit -q -m "touch present.sh only"
+FIXTURE_HEAD="$(git -C "$fixture" rev-parse HEAD)"
+
+fixture_corpus() { # <location>
+  cat <<EOF
+{"agent":"rex","schema_version":1,"entries":[{"id":"fixture-1","pr":1,"repo":"x/y","commit":"$FIXTURE_HEAD","diff_range":"$FIXTURE_HEAD~1..$FIXTURE_HEAD","oracle":{"source":"human","established_by":"fixture"},"ground_truth_defects":[{"id":"D1","description":"fixture defect","severity":"LOW","location":"$1"}],"recorded_verdict":{"verdict":"CHANGES REQUESTED","was_justified":true}}]}
+EOF
+}
+
+fixture_corpus "present.sh" > "$fixture/good.json"
+check "defect-in-diff guard: location in diff passes" 0 bash "$VALIDATE" rex "$fixture/good.json"
+
+fixture_corpus "absent.sh" > "$fixture/bad.json"
+check "defect-in-diff guard: location NOT in diff fails (rex-770-class mislabel)" 1 bash "$VALIDATE" rex "$fixture/bad.json"
+
+rm -rf "$fixture"
+
 echo
 echo "eval-agents smoke: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/docs/eval-agents/README.md
+++ b/docs/eval-agents/README.md
@@ -18,9 +18,9 @@ docs/eval-agents/
 
 ## What's seeded, and what isn't
 
-- **Rex (`corpus/rex.json`)** — 6 entries mined from this repo's own review history: two confirmed MISSes (wrong approvals — both caught by Hakim's independent review of the identical commit; both entries carry `oracle.source: independent_review`, not `confirmed_fix` — the fix that landed afterward corroborates the defect but isn't the oracle basis), two GOOD_CATCH (correctly required changes), and two GOOD_CLEAN (correctly approved a genuinely clean diff).
+- **Rex (`corpus/rex.json`)** — 9 entries mined from this repo's own review history: two confirmed MISSes (wrong approvals — both caught by Hakim's independent review of the identical commit; both entries carry `oracle.source: independent_review`, not `confirmed_fix` — the fix that landed afterward corroborates the defect but isn't the oracle basis), two GOOD_CATCH (correctly required changes), and five GOOD_CLEAN (correctly approved a genuinely clean diff).
 - **Hakim (`corpus/hakim.json`)** — 4 entries: three GOOD_CATCH, one GOOD_CLEAN. **No confirmed Hakim MISS is seeded yet** — the spike's sample didn't surface a clean Hakim-authored wrong approval. This is a real, documented gap. Approve-precision on the Hakim starter run will trivially read 1.0 until a genuine miss is harvested and added; treat that number as "no counter-evidence yet," not "Hakim is perfect."
-- **Two entries are same-diff cross-agent pairs** (`rex-792-2ce6708` / `hakim-792-2ce6708`, and `rex-767-a99f1009` / `hakim-767-a99f1009`) — the identical commit, reviewed by both agents the same day, with different outcomes (Rex approved, Hakim caught a real defect). These are the cleanest possible corpus entries: the diff is held constant, only the reviewing agent varies.
+- **Three entries are same-diff cross-agent pairs** (`rex-792-2ce6708` / `hakim-792-2ce6708`, `rex-767-a99f1009` / `hakim-767-a99f1009`, and `rex-773-ca3a9400` / `hakim-773-ca3a9400`) — the identical commit, reviewed by both agents the same day. The first two have different outcomes (Rex approved, Hakim caught a real defect); the third is a matched clean pair (both agents correctly approved). These are the cleanest possible corpus entries: the diff is held constant, only the reviewing agent varies.
 - **Tariq — no starter corpus.** No Tariq-reviewed PRs were in the spike's sample. `/eval-agents tariq` requires an operator-supplied `--corpus <path>` until one exists.
 - **Naqid — out of scope for v1.** Naqid challenges premises, not diffs; it has no defect-set structure to score against. See AgDR-0089 § Decision point 7.
 
@@ -48,3 +48,37 @@ Corpus growth is deliberately manual and human-adjudicated in v1 — `/eval-agen
 4. Validate with `/eval-agents <agent> --check-only`.
 
 See [`SCHEMA.md`](SCHEMA.md) for the field-by-field format.
+
+## Candidate corpus entries (needs human adjudication before adding)
+
+Found while working me2resh/apexyard#861 (the first `/eval-agents rex` run's follow-ups). These are **proposed only** — none are promoted into `corpus/*.json` yet, per rule 7 (no fabricated ground truth; an entry only ships with real, checkable evidence). Two sources were mined:
+
+### A. Unpromoted rows from spike #825's own labeled set
+
+`docs/spike-825/judge_calibration.py`'s `DATA` table has **19** hand-labeled review-units; the starter corpus only promoted **10** of them into JSON (6 Rex + 4 Hakim). Three more Rex GOOD_CLEAN rows were promoted directly into `rex.json` during #861 (`rex-773-ca3a9400`, `rex-778-64c3ff5`, `rex-787-512d253` — all independently re-verified via the GitHub reviews API before adding, not taken on the spike's label alone). The rows below are the **remaining unpromoted** ones — real, human-labeled by the spike, PR numbers confirmed to exist and be merged, but not yet re-verified against the actual review text/commit SHA the way the promoted ones were:
+
+| Spike row | PR | Commit (short, per spike) | Outcome | Note (per spike) |
+|---|---|---|---|---|
+| R11 | #688 | `0a54561` | GOOD_CLEAN | "cd-target re-root; adversarial verify; correct" |
+| R12 | #689 | `c00e644` | GOOD_CLEAN | "merge-gate re-root; flagged latent follow-up; correct" |
+| R13 | #634 | `10969b1` | GOOD_CLEAN | "push-ref regex; full edge-case table; correct" |
+| R14 | #789 | `bc429fb` | GOOD_CLEAN | "agent-role rule; diff-scope verified; correct" |
+| R16 | #747 | (unresolved — spike tagged it `chg?`) | GOOD_CLEAN | "active-ticket re-root; proved regression by revert; correct" |
+
+All five PR numbers are confirmed real and merged (`gh pr view <N> --repo me2resh/apexyard`). **R16 needs the most care before promotion**: PR #747 has 3 separate `atlas-apex` review rounds recorded (not 1), so the specific commit SHA and verdict the spike's `chg?` tag refers to needs to be resolved from the PR's actual review timeline before writing `ground_truth_defects`/`recorded_verdict` — don't guess which round matches "proved regression by revert."
+
+To promote any of these: pull the PR's review history (`gh api repos/me2resh/apexyard/pulls/<N>/reviews`), confirm the actual reviewed commit SHA and verdict text (mirror the process used for `rex-773`/`rex-778`/`rex-787` above — re-verify from the primary source, don't trust the spike's shorthand note alone), then follow "Growing the corpus" above.
+
+### B. Real framework bugs that do NOT cleanly fit the corpus shape (documented so this ground isn't re-covered)
+
+Several real, merged-and-fixed framework bugs were investigated as candidates and rejected — not because they aren't real defects, but because the corpus needs a **specific commit Rex/Hakim actually reviewed and gave a verdict on**, and these were discovered operationally (a user or an agent hit the bug in practice) rather than through a review-round disagreement:
+
+- **#47** (`gh api .../merge` bypass) — the introducing commit (`c93cc52`, PR #10, April 2026) predates any recorded formal review state on this repo (bootstrap era — the PR that added the review-enforcement mechanism itself). No `recorded_verdict` can be honestly reconstructed. Its *class* of bug (a forge-specific merge-shape gate gap) is already represented via `rex-767`/`hakim-767` (the GitLab-side reopening of the same bypass class).
+- **#568** (PR-extractor grabs a stray number from a `2>&1` redirect) and **#643** (same class, recurring in `block-merge-on-red-ci.sh` because the #568 fix didn't propagate to every call site) — both filed by external reporters/operators (`rafik-wahid-cubeish`, `khaledmedra`) hitting the bug in real usage, not surfaced by a review round.
+- **#559** / **#746** / **#230** / **#229** / **#485** / **#728** (review-marker path/keying mismatches — split-portfolio resolution, repo-qualification, forged-marker guardrail) — all self-reported by `atlas-apex` ("observed in practice") after hitting the failure operationally, not from a Rex/Hakim review catching it in a diff.
+
+If a future search wants to turn any of these into a corpus entry, the missing piece is the same in every case: find the PR that *introduced* the bug and confirm it received a real Rex/Hakim review verdict (not just that the bug shipped) — otherwise there's no `recorded_verdict` to record honestly.
+
+### C. The standing Hakim-MISS gap
+
+Per "What's seeded" above, `hakim.json` has zero confirmed MISS entries. Spike #825's 19-row sample didn't surface one either (the two Hakim rows outside GOOD_CLEAN are both `hakim-792` GOOD_CATCH). This is the single highest-value gap to close — closing it requires a security-relevant PR where Hakim approved and a subsequent finding (a later security review, an incident, or a confirmed fix to a Hakim-approved commit) proved a real defect was missed. None was found during #861; flagged here so the next corpus-growth pass starts here instead of re-discovering the gap.

--- a/docs/eval-agents/corpus/rex.json
+++ b/docs/eval-agents/corpus/rex.json
@@ -28,14 +28,14 @@
       "notes": "Canonical false-confidence case from spike #825 (row R1): a fluent, verification-heavy APPROVED review of a commit that carried a real BLOCKING defect Hakim caught on the identical commit. This is the case the prose-rubric method scored 15/16 — higher than 7 of the 10 genuinely-correct approvals in the spike's sample."
     },
     {
-      "id": "rex-770-d8ad5325",
+      "id": "rex-770-6b19e2b5a",
       "pr": 770,
       "repo": "me2resh/apexyard",
-      "commit": "d8ad5325b",
-      "diff_range": "d8ad5325b~1..d8ad5325b",
+      "commit": "6b19e2b5a",
+      "diff_range": "6b19e2b5a~1..6b19e2b5a",
       "oracle": {
         "source": "confirmed_fix",
-        "established_by": "Both defects were fixed in the commit that followed this CHANGES REQUESTED review (6b19e2b5a); the fixes match exactly what was flagged.",
+        "established_by": "Re-pointed from the original rex-770-d8ad5325 entry (me2resh/apexyard#861), which mis-cited d8ad5325b (the PR's 3rd commit, touching only .claude/skills/approve-architecture/SKILL.md) as carrying the ground-truth defect. This commit (the PR's 1st commit) is where pr_base_repo() and its gh test mock were actually introduced, self-contained: it adds pr_base_repo() scoping its primary gh query with `--repo \"$hint\"` (the fork) in _lib-review-markers.sh, plus a gh mock in test_pr_base_repo.sh that ignores --repo entirely so the cross-fork case passes vacuously. Both defects persisted through the PR's cumulative state and were caught by a CHANGES REQUESTED review at the PR's later head (d8ad5325b/ce2416ba, 2026-07-03T23:35:56Z per `gh api repos/me2resh/apexyard/pulls/770/reviews`). Both were fixed 3 commits later, in the same PR, by 7a8292fe ('fix(#765): query pr_base_repo unscoped so cross-fork resolves the base') — that commit's message states the defect explicitly and makes the test --repo-aware.",
         "reference": "me2resh/apexyard#765"
       },
       "ground_truth_defects": [
@@ -56,7 +56,7 @@
         "verdict": "CHANGES REQUESTED",
         "was_justified": true
       },
-      "notes": "Rex correctly caught both the fork-scope regression and the vacuous test at this commit (spike #825 row R6, GOOD_CATCH). An earlier round on this same PR (commit f11415c41) had APPROVED — that miss is the human/Rex review the spike's row R2 refers to, but it isn't included as its own corpus entry here because the spike's own reviewer tag for that round is ambiguous."
+      "notes": "Rex correctly caught both the fork-scope regression and the vacuous test on this PR (spike #825 row R6, GOOD_CATCH). The original corpus entry (rex-770-d8ad5325) pointed at the wrong commit in the same PR — its diff_range covered only the 3rd commit (the SKILL.md-only 5th-writer migration), which never touches either defect's location, making the entry unscoreable (found during the first /eval-agents rex run, me2resh/apexyard#861). This entry re-points to the commit that actually introduces both defects. An earlier round on this same PR (commit f11415c41) had APPROVED — that miss is the human/Rex review the spike's row R2 refers to, but it isn't included as its own corpus entry here because the spike's own reviewer tag for that round is ambiguous."
     },
     {
       "id": "rex-767-a99f1009",
@@ -149,6 +149,60 @@
         "was_justified": true
       },
       "notes": "Spike #825 row R15 (GOOD_CLEAN) — the lowest-scoring correct approval under the disproven prose-rubric method, precisely because a docs-only diff gives a reviewer little to 'catch'. Included here deliberately: a good eval must not penalise a correct approval of a low-defect diff."
+    },
+    {
+      "id": "rex-773-ca3a9400",
+      "pr": 773,
+      "repo": "me2resh/apexyard",
+      "commit": "ca3a94003",
+      "diff_range": "ca3a94003~1..ca3a94003",
+      "oracle": {
+        "source": "no_contradiction",
+        "established_by": "Same-diff cross-agent pair with hakim-773-ca3a9400 (identical commit, reviewed by both agents the same day). Rex's APPROVED review independently verified the fix by cloning PR HEAD, running the suite (20/1), then reverting both hunks and re-running (17/4, all 3 new regression cases flip to FAIL) — proving the tests genuinely exercise the fix rather than passing vacuously. No later review or fix on this file ever contradicted the approval.",
+        "reference": "me2resh/apexyard#769"
+      },
+      "ground_truth_defects": [],
+      "recorded_verdict": {
+        "verdict": "APPROVED",
+        "was_justified": true
+      },
+      "notes": "Found while growing the corpus for me2resh/apexyard#861 (Spike #825 row R17 is hakim-773's counterpart; this Rex-side pairing wasn't in the spike's own DATA table but is the same PR/commit, discovered independently via the GitHub reviews API). Two non-blocking nits noted (an edge-case trade-off and a cosmetic doc-vs-code glob note), consistent with the empty ground_truth_defects set."
+    },
+    {
+      "id": "rex-778-64c3ff5",
+      "pr": 778,
+      "repo": "me2resh/apexyard",
+      "commit": "64c3ff5",
+      "diff_range": "64c3ff5~1..64c3ff5",
+      "oracle": {
+        "source": "no_contradiction",
+        "established_by": "No later review or fix on this file ever contradicted the approval. Rex independently probed the new trigger glob at PR HEAD (confirmed it fires on the trust-chain paths and stays silent on non-trust-chain `.claude/` paths) and confirmed the existing auth/crypto/secrets trigger and other role triggers were byte-for-byte unchanged (no regression).",
+        "reference": "me2resh/apexyard#777"
+      },
+      "ground_truth_defects": [],
+      "recorded_verdict": {
+        "verdict": "APPROVED",
+        "was_justified": true
+      },
+      "notes": "Found while growing the corpus for me2resh/apexyard#861; matches Spike #825 row R18 (GOOD_CLEAN, 'security-auditor trust-chain trigger; regression-free; correct'), not previously promoted into the JSON corpus. Two non-blocking nits noted (settings.local.json scope, doc-glob-vs-code-glob cosmetics), consistent with the empty ground_truth_defects set."
+    },
+    {
+      "id": "rex-787-512d253",
+      "pr": 787,
+      "repo": "me2resh/apexyard",
+      "commit": "512d253",
+      "diff_range": "512d253~1..512d253",
+      "oracle": {
+        "source": "no_contradiction",
+        "established_by": "No later review or fix on this file ever contradicted the approval. Rex independently fetched the PR from upstream, ran the full test suite locally, confirmed the branch was based exactly on dev tip with no diff-scope contamination, and confirmed a pre-existing unrelated test failure was genuinely pre-existing (fails identically on dev, untouched by this diff).",
+        "reference": "me2resh/apexyard#784"
+      },
+      "ground_truth_defects": [],
+      "recorded_verdict": {
+        "verdict": "APPROVED",
+        "was_justified": true
+      },
+      "notes": "Found while growing the corpus for me2resh/apexyard#861; matches Spike #825 row R19 (GOOD_CLEAN, 'isolated-builds rule; wiring guard passes; correct'), not previously promoted into the JSON corpus. One non-blocking nit noted (narrower destructive-git regex coverage, explicitly out of scope), consistent with the empty ground_truth_defects set."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Re-pointed the rex-770 corpus entry** — the ground-truth defect (`pr_base_repo`'s fork-scoped `--repo` query, plus a vacuous gh test mock) actually lives in commit `6b19e2b5a` (the PR's 1st commit), not `d8ad5325b` (the 3rd commit, which touches only `approve-architecture/SKILL.md`). The old `diff_range` never contained the defect it claimed to score, so the entry was unscoreable — this is the corpus mislabel the first `/eval-agents rex` run surfaced (#861). Confirmed via `gh api repos/me2resh/apexyard/commits/6b19e2b5a...` that both `.claude/hooks/_lib-review-markers.sh` and `.claude/hooks/tests/test_pr_base_repo.sh` are touched in that single commit's diff.
- **Added a durable validator guard** — `validate-corpus.sh` now asserts every `ground_truth_defects[].location` appears in the entry's `diff_range` changed-file set (git-resolved), turning this exact mislabel class into a schema-validation **failure** instead of a silent runtime discard. An unresolvable commit (not fetched locally — common after a squash-merge, or on a shallow CI checkout) is a best-effort **skip with a warning**, never a hard failure. Two new smoke tests build a disposable fixture git repo (not this repo's own history) so both the pass and fail paths are deterministic regardless of checkout depth.
- **Grew the Rex corpus from 6 to 9 entries** — added `rex-773-ca3a9400`, `rex-778-64c3ff5`, and `rex-787-512d253`, all GOOD_CLEAN APPROVED reviews independently re-verified against the real GitHub review text via the API (not taken on any label alone). `rex-773` also completes a third same-diff Rex/Hakim cross-agent pair alongside the existing `rex-792`/`hakim-792` and `rex-767`/`hakim-767` pairs.
- **Documented, not fabricated, further corpus-growth candidates** — a new `## Candidate corpus entries` section in `docs/eval-agents/README.md` lists 5 unpromoted rows from spike #825's own labeled dataset (with the specific PR each needs re-verification against), a survey of real framework bugs that were investigated and explicitly rejected as corpus material (because they were discovered operationally, not through a Rex/Hakim review event with a recorded verdict), and flags the standing Hakim-MISS gap as the highest-value target for the next pass. Per rule 7, no defect was invented to fill a gap.

## Testing
1. `bash .claude/skills/eval-agents/lib/validate-corpus.sh rex docs/eval-agents/corpus/rex.json` → `✓ schema valid — 9 entries, 4 BLOCKING/HIGH ground-truth defects, 2 recorded MISS(es)`
2. `bash .claude/skills/eval-agents/tests/smoke.sh` → `8 passed, 0 failed` (includes the 2 new defect-in-diff guard tests)
3. Reproduced the original mislabel against the new guard by hand-constructing the pre-fix `rex-770-d8ad5325` entry (commit `d8ad5325b`, location `.claude/hooks/_lib-review-markers.sh`) and confirmed the validator now correctly rejects it: `entry rex-770-d8ad5325 defect[0]: location '.claude/hooks/_lib-review-markers.sh' does not appear in diff_range 'd8ad5325b~1..d8ad5325b'`
4. `bash -n` clean on both edited shell scripts

Closes #861

## Glossary
| Term | Definition |
|------|------------|
| Ground-truth defect | A frozen, human-adjudicated defect record in a corpus entry — the "answer key" `/eval-agents` scores a fresh agent run against. |
| `diff_range` | The `git diff`-compatible commit range (`<sha>~1..<sha>`) a corpus entry points at as "the diff that was reviewed." |
| Defect-in-diff guard | The new validator check: a defect's `location` file must actually be part of the changed-file set in `diff_range`, or the entry can't have been caught by the reviewer it's scored against. |
| GOOD_CLEAN | Spike #825's label for a correct APPROVED verdict on a genuinely defect-free diff — as valuable a corpus entry as a caught defect, since it proves the agent doesn't false-alarm. |
| Same-diff cross-agent pair | Two corpus entries (one per agent) pointing at the identical commit, letting a run compare how Rex vs. Hakim handled the exact same code. |