### PR TITLE
fix(#888): exempt 'development' + config-driven trunk whitelist in validate-branch-name

### DIFF
--- a/.claude/hooks/tests/test_validate_branch_name_pushref.sh
+++ b/.claude/hooks/tests/test_validate_branch_name_pushref.sh
@@ -128,6 +128,15 @@ run_case "main is exempt as trunk" \
 run_case "dev is exempt as trunk (release-cut model)" \
   "git push origin dev" 0
 
+# ---- #888: 'development' (gitflow long form) trunk exemption -----------
+#
+# Bug: the original hardcoded exact-name list (main|master|develop|dev)
+# missed `development`, the long form used as the integration branch by
+# many Bitbucket/gitflow remotes — a legitimate mirror push to that branch
+# was wrongly blocked as a malformed feature branch.
+run_case "#888: development is exempt as trunk (gitflow long form)" \
+  "git push origin development" 0
+
 # Non-conforming push refs → block (the push-ref is now the source of truth).
 run_case "explicit ref: bogus-branch blocks" \
   "git push origin bogus-branch" 2
@@ -284,6 +293,66 @@ run_case "#693: no-cd explicit non-conforming ref still blocks" \
   "git push origin bogus-branch" 2
 run_case "#693: no-cd no-ref falls back to host HEAD (bogus) → blocks" \
   "git push origin" 2
+
+# ---- #888: config-driven trunk whitelist --------------------------------
+#
+# .branch.trunk_whitelist in .claude/project-config.json is config-driven,
+# mirroring .branch.type_whitelist. A project can add a client-mandated
+# trunk name (e.g. `trunk`) without another upstream PR per name. A real
+# malformed feature branch must still block even with the override present.
+
+# Like make_sandbox_with_wrong_local_branch, but also drops a
+# .claude/project-config.json overriding .branch.trunk_whitelist so the
+# custom name is exempt. Since config_get shallow-merges at the top-level
+# key, this override's "branch" object replaces the defaults' "branch"
+# object wholesale — type_whitelist then falls back to the hook's hardcoded
+# TYPES default, which still contains "feature"/"fix" so the ticket-shape
+# assertions below are unaffected.
+make_sandbox_with_custom_trunk() {
+  local sb
+  sb=$(make_sandbox_with_wrong_local_branch)
+  cat > "$sb/.claude/project-config.json" <<'JSON'
+{
+  "branch": {
+    "trunk_whitelist": ["main", "master", "develop", "dev", "development", "trunk"]
+  }
+}
+JSON
+  echo "$sb"
+}
+
+run_custom_trunk_case() {
+  local label="$1" cmd="$2" want_rc="$3"
+  local sb; sb=$(make_sandbox_with_custom_trunk)
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_rc got_stderr
+  got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/validate-branch-name.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc" >&2
+    echo "    cmd: $cmd" >&2
+    echo "    stderr: ${got_stderr:0:300}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+run_custom_trunk_case "#888: config-added custom trunk 'trunk' is exempt" \
+  "git push origin trunk" 0
+
+run_custom_trunk_case "#888: 'development' still exempt via config override (explicitly listed)" \
+  "git push origin development" 0
+
+run_custom_trunk_case "#888: real malformed feature branch still blocks with trunk override present" \
+  "git push origin feature/no-ticket-id" 2
+
+run_custom_trunk_case "#888: bogus branch still blocks with trunk override present" \
+  "git push origin bogus-branch" 2
 
 # ---- Summary ------------------------------------------------------------
 

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -85,7 +85,28 @@ fi
 
 # Allow trunk and shared integration branches.
 # Match the dev/main release model (apexyard#116) — dev is a valid trunk.
-if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ] || [ "$CURRENT_BRANCH" = "develop" ] || [ "$CURRENT_BRANCH" = "dev" ]; then
+#
+# The trunk list is project-configurable via .claude/project-config.json
+# (.branch.trunk_whitelist), mirroring how .branch.type_whitelist is read
+# below. This covers client-mandated trunk names apexyard doesn't ship by
+# default (e.g. `trunk`, `staging`) without another upstream PR per name.
+# Defaults ship at .claude/project-config.defaults.json and include
+# `development` — the gitflow long form used as the integration branch by
+# many Bitbucket/gitflow remotes, missed by the original hardcoded exact-name
+# list. See me2resh/apexyard#888.
+REPO_ROOT_FOR_TRUNK=$(git rev-parse --show-toplevel 2>/dev/null)
+TRUNK_BRANCHES=""
+if [ -n "$REPO_ROOT_FOR_TRUNK" ] && [ -f "$REPO_ROOT_FOR_TRUNK/.claude/hooks/_lib-read-config.sh" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$REPO_ROOT_FOR_TRUNK/.claude/hooks/_lib-read-config.sh"
+  TRUNK_BRANCHES=$(config_get '.branch.trunk_whitelist[]')
+fi
+# Fallback if config unavailable (jq missing, standalone install, no config
+# entry, etc.) — preserves today's behaviour plus the `development` fix.
+if [ -z "$TRUNK_BRANCHES" ]; then
+  TRUNK_BRANCHES=$'main\nmaster\ndevelop\ndev\ndevelopment'
+fi
+if echo "$TRUNK_BRANCHES" | grep -qxF "$CURRENT_BRANCH"; then
   exit 0
 fi
 

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -68,6 +68,14 @@
       "build",
       "perf",
       "sync"
+    ],
+    "_trunk_whitelist_comment": "Trunk/shared-integration branch names validate-branch-name.sh exempts from the {type}/{TICKET}-{description} shape entirely. Includes `development` — the gitflow long form some Bitbucket/gitflow remotes use as the integration branch, missed by the original hardcoded main/master/develop/dev list. Extend in .claude/project-config.json (REPLACES this array) to add client-mandated trunk names (e.g. `trunk`, `staging`). See me2resh/apexyard#888.",
+    "trunk_whitelist": [
+      "main",
+      "master",
+      "develop",
+      "dev",
+      "development"
     ]
   },
 


