### PR TITLE
feat(#891): SessionStart self-heal for apexyard-search config (non-premium-safe)

### DIFF
--- a/.claude/hooks/tests/test_validate_search_config.sh
+++ b/.claude/hooks/tests/test_validate_search_config.sh
@@ -1,0 +1,313 @@
+#!/bin/bash
+# Tests for validate-search-config.sh (apexyard-premium#514).
+#
+# The hook validates (read-only, LOUD-warn by default) the apexyard-search
+# MCP config at SessionStart. The load-bearing acceptance criterion is the
+# INTENT GATE: with no evidence the operator wants search (no
+# "apexyard-search" entry in .mcp.json AND no vector_index.enabled: true in
+# features.yaml), the hook MUST be a totally silent no-op — zero output,
+# exit 0, no file writes. That's what every non-premium framework adopter
+# sees at every session start, so it's tested first and most thoroughly.
+#
+# Auto-rewrite of .mcp.json is opt-in (APEXYARD_SEARCH_SELFHEAL=1) and
+# off by default per the course-correction on this ticket — the default
+# behaviour under test is detect + warn, never mutate.
+#
+# Each case builds an isolated sandbox under $TMPDIR with synthetic
+# onboarding.yaml + apexyard.projects.yaml (the legacy v1 ops-fork anchor
+# _lib-ops-root.sh recognises), runs the hook from inside it, and asserts
+# stdout+stderr / exit code / file-unchanged as appropriate.
+#
+# Run: bash .claude/hooks/tests/test_validate_search_config.sh
+
+set -u
+
+HOOK="$(cd "$(dirname "$0")/.." && pwd)/validate-search-config.sh"
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: hook not found at $HOOK" >&2
+  exit 1
+fi
+
+# Disable the ops-root session pin so every case resolves by walk-up to its
+# own sandbox, never escaping onto the real ops fork (same isolation used by
+# bin/run-hook-tests.sh for the whole suite).
+export APEXYARD_OPS_DISABLE_PIN=1
+
+mark_pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+mark_fail() { FAIL=$((FAIL + 1)); FAILED_CASES="$FAILED_CASES|$1"; echo "  FAIL: $1 -- $2" >&2; }
+
+# build_sandbox <dir>: minimal ops-fork anchor (legacy v1 shape).
+build_sandbox() {
+  mkdir -p "$1"
+  : > "$1/onboarding.yaml"
+  : > "$1/apexyard.projects.yaml"
+}
+
+run_hook_in() {
+  # run_hook_in <dir> [env assignments...]
+  local dir="$1"; shift
+  ( cd "$dir" && env "$@" bash "$HOOK" ) 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: no .mcp.json apexyard-search entry, no features.yaml at all —
+# the non-premium / unconfigured shape. MUST be silent, exit 0.
+# ---------------------------------------------------------------------------
+test_no_intent_at_all_is_silent() {
+  local sb; sb=$(mktemp -d)
+  build_sandbox "$sb"
+
+  local out rc
+  out=$(run_hook_in "$sb"); rc=$?
+  rm -rf "$sb"
+
+  if [ -z "$out" ] && [ "$rc" -eq 0 ]; then
+    mark_pass "no intent evidence -> silent, exit 0"
+  else
+    mark_fail "no intent evidence -> silent, exit 0" "got output=[$out] rc=$rc"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: .mcp.json exists but has no "apexyard-search" entry, and
+# features.yaml exists but vector_index.enabled is false/absent — still
+# the unconfigured shape (a different MCP server is configured). Silent.
+# ---------------------------------------------------------------------------
+test_other_mcp_server_no_vector_index_is_silent() {
+  local sb; sb=$(mktemp -d)
+  build_sandbox "$sb"
+  cat > "$sb/.mcp.json" <<'EOF'
+{"mcpServers":{"some-other-server":{"command":"something"}}}
+EOF
+  cat > "$sb/features.yaml" <<'EOF'
+version: 1
+features:
+  budget:
+    enabled: true
+vector_index:
+  enabled: false
+EOF
+
+  local out rc
+  out=$(run_hook_in "$sb"); rc=$?
+  rm -rf "$sb"
+
+  if [ -z "$out" ] && [ "$rc" -eq 0 ]; then
+    mark_pass "other MCP server + vector_index disabled -> silent, exit 0"
+  else
+    mark_fail "other MCP server + vector_index disabled -> silent, exit 0" "got output=[$out] rc=$rc"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: intent present (apexyard-search entry in .mcp.json), roots don't
+# exist and command isn't launchable -> default (no SELFHEAL): LOUD warn on
+# stderr, exit 0, .mcp.json UNCHANGED (no auto-mutation without opt-in).
+# ---------------------------------------------------------------------------
+test_broken_config_warns_loudly_and_does_not_mutate() {
+  local sb; sb=$(mktemp -d)
+  build_sandbox "$sb"
+  cat > "$sb/.mcp.json" <<'EOF'
+{
+  "mcpServers": {
+    "apexyard-search": {
+      "command": "apexyard-search-does-not-exist-anywhere",
+      "env": {
+        "APEXYARD_OPS_ROOT": "/nonexistent/old/path",
+        "APEXYARD_PORTFOLIO_ROOT": "/nonexistent/old/portfolio"
+      }
+    }
+  }
+}
+EOF
+  local before after out rc
+  before=$(cat "$sb/.mcp.json")
+  out=$(run_hook_in "$sb"); rc=$?
+  after=$(cat "$sb/.mcp.json")
+
+  local ok=true
+  case "$out" in
+    *BROKEN*) ;;
+    *) ok=false ;;
+  esac
+  [ "$before" = "$after" ] || ok=false
+  [ "$rc" -eq 0 ] || ok=false
+  # No backup should have been written without the opt-in.
+  find "$sb" -maxdepth 1 -name '*.bak.*' | grep -q . && ok=false
+
+  rm -rf "$sb"
+
+  if $ok; then
+    mark_pass "broken config (no opt-in) -> loud warn, unchanged, exit 0"
+  else
+    mark_fail "broken config (no opt-in) -> loud warn, unchanged, exit 0" "out=[$out] rc=$rc changed=$([ "$before" = "$after" ] && echo no || echo YES)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: intent present, config is healthy (absolute launchable command,
+# both roots exist) -> silent, exit 0.
+# ---------------------------------------------------------------------------
+test_healthy_config_is_silent() {
+  local sb; sb=$(mktemp -d)
+  build_sandbox "$sb"
+  # A real, always-present executable stands in for the search binary so
+  # this test doesn't depend on apexyard-search actually being installed.
+  # NOTE: don't use `command -v true` — in many shells `true` is a builtin
+  # and `command -v` returns the bare word "true" with no path, which
+  # would make this fixture itself unlaunchable-by-absolute-path.
+  local real_bin
+  if [ -x /usr/bin/true ]; then real_bin=/usr/bin/true; else real_bin=/bin/true; fi
+  cat > "$sb/.mcp.json" <<EOF
+{
+  "mcpServers": {
+    "apexyard-search": {
+      "command": "$real_bin",
+      "env": {
+        "APEXYARD_OPS_ROOT": "$sb",
+        "APEXYARD_PORTFOLIO_ROOT": "$sb"
+      }
+    }
+  }
+}
+EOF
+  local out rc
+  out=$(run_hook_in "$sb"); rc=$?
+  rm -rf "$sb"
+
+  if [ -z "$out" ] && [ "$rc" -eq 0 ]; then
+    mark_pass "healthy config -> silent, exit 0"
+  else
+    mark_fail "healthy config -> silent, exit 0" "got output=[$out] rc=$rc"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: intent from features.yaml (vector_index.enabled: true) but NO
+# .mcp.json entry at all -> loud warn (nothing to heal, nothing to
+# silently miss either), exit 0.
+# ---------------------------------------------------------------------------
+test_features_intent_without_mcp_entry_warns() {
+  local sb; sb=$(mktemp -d)
+  build_sandbox "$sb"
+  cat > "$sb/features.yaml" <<'EOF'
+version: 1
+vector_index:
+  db: chromadb
+  enabled: true
+EOF
+  local out rc
+  out=$(run_hook_in "$sb"); rc=$?
+  rm -rf "$sb"
+
+  local ok=true
+  case "$out" in
+    *"not wired up"*|*"not been wired"*|*"vector_index.enabled"*) ;;
+    *) ok=false ;;
+  esac
+  [ "$rc" -eq 0 ] || ok=false
+
+  if $ok; then
+    mark_pass "features.yaml intent, no .mcp.json entry -> loud warn, exit 0"
+  else
+    mark_fail "features.yaml intent, no .mcp.json entry -> loud warn, exit 0" "out=[$out] rc=$rc"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 6: opt-in self-heal (APEXYARD_SEARCH_SELFHEAL=1) with a broken
+# config -> backs up the file, heals ONLY the apexyard-search entry,
+# leaves sibling MCP server entries untouched, exit 0.
+# ---------------------------------------------------------------------------
+test_selfheal_opt_in_backs_up_and_heals_only_search_entry() {
+  command -v jq >/dev/null 2>&1 || { echo "  SKIP: jq not installed, skipping self-heal test"; return 0; }
+
+  local sb; sb=$(mktemp -d)
+  build_sandbox "$sb"
+  cat > "$sb/.mcp.json" <<'EOF'
+{
+  "mcpServers": {
+    "other-server": {"command": "something-else"},
+    "apexyard-search": {
+      "command": "apexyard-search-does-not-exist-anywhere",
+      "env": {
+        "APEXYARD_OPS_ROOT": "/nonexistent/old/path",
+        "APEXYARD_PORTFOLIO_ROOT": "/nonexistent/old/portfolio"
+      }
+    }
+  }
+}
+EOF
+  local real_bin
+  if [ -x /usr/bin/true ]; then real_bin=/usr/bin/true; else real_bin=/bin/true; fi
+  # Make the broken command resolvable via PATH so self-heal has something
+  # to resolve to (mirrors "bare command not on PATH" becoming launchable).
+  local fakebin; fakebin=$(mktemp -d)
+  ln -sf "$real_bin" "$fakebin/apexyard-search-does-not-exist-anywhere"
+
+  local out rc
+  out=$(cd "$sb" && env APEXYARD_OPS_DISABLE_PIN=1 APEXYARD_SEARCH_SELFHEAL=1 PATH="$fakebin:$PATH" bash "$HOOK" 2>&1); rc=$?
+
+  local ok=true
+  [ "$rc" -eq 0 ] || ok=false
+  find "$sb" -maxdepth 1 -name '*.bak.*' | grep -q . || ok=false
+  jq -e '.mcpServers["other-server"].command == "something-else"' "$sb/.mcp.json" >/dev/null 2>&1 || ok=false
+  jq -e '.mcpServers["apexyard-search"].env.APEXYARD_OPS_ROOT == "'"$sb"'"' "$sb/.mcp.json" >/dev/null 2>&1 || ok=false
+
+  rm -rf "$sb" "$fakebin"
+
+  if $ok; then
+    mark_pass "opt-in self-heal: backs up, heals only apexyard-search entry"
+  else
+    mark_fail "opt-in self-heal: backs up, heals only apexyard-search entry" "out=[$out] rc=$rc"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 7: the operator kill-switch (APEXYARD_SEARCH_VALIDATE_DISABLE) skips
+# the hook entirely, even with a broken + intent-bearing config.
+# ---------------------------------------------------------------------------
+test_kill_switch_disables_entirely() {
+  local sb; sb=$(mktemp -d)
+  build_sandbox "$sb"
+  cat > "$sb/.mcp.json" <<'EOF'
+{
+  "mcpServers": {
+    "apexyard-search": {
+      "command": "apexyard-search-does-not-exist-anywhere",
+      "env": {"APEXYARD_OPS_ROOT": "/nope", "APEXYARD_PORTFOLIO_ROOT": "/nope"}
+    }
+  }
+}
+EOF
+  local out rc
+  out=$(run_hook_in "$sb" APEXYARD_SEARCH_VALIDATE_DISABLE=1); rc=$?
+  rm -rf "$sb"
+
+  if [ -z "$out" ] && [ "$rc" -eq 0 ]; then
+    mark_pass "kill-switch -> silent regardless of config state"
+  else
+    mark_fail "kill-switch -> silent regardless of config state" "got output=[$out] rc=$rc"
+  fi
+}
+
+echo "Running validate-search-config.sh tests..."
+test_no_intent_at_all_is_silent
+test_other_mcp_server_no_vector_index_is_silent
+test_broken_config_warns_loudly_and_does_not_mutate
+test_healthy_config_is_silent
+test_features_intent_without_mcp_entry_warns
+test_selfheal_opt_in_backs_up_and_heals_only_search_entry
+test_kill_switch_disables_entirely
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/validate-search-config.sh
+++ b/.claude/hooks/validate-search-config.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# SessionStart hook: validate the apexyard-search MCP config and warn LOUDLY
+# when it's broken — closes the "silent rot" failure mode described in
+# apexyard-premium#514.
+#
+# THE BUG THIS FIXES: `.mcp.json` bakes in absolute roots
+# (APEXYARD_OPS_ROOT / APEXYARD_PORTFOLIO_ROOT) and a `command` that can be
+# a bare binary name resolved against a pipx venv at install time. Neither
+# self-corrects when a repo moves, gets renamed, or is cloned onto a new
+# machine — the MCP server then fails to launch, every search silently
+# returns nothing, and nobody notices for weeks.
+#
+# SAFE SHAPE (mirrors reindex-on-session-start.sh / check-upstream-drift.sh):
+# this hook NEVER blocks session start and ALWAYS exits 0. It is fully
+# read-only by default — see "SCOPE" below on why auto-rewrite is opt-in.
+#
+# THE INTENT GATE (the load-bearing design constraint from the #514 review
+# comment — see the ticket before touching this file):
+#
+#   The LOUD path (validate / warn) fires ONLY when there is EVIDENCE the
+#   operator INTENDS to use search:
+#     - an "apexyard-search" entry exists in .mcp.json, OR
+#     - features.yaml has `vector_index: { enabled: true }`
+#
+#   Absent BOTH -> silent `exit 0`, zero output, no file reads beyond the
+#   two candidate files, no file writes ever. This is the non-premium /
+#   unconfigured case and MUST stay completely quiet — it's what every
+#   framework adopter (not just apexyard-premium subscribers) sees at
+#   every session start, so it also has to be fast and side-effect-free.
+#
+#   This is deliberately NOT `command -v apexyard-search` (on-PATH). That
+#   guard conflates two different situations into the same silent no-op:
+#     - not installed              -> non-premium, correct silent no-op
+#     - installed, bare command
+#       not resolvable on PATH     -> premium, BROKEN (exactly the #514 case)
+#   Gating on intent-evidence instead of on-PATH resolution is what makes
+#   the broken-but-premium case impossible to miss while keeping the free
+#   experience silent.
+#
+# SCOPE (read-only by default): this hook runs at SessionStart for every
+# adopter of the framework, not just the reporter of #514. Auto-rewriting
+# a user's `.mcp.json` on their behalf is the one failure mode that could
+# make things WORSE than silent rot — a bad rewrite could mangle other,
+# unrelated MCP server entries in the same file, or write wrong paths on a
+# layout this hook mis-detects. So the default (and the only behaviour
+# shipped in this PR) is DETECT + WARN LOUDLY with an actionable message —
+# zero mutation risk. Auto-heal exists ONLY behind an explicit opt-in
+# (`APEXYARD_SEARCH_SELFHEAL=1`), and even then it backs up the file,
+# touches only the "apexyard-search" entry, and validates the rewritten
+# JSON round-trips before replacing the original. See "AUTO-HEAL" below.
+#
+# ONCE INTENT-EVIDENCE IS PRESENT, this hook validates the existing
+# "apexyard-search" .mcp.json entry (or, if features.yaml wants search but
+# no entry exists at all, warns that nothing is wired up):
+#   a. is `command` actually launchable? (absolute + executable, OR
+#      bare + resolvable on PATH, OR bare + found in the well-known pipx
+#      venv `$HOME/.local/pipx/venvs/apexyard-premium/bin/<name>`)
+#   b. do APEXYARD_OPS_ROOT / APEXYARD_PORTFOLIO_ROOT point at
+#      directories that actually exist?
+# If both check out: silent exit 0 (healthy, common case). If either is
+# broken: LOUD, actionable stderr message naming the exact fix — never a
+# silent no-op once intent-evidence says search should work.
+#
+# AUTO-HEAL (opt-in, off by default): set APEXYARD_SEARCH_SELFHEAL=1 to let
+# this hook rewrite the broken fields in `.mcp.json` itself, using roots
+# resolved dynamically from the same ops-fork/portfolio anchors every other
+# hook uses (_lib-ops-root.sh / _lib-portfolio-paths.sh). Even then:
+#   - a timestamped backup of the whole file is written first
+#   - only the "apexyard-search" entry's `command` / `env.*` fields change
+#   - the rewritten file is validated (valid JSON + the entry still has the
+#     expected shape) before it replaces the original; any validation
+#     failure discards the rewrite and falls through to the warn path
+#     with the original file untouched.
+#
+# Tunables (env):
+#   APEXYARD_SEARCH_VALIDATE_DISABLE   non-empty -> skip entirely (operator kill-switch)
+#   APEXYARD_SEARCH_SELFHEAL           1 -> opt in to the backed-up, validated auto-heal
+#
+# Performance note: every check here is local filesystem stats + jq/awk on
+# small files — no network calls, no invocation of apexyard-search itself,
+# nothing that can hang. No timeout wrapper needed (contrast
+# reindex-on-session-start.sh, which DOES wrap a real CLI invocation).
+#
+# See: me2resh/apexyard-premium#514.
+
+set -u
+
+# Operator kill-switch.
+if [ -n "${APEXYARD_SEARCH_VALIDATE_DISABLE:-}" ]; then
+  exit 0
+fi
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# -----------------------------------------------------------------------
+# Resolve the ops-fork root the same way every other hook does (pin-first,
+# walk-up fallback). This is ALSO one of the two dynamic roots we'd heal
+# APEXYARD_OPS_ROOT to (auto-heal path only) and quote in the warn message.
+# -----------------------------------------------------------------------
+OPS_ROOT=""
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  OPS_ROOT=$(resolve_ops_root "$PWD")
+fi
+if [ -z "$OPS_ROOT" ]; then
+  # Fall back to this hook's own fork location — still correct even if the
+  # walk-up resolver couldn't run (e.g. lib missing on an old checkout).
+  OPS_ROOT="$(cd "$HOOK_DIR/../.." 2>/dev/null && pwd)"
+fi
+[ -n "$OPS_ROOT" ] && [ -d "$OPS_ROOT" ] || exit 0
+
+# -----------------------------------------------------------------------
+# Resolve the portfolio root — the directory that holds the registry
+# (apexyard.projects.yaml). In single-fork mode this IS the ops root; in
+# split-portfolio v2 mode it's the sibling private repo
+# (../<fork>-portfolio). features.yaml and .mcp.json both conventionally
+# live next to the registry, so this is also where we look for them.
+# -----------------------------------------------------------------------
+PORTFOLIO_ROOT=""
+if [ -f "$HOOK_DIR/_lib-read-config.sh" ] && [ -f "$HOOK_DIR/_lib-portfolio-paths.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-read-config.sh"
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-portfolio-paths.sh"
+  _registry=$(portfolio_registry 2>/dev/null)
+  if [ -n "$_registry" ]; then
+    PORTFOLIO_ROOT=$(cd "$(dirname "$_registry")" 2>/dev/null && pwd)
+  fi
+fi
+[ -n "$PORTFOLIO_ROOT" ] && [ -d "$PORTFOLIO_ROOT" ] || PORTFOLIO_ROOT="$OPS_ROOT"
+
+# -----------------------------------------------------------------------
+# Locate an existing "apexyard-search" entry in .mcp.json, checking every
+# plausible location (ops root, portfolio root, and an explicit
+# $APEXYARD_PORTFOLIO_ROOT env override if the operator's shell sets one).
+# Pure string grep — no jq dependency for INTENT DETECTION, so this branch
+# works even on a box that doesn't have jq installed.
+# -----------------------------------------------------------------------
+MCP_JSON=""
+for _candidate in "$OPS_ROOT/.mcp.json" "$PORTFOLIO_ROOT/.mcp.json" "${APEXYARD_PORTFOLIO_ROOT:-}/.mcp.json"; do
+  [ -n "$_candidate" ] && [ -f "$_candidate" ] || continue
+  if grep -q '"apexyard-search"' "$_candidate" 2>/dev/null; then
+    MCP_JSON="$_candidate"
+    break
+  fi
+done
+
+# -----------------------------------------------------------------------
+# Locate features.yaml and check for vector_index.enabled: true — scoped
+# to the vector_index: block only (not a blanket "enabled: true" grep,
+# which would false-positive on every other feature flag in the file).
+# -----------------------------------------------------------------------
+FEATURES_YAML=""
+for _candidate in "$PORTFOLIO_ROOT/features.yaml" "$OPS_ROOT/features.yaml" "${APEXYARD_PORTFOLIO_ROOT:-}/features.yaml"; do
+  [ -n "$_candidate" ] && [ -f "$_candidate" ] || continue
+  FEATURES_YAML="$_candidate"
+  break
+done
+
+_vector_index_enabled() {
+  local f="$1"
+  [ -n "$f" ] && [ -f "$f" ] || return 1
+  awk '
+    /^vector_index:[[:space:]]*$/ { inblk=1; next }
+    inblk && /^[^[:space:]]/ { inblk=0 }
+    inblk && /enabled:[[:space:]]*true/ { found=1 }
+    END { exit(found ? 0 : 1) }
+  ' "$f" 2>/dev/null
+}
+
+FEATURES_WANT_SEARCH=false
+if _vector_index_enabled "$FEATURES_YAML"; then
+  FEATURES_WANT_SEARCH=true
+fi
+
+# -----------------------------------------------------------------------
+# THE INTENT GATE. No evidence of intent -> silent, zero-output, exit 0.
+# This is the load-bearing acceptance criterion (#514): free / unconfigured
+# adopters must see NOTHING from this hook, ever.
+# -----------------------------------------------------------------------
+if [ -z "$MCP_JSON" ] && ! $FEATURES_WANT_SEARCH; then
+  exit 0
+fi
+
+# Intent from features.yaml but no .mcp.json entry to validate at all —
+# nothing to inspect, so this is a loud warn, not a silent no-op.
+if [ -z "$MCP_JSON" ]; then
+  {
+    echo "ApexYard: features.yaml has vector_index.enabled: true (in $FEATURES_YAML)"
+    echo "  but no \"apexyard-search\" entry was found in .mcp.json (checked:"
+    echo "  $OPS_ROOT/.mcp.json, $PORTFOLIO_ROOT/.mcp.json)."
+    echo "  Search is configured ON but not wired up — install/configure the"
+    echo "  apexyard-search MCP server (run: apexyard-premium doctor), or set"
+    echo "  vector_index.enabled: false if you don't intend to use it."
+  } >&2
+  exit 0
+fi
+
+# -----------------------------------------------------------------------
+# We have a real "apexyard-search" entry to validate. Read its command +
+# roots. Prefer jq (structured, robust); fall back to a best-effort grep
+# for read-only diagnosis when jq isn't installed.
+# -----------------------------------------------------------------------
+HAVE_JQ=false
+command -v jq >/dev/null 2>&1 && HAVE_JQ=true
+
+if $HAVE_JQ; then
+  CUR_CMD=$(jq -r '.mcpServers["apexyard-search"].command // empty' "$MCP_JSON" 2>/dev/null)
+  CUR_OPS_ENV=$(jq -r '.mcpServers["apexyard-search"].env.APEXYARD_OPS_ROOT // empty' "$MCP_JSON" 2>/dev/null)
+  CUR_PORTFOLIO_ENV=$(jq -r '.mcpServers["apexyard-search"].env.APEXYARD_PORTFOLIO_ROOT // empty' "$MCP_JSON" 2>/dev/null)
+else
+  _blk=$(awk '/"apexyard-search"/{f=1} f{print} f && /\}/{c++} c>1{exit}' "$MCP_JSON" 2>/dev/null)
+  CUR_CMD=$(printf '%s\n' "$_blk" | grep '"command"' | head -1 | sed -E 's/.*"command"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+  CUR_OPS_ENV=$(printf '%s\n' "$_blk" | grep '"APEXYARD_OPS_ROOT"' | head -1 | sed -E 's/.*"APEXYARD_OPS_ROOT"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+  CUR_PORTFOLIO_ENV=$(printf '%s\n' "$_blk" | grep '"APEXYARD_PORTFOLIO_ROOT"' | head -1 | sed -E 's/.*"APEXYARD_PORTFOLIO_ROOT"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+fi
+
+# Is a command string actually launchable right now?
+_cmd_launchable() {
+  local c="$1"
+  [ -n "$c" ] || return 1
+  case "$c" in
+    /*) [ -x "$c" ] ;;
+    *) command -v "$c" >/dev/null 2>&1 ;;
+  esac
+}
+
+need_cmd_heal=false
+_cmd_launchable "$CUR_CMD" || need_cmd_heal=true
+
+need_ops_heal=false
+{ [ -n "$CUR_OPS_ENV" ] && [ -d "$CUR_OPS_ENV" ]; } || need_ops_heal=true
+
+need_portfolio_heal=false
+{ [ -n "$CUR_PORTFOLIO_ENV" ] && [ -d "$CUR_PORTFOLIO_ENV" ]; } || need_portfolio_heal=true
+
+# Nothing broken -> healthy, silent.
+if ! $need_cmd_heal && ! $need_ops_heal && ! $need_portfolio_heal; then
+  exit 0
+fi
+
+# -----------------------------------------------------------------------
+# Something is broken. If the command needs fixing, try to find a
+# launchable binary so the warn message (and, if opted in, the heal) can
+# name a concrete replacement: basename off PATH, then the well-known
+# pipx venv layout (apexyard-premium#504 installs there; existing
+# .mcp.json files predate that fix and don't self-update).
+# -----------------------------------------------------------------------
+RESOLVED_CMD="$CUR_CMD"
+if $need_cmd_heal; then
+  RESOLVED_CMD=""
+  _bin_name="apexyard-search"
+  case "$CUR_CMD" in
+    */*) _bin_name=$(basename "$CUR_CMD") ;;
+    "") : ;;
+    *) _bin_name="$CUR_CMD" ;;
+  esac
+
+  if command -v "$_bin_name" >/dev/null 2>&1; then
+    RESOLVED_CMD=$(command -v "$_bin_name")
+  else
+    for _venv in "$HOME/.local/pipx/venvs/apexyard-premium" "$HOME/.local/pipx/venvs/$_bin_name"; do
+      if [ -x "$_venv/bin/$_bin_name" ]; then
+        RESOLVED_CMD="$_venv/bin/$_bin_name"
+        break
+      fi
+    done
+  fi
+fi
+
+# -----------------------------------------------------------------------
+# AUTO-HEAL — strictly opt-in (APEXYARD_SEARCH_SELFHEAL=1), OFF by default.
+# Backs up the whole file first, rewrites only the apexyard-search entry,
+# and validates the result before replacing the original. Any failure at
+# any step discards the attempt (original file left untouched) and falls
+# through to the read-only warn below.
+# -----------------------------------------------------------------------
+HEALED=false
+if [ "${APEXYARD_SEARCH_SELFHEAL:-}" = "1" ] && $HAVE_JQ; then
+  _can_heal=true
+  if $need_cmd_heal && [ -z "$RESOLVED_CMD" ]; then
+    _can_heal=false
+  fi
+
+  if $_can_heal; then
+    NEW_CMD="$CUR_CMD"
+    $need_cmd_heal && NEW_CMD="$RESOLVED_CMD"
+
+    _backup="${MCP_JSON}.bak.$(date +%s 2>/dev/null || echo 0)"
+    if cp "$MCP_JSON" "$_backup" 2>/dev/null; then
+      TMP="$(mktemp "${MCP_JSON}.XXXXXX" 2>/dev/null)" || TMP=""
+      if [ -n "$TMP" ] && jq \
+          --arg cmd "$NEW_CMD" \
+          --arg ops "$OPS_ROOT" \
+          --arg pf "$PORTFOLIO_ROOT" \
+          '.mcpServers["apexyard-search"].command = $cmd
+           | .mcpServers["apexyard-search"].env.APEXYARD_OPS_ROOT = $ops
+           | .mcpServers["apexyard-search"].env.APEXYARD_PORTFOLIO_ROOT = $pf' \
+          "$MCP_JSON" > "$TMP" 2>/dev/null; then
+        # Validate: still parses AND the entry still has the expected shape
+        # (round-trip check) before trusting it over the original.
+        if jq -e '.mcpServers["apexyard-search"].command | type == "string"' "$TMP" >/dev/null 2>&1; then
+          mv "$TMP" "$MCP_JSON"
+          HEALED=true
+          {
+            echo "ApexYard: apexyard-search config self-healed in $MCP_JSON (backup at $_backup)"
+            $need_cmd_heal && echo "  - command: '$CUR_CMD' -> '$NEW_CMD' (resolved to a launchable absolute path)"
+            $need_ops_heal && echo "  - APEXYARD_OPS_ROOT: '$CUR_OPS_ENV' -> '$OPS_ROOT'"
+            $need_portfolio_heal && echo "  - APEXYARD_PORTFOLIO_ROOT: '$CUR_PORTFOLIO_ENV' -> '$PORTFOLIO_ROOT'"
+          } >&2
+        else
+          rm -f "$TMP"
+        fi
+      else
+        [ -n "$TMP" ] && rm -f "$TMP"
+      fi
+    fi
+  fi
+fi
+
+$HEALED && exit 0
+
+# -----------------------------------------------------------------------
+# Read-only path (the default): broken and not auto-healed. Fail LOUDLY
+# with an actionable, concrete fix — this is the case #514 exists to make
+# impossible to miss. Never a silent no-op once intent-evidence says
+# search should work.
+# -----------------------------------------------------------------------
+{
+  echo "ApexYard: apexyard-search MCP config looks BROKEN (in $MCP_JSON):"
+  if $need_cmd_heal; then
+    if [ -n "$RESOLVED_CMD" ]; then
+      echo "  - command '$CUR_CMD' is not launchable (not an executable absolute path, not on"
+      echo "    PATH). Found a launchable binary at: $RESOLVED_CMD"
+    else
+      echo "  - command '$CUR_CMD' is not launchable: not an executable absolute path, not on"
+      echo "    PATH, and not found under \$HOME/.local/pipx/venvs/apexyard-premium/bin/"
+    fi
+  fi
+  if $need_ops_heal; then
+    echo "  - APEXYARD_OPS_ROOT ('$CUR_OPS_ENV') does not exist. Current ops root: $OPS_ROOT"
+  fi
+  if $need_portfolio_heal; then
+    echo "  - APEXYARD_PORTFOLIO_ROOT ('$CUR_PORTFOLIO_ENV') does not exist. Current portfolio root: $PORTFOLIO_ROOT"
+  fi
+  echo "  Fix: run 'apexyard-premium doctor' to diagnose/repair, or edit $MCP_JSON by hand:"
+  echo "    command -> ${RESOLVED_CMD:-<absolute path to the apexyard-search binary>}"
+  echo "    env.APEXYARD_OPS_ROOT -> $OPS_ROOT"
+  echo "    env.APEXYARD_PORTFOLIO_ROOT -> $PORTFOLIO_ROOT"
+  echo "  (Set APEXYARD_SEARCH_SELFHEAL=1 to let ApexYard auto-correct this on next"
+  echo "   session start — it backs up $MCP_JSON first and only touches this entry.)"
+} >&2
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,6 +47,10 @@
           {
             "type": "command",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/remind-mcp-tools.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/validate-search-config.sh\"'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- **New SessionStart hook (`.claude/hooks/validate-search-config.sh`) that stops apexyard-search from rotting silently.** `apexyard-premium#514` reported that `.mcp.json` bakes in absolute roots and a bare command resolved against a pipx venv at install time — neither self-corrects when a repo moves, gets renamed, or is cloned onto a new machine, so the MCP server silently fails to launch and search returns nothing with no error for weeks. This hook validates the config at every session start and, when it's broken, prints a loud, actionable stderr warning instead of staying quiet.
- **Gated on evidence of intent, not on-PATH resolution — the load-bearing design constraint from the #514 review.** The old failure mode conflated "not installed" (correct silent no-op) with "installed but the bare command isn't on PATH" (broken, and exactly the case #514 exists to surface) because both hit `command -v apexyard-search` the same way. This hook instead checks for an `apexyard-search` entry in `.mcp.json` OR `vector_index.enabled: true` in `features.yaml` — either signal means the operator intends to use search, and only then does the hook do anything at all. Absent both, it's a totally silent `exit 0`: zero output, zero file reads beyond the two candidate files, zero writes. Every non-premium / unconfigured adopter sees nothing at every session start.
- **Read-only by default — auto-rewrite is a strict opt-in, not the shipped default.** An earlier draft of this hook auto-rewrote `.mcp.json` whenever it found a fixable problem. That was flagged as too much blast radius for a hook that runs at every adopter's SessionStart (a bad rewrite could mangle unrelated MCP server entries in the same file). The shipped default is detect + warn with the exact fix named in the message. Auto-heal exists behind `APEXYARD_SEARCH_SELFHEAL=1` (default off), and even then it backs up the file first, touches only the `apexyard-search` entry, and validates the rewritten JSON round-trips before replacing the original.
- **New test suite** (`test_validate_search_config.sh`, 7 cases) plus a site marketing-copy fixup: adding the hook bumped the real hook count from 40 to 41, so `test_site_counts.sh`'s drift guard required updating the quoted counts in `site/*.html`, `site/*.md.gen`, and `site/llms*.txt`.

## Testing

- `bash -n .claude/hooks/validate-search-config.sh` — syntax check, clean.
- `bash .claude/hooks/tests/test_validate_search_config.sh` — 7/7 pass:
  1. No `.mcp.json` entry + no `features.yaml` at all → silent, exit 0.
  2. A *different* MCP server configured + `vector_index.enabled: false` → silent, exit 0 (still the unconfigured shape).
  3. Intent present, broken command + nonexistent roots, no opt-in → loud stderr warning, `.mcp.json` byte-for-byte unchanged, no backup file created.
  4. Intent present, healthy config (launchable absolute command, both roots exist) → silent, exit 0.
  5. Intent from `features.yaml` alone (no `.mcp.json` entry at all) → loud warning that nothing is wired up.
  6. Opt-in self-heal (`APEXYARD_SEARCH_SELFHEAL=1`) → backup written, only the `apexyard-search` entry changes, a sibling `other-server` entry is verified byte-identical after the heal.
  7. Kill-switch (`APEXYARD_SEARCH_VALIDATE_DISABLE=1`) → silent regardless of config state.
- Full framework hook test suite (`bin/run-hook-tests.sh`) on a **clean `origin/dev` checkout** (built in an isolated `git worktree` so no ambient uncommitted state leaked in): **72/72 pass**, including the new test and `test_site_counts.sh` after the count bump.
- Manual fixture walkthroughs for all of the above cases plus the opt-in heal path, run by hand before the automated suite was written, to eyeball the actual stderr wording.

## Glossary

| Term | Definition |
|------|------------|
| Silent rot | `.mcp.json` points at nonexistent roots or an unlaunchable binary; search returns empty with no error, so the breakage goes unnoticed for weeks |
| Intent gate | The check that decides whether this hook does anything at all: evidence the operator configured search (an `.mcp.json` entry or `vector_index.enabled: true`), not whether the binary happens to resolve on `$PATH` right now |
| Self-heal | The opt-in (`APEXYARD_SEARCH_SELFHEAL=1`) auto-correction of the broken `command` / `env.*` fields in the `apexyard-search` `.mcp.json` entry — backed up and validated before it replaces the original |
| pipx venv | The isolated Python virtualenv `pipx` creates per package (`~/.local/pipx/venvs/apexyard-premium/bin/...`); its binaries aren't on `$PATH` by default, which is the root cause of the "bare command" half of #514 |

Refs #891
Refs me2resh/apexyard-premium#514
