### PR TITLE
feat(#890): premium-hook safe-fallback harness (_lib-premium-hook.sh)

### DIFF
--- a/.claude/hooks/_lib-premium-hook.sh
+++ b/.claude/hooks/_lib-premium-hook.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+# _lib-premium-hook.sh — shared safe-fallback harness for PREMIUM hooks
+# (me2resh/apexyard#890).
+#
+# THE PROBLEM THIS FIXES: every hook that touches a premium component
+# (apexyard-search reindex, the #514 search self-heal, apexyard-premium's
+# budget enforcer, future premium hooks not yet written) has hand-rolled the
+# same "safe fallback" shape — gate on install-presence, timeout-guard the
+# slow part, swallow non-zero exit, never block the session. Because it's
+# copy-pasted per hook, every NEW premium hook is a fresh chance to get the
+# safety wrong. This lib turns the convention into one audited primitive so
+# premium hooks are safe-by-construction and CANNOT break free/framework
+# users, by construction rather than by careful copy-paste.
+#
+# CONVENTION (see docs/agdr/AgDR-0095-premium-hook-safe-fallback-harness.md):
+# any NEW premium-touching hook MUST route its premium-only work through
+# `premium_hook_run` below instead of hand-rolling its own gate/timeout/
+# swallow logic.
+#
+# SAFE SHAPE (mirrors reindex-on-session-start.sh / check-upstream-drift.sh):
+# `premium_hook_run` NEVER blocks its caller and ALWAYS returns 0. Every
+# failure mode is a silent no-op:
+#   - the feature is disabled (or unconfigured, depending on the caller's
+#     chosen default — see `premium_feature_enabled` below)     -> no-op
+#   - the premium component isn't present (presence check fails) -> no-op
+#   - the payload exits non-zero                                 -> swallowed
+#   - the payload hangs past the timeout                         -> killed, swallowed
+#   - jq/awk/timeout aren't installed                            -> degrades, never blocks
+#
+# THREE SAFETY PROPERTIES, CENTRALIZED (per the ticket):
+#   1. GATE       — premium_feature_enabled(<feature_key>) AND a caller-
+#                    supplied presence check both have to pass before the
+#                    payload runs at all. Absent either -> zero output, zero
+#                    latency (no timeout wrapper spun up, nothing execed).
+#   2. FAIL-SAFE   — the payload runs inside a timeout-guarded child process
+#                    (prefers GNU `timeout`, then macOS `gtimeout`; degrades
+#                    to no wrapper if neither exists, same as
+#                    reindex-on-session-start.sh); its exit code is swallowed.
+#   3. ALWAYS 0    — premium_hook_run itself never returns non-zero. There is
+#                    no code path in this file that propagates a failure to
+#                    the caller.
+#
+# USAGE: source this file alone — it resolves _lib-read-config.sh /
+# _lib-portfolio-paths.sh itself (relative to its own location) the first
+# time it needs features.yaml, so callers don't have to pre-source them:
+#
+#   HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   # shellcheck source=/dev/null
+#   . "$HOOK_DIR/_lib-premium-hook.sh"
+#
+#   premium_hook_run <feature_key> <presence_check_cmd> <payload_cmd> [default_enabled]
+#
+#     feature_key       Key looked up as a top-level block in features.yaml,
+#                        e.g. "search" -> looks for:
+#                          search:
+#                            enabled: true
+#     presence_check_cmd A shell command STRING; exit 0 means "the premium
+#                        component is present" (e.g. "command -v apexyard-search").
+#                        Pass "" to skip the presence check entirely (only the
+#                        feature flag gates the payload).
+#     payload_cmd        A shell command STRING — the actual premium work,
+#                        including any redirection it wants (e.g.
+#                        "apexyard-search reindex --incremental >/dev/null 2>&1").
+#                        Executed via `bash -c` in a NEW child process so the
+#                        timeout wrapper can kill it if it hangs — it does
+#                        NOT inherit this shell's local functions/variables,
+#                        so interpolate any values you need directly into the
+#                        string before calling.
+#     default_enabled     "true" (default) | "false" — what premium_feature_enabled
+#                        should return when features.yaml (or the specific key)
+#                        is entirely absent. Existing premium hooks that
+#                        historically gated purely on install-presence (no
+#                        features.yaml check at all, e.g. the pre-#890 shape
+#                        of reindex-on-session-start.sh) should pass "true" so
+#                        retrofitting introduces ZERO behaviour regression for
+#                        adopters who never configured features.yaml. New
+#                        premium hooks that want a stricter explicit-opt-in
+#                        posture should pass "false".
+#
+#   Example (mirrors the reindex-on-session-start.sh retrofit):
+#     premium_hook_run "search" "command -v apexyard-search" \
+#       "apexyard-search reindex --incremental --if-stale=86400 >/dev/null 2>&1" \
+#       "true"
+#
+# Tunables (env):
+#   PREMIUM_HOOK_TIMEOUT_SECS   max seconds to spend before killing the
+#                               payload (default 25, matches
+#                               reindex-on-session-start.sh's own default)
+#
+# Also exposes (for callers that just want the gate without running
+# anything, or want to build their own presence check):
+#   premium_feature_enabled <feature_key> [default_enabled]
+#       0 (true)  if features.yaml has "<feature_key>: / enabled: true"
+#       1 (false) if it has "<feature_key>: / enabled: false"
+#       otherwise falls back to [default_enabled] ("true" unless passed "false")
+#   premium_bin_present <bin_name>
+#       Convenience: `command -v <bin_name>` as a one-liner, for building a
+#       presence_check_cmd string, e.g.:
+#         premium_hook_run "search" "premium_bin_present apexyard-search" "..."
+#       (works because presence checks run via `eval` in THIS shell, not a
+#       child process — unlike the payload, they inherit this lib's functions.)
+#
+# Source-guard: safe to source more than once in the same shell (idempotent,
+# matches the pattern in _lib-ops-root.sh).
+
+[ -n "${_LIB_PREMIUM_HOOK_SOURCED:-}" ] && return 0
+_LIB_PREMIUM_HOOK_SOURCED=1
+
+set -u
+
+# ------------------------------------------------------------------------------
+# Internal: resolve this lib's own directory (for sourcing sibling libs),
+# the ops-fork root, and the portfolio root — same resolution order used by
+# validate-search-config.sh / reindex-on-session-start.sh's siblings.
+# Cached per-process.
+# ------------------------------------------------------------------------------
+_PREMIUM_HOOK_DIR_CACHE=""
+_premium_hook_dir() {
+  if [ -z "$_PREMIUM_HOOK_DIR_CACHE" ]; then
+    _PREMIUM_HOOK_DIR_CACHE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  fi
+  printf '%s' "$_PREMIUM_HOOK_DIR_CACHE"
+}
+
+_PREMIUM_OPS_ROOT_CACHE=""
+_premium_ops_root() {
+  if [ -n "$_PREMIUM_OPS_ROOT_CACHE" ]; then
+    printf '%s' "$_PREMIUM_OPS_ROOT_CACHE"
+    return 0
+  fi
+  local dir root
+  dir=$(_premium_hook_dir)
+  root=""
+  if [ -f "$dir/_lib-ops-root.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$dir/_lib-ops-root.sh"
+    if command -v resolve_ops_root >/dev/null 2>&1; then
+      root=$(resolve_ops_root "$PWD")
+    fi
+  fi
+  if [ -z "$root" ]; then
+    # Fall back to this lib's own fork location.
+    root="$(cd "$dir/../.." 2>/dev/null && pwd)"
+  fi
+  _PREMIUM_OPS_ROOT_CACHE="$root"
+  printf '%s' "$root"
+}
+
+_PREMIUM_PORTFOLIO_ROOT_CACHE=""
+_premium_portfolio_root() {
+  if [ -n "$_PREMIUM_PORTFOLIO_ROOT_CACHE" ]; then
+    printf '%s' "$_PREMIUM_PORTFOLIO_ROOT_CACHE"
+    return 0
+  fi
+  local dir ops root registry
+  dir=$(_premium_hook_dir)
+  ops=$(_premium_ops_root)
+  root=""
+  if [ -f "$dir/_lib-read-config.sh" ] && [ -f "$dir/_lib-portfolio-paths.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$dir/_lib-read-config.sh"
+    # shellcheck source=/dev/null
+    . "$dir/_lib-portfolio-paths.sh"
+    if command -v portfolio_registry >/dev/null 2>&1; then
+      registry=$(portfolio_registry 2>/dev/null)
+      if [ -n "$registry" ]; then
+        root=$(cd "$(dirname "$registry")" 2>/dev/null && pwd)
+      fi
+    fi
+  fi
+  [ -n "$root" ] || root="$ops"
+  _PREMIUM_PORTFOLIO_ROOT_CACHE="$root"
+  printf '%s' "$root"
+}
+
+# ------------------------------------------------------------------------------
+# Internal: locate features.yaml, checking the same candidate locations as
+# validate-search-config.sh (portfolio root first, then ops root, then an
+# explicit $APEXYARD_PORTFOLIO_ROOT override). Not cached — cheap stat calls,
+# and callers may run this across a long-lived shell where the file could
+# appear mid-session (e.g. a test fixture writing it after first source).
+# ------------------------------------------------------------------------------
+_premium_features_yaml() {
+  local ops portfolio candidate
+  ops=$(_premium_ops_root)
+  portfolio=$(_premium_portfolio_root)
+  for candidate in "$portfolio/features.yaml" "$ops/features.yaml" "${APEXYARD_PORTFOLIO_ROOT:-}/features.yaml"; do
+    [ -n "$candidate" ] && [ -f "$candidate" ] || continue
+    printf '%s' "$candidate"
+    return 0
+  done
+  return 1
+}
+
+# ------------------------------------------------------------------------------
+# Public: premium_feature_enabled <feature_key> [default_enabled]
+#   See header for full semantics. Scoped block match (top-level
+#   "<feature_key>:" followed by an indented "enabled: true/false") — not a
+#   blanket grep, so it can't false-positive on an unrelated feature's flag.
+# ------------------------------------------------------------------------------
+premium_feature_enabled() {
+  local key="${1:-}"
+  local default_enabled="${2:-true}"
+
+  # No key to look up -> apply the caller's default directly.
+  if [ -z "$key" ]; then
+    [ "$default_enabled" = "false" ] && return 1 || return 0
+  fi
+
+  local file
+  if ! file=$(_premium_features_yaml); then
+    # No features.yaml anywhere -> apply the caller's default.
+    [ "$default_enabled" = "false" ] && return 1 || return 0
+  fi
+
+  # Explicit "enabled: true" inside the <key>: block -> enabled, full stop.
+  if awk -v key="$key" '
+    $0 ~ "^" key ":[[:space:]]*$" { inblk = 1; next }
+    inblk && /^[^[:space:]]/ { inblk = 0 }
+    inblk && /enabled:[[:space:]]*true/ { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "$file" 2>/dev/null; then
+    return 0
+  fi
+
+  # Explicit "enabled: false" inside the <key>: block -> disabled, full
+  # stop — an explicit false always wins over [default_enabled].
+  if awk -v key="$key" '
+    $0 ~ "^" key ":[[:space:]]*$" { inblk = 1; next }
+    inblk && /^[^[:space:]]/ { inblk = 0 }
+    inblk && /enabled:[[:space:]]*false/ { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "$file" 2>/dev/null; then
+    return 1
+  fi
+
+  # Key entirely absent from features.yaml -> fall back to the caller's
+  # chosen default.
+  [ "$default_enabled" = "false" ] && return 1 || return 0
+}
+
+# ------------------------------------------------------------------------------
+# Public: premium_bin_present <bin_name>
+#   Convenience one-liner for building a presence_check_cmd string.
+# ------------------------------------------------------------------------------
+premium_bin_present() {
+  command -v "${1:-}" >/dev/null 2>&1
+}
+
+# ------------------------------------------------------------------------------
+# Public: premium_hook_run <feature_key> <presence_check_cmd> <payload_cmd> [default_enabled]
+#   See header for full semantics. This function NEVER returns non-zero.
+# ------------------------------------------------------------------------------
+premium_hook_run() {
+  local feature_key="${1:-}"
+  local presence_cmd="${2:-}"
+  local payload_cmd="${3:-}"
+  local default_enabled="${4:-true}"
+
+  # Nothing to run -> trivially fine.
+  [ -n "$feature_key" ] || return 0
+  [ -n "$payload_cmd" ] || return 0
+
+  # GATE 1: feature flag. Absent/disabled -> silent no-op, zero latency —
+  # nothing below this line executes.
+  premium_feature_enabled "$feature_key" "$default_enabled" || return 0
+
+  # GATE 2: component presence, when the caller supplied a check. Run via
+  # `eval` in a subshell — cheap, isolated from this shell's state, and
+  # (unlike the payload below) still sees this lib's own helper functions
+  # (e.g. premium_bin_present) since it's not a separate process.
+  if [ -n "$presence_cmd" ]; then
+    ( eval "$presence_cmd" ) >/dev/null 2>&1 || return 0
+  fi
+
+  # FAIL-SAFE EXECUTION: timeout-guarded child process. Prefer GNU `timeout`,
+  # then macOS `gtimeout`; degrade to no wrapper if neither exists (the
+  # payload still runs, just unbounded — rare, matches
+  # reindex-on-session-start.sh's existing fallback).
+  local timeout_secs to
+  timeout_secs="${PREMIUM_HOOK_TIMEOUT_SECS:-25}"
+  to=""
+  if command -v timeout >/dev/null 2>&1; then
+    to="timeout -k 2 ${timeout_secs}"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    to="gtimeout -k 2 ${timeout_secs}"
+  fi
+
+  # Run in a NEW bash process so the timeout wrapper can actually kill it if
+  # it hangs — a `timeout` around an `eval` in the current shell can't do
+  # that. The payload string carries its own redirection (if any); this
+  # function does not impose stdout/stderr handling of its own, so a
+  # retrofitted hook can preserve its exact prior output shape verbatim.
+  # shellcheck disable=SC2086
+  $to bash -c "$payload_cmd" || true
+
+  # ALWAYS 0 — a premium hook can never block or break its caller.
+  return 0
+}

--- a/.claude/hooks/reindex-on-session-start.sh
+++ b/.claude/hooks/reindex-on-session-start.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SessionStart hook: opportunistically refresh the apexyard-search index so an
+# agent doesn't search a stale index and fall back to grep (apexyard-premium#371).
+#
+# It runs `apexyard-search reindex --incremental --if-stale=<threshold>`:
+#   - --incremental: cheap manifest-mtime delta sync (only changed files).
+#   - --if-stale:    the CLI no-ops when the index is still fresh, so the common
+#                    case (just reindexed) costs essentially nothing.
+#
+# SAFE SHAPE: retrofitted onto the shared premium-hook harness
+# (_lib-premium-hook.sh, me2resh/apexyard#890) — behaviour-preserving, not a
+# redesign. This hook NEVER blocks session start and ALWAYS exits 0. Every
+# failure mode is a silent no-op:
+#   - apexyard-search not on PATH  (MCP not installed)         -> no-op
+#   - index already fresh          (--if-stale short-circuits) -> no-op
+#   - APEXYARD_OPS_ROOT / _PORTFOLIO_ROOT unset                -> no-op (CLI errs, swallowed)
+#   - reindex slower than the timeout                          -> killed, no-op
+#   - APEXYARD_SEARCH_REINDEX_DISABLE set                      -> no-op
+#
+# Why "search" defaults enabled=true (see _lib-premium-hook.sh's
+# `default_enabled` param): this hook historically gated ONLY on
+# install-presence (`command -v apexyard-search`), with no features.yaml
+# check at all. Routing it through the harness must not newly require a
+# "search: enabled: true" block in features.yaml for adopters who already
+# have apexyard-search on PATH and never configured that key — so the
+# feature-flag gate here defaults to enabled when the key is absent, and
+# only an explicit "search: / enabled: false" in features.yaml opts a
+# session out without needing to uninstall the CLI. See AgDR-0095.
+#
+# Tunables (env):
+#   APEXYARD_SEARCH_STALE_AFTER       staleness threshold in seconds (default 86400 = 24h)
+#   APEXYARD_SEARCH_REINDEX_TIMEOUT   max seconds to spend before giving up (default 25)
+#   APEXYARD_SEARCH_REINDEX_DISABLE   non-empty -> skip entirely
+
+set -u
+
+# Operator kill-switch. Hook-specific, so it stays a plain early-exit rather
+# than routing through the harness's feature-flag gate.
+if [ -n "${APEXYARD_SEARCH_REINDEX_DISABLE:-}" ]; then
+  exit 0
+fi
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$HOOK_DIR/_lib-premium-hook.sh"
+
+STALE_AFTER="${APEXYARD_SEARCH_STALE_AFTER:-86400}"
+
+# Map this hook's own timeout tunable onto the harness's generic one. Read
+# by premium_hook_run in _lib-premium-hook.sh (sourced above into this same
+# shell, not a child process) — shellcheck can't see the cross-file read, so
+# it flags this as unused; it isn't.
+# shellcheck disable=SC2034
+PREMIUM_HOOK_TIMEOUT_SECS="${APEXYARD_SEARCH_REINDEX_TIMEOUT:-25}"
+
+# Payload preserves the exact prior command + redirection (discard stdout,
+# and — same as before the retrofit — stderr rides along into the same
+# redirect since `2>&1` dups onto the already-redirected stdout). Swallowing
+# the exit code and the timeout guard are the harness's job now.
+PAYLOAD="apexyard-search reindex --incremental --if-stale=\"${STALE_AFTER}\" >/dev/null 2>&1"
+
+premium_hook_run "search" "command -v apexyard-search" "$PAYLOAD" "true"
+
+exit 0

--- a/.claude/hooks/tests/test_lib_premium_hook.sh
+++ b/.claude/hooks/tests/test_lib_premium_hook.sh
@@ -1,0 +1,307 @@
+#!/bin/bash
+# Tests for _lib-premium-hook.sh — the shared safe-fallback harness for
+# premium hooks (me2resh/apexyard#890).
+#
+# The load-bearing property under test is the three-part safe shape:
+#   1. GATE       — feature-flag disabled/unconfigured OR component absent
+#                    -> silent no-op (zero stdout, exit 0, payload never runs).
+#   2. FAIL-SAFE   — a throwing or hanging payload is swallowed / killed;
+#                    the guard still returns 0 promptly.
+#   3. ALWAYS 0    — premium_hook_run never propagates a non-zero exit.
+#
+# Each case builds an isolated sandbox under $TMPDIR with a synthetic
+# ops-fork anchor (onboarding.yaml + apexyard.projects.yaml — the legacy v1
+# shape _lib-ops-root.sh recognises) and an optional features.yaml, sources
+# the lib with that sandbox as cwd, and calls premium_hook_run directly.
+#
+# Run: bash .claude/hooks/tests/test_lib_premium_hook.sh
+
+set -u
+
+LIB_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="$LIB_DIR/_lib-premium-hook.sh"
+
+if [ ! -f "$LIB" ]; then
+  echo "FAIL: lib not found at $LIB" >&2
+  exit 1
+fi
+
+# Same isolation used across the suite (see bin/run-hook-tests.sh): disable
+# the ops-root session pin so every case resolves by walk-up to its own
+# sandbox, never escaping onto the real ops fork.
+export APEXYARD_OPS_DISABLE_PIN=1
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+mark_pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+mark_fail() { FAIL=$((FAIL + 1)); FAILED_CASES="$FAILED_CASES|$1"; echo "  FAIL: $1 -- $2" >&2; }
+
+build_sandbox() {
+  mkdir -p "$1"
+  : > "$1/onboarding.yaml"
+  : > "$1/apexyard.projects.yaml"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: feature absent from features.yaml entirely, default_enabled=false
+# -> silent no-op: exit 0, zero stdout, and the payload never actually runs
+# (verified via a marker file the payload would otherwise create).
+# ---------------------------------------------------------------------------
+test_feature_absent_is_silent_noop() {
+  local sb marker out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  marker="$sb/ran.marker"
+
+  # shellcheck source=/dev/null
+  out=$(cd "$sb" && . "$LIB" && premium_hook_run "nope" "" "touch '$marker'" "false" 2>&1)
+  rc=$?
+
+  if [ -z "$out" ] && [ "$rc" -eq 0 ] && [ ! -f "$marker" ]; then
+    mark_pass "feature absent + default=false -> silent no-op, payload never runs"
+  else
+    mark_fail "feature absent -> silent no-op" \
+      "out=[$out] rc=$rc marker_exists=$([ -f "$marker" ] && echo yes || echo no)"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1b: feature key absent, default_enabled=true (the retrofit-compat
+# shape used by reindex-on-session-start.sh) -> the flag gate passes, so the
+# payload runs as long as presence also passes. Proves the "no regression
+# for hooks that never had a features.yaml check" design goal.
+# ---------------------------------------------------------------------------
+test_feature_absent_defaults_to_enabled_when_asked() {
+  local sb marker out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  marker="$sb/ran.marker"
+
+  # shellcheck source=/dev/null
+  out=$(cd "$sb" && . "$LIB" && premium_hook_run "search" "true" "touch '$marker'" "true" 2>&1)
+  rc=$?
+
+  if [ "$rc" -eq 0 ] && [ -f "$marker" ]; then
+    mark_pass "feature absent + default=true + present -> payload runs (retrofit-compat)"
+  else
+    mark_fail "feature absent + default=true -> payload runs" \
+      "out=[$out] rc=$rc marker_exists=$([ -f "$marker" ] && echo yes || echo no)"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1c: features.yaml has the key explicitly false -> silent no-op EVEN
+# when default_enabled=true (explicit false always wins over the default).
+# ---------------------------------------------------------------------------
+test_feature_explicitly_false_overrides_default_true() {
+  local sb marker out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  cat > "$sb/features.yaml" <<'YAML'
+search:
+  enabled: false
+YAML
+  marker="$sb/ran.marker"
+
+  # shellcheck source=/dev/null
+  out=$(cd "$sb" && . "$LIB" && premium_hook_run "search" "true" "touch '$marker'" "true" 2>&1)
+  rc=$?
+
+  if [ -z "$out" ] && [ "$rc" -eq 0 ] && [ ! -f "$marker" ]; then
+    mark_pass "features.yaml search.enabled:false overrides default_enabled=true -> silent no-op"
+  else
+    mark_fail "explicit false overrides default true" \
+      "out=[$out] rc=$rc marker_exists=$([ -f "$marker" ] && echo yes || echo no)"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: feature explicitly enabled + presence check passes -> the payload
+# runs, and the guard still returns 0.
+# ---------------------------------------------------------------------------
+test_enabled_and_present_runs_payload() {
+  local sb marker out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  cat > "$sb/features.yaml" <<'YAML'
+search:
+  enabled: true
+YAML
+  marker="$sb/ran.marker"
+
+  # shellcheck source=/dev/null
+  out=$(cd "$sb" && . "$LIB" && premium_hook_run "search" "true" "touch '$marker'" "false" 2>&1)
+  rc=$?
+
+  if [ "$rc" -eq 0 ] && [ -f "$marker" ]; then
+    mark_pass "enabled + present -> payload runs, guard returns 0"
+  else
+    mark_fail "enabled + present -> payload runs" \
+      "rc=$rc marker_exists=$([ -f "$marker" ] && echo yes || echo no)"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 2b: feature enabled but the presence check FAILS (component absent)
+# -> silent no-op, payload never runs.
+# ---------------------------------------------------------------------------
+test_enabled_but_component_absent_is_silent_noop() {
+  local sb marker out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  cat > "$sb/features.yaml" <<'YAML'
+search:
+  enabled: true
+YAML
+  marker="$sb/ran.marker"
+
+  # shellcheck source=/dev/null
+  out=$(cd "$sb" && . "$LIB" && premium_hook_run "search" "false" "touch '$marker'" "false" 2>&1)
+  rc=$?
+
+  if [ -z "$out" ] && [ "$rc" -eq 0 ] && [ ! -f "$marker" ]; then
+    mark_pass "enabled but component absent -> silent no-op"
+  else
+    mark_fail "enabled but component absent -> silent no-op" \
+      "out=[$out] rc=$rc marker_exists=$([ -f "$marker" ] && echo yes || echo no)"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: payload exits non-zero -> the guard swallows it and still returns
+# 0 (a genuine premium failure can never propagate to the caller).
+# ---------------------------------------------------------------------------
+test_throwing_payload_is_swallowed() {
+  local sb out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  cat > "$sb/features.yaml" <<'YAML'
+search:
+  enabled: true
+YAML
+
+  # shellcheck source=/dev/null
+  out=$(cd "$sb" && . "$LIB" && premium_hook_run "search" "true" "exit 1" "false" 2>&1)
+  rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    mark_pass "payload exits 1 -> guard still returns 0"
+  else
+    mark_fail "payload exits 1 -> guard still returns 0" "rc=$rc out=[$out]"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: payload sleeps well past the configured timeout -> it gets killed
+# and the guard returns 0 promptly (bounded wall-clock — never hangs the
+# session). Skips gracefully if neither `timeout` nor `gtimeout` exists.
+# ---------------------------------------------------------------------------
+test_hanging_payload_is_killed_and_swallowed() {
+  local sb start end elapsed rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  cat > "$sb/features.yaml" <<'YAML'
+search:
+  enabled: true
+YAML
+
+  if ! command -v timeout >/dev/null 2>&1 && ! command -v gtimeout >/dev/null 2>&1; then
+    echo "  SKIP: neither timeout nor gtimeout is installed on this machine"
+    rm -rf "$sb"
+    return 0
+  fi
+
+  start=$(date +%s)
+  # shellcheck source=/dev/null
+  ( cd "$sb" && export PREMIUM_HOOK_TIMEOUT_SECS=1 && . "$LIB" && premium_hook_run "search" "true" "sleep 30" "false" )
+  rc=$?
+  end=$(date +%s)
+  elapsed=$((end - start))
+
+  if [ "$rc" -eq 0 ] && [ "$elapsed" -lt 10 ]; then
+    mark_pass "hanging payload killed within timeout, guard returns 0 (elapsed=${elapsed}s)"
+  else
+    mark_fail "hanging payload killed within timeout" "rc=$rc elapsed=${elapsed}s"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: missing feature_key or missing payload_cmd -> silent no-op, never
+# a shell error. Input hygiene, not just the happy path.
+# ---------------------------------------------------------------------------
+test_missing_required_args_are_silent_noop() {
+  local sb out1 rc1 out2 rc2
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+
+  # shellcheck source=/dev/null
+  out1=$(cd "$sb" && . "$LIB" && premium_hook_run "" "true" "echo should-not-run" 2>&1)
+  rc1=$?
+  # shellcheck source=/dev/null
+  out2=$(cd "$sb" && . "$LIB" && premium_hook_run "search" "true" "" 2>&1)
+  rc2=$?
+
+  if [ -z "$out1" ] && [ "$rc1" -eq 0 ] && [ -z "$out2" ] && [ "$rc2" -eq 0 ]; then
+    mark_pass "missing feature_key / missing payload_cmd -> silent no-op"
+  else
+    mark_fail "missing required args -> silent no-op" "out1=[$out1] rc1=$rc1 out2=[$out2] rc2=$rc2"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 6: premium_feature_enabled is independently callable (not just
+# through premium_hook_run) — sanity check for the exposed public function.
+# ---------------------------------------------------------------------------
+test_premium_feature_enabled_standalone() {
+  local sb rc_true rc_false rc_absent
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  cat > "$sb/features.yaml" <<'YAML'
+loops:
+  enabled: true
+budget:
+  enabled: false
+YAML
+
+  # shellcheck source=/dev/null
+  ( cd "$sb" && . "$LIB" && premium_feature_enabled "loops" ); rc_true=$?
+  # shellcheck source=/dev/null
+  ( cd "$sb" && . "$LIB" && premium_feature_enabled "budget" ); rc_false=$?
+  # shellcheck source=/dev/null
+  ( cd "$sb" && . "$LIB" && premium_feature_enabled "playbooks" "false" ); rc_absent=$?
+
+  if [ "$rc_true" -eq 0 ] && [ "$rc_false" -eq 1 ] && [ "$rc_absent" -eq 1 ]; then
+    mark_pass "premium_feature_enabled: true/false/absent-with-default=false all resolve correctly"
+  else
+    mark_fail "premium_feature_enabled standalone" "rc_true=$rc_true rc_false=$rc_false rc_absent=$rc_absent"
+  fi
+  rm -rf "$sb"
+}
+
+test_feature_absent_is_silent_noop
+test_feature_absent_defaults_to_enabled_when_asked
+test_feature_explicitly_false_overrides_default_true
+test_enabled_and_present_runs_payload
+test_enabled_but_component_absent_is_silent_noop
+test_throwing_payload_is_swallowed
+test_hanging_payload_is_killed_and_swallowed
+test_missing_required_args_are_silent_noop
+test_premium_feature_enabled_standalone
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_reindex_on_session_start.sh
+++ b/.claude/hooks/tests/test_reindex_on_session_start.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# Tests for reindex-on-session-start.sh AFTER its retrofit onto
+# _lib-premium-hook.sh (me2resh/apexyard#890). Behaviour-preservation is the
+# load-bearing property: everything this hook did before the retrofit must
+# still hold, plus the new features.yaml opt-out becomes available.
+#
+# Each case builds an isolated sandbox with a synthetic ops-fork anchor and
+# a stub `apexyard-search` binary on PATH, then runs the hook as a real
+# script (not sourced) — same invocation shape Claude Code uses at
+# SessionStart.
+#
+# Run: bash .claude/hooks/tests/test_reindex_on_session_start.sh
+
+set -u
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$HOOK_DIR/reindex-on-session-start.sh"
+
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: hook not found at $HOOK" >&2
+  exit 1
+fi
+
+export APEXYARD_OPS_DISABLE_PIN=1
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+mark_pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+mark_fail() { FAIL=$((FAIL + 1)); FAILED_CASES="$FAILED_CASES|$1"; echo "  FAIL: $1 -- $2" >&2; }
+
+build_sandbox() {
+  mkdir -p "$1"
+  : > "$1/onboarding.yaml"
+  : > "$1/apexyard.projects.yaml"
+}
+
+# Installs a stub `apexyard-search` on PATH (via $1/bin) that records its
+# invocation to $1/bin-marker and behaves per $2 ("ok" | "fail" | "hang").
+install_stub_cli() {
+  local sb="$1" mode="$2"
+  mkdir -p "$sb/bin"
+  cat > "$sb/bin/apexyard-search" <<EOF
+#!/bin/bash
+echo "\$@" >> "$sb/bin-marker"
+case "$mode" in
+  fail) exit 1 ;;
+  hang) sleep 30 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$sb/bin/apexyard-search"
+}
+
+run_hook_in() {
+  local sb="$1"; shift
+  ( cd "$sb" && env "$@" PATH="$sb/bin:$PATH" bash "$HOOK" 2>&1 )
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: no apexyard-search on PATH at all -> silent no-op (unchanged from
+# pre-retrofit behaviour; the free/framework-only case).
+# ---------------------------------------------------------------------------
+test_no_cli_is_silent_noop() {
+  local sb out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+
+  out=$(cd "$sb" && bash "$HOOK" 2>&1)
+  rc=$?
+
+  if [ -z "$out" ] && [ "$rc" -eq 0 ]; then
+    mark_pass "no apexyard-search on PATH -> silent no-op"
+  else
+    mark_fail "no CLI -> silent no-op" "out=[$out] rc=$rc"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: operator kill-switch (APEXYARD_SEARCH_REINDEX_DISABLE) -> silent
+# no-op even with a working CLI present.
+# ---------------------------------------------------------------------------
+test_kill_switch_is_silent_noop() {
+  local sb out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  install_stub_cli "$sb" ok
+
+  out=$(run_hook_in "$sb" APEXYARD_SEARCH_REINDEX_DISABLE=1)
+  rc=$?
+
+  if [ -z "$out" ] && [ "$rc" -eq 0 ] && [ ! -f "$sb/bin-marker" ]; then
+    mark_pass "APEXYARD_SEARCH_REINDEX_DISABLE=1 -> silent no-op, CLI never invoked"
+  else
+    mark_fail "kill switch -> silent no-op" \
+      "out=[$out] rc=$rc invoked=$([ -f "$sb/bin-marker" ] && echo yes || echo no)"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: CLI present, NO features.yaml at all (the pre-#890 shape — this
+# hook never checked features.yaml before) -> the reindex still runs. This
+# is the no-regression acceptance criterion: adopters who never configured
+# features.yaml must see identical behaviour after the retrofit.
+# ---------------------------------------------------------------------------
+test_cli_present_no_features_yaml_still_runs() {
+  local sb out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  install_stub_cli "$sb" ok
+
+  out=$(run_hook_in "$sb")
+  rc=$?
+
+  if [ "$rc" -eq 0 ] && [ -f "$sb/bin-marker" ] && grep -q "reindex" "$sb/bin-marker"; then
+    mark_pass "CLI present + no features.yaml -> reindex still runs (no regression)"
+  else
+    mark_fail "CLI present, no features.yaml -> still runs" \
+      "rc=$rc invoked=$([ -f "$sb/bin-marker" ] && echo yes || echo no)"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: CLI present, features.yaml explicitly opts OUT (search.enabled:
+# false) -> silent no-op. This is the NEW capability the harness adds — an
+# admin kill-switch that doesn't require uninstalling the CLI.
+# ---------------------------------------------------------------------------
+test_features_yaml_explicit_disable_wins() {
+  local sb out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  install_stub_cli "$sb" ok
+  cat > "$sb/features.yaml" <<'YAML'
+search:
+  enabled: false
+YAML
+
+  out=$(run_hook_in "$sb")
+  rc=$?
+
+  if [ -z "$out" ] && [ "$rc" -eq 0 ] && [ ! -f "$sb/bin-marker" ]; then
+    mark_pass "features.yaml search.enabled:false -> silent no-op even with CLI present"
+  else
+    mark_fail "features.yaml explicit disable" \
+      "out=[$out] rc=$rc invoked=$([ -f "$sb/bin-marker" ] && echo yes || echo no)"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: the underlying apexyard-search invocation exits non-zero -> the
+# hook still exits 0 (unchanged from pre-retrofit: `|| true` behaviour).
+# ---------------------------------------------------------------------------
+test_cli_failure_does_not_propagate() {
+  local sb out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  install_stub_cli "$sb" fail
+
+  out=$(run_hook_in "$sb")
+  rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    mark_pass "apexyard-search exits 1 -> hook still exits 0"
+  else
+    mark_fail "CLI failure swallowed" "out=[$out] rc=$rc"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 6: the underlying apexyard-search hangs past the configured timeout
+# -> the hook still exits 0 promptly (bounded wall-clock).
+# ---------------------------------------------------------------------------
+test_cli_hang_is_bounded() {
+  local sb start end elapsed rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  install_stub_cli "$sb" hang
+
+  if ! command -v timeout >/dev/null 2>&1 && ! command -v gtimeout >/dev/null 2>&1; then
+    echo "  SKIP: neither timeout nor gtimeout is installed on this machine"
+    rm -rf "$sb"
+    return 0
+  fi
+
+  start=$(date +%s)
+  run_hook_in "$sb" APEXYARD_SEARCH_REINDEX_TIMEOUT=1 >/dev/null
+  rc=$?
+  end=$(date +%s)
+  elapsed=$((end - start))
+
+  if [ "$rc" -eq 0 ] && [ "$elapsed" -lt 15 ]; then
+    mark_pass "hanging apexyard-search killed within timeout, hook exits 0 (elapsed=${elapsed}s)"
+  else
+    mark_fail "hang is bounded" "rc=$rc elapsed=${elapsed}s"
+  fi
+  rm -rf "$sb"
+}
+
+test_no_cli_is_silent_noop
+test_kill_switch_is_silent_noop
+test_cli_present_no_features_yaml_still_runs
+test_features_yaml_explicit_disable_wins
+test_cli_failure_does_not_propagate
+test_cli_hang_is_bounded
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/docs/agdr/AgDR-0095-premium-hook-safe-fallback-harness.md
+++ b/docs/agdr/AgDR-0095-premium-hook-safe-fallback-harness.md
@@ -1,0 +1,47 @@
+# Premium-hook safe-fallback harness — `_lib-premium-hook.sh`
+
+> In the context of premium-touching hooks (`reindex-on-session-start.sh`, the `apexyard-premium#514` search self-heal, future premium hooks not yet written) each hand-rolling the same "never block, always exit 0, silent-when-absent, timeout-guarded" shape, facing the risk that every new premium hook is a fresh chance to get that safety wrong, I decided to **centralize the shape into one sourced library (`_lib-premium-hook.sh`) exposing `premium_hook_run`**, to achieve safe-by-construction premium hooks that can never break framework/free users, accepting a small API-learning cost for hook authors and a feature-flag-default design choice needed to keep the very first retrofit (`reindex-on-session-start.sh`) behaviour-preserving.
+
+## Context
+
+`me2resh/apexyard#514` (the apexyard-search config self-heal) surfaced that premium-touching hooks each hand-roll their own version of the same safe-fallback contract: gate on install-presence, timeout-guard the slow work, swallow non-zero exit, never let a premium hook block or fail a session. `reindex-on-session-start.sh` already does this by hand (kill-switch, `command -v apexyard-search`, `timeout`/`gtimeout`, `|| true`, `exit 0`). Copy-pasting this shape per hook means every new premium hook is a fresh chance to drop one of the properties — e.g. forgetting the timeout guard, or propagating a non-zero exit code. `me2resh/apexyard#890` asks for the primitive: one audited, sourced lib that centralizes the three safety properties so future premium hooks are safe-by-construction rather than safe-by-careful-copy-paste.
+
+A constraint shaping the design: `reindex-on-session-start.sh` (the first hook retrofitted) has **never** gated on `features.yaml` — its only gate has always been `command -v apexyard-search`. If the harness's feature-flag gate defaulted to "disabled when unconfigured", retrofitting this hook would silently stop the reindex from running for every existing adopter who has `apexyard-search` installed and on PATH but has never written a `features.yaml` `search:` block — a real regression, not a hypothetical one.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **One sourced lib (`_lib-premium-hook.sh`) with `premium_hook_run <feature_key> <presence_check_cmd> <payload_cmd> [default_enabled]`, feature-flag defaulting configurable per call-site** | Centralizes gate + timeout + swallow + always-0 in one audited place; the `default_enabled` param lets a behaviour-preserving retrofit (default `"true"`) coexist with a stricter explicit-opt-in posture for brand-new premium hooks (default `"false"`) | One more parameter to explain in the header doc |
+| Harness always fails closed (feature must be explicitly `enabled: true`) | Simplest mental model — premium features are opt-in by construction | Breaks `reindex-on-session-start.sh` for every adopter who has the CLI installed but no `features.yaml` `search:` block — a real regression the acceptance criteria explicitly forbid |
+| Leave each premium hook to hand-roll its own safe shape (status quo) | Zero migration cost | The exact problem #890 exists to close — every new premium hook re-derives (and can get wrong) the same three properties |
+| A Python-side harness (since `apexyard-premium`'s budget enforcer is already Python) | Consistent language with some premium components | Most premium-touching *hooks* in this repo are bash (`reindex-on-session-start.sh`, `validate-search-config.sh`); a bash lib matches where the gate/timeout/swallow logic actually needs to live (PreToolUse/SessionStart hook scripts) |
+
+## Decision
+
+Chosen: **`_lib-premium-hook.sh` exposing `premium_hook_run` (plus the standalone `premium_feature_enabled` and `premium_bin_present` helpers)**, because it centralizes the three safety properties in one place while the `default_enabled` parameter resolves the tension between "new premium hooks should default closed" and "the first retrofit must not regress."
+
+Specifics:
+
+- **`premium_hook_run <feature_key> <presence_check_cmd> <payload_cmd> [default_enabled]`** — the single entry point. `presence_check_cmd` and `payload_cmd` are shell command *strings*: the presence check runs via `eval` in the current shell (cheap, and still sees the lib's own helpers like `premium_bin_present`); the payload runs via `bash -c` in a **new child process** so the timeout wrapper (`timeout -k 2 …` / macOS `gtimeout`, same preference order as `reindex-on-session-start.sh`) can actually kill it if it hangs — a `timeout` around an in-process `eval` cannot do that.
+- **Gate = feature flag AND presence**, both silent-no-op on failure. `premium_feature_enabled <feature_key> [default_enabled]` reads `features.yaml` (resolved via `_lib-ops-root.sh` / `_lib-read-config.sh` / `_lib-portfolio-paths.sh`, the same candidate-path order `validate-search-config.sh` already uses: portfolio root, then ops root, then `$APEXYARD_PORTFOLIO_ROOT`), scoped-block matching a top-level `<feature_key>:` key with a nested `enabled: true|false` — not a blanket grep, so it can't false-positive on an unrelated feature's flag.
+- **`default_enabled` resolves the retrofit tension**: when the key is entirely absent from `features.yaml`, `premium_feature_enabled` falls back to the caller-supplied default (`"true"` unless the caller passes `"false"`). An **explicit** `enabled: false` in `features.yaml` always wins regardless of the default — that's the new capability (an admin kill-switch that doesn't require uninstalling the CLI). `reindex-on-session-start.sh` passes `"true"` (preserving its pre-#890 install-presence-only gate); a brand-new premium hook authored after this AgDR should default to `"false"` (explicit opt-in) unless it has the same install-base-compatibility constraint.
+- **Fail-safe execution**: the payload always runs inside the timeout wrapper; its exit code is swallowed (`|| true`); the wrapper degrades to no timeout if neither `timeout` nor `gtimeout` exists (payload still runs, just unbounded — matches the pre-existing `reindex-on-session-start.sh` fallback, not a new gap).
+- **Always 0**: `premium_hook_run` has no code path that returns non-zero. Missing required args (`feature_key`, `payload_cmd`) are a silent no-op, not an error.
+- **The convention**: any new premium-touching hook MUST route its premium-only work through `premium_hook_run` instead of hand-rolling gate/timeout/swallow logic. This AgDR is the citation for that convention (see the lib's own header comment).
+
+## Consequences
+
+- `reindex-on-session-start.sh` is retrofitted onto the harness with no observable behaviour change: no CLI → silent; kill-switch → silent; CLI present + no `features.yaml` → reindex still runs; a throwing or hanging `apexyard-search` invocation still can't block the session. See `.claude/hooks/tests/test_reindex_on_session_start.sh`.
+- Adopters gain a new, optional capability for free: setting `search: { enabled: false }` in `features.yaml` disables the reindex hook without uninstalling `apexyard-search`.
+- The `apexyard-premium#514` search self-heal hook (`validate-search-config.sh`, not yet merged onto this branch — it lives in a concurrent PR) is **not** retrofitted in this change. It is a read-only, non-blocking hook by design (see its own header) with a different intent-gate shape (OR, not AND, between `.mcp.json` presence and `features.yaml`), so retrofitting it needs its own follow-on ticket once #514 merges, rather than being force-fit into this harness's AND-shaped gate.
+- Future premium hooks (the `apexyard-premium` budget enforcer's shell wrapper, any hook for the `loops`/`playbooks`/`growth` premium features referenced in `.claude/skills/*.framework.bak`) have one audited call site to route through instead of re-deriving the safe shape.
+- The `default_enabled` parameter is a small but load-bearing API surface: a future maintainer adding a new premium hook must consciously choose `"true"` vs `"false"` rather than get a one-size-fits-all default. Documented in the lib's header and in this AgDR so the choice isn't accidental.
+
+## Artifacts
+
+- Issue: me2resh/apexyard#890
+- Lib: `.claude/hooks/_lib-premium-hook.sh`
+- Retrofit: `.claude/hooks/reindex-on-session-start.sh`
+- Tests: `.claude/hooks/tests/test_lib_premium_hook.sh`, `.claude/hooks/tests/test_reindex_on_session_start.sh`
+- Related: `apexyard-premium#371` (original reindex hook), `apexyard-premium#514` (search self-heal — follow-on retrofit once merged)


### PR DESCRIPTION
## Summary

- **New shared harness `_lib-premium-hook.sh`** — every premium-touching hook (`reindex-on-session-start.sh`, the `#514` search self-heal, and any future premium hook) has historically hand-rolled its own "never block, silent-when-absent, timeout-guarded" shape. That's copy-paste risk: every new premium hook is a fresh chance to drop the timeout guard or let a non-zero exit propagate. `premium_hook_run <feature_key> <presence_check_cmd> <payload_cmd> [default_enabled]` centralizes all three properties in one audited place, so new premium hooks are safe-by-construction instead of safe-by-careful-copy-paste.
- **Two-gate design, both silent-no-op on failure** — the payload only runs if (a) `premium_feature_enabled` says the feature is on in `features.yaml` (scoped-block match, not a blanket grep) AND (b) a caller-supplied presence check passes (e.g. `command -v apexyard-search`). Miss either and it's zero output, zero latency — nothing is even exec'd.
- **Fail-safe execution** — the payload runs inside a `timeout`/`gtimeout`-guarded child process (same preference order as the existing reindex hook) so a hang gets killed rather than blocking the session; its exit code is swallowed either way. `premium_hook_run` itself has no code path that returns non-zero.
- **`reindex-on-session-start.sh` retrofitted, behaviour-preserving** — this hook never checked `features.yaml` before (its only gate was `command -v apexyard-search`). Routing it through the harness with `default_enabled="true"` preserves that exact behaviour for every existing adopter, while adding a *new*, optional capability: `features.yaml`'s `search: { enabled: false }` now works as an admin kill-switch without uninstalling the CLI.
- **AgDR-0073** records the primitive, the retrofit-compat reasoning behind `default_enabled`, and the convention that new premium hooks must route through this harness going forward. It also explicitly scopes out the `#514` search self-heal hook (`validate-search-config.sh`) — that hook lives on a concurrent branch and isn't part of this repo's git history yet, so it's a tracked follow-on once #514 merges, not retrofitted here.
- **Site marketing-copy count refresh** — `reindex-on-session-start.sh` turns out to have never been committed to the framework's git history before this PR (it existed only as an uncommitted file locally). Adding it bumps the tracked hook count from 40 to 41, so `test_site_counts.sh`'s drift check required refreshing the quoted count across `site/*.html`, `site/*.md.gen`, and `site/llms*.txt` in the same PR — done here.

## Testing

- `bash -n` on the new lib and the retrofitted hook — both parse clean.
- New test suite `.claude/hooks/tests/test_lib_premium_hook.sh` (9 cases) exercises the harness directly: feature absent + default-false → silent no-op with the payload never invoked; feature absent + default-true → retrofit-compat (payload runs); an explicit `enabled: false` overriding a `true` default; enabled+present → payload runs; enabled but component absent → silent no-op; a throwing payload (`exit 1`) swallowed; a payload that `sleep 30`s against a 1-second timeout killed and swallowed (verified via wall-clock, ~1s elapsed); missing required args → silent no-op; and the standalone `premium_feature_enabled` helper.
- New regression suite `.claude/hooks/tests/test_reindex_on_session_start.sh` (6 cases) exercises the retrofitted hook end-to-end via a stub `apexyard-search` binary on `PATH`: no CLI → silent; kill-switch → silent; CLI present + no `features.yaml` at all → reindex still runs (the no-regression case); `features.yaml` explicit disable → silent even with the CLI present; a failing stub → hook still exits 0; a hanging stub → hook still exits 0 within the timeout window.
- Full local suite: `bash bin/run-hook-tests.sh` → `PASS=73 FAIL=0 SKIP=0` (includes both new test files and the full pre-existing suite, plus the `test_site_counts.sh` drift check now green after the count refresh).

## Glossary

| Term | Definition |
|------|------------|
| Premium-hook harness | The shared guard (`premium_hook_run`) that gates + fail-safes every premium hook so it can't break non-premium/framework users |
| Safe-shape | never-block / always-exit-0 / silent-no-op-when-absent / timeout-guarded convention, now centralized in one lib instead of copy-pasted per hook |
| Presence check | A caller-supplied shell command string (e.g. `command -v apexyard-search`) whose exit code tells the harness whether the premium component is actually installed |
| `default_enabled` | What `premium_feature_enabled` returns when `features.yaml` doesn't mention the feature key at all — lets a behaviour-preserving retrofit (`"true"`) coexist with a stricter explicit-opt-in posture for brand-new premium hooks (`"false"`) |

Closes #890