### PR TITLE
fix(#872): resolve release-changelog range from a Released-From trailer

### DIFF
--- a/.claude/hooks/tests/test_release_changelog.sh
+++ b/.claude/hooks/tests/test_release_changelog.sh
@@ -281,6 +281,70 @@ out=$(run_test '
 ')
 contains "feat mentioning the unversioned string still included" "document the sync/main-to-dev-after convention" "$out"
 
+# ── Test: AgDR-0094 (#872) — Released-From trailer wins over the sync heuristic ──
+# The v5.0.0 regression case: the prior release-sync PR merged LATE, landing near
+# HEAD after real unreleased work. With no trailer, the #737 heuristic anchors on
+# that late sync marker and silently drops everything before it. With the trailer
+# present on PREV_TAG's own commit, the range anchors on the RECORDED cut sha
+# instead — deterministic, and immune to where the sync marker happens to land.
+echo "--- AgDR-0094 trailer wins over late sync (v5.0.0 regression) ---"
+out=$(run_test '
+  mc "chore: initial"
+  CUT=$(git rev-parse HEAD)
+  git commit -q --allow-empty -m "chore: release v10.0.0" -m "Released-From: $CUT"
+  git tag v10.0.0
+  mc "feat(#1001): pre-sync unreleased feature one"
+  mc "feat(#1002): pre-sync unreleased feature two"
+  mc "sync: merge main into dev after v10.0.0 release"
+  mc "feat(#1003): post-sync unreleased feature"
+  PREV_TAG="v10.0.0" HEAD_REF="HEAD" VERSION="v10.1.0" DATE="2026-07-10" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "pre-sync feature one included (the under-count fix)" "pre-sync unreleased feature one" "$out"
+contains "pre-sync feature two included (the under-count fix)" "pre-sync unreleased feature two" "$out"
+contains "post-sync feature still included" "post-sync unreleased feature" "$out"
+not_contains "release commit itself excluded" "chore: release v10.0.0" "$out"
+not_contains "sync commit itself excluded" "merge main into dev after v10.0.0" "$out"
+
+# ── Test: AgDR-0094 — trailer-absent releases keep the old #737 fallback ────────
+# PREV_TAG carries no trailer (a pre-AgDR-0094 release, or any plain tag) — the
+# range must fall back to the existing sync-boundary heuristic unchanged. This
+# is the explicit trailer-absent counterpart to the trailer-present test above;
+# every pre-existing #737 case elsewhere in this file is a trailer-absent case
+# too, so this one exists mainly to name the fallback path directly.
+echo "--- AgDR-0094 trailer-absent falls back to #737 heuristic ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v11.0.0
+  mc "feat(#1101): already-released work"
+  mc "sync: merge main into dev after v11.0.0 release"
+  mc "feat(#1102): the real unreleased delta"
+  PREV_TAG="v11.0.0" HEAD_REF="HEAD" VERSION="v11.1.0" DATE="2026-07-10" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "post-sync delta included (unchanged #737 behaviour)" "the real unreleased delta" "$out"
+not_contains "pre-sync work still excluded (unchanged #737 behaviour)" "already-released work" "$out"
+
+# ── Test: AgDR-0094 — a bogus/unknown trailer sha falls back safely, never errors ──
+# A mangled or stale Released-From trailer (sha doesn't resolve to a commit in
+# this repo) must not crash the script — it should fall back to the #737
+# heuristic exactly as if no trailer existed, and exit 0.
+echo "--- AgDR-0094 bogus trailer sha falls back safely ---"
+out=$(run_test '
+  mc "chore: initial"
+  git commit -q --allow-empty -m "chore: release v12.0.0" -m "Released-From: not-a-real-sha"
+  git tag v12.0.0
+  mc "feat(#1201): unreleased work before late sync"
+  mc "sync: merge main into dev after v12.0.0 release"
+  mc "feat(#1202): unreleased work after late sync"
+  PREV_TAG="v12.0.0" HEAD_REF="HEAD" VERSION="v12.1.0" DATE="2026-07-10" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+  echo "EXIT_CODE=$?"
+')
+contains "script exits cleanly despite the bogus sha" "EXIT_CODE=0" "$out"
+contains "falls back to sync heuristic (post-sync work included)" "unreleased work after late sync" "$out"
+not_contains "falls back to sync heuristic (pre-sync work excluded, same as #737 fallback)" "unreleased work before late sync" "$out"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Write
 
 # /release — Cut an apexyard release
 
-Standardises the `dev` → `main` release flow introduced by AgDR-0007. Reads the conventional-commit log between `main` and `dev`, proposes a semver bump, **generates and writes the CHANGELOG entry**, **opens the release PR** (dev→main), and triggers the `auto-tag-on-release-pr-merge` GitHub Actions workflow that tags the squash commit and creates a GitHub Release after merge. One command drives the operator from "nothing" to "PR open, ready for Rex + CEO". The tag and GitHub Release entry are created automatically by CI when the PR merges. Design rationale: AgDR-0076.
+Standardises the `dev` → `main` release flow introduced by AgDR-0007. Reads the conventional-commit log between `main` and `dev`, proposes a semver bump, **generates and writes the CHANGELOG entry**, **opens the release PR** (dev→main), and triggers the `auto-tag-on-release-pr-merge` GitHub Actions workflow that tags the squash commit and creates a GitHub Release after merge. One command drives the operator from "nothing" to "PR open, ready for Rex + CEO". The tag and GitHub Release entry are created automatically by CI when the PR merges. The release PR also records a `Released-From` trailer with the exact `dev` cut-point SHA, and the changelog step warns loudly on a large main↔dev commit-count mismatch — both close the #872 changelog-truncation gap. Design rationale: AgDR-0076, AgDR-0094.
 
 This skill is **framework-only** — it's for cutting apexyard releases, not for releasing managed projects under governance. Managed projects stay trunk-based and don't have a release-cut flow.
 
@@ -61,14 +61,15 @@ Override? [Enter to accept, or type a version like v1.3.0]
 
 ### 3. Generate the CHANGELOG draft
 
-Call the helper script `bin/release-changelog.sh`, which encapsulates the `git log` + conventional-commit grouping + PR-number extraction logic and is independently tested:
+Call the helper script `bin/release-changelog.sh`, which encapsulates the `git log` + conventional-commit grouping + PR-number extraction logic and is independently tested. Capture its output — the count-mismatch guard below needs it:
 
 ```bash
-PREV_TAG="vX.Y.Z" \
-HEAD_REF="upstream/dev" \
-VERSION="vA.B.C" \
-DATE="$(date +%F)" \
-  bash bin/release-changelog.sh
+CHANGELOG_DRAFT=$(PREV_TAG="vX.Y.Z" \
+  HEAD_REF="upstream/dev" \
+  VERSION="vA.B.C" \
+  DATE="$(date +%F)" \
+  bash bin/release-changelog.sh)
+echo "$CHANGELOG_DRAFT"
 ```
 
 The helper emits markdown to stdout in the format:
@@ -95,7 +96,28 @@ Minor release — N features, M fixes.
 - Closes #N, #M, ...
 ```
 
-**Show the draft** and let the user edit interactively before proceeding. On `--dry-run`, print the draft and stop here with:
+#### Count-mismatch guard (AgDR-0094, option D)
+
+Immediately after generating the draft, sanity-check its entry count against the raw commit count between `main` and `dev`. This is the cheap, always-on backstop behind the `Released-From` trailer (step 4) — it's what caught the v5.0.0 under-count by hand, and it stays even after the trailer exists as defence in depth against a mangled trailer or a trailer-less pre-AgDR-0094 tag:
+
+```bash
+RAW_COUNT=$(git rev-list --count upstream/main..upstream/dev)
+# Count changelog entry bullets (every "- " line except the trailing "Closes" summary).
+ENTRY_COUNT=$(printf '%s\n' "$CHANGELOG_DRAFT" | grep -cE '^- ' || true)
+[ -n "$ENTRY_COUNT" ] || ENTRY_COUNT=0
+GAP=$(( RAW_COUNT - ENTRY_COUNT ))
+# Tolerance: release/sync/"Merge branch" marker commits are excluded from the
+# changelog BY DESIGN (bin/release-changelog.sh's classify step) — a handful
+# of those is normal, not a bug. A gap much larger than that is the #872
+# signature (a silently truncated range).
+TOLERANCE=5
+if [ "$GAP" -gt "$TOLERANCE" ]; then
+  echo "⚠️  WARNING: main..dev has $RAW_COUNT commits but the changelog lists only $ENTRY_COUNT entries (gap: $GAP, tolerance: $TOLERANCE)."
+  echo "    This is the #872 signature — a truncated changelog range. Verify PREV_TAG/HEAD_REF and the generated LOG_RANGE before proceeding."
+fi
+```
+
+**Show the draft** (and the warning, if any) and let the user edit interactively before proceeding. On `--dry-run`, print the draft and stop here with:
 
 ```
 Dry run — no changes made. Remove --dry-run to execute.
@@ -108,6 +130,14 @@ Skip all of steps 4–5 on `--dry-run`.
 ```bash
 # Check out the release branch from dev
 git fetch upstream
+
+# AgDR-0094: record the exact cut point NOW, while it's still knowable. This is
+# the sha bin/release-changelog.sh will read back out of the NEXT release's
+# PREV_TAG trailer — capture it here, not after checkout (the ref is what
+# matters, not the local branch's HEAD, but capturing immediately after fetch
+# keeps this unambiguous).
+DEV_SHA=$(git rev-parse upstream/dev)
+
 git checkout -b "release/vA.B.C" upstream/dev
 
 # Write the CHANGELOG entry at the top of CHANGELOG.md
@@ -135,7 +165,7 @@ gh pr create \
   --body-file /tmp/release-pr-body.md
 ```
 
-**PR body template** (write to `/tmp/release-pr-body.md` before the `gh pr create` call):
+**PR body template** (write to `/tmp/release-pr-body.md` before the `gh pr create` call). Interpolate `$DEV_SHA` (captured above) into the final line — it MUST be the very last line of the file, with nothing after it, so it lands as the final paragraph of the squash commit message and `git interpret-trailers` parses it (AgDR-0094):
 
 ```markdown
 <!-- multi-close: approved -->
@@ -145,6 +175,7 @@ gh pr create \
 - **Releases vA.B.C** — see CHANGELOG section below for the full list of changes included in this release
 - **CHANGELOG.md updated** — new section prepended at the top with grouped feat/fix/chore entries and PR refs
 - **Auto-tag on merge** — `.github/workflows/auto-tag-on-release-pr-merge.yml` will tag the squash commit on main and create a GitHub Release entry automatically when this PR merges (AgDR-0076)
+- **Release provenance recorded** — a `Released-From` trailer captures the exact `dev` SHA this release was cut from, so the next release's changelog range is deterministic instead of inferred (AgDR-0094, #872)
 
 ## CHANGELOG
 
@@ -155,6 +186,7 @@ gh pr create \
 1. After merge, confirm CI creates tag `vA.B.C` on `main` (check the `auto-tag-on-release-pr-merge` workflow run)
 2. Verify `git describe --tags --abbrev=0 upstream/main` returns `vA.B.C`
 3. Run `/release-sync vA.B.C` to sync main→dev and prevent squash divergence
+4. Verify the squash commit's message carries the trailer: `git log -1 --pretty=format:'%(trailers:key=Released-From,valueonly)' vA.B.C`
 
 Refs #<release-ticket>
 
@@ -168,7 +200,12 @@ Refs #<release-ticket>
 | Auto-tag | The `auto-tag-on-release-pr-merge.yml` workflow fires on `pull_request` → `closed` + `merged` for `release/v*` branches, tags `github.sha` (the squash commit), and creates a GitHub Release |
 | Ancestry guard | `git merge-base --is-ancestor <sha> main` — fails if the tag would not be reachable from main, preventing a mis-placed tag like v2.3.0 |
 | `/release-sync` | The mandatory follow-up skill that merges main→dev after a squash-merge release, preventing SHA divergence accumulation |
+| `Released-From` trailer | A git trailer (`Key: value` in the commit message's final paragraph) recording the exact `dev` SHA this release was cut from — `bin/release-changelog.sh` reads it back for the next release's changelog range (AgDR-0094) |
+
+Released-From: $DEV_SHA
 ```
+
+**Why the trailer sits after the Glossary, as its own final paragraph:** `git interpret-trailers` (and the `%(trailers:...)` pretty-format used by `bin/release-changelog.sh`) only recognises a trailer block when it is the LAST paragraph of the message — a blank line before it, nothing but `Key: value` lines after it. Putting `Released-From:` anywhere earlier (e.g. inside the Summary or Testing sections) would make it invisible to the reader on the next release cut. Do not add anything below the trailer line.
 
 **PR title format** (`release` is whitelisted in `pr.title_type_whitelist` since #168):
 
@@ -262,11 +299,14 @@ This files a `sync/main-to-dev-after-vA.B.C → dev` PR that merges `upstream/ma
 6. **Never tag before merge, and never tag the release-branch HEAD.** The auto-tag workflow handles tagging after merge, always using `github.sha` (the squash commit). The manual fallback similarly tags `upstream/main`. See step 7 for the full guard.
 7. **`<!-- multi-close: approved -->`** in the release PR body is required — release PRs legitimately close many tickets at once.
 8. **`--dry-run` stops before writing any files.** The draft CHANGELOG section and PR body are shown; nothing is committed, branched, pushed, or filed.
+9. **The `Released-From` trailer must be the PR body's final line, alone in its own paragraph** (AgDR-0094). It is what makes the next release's changelog range deterministic — a trailer that lands mid-body (or gets pushed off the end by later edits) silently degrades back to the pre-AgDR-0094 sync-boundary heuristic, with all its known failure modes (#737, #872).
+10. **Show the count-mismatch warning if it fires** — a loud gap between `main..dev`'s raw commit count and the changelog's entry count is the #872 signature. Don't proceed past it without the operator explicitly confirming the range is correct.
 
 ## Related
 
 - `AgDR-0007` — the release-cut branch model this skill enacts
 - `AgDR-0076` — the automation design record (this enhancement)
+- `AgDR-0094` — release provenance via the `Released-From` trailer + count-mismatch guard (#872)
 - `bin/release-changelog.sh` — the changelog generation helper script, independently tested
 - `docs/release-process.md` — the prose runbook (this skill is the automation; the doc is the manual fallback)
 - `.github/workflows/auto-tag-on-release-pr-merge.yml` — the CI workflow that tags the squash commit after merge

--- a/bin/release-changelog.sh
+++ b/bin/release-changelog.sh
@@ -58,29 +58,53 @@ REPO_REMOTE="${REPO_REMOTE:-upstream}"
 if [ "$PREV_TAG" = "NONE" ]; then
   LOG_RANGE="${HEAD_REF}"
 else
-  # #737: PREV_TAG is a *squash* commit on main. Under the release-cut model the
-  # individual commits it squashed live on HEAD_REF (dev) but are NOT ancestors
-  # of the tag — so a naive PREV_TAG..HEAD_REF range (and even
-  # merge-base(PREV_TAG,dev)..dev) surfaces EVERY already-released commit,
-  # massively over-counting (v4.1.0 reported 102 feats / 263 commits for a
-  # ~1-feature delta). The correct start is the POST-SYNC BOUNDARY: after each
-  # release, `/release-sync` lands a "sync: merge main into dev after <ver>"
-  # commit (and its "...sync/main-to-dev-after-<ver>" PR merge) on dev. Commits
-  # AFTER the most recent such marker are exactly the unreleased delta.
-  # Patterns are VERSION-ANCHORED so they only match real sync commits, never a
-  # prose mention of the convention in some other commit body (e.g. this very
-  # fix's commit, or a doc PR) — an unanchored 'sync/main-to-dev-after' would
-  # let a later commit hijack the boundary and DROP unreleased work (#749 review).
-  SYNC=$(git log "$HEAD_REF" --max-count=1 --pretty=format:'%H' \
-           --grep='^sync: merge main into dev after v[0-9]' \
-           --grep='sync/main-to-dev-after-v[0-9]' 2>/dev/null || true)
-  if [ -n "$SYNC" ]; then
-    LOG_RANGE="${SYNC}..${HEAD_REF}"
+  # AgDR-0094 (#872): prefer the RECORDED cut point over inferring one. Since
+  # the fix landed, `/release` writes a `Released-From: <dev-sha>` trailer into
+  # the release squash commit — that sha IS the exact dev tip the release was
+  # cut from, so TRAILER..HEAD_REF is deterministic and immune to both the
+  # #737 over-count and the #872 late-sync under-count (a late `/release-sync`
+  # merge can no longer mis-anchor the boundary, because we're not inferring
+  # it from sync-commit position anymore). Only look at PREV_TAG's own commit
+  # message — that's the squash commit the trailer was written into.
+  TRAILER_SHA=$(git log -1 --pretty=format:'%(trailers:key=Released-From,valueonly,separator=%x0A)' "$PREV_TAG" 2>/dev/null \
+                  | tail -n 1 | tr -d '[:space:]' || true)
+
+  if [ -n "$TRAILER_SHA" ] && git cat-file -e "${TRAILER_SHA}^{commit}" 2>/dev/null; then
+    LOG_RANGE="${TRAILER_SHA}..${HEAD_REF}"
   else
-    # No sync boundary on dev (first release under the model, or sync skipped):
-    # best available fallback is the merge-base, then the raw tag range.
-    BASE=$(git merge-base "$PREV_TAG" "$HEAD_REF" 2>/dev/null || true)
-    LOG_RANGE="${BASE:-$PREV_TAG}..${HEAD_REF}"
+    # No trailer (pre-AgDR-0094 release, or a mangled/unknown sha) — fall back
+    # to the #737 sync-boundary heuristic below, unchanged.
+    #
+    # #737: PREV_TAG is a *squash* commit on main. Under the release-cut model
+    # the individual commits it squashed live on HEAD_REF (dev) but are NOT
+    # ancestors of the tag — so a naive PREV_TAG..HEAD_REF range (and even
+    # merge-base(PREV_TAG,dev)..dev) surfaces EVERY already-released commit,
+    # massively over-counting (v4.1.0 reported 102 feats / 263 commits for a
+    # ~1-feature delta). The correct start is the POST-SYNC BOUNDARY: after each
+    # release, `/release-sync` lands a "sync: merge main into dev after <ver>"
+    # commit (and its "...sync/main-to-dev-after-<ver>" PR merge) on dev. Commits
+    # AFTER the most recent such marker are exactly the unreleased delta.
+    # Patterns are VERSION-ANCHORED so they only match real sync commits, never a
+    # prose mention of the convention in some other commit body (e.g. this very
+    # fix's commit, or a doc PR) — an unanchored 'sync/main-to-dev-after' would
+    # let a later commit hijack the boundary and DROP unreleased work (#749 review).
+    #
+    # KNOWN LIMITATION this heuristic cannot fix (why AgDR-0094 exists): if the
+    # matching `/release-sync` merges LATE — landing near dev's tip, after many
+    # newer commits — this still anchors on that late marker and silently drops
+    # everything merged before it (#872). The trailer above is the real fix;
+    # this stays as the fallback for releases cut before it existed.
+    SYNC=$(git log "$HEAD_REF" --max-count=1 --pretty=format:'%H' \
+             --grep='^sync: merge main into dev after v[0-9]' \
+             --grep='sync/main-to-dev-after-v[0-9]' 2>/dev/null || true)
+    if [ -n "$SYNC" ]; then
+      LOG_RANGE="${SYNC}..${HEAD_REF}"
+    else
+      # No sync boundary on dev (first release under the model, or sync skipped):
+      # best available fallback is the merge-base, then the raw tag range.
+      BASE=$(git merge-base "$PREV_TAG" "$HEAD_REF" 2>/dev/null || true)
+      LOG_RANGE="${BASE:-$PREV_TAG}..${HEAD_REF}"
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary

- **`bin/release-changelog.sh` now prefers a recorded cut point over inferring one** — if the previous release's squash commit (`PREV_TAG`) carries a `Released-From: <dev-sha>` trailer, the range anchors on that exact sha (`TRAILER..HEAD_REF`), immune to both the #737 over-count and the #872 late-sync under-count. Falls back to the existing #737 sync-boundary heuristic when no trailer exists, and falls back safely (never errors) when the trailer sha doesn't resolve to a real commit.
- **`/release` now records the cut point at the moment it's knowable** — it captures `dev`'s SHA right after `git fetch upstream`, then writes it as a `Released-From` trailer in the release PR body's final paragraph (so it survives squash-merge and stays parseable by `git interpret-trailers`), plus a loud warning if `main..dev`'s raw commit count and the changelog's entry count diverge by more than a small tolerance — the same manual eyeball check that caught the v5.0.0 under-count, now automated.
- **Three new test cases** reproduce the exact v5.0.0 regression shape (a late `/release-sync` merge landing near HEAD, with real unreleased work before it) and prove the trailer wins, the trailer-absent path is byte-for-byte unchanged, and a bogus trailer sha degrades safely to the old heuristic instead of crashing.

## Testing

```
$ env -u CLAUDE_CODE_SESSION_ID bash .claude/hooks/tests/test_release_changelog.sh
...
All 51 test(s) passed.

$ shellcheck bin/release-changelog.sh
(clean, exit 0)

$ bash -n bin/release-changelog.sh .claude/hooks/tests/test_release_changelog.sh
(clean, exit 0)
```

All 48 pre-existing cases still pass unchanged; 3 new AgDR-0094 cases added (trailer-wins-over-late-sync / trailer-absent-fallback / bogus-trailer-safe-fallback).

Refs #872

---

## Glossary

| Term | Definition |
|------|------------|
| `Released-From` trailer | A git trailer (`Key: value` line in a commit message's final paragraph) recording the exact `dev` SHA a release was cut from. `git interpret-trailers` / the `%(trailers:...)` pretty-format only recognise it if it's the message's last paragraph — nothing may follow it. |
| Sync-boundary heuristic (#737) | The pre-existing fallback: anchor the changelog range on the most recent `sync: merge main into dev after vX.Y.Z` commit. Correct when that sync merges promptly; silently drops unreleased work when it merges late (#872). |
| Late sync merge | A `/release-sync` PR that merges to `dev` well after its corresponding release, landing near `dev`'s tip and mis-anchoring the sync-boundary heuristic. |
| Count-mismatch guard | A cheap, always-on sanity check comparing `main..dev`'s raw commit count to the generated changelog's entry count, warning loudly on a large gap — defence in depth behind the trailer. |
| Squash merge | GitHub merges all commits on a PR branch into a single commit; the PR body becomes (part of) that commit's message — which is why the trailer's placement in the body matters. |

AgDR: `docs/agdr/AgDR-0094-release-provenance-trailer.md` — the decision this PR implements (already merged; not re-litigated here).
