### PR TITLE
feat(#910): increment-1 walking-skeleton first-run onboarding flow

### DIFF
--- a/.claude/hooks/_lib-fresh-fork.sh
+++ b/.claude/hooks/_lib-fresh-fork.sh
@@ -11,6 +11,14 @@
 # Functions (sourced; do not exec this file directly):
 #   fresh_fork_state()
 #       Echoes one of: fresh | configured | not-a-fork ; always exits 0.
+#   fresh_fork_config_path()
+#       Echoes the resolved onboarding.yaml path this lib actually checked
+#       (in-fork default, or the split-portfolio v2 sibling-repo override).
+#       Empty string if there's no git toplevel at all. Callers that need
+#       to distinguish "config file missing" from "config file present but
+#       placeholder" (e.g. to pick a message) should check THIS path, not
+#       a hardcoded in-fork default — otherwise split-portfolio v2 forks
+#       (whose real onboarding.yaml lives in the sibling repo) mis-render.
 #
 # Detection rules (identical to the pre-extraction onboarding-check.sh —
 # see docs/technical-designs/onboarding-increment-1.md § D2):
@@ -50,6 +58,26 @@ if [ -f "$_FRESH_FORK_LIB_DIR/_lib-portfolio-paths.sh" ]; then
   . "$_FRESH_FORK_LIB_DIR/_lib-portfolio-paths.sh"
 fi
 
+# Internal: resolve the onboarding.yaml path this lib checks, given a repo
+# root. Shared by fresh_fork_state() and the public fresh_fork_config_path()
+# so there is exactly one resolution — not one inline in each.
+_fresh_fork_resolve_config() {
+  local repo_root="$1"
+  local config=""
+
+  # Resolve onboarding.yaml through the portfolio helper so split-portfolio
+  # v2 adopters get the sibling repo's copy. Falls back to the in-fork
+  # default (single-fork mode, or the helper unavailable) — same fallback
+  # onboarding-check.sh used pre-extraction.
+  if command -v portfolio_onboarding_path >/dev/null 2>&1; then
+    config=$(portfolio_onboarding_path 2>/dev/null)
+  fi
+  if [ -z "$config" ]; then
+    config="$repo_root/onboarding.yaml"
+  fi
+  echo "$config"
+}
+
 fresh_fork_state() {
   local repo_root config
 
@@ -59,17 +87,7 @@ fresh_fork_state() {
     return 0
   fi
 
-  # Resolve onboarding.yaml through the portfolio helper so split-portfolio
-  # v2 adopters get the sibling repo's copy. Falls back to the in-fork
-  # default (single-fork mode, or the helper unavailable) — same fallback
-  # onboarding-check.sh used pre-extraction.
-  config=""
-  if command -v portfolio_onboarding_path >/dev/null 2>&1; then
-    config=$(portfolio_onboarding_path 2>/dev/null)
-  fi
-  if [ -z "$config" ]; then
-    config="$repo_root/onboarding.yaml"
-  fi
+  config=$(_fresh_fork_resolve_config "$repo_root")
 
   if [ ! -f "$config" ]; then
     if [ -f "$repo_root/onboarding.example.yaml" ]; then
@@ -85,5 +103,18 @@ fresh_fork_state() {
   else
     echo "configured"
   fi
+  return 0
+}
+
+fresh_fork_config_path() {
+  local repo_root
+
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [ -z "$repo_root" ]; then
+    echo ""
+    return 0
+  fi
+
+  _fresh_fork_resolve_config "$repo_root"
   return 0
 }

--- a/.claude/hooks/_lib-fresh-fork.sh
+++ b/.claude/hooks/_lib-fresh-fork.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# _lib-fresh-fork.sh — single source of truth for "is this an apexyard fork,
+# and has it been configured yet?"
+#
+# Extracted (behaviour-preserving) from onboarding-check.sh per AgDR-0098.
+# The guided first-run onboarding PRD's Technical Constraint forbids a
+# second, competing fresh-fork detection mechanism — both
+# onboarding-check.sh (SessionStart hook) and /onboard source this file and
+# call the same function, so there is exactly one implementation.
+#
+# Functions (sourced; do not exec this file directly):
+#   fresh_fork_state()
+#       Echoes one of: fresh | configured | not-a-fork ; always exits 0.
+#
+# Detection rules (identical to the pre-extraction onboarding-check.sh —
+# see docs/technical-designs/onboarding-increment-1.md § D2):
+#   - No onboarding.yaml at the resolved path:
+#       - onboarding.example.yaml present  → fresh (an apexyard fork that
+#         hasn't been configured yet, per the #517 gitignored-config model)
+#       - onboarding.example.yaml absent   → not-a-fork
+#   - onboarding.yaml present:
+#       - company.name still the placeholder "Your Company Name" → fresh
+#       - otherwise                                               → configured
+#
+# Path resolution goes through portfolio_onboarding_path (from
+# _lib-portfolio-paths.sh) so split-portfolio v2 adopters (onboarding.yaml
+# committed in the private sibling repo) resolve correctly, exactly like
+# every other consumer of that helper.
+#
+# Contract: read-only. No writes, no network calls. Safe to call from a
+# SessionStart hook and from a bootstrap skill alike.
+#
+# Usage:
+#   source ".../_lib-fresh-fork.sh"
+#   state=$(fresh_fork_state)   # fresh | configured | not-a-fork
+
+# Don't run twice in the same shell.
+[ -n "${_LIB_FRESH_FORK_SOURCED:-}" ] && return 0
+_LIB_FRESH_FORK_SOURCED=1
+
+# Locate the lib's own dir so we can source siblings (read-config, portfolio-paths).
+_FRESH_FORK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -f "$_FRESH_FORK_LIB_DIR/_lib-read-config.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$_FRESH_FORK_LIB_DIR/_lib-read-config.sh"
+fi
+if [ -f "$_FRESH_FORK_LIB_DIR/_lib-portfolio-paths.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$_FRESH_FORK_LIB_DIR/_lib-portfolio-paths.sh"
+fi
+
+fresh_fork_state() {
+  local repo_root config
+
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [ -z "$repo_root" ]; then
+    echo "not-a-fork"
+    return 0
+  fi
+
+  # Resolve onboarding.yaml through the portfolio helper so split-portfolio
+  # v2 adopters get the sibling repo's copy. Falls back to the in-fork
+  # default (single-fork mode, or the helper unavailable) — same fallback
+  # onboarding-check.sh used pre-extraction.
+  config=""
+  if command -v portfolio_onboarding_path >/dev/null 2>&1; then
+    config=$(portfolio_onboarding_path 2>/dev/null)
+  fi
+  if [ -z "$config" ]; then
+    config="$repo_root/onboarding.yaml"
+  fi
+
+  if [ ! -f "$config" ]; then
+    if [ -f "$repo_root/onboarding.example.yaml" ]; then
+      echo "fresh"
+    else
+      echo "not-a-fork"
+    fi
+    return 0
+  fi
+
+  if grep -q '"Your Company Name"' "$config" 2>/dev/null; then
+    echo "fresh"
+  else
+    echo "configured"
+  fi
+  return 0
+}

--- a/.claude/hooks/onboarding-check.sh
+++ b/.claude/hooks/onboarding-check.sh
@@ -32,8 +32,14 @@ STATE=$(fresh_fork_state)
 
 case "$STATE" in
   fresh)
-    if [ -f "$REPO_ROOT/onboarding.yaml" ]; then
-      # Real onboarding.yaml exists but still carries the placeholder.
+    # Check the SAME resolved config path fresh_fork_state() checked (via
+    # fresh_fork_config_path()) — not a hardcoded $REPO_ROOT/onboarding.yaml.
+    # In split-portfolio v2 the real onboarding.yaml lives in the sibling
+    # repo; hardcoding the in-fork path here would print "no onboarding.yaml"
+    # even when a placeholder sibling file is what actually made this fresh.
+    CONFIG="$(fresh_fork_config_path)"
+    if [ -n "$CONFIG" ] && [ -f "$CONFIG" ]; then
+      # Config file exists but still carries the placeholder.
       echo "ApexYard: onboarding.yaml is unconfigured (placeholder still present). Run /onboard for the guided tour, or /setup to configure directly."
     else
       # No onboarding.yaml yet — fresh clone, example present.

--- a/.claude/hooks/onboarding-check.sh
+++ b/.claude/hooks/onboarding-check.sh
@@ -1,58 +1,51 @@
 #!/bin/bash
 # SessionStart hook: checks whether this ApexYard fork has been configured.
 #
-# Detection: reads the resolved onboarding.yaml path (via
-# portfolio_onboarding_path — handles both single-fork mode where
-# onboarding.yaml lives in the fork AND split-portfolio v2 mode where it
-# lives in the private sibling repo) and checks if company.name is still
-# the placeholder value "Your Company Name". If so, the fork hasn't been
-# set up yet and the user should run /setup.
+# Detection lives in the shared _lib-fresh-fork.sh (AgDR-0098) — this hook
+# is now a thin caller so there is exactly one fresh-fork detector shared
+# with /onboard (the guided first-run orchestrator). See
+# docs/technical-designs/onboarding-increment-1.md § D2.
 #
 # Detection model (#517): in single-fork mode `onboarding.yaml` is now
 # GITIGNORED (real config stays local) and `onboarding.example.yaml` is the
 # tracked placeholder template. "Configured" = a real onboarding.yaml exists
 # with a non-placeholder company.name. A fresh clone has only the example (no
-# onboarding.yaml) → unconfigured → prompt /setup, which copies the example to
-# onboarding.yaml and fills it in. In split-portfolio v2 mode the real
-# onboarding.yaml lives (committed) in the private sibling repo, which
-# portfolio_onboarding_path resolves — that path still reads as configured.
+# onboarding.yaml) → unconfigured → prompt /onboard, which walks the adopter
+# through a tour + /setup + a guided first win. In split-portfolio v2 mode
+# the real onboarding.yaml lives (committed) in the private sibling repo,
+# which portfolio_onboarding_path resolves — that path still reads as
+# configured.
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 if [ -z "$REPO_ROOT" ]; then
   exit 0
 fi
 
-# Resolve onboarding path through the portfolio helper so split-portfolio
-# v2 adopters (onboarding.yaml in the private sibling repo) get the right
-# file. Falls back to the in-fork default for single-fork mode.
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-CONFIG=""
-if [ -f "$HOOK_DIR/_lib-portfolio-paths.sh" ] && [ -f "$HOOK_DIR/_lib-read-config.sh" ]; then
-  # shellcheck source=/dev/null
-  . "$HOOK_DIR/_lib-read-config.sh"
-  # shellcheck source=/dev/null
-  . "$HOOK_DIR/_lib-portfolio-paths.sh"
-  CONFIG=$(portfolio_onboarding_path 2>/dev/null)
-fi
-if [ -z "$CONFIG" ]; then
-  CONFIG="$REPO_ROOT/onboarding.yaml"
-fi
-
-# No onboarding.yaml at the resolved path. Two cases:
-#   - A tracked onboarding.example.yaml exists → this IS an apexyard fork that
-#     hasn't been configured yet (fresh clone in the #517 model) → prompt /setup.
-#   - No example either → not an apexyard fork (or split-portfolio v2
-#     misconfigured); skip silently. check-portfolio-config.sh handles paths.
-if [ ! -f "$CONFIG" ]; then
-  if [ -f "$REPO_ROOT/onboarding.example.yaml" ]; then
-    echo "ApexYard: not configured yet (no onboarding.yaml). Run /setup — it copies onboarding.example.yaml → onboarding.yaml (gitignored) and fills it in."
-  fi
+if [ ! -f "$HOOK_DIR/_lib-fresh-fork.sh" ]; then
   exit 0
 fi
+# shellcheck source=/dev/null
+. "$HOOK_DIR/_lib-fresh-fork.sh"
 
-# onboarding.yaml exists — configured unless the placeholder is still present
-if grep -q '"Your Company Name"' "$CONFIG" 2>/dev/null; then
-  echo "ApexYard: onboarding.yaml is unconfigured (placeholder still present). Run /setup to configure this fork."
-fi
+STATE=$(fresh_fork_state)
+
+case "$STATE" in
+  fresh)
+    if [ -f "$REPO_ROOT/onboarding.yaml" ]; then
+      # Real onboarding.yaml exists but still carries the placeholder.
+      echo "ApexYard: onboarding.yaml is unconfigured (placeholder still present). Run /onboard for the guided tour, or /setup to configure directly."
+    else
+      # No onboarding.yaml yet — fresh clone, example present.
+      echo "ApexYard: not configured yet (no onboarding.yaml). Run /onboard for the guided first-run tour, or /setup for just the config bootstrap."
+    fi
+    ;;
+  configured|not-a-fork)
+    # configured: fork is set up, nothing to prompt.
+    # not-a-fork: no onboarding.yaml and no example — not an apexyard fork
+    # (or split-portfolio v2 misconfigured); check-portfolio-config.sh
+    # handles that case. Stay silent here either way.
+    ;;
+esac
 
 exit 0

--- a/.claude/hooks/tests/test_fresh_fork.sh
+++ b/.claude/hooks/tests/test_fresh_fork.sh
@@ -16,8 +16,9 @@ LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-fresh-fork.sh"
 PORTFOLIO_LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-portfolio-paths.sh"
 CONFIG_LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-read-config.sh"
 DEFAULTS_SRC="$(cd "$(dirname "$0")/../.." && pwd)/project-config.defaults.json"
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/onboarding-check.sh"
 
-for f in "$LIB_SRC" "$PORTFOLIO_LIB_SRC" "$CONFIG_LIB_SRC" "$DEFAULTS_SRC"; do
+for f in "$LIB_SRC" "$PORTFOLIO_LIB_SRC" "$CONFIG_LIB_SRC" "$DEFAULTS_SRC" "$HOOK_SRC"; do
   if [ ! -f "$f" ]; then
     echo "FAIL: required file not found at $f" >&2
     exit 1
@@ -50,6 +51,8 @@ make_fork() {
     cp "$PORTFOLIO_LIB_SRC" .claude/hooks/_lib-portfolio-paths.sh
     cp "$CONFIG_LIB_SRC" .claude/hooks/_lib-read-config.sh
     cp "$DEFAULTS_SRC" .claude/project-config.defaults.json
+    cp "$HOOK_SRC" .claude/hooks/onboarding-check.sh
+    chmod +x .claude/hooks/onboarding-check.sh
 
     git add -A
     git commit -q -m "test fixture" >/dev/null
@@ -189,6 +192,104 @@ r=$(fresh_fork_state)
 if [ "$r" = "fresh" ]; then exit 0; else echo "got=$r expected=fresh"; exit 1; fi
 '
 rm -rf "$SB" "$SIB"
+
+# ---------------------------------------------------------------------------
+# Case 6b: fresh_fork_config_path() defaults to the in-fork onboarding.yaml
+# path (no override configured).
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+run_case "config-path: defaults to in-fork onboarding.yaml" "$SB" '
+r=$(fresh_fork_config_path)
+expected="'"$SB"'/onboarding.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 6c: fresh_fork_config_path() resolves to the sibling repo path when
+# split-portfolio v2 overrides portfolio.onboarding. This is the path the
+# hook's message-selection logic must check (Rex nit) instead of a
+# hardcoded in-fork default.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+cat > "$SIB/onboarding.yaml" <<'YAML'
+company:
+  name: "Your Company Name"
+YAML
+cat > "$SB/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "onboarding": "$SIB/onboarding.yaml"
+  }
+}
+JSON
+run_case "config-path: v2 override resolves to sibling repo path" "$SB" '
+r=$(fresh_fork_config_path)
+expected="'"$SIB"'/onboarding.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SB" "$SIB"
+
+# ---------------------------------------------------------------------------
+# Case 6d (hook-level regression, Rex nit): in split-portfolio v2 with the
+# sibling repo's onboarding.yaml still carrying the placeholder,
+# onboarding-check.sh must print the "placeholder still present" wording —
+# NOT the "no onboarding.yaml" wording. Before the fix, the hook's fresh
+# branch checked the hardcoded in-fork path ($REPO_ROOT/onboarding.yaml),
+# which doesn't exist in v2 mode, so it always fell into the wrong message.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+cat > "$SIB/onboarding.yaml" <<'YAML'
+company:
+  name: "Your Company Name"
+YAML
+cat > "$SB/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "onboarding": "$SIB/onboarding.yaml"
+  }
+}
+JSON
+run_case "hook (v2): sibling placeholder → \"placeholder still present\" wording" "$SB" '
+out=$(bash .claude/hooks/onboarding-check.sh 2>&1)
+case "$out" in
+  *"placeholder still present"*) exit 0 ;;
+esac
+echo "got: $out"
+exit 1
+'
+run_case "hook (v2): sibling placeholder → does NOT say \"no onboarding.yaml\"" "$SB" '
+out=$(bash .claude/hooks/onboarding-check.sh 2>&1)
+case "$out" in
+  *"no onboarding.yaml"*) echo "got: $out"; exit 1 ;;
+esac
+exit 0
+'
+rm -rf "$SB" "$SIB"
+
+# ---------------------------------------------------------------------------
+# Case 6e (hook-level regression guard): single-fork mode with no
+# onboarding.yaml at all still prints the "no onboarding.yaml" wording
+# (confirms the fix didn't flip the single-fork case).
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+cat > "$SB/onboarding.example.yaml" <<'YAML'
+company:
+  name: "Your Company Name"
+YAML
+run_case "hook (v1): no onboarding.yaml → \"no onboarding.yaml\" wording" "$SB" '
+out=$(bash .claude/hooks/onboarding-check.sh 2>&1)
+case "$out" in
+  *"no onboarding.yaml"*) exit 0 ;;
+esac
+echo "got: $out"
+exit 1
+'
+rm -rf "$SB"
 
 # ---------------------------------------------------------------------------
 # Case 7: not inside any git repo at all → not-a-fork

