### PR TITLE
docs(#723): trim verbose squash-merge note in README contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Thanks to everyone who has helped forge ApexYard:
   </tr>
 </table>
 
-<sub>External contributors' PRs are squash-merged, so GitHub's commit-author graph under-counts them — this list credits the humans directly. New contributor? Open a PR and you'll be added.</sub>
+<sub>This list credits every human directly, since squash-merges hide them from GitHub's contributor graph. New contributor? Open a PR and you'll be added.</sub>
 
 ## License
 


### PR DESCRIPTION
## Summary
- **Tightened the contributors sub-note** — the old note spent a full sentence explaining git internals (*"External contributors' PRs are squash-merged, so GitHub's commit-author graph under-counts them"*), which is more mechanics than a README reader needs. It now conveys the same point in one light clause: the list credits humans directly because squash-merges hide them from GitHub's graph.
- **Kept the friendly invite** — the *"New contributor? Open a PR and you'll be added"* line is unchanged, so the welcoming tone stays.
- **Grid untouched** — the 4-human contributor table is exactly as before; this is a prose-only trim of the sub-note beneath it.

## Testing
1. Open `README.md` and scroll to the **Contributors** section.
2. Eyeball the `<sub>` line under the contributor table — it should read as one short, friendly sentence plus the open-a-PR invite, with no paragraph-length explanation of squash-merge / commit-author-graph mechanics.
3. `markdownlint-cli2 README.md` reports 0 errors (verified locally).

Closes #723

---

## Glossary
| Term | Definition |
|------|------------|
| Squash-merge | A merge strategy that collapses all of a PR's commits into a single commit on the base branch, so the individual commit authorship is not preserved in the target branch's history. |
| Commit-author graph | GitHub's per-repo contributor view, derived from commit authorship. Because squash-merges attribute the squashed commit to the merger, external contributors can be under-counted there — the manual list exists to credit them directly. |
| `<sub>` | The HTML small-text element used for the fine-print note beneath the contributor grid in the README. |