### PR TITLE
fix(#887): scope pr_base_repo to an explicit repo (no ambient gh resolution)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -57,8 +57,8 @@ Invoked when a PR is ready for review.
 
 ## Input
 
-- PR number or URL
-- Repository (any repository the user authorises)
+- PR number or URL — `{number}` below
+- Repository (any repository the user authorises) — `{repo}` below, threaded in by the invoking skill (`/code-review <pr> [repo]`). Never re-derive this from an unscoped `gh pr view {number} --json headRepository` call — see the marker section's `#887` note.
 
 ## Codebase grounding — prefer semantic search when available
 
@@ -661,18 +661,33 @@ MARKER_HOME="${OPS_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 # shellcheck source=/dev/null
 . "$MARKER_HOME/.claude/hooks/_lib-tracker.sh"
 mkdir -p "$MARKER_HOME/.claude/session/reviews"
-# Resolve the head (fork) repo — used ONLY as the hint/fallback for the base
-# resolver below. It is NO LONGER the marker key (that was the cross-fork bug —
-# see #765).
-PR_REPO=$(gh pr view {number} --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+# Resolve the repo YOU already know hosts this PR — that is how you got
+# {number} in the first place (the `{repo}` input above, when the invoking
+# skill threaded it through). NEVER re-derive this via an unscoped
+# `gh pr view {number} --json headRepository` call: that call (a) reads the
+# WRONG field for this purpose (the PR's head/fork, not its base) and (b) is
+# itself an unscoped, ambient-resolved gh query — the exact class of bug #887
+# fixed (gh's ambient default prefers the parent/upstream, which is wrong for
+# a same-repo fork PR opened against the fork's own main). When {repo} wasn't
+# threaded through, fall back to the CURRENT checkout's own remote — a
+# deterministic, non-ambient source of truth — never to a second gh guess.
+REPO="{repo}"
+if [ -z "$REPO" ] || [ "$REPO" = "{repo}" ]; then
+  origin_url=$(git remote get-url origin 2>/dev/null)
+  origin_url="${origin_url%.git}"
+  REPO=$(printf '%s' "$origin_url" | sed -E 's#^(https?://[^/]+/|git@[^:]+:)##')
+fi
 
 # Resolve the PR/MR HOST (base) repo — the repo the PR lives on. It is BOTH where
 # the review must be POSTED (posting to the fork fails on a cross-fork PR: the PR
 # lives on the base) AND the canonical key for the approval marker. `pr_base_repo`
-# (in _lib-review-markers.sh) parses the PR URL — gh pr view has no baseRepository
-# field — and falls back to PR_REPO when base == head, so same-repo PRs are
-# unchanged.
-PR_HOST_REPO=$(pr_base_repo {number} "$PR_REPO")
+# (in _lib-review-markers.sh) now REQUIRES this explicit $REPO and scopes its gh
+# query to it — NEVER gh's ambient/parent-preferring default (#887). Scoping to
+# the repo you already know hosts the PR is authoritative, not a guess: a PR
+# object only resolves through its own base repo's API path, so passing the
+# wrong repo here fails closed instead of silently keying the marker on an
+# unrelated repo.
+PR_HOST_REPO=$(pr_base_repo {number} "$REPO")
 
 # Marker keyed on the BASE repo (#765) — this MATCHES what block-unreviewed-merge.sh
 # looks up: the gate keys on the merge command's --repo / API-path, which for a

--- a/.claude/agents/solution-architect.md
+++ b/.claude/agents/solution-architect.md
@@ -188,16 +188,23 @@ THREADED_REPO="{repo}"
 
 # 2a. Resolve the PR's BASE (host) repo ONCE — the canonical key for BOTH the
 # review posting AND the sign-off marker (#765). $THREADED_REPO (when
-# /design-review passed it, #687) is the hint; otherwise headRepository. Then
-# pr_base_repo (in _lib-review-markers.sh) resolves the base from the PR URL
-# (gh pr view has no baseRepository field) and falls back to the hint when
-# base == head — so same-repo PRs are unchanged.
+# /design-review passed it, #687) is the repo you already know hosts the PR;
+# otherwise fall back to the CURRENT checkout's own remote — a deterministic,
+# non-ambient source of truth. Do NOT fall back to an unscoped
+# `gh pr view {number} --json headRepository`: that call reads the WRONG field
+# (the PR's head/fork) AND is itself an ambient-resolved gh query that prefers
+# the parent/upstream — the exact class of bug that misresolved same-repo fork
+# PRs (#887). `pr_base_repo` (in _lib-review-markers.sh) now REQUIRES this
+# explicit repo and scopes its own gh query to it — never gh's ambient
+# default — so same-repo PRs still resolve unchanged.
 if [ -n "$THREADED_REPO" ]; then
-  HINT_REPO="$THREADED_REPO"
+  REPO_FOR_BASE="$THREADED_REPO"
 else
-  HINT_REPO=$(gh pr view {number} --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+  origin_url=$(git remote get-url origin 2>/dev/null)
+  origin_url="${origin_url%.git}"
+  REPO_FOR_BASE=$(printf '%s' "$origin_url" | sed -E 's#^(https?://[^/]+/|git@[^:]+:)##')
 fi
-PR_HOST_REPO=$(pr_base_repo {number} "$HINT_REPO")
+PR_HOST_REPO=$(pr_base_repo {number} "$REPO_FOR_BASE")
 REPO="$PR_HOST_REPO"      # the --repo flag for gh pr view when writing the marker SHA
 PR_REPO="$PR_HOST_REPO"   # marker key = the base repo (matches the gate's lookup)
 

--- a/.claude/hooks/_lib-review-markers.sh
+++ b/.claude/hooks/_lib-review-markers.sh
@@ -89,7 +89,7 @@ review_marker_path() {
   printf '%s/%s__%s-%s.approved' "$reviews_dir" "$safe_repo" "$pr" "$role"
 }
 
-# pr_base_repo <pr> [hint_repo]
+# pr_base_repo <pr> <repo>
 #
 # Echoes the PR/MR's BASE (host) repo as "owner/repo" — the repo the PR *lives
 # on* and is numbered against. This is the canonical key for approval markers
@@ -108,38 +108,68 @@ review_marker_path() {
 # a valid approval never satisfied the gate. Keying every writer on the base via
 # this helper makes writer/reader agreement STRUCTURAL, not coincidental.
 #
+# WHY A REQUIRED <repo>, NOT GH'S AMBIENT DEFAULT (me2resh/apexyard#887)
+# -----------------------------------------------------------------------
+# An earlier version queried `gh pr view "$pr" --json url` with NO --repo,
+# trusting gh's ambient base-repo resolution (from the working copy's remotes)
+# to prefer the parent/upstream. That assumption holds for a PR filed FROM a
+# fork branch TO upstream (ambient parent happens to equal the true base) but
+# NOT for a SAME-REPO fork PR (opened against the fork's own main) — there
+# gh's ambient default STILL prefers the parent even though the true base is
+# the fork itself. The unscoped call then SUCCEEDS with the WRONG repo: it
+# resolves to an unrelated PR of the same number on the parent, and the old
+# hint/fallback path only fired on a gh ERROR, never on this wrong-but-
+# successful resolution. Reviews got posted to, and merge markers got keyed
+# on, a public repo the PR never lived on. See #887.
+#
+# The fix: never let gh guess. `<repo>` is now REQUIRED — the repo the CALLER
+# already knows hosts this PR (that is how it found the PR number in the
+# first place: an explicit `[repo]` skill argument, an `owner/repo#N` the user
+# named, or the current checkout's own remote). Scoping to it is authoritative,
+# not a "hint": a PR object only resolves through its own base repo's API
+# namespace, so `gh pr view <pr> --repo <repo>` can only succeed when <repo>
+# IS that PR's base — querying through the wrong repo (e.g. the head/fork of a
+# genuine cross-fork PR) fails closed (gh 404s) instead of silently returning
+# an unrelated repo's data. Do NOT pass the head/fork repo here on the
+# assumption it's "close enough" — pass the repo you are confident hosts the
+# PR (almost always the project's own base repo you're reviewing/merging
+# against).
+#
 # `gh pr view` exposes no baseRepository field, but the PR URL is ALWAYS rooted
 # on the base repo — parse owner/repo from it (handles GitHub /pull/ and GitLab
-# /-/merge_requests/, including nested GitLab groups). Falls back to <hint_repo>
-# (typically the headRepository value) when the URL can't be parsed or gh is
-# unavailable — so SAME-REPO PRs (base == head) resolve exactly as before and
-# this change is a provable no-op for them.
+# /-/merge_requests/, including nested GitLab groups). Falls back to the passed
+# <repo> when the URL can't be parsed or the scoped gh call fails — so SAME-REPO
+# PRs (base == head) resolve exactly as before and this change is a provable
+# no-op for them.
 #
 # Args:
-#   pr        — the PR/MR number.
-#   hint_repo — optional "owner/repo": the VALUE fallback when the URL can't be
-#               parsed or gh is unavailable. It is NEVER used to scope the gh
-#               query — see the WHY-UNSCOPED note in the body below.
+#   pr    — the PR/MR number.
+#   repo  — REQUIRED "owner/repo": the repo the caller already knows hosts
+#           this PR. Used to SCOPE the gh query (`--repo`), never omitted in
+#           favour of gh's ambient default.
 #
-# Output (stdout): "owner/repo", or the hint (or empty) when unresolved.
+# Output (stdout): "owner/repo" derived from the resolved PR URL, or the
+# passed-in <repo> when the scoped query fails/is unparseable (fail-soft — the
+# caller's own repo is still the best available answer).
+# Exit code: 0 normally; 1 (with a stderr message, no stdout) when <pr> is
+# given but <repo> is missing — there is nothing safe to scope the query to.
 pr_base_repo() {
-  local pr="${1:-}" hint="${2:-}" url base
+  local pr="${1:-}" repo="${2:-}" url base
   if [ -z "$pr" ]; then
-    [ -n "$hint" ] && printf '%s' "$hint"
+    [ -n "$repo" ] && printf '%s' "$repo"
     return 0
   fi
-  # WHY UNSCOPED (me2resh/apexyard#770 review): query with NO --repo. gh's ambient
-  # base-repo resolution (from the working copy's remotes) prefers the parent /
-  # upstream — i.e. the BASE repo — which is exactly the key we want. Scoping with
-  # `--repo "$hint"` (the head/fork) would look up the base-numbered PR on the fork,
-  # where it does not exist → gh errors → empty url → the hint (fork) fallback fires
-  # → the #765 divergence is re-created on the very cross-fork path this helper
-  # exists to fix. So the hint is a VALUE fallback only, never a query scope.
-  url=$(gh pr view "$pr" --json url --jq '.url' 2>/dev/null)
+  if [ -z "$repo" ]; then
+    echo "_lib-review-markers.sh: pr_base_repo requires an explicit <repo> (never gh's ambient default — see me2resh/apexyard#887)" >&2
+    return 1
+  fi
+  # ALWAYS scoped to the caller-supplied repo — never an unscoped/ambient gh
+  # call. See the WHY-A-REQUIRED-REPO note above.
+  url=$(gh pr view "$pr" --repo "$repo" --json url,baseRefName --jq '.url' 2>/dev/null)
   base=$(printf '%s' "$url" | sed -E 's#^https?://[^/]+/(.+)/(pull|-/merge_requests)/[0-9].*#\1#')
   if [ -n "$base" ] && [ "$base" != "$url" ]; then
     printf '%s' "$base"
   else
-    [ -n "$hint" ] && printf '%s' "$hint"
+    printf '%s' "$repo"
   fi
 }

--- a/.claude/hooks/tests/test_pr_base_repo.sh
+++ b/.claude/hooks/tests/test_pr_base_repo.sh
@@ -1,20 +1,26 @@
 #!/bin/bash
 # Tests for pr_base_repo (+ its interaction with review_marker_path) in
-# _lib-review-markers.sh — the cross-fork approval-marker fix (me2resh/apexyard#765).
+# _lib-review-markers.sh — the cross-fork approval-marker fix (me2resh/apexyard#765)
+# and the scoping fix for the same-repo-fork-PR regression (me2resh/apexyard#887).
 #
-# pr_base_repo resolves a PR's BASE repo (the canonical marker key) by parsing the
-# PR URL, falling back to a hint when base == head or gh fails. The discriminating
-# assertions prove: (a) cross-fork keys on BASE, (b) same-repo is UNCHANGED.
+# pr_base_repo resolves a PR's BASE repo (the canonical marker key) by SCOPING
+# its gh query to a REQUIRED <repo> arg — the repo the caller already knows
+# hosts the PR — and parsing the base out of the returned PR URL. It no longer
+# accepts an optional "hint" queried unscoped: #887 showed that an unscoped
+# `gh pr view` can SUCCEED with the WRONG repo whenever gh's ambient default
+# (which prefers the parent/upstream) doesn't match the PR's true base — e.g. a
+# same-repo fork PR opened against the fork's own main. Scoping to the repo the
+# caller enumerated the PR from turns "wrong repo" into a clean gh failure
+# instead of a silently wrong answer.
 #
-# gh is mocked via a file-driven stub (no env-export subtleties): the stub prints
-# the contents of $MOCKBIN/url, or exits non-zero when that file is empty.
-#
-# The stub is --repo-AWARE (me2resh/apexyard#770 review): a `gh pr view --repo <r>`
-# call only resolves when <r> is the BASE repo in the queued URL; scoping to any
-# other repo (e.g. the fork on a cross-fork PR) fails exactly like real gh rejecting
-# a base-numbered PR looked up on the fork. This makes the cross-fork case below
-# LOAD-BEARING: it fails if pr_base_repo ever re-introduces `--repo "$hint"` scoping
-# (the query MUST be unscoped) and passes only when the base is genuinely resolved.
+# gh is mocked via a file-driven stub (no env-export subtleties): the stub
+# prints the contents of $MOCKBIN/url when queried --repo-scoped to the URL's
+# own base, exits non-zero when scoped to any other repo (mirroring real gh
+# refusing to resolve a base-numbered PR through an unrelated repo's API path),
+# and — to make the #887 regression provable — returns $MOCKBIN/wrong-url
+# instead when called WITHOUT --repo at all (modelling gh's ambient default
+# wrongly-but-successfully resolving to the parent). If pr_base_repo ever stops
+# passing --repo, the wrong-url path fires and the assertions below catch it.
 
 set -u
 
@@ -32,64 +38,107 @@ assert_eq() { # <label> <want> <got>
 MOCKBIN=$(mktemp -d)
 cat > "$MOCKBIN/gh" <<EOF
 #!/bin/bash
-# mock gh (--repo-aware): emit the queued URL only when the query would resolve —
-# i.e. UNSCOPED (ambient base resolution) OR --repo naming the base repo in the
-# queued URL. A --repo pointing anywhere else (the fork) fails, like real gh
-# rejecting a base-numbered PR looked up on the fork. Empty queue → fail.
+# mock gh (--repo-aware, #887-aware):
+#   - --repo omitted            → return \$MOCKBIN/wrong-url if set (models gh's
+#                                  ambient/parent-preferring default resolving
+#                                  successfully to the WRONG PR), else \$url.
+#                                  A fixed implementation must never hit this
+#                                  branch — pr_base_repo always passes --repo.
+#   - --repo == the URL's base  → success, prints \$url.
+#   - --repo == anything else   → fails (gh 404, as real gh would for a PR
+#                                  number that doesn't belong to that repo).
 [ -s "$MOCKBIN/url" ] || exit 1
 url="\$(cat "$MOCKBIN/url")"
 base="\$(printf '%s' "\$url" | sed -E 's#^https?://[^/]+/(.+)/(pull|-/merge_requests)/[0-9].*#\1#')"
 repo=""
+scoped=0
 while [ \$# -gt 0 ]; do
   case "\$1" in
-    --repo) repo="\$2"; shift 2 ;;
+    --repo) repo="\$2"; scoped=1; shift 2 ;;
     *) shift ;;
   esac
 done
-if [ -n "\$repo" ] && [ "\$repo" != "\$base" ]; then exit 1; fi
+if [ "\$scoped" -eq 0 ]; then
+  if [ -s "$MOCKBIN/wrong-url" ]; then cat "$MOCKBIN/wrong-url"; else printf '%s' "\$url"; fi
+  exit 0
+fi
+if [ "\$repo" != "\$base" ]; then exit 1; fi
 printf '%s' "\$url"
 EOF
 chmod +x "$MOCKBIN/gh"
 export PATH="$MOCKBIN:$PATH"
 seturl() { printf '%s' "$1" > "$MOCKBIN/url"; }
+setwrongurl() { printf '%s' "$1" > "$MOCKBIN/wrong-url"; }
+clearwrongurl() { rm -f "$MOCKBIN/wrong-url"; }
 
-# 1. cross-fork gh PR → base parsed from URL (hint = the fork, must be ignored).
+# 1. Caller passes the repo it's confident hosts the PR (the base) → the
+#    scoped query confirms it and parses the canonical form from the URL.
 seturl 'https://github.com/me2resh/apexyard/pull/762'
-assert_eq "cross-fork → base from URL" "me2resh/apexyard" \
-  "$(pr_base_repo 762 AbdElrahmaN31/apexyard)"
+assert_eq "caller-known base repo → confirmed via scoped query" "me2resh/apexyard" \
+  "$(pr_base_repo 762 me2resh/apexyard)"
 
-# 2. same-repo → base == head (UNCHANGED — the provable no-op).
+# 2. same-repo → base == head (UNCHANGED — the provable no-op from #765).
 seturl 'https://github.com/me2resh/apexyard/pull/5'
 assert_eq "same-repo → unchanged" "me2resh/apexyard" \
   "$(pr_base_repo 5 me2resh/apexyard)"
 
-# 3. GitLab MR URL with a nested group → group/subgroup/project.
+# 3. GitLab MR URL with a nested group → group/subgroup/project, confirmed via
+#    the correct repo (not a head/fork guess).
 seturl 'https://gitlab.com/grp/sub/proj/-/merge_requests/12'
-assert_eq "glab nested MR → base" "grp/sub/proj" \
-  "$(pr_base_repo 12 grp/fork)"
+assert_eq "glab nested MR → base confirmed via scoped query" "grp/sub/proj" \
+  "$(pr_base_repo 12 grp/sub/proj)"
 
-# 4. gh fails (no URL queued) → fall back to the hint.
+# 4. gh fails (no URL queued) → fall back to the passed-in repo.
 seturl ''
-assert_eq "gh fail → hint fallback" "me2resh/apexyard" \
+assert_eq "gh fail → repo fallback" "me2resh/apexyard" \
   "$(pr_base_repo 999 me2resh/apexyard)"
 
-# 5. unparseable URL → hint fallback (sed leaves it unchanged → base==url → hint).
+# 5. unparseable URL → repo fallback (sed leaves it unchanged → base==url →
+#    the mock's own base/repo comparison fails closed → repo fallback fires).
 seturl 'https://github.com/not-a-pr-url'
-assert_eq "bad URL → hint fallback" "owner/repo" \
+assert_eq "bad URL → repo fallback" "owner/repo" \
   "$(pr_base_repo 1 owner/repo)"
 
-# 6. no pr number → hint (guard, no gh call).
-assert_eq "no pr → hint" "owner/repo" "$(pr_base_repo '' owner/repo)"
+# 6. no pr number → repo (guard, no gh call).
+assert_eq "no pr → repo" "owner/repo" "$(pr_base_repo '' owner/repo)"
 
-# 7. self-hosted GitHub Enterprise host → base still parsed (host-agnostic).
+# 7. no repo passed (pr given) → required-arg guard fires; empty stdout, no
+#    unscoped gh call is attempted as a substitute.
+seturl 'https://github.com/me2resh/apexyard/pull/5'
+assert_eq "missing repo w/ pr → empty (error path, not a silent guess)" "" \
+  "$(pr_base_repo 5 2>/dev/null)"
+
+# 8. wrong repo passed (e.g. the head/fork of a genuine cross-fork PR) → the
+#    scoped query fails closed and returns the passed repo itself — NOT an
+#    ambient guess at some unrelated repo. Documents the contract: callers
+#    must pass the repo they're confident hosts the PR; passing the wrong one
+#    degrades safely rather than silently returning wrong data.
+seturl 'https://github.com/me2resh/apexyard/pull/762'
+assert_eq "wrong (head/fork) repo passed → fails closed, returns itself" \
+  "AbdElrahmaN31/apexyard" "$(pr_base_repo 762 AbdElrahmaN31/apexyard)"
+
+# 9. self-hosted GitHub Enterprise host → base still parsed (host-agnostic),
+#    confirmed via the correct repo.
 seturl 'https://github.example.com/team/svc/pull/8'
-assert_eq "GHE host → base" "team/svc" "$(pr_base_repo 8 team/fork)"
+assert_eq "GHE host → base confirmed via scoped query" "team/svc" \
+  "$(pr_base_repo 8 team/svc)"
+
+# 10. THE #887 REGRESSION GUARD: a same-repo fork PR, where an unscoped
+#     ambient gh call would succeed but return the WRONG (parent) repo. The
+#     caller passes the repo it actually knows hosts the PR (its own fork);
+#     the fixed implementation must return THAT, never the ambient "wrong"
+#     answer the ungoverned mock branch would produce.
+seturl 'https://github.com/atlas-apex/apexyard/pull/900'
+setwrongurl 'https://github.com/me2resh/apexyard/pull/900'
+assert_eq "#887 same-repo-fork-PR: scoped call ignores ambient parent-preferring default" \
+  "atlas-apex/apexyard" "$(pr_base_repo 900 atlas-apex/apexyard)"
+clearwrongurl
 
 # --- discriminating: the marker PATH keyed via pr_base_repo ---
 MH=$(mktemp -d)
-# cross-fork → marker keyed on BASE (this is the fix).
+# cross-fork → marker keyed on BASE (the #765 fix), repo passed is the base.
 seturl 'https://github.com/me2resh/apexyard/pull/762'
-CF=$(review_marker_path "$(pr_base_repo 762 AbdElrahmaN31/apexyard)" 762 rex "$MH")
+CF=$(review_marker_path "$(pr_base_repo 762 me2resh/apexyard)" 762 rex "$MH")
 assert_eq "cross-fork marker keyed on BASE" \
   "$MH/.claude/session/reviews/me2resh__apexyard__762-rex.approved" "$CF"
 # same-repo → marker path UNCHANGED from the pre-#765 (base==head) behaviour.

--- a/.claude/skills/approve-architecture/SKILL.md
+++ b/.claude/skills/approve-architecture/SKILL.md
@@ -72,11 +72,21 @@ MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
 # Base (host) repo — the canonical marker key: it matches solution-architect.md's
 # architecture marker AND the require-architecture-review.sh gate's lookup (which
 # keys on the merge command's base repo, #765). Prefer the repo resolved in step 1
-# (already the base, #687) as the hint; else headRepository. pr_base_repo confirms
-# the base from the PR URL and falls back to the hint when base == head, so
-# same-repo PRs are unchanged.
-HINT_REPO="${REPO:-$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)}"
-PR_HOST_REPO=$(pr_base_repo <pr> "$HINT_REPO")
+# (already the base, #687); if it wasn't given, fall back to the CURRENT
+# checkout's own remote — a deterministic, non-ambient source of truth. Do NOT
+# fall back to an unscoped `gh pr view <pr> --json headRepository`: that call
+# reads the wrong field (the PR's head/fork) and is itself an ambient-resolved
+# gh query that can silently prefer the wrong repo in a fork checkout (#887).
+# pr_base_repo now REQUIRES this repo and scopes its own gh query to it — never
+# gh's ambient default — so same-repo PRs still resolve unchanged.
+if [ -n "$REPO" ]; then
+  REPO_FOR_BASE="$REPO"
+else
+  origin_url=$(git remote get-url origin 2>/dev/null)
+  origin_url="${origin_url%.git}"
+  REPO_FOR_BASE=$(printf '%s' "$origin_url" | sed -E 's#^(https?://[^/]+/|git@[^:]+:)##')
+fi
+PR_HOST_REPO=$(pr_base_repo <pr> "$REPO_FOR_BASE")
 PR_REPO="$PR_HOST_REPO"
 REX=$(review_marker_path "$PR_HOST_REPO" <pr> rex "$MARKER_HOME")
 [ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "<headRefOid from step 3>" ]

--- a/.claude/skills/approve-design/SKILL.md
+++ b/.claude/skills/approve-design/SKILL.md
@@ -81,11 +81,22 @@ MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
 . "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
 # Base (host) repo — the canonical marker key: it matches Rex's marker AND the
 # merge gate's lookup (which keys on the merge command's base repo, #765). Prefer
-# the repo resolved in step 1 (already the base, #687) as the hint; else
-# headRepository. pr_base_repo confirms the base from the PR URL and falls back to
-# the hint when base == head, so same-repo PRs are unchanged.
-HINT_REPO="${REPO:-$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)}"
-PR_HOST_REPO=$(pr_base_repo <pr> "$HINT_REPO")
+# the repo resolved in step 1 (already the base, #687); if it wasn't given, fall
+# back to the CURRENT checkout's own remote — a deterministic, non-ambient
+# source of truth. Do NOT fall back to an unscoped
+# `gh pr view <pr> --json headRepository`: that call reads the wrong field (the
+# PR's head/fork) and is itself an ambient-resolved gh query that can silently
+# prefer the wrong repo in a fork checkout (#887). pr_base_repo now REQUIRES
+# this repo and scopes its own gh query to it — never gh's ambient default —
+# so same-repo PRs still resolve unchanged.
+if [ -n "$REPO" ]; then
+  REPO_FOR_BASE="$REPO"
+else
+  origin_url=$(git remote get-url origin 2>/dev/null)
+  origin_url="${origin_url%.git}"
+  REPO_FOR_BASE=$(printf '%s' "$origin_url" | sed -E 's#^(https?://[^/]+/|git@[^:]+:)##')
+fi
+PR_HOST_REPO=$(pr_base_repo <pr> "$REPO_FOR_BASE")
 PR_REPO="$PR_HOST_REPO"
 REX=$(review_marker_path "$PR_HOST_REPO" <pr> rex "$MARKER_HOME")
 [ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "$(git rev-parse HEAD)" ]

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -34,7 +34,7 @@ The fact that this skill now runs the merge as part of its default flow does **n
 
 ## Process
 
-### 1. Parse the PR number and flags
+### 1. Parse the PR number, the repo, and flags
 
 Extract the PR number from `$ARGUMENTS`. If no number is given, try to infer from:
 
@@ -42,6 +42,8 @@ Extract the PR number from `$ARGUMENTS`. If no number is given, try to infer fro
 - The user's most recent message, if it named a PR explicitly
 
 If the PR number is ambiguous (multiple PRs on the branch, unclear which was approved), STOP and ask the user which PR.
+
+**Also resolve the repo (`REPO`).** Accept a fully-qualified `owner/repo#N` form, or an explicit `owner/repo` token in `$ARGUMENTS`. When neither was given, fall back to the CURRENT checkout's own remote (`git remote get-url origin`, parsed to `owner/repo`) — a deterministic, non-ambient source of truth. Do **NOT** resolve this via an unscoped `gh pr view <pr> --json headRepository`: that call reads the wrong field (the PR's head/fork, not something to key markers on) and is itself an ambient-resolved gh query that can silently prefer the wrong repo in a fork checkout (me2resh/apexyard#887). Every `gh pr view` call below must pass `--repo "$REPO"`.
 
 Recognise the optional `--no-merge` flag. When present, the skill writes the marker but does NOT run the merge. Useful for the rare cases below — see § "Notes" for when to use it.
 
@@ -59,7 +61,7 @@ Only proceed past this step if the user has given an unambiguous per-PR approval
 ### 3. Verify the PR state
 
 ```bash
-gh pr view <pr> --repo <owner/repo> --json state,isDraft,mergeable,headRefOid
+gh pr view <pr> --repo "$REPO" --json state,isDraft,mergeable,headRefOid
 ```
 
 Sanity checks:
@@ -106,15 +108,15 @@ MARKER_HOME="${OPS_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 # Source the marker path helper — repo-qualified naming (#485, AgDR-0060).
 # shellcheck source=/dev/null
 . "$MARKER_HOME/.claude/hooks/_lib-review-markers.sh"
-# The PR's HEAD (fork) repo — used ONLY as the hint/fallback for the base resolver.
-PR_REPO=$(gh pr view <pr> --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
 # The PR's BASE (host) repo — the canonical marker key AND the repo you merge
 # against. Rex wrote its marker under the BASE (that is what code-reviewer.md and
-# the merge gate use, #765), so read + write markers here. `pr_base_repo` parses
-# the PR URL and falls back to PR_REPO when base == head, so same-repo PRs are
-# unchanged. Use $PR_HOST_REPO as `--repo` for EVERY gh call in this skill
-# (`<owner/repo>` throughout = $PR_HOST_REPO) — you cannot merge a fork's copy.
-PR_HOST_REPO=$(pr_base_repo <pr> "$PR_REPO")
+# the merge gate use, #765), so read + write markers here. `pr_base_repo` REQUIRES
+# the $REPO resolved in step 1 (the repo you already know hosts this PR) and
+# scopes its own gh query to it — never gh's ambient/parent-preferring default
+# (#887) — so same-repo PRs still resolve unchanged. Use $PR_HOST_REPO as
+# `--repo` for EVERY gh call in this skill (`<owner/repo>` throughout =
+# $PR_HOST_REPO) — you cannot merge a fork's copy.
+PR_HOST_REPO=$(pr_base_repo <pr> "$REPO")
 REX=$(review_marker_path "$PR_HOST_REPO" <pr> rex "$MARKER_HOME")
 [ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "<headRefOid from step 3>" ]
 ```


### PR DESCRIPTION
## Summary

- **`pr_base_repo()` no longer trusts gh's ambient repo resolution** — it previously ran `gh pr view "$pr" --json url` with no `--repo`, relying on gh's ambient default (which prefers the parent/upstream in a fork checkout) to land on the PR's base repo. That happened to work for a PR filed *from* a fork *to* upstream, but broke silently for a same-repo fork PR (opened against the fork's own `main`): ambient resolution still preferred the parent, so the call **succeeded with the wrong repo** — reviews posted to an unrelated public PR of the same number, and merge markers keyed to the wrong repo so a valid review never satisfied the fork's own merge gate.
- **The function now requires an explicit `<repo>` argument** — the repo the caller already knows hosts the PR — and scopes every `gh pr view` call to it. This turns "wrong repo" into a clean gh failure instead of a silently wrong answer: a PR object only resolves through its own base repo's API path, so scoping to the correct repo is authoritative, not a guess.
- **Updated all five callers** (`code-reviewer.md`, `solution-architect.md`, and the `approve-merge` / `approve-architecture` / `approve-design` skills) to stop deriving "the repo" via an unscoped `gh pr view --json headRepository` call — which read the wrong field (the PR's head/fork, not something to key a base-repo marker on) *and* was itself an ambient-resolved query. They now thread through the repo already known from context (an explicit skill/agent argument) or fall back to the current checkout's own `git remote get-url origin` — never a second ambient gh guess.
- **Rewrote `test_pr_base_repo.sh`** for the new required-repo signature, including a regression case that models the exact #887 scenario: an unscoped call would succeed with the wrong (parent) repo, but the fixed, always-scoped call returns the correct one.

## Testing

```bash
bash .claude/hooks/tests/test_pr_base_repo.sh   # 12/12 assertions pass
bash bin/run-hook-tests.sh                       # 102 PASS / 1 FAIL (pre-existing, unrelated)
```

The one failing suite (`test_sync_codex_adapter.sh`) fails identically on `upstream/dev` before this change (a stale local fixture path, `block-test.sh`, unrelated to review markers) — confirmed by stashing this diff and re-running the same test.

## Glossary

| Term | Definition |
|------|------------|
| Ambient repo resolution | `gh`'s behaviour of inferring the target repo from the working copy's remotes when `--repo` is omitted — in a fork checkout it prefers the parent/upstream |
| Same-repo fork PR | A PR whose base and head branches both live in the fork (base != upstream) |
| Base (host) repo | The repo a PR is numbered against and lives on — the canonical key for review/approval markers (#765) |
| Fail closed | When the repo passed to `pr_base_repo` is wrong, the scoped gh query cleanly fails and the function returns the caller's own (wrong) input rather than silently guessing at an unrelated repo |

Closes #887
