### PR TITLE
fix(#882): resolve /start-ticket's ops root correctly on split-portfolio v2

### DIFF
--- a/.claude/skills/start-ticket/SKILL.md
+++ b/.claude/skills/start-ticket/SKILL.md
@@ -86,29 +86,26 @@ Per apexyard#41, the marker path depends on whether the ticket's tracker repo ma
 
 #### 4a. Locate the ops root
 
-The ops root is the apexyard fork root — the directory containing BOTH `onboarding.yaml` and `apexyard.projects.yaml`. Walk up from CWD / the nearest git toplevel until you find it:
+The ops root is the apexyard fork root, anchored by EITHER the `.apexyard-fork` marker (split-portfolio v2, framework ≥ #242 — `onboarding.yaml` and `apexyard.projects.yaml` live in the sibling portfolio repo, not the fork) OR the legacy v1 pair (`onboarding.yaml` AND `apexyard.projects.yaml` both present in the same directory). Resolve it via the shared lib instead of re-deriving the walk inline — `_lib-ops-root.sh` ships in every managed project's `.claude/hooks/` tree the same way `_lib-tracker.sh` does (that's why sourcing it via `git rev-parse --show-toplevel` below is safe regardless of whether cwd is the ops fork or a `workspace/<project>/` clone), and it resolves pin-first (apexyard#381) so a session pin set at launch beats a fresh walk when Claude Code is running from an ops-fork-shaped clone elsewhere on disk (e.g. a `/tmp` build checkout):
 
 ```bash
-ops_root=""
-r=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-while [ -n "$r" ] && [ "$r" != "/" ]; do
-  if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
-    ops_root="$r"
-    break
-  fi
-  r=$(dirname "$r")
-done
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-ops-root.sh"
+ops_root=$(resolve_ops_root)
 ```
 
-If not found (user is outside an apexyard fork), tell the user and stop. Starting a ticket without the fork doesn't make sense.
+If `$ops_root` is empty (user is outside an apexyard fork — neither anchor found walking up), tell the user and stop. Starting a ticket without the fork doesn't make sense.
 
 #### 4b. Look the tracker repo up in the registry
 
-Given the ticket's `owner/repo` (from step 1), grep `apexyard.projects.yaml` for a project whose `repo:` field matches. One registry-safe way (uses `yq` when available, falls back to a greppy read):
+Given the ticket's `owner/repo` (from step 1), resolve the registry path via `portfolio_registry` (see "Path resolution" above — do NOT hardcode `$ops_root/apexyard.projects.yaml`; in split-portfolio v2 the registry lives in the sibling repo, not the ops fork) and grep it for a project whose `repo:` field matches. One registry-safe way (uses `yq` when available, falls back to a greppy read):
 
 ```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+
 if command -v yq >/dev/null 2>&1; then
-  project=$(yq eval ".projects[] | select(.repo == \"${OWNER_REPO}\") | .name" "$ops_root/apexyard.projects.yaml")
+  project=$(yq eval ".projects[] | select(.repo == \"${OWNER_REPO}\") | .name" "$registry")
 else
   # Greppy fallback: find the `name:` whose sibling `repo:` matches.
   # Strips surrounding quotes from both `name:` and `repo:` values so the
@@ -118,7 +115,7 @@ else
     function unquote(s) { gsub(/^["\x27]|["\x27]$/, "", s); return s }
     /^[[:space:]]*- name:/ { name = unquote($3) }
     /^[[:space:]]*repo:/   { if (unquote($2) == r) { print name; exit } }
-  ' "$ops_root/apexyard.projects.yaml")
+  ' "$registry")
 fi
 ```
 

--- a/.claude/skills/start-ticket/SKILL.md
+++ b/.claude/skills/start-ticket/SKILL.md
@@ -86,22 +86,34 @@ Per apexyard#41, the marker path depends on whether the ticket's tracker repo ma
 
 #### 4a. Locate the ops root
 
-The ops root is the apexyard fork root, anchored by EITHER the `.apexyard-fork` marker (split-portfolio v2, framework ≥ #242 — `onboarding.yaml` and `apexyard.projects.yaml` live in the sibling portfolio repo, not the fork) OR the legacy v1 pair (`onboarding.yaml` AND `apexyard.projects.yaml` both present in the same directory). Resolve it via the shared lib instead of re-deriving the walk inline — `_lib-ops-root.sh` ships in every managed project's `.claude/hooks/` tree the same way `_lib-tracker.sh` does (that's why sourcing it via `git rev-parse --show-toplevel` below is safe regardless of whether cwd is the ops fork or a `workspace/<project>/` clone), and it resolves pin-first (apexyard#381) so a session pin set at launch beats a fresh walk when Claude Code is running from an ops-fork-shaped clone elsewhere on disk (e.g. a `/tmp` build checkout):
+The ops root is the apexyard fork root, anchored by EITHER the `.apexyard-fork` marker (split-portfolio v2, framework ≥ #242 — `onboarding.yaml` and `apexyard.projects.yaml` live in the sibling portfolio repo, not the fork) OR the legacy v1 pair (`onboarding.yaml` AND `apexyard.projects.yaml` both present in the same directory).
+
+Locate `_lib-ops-root.sh` by walking up from `$PWD` — **not** via `git rev-parse --show-toplevel`. Inside a `workspace/<project>/` clone, `--show-toplevel` resolves to the *project* repo, and managed-project clones carry **no `.claude/hooks/` directory at all** (there is no framework mechanism that installs one there) — sourcing from that path silently fails, `resolve_ops_root` is never defined, and this step dead-ends exactly where split-portfolio v2 operators most often run `/start-ticket`. This is the same sibling walk-up pattern `bug`, `feature`, `task`, `migration`, `spike`, `prototype`, and 8 other ticket skills already use to locate `_lib-tracker.sh` — walk up until a directory containing the lib is found, then source it.
+
+Keep two steps distinct: the walk-up below only finds a directory to **source the lib from** (the nearest fork-shaped root above cwd); `resolve_ops_root` then **decides the real ops root**, pin-first (apexyard#381) — the two can differ, e.g. a session pin can point at a different real ops fork than the nearest fork-shaped directory on the walk (say, cwd is inside an ops-fork-shaped `/tmp` build clone).
 
 ```bash
-source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-ops-root.sh"
+ops_lib="$(r="$PWD"; while [ -n "$r" ] && [ "$r" != / ]; do \
+  [ -f "$r/.claude/hooks/_lib-ops-root.sh" ] && { echo "$r/.claude/hooks/_lib-ops-root.sh"; break; }; \
+  r="${r%/*}"; done)"
+if [ -z "$ops_lib" ]; then
+  echo "Not inside an apexyard fork (no .claude/hooks/_lib-ops-root.sh found walking up from $PWD)." >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+. "$ops_lib"
 ops_root=$(resolve_ops_root)
 ```
 
-If `$ops_root` is empty (user is outside an apexyard fork — neither anchor found walking up), tell the user and stop. Starting a ticket without the fork doesn't make sense.
+If `$ops_root` is still empty after sourcing (no pin, and `resolve_ops_root`'s own internal walk also found no anchor above cwd), tell the user and stop. Starting a ticket without the fork doesn't make sense.
 
 #### 4b. Look the tracker repo up in the registry
 
-Given the ticket's `owner/repo` (from step 1), resolve the registry path via `portfolio_registry` (see "Path resolution" above — do NOT hardcode `$ops_root/apexyard.projects.yaml`; in split-portfolio v2 the registry lives in the sibling repo, not the ops fork) and grep it for a project whose `repo:` field matches. One registry-safe way (uses `yq` when available, falls back to a greppy read):
+Given the ticket's `owner/repo` (from step 1), resolve the registry path via `portfolio_registry` (see "Path resolution" above — do NOT hardcode `$ops_root/apexyard.projects.yaml`; in split-portfolio v2 the registry lives in the sibling repo, not the ops fork) and grep it for a project whose `repo:` field matches. `$ops_root` is already resolved and guaranteed to carry a `.claude/hooks/` tree (step 4a only succeeds when it does), so source directly from it — no second walk-up needed. One registry-safe way (uses `yq` when available, falls back to a greppy read):
 
 ```bash
-source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
-source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+source "$ops_root/.claude/hooks/_lib-read-config.sh"
+source "$ops_root/.claude/hooks/_lib-portfolio-paths.sh"
 registry=$(portfolio_registry)
 
 if command -v yq >/dev/null 2>&1; then

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -252,7 +252,7 @@ ln -s "$(pwd)/bin/apexyard" ~/.local/bin/apexyard
 apexyard status
 ```
 
-The shim walks up from `$PWD` looking for the apexyard fork root (`onboarding.yaml` + `apexyard.projects.yaml`), then runs the same briefing helper. No PATH-shadowing of the `claude` binary, no recursion into Claude Code — pure `bash` end-to-end.
+The shim walks up from `$PWD` looking for the apexyard fork root — the `.apexyard-fork` marker (split-portfolio v2) OR the legacy `onboarding.yaml` + `apexyard.projects.yaml` pair (v1) — then runs the same briefing helper. No PATH-shadowing of the `claude` binary, no recursion into Claude Code — pure `bash` end-to-end.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

- **`/start-ticket` step 4a now resolves the ops root on split-portfolio v2** — the original inline walk-up only checked for the legacy v1 pair (`onboarding.yaml` + `apexyard.projects.yaml`), both of which live in the sibling portfolio repo on v2 forks, not the fork itself. That made the walk return empty on every v2 fork, so the session marker couldn't be written — a real operator hit this on a fresh machine and had to write the marker by hand (see #882). The fix sources `_lib-ops-root.sh::resolve_ops_root`, the shared resolver every hook already trusts, instead of re-deriving the walk inline.
- **The lib is now *located* via a sibling walk-up, not `git rev-parse --show-toplevel`** — Rex's review caught that the first pass regressed the same class of bug one level up: from a managed-project `workspace/<project>/` clone, `--show-toplevel` resolves to the *project* repo, and those clones carry no `.claude/hooks/` directory at all, so the source silently failed and `resolve_ops_root` was never defined. Step 4a now walks up from `$PWD` until it finds a directory containing `_lib-ops-root.sh`, then sources it — the same pattern `bug`/`feature`/`task`/`migration`/`spike`/`prototype` (13 skills total) already use for `_lib-tracker.sh`. The walk-up only picks a directory to source *from*; `resolve_ops_root` (pin-first, apexyard#381) still decides the real ops root afterward — kept as two distinct steps, since a session pin can point elsewhere than the nearest fork-shaped directory on the walk.
- **Step 4b's registry lookup was hardcoded to `$ops_root/apexyard.projects.yaml`, which is also wrong on v2** — the registry lives in the sibling repo, not `$ops_root`. Switched to `portfolio_registry` from `_lib-portfolio-paths.sh`, sourced directly from `$ops_root` (already resolved and guaranteed to carry `.claude/hooks/` by the time step 4b runs — no second walk-up needed).
- **Swept every other `SKILL.md` for the same stale predicate**, per the ticket's second acceptance criterion. Result: `start-ticket` step 4a was the only genuinely stale one. The other 15 skills that anchor on the ops root already `OR` in `.apexyard-fork` correctly. `mutation-test`'s refuse-check already handles both. `update`/`split-portfolio` do sibling-repo migration comparisons, a different concern.
- **Fixed a doc-accuracy gap in `status/SKILL.md`** found during the sweep — the prose describing the `bin/apexyard` CLI shim's walk-up only mentioned the legacy pair; the shim script itself was already correct.

## Testing

No runnable test harness exists for `SKILL.md` prose+bash — validated by extracting the edited bash blocks and running them against layouts in temp dirs, `APEXYARD_OPS_DISABLE_PIN=1` to isolate the walk-up logic from this session's own live ops-root pin. Extended per Rex's review to add the workspace-clone case (row 3 below):

| cwd | `.claude/hooks/` present? | Step 4a result | Step 4b result |
|-----|---------------------------|-----------------|------------------|
| v1 ops fork root / subdir | yes | resolves to fork root | registry resolves |
| v2 ops fork root / subdir (`.apexyard-fork` only) | yes | resolves to fork root | registry resolves |
| **v2 managed-project `workspace/<project>/` clone (root / subdir) — NEW** | **no** | **resolves to the ops fork above it, via the walk-up** | **registry resolves (sourced from `$ops_root`, not the clone)** |
| outside any apexyard fork | n/a | fails closed: `Not inside an apexyard fork (...)`, no crash | n/a |

Reproduced Rex's regression finding directly, for contrast — the *previous* commit's sourcing form (`git rev-parse --show-toplevel`), run from the same simulated workspace clone:

```
git rev-parse --show-toplevel -> .../gh882-v2/workspace/sample-proj
REGRESSION REPRODUCED: source ".../gh882-v2/workspace/sample-proj/.claude/hooks/_lib-ops-root.sh"
would SOURCE-FAIL (file does not exist there)
```

...versus the new sibling-walk-up form, from the identical cwd:

```
v2 workspace clone: 4a ops_root=.../gh882-v2
v2 workspace clone: 4b registry=.../gh882-v2/apexyard.projects.yaml
v2 workspace clone subdir: 4a ops_root=.../gh882-v2
v2 workspace clone subdir: 4b registry=.../gh882-v2/apexyard.projects.yaml
```

Also re-ran the existing regression suite for the underlying lib (unmodified by this PR — only `SKILL.md` docs changed):

```
$ APEXYARD_OPS_DISABLE_PIN=1 bash .claude/hooks/tests/test_ops_root.sh
Results: 8 passed, 0 failed

$ bash .claude/hooks/tests/test_resolve_ops_root_pin.sh
Results: 8 passed, 0 failed
```

(`test_ops_root.sh` needs `APEXYARD_OPS_DISABLE_PIN=1` in this environment specifically because this session's own launch-cwd pin — pointing at the real ops fork — otherwise overrides the test's synthetic fixtures. Unrelated to this change; `_lib-ops-root.sh` itself is untouched by either commit on this branch.)

Closes #882

## Glossary

| Term | Definition |
|------|------------|
| Ops root | The apexyard fork root — where `.claude/`, `roles/`, `workflows/`, etc. live. Session markers (active ticket, review approvals) are always written here, never inside a managed-project clone. |
| Split-portfolio v2 | A fork layout (framework ≥ #242) where `onboarding.yaml` and `apexyard.projects.yaml` live in a private sibling repo instead of the public fork, anchored by a presence-only `.apexyard-fork` marker file. |
| `.apexyard-fork` | The v2 ops-fork anchor — a marker file whose *presence* (not content) identifies the fork root, written by `/setup` and `/update`. |
| `resolve_ops_root` | The shared resolver in `_lib-ops-root.sh` — pin-first (checks a session-scoped pin file before walking), then falls back to a directory walk-up checking both the v2 marker and the legacy v1 pair. Decides the *real* ops root; distinct from the sibling walk-up that merely locates the lib file to source. |
| Sibling walk-up (to locate a lib) | Walking up from `$PWD` until a directory containing a specific `.claude/hooks/<lib>.sh` file is found, then sourcing it from that path — the established pattern 13+ ticket skills use for `_lib-tracker.sh`, because managed-project clones carry no `.claude/hooks/` tree and `git rev-parse --show-toplevel` would otherwise resolve to the wrong repo. |
| `portfolio_registry` | A resolver in `_lib-portfolio-paths.sh` that returns the absolute path to `apexyard.projects.yaml`, honouring a `.portfolio.registry` override in `project-config.json` for split-portfolio adopters. |
