### PR TITLE
fix(#866): gitignore agent-routing.local.yaml and .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,14 @@ workspace/*/
 # agent routing" and docs/agdr/AgDR-0050-agent-runtime-overhaul.md.
 /agent-routing.yaml
 
+# Per-machine model-routing overrides — the local variant of the file above
+# (machine-specific model assignments). Adopter-local; never committed.
+/agent-routing.local.yaml
+
+# MCP server config — contains hardcoded local absolute paths; created per
+# adopter machine, must not be committed.
+/.mcp.json
+
 # Framework-defaults snapshot written by apply-agent-routing.sh on
 # SessionStart. The drift guard (block-agent-routing-drift.sh) reads it
 # to know what each agent's framework-default model: line was BEFORE the


### PR DESCRIPTION
## Summary

- **`.gitignore` now ignores `agent-routing.local.yaml` and `.mcp.json`** — both are per-machine adopter files (local model-routing overrides and MCP server config with hardcoded local absolute paths) that were showing up as untracked in `git status` for every adopter who uses MCP or local agent routing. Neither was referenced in `.gitignore` at all (this corrects the original report's claim that a documenting comment already existed).
- **Root-anchored, matching the existing convention** — the entries are `/agent-routing.local.yaml` and `/.mcp.json`, anchored like the sibling `/agent-routing.yaml` so they match only the fork-root files and can't accidentally ignore nested same-named files.

## Testing

Verified in a clean worktree off `dev`:

```
$ git check-ignore -v .mcp.json agent-routing.local.yaml
.gitignore:41:/.mcp.json                .mcp.json
.gitignore:37:/agent-routing.local.yaml agent-routing.local.yaml
```

Both files are now ignored; `git status` is clean for them. No behaviour change beyond ignore coverage.

Closes #866

---

## Glossary

| Term | Definition |
|------|------------|
| `agent-routing.local.yaml` | Per-machine model-routing override file; read by framework hooks alongside `agent-routing.yaml`. |
| `.mcp.json` | MCP server configuration file with local absolute paths; adopter-created per machine, never shared. |
| Root-anchored ignore (`/name`) | A `.gitignore` pattern with a leading `/` matches only at the repo root, not in nested directories — matches the existing `/agent-routing.yaml` style. |