--- a/.claude/hooks/tests/test_fresh_fork.sh
+++ b/.claude/hooks/tests/test_fresh_fork.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/_lib-fresh-fork.sh
+#
+# Covers the three fresh_fork_state() outcomes (fresh / configured /
+# not-a-fork) plus split-portfolio v2 path resolution, per
+# docs/technical-designs/onboarding-increment-1.md § D2 and AgDR-0098.
+#
+# Each case builds an isolated sandbox apexyard fork under a tmp dir,
+# sources the lib, and asserts fresh_fork_state()'s stdout.
+#
+# Exit 0 means all cases passed. Exit 1 on first failure.
+
+set -u
+
+LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-fresh-fork.sh"
+PORTFOLIO_LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-portfolio-paths.sh"
+CONFIG_LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-read-config.sh"
+DEFAULTS_SRC="$(cd "$(dirname "$0")/../.." && pwd)/project-config.defaults.json"
+
+for f in "$LIB_SRC" "$PORTFOLIO_LIB_SRC" "$CONFIG_LIB_SRC" "$DEFAULTS_SRC"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: required file not found at $f" >&2
+    exit 1
+  fi
+done
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# ---------------------------------------------------------------------------
+# make_fork: build an isolated apexyard fork sandbox with the fresh-fork lib
+# + its dependencies. Returns the sandbox path on stdout. By default the
+# sandbox has NEITHER onboarding.yaml NOR onboarding.example.yaml — callers
+# add whichever fixture files their case needs.
+# ---------------------------------------------------------------------------
+make_fork() {
+  local sb
+  sb=$(mktemp -d)
+  # Canonicalize for macOS (mktemp returns /var/..., real path is /private/var/...).
+  sb=$(cd "$sb" && pwd -P)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+
+    mkdir -p .claude/hooks
+    cp "$LIB_SRC" .claude/hooks/_lib-fresh-fork.sh
+    cp "$PORTFOLIO_LIB_SRC" .claude/hooks/_lib-portfolio-paths.sh
+    cp "$CONFIG_LIB_SRC" .claude/hooks/_lib-read-config.sh
+    cp "$DEFAULTS_SRC" .claude/project-config.defaults.json
+
+    git add -A
+    git commit -q -m "test fixture" >/dev/null
+  )
+  echo "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# run_case <name> <sandbox> <snippet>: source the lib in a fresh subshell
+# rooted at <sandbox> and run the snippet. The snippet asserts behavior +
+# exits 0 on pass, non-zero on fail.
+# ---------------------------------------------------------------------------
+run_case() {
+  local name="$1"
+  local sb="$2"
+  local snippet="$3"
+  local out rc
+
+  out=$(
+    cd "$sb" || exit 99
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-fresh-fork.sh
+    eval "$snippet"
+  )
+  rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    PASS=$((PASS + 1))
+    echo "PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  - $name"
+    echo "FAIL: $name"
+    if [ -n "$out" ]; then
+      echo "  output: $out"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: no onboarding.yaml, no example → not-a-fork
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+run_case "not-a-fork: neither onboarding.yaml nor example present" "$SB" '
+r=$(fresh_fork_state)
+if [ "$r" = "not-a-fork" ]; then exit 0; else echo "got=$r expected=not-a-fork"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 2: no onboarding.yaml, example present → fresh
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+cat > "$SB/onboarding.example.yaml" <<'YAML'
+company:
+  name: "Your Company Name"
+YAML
+run_case "fresh: no onboarding.yaml, example present" "$SB" '
+r=$(fresh_fork_state)
+if [ "$r" = "fresh" ]; then exit 0; else echo "got=$r expected=fresh"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 3: onboarding.yaml present with placeholder company.name → fresh
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+cat > "$SB/onboarding.yaml" <<'YAML'
+company:
+  name: "Your Company Name"
+YAML
+run_case "fresh: onboarding.yaml present but placeholder company.name" "$SB" '
+r=$(fresh_fork_state)
+if [ "$r" = "fresh" ]; then exit 0; else echo "got=$r expected=fresh"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 4: onboarding.yaml present with a real company.name → configured
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+cat > "$SB/onboarding.yaml" <<'YAML'
+company:
+  name: "Acme Corp"
+YAML
+run_case "configured: onboarding.yaml present with a real company.name" "$SB" '
+r=$(fresh_fork_state)
+if [ "$r" = "configured" ]; then exit 0; else echo "got=$r expected=configured"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 5 (split-portfolio v2): onboarding.yaml lives in a sibling repo,
+# resolved via the portfolio.onboarding override — configured.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+cat > "$SIB/onboarding.yaml" <<'YAML'
+company:
+  name: "Sibling Co"
+YAML
+cat > "$SB/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "onboarding": "$SIB/onboarding.yaml"
+  }
+}
+JSON
+run_case "v2: sibling-repo onboarding.yaml with real company.name → configured" "$SB" '
+r=$(fresh_fork_state)
+if [ "$r" = "configured" ]; then exit 0; else echo "got=$r expected=configured"; exit 1; fi
+'
+rm -rf "$SB" "$SIB"
+
+# ---------------------------------------------------------------------------
+# Case 6 (split-portfolio v2): sibling repo onboarding.yaml still carries
+# the placeholder → fresh. Confirms the override path, not just the
+# in-fork default, participates in the placeholder check.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+cat > "$SIB/onboarding.yaml" <<'YAML'
+company:
+  name: "Your Company Name"
+YAML
+cat > "$SB/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "onboarding": "$SIB/onboarding.yaml"
+  }
+}
+JSON
+run_case "v2: sibling-repo onboarding.yaml with placeholder → fresh" "$SB" '
+r=$(fresh_fork_state)
+if [ "$r" = "fresh" ]; then exit 0; else echo "got=$r expected=fresh"; exit 1; fi
+'
+rm -rf "$SB" "$SIB"
+
+# ---------------------------------------------------------------------------
+# Case 7: not inside any git repo at all → not-a-fork
+# ---------------------------------------------------------------------------
+NOGIT=$(mktemp -d)
+NOGIT=$(cd "$NOGIT" && pwd -P)
+mkdir -p "$NOGIT/.claude/hooks"
+cp "$LIB_SRC" "$NOGIT/.claude/hooks/_lib-fresh-fork.sh"
+cp "$PORTFOLIO_LIB_SRC" "$NOGIT/.claude/hooks/_lib-portfolio-paths.sh"
+cp "$CONFIG_LIB_SRC" "$NOGIT/.claude/hooks/_lib-read-config.sh"
+cp "$DEFAULTS_SRC" "$NOGIT/.claude/project-config.defaults.json"
+run_case "not-a-fork: outside any git repo" "$NOGIT" '
+r=$(fresh_fork_state)
+if [ "$r" = "not-a-fork" ]; then exit 0; else echo "got=$r expected=not-a-fork"; exit 1; fi
+'
+rm -rf "$NOGIT"
+
+# ---------------------------------------------------------------------------
+# Case 8: read-only contract — calling fresh_fork_state() never writes
+# anything to the sandbox (no new files, no modified files).
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+cat > "$SB/onboarding.example.yaml" <<'YAML'
+company:
+  name: "Your Company Name"
+YAML
+BEFORE=$(cd "$SB" && find . -type f | sort)
+(
+  cd "$SB" || exit 1
+  # shellcheck source=/dev/null
+  . .claude/hooks/_lib-fresh-fork.sh
+  fresh_fork_state >/dev/null
+)
+AFTER=$(cd "$SB" && find . -type f | sort)
+if [ "$BEFORE" = "$AFTER" ]; then
+  PASS=$((PASS + 1))
+  echo "PASS: read-only: fresh_fork_state() writes nothing"
+else
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  - read-only: fresh_fork_state() writes nothing"
+  echo "FAIL: read-only: fresh_fork_state() writes nothing"
+  diff <(echo "$BEFORE") <(echo "$AFTER")
+fi
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "===== test_fresh_fork.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed cases:$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -39,7 +39,8 @@
       "setup",
       "handover",
       "update",
