### PR TITLE
feat(#761): widen tracker_view body support to jira/linear/asana adapters

### DIFF
--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -17,12 +17,15 @@
 #   tracker_view <id> [<owner_repo>]   dispatches the view command and emits normalised JSON on stdout
 #                                      Exit 0 = ticket exists; non-zero = doesn't, or CLI errored.
 #                                      JSON shape: {"state":..., "title":..., "url":..., "labels":[...], "body":...}
-#                                      `body` is populated for the gh and glab adapters (the kinds
-#                                      that have a consumer needing it — the migration gate reads it
-#                                      to find the linked AgDR, #755). Other adapters omit the body
-#                                      key entirely (consumers read it as `.body // empty`) until one
-#                                      needs it (jira `.description` is ADF, not a grep-able string;
-#                                      linear/asana bodies have no consumer yet).
+#                                      `body` is populated for the gh, glab, jira, linear, and asana
+#                                      adapters — every built-in kind the migration gate (which reads
+#                                      the body to find the linked AgDR, #755/#761) can query. jira's
+#                                      `.fields.description` may be ADF (a JSON object, not a string)
+#                                      on Jira Cloud; the adapter flattens ADF text nodes to plain
+#                                      text so the body stays grep-able (Jira Server/DC returns a
+#                                      plain string, passed through). The `custom` adapter still omits
+#                                      body unless the operator's `normalise_jq` emits one (consumers
+#                                      read it as `.body // empty`).
 #   tracker_create <owner/repo> <title> [<body_file>] [<labels_csv>]
 #                                      creates a ticket via the per-project CLI; emits {ref,url}.
 #   tracker_review_submit <owner/repo> <pr> <verdict> [<body_file>]  (#758)
@@ -358,8 +361,10 @@ _tracker_normalise_glab() {
 #
 # Documented assumption: `linear issue view <ID> --json` emits a JSON object
 # with .state (or .state.name), .title, .url, .labels (array of strings or
-# array of {name} objects). Both shapes are handled — older linear CLI
-# versions returned strings; newer return objects.
+# array of {name} objects), and .description (a markdown string). Both label
+# shapes are handled — older linear CLI versions returned strings; newer return
+# objects. body maps to .description so the migration gate can read the linked
+# AgDR (#761).
 # ------------------------------------------------------------------------------
 _tracker_normalise_linear() {
   local raw="$1"
@@ -369,7 +374,8 @@ _tracker_normalise_linear() {
     state:  ((.state | if type == "object" then .name else . end) // ""),
     title:  (.title // ""),
     url:    (.url // ""),
-    labels: ((.labels // []) | map(if type == "object" then .name else . end))
+    labels: ((.labels // []) | map(if type == "object" then .name else . end)),
+    body:   (.description // "")
   }' 2>/dev/null
 }
 
@@ -377,8 +383,18 @@ _tracker_normalise_linear() {
 # Internal adapter: jira → normalised JSON.
 #
 # Documented assumption: `jira issue view <ID> --raw` emits Jira's REST JSON
-# with .fields.{summary,status.name,labels} and .self for the URL. The
-# `jira` CLI (ankitpokhrel/jira-cli) is the de-facto standard.
+# with .fields.{summary,status.name,labels,description} and .self for the URL.
+# The `jira` CLI (ankitpokhrel/jira-cli) is the de-facto standard.
+#
+# body maps to .fields.description (#761). Jira Cloud returns the description as
+# ADF — Atlassian Document Format, a JSON object ({type:"doc",content:[…]}), not
+# a string — so a naive pass-through would emit an unusable object and the
+# migration gate could never grep an AgDR link out of it. The `if type` branch
+# below flattens ADF: it recursively collects every `text` leaf from the content
+# tree (`[.. | .text? // empty]`) and joins them with newlines, yielding
+# grep-able plain text. Jira Server / Data Center returns description as a plain
+# string, which the string branch passes through verbatim. A missing/null
+# description degrades to "".
 # ------------------------------------------------------------------------------
 _tracker_normalise_jira() {
   local raw="$1"
@@ -388,7 +404,13 @@ _tracker_normalise_jira() {
     state:  ((.fields.status.name // .status // "") | tostring),
     title:  ((.fields.summary // .summary // .title // "") | tostring),
     url:    ((.self // .url // "") | tostring),
-    labels: ((.fields.labels // .labels // []) | map(if type == "object" then .name else . end))
+    labels: ((.fields.labels // .labels // []) | map(if type == "object" then .name else . end)),
+    body:   (
+      (.fields.description // .description // "") as $d |
+      if ($d | type) == "string" then $d
+      elif ($d | type) == "object" then ([$d | .. | .text? // empty] | join("\n"))
+      else "" end
+    )
   }' 2>/dev/null
 }
 
@@ -396,8 +418,10 @@ _tracker_normalise_jira() {
 # Internal adapter: asana → normalised JSON.
 #
 # Documented assumption: `asana task get <gid> --json` emits {data: {name,
-# completed, permalink_url, tags}}. State is derived from .completed
-# (true → "Closed", false → "Open").
+# completed, permalink_url, tags, notes}}. State is derived from .completed
+# (true → "Closed", false → "Open"). body maps to .notes (Asana's plain-text
+# task description), falling back to .html_notes when only the rich-text form is
+# present, so the migration gate can read the linked AgDR (#761).
 # ------------------------------------------------------------------------------
 _tracker_normalise_asana() {
   local raw="$1"
@@ -409,7 +433,8 @@ _tracker_normalise_asana() {
       state:  (if ($t.completed == true) then "Closed" else "Open" end),
       title:  ($t.name // ""),
       url:    ($t.permalink_url // ""),
-      labels: (($t.tags // []) | map(if type == "object" then .name else . end))
+      labels: (($t.tags // []) | map(if type == "object" then .name else . end)),
+      body:   ($t.notes // $t.html_notes // "")
     }
   ' 2>/dev/null
 }

--- a/.claude/hooks/require-migration-ticket.sh
+++ b/.claude/hooks/require-migration-ticket.sh
@@ -304,7 +304,8 @@ fi
 # false-blocked every migration edit even when the GitLab ticket was valid.
 # tracker_view emits the normalised {state,title,url,labels,body} shape
 # regardless of tracker; labels come back as a flat string array and body is
-# populated for gh/glab (the kinds the migration gate reads).
+# populated for gh/glab/jira/linear/asana — every built-in kind the migration
+# gate reads (#761 widened body beyond the original gh/glab of #755).
 if [ -f "$HOOK_DIR/_lib-tracker.sh" ]; then
   # shellcheck source=/dev/null
   . "$HOOK_DIR/_lib-tracker.sh"
@@ -395,22 +396,25 @@ MSG
 fi
 
 # --------- Gate 3: body references a migration AgDR ---------
-# The issue body is populated by tracker_view only for the gh and glab adapters
-# (see _lib-tracker.sh). For any other tracker kind the body comes back empty,
-# so this gate cannot see an AgDR link even when one exists — surface that in the
-# failure message rather than blaming the ticket. Adopters on those trackers can
-# set tracker.kind=none to skip online migration verification. (Widening body to
-# jira/linear/asana is tracked separately from #755.)
+# The issue body is populated by tracker_view for the gh, glab, jira, linear, and
+# asana adapters (see _lib-tracker.sh — #761 widened it beyond the original
+# gh/glab of #755). Only the `custom` adapter can leave body empty (unless the
+# operator's normalise_jq emits one), so this gate cannot see an AgDR link there
+# even when one exists — surface that in the failure message rather than blaming
+# the ticket. Adopters on custom can set tracker.kind=none to skip online
+# migration verification.
 if ! echo "$BODY" | grep -qE 'docs/agdr/AgDR-[0-9]+-[^[:space:]]*migration[^[:space:]]*\.md'; then
   KIND_NOTE=""
   case "$TICKET_KIND" in
-    gh|glab) ;;
+    gh|glab|jira|linear|asana) ;;
     *) KIND_NOTE="
 
-NOTE: tracker.kind=${TICKET_KIND} — this gate reads the issue body only for the
-gh and glab trackers, so for ${TICKET_KIND} the body is not fetched and this
-check cannot see an AgDR link even if the ticket has one. Track migrations on a
-gh/glab ticket, or set tracker.kind=none to skip online migration verification." ;;
+NOTE: tracker.kind=${TICKET_KIND} — this gate reads the issue body via
+tracker_view, which only populates body for the gh, glab, jira, linear, and
+asana adapters. For ${TICKET_KIND} the body may not be fetched, so this check
+cannot see an AgDR link even if the ticket has one. Emit body from your
+custom normalise_jq, track migrations on a built-in tracker, or set
+tracker.kind=none to skip online migration verification." ;;
   esac
   cat >&2 <<MSG
 BLOCKED: Active ticket ${TICKET_REPO}#${TICKET_NUM} has the

--- a/.claude/hooks/tests/test_require_migration_ticket.sh
+++ b/.claude/hooks/tests/test_require_migration_ticket.sh
@@ -15,7 +15,11 @@
 #   9. glab unfetchable → block (2) — migration gate is fail-closed by design
 #  10. non-migration path → pass-through allow (0)
 #  11. no active-ticket marker → block (2)
-#  12. non-gh/glab (jira) reaches Gate 3, blocks with body-scoping note (2)
+#  12. jira happy path — ADF (Cloud) body links AgDR → allow (0) (#761)
+#  12b. jira happy path — plain-string (Server/DC) body links AgDR → allow (0)
+#  12c. linear happy path — description body links AgDR → allow (0) (#761)
+#  12d. asana happy path — notes body links AgDR → allow (0) (#761)
+#  12e. custom (body unmapped) reaches Gate 3, blocks with scoping note (2)
 #  13. injection: metachar marker `number=` → block (2) and NOT executed
 #  14. injection: metachar marker `repo=` → block (2) and NOT executed
 #  15. guard: `#`-prefixed number passes and is shell-safe (printf %q escapes #)
@@ -321,9 +325,10 @@ fi
 rm -rf "$SB"
 
 # =============================================================================
-# Case 12: non-gh/glab tracker (jira) reaches Gate 3 but body is unmapped, so it
-# blocks with the scoping note (documents the known limitation; the migration
-# gate's body read is gh/glab-only until body support is widened).
+# Case 12: jira happy path (#761). Body is now mapped for jira, so an OPEN,
+# migration-labelled ticket whose ADF description (Jira Cloud) links a migration
+# AgDR passes Gate 3 → allow (0). This replaces the pre-#761 case that asserted
+# jira blocked with a body-scoping note (that limitation is now closed).
 # =============================================================================
 SB=$(make_fork)
 cat > "$SB/.claude/project-config.json" <<'JSON'
@@ -332,22 +337,113 @@ JSON
 set_marker "$SB" test-org/test-repo JIRA-42
 install_mock "$SB" jira '
 if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
-  printf "{\"self\":\"https://jira/JIRA-42\",\"fields\":{\"status\":{\"name\":\"In Progress\"},\"summary\":\"S\",\"labels\":[\"migration\"]}}\n"
+  printf "{\"self\":\"https://jira/JIRA-42\",\"fields\":{\"status\":{\"name\":\"In Progress\"},\"summary\":\"S\",\"labels\":[\"migration\"],\"description\":{\"type\":\"doc\",\"version\":1,\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"refs docs/agdr/AgDR-0011-schema-migration.md\"}]}]}}}\n"
   exit 0
 fi
 exit 0
 '
-# Capture stderr to assert the scoping note is present.
+if run_hook "$SB" "$SB/$MIG" 0; then
+  record_pass "jira: OPEN + migration label + AgDR in ADF body → allow (#761)"
+else
+  record_fail "jira: OPEN + migration label + AgDR in ADF body → allow (#761)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 12b: jira Server/DC plain-string description → allow (#761). Same as 12
+# but the description comes back as a plain string (not ADF), exercising the
+# adapter's string pass-through branch.
+# =============================================================================
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{ "tracker": { "kind": "jira", "view_command": "jira issue view {id} --raw" } }
+JSON
+set_marker "$SB" test-org/test-repo JIRA-43
+install_mock "$SB" jira '
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  printf "{\"self\":\"https://jira/JIRA-43\",\"fields\":{\"status\":{\"name\":\"In Progress\"},\"summary\":\"S\",\"labels\":[\"migration\"],\"description\":\"refs docs/agdr/AgDR-0012-data-migration.md\"}}\n"
+  exit 0
+fi
+exit 0
+'
+if run_hook "$SB" "$SB/$MIG" 0; then
+  record_pass "jira: OPEN + label + AgDR in plain-string (Server/DC) body → allow (#761)"
+else
+  record_fail "jira: OPEN + label + AgDR in plain-string (Server/DC) body → allow (#761)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 12c: linear happy path (#761). Body maps to .description (markdown).
+# =============================================================================
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{ "tracker": { "kind": "linear", "view_command": "linear issue view {id} --json" } }
+JSON
+set_marker "$SB" test-org/test-repo LIN-42
+install_mock "$SB" linear '
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  printf "{\"state\":{\"name\":\"In Progress\"},\"title\":\"L\",\"url\":\"https://linear/LIN-42\",\"labels\":[{\"name\":\"migration\"}],\"description\":\"refs docs/agdr/AgDR-0013-schema-migration.md\"}\n"
+  exit 0
+fi
+exit 0
+'
+if run_hook "$SB" "$SB/$MIG" 0; then
+  record_pass "linear: OPEN + migration label + AgDR in description body → allow (#761)"
+else
+  record_fail "linear: OPEN + migration label + AgDR in description body → allow (#761)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 12d: asana happy path (#761). Body maps to .notes; state derives from
+# .completed (false → Open). Asana uses a numeric task gid.
+# =============================================================================
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{ "tracker": { "kind": "asana", "view_command": "asana task get {id} --json" } }
+JSON
+set_marker "$SB" test-org/test-repo 1122334455
+install_mock "$SB" asana '
+if [ "$1" = "task" ] && [ "$2" = "get" ]; then
+  printf "{\"data\":{\"name\":\"A\",\"completed\":false,\"permalink_url\":\"https://asana/1\",\"tags\":[{\"name\":\"migration\"}],\"notes\":\"refs docs/agdr/AgDR-0014-schema-migration.md\"}}\n"
+  exit 0
+fi
+exit 0
+'
+if run_hook "$SB" "$SB/$MIG" 0; then
+  record_pass "asana: Open + migration tag + AgDR in notes body → allow (#761)"
+else
+  record_fail "asana: Open + migration tag + AgDR in notes body → allow (#761)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 12e: custom tracker WITHOUT body still reaches Gate 3 with an empty body
+# and blocks WITH the scoping note. Custom is deliberately out of #761 scope —
+# its body depends on the operator's normalise_jq — so the KIND_NOTE path must
+# still fire for it (and must NOT name jira/linear/asana as unsupported).
+# =============================================================================
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{ "tracker": { "kind": "custom", "view_command": "customcli view {id}" } }
+JSON
+set_marker "$SB" test-org/test-repo CUST-42
+# Identity normalise (default): raw already shaped as {state,labels}; no body key.
+install_mock "$SB" customcli '
+printf "{\"state\":\"OPEN\",\"labels\":[\"migration\"]}\n"
+exit 0
+'
 OUT=$(
   cd "$SB" || exit 99
   PATH="$SB/bin:$PATH" .claude/hooks/require-migration-ticket.sh \
     <<<"$(jq -nc --arg fp "$SB/$MIG" '{tool_name:"Write", tool_input:{file_path:$fp}}')" 2>&1
 )
 RC=$?
-if [ "$RC" = "2" ] && echo "$OUT" | grep -q "tracker.kind=jira"; then
-  record_pass "jira: Gate 3 blocks with body-scoping note (known gh/glab-only limitation)"
+if [ "$RC" = "2" ] && echo "$OUT" | grep -q "tracker.kind=custom"; then
+  record_pass "custom: Gate 3 blocks with body-scoping note (custom out of #761 scope)"
 else
-  record_fail "jira: Gate 3 blocks with body-scoping note (known gh/glab-only limitation)" "rc=$RC note-present=$(echo "$OUT" | grep -c 'tracker.kind=jira')"
+  record_fail "custom: Gate 3 blocks with body-scoping note (custom out of #761 scope)" "rc=$RC note-present=$(echo "$OUT" | grep -c 'tracker.kind=custom')"
 fi
 rm -rf "$SB"
 

--- a/.claude/hooks/tests/test_tracker_aware_hooks.sh
+++ b/.claude/hooks/tests/test_tracker_aware_hooks.sh
@@ -549,7 +549,7 @@ cat > "$SB/.claude/project-config.json" <<'JSON'
 }
 JSON
 install_mock "$SB" linear '
-printf "{\"state\":{\"name\":\"In Progress\"},\"title\":\"L1\",\"url\":\"https://l/1\",\"labels\":[{\"name\":\"a\"},{\"name\":\"b\"}]}\n"
+printf "{\"state\":{\"name\":\"In Progress\"},\"title\":\"L1\",\"url\":\"https://l/1\",\"labels\":[{\"name\":\"a\"},{\"name\":\"b\"}],\"description\":\"see docs/agdr/AgDR-0001-schema-migration.md\"}\n"
 exit 0
 '
 out=$(
@@ -562,10 +562,12 @@ out=$(
 )
 got_state=$(echo "$out" | jq -r '.state')
 got_labels=$(echo "$out" | jq -r '.labels | join(",")')
-if [ "$got_state" = "In Progress" ] && [ "$got_labels" = "a,b" ]; then
-  record_pass "lib: tracker_view (linear) flattens state.name + label objects"
+got_body=$(echo "$out" | jq -r '.body')
+# body must survive (#761) — the migration gate reads .description for the AgDR link.
+if [ "$got_state" = "In Progress" ] && [ "$got_labels" = "a,b" ] && echo "$got_body" | grep -q "AgDR-0001-schema-migration.md"; then
+  record_pass "lib: tracker_view (linear) flattens state.name + label objects, maps description→body"
 else
-  record_fail "lib: tracker_view (linear) flattens state.name + label objects" "got state='$got_state' labels='$got_labels'"
+  record_fail "lib: tracker_view (linear) flattens state.name + label objects, maps description→body" "got state='$got_state' labels='$got_labels' body='$got_body'"
 fi
 rm -rf "$SB"
 
@@ -579,8 +581,11 @@ cat > "$SB/.claude/project-config.json" <<'JSON'
   }
 }
 JSON
+# Jira Cloud returns .fields.description as ADF (a JSON object, not a string).
+# The adapter must flatten ADF text leaves so body stays grep-able (#761) —
+# otherwise the migration gate could never see the AgDR link.
 install_mock "$SB" jira '
-printf "{\"self\":\"https://j/1\",\"fields\":{\"status\":{\"name\":\"To Do\"},\"summary\":\"S1\",\"labels\":[\"x\",\"y\"]}}\n"
+printf "{\"self\":\"https://j/1\",\"fields\":{\"status\":{\"name\":\"To Do\"},\"summary\":\"S1\",\"labels\":[\"x\",\"y\"],\"description\":{\"type\":\"doc\",\"version\":1,\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"see docs/agdr/AgDR-0002-schema-migration.md\"}]}]}}}\n"
 exit 0
 '
 out=$(
@@ -594,10 +599,65 @@ out=$(
 got_state=$(echo "$out" | jq -r '.state')
 got_title=$(echo "$out" | jq -r '.title')
 got_labels=$(echo "$out" | jq -r '.labels | join(",")')
-if [ "$got_state" = "To Do" ] && [ "$got_title" = "S1" ] && [ "$got_labels" = "x,y" ]; then
-  record_pass "lib: tracker_view (jira) reads .fields.status.name + summary + labels"
+got_body=$(echo "$out" | jq -r '.body')
+if [ "$got_state" = "To Do" ] && [ "$got_title" = "S1" ] && [ "$got_labels" = "x,y" ] && echo "$got_body" | grep -q "AgDR-0002-schema-migration.md"; then
+  record_pass "lib: tracker_view (jira) reads status/summary/labels + flattens ADF description→body"
 else
-  record_fail "lib: tracker_view (jira) reads .fields.status.name + summary + labels" "got state='$got_state' title='$got_title' labels='$got_labels'"
+  record_fail "lib: tracker_view (jira) reads status/summary/labels + flattens ADF description→body" "got state='$got_state' title='$got_title' labels='$got_labels' body='$got_body'"
+fi
+
+# Jira Server / Data Center returns .fields.description as a plain string — the
+# string branch must pass it through verbatim (not swallow it via ADF flatten).
+install_mock "$SB" jira '
+printf "{\"self\":\"https://j/2\",\"fields\":{\"status\":{\"name\":\"Open\"},\"summary\":\"S2\",\"labels\":[],\"description\":\"link docs/agdr/AgDR-0003-data-migration.md here\"}}\n"
+exit 0
+'
+got_body=$(
+  cd "$SB" || exit 99
+  PATH="$SB/bin:$PATH"
+  . .claude/hooks/_lib-read-config.sh
+  . .claude/hooks/_lib-tracker.sh
+  tracker_clear_cache
+  tracker_view JIRA-2 | jq -r '.body'
+)
+if echo "$got_body" | grep -q "AgDR-0003-data-migration.md"; then
+  record_pass "lib: tracker_view (jira) passes through a plain-string (Server/DC) description→body"
+else
+  record_fail "lib: tracker_view (jira) passes through a plain-string (Server/DC) description→body" "got body='$got_body'"
+fi
+rm -rf "$SB"
+
+# Asana lib smoke (#761): body maps to .notes (plain-text task description). No
+# lib-level asana test existed before body was mapped — add one alongside the
+# linear/jira siblings so the migration gate's read of .notes is covered.
+SB=$(make_fork)
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{
+  "tracker": {
+    "kind": "asana",
+    "view_command": "asana task get {id} --json"
+  }
+}
+JSON
+install_mock "$SB" asana '
+printf "{\"data\":{\"name\":\"A1\",\"completed\":false,\"permalink_url\":\"https://asana/1\",\"tags\":[{\"name\":\"backend\"}],\"notes\":\"rollback in docs/agdr/AgDR-0004-schema-migration.md\"}}\n"
+exit 0
+'
+out=$(
+  cd "$SB" || exit 99
+  PATH="$SB/bin:$PATH"
+  . .claude/hooks/_lib-read-config.sh
+  . .claude/hooks/_lib-tracker.sh
+  tracker_clear_cache
+  tracker_view 12345
+)
+got_state=$(echo "$out" | jq -r '.state')
+got_labels=$(echo "$out" | jq -r '.labels | join(",")')
+got_body=$(echo "$out" | jq -r '.body')
+if [ "$got_state" = "Open" ] && [ "$got_labels" = "backend" ] && echo "$got_body" | grep -q "AgDR-0004-schema-migration.md"; then
+  record_pass "lib: tracker_view (asana) derives Open from completed + maps notes→body"
+else
+  record_fail "lib: tracker_view (asana) derives Open from completed + maps notes→body" "got state='$got_state' labels='$got_labels' body='$got_body'"
 fi
 rm -rf "$SB"
 


### PR DESCRIPTION
## Summary

- **Mapped `body` in the jira / linear / asana `tracker_view` adapters** so the migration gate (`require-migration-ticket.sh` Gate 3) actually works on those trackers. Gate 3 greps the issue **body** for the linked migration AgDR, but before this only the gh/glab adapters populated `body` — so on jira/linear/asana every migration-path edit false-blocked with a scoping note, and the only escape was `tracker.kind=none` (which disables migration verification entirely). Those adopters now get full Gate 2 + Gate 3 discipline.
- **jira → `.fields.description`, with ADF flattening.** Jira Cloud returns the description as ADF (Atlassian Document Format — a JSON *object*, `{type:"doc",content:[…]}`, not a string), so a naive pass-through would emit an unusable object that no `grep` could match. The adapter recursively collects every `text` leaf from the ADF tree and newline-joins them to grep-able plain text. Jira Server / Data Center returns a plain string, which the adapter passes through verbatim; a missing description degrades to `""`.
- **linear → `.description`** (markdown) and **asana → `.notes`** (falling back to `.html_notes`) — straight field maps, matching the gh/glab shape.
- **Dropped the now-unnecessary `KIND_NOTE`** from Gate 3's block message for gh/glab/jira/linear/asana (all five built-in kinds now populate body). The note is **kept for the `custom` adapter**, whose body still depends on the operator's `normalise_jq` — out of scope here per the ticket.
- **Tests.** Added `body` assertions to the linear + jira lib smokes in `test_tracker_aware_hooks.sh` (jira covers both the ADF-object and plain-string paths), added a new asana lib smoke (none existed), and in `test_require_migration_ticket.sh` replaced the old "jira blocks with scoping note" case with Gate-3 **happy-path** cases per newly-supported kind (jira ADF, jira plain-string, linear, asana) plus a retained "custom still blocks with note" case.

## Testing

```bash
bash .claude/hooks/tests/test_tracker_aware_hooks.sh      # 28 passed, 0 failed
bash .claude/hooks/tests/test_require_migration_ticket.sh # 19 passed, 0 failed
shellcheck .claude/hooks/_lib-tracker.sh                  # clean (rc=0)
```

The adapters are exercised end-to-end through mock `linear` / `jira` / `asana` CLIs (the same mock-CLI harness the existing gh/glab cases use), so the body mapping and ADF flattening are verified without live tracker credentials. No live jira/linear/asana account is required — everything reachable in these hooks is covered by the mock harness; nothing in this change is left unverifiable.

Closes #761

---

## Glossary

| Term | Definition |
|------|------------|
| `tracker_view` | The normalising issue-fetch dispatcher in `_lib-tracker.sh`; emits `{state,title,url,labels,body}` regardless of the underlying tracker CLI (gh/glab/jira/linear/asana/custom). |
| `_tracker_normalise_<kind>` | Per-tracker adapter mapping a CLI's raw JSON into the normalised contract shape. |
| ADF | Atlassian Document Format — Jira Cloud's rich-text body as a JSON object (not plain text). Flattened here to newline-joined `text` leaves so the body stays grep-able. |
| Gate 3 (migration) | The `require-migration-ticket.sh` check that an OPEN, `migration`-labelled ticket's body links a migration AgDR (`docs/agdr/AgDR-\d+-.*migration.*\.md`). |
| `KIND_NOTE` | The explanatory footer Gate 3's block message appends when the active tracker can't populate body — now scoped to the `custom` adapter only. |
