### PR TITLE
fix(#899): add dotall flag to globToRegExp — close multi-line gate-bypass on adapters

### DIFF
--- a/harness-adapters/_shared/derive-gates-core.ts
+++ b/harness-adapters/_shared/derive-gates-core.ts
@@ -173,7 +173,13 @@ export function deriveGatesFromSettings(settings: RawSettings): GateDefinition[]
 /** Converts a Claude Code `if: "Bash(<glob>)"` glob (shell-style `*` wildcard) into an anchored RegExp. */
 export function globToRegExp(glob: string): RegExp {
   const escaped = glob.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
-  return new RegExp(`^${escaped}$`);
+  // `s` (dotall) flag: without it, `.` never matches `\n`, so `.*` cannot
+  // cross the newlines in a multi-line command string (e.g. a conventional
+  // commit's `-m $'subject\n\nbody'`, or a `gh issue create --body` with a
+  // multi-line body). A gate whose glob fails to match a real multi-line
+  // command is a silent fail-open (see gateMatchesClaudeMatcher below) —
+  // #899.
+  return new RegExp(`^${escaped}$`, "s");
 }
 
 /**

--- a/harness-adapters/_shared/test/derive-gates-core.test.ts
+++ b/harness-adapters/_shared/test/derive-gates-core.test.ts
@@ -59,6 +59,43 @@ test("globToRegExp anchors — a glob must match the whole command, not a substr
   assert.ok(!re.test("echo 'not git commit at all but contains git commit inside'"));
 });
 
+// Regression test for #899: globToRegExp must carry the `s` (dotall) flag so
+// `.*` crosses embedded newlines. Without it, a multi-line command string
+// (the conventional-commit norm — a subject line plus a body) fails to
+// match its own `Bash(<prefix> *)` glob, and the consuming gate is silently
+// skipped (fail-open) instead of firing. Both assertions below FAIL if the
+// `s` flag is removed from globToRegExp's `new RegExp(...)` call.
+test("globToRegExp — the derived RegExp carries the dotall (s) flag, so it matches across embedded newlines (#899)", () => {
+  const re = globToRegExp("git commit *");
+  assert.ok(re.flags.includes("s"), "globToRegExp's RegExp must carry the `s` (dotall) flag");
+});
+
+test("globToRegExp matches a multi-line `git commit -m` command (conventional-commit subject + body) — #899", () => {
+  const re = globToRegExp("git commit *");
+  // Real embedded newlines (template literal), not escaped "\n" text — this
+  // is what a shell actually hands the hook for `git commit -m $'subject\n\nbody'`.
+  const multiLineCommit = `git commit -m $'feat: add widget
+
+- detail one
+- detail two
+
+Closes #1'`;
+  assert.ok(re.test(multiLineCommit), "a multi-line git commit command must match its own Bash(git commit *) glob");
+});
+
+test("globToRegExp matches a multi-line `gh issue create --body` command — #899", () => {
+  const re = globToRegExp("gh issue create *");
+  const multiLineIssueCreate = `gh issue create --title "Bug: X" --body "Given a user
+When they do Y
+Then Z happens
+
+Repro steps here."`;
+  assert.ok(
+    re.test(multiLineIssueCreate),
+    "a multi-line gh issue create --body command must match its own Bash(gh issue create *) glob",
+  );
+});
+
 // ---------------------------------------------------------------------
 // deriveGatesFromSettings — keyed by raw Claude matcher token, not by any
 // runtime's tool id.


### PR DESCRIPTION
## Summary
- **Closes a security fail-open (#899).** `globToRegExp` in `harness-adapters/_shared/derive-gates-core.ts` built `^…$` **without the `s` (dotall) flag**, so a **multi-line command** — the conventional-commit norm (subject + blank line + body) — didn't match the derived matcher. The gate consumer (`gateMatchesClaudeMatcher`) then **silently skipped** the gate instead of firing: multi-line `git commit` / multi-line `gh issue create --body` bypassed `check-secrets.sh`, `verify-commit-refs.sh`, commit-format, and the leak-protection / skill-required gates on the **pi & opencode adapters**. (Claude Code's native hooks are unaffected — this is adapter-only.)
- **One-line fix:** add the `s` flag → `new RegExp(\`^${escaped}$\`, "s")`.
- **3 regression tests** using real embedded newlines: the derived RegExp carries `s`; a multi-line `git commit` matches its glob; a multi-line `gh issue create --body` matches its glob. Verified fail-without / pass-with by temporarily reverting the fix.

## Testing
- shared core 19/19 · opencode 52/52 · pi 27/27 (2 LIVE credential tests skipped, unrelated). Reverting the `s` flag makes the 3 new tests fail; restoring makes them pass.

Closes #899

## Glossary
| Term | Definition |
|------|------------|
| dotall (`s`) flag | Makes regex `.` match newline characters |
| Fail-open | A gate that *allows* on a match-miss instead of blocking — the dangerous direction for a security gate |
| Adapter | The pi/opencode harness adapters that derive gate matchers from the framework's Bash-tool matchers |
