### PR TITLE
feat(#900): split-portfolio session-start primer

### DIFF
--- a/.claude/hooks/print-portfolio-primer.sh
+++ b/.claude/hooks/print-portfolio-primer.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# SessionStart hook: split-portfolio v2 primer banner.
+#
+# Adopter feedback (me2resh/apexyard#900): in split-portfolio v2 mode
+# (a public ops fork sitting beside a private `<company>-portfolio`
+# repo), agents repeatedly looked in the WRONG place for a managed
+# project's workspace clone and missed the sibling repo entirely —
+# reproduced across both Claude Code and Codex. Nothing told the agent
+# at session start where things actually live, so every session
+# re-guessed. This hook closes that gap: it prints a concise banner,
+# with absolute paths, naming the ops-fork root, the sibling portfolio
+# dir, the workspace dir, and the registry — the four paths every
+# portfolio-aware skill needs and that adopters kept having to point
+# out by hand.
+#
+# Detection (per the ticket): BOTH of —
+#   1. the `.apexyard-fork` marker is present at the resolved ops root
+#   2. the resolved `portfolio.*` paths (registry / workspace_dir /
+#      onboarding) actually point OUTSIDE the ops-fork root — i.e. at a
+#      sibling repo, not just the in-fork defaults.
+#
+# Condition 1 alone is NOT sufficient — the marker is written by /setup
+# for single-fork adopters too (see _lib-ops-root.sh's header comment),
+# so single-fork-but-migrated forks must stay silent. Only the
+# combination of "v2 marker present" AND "portfolio paths resolve to a
+# sibling directory" means the banner has something useful to say.
+#
+# Silent (no output, exit 0) when:
+#   - not a git repo
+#   - no ops-fork root can be resolved (not an apexyard fork at all)
+#   - the portfolio-paths / config helper libs are missing
+#   - the `.apexyard-fork` marker is absent (not on v2 at all)
+#   - the marker is present but every portfolio path still resolves
+#     in-fork (single-fork mode, just carrying the v2 marker)
+#
+# Always exits 0 — this is a pure informational primer, never a gate.
+#
+# Runtime: a few ms (no network, one JSON parse of project-config.json
+# via the already-shared _lib-read-config.sh cache).
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Resolve the ops-fork root via the shared pin-first/walk-up resolver so
+# this hook behaves consistently with every other portfolio-aware hook.
+ROOT=""
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  ROOT=$(resolve_ops_root "$REPO_ROOT")
+else
+  cur="$REPO_ROOT"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/.apexyard-fork" ]; then
+      ROOT="$cur"
+      break
+    fi
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      ROOT="$cur"
+      break
+    fi
+    parent=$(dirname "$cur"); [ "$parent" = "$cur" ] && break; cur="$parent"
+  done
+fi
+
+if [ -z "$ROOT" ]; then
+  exit 0
+fi
+
+# Condition 1: the v2 marker must be present. Its absence means either a
+# legacy un-migrated fork or a v1 layout — neither is split-portfolio v2,
+# so there is nothing to primer.
+if [ ! -f "$ROOT/.apexyard-fork" ]; then
+  exit 0
+fi
+
+CONFIG_LIB="$ROOT/.claude/hooks/_lib-read-config.sh"
+PORTFOLIO_LIB="$ROOT/.claude/hooks/_lib-portfolio-paths.sh"
+
+if [ ! -f "$CONFIG_LIB" ] || [ ! -f "$PORTFOLIO_LIB" ]; then
+  # Helpers not present — can't resolve paths safely. Silent.
+  exit 0
+fi
+
+# shellcheck source=/dev/null
+. "$CONFIG_LIB"
+# shellcheck source=/dev/null
+. "$PORTFOLIO_LIB"
+
+REGISTRY=$(portfolio_registry)
+WORKSPACE_DIR=$(portfolio_workspace_dir)
+ONBOARDING=$(portfolio_onboarding_path)
+
+# Condition 2: at least one of the portfolio paths must resolve OUTSIDE
+# the ops-fork root. Compare against the real (symlink-resolved) root so
+# this matches portfolio_validate's own outside-fork check.
+ROOT_REAL=$(cd "$ROOT" 2>/dev/null && pwd -P) || ROOT_REAL="$ROOT"
+
+_outside_root() {
+  case "$1" in
+    "$ROOT_REAL"|"$ROOT_REAL"/*) return 1 ;;
+  esac
+  return 0
+}
+
+IS_SPLIT=1
+if ! _outside_root "$REGISTRY" && ! _outside_root "$WORKSPACE_DIR" && ! _outside_root "$ONBOARDING"; then
+  IS_SPLIT=0
+fi
+
+if [ "$IS_SPLIT" -ne 1 ]; then
+  # Marker present but every path still resolves in-fork — single-fork
+  # mode that merely carries the v2 marker. Silent.
+  exit 0
+fi
+
+# The sibling `<company>-portfolio` dir is the directory that holds the
+# registry file — that's the private repo every split-portfolio v2
+# adopter is told to create in docs/multi-project.md. Fall back to the
+# workspace dir's parent if the registry itself is (unusually) in-fork
+# but the workspace isn't, so the banner still names a sibling path.
+if _outside_root "$REGISTRY"; then
+  SIBLING_DIR=$(dirname "$REGISTRY")
+else
+  SIBLING_DIR=$(dirname "$WORKSPACE_DIR")
+fi
+
+cat <<MSG
+ApexYard: split-portfolio v2 detected — here's where things live (absolute paths):
+  Ops-fork root:     $ROOT
+  Portfolio (sibling): $SIBLING_DIR
+  Workspace dir:      $WORKSPACE_DIR
+  Registry:            $REGISTRY
+MSG
+
+exit 0

--- a/.claude/hooks/tests/test_print_portfolio_primer.sh
+++ b/.claude/hooks/tests/test_print_portfolio_primer.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/print-portfolio-primer.sh (me2resh/apexyard#900)
+#
+# Each case builds an isolated sandbox git repo under $TMPDIR, drops the
+# hook + its shared libs (_lib-ops-root.sh, _lib-read-config.sh,
+# _lib-portfolio-paths.sh, project-config.defaults.json) into it, then
+# asserts the hook's banner / silence behavior:
+#
+#   1. split-portfolio v2 (marker + sibling-pointing portfolio block)
+#      → banner fires, naming all four absolute paths
+#   2. single-fork mode (no .apexyard-fork marker at all)
+#      → silent
+#   3. marker present but portfolio block still resolves in-fork
+#      (single-fork adopter who merely carries the v2 marker)
+#      → silent
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/print-portfolio-primer.sh"
+LIB_OPS="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
+LIB_PORT="$SRC_ROOT/.claude/hooks/_lib-portfolio-paths.sh"
+LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+
+for f in "$HOOK_SRC" "$LIB_OPS" "$LIB_PORT" "$LIB_CFG" "$DEFAULTS"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: missing $f" >&2
+    exit 1
+  fi
+done
+
+PASS=0
+FAIL=0
+FAILED=""
+
+mark_pass() { echo "PASS [$1]"; PASS=$((PASS+1)); }
+mark_fail() { echo "FAIL [$1] — $2" >&2; FAIL=$((FAIL+1)); FAILED="${FAILED}${1}; "; }
+
+assert_silent() {
+  local label="$1" output="$2"
+  if [ -z "$output" ]; then
+    mark_pass "$label"
+  else
+    mark_fail "$label" "expected silent, got: $output"
+  fi
+}
+
+assert_contains_all() {
+  local label="$1" output="$2"; shift 2
+  local missing=""
+  for pattern in "$@"; do
+    if ! printf '%s' "$output" | grep -qF -- "$pattern"; then
+      missing="${missing}[$pattern] "
+    fi
+  done
+  if [ -z "$missing" ]; then
+    mark_pass "$label"
+  else
+    mark_fail "$label" "missing patterns: $missing — got: $output"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# make_public_fork_base: build a public-fork-shaped sandbox with the hook +
+# shared libs copied in and initialised as a git repo. No portfolio config
+# or marker yet — callers add those per-case.
+# ---------------------------------------------------------------------------
+make_public_fork_base() {
+  local sb
+  sb=$(mktemp -d)
+  sb=$(cd "$sb" && pwd -P)
+  mkdir -p "$sb/.claude/hooks"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/print-portfolio-primer.sh"
+  cp "$LIB_OPS" "$sb/.claude/hooks/_lib-ops-root.sh"
+  cp "$LIB_PORT" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  cp "$LIB_CFG" "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$DEFAULTS" "$sb/.claude/project-config.defaults.json"
+  chmod +x "$sb/.claude/hooks/print-portfolio-primer.sh"
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    git add -A
+    git commit -q -m "fixture: base fork"
+  )
+  echo "$sb"
+}
+
+run_hook_from() {
+  local dir="$1"
+  ( cd "$dir" || exit 1; APEXYARD_OPS_DISABLE_PIN=1 bash .claude/hooks/print-portfolio-primer.sh 2>&1 )
+}
+
+# ---------------------------------------------------------------------------
+# CASE 1: split-portfolio v2 — marker present, portfolio block points at a
+# sibling repo. Banner must fire and name all four absolute paths.
+# ---------------------------------------------------------------------------
+case_split_v2_prints_paths() {
+  local pub priv
+  pub=$(make_public_fork_base)
+  priv=$(mktemp -d); priv=$(cd "$priv" && pwd -P)/acme-portfolio
+  mkdir -p "$priv/projects" "$priv/workspace"
+  cat > "$priv/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: demo
+    repo: example/demo
+YAML
+  echo "# Ideas" > "$priv/projects/ideas-backlog.md"
+  echo "company: {name: Acme}" > "$priv/onboarding.yaml"
+
+  (
+    cd "$pub" || exit 1
+    echo "# v2 marker" > .apexyard-fork
+    cat > .claude/project-config.json <<JSON
+{
+  "portfolio": {
+    "registry": "$priv/apexyard.projects.yaml",
+    "projects_dir": "$priv/projects",
+    "ideas_backlog": "$priv/projects/ideas-backlog.md",
+    "onboarding": "$priv/onboarding.yaml",
+    "workspace_dir": "$priv/workspace"
+  }
+}
+JSON
+    git add -A
+    git commit -q -m "fixture: split-portfolio v2 config"
+  )
+
+  local out
+  out=$(run_hook_from "$pub")
+  assert_contains_all "split-portfolio v2 prints all four absolute paths" "$out" \
+    "$pub" \
+    "$priv" \
+    "$priv/workspace" \
+    "$priv/apexyard.projects.yaml"
+
+  rm -rf "$pub" "$(dirname "$priv")"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 2: single-fork mode — no .apexyard-fork marker at all, no portfolio
+# override. Must stay silent.
+# ---------------------------------------------------------------------------
+case_single_fork_silent() {
+  local sb
+  sb=$(make_public_fork_base)
+  # Legacy v1 anchor so the ops-root resolver still finds a root, but no
+  # .apexyard-fork marker and no portfolio config override.
+  (
+    cd "$sb" || exit 1
+    touch onboarding.yaml
+    cat > apexyard.projects.yaml <<'YAML'
+version: 1
+projects: []
+YAML
+    git add -A
+    git commit -q -m "fixture: single-fork v1 anchor"
+  )
+
+  assert_silent "single-fork mode (no v2 marker) → silent" "$(run_hook_from "$sb")"
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 3: marker present but every portfolio path still resolves in-fork
+# (a single-fork adopter who has the v2 marker from /setup but never split
+# out a sibling repo). Must stay silent — marker alone is not sufficient.
+# ---------------------------------------------------------------------------
+case_marker_without_split_silent() {
+  local sb
+  sb=$(make_public_fork_base)
+  (
+    cd "$sb" || exit 1
+    echo "# v2 marker, single-fork adopter" > .apexyard-fork
+    mkdir -p projects
+    cat > apexyard.projects.yaml <<'YAML'
+version: 1
+projects: []
+YAML
+    echo "# Ideas" > projects/ideas-backlog.md
+    touch onboarding.yaml
+    # No .claude/project-config.json override at all — every portfolio.*
+    # path resolves to its in-fork default.
+    git add -A
+    git commit -q -m "fixture: v2 marker, no sibling split"
+  )
+
+  assert_silent "v2 marker present but no sibling split → silent" "$(run_hook_from "$sb")"
+  rm -rf "$sb"
+}
+
+case_split_v2_prints_paths
+case_single_fork_silent
+case_marker_without_split_silent
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,10 @@
           {
             "type": "command",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/validate-search-config.sh\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/print-portfolio-primer.sh\"'"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- **Adds a SessionStart primer banner for split-portfolio v2** — adopters reported (across both Claude Code and Codex) that agents kept guessing wrong about where a managed project's workspace clone and the sibling `<company>-portfolio` repo actually live. Nothing told the agent at session start, so every session re-derived it from scratch (or asked the user). The new `print-portfolio-primer.sh` hook prints the ops-fork root, the sibling portfolio dir, the workspace dir, and the registry path — all as absolute paths — the moment a session starts in split-portfolio v2 mode.
- **Detection is deliberately two-part, not just the marker** — the `.apexyard-fork` marker alone isn't sufficient evidence of a *split* layout, because `/setup` also writes it for single-fork adopters (see `_lib-ops-root.sh`'s own header comment). The hook only fires when the marker is present **and** at least one `portfolio.*` path (registry / workspace_dir / onboarding) actually resolves outside the ops-fork root — i.e. genuinely points at a sibling repo. A single-fork adopter carrying the v2 marker stays silent.
- **No ad-hoc path logic** — the hook sources the existing `_lib-ops-root.sh` (pin-first/walk-up resolver) and `_lib-portfolio-paths.sh` (single source of truth for registry/workspace/onboarding resolution) rather than re-deriving any of it, matching the pattern `check-portfolio-config.sh` already established for this class of hook.
- **Always advisory, never a gate** — exits 0 unconditionally; silent on every no-op path (not a git repo, no ops-fork root, marker absent, helper libs missing, or marker present but nothing actually split out).

## Testing
1. `bash -n .claude/hooks/print-portfolio-primer.sh` — syntax check, passes.
2. `shellcheck --severity=warning .claude/hooks/print-portfolio-primer.sh .claude/hooks/tests/test_print_portfolio_primer.sh` — clean, zero warnings.
3. `bash .claude/hooks/tests/test_print_portfolio_primer.sh` — 3/3 passing:
   - split-portfolio v2 (marker + sibling-pointing config) → banner prints all four absolute paths
   - single-fork mode (no marker at all) → silent
   - marker present but every portfolio path still resolves in-fork → silent
4. Regression-checked the sibling suites this hook shares libraries with: `test_portfolio_paths.sh` (39/39), `test_settings_wrappers_silent_noop.sh` (4/4, including the wrapper-invariant + `/tmp`-invocation-silent checks), `test_check_upstream_drift.sh` (5/5), `test_portfolio_agent_routing.sh` (6/6) — all green, no regressions from the new hook or the `.claude/settings.json` wiring.

Closes #900

---

## Glossary
| Term | Definition |
|------|------------|
| Split-portfolio v2 | Layout with a public framework fork living beside a private `<company>-portfolio` repo — company config, the project registry, per-project docs, and the workspace clones all live in the sibling repo instead of the public fork |
| `.apexyard-fork` marker | A presence-only file at the ops-fork root that tells hooks "this directory is an apexyard ops fork"; written by `/setup` and `/update`, for both single-fork and split-portfolio v2 adopters |
| `_lib-portfolio-paths.sh` | The shared hook library that resolves portfolio-related paths (registry, workspace, onboarding, etc.) from `.claude/project-config.json`'s `portfolio` block — single source of truth so no hook re-derives this logic |
| SessionStart hook | A Claude Code hook that runs once when a session begins; used here for an informational banner, never a blocking gate |