### PR DESCRIPTION
## Summary
- **`development` was silently blocked as a trunk branch** — `validate-branch-name.sh`'s trunk exemption used a hardcoded exact-name list (`main`/`master`/`develop`/`dev`) that missed `development`, the gitflow long form many Bitbucket/gitflow remotes use as their shared integration branch. A legitimate mirror push targeting that branch was rejected as a malformed feature branch even though the hook's own intent is to allow shared integration branches.
- **Trunk list is now config-driven** — the hook reads `.branch.trunk_whitelist` via `_lib-read-config.sh`, mirroring how `.branch.type_whitelist` is already read a few lines below it. Adopters with a client-mandated trunk name (e.g. `trunk`, `staging`) can add it via `.claude/project-config.json` without waiting on another upstream PR.
- **Fallback preserved** — when config is unavailable (jq missing, standalone install), the hook falls back to a hardcoded list that now includes `development` alongside the original four names, so the fix holds even without `jq`.
- **`project-config.defaults.json`** ships the new `.branch.trunk_whitelist` default (`main`, `master`, `develop`, `dev`, `development`).

## Testing
1. `bash .claude/hooks/tests/test_validate_branch_name_pushref.sh` — 39/39 pass, including new cases:
   - `git push origin development` → exempt (was: blocked)
   - a config-added custom trunk (`trunk`) → exempt
   - a real malformed feature branch (`feature/no-ticket-id`) → still blocked, even with a trunk override present
2. `bash -n .claude/hooks/validate-branch-name.sh` and `shellcheck` both clean.
3. `jq empty .claude/project-config.defaults.json` confirms the config edit is valid JSON.

**Follow-up (separate issue, not fixed here):** the issue's bonus finding — the push-command detection greps the whole Bash command string and can misparse a heredoc body containing a literal push example — is a distinct defect worth its own ticket. Not addressed in this PR.

Closes #888

---

## Glossary
| Term | Definition |
|------|------------|
| Trunk / integration branch | A long-lived shared branch (e.g. `main`, `dev`, `develop`) that individual feature branches merge into; exempt from the `{type}/{TICKET}-{description}` naming convention because it has no ticket of its own. |
| gitflow long form | Some gitflow/Bitbucket setups name their integration branch `development` instead of the shorter `develop`/`dev` — same role, different spelling. |
| Config-driven whitelist | A list read from `.claude/project-config.json` (via `_lib-read-config.sh`) instead of hardcoded in the shell script, so adopters can extend it without a code change. |
| Push-ref extraction | The hook resolves the branch to validate from the actual `git push` command's destination ref (via `_lib-extract-push-ref.sh`), not from local `HEAD` — needed for worktree-safe validation. |