-      "split-portfolio"
+      "split-portfolio",
+      "onboard"
     ],
     "_create_command_patterns_comment": "Raw ticket-create CLI shapes that require-skill-for-issue-create.sh blocks unless a structured ticket skill (/task, /feature, /bug, /spike, /migration, /investigation, /idea) is in flight (marker at .claude/session/active-issue-skill). Tracker-agnostic: extend this list in .claude/project-config.json for Linear, Jira, Asana, or custom trackers. Patterns are matched as substrings of the (whitespace-collapsed) bash command. See AgDR-0030 and me2resh/apexyard#268.",
     "create_command_patterns": [

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -1,32 +1,305 @@
 ---
 name: onboard
-description: "DEPRECATED — use /setup (framework config) or /handover (adopt a project). This skill redirects."
+description: "Guided first-run onboarding — capability tour, handover-vs-new-project branch, and a guided first win via a real filed ticket. The front door for a brand-new ApexYard fork."
 disable-model-invocation: false
 argument-hint: ""
-effort: low
+effort: medium
+allowed-tools: Bash, Read, Write
 ---
 
-# /onboard — DEPRECATED
+# /onboard — Guided First-Run Onboarding
 
-This skill has been split into two purpose-specific flows:
+This is increment 1 of the guided-onboarding walking skeleton (technical
+design: `docs/technical-designs/onboarding-increment-1.md`, ticket #910).
+`/onboard` is a **thin orchestrator + router**, not a replacement for
+`/setup` or `/handover` — it sequences those two skills (plus `/feature`)
+behind a capability tour and an explicit branch. It never edits `/setup`,
+`/handover`, or `/feature`; their direct and scripted behaviour stays
+byte-for-byte unchanged (see AgDR-0097).
 
-| What you want to do | Run instead |
-|---------------------|-------------|
-| **Configure the ApexYard fork** (first-run setup, company info, tech stack defaults) | `/setup` |
-| **Add a project to the portfolio** (onboard an external repo, per-project discovery) | `/handover <repo>` |
+Ships **terse mode only** in this increment — the teach-in-context glossary
+and terse/guided depth adaptivity are increment 2 (#911 and beyond). This
+flow *captures* a technical-level signal (D5) but does not yet branch
+rendering on it.
 
-## Why the split
+## Path resolution
 
-`/onboard` mixed two concerns: framework-level bootstrap (writing `onboarding.yaml`) and per-project discovery (writing `project-config.json`). These happen at different times, write to different files, and have different triggers:
+Read the registry path via `portfolio_registry` and the onboarding config
+path via `portfolio_onboarding_path` — both from
+`.claude/hooks/_lib-portfolio-paths.sh`. Source the helper at the top of any
+bash block that touches those paths:
 
-- `/setup` runs **once per fork** and writes `onboarding.yaml` (committed, framework-wide).
-- `/handover` runs **once per project** and writes `project-config.json` (per-project, in the workspace).
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+registry=$(portfolio_registry)
+```
 
-The per-project discovery questions (tracker repo, CI checks, architecture paths, UI paths, commit types) are now part of `/handover`'s assessment flow — they're asked when a project enters the portfolio, not as a standalone ceremony.
+## Process
 
-## If you got here from the SessionStart hook
+### 0. Mark this session as bootstrap (REQUIRED)
 
-The `onboarding-check.sh` hook now checks `onboarding.yaml` for placeholder values, not a session marker. Run `/setup` to configure your fork.
+`/onboard` runs before any portfolio is configured, so no project tickets
+can exist yet. Write the bootstrap marker so `require-active-ticket.sh`
+exempts this skill's writes (it's on the `ticket.bootstrap_skills` list in
+`.claude/project-config.defaults.json`):
+
+```bash
+mkdir -p .claude/session && echo "onboard" > .claude/session/active-bootstrap
+```
+
+Clear this marker on **every** exit path below (success, bail, decline) —
+see the final step. `clear-bootstrap-marker.sh` sweeps stale markers from
+interrupted sessions as a backstop, same as `/setup`.
+
+### 1. Detect fresh-fork state
+
+Source the shared detector (single source of truth — AgDR-0098; the same
+function `onboarding-check.sh` uses):
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-fresh-fork.sh"
+state=$(fresh_fork_state)   # fresh | configured | not-a-fork
+```
+
+Branch on `$state`:
+
+- **`not-a-fork`** — this isn't an ApexYard fork (no `onboarding.yaml`, no
+  `onboarding.example.yaml`). Say so plainly and stop — there's nothing to
+  onboard:
+
+  ```
+  This doesn't look like an ApexYard fork (no onboarding.yaml or
+  onboarding.example.yaml found). If you meant to set up ApexYard, fork
+  me2resh/apexyard first, then run /onboard from the fork.
+  ```
+
+  Clear the bootstrap marker and exit.
+
+- **`configured`** — the fork is already set up. Don't force the full
+  first-run flow (that would re-run config bootstrap and the guided first
+  win on someone who's past that stage). Offer a lightweight re-run
+  instead:
+
+  ```
+  This fork is already configured. Want to:
+    1. Replay the capability tour (roles / skills / gates, 60 seconds)
+    2. Re-run /setup to update your config
+    3. Nothing — exit
+
+  (1/2/3)
+  ```
+
+  - **1** → render the tour (Step 2 below), then exit.
+  - **2** → invoke the `Skill` tool with `skill: setup` and hand off entirely.
+  - **3** → exit.
+
+  Clear the bootstrap marker on every branch above.
+
+- **`fresh`** — proceed to Step 2, the full guided flow.
+
+### 2. Capability tour
+
+Read `docs/onboarding/capability-tour.md` and render it verbatim (it's
+already terse and scannable — don't summarize or re-word it). Tell the
+adopter up front they can skip:
+
+```
+Before we configure anything, a 60-second tour of the three ideas that make
+ApexYard different — say "skip" any time to jump straight to setup.
+```
+
+Then render the file's content. If the adopter says "skip" at any point
+(before or during), stop rendering and move to Step 3 immediately.
+
+This is the **same** content `/tutorial` (#911) will render later — never
+paraphrase or fork the prose here; both skills read the one shared file.
+
+### 3. Phase 2 — config bootstrap via `/setup`
+
+Invoke the `Skill` tool with `skill: setup` to run the full config bootstrap
+(company info, tech stack, defaults). This is `/setup`'s Steps 2–7,
+unmodified — `/onboard` does not re-implement any of it.
+
+**Capture the technical-level signal (D5).** While `/setup`'s Step 2 asks
+"tell me about your company and tech stack," read that answer for how
+technically fluent it reads (mentions of specific languages/frameworks/CI
+tools vs. a vague or absent description). Infer silently:
+
+- Fluent, specific stack description → `engineer`
+- Vague, absent, or genuinely ambiguous → ask one direct fallback question:
+
+  ```
+  Quick one — have you used git/GitHub before, or is this new to you?
+  ```
+
+  Answer maps to `engineer` (used before) or `non-engineer` (new to it).
+
+Record the captured signal — this is a one-line seam for increment 2, not a
+rendering switch yet (increment 1 is terse-only regardless of the signal):
+
+```bash
+mkdir -p .claude/session && echo "$SIGNAL" > .claude/session/onboarding-tech-level
+```
+
+Where `$SIGNAL` is `engineer`, `non-engineer`, or `ambiguous` (if neither
+signal was usable). Never block on this — a wrong guess costs nothing since
+increment 1 doesn't act on it, and increment 2's reversibility NFR lets the
+adopter override in plain language whenever depth adaptivity ships.
+
+### 4. Phase 3 — handover-vs-new-project branch
+
+Ask directly:
+
+```
+Are you handing over an existing repo, or starting a brand-new project?
+  1. Handing over an existing repo
+  2. Starting something new
+
+(1/2)
+```
+
+#### 4a. Handing over (existing repo)
+
+Ask for the repo path or URL if not already clear from context, then invoke
+the `Skill` tool with `skill: handover` and pass that repo path/URL as its
+argument. Let `/handover`'s full assessment flow run to completion
+unmodified — this is exactly what a direct `/handover <repo>` invocation
+does. `/handover` registers the project in `apexyard.projects.yaml` itself
+(its own Step 7); `/onboard` does not touch the registry on this branch.
+
+#### 4b. Starting new (lightweight registration)
+
+This is intentionally **lighter** than `/handover` — no harnessability
+assessment, no codebase read, just enough to register a project so
+`/feature` has somewhere real to file. Ask, one at a time:
+
+**i) Project name**
+
+```
+What should we call this project? (short, lowercase, kebab-case — this
+becomes the folder name under projects/ and workspace/)
+```
+
+**ii) Repo status**
+
+```
+Does this project already have a GitHub repo?
+  1. Yes — give me the owner/repo
+  2. Not yet — should I create one now? (gh repo create, I'll confirm first)
+  3. No repo yet, and not creating one right now (fully greenfield)
+
+(1/2/3)
+```
+
+- **1** → record `repo: {owner/repo}` as given.
+- **2** → confirm the exact `gh repo create` invocation (name, visibility)
+  before running it; on success record the created `owner/repo`.
+- **3** → no `repo` field — record this project as repo-less for now. This
+  is the greenfield-no-repo edge case D6 calls out; Step 5 below handles it
+  honestly.
+
+**Append to the registry** (mirrors `/handover`'s own Step 7 — same
+mechanism, minimal entry):
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-portfolio-paths.sh"
+REGISTRY=$(portfolio_registry)
+
+if command -v yq >/dev/null 2>&1; then
+  yq eval -i '.projects += [{"name": "{name}", "repo": "{owner/repo or omit}", "workspace": "workspace/{name}", "docs": "projects/{name}", "status": "active"}]' "$REGISTRY"
+else
+  cat >> "$REGISTRY" <<'YAML'
+  - name: {name}
+    repo: {owner/repo or omit}
+    workspace: workspace/{name}
+    docs: projects/{name}
+    status: active
+YAML
+fi
+```
+
+Validate the same way `/handover` does (`yq eval '.' "$REGISTRY"` or the
+`python3 -c 'import yaml; ...'` fallback); on failure, restore the
+pre-write backup and tell the adopter to fix the file manually — never
+leave the registry broken. Confirm success:
+
+```
+✓ Registered {name} in apexyard.projects.yaml
+```
+
+### 5. Phase 4 — guided first win via `/feature`
+
+Only proceed here **after** the branch above has resolved (D6) — a real
+registered project (or an honest "no repo yet") must exist before offering
+to file a ticket; never fabricate a ticket number.
+
+```
+Want to try filing your first ticket? It's a real GitHub issue, not a demo
+— I'll walk you through it with /feature.
+
+(yes/no)
+```
+
+- **Adopter declines** → skip straight to Step 6 (closing).
+- **Adopter accepts, and a real repo target exists** (handover path always
+  has one; new-project path has one unless the operator chose greenfield
+  option 3) → invoke the `Skill` tool with `skill: feature`, letting
+  `/feature`'s full flow run (user story, acceptance criteria, confirmation,
+  real `gh issue create` via `tracker_create`). When it returns the real
+  issue reference, celebrate honestly — **never** fabricate a `#N`:
+
+  ```
+  🎉 First ticket filed — {owner/repo}#{N}: {title}
+  That's the loop: idea → ticket → PR → review → merge. You just did step one.
+  ```
+
+- **Adopter accepts, but no real repo exists yet** (greenfield-no-repo,
+  D6's must-handle edge case) — do NOT fabricate a ticket. Defer honestly:
+
+  ```
+  Your project doesn't have a repo yet, so there's nowhere real to file a
+  ticket into. Once you've got a repo (create one with `gh repo create`,
+  or run /onboard again), run /feature any time — no need to redo the tour.
+  ```
+
+### 6. Closing
+
+Always end with a pointer to the standalone re-entry point (even though
+`/tutorial` ships in #911 — name it now so the reference lands with the
+first PR that needs it):
+
+```
+Come back anytime with /tutorial to replay this tour — it works on any
+fork state and never changes anything.
+```
+
+### 7. Clear the bootstrap marker (REQUIRED — every exit path)
+
+```bash
+rm -f .claude/session/active-bootstrap
+```
+
+Run this on success, on the `not-a-fork` bail, on the `configured`
+re-run-offer exits, and on any decline/cancel path. Never leave it set.
+
+## Rules
+
+1. **Never re-implement `/setup`, `/handover`, or `/feature`.** Invoke them
+   via the `Skill` tool and let their own flows run. This orchestrator adds
+   a tour, a branch, and a first-win prompt around them — nothing more.
+2. **Never fabricate a ticket number.** The guided first win only reports a
+   real `#N` returned by `/feature`'s `tracker_create` call. If there's no
+   real repo target, decline honestly (Step 5).
+3. **One question at a time.** Same conversational rule as `/setup`,
+   `/handover`, and `/feature`.
+4. **Terse mode only, this increment.** Don't add glossary asides or
+   depth-adaptive rendering — that's increment 2 (#911+). Capture the
+   technical-level signal; don't act on it yet.
+5. **The tour content lives in one file.** Never inline or paraphrase
+   `docs/onboarding/capability-tour.md` — both `/onboard` and `/tutorial`
+   read the same asset verbatim.
 
 ---
 

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -4,7 +4,7 @@ description: "Guided first-run onboarding — capability tour, handover-vs-new-p
 disable-model-invocation: false
 argument-hint: ""
 effort: medium
-allowed-tools: Bash, Read, Write
+allowed-tools: Bash, Read, Write, Skill
 ---
 
 # /onboard — Guided First-Run Onboarding

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,7 @@ One-line summary per skill; canonical details live in each `.claude/skills/<name
 | `/investigation` | Create an investigation ticket + live-doc for sustained root-cause work |
 | `/idea` | Capture a new product idea to the shared backlog |
 | `/handover` | Onboard an external repo — harnessability scoring across 5 dimensions, checklist-pick which docs to generate, and offer to file Next Steps as tracker tickets |
-| `/onboard` | Deprecated alias — redirects to `/setup` or `/handover` |
+| `/onboard` | Guided first-run onboarding — capability tour, handover-vs-new-project branch, guided first win (front door for a brand-new fork; standalone `/tutorial` re-entry coming in a follow-up) |
 | `/extract-features` | Six-axis Feature Inventory (routes / models / jobs / tests / UI / docs) for rewrites |
 | `/feature-diagram` | Per-feature Mermaid flowchart of routes / models / jobs / screens involved |
 | `/process` | Extract a business process from registered repos and emit lint-clean BPMN 2.0 |

--- a/docs/onboarding/capability-tour.md
+++ b/docs/onboarding/capability-tour.md
@@ -1,0 +1,53 @@
+# ApexYard Capability Tour
+
+A 60-second orientation to the three ideas that make ApexYard different from
+"just a folder of prompts": **roles**, **skills**, and **gates**. This is the
+shared tour content rendered by both `/onboard` (first-run) and `/tutorial`
+(re-entry, any time) — one asset, read by both, never duplicated. See
+`docs/technical-designs/onboarding-increment-1.md` § D3.
+
+Skippable in one word — say "skip" at any point and move on.
+
+---
+
+## What's a role?
+
+A role is a named persona with its own responsibilities and CAN/CANNOT
+boundaries — think of it as a teammate, not a mode. When work matches a
+role's trigger (a PR touches `**/auth/**`, a technical design needs review),
+that role activates and drives the task.
+
+**Example**: open a PR that touches authentication code, and Hakim (the
+Security Auditor) activates automatically to review it — you didn't have to
+ask.
+
+## What's a skill?
+
+A skill is a slash command that packages a whole workflow — questions to
+ask, a template to fill in, a place to file the result — so you don't have
+to reconstruct the process by hand each time.
+
+**Example**: `/feature` asks you for a user story and acceptance criteria,
+shows you the formatted ticket, and files it as a real GitHub issue once you
+confirm.
+
+## What's a gate?
+
+A gate is a checkpoint the work can't pass until a specific condition is
+met — tests green, a reviewer's sign-off, your explicit approval. Gates are
+mechanically enforced, not just written down: a hook blocks the action until
+the gate is satisfied.
+
+**Example**: `gh pr merge` is blocked until both Rex (the automated code
+reviewer) and you, the human, have each approved that exact commit — no
+merge slips through on a plan-level "go".
+
+## How the loop works
+
+Idea → ticket → PR → review → merge. Every feature moves through this loop;
+roles drive each stage, skills do the mechanical work, gates make sure
+nothing skips a step.
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*


### PR DESCRIPTION
## Summary

- **`/onboard` is now the guided first-run front door** — rewritten from a dead "use /setup or /handover" redirect into a thin orchestrator that walks a brand-new adopter through a capability tour, an explicit handover-vs-new-project branch, and a guided first win that files a real GitHub issue. `/setup`, `/handover`, and `/feature` stay byte-for-byte unchanged — `/onboard` invokes them, never edits them (AgDR-0097).
- **One fresh-fork detector, not two** — extracted `onboarding-check.sh`'s inline "is this fork configured yet?" logic into a shared `_lib-fresh-fork.sh` (`fresh_fork_state()` → `fresh` / `configured` / `not-a-fork`). Both the SessionStart hook and `/onboard` now source the same function, so the two can never drift out of sync (AgDR-0098).
- **One tour, read by two skills** — added `docs/onboarding/capability-tour.md` (roles / skills / gates, one example each, plus the idea→ticket→PR→review→merge closer). `/onboard` reads it verbatim today; the standalone `/tutorial` re-entry point (a follow-up ticket) will read the exact same file so the two never fork.
- **Bootstrap-gate coherence** — `onboard` is added to `ticket.bootstrap_skills` so it can write/clear its own `.claude/session/active-bootstrap` marker before any portfolio exists, same pattern `/setup` and `/handover` already use.
- **Honest failure modes, not fabricated ones** — the guided first win only reports a ticket number that `/feature`'s real `tracker_create` call returned; a greenfield project with no repo yet gets an honest "there's nowhere to file into yet" instead of a made-up `#N` (ticket-vocabulary discipline, D6 in the design).

## Testing

- Added `.claude/hooks/tests/test_fresh_fork.sh` — 8 cases covering `fresh` / `configured` / `not-a-fork`, split-portfolio v2 path resolution (both a real company name and a lingering placeholder in the sibling repo), a not-inside-git-at-all case, and a read-only-contract check (the function writes nothing to disk). All pass.
- Ran the full hook test suite (`bin/run-hook-tests.sh`): 105/106 pass. The one failure (`test_sync_codex_adapter.sh`) is pre-existing and unrelated — reproduces identically on a clean `upstream/dev` checkout (environment coupling to the real `/Users/ahmed/apex/apexyard` path in a codex-adapter sandbox fixture, nothing to do with onboarding).
- `bash -n` on every new/changed shell script; `jq empty` on `project-config.defaults.json`; `markdownlint-cli2` clean on every changed Markdown file.
- Manually ran `onboarding-check.sh` against this worktree's genuinely fresh state (no `onboarding.yaml`) and confirmed the new banner text recommends `/onboard` and stays inside the SessionStart character budget (`test_token_efficiency_wave1.sh` Invariant 4 — 510/600 chars).

Closes #910

---

## Glossary

| Term | Definition |
|------|------------|
| Walking skeleton | The thinnest end-to-end slice through every architectural layer, kept and grown into the product — not a throwaway spike/prototype. This PR is increment 1 of that skeleton for the onboarding overhaul. |
| Fresh-fork state | Whether an ApexYard fork has been configured yet: `fresh` (no real config, or a placeholder company name), `configured` (real config present), or `not-a-fork` (no ApexYard markers at all). |
| Orchestrator skill | A skill whose job is to sequence other, unmodified skills behind a guided flow — `/onboard` invokes `/setup`, `/handover`, and `/feature` rather than re-implementing any of their logic. |
| Bootstrap-class skill | A skill that must run before any tracker ticket can exist (e.g. `/setup`, `/handover`, and now `/onboard`), exempted from the ticket-first gate via a session marker. |
