### PR TITLE
fix(#907): gate scorecard.yml to the canonical repo (skip on forks)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,6 +24,7 @@ permissions:
 jobs:
   analysis:
     name: Scorecard analysis
+    if: github.repository == 'me2resh/apexyard'
     runs-on: ubuntu-latest
     permissions:
       security-events: write   # upload results to code-scanning

--- a/docs/agdr/AgDR-0096-scorecard-fork-guard.md
+++ b/docs/agdr/AgDR-0096-scorecard-fork-guard.md
@@ -1,0 +1,36 @@
+# Gate `scorecard.yml` to the Canonical Repo
+
+> In the context of `.github/workflows/scorecard.yml` (OSSF Scorecard) running unconditionally on `push` / `schedule` / `branch_protection_rule`, facing the fact that every adopter fork inherits the workflow and shows a persistent, non-actionable red ❌ (Scorecard can only publish results for the tracked canonical project), I decided to add a job-level `if: github.repository == 'me2resh/apexyard'` guard to achieve a clean CI signal on forks without weakening the scan on the canonical repo, accepting that adopters who want their own Scorecard run must explicitly re-enable the job for their fork.
+
+## Context
+
+`scorecard.yml` runs OSSF Scorecard's supply-chain security analysis and publishes results to the Security > Code scanning tab (see #518). It has no repo guard, so cloning/forking apexyard (which every adopter does per the framework's fork-based distribution model) inherits the workflow verbatim. On a fork:
+
+- `publish_results` cannot succeed — the OSSF badge API only accepts results for the tracked, canonical public repo
+- The fork lacks the branch-protection / security metadata Scorecard expects, so the "Run analysis" step fails outright
+
+The net effect is a red ❌ on every adopter fork's Actions tab that looks like a security regression but is actually structural noise — a false signal a new adopter has no way to distinguish from a real one.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| `if: github.repository == 'me2resh/apexyard'` | Always set on every trigger this workflow uses (`push`, `schedule`, `branch_protection_rule`); simple string equality; skips (not fails) on forks | Requires the canonical repo's exact `owner/name` hardcoded in the workflow |
+| `if: ${{ !github.event.repository.fork }}` | Reads as "not a fork" | `github.event.repository` is **absent on `schedule` runs** — this workflow's primary trigger is a weekly cron, so the condition would evaluate to a falsy/undefined lookup unreliably rather than deterministically skip |
+| Delete the workflow from `.github/workflows/` in each fork post-clone | No conditional logic needed | Not automatable at fork-creation time; every adopter would have to remember to delete it manually, and re-adding it upstream would silently reintroduce the failure for existing forks that already deleted their copy |
+| Leave as-is, document the failure as expected/ignorable | Zero code change | A red ❌ that adopters are told to ignore erodes trust in the rest of the CI signal — exactly the failure mode this ticket exists to fix |
+
+## Decision
+
+Chosen: **`if: github.repository == 'me2resh/apexyard'`**, because `github.repository` is populated on every event type this workflow listens for — including `schedule`, where `github.event.repository.fork` does not exist — making it the only reliable, deterministic way to restrict the job to the canonical repo across all three triggers.
+
+## Consequences
+
+- The Scorecard job now **skips** (not fails) on every fork, on all three triggers (`push`, `schedule`, `branch_protection_rule`)
+- No change to scan behavior, permissions, or steps on the canonical `me2resh/apexyard` repo
+- An adopter who wants their *own* fork's Scorecard/badge published must intentionally edit the `if:` condition to their own `owner/repo` — a one-line, discoverable change, not a silent gap
+
+## Artifacts
+
+- me2resh/apexyard#907
+- `.github/workflows/scorecard.yml`


### PR DESCRIPTION
## Summary
- **Gated the Scorecard analysis job to the canonical repo** — added `if: github.repository == 'me2resh/apexyard'` at the job level (sibling of `runs-on`). Every adopter fork was previously running (and failing) this job on `push`/`schedule`/`branch_protection_rule`, because OSSF Scorecard can only publish results for the tracked canonical public project — the fork isn't wrong, the job just can't succeed there. That produced a persistent, non-actionable red ❌ on every fork's Actions tab that looked like a security regression but wasn't.
- **Used `github.repository`, not `github.event.repository.fork`** — the latter is absent on `schedule`-triggered runs, and this workflow's primary trigger is a weekly cron (`19 4 * * 1`). `github.repository` is populated on every event type the workflow listens for, so it's the only condition that reliably distinguishes canonical-vs-fork across all three triggers.
- **No other behavior change** — the scan itself, its permissions, and its steps are untouched; on `me2resh/apexyard` the job runs exactly as before.
- **Added AgDR-0096** recording the options considered (the two `if:` conditions, deleting the workflow per-fork, and doing nothing) and why `github.repository` won.

## Testing
1. Read the current `.github/workflows/scorecard.yml` and confirmed the job name is `analysis`.
2. Added `if: github.repository == 'me2resh/apexyard'` as a direct sibling of `runs-on` under the `analysis` job (correct indentation level — job-scoped, not step-scoped).
3. Validated the YAML two ways:
   - `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scorecard.yml'))"` — loads cleanly
   - Asserted programmatically that `jobs.analysis.if == "github.repository == 'me2resh/apexyard'"` — passed
4. Confirmed via `git diff` that the change is a single added line with zero other diff noise.
5. Reasoning for `github.repository` over `github.event.repository.fork`: the workflow's primary trigger is `schedule` (weekly cron) — GitHub does not populate `github.event.repository` (and therefore `.fork`) on scheduled runs, only on `push`-style events carrying a real webhook payload. `github.repository` (`owner/repo` string) is set unconditionally by the Actions runtime regardless of trigger type, so it's the only condition guaranteed to evaluate correctly on all three of this workflow's triggers (`push`, `schedule`, `branch_protection_rule`).

Closes #907

---

## Glossary
| Term | Definition |
|------|------------|
| OSSF Scorecard | Open Source Security Foundation's supply-chain security scorer — assesses branch protection, token permissions, pinned actions, dangerous workflow patterns, etc., and publishes a score/badge for a tracked public repo |
| Fork guard | A job-level `if:` condition that restricts a workflow (or job) to running only on the canonical repo, skipping (not failing) on forks |
| `github.repository` | A GitHub Actions context variable set to `owner/repo` on every triggered run, regardless of event type |
| `github.event.repository.fork` | A boolean nested in the webhook event payload; only present on events that carry a full repository payload (e.g. `push`) — absent on `schedule` runs |