### PR TITLE
fix(#883): exempt out-of-repo writes from the ticket-first gate

### DIFF
--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -34,6 +34,64 @@
 #   - anything under projects/*/docs/ (per-project apexyard docs)
 #
 # Everything else (source code, config, infra) requires a ticket marker.
+#
+# Out-of-governance exemption (apexyard#883): a write TARGET entirely
+# outside every governed tree (the ops fork AND every registered
+# workspace/<project> clone) AND not inside ANY git repository at all is
+# outside this gate's jurisdiction — home dotfiles (~/.zshrc), /etc-style
+# machine config, /tmp scratch files. See the "Out-of-governance
+# exemption" block below for the fail-closed resolution rules (symlinks
+# resolved before judging; unresolvable/ambiguous targets stay gated).
+
+# Resolve PATH to its canonical, symlink-free absolute form. Walks up to
+# the nearest EXISTING ancestor, physically resolves it (`pwd -P`, which
+# follows symlinks), then re-appends any not-yet-created tail literally —
+# a tail that doesn't exist yet cannot itself be a symlink. This mirrors
+# `realpath -m` without depending on GNU coreutils (not guaranteed present
+# on macOS/BSD). Echoes the resolved path, or nothing if even "/" can't be
+# stat'd (should not happen for a well-formed absolute path).
+#
+# Why this matters (#883): without resolving symlinks first, a symlink
+# living under $HOME that POINTS INTO a governed tree (e.g.
+# ~/link-into-repo → the ops fork) would compare as "outside" the repo
+# under a naive string-prefix check, silently bypassing the gate.
+_resolve_real_path() {
+  local p="$1" dir tail=""
+  [ -n "$p" ] || return 0
+  dir="$p"
+  while [ -n "$dir" ] && [ "$dir" != "/" ] && [ ! -e "$dir" ]; do
+    if [ -z "$tail" ]; then
+      tail="$(basename "$dir")"
+    else
+      tail="$(basename "$dir")/$tail"
+    fi
+    dir="$(dirname "$dir")"
+  done
+  if [ ! -e "$dir" ]; then
+    # Nothing on the path exists at all — cannot resolve. Should not
+    # happen for an absolute path since "/" always exists.
+    return 0
+  fi
+  if [ -d "$dir" ]; then
+    dir="$(cd "$dir" 2>/dev/null && pwd -P)"
+  else
+    # $dir resolved to an existing FILE (not a directory) partway through
+    # the walk — canonicalize its parent and re-append its own basename.
+    local parent
+    parent="$(cd "$(dirname "$dir")" 2>/dev/null && pwd -P)"
+    if [ -n "$parent" ]; then
+      dir="$parent/$(basename "$dir")"
+    else
+      dir=""
+    fi
+  fi
+  [ -n "$dir" ] || return 0
+  if [ -n "$tail" ]; then
+    printf '%s/%s' "$dir" "$tail"
+  else
+    printf '%s' "$dir"
+  fi
+}
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
@@ -170,25 +228,12 @@ if [ -n "$REPO_ROOT" ] && [ -n "$FILE_PATH" ]; then
   esac
 fi
 
-# Bash-write: absolute paths outside the repo root are outside the tracked
-# source tree (e.g. /tmp/, /var/, /usr/, system-temp paths). A write there
-# cannot mutate apexyard-governed content, so no ticket is required (#569).
-# This check runs only for the Bash path (FILE_PATH set via extractor) and
-# only when FILE_PATH is absolute and does NOT strip to a REL_PATH (meaning
-# it's outside REPO_ROOT). We conservatively skip this for non-Bash tools —
-# they supply an explicit file_path from the tool call that we trust fully.
-if [ "$TOOL_NAME" = "Bash" ] && [ -n "$FILE_PATH" ] && [ -n "$REPO_ROOT" ]; then
-  case "$FILE_PATH" in
-    /*)
-      # Absolute path — was it stripped to a repo-relative form?
-      if [ "$REL_PATH" = "$FILE_PATH" ]; then
-        # REL_PATH is still absolute: FILE_PATH is NOT under REPO_ROOT.
-        # It's a system path or temp path — exempt.
-        exit 0
-      fi
-      ;;
-  esac
-fi
+# NOTE: the narrow "Bash absolute path outside REPO_ROOT" exemption that
+# used to live here (#569) has been superseded by the out-of-governance
+# exemption below (apexyard#883), which covers BOTH Bash and Edit/Write/
+# MultiEdit, resolves symlinks before judging, and checks the actual
+# governance boundaries (ops root + registered workspaces) rather than
+# just "outside the nearest git repo". See that block for the full design.
 
 # Exempt paths.
 #
@@ -271,6 +316,81 @@ if [ -n "$OPS_ROOT" ] && [ -f "$HOOK_DIR/_lib-portfolio-paths.sh" ] && [ -f "$HO
   resolved_ws=$(portfolio_workspace_dir 2>/dev/null)
   if [ -n "$resolved_ws" ]; then
     WORKSPACE_DIR="$resolved_ws"
+  fi
+fi
+
+# --- Out-of-governance exemption (apexyard#883) -------------------------
+#
+# A write TARGET that is outside every governed tree — the ops fork
+# itself AND every registered workspace/<project> clone — AND not inside
+# ANY git repository at all is outside this gate's jurisdiction. Applies
+# to BOTH Bash-detected writes and Edit/Write/MultiEdit tool calls (the
+# earlier #569 exemption was Bash-only, which left Edit-tool writes to
+# e.g. ~/.zshrc gated with no legitimate way to satisfy the gate on forks
+# with GitHub Issues disabled — the exact bug reported in #883).
+#
+# Fail-closed directions (deliberate):
+#   - An unresolvable FILE_PATH (empty — a Bash target the extractor
+#     couldn't identify) is NEVER exempted here; it falls through to the
+#     ticket gate below, unchanged from before this change.
+#   - Relative paths (a Bash write-target like `src/app.ts`) resolve
+#     against the hook's CWD before judging.
+#   - Symlinks are resolved to their real path before judging (via
+#     _resolve_real_path above), so a symlink living under $HOME that
+#     POINTS INTO a governed tree does not slip through as "outside" it.
+#   - Being inside SOME git repository that is neither the ops fork nor a
+#     registered workspace project does NOT exempt the write on its own —
+#     but see the three-way check below: ops-root and workspace
+#     boundaries are checked EXPLICITLY (not merely inferred from "is
+#     this a git repo"), because a split-portfolio workspace project is
+#     governed even when its clone isn't itself a git repository (e.g. a
+#     docs-only project, or a test fixture that never ran `git init`).
+#     Exemption requires ALL THREE checks below to say "outside".
+if [ -n "$FILE_PATH" ]; then
+  case "$FILE_PATH" in
+    /*) _og_abs_target="$FILE_PATH" ;;
+    *)  _og_abs_target="$PWD/$FILE_PATH" ;;
+  esac
+  _og_real_target="$(_resolve_real_path "$_og_abs_target")"
+  if [ -n "$_og_real_target" ]; then
+    _og_in_ops=0
+    _og_in_ws=0
+    _og_in_git=0
+
+    if [ -n "$OPS_ROOT" ]; then
+      _og_real_ops="$(cd "$OPS_ROOT" 2>/dev/null && pwd -P)"
+      if [ -n "$_og_real_ops" ]; then
+        case "$_og_real_target" in
+          "$_og_real_ops") _og_in_ops=1 ;;
+          "$_og_real_ops"/*) _og_in_ops=1 ;;
+        esac
+      fi
+    fi
+
+    if [ -n "$WORKSPACE_DIR" ] && [ -d "$WORKSPACE_DIR" ]; then
+      _og_real_ws="$(cd "$WORKSPACE_DIR" 2>/dev/null && pwd -P)"
+      if [ -n "$_og_real_ws" ]; then
+        case "$_og_real_target" in
+          "$_og_real_ws") _og_in_ws=1 ;;
+          "$_og_real_ws"/*) _og_in_ws=1 ;;
+        esac
+      fi
+    fi
+
+    # Nearest-existing-ancestor git-repo probe on the REAL (symlink-
+    # resolved) target — catches any git repo, governed or not.
+    _og_probe="$_og_real_target"
+    while [ -n "$_og_probe" ] && [ "$_og_probe" != "/" ] && [ ! -d "$_og_probe" ]; do
+      _og_probe="$(dirname "$_og_probe")"
+    done
+    if [ -n "$_og_probe" ] && [ -d "$_og_probe" ] \
+       && git -C "$_og_probe" rev-parse --show-toplevel >/dev/null 2>&1; then
+      _og_in_git=1
+    fi
+
+    if [ "$_og_in_ops" = 0 ] && [ "$_og_in_ws" = 0 ] && [ "$_og_in_git" = 0 ]; then
+      exit 0
+    fi
   fi
 fi
 

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -340,12 +340,33 @@ fi
 #     POINTS INTO a governed tree does not slip through as "outside" it.
 #   - Being inside SOME git repository that is neither the ops fork nor a
 #     registered workspace project does NOT exempt the write on its own —
-#     but see the three-way check below: ops-root and workspace
-#     boundaries are checked EXPLICITLY (not merely inferred from "is
-#     this a git repo"), because a split-portfolio workspace project is
-#     governed even when its clone isn't itself a git repository (e.g. a
-#     docs-only project, or a test fixture that never ran `git init`).
-#     Exemption requires ALL THREE checks below to say "outside".
+#     the ops-root/workspace boundaries are checked EXPLICITLY (not
+#     merely inferred from "is this a git repo"), because a
+#     split-portfolio workspace project is governed even when its clone
+#     isn't itself a git repository (e.g. a docs-only project, or a test
+#     fixture that never ran `git init`).
+#   - RAW-AND-RESOLVED containment (security review finding on #885,
+#     apexyard PR #885 — Hakim/security-reviewer): checking ops-root and
+#     workspace containment ONLY on the symlink-resolved target has a
+#     mirror-image hole to the one `_resolve_real_path` fixes. If a
+#     REGISTERED workspace/<project> entry is ITSELF a symlink whose real
+#     target lives OUTSIDE workspace/ in a non-git directory
+#     (`workspace/proj -> /some/nongit/dir`), resolving the target
+#     "escapes" the workspace boundary the same way the fix escapes a
+#     symlink-into-repo attack — the RESOLVED path no longer sits under
+#     WORKSPACE_DIR, so the naive single-check reads it as ungoverned and
+#     wrongly exempts it. The fix: evaluate ops-root/workspace
+#     containment against BOTH the RAW (pre-resolution) absolute target
+#     AND the fully resolved target, using the SAME canonicalized
+#     boundary anchors for both comparisons (only the anchors are
+#     canonicalized once; the raw target itself is deliberately left
+#     symlink-unresolved so a governed raw path can't be laundered away
+#     by a symlink further down it). A path counts as governed — and
+#     therefore NOT exempt — if EITHER the raw or the resolved check
+#     lands inside ops-root or workspace. Exemption requires ALL FOUR
+#     containment checks below (raw-ops, raw-ws, resolved-ops,
+#     resolved-ws) to say "outside", plus the git-repo probe to say "not
+#     in a repo".
 if [ -n "$FILE_PATH" ]; then
   case "$FILE_PATH" in
     /*) _og_abs_target="$FILE_PATH" ;;
@@ -353,32 +374,67 @@ if [ -n "$FILE_PATH" ]; then
   esac
   _og_real_target="$(_resolve_real_path "$_og_abs_target")"
   if [ -n "$_og_real_target" ]; then
-    _og_in_ops=0
-    _og_in_ws=0
+    _og_in_ops_raw=0
+    _og_in_ws_raw=0
+    _og_in_ops_res=0
+    _og_in_ws_res=0
     _og_in_git=0
 
+    # Canonicalize the boundary anchors ONCE — used as the comparison
+    # basis for both the raw-target check and the resolved-target check.
+    # This keeps the two checks internally consistent even when OPS_ROOT
+    # was resolved via a non-canonical path (e.g. a CWD-based walk-up
+    # that never ran through `pwd -P`).
+    _og_real_ops=""
     if [ -n "$OPS_ROOT" ]; then
       _og_real_ops="$(cd "$OPS_ROOT" 2>/dev/null && pwd -P)"
-      if [ -n "$_og_real_ops" ]; then
-        case "$_og_real_target" in
-          "$_og_real_ops") _og_in_ops=1 ;;
-          "$_og_real_ops"/*) _og_in_ops=1 ;;
-        esac
-      fi
     fi
-
+    _og_real_ws=""
     if [ -n "$WORKSPACE_DIR" ] && [ -d "$WORKSPACE_DIR" ]; then
       _og_real_ws="$(cd "$WORKSPACE_DIR" 2>/dev/null && pwd -P)"
-      if [ -n "$_og_real_ws" ]; then
-        case "$_og_real_target" in
-          "$_og_real_ws") _og_in_ws=1 ;;
-          "$_og_real_ws"/*) _og_in_ws=1 ;;
-        esac
-      fi
+    fi
+
+    # RAW check — the pre-resolution absolute target against the
+    # canonical boundary. Catches a registered workspace/<project> that
+    # is itself a symlink pointing OUTSIDE workspace/: the raw path
+    # still literally names the governed workspace/<project> location,
+    # even though resolving it lands elsewhere.
+    if [ -n "$_og_real_ops" ]; then
+      case "$_og_abs_target" in
+        "$_og_real_ops") _og_in_ops_raw=1 ;;
+        "$_og_real_ops"/*) _og_in_ops_raw=1 ;;
+      esac
+    fi
+    if [ -n "$_og_real_ws" ]; then
+      case "$_og_abs_target" in
+        "$_og_real_ws") _og_in_ws_raw=1 ;;
+        "$_og_real_ws"/*) _og_in_ws_raw=1 ;;
+      esac
+    fi
+
+    # RESOLVED check — the symlink-resolved target against the same
+    # canonical boundary. Catches a symlink OUTSIDE any governed tree
+    # that POINTS INTO one (the original #883 defense).
+    if [ -n "$_og_real_ops" ]; then
+      case "$_og_real_target" in
+        "$_og_real_ops") _og_in_ops_res=1 ;;
+        "$_og_real_ops"/*) _og_in_ops_res=1 ;;
+      esac
+    fi
+    if [ -n "$_og_real_ws" ]; then
+      case "$_og_real_target" in
+        "$_og_real_ws") _og_in_ws_res=1 ;;
+        "$_og_real_ws"/*) _og_in_ws_res=1 ;;
+      esac
     fi
 
     # Nearest-existing-ancestor git-repo probe on the REAL (symlink-
-    # resolved) target — catches any git repo, governed or not.
+    # resolved) target — catches any git repo, governed or not. A single
+    # probe suffices for both raw and resolved forms: directory
+    # traversal (`-d`, `git -C`) transparently follows symlinks at the
+    # OS level regardless of which path string reaches the location, so
+    # raw-path traversal and resolved-path traversal of the SAME logical
+    # target always land on the same physical directory.
     _og_probe="$_og_real_target"
     while [ -n "$_og_probe" ] && [ "$_og_probe" != "/" ] && [ ! -d "$_og_probe" ]; do
       _og_probe="$(dirname "$_og_probe")"
@@ -388,7 +444,9 @@ if [ -n "$FILE_PATH" ]; then
       _og_in_git=1
     fi
 
-    if [ "$_og_in_ops" = 0 ] && [ "$_og_in_ws" = 0 ] && [ "$_og_in_git" = 0 ]; then
+    if [ "$_og_in_ops_raw" = 0 ] && [ "$_og_in_ws_raw" = 0 ] \
+       && [ "$_og_in_ops_res" = 0 ] && [ "$_og_in_ws_res" = 0 ] \
+       && [ "$_og_in_git" = 0 ]; then
       exit 0
     fi
   fi

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -558,6 +558,50 @@ in=$(jq -nc --arg c "python3 -c \"import pathlib,os; pathlib.Path(os.environ.get
   '{tool_name:"Bash", tool_input:{command:$c}}')
 run_case "#883 unresolvable bash target stays gated (fail-closed)" 2 "BLOCKED" "$in" "$sb"
 
+# --- Security review finding on PR #885 (Hakim): symlinked-out non-git --
+# --- workspace project must NOT be exempted -----------------------------
+#
+# A registered workspace/<proj> that is ITSELF a symlink whose real
+# target lives OUTSIDE workspace/ in a directory that is not itself a git
+# repo used to be wrongly exempted: resolving the symlink made the
+# containment checks read "outside ops, outside workspace, not a git
+# repo" even though the RAW path plainly names a governed
+# workspace/<project> location. The fix evaluates ops/workspace
+# containment against BOTH the raw and the resolved target.
+
+# 39. workspace/proj -> <external non-git dir>; write through the raw
+#     workspace/proj path, no ticket → BLOCKED (was wrongly EXEMPT
+#     before the raw-AND-resolved fix).
+sb=$(make_sandbox)
+rsb=$(cd "$sb" && pwd -P)
+mkdir -p "$sb/workspace"
+external=$(mktemp -d)
+mkdir -p "$external/src"
+ln -s "$external" "$sb/workspace/proj"
+in=$(jq -nc --arg p "$rsb/workspace/proj/src/x.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "#885 symlinked-out non-git workspace project still blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+rm -rf "$external"
+
+# 40. Same symlinked-out workspace project, WITH an active ticket marker
+#     → ALLOWED. Keeps the existing "symlink governed content works with
+#     a ticket" behaviour coherent: the raw-containment check correctly
+#     routes this through the normal ticket-gate logic (not the
+#     out-of-governance exemption), and the ticket marker satisfies it.
+sb=$(make_sandbox)
+rsb=$(cd "$sb" && pwd -P)
+mkdir -p "$sb/workspace"
+external=$(mktemp -d)
+mkdir -p "$external/src"
+ln -s "$external" "$sb/workspace/proj"
+cat > "$sb/.claude/session/current-ticket" <<EOF
+repo=me2resh/apexyard
+number=885
+title=symlinked-out workspace project test
+EOF
+in=$(jq -nc --arg p "$rsb/workspace/proj/src/x.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "#885 symlinked-out non-git workspace project allowed WITH active ticket" 0 "" "$in" "$sb"
+rm -rf "$external"
+
 # --- Summary -----------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -463,6 +463,101 @@ else
   PASS=$((PASS+1))
 fi
 
+# --- Out-of-governance exemption (#883): the ~/.zshrc-style bug repro --
+#
+# Prior to #883, the "outside the repo" exemption (#569) only fired for
+# the Bash-write path — an Edit-tool write to a home dotfile like
+# ~/.zshrc was gated with no legitimate way to satisfy the gate on a fork
+# with GitHub Issues disabled (no tracker to file a chore ticket in).
+# These cases prove the fix (Edit/MultiEdit AND Bash, symlinks resolved,
+# governed-tree boundaries unchanged).
+
+# 31. Edit tool absolute write to a home-dotfile-style path OUTSIDE any
+#     git repo and OUTSIDE the ops fork, no ticket → EXEMPT. The core
+#     #883 repro.
+sb=$(make_sandbox)
+home_sim=$(mktemp -d)
+in=$(jq -nc --arg p "$home_sim/.zshrc" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "#883 Edit-tool write to out-of-repo dotfile exempt (no ticket)" 0 "" "$in" "$sb"
+rm -rf "$home_sim"
+
+# 32. Same but MultiEdit tool shape (file_path key) → EXEMPT.
+sb=$(make_sandbox)
+home_sim=$(mktemp -d)
+in=$(jq -nc --arg p "$home_sim/.bashrc" '{tool_name:"MultiEdit", tool_input:{file_path:$p}}')
+run_case "#883 MultiEdit-tool write to out-of-repo dotfile exempt" 0 "" "$in" "$sb"
+rm -rf "$home_sim"
+
+# 33. Bash relative write from a CWD entirely outside any git repo /
+#     governed tree (simulates `cd ~ && echo 'export X=1' >> .zshrc`)
+#     → EXEMPT. Uses run_case_cwd so the hook actually executes with
+#     CWD=home_sim (not the sandbox) and has no session pin to fall back
+#     on — proving the exemption doesn't depend on the ops root being
+#     resolvable.
+sb=$(make_sandbox)
+home_sim=$(mktemp -d)
+in=$(jq -nc --arg c "echo 'export X=1' >> .zshrc" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case_cwd "#883 bash relative write from out-of-repo CWD exempt" 0 "" "$in" "$sb" "$home_sim"
+rm -rf "$home_sim"
+
+# 34. In-repo source Edit write is UNCHANGED — still blocked without a
+#     ticket (regression guard: the new exemption must not widen scope
+#     for governed content).
+sb=$(make_sandbox)
+mkdir -p "$sb/src"
+rsb=$(cd "$sb" && pwd -P)
+in=$(jq -nc --arg p "$rsb/src/app.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "#883 regression: in-repo Edit write still blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 35. Symlink from OUTSIDE the repo INTO the governed sandbox tree must
+#     NOT bypass the gate: resolving the write target's real path (not
+#     its literal path) is what fail-closed requires.
+sb=$(make_sandbox)
+rsb=$(cd "$sb" && pwd -P)
+mkdir -p "$sb/src"
+home_sim=$(mktemp -d)
+ln -s "$rsb" "$home_sim/link-into-repo"
+in=$(jq -nc --arg p "$home_sim/link-into-repo/src/app.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "#883 symlink into governed repo does NOT bypass gate" 2 "BLOCKED" "$in" "$sb"
+rm -rf "$home_sim"
+
+# 36. Symlink case WITH an active ticket → allowed (proves the symlink IS
+#     correctly resolved to governed content, and the normal ticket-gate
+#     logic — not the out-of-governance exemption — is what applies).
+sb=$(make_sandbox)
+rsb=$(cd "$sb" && pwd -P)
+mkdir -p "$sb/src"
+cat > "$sb/.claude/session/current-ticket" <<EOF
+repo=me2resh/apexyard
+number=883
+title=symlink test
+EOF
+home_sim=$(mktemp -d)
+ln -s "$rsb" "$home_sim/link-into-repo"
+in=$(jq -nc --arg p "$home_sim/link-into-repo/src/app.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "#883 symlink into governed repo allowed WITH active ticket" 0 "" "$in" "$sb"
+rm -rf "$home_sim"
+
+# 37. Workspace-project write (governed, even without its own .git) still
+#     blocks without a ticket — proves the explicit WORKSPACE_DIR check
+#     (not merely "is this a git repo") governs the boundary. Mirrors the
+#     #745 split-portfolio layout, where a workspace project clone may
+#     have no .git of its own.
+sb=$(make_sandbox)
+rsb=$(cd "$sb" && pwd -P)
+mkdir -p "$sb/workspace/myproj/src"
+in=$(jq -nc --arg p "$rsb/workspace/myproj/src/x.ts" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "#883 workspace-project write (no .git) still blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 38. Unresolvable Bash write target (embedded interpreter, no
+#     extractable path) remains categorically gated — fail-closed,
+#     unchanged. The out-of-governance check must never fire on an empty
+#     FILE_PATH.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "python3 -c \"import pathlib,os; pathlib.Path(os.environ.get('HOME','/tmp')+'/.railsrc').write_text('x')\"" \
+  '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#883 unresolvable bash target stays gated (fail-closed)" 2 "BLOCKED" "$in" "$sb"
+
 # --- Summary -----------------------------------------------------------
 
 echo ""

--- a/.claude/rules/workflow-gates.md
+++ b/.claude/rules/workflow-gates.md
@@ -52,6 +52,18 @@ The list lives at `.claude/project-config.defaults.json` → `ticket.bootstrap_s
 
 **Mechanism:** each bootstrap skill writes its name to `.claude/session/active-bootstrap` on entry and removes the file on completion. The hook reads the marker and exempts skills on the configured list. The `clear-bootstrap-marker.sh` SessionStart hook sweeps stale markers from interrupted sessions so a crashed / killed skill can't leave the exemption open forever.
 
+### Out-of-repo exemption (apexyard#883)
+
+The pre-build gate exists to protect **governed content** — the ops fork itself and every registered `workspace/<project>` clone. A write target entirely outside those trees, and not inside any git repository at all (a home dotfile like `~/.zshrc`, `/etc`-style machine config, `/tmp` scratch files), is outside the gate's jurisdiction: there is nothing here for a ticket to track, and on a fork with GitHub Issues disabled there would otherwise be no legitimate way to satisfy the gate for routine machine setup.
+
+`require-active-ticket.sh` resolves the write target's real (symlink-free) path and exempts it only when **all three** of the following hold:
+
+- outside the ops fork
+- outside every registered `workspace/<project>`
+- not inside any git repository at all
+
+This is deliberately narrower than "not inside a *registered* repo" — being inside some unrelated, unregistered git repository does **not** exempt a write; only a target with no git repository anywhere in its ancestry qualifies. Symlinks are resolved before judging, so a symlink under `$HOME` that points into a governed tree cannot be used to slip a write past the gate. An unresolvable or ambiguous target (an unextractable Bash write-target, in particular) is never exempted here — it falls straight through to the ticket gate, unchanged. See `require-active-ticket.sh`'s "Out-of-governance exemption" comment block for the full fail-closed reasoning, and `.claude/hooks/tests/test_require_active_ticket_bash.sh` cases 31–38 for the test coverage.
+
 See AgDR-0011 + me2resh/apexyard#150 for the full design rationale.
 
 ## Migration Gate (3a) — dedicated ticket + AgDR


### PR DESCRIPTION
## Summary

- **Extended the out-of-repo exemption to Edit/Write/MultiEdit, not just Bash** — the existing #569 exemption only fired for Bash-detected writes (`echo > file`, `tee`, etc.). An `Edit`-tool write to a home dotfile like `~/.zshrc` during machine setup was still gated, and on a fork with GitHub Issues disabled there was no legitimate way to satisfy the gate (no tracker to file a chore ticket in). This PR moves the exemption logic into a single check that fires for both tool shapes.
- **Resolves the write target's real (symlink-free) path before judging** — the old exemption compared raw string paths, so a symlink living under `$HOME` that pointed *into* a governed tree (e.g. `~/link-into-repo → the ops fork`) would look "outside" the repo under a naive prefix check and silently bypass the gate. The new `_resolve_real_path` helper canonicalizes the target (following symlinks in the existing portion of the path, since a not-yet-created tail can't itself be a symlink) before any boundary check runs.
- **Exemption requires all three conditions, not just "not a git repo"** — outside the ops fork, outside every registered `workspace/<project>`, and not inside any git repository at all. The three-way check matters for split-portfolio layouts where a workspace project clone may not itself be a `git init`'d repo (a docs-only project, or a test fixture) — relying only on "is this inside some git repo" would have wrongly exempted a governed-but-non-git workspace path.
- **Fail-closed on ambiguity** — an unresolvable Bash write-target (the extractor couldn't identify a path, e.g. `python -c '...'` with a dynamically constructed path) is never exempted; it falls straight through to the existing ticket gate, unchanged.
- **Checks BOTH the raw and the resolved target for ops/workspace containment** — added after Hakim's security review (see "Security review follow-up" below) surfaced the mirror-image hole: a registered `workspace/<proj>` that is *itself* a symlink pointing OUTSIDE `workspace/` to a non-git directory was wrongly exempted, because containment was checked only on the symlink-resolved path. Ops-root and workspace containment are now evaluated against both the raw (pre-resolution) target and the fully resolved target, against the same canonicalized boundary anchors — a path is governed (not exempt) if *either* check lands inside.

## Security review follow-up

Hakim (security-reviewer) reviewed this PR and flagged one LOW, non-blocking finding: a `workspace/<proj>` entry that is itself a symlink to an outside, non-git directory was wrongly exempted (`ops=0 ws=0 git=0 → exempt`), because the symlink resolution that correctly defends "link INTO the repo" defeats the workspace containment check when the governed path *contains* a link pointing *out*. Fixed by checking both the raw and resolved path against the ops/workspace boundaries (exempt only if both say "outside"), with a dedicated regression pair (cases 39–40 below).

## Testing

Extended `.claude/hooks/tests/test_require_active_ticket_bash.sh` with 10 new cases (31–40) covering: Edit-tool out-of-repo dotfile write (the core #883 repro), MultiEdit shape, Bash relative write from an out-of-repo CWD, in-repo Edit write still blocked (regression), symlink-into-repo NOT bypassing the gate, the same symlink case working correctly WITH an active ticket, a workspace-project write with no `.git` still blocked, an unresolvable Bash target staying gated, a `workspace/<proj>` symlink to an outside non-git directory still blocked without a ticket (case 39 — the security-review finding), and the same symlinked-workspace case working correctly WITH an active ticket (case 40).

```
.claude/hooks/tests/test_require_active_ticket_bash.sh: PASS 43  FAIL 0   (33 pre-existing + 10 new)
bin/run-hook-tests.sh (full suite):                     PASS 98  FAIL 0  SKIP 0
```

`bash -n` and `shellcheck -x` both clean on the modified hook — the shellcheck notes present are pre-existing (SC2016/SC2295 on lines untouched by this diff), not introduced by this change. Case 39 was verified to fail (wrongly exempt, rc=0) against the pre-fix hook and pass against the fix, confirming the regression test is load-bearing.

Closes #883

## Glossary

| Term | Definition |
|------|------------|
| Ticket-first gate | `require-active-ticket.sh` — blocks code writes until a session ticket marker exists (workflow-gates Pre-Build Gate). |
| Out-of-governance exemption | The escape valve this PR adds: a write target outside the ops fork, outside every registered workspace project, and outside any git repository at all is exempt from the ticket gate. |
| Governed tree | The ops fork itself, plus every project registered in `apexyard.projects.yaml` under `workspace/<project>`. |
| Fail-closed | When a check can't confidently determine "this is safe to exempt," it defaults to gating (blocking) rather than exempting. |
| Raw vs. resolved path | Raw = the write target exactly as named (before following any symlinks). Resolved = the same target after all symlinks in its existing ancestry are followed to their real location. Containment is now checked against both. |
