### PR TITLE
ci(#880): conformance dispatch-streak guard + Codex model pin

### DIFF
--- a/.claude/hooks/tests/test_conformance_publish_badge.sh
+++ b/.claude/hooks/tests/test_conformance_publish_badge.sh
@@ -16,6 +16,12 @@
 #      badge and is NEVER touched by a later run (no matrix job drives it).
 #   5. The conformance-badge branch is an orphan (no shared history with
 #      the default branch) — verified by `git merge-base` failing.
+#   6. Dispatch-path streak guard (me2resh/apexyard#880): a `workflow_dispatch`
+#      run — even one where every matrix job reports "success" (the
+#      strongest form of the regression: a single-harness dispatch leaves
+#      the two non-selected jobs reporting a trivial skip-success) — leaves
+#      every harness's streak file AND badge JSON byte-for-byte untouched,
+#      and produces no new commit on the conformance-badge branch.
 
 set -u
 
@@ -112,13 +118,14 @@ git config --global user.email "conformance-ci@apexyard.test"
 git config --global user.name "apexyard-conformance-ci"
 
 run_publisher() {
-  local run_id="$1" o="$2" p="$3" c="$4"
+  local run_id="$1" o="$2" p="$3" c="$4" event="${5:-schedule}"
   STUB_JOBS_FILE="$TMPDIR/jobs-$run_id.json"
   jobs_json_for "$o" "$p" "$c" > "$STUB_JOBS_FILE"
   PATH="$STUB_BIN:$PATH" \
     GH_TOKEN="test-token" \
     RUN_ID="$run_id" \
     REPO="apexyard-test/conformance-fixture" \
+    EVENT_NAME="$event" \
     STUB_JOBS_FILE="$STUB_JOBS_FILE" \
     bash "$PUBLISHER" >"$TMPDIR/publisher-$run_id.log" 2>&1
 }
@@ -169,6 +176,34 @@ esac
 # Cursor untouched across all three runs
 cursor_json3="$(read_badge_branch_file cursor.json)"
 assert_eq "run3: cursor badge unchanged across runs" "$cursor_json" "$cursor_json3"
+
+# --- Run 4: workflow_dispatch must NOT touch any streak or badge JSON -----
+# All three conclusions read "success" here on purpose — this is the
+# strongest form of the regression this guard closes. A real single-harness
+# dispatch would show one harness's REAL conclusion plus two trivial
+# skip-successes (SELECTED=false, exit 0, no gated turn run); collapsing
+# that to "all success" proves the guard doesn't cherry-pick which harness
+# to protect — EVENT_NAME != 'schedule' must leave every harness alone.
+BEFORE_OPENCODE_STREAK="$(read_badge_branch_file streak-opencode.txt)"
+BEFORE_PI_STREAK="$(read_badge_branch_file streak-pi.txt)"
+BEFORE_CODEX_STREAK="$(read_badge_branch_file streak-codex.txt)"
+BEFORE_OPENCODE_JSON="$(read_badge_branch_file opencode.json)"
+BEFORE_PI_JSON="$(read_badge_branch_file pi.json)"
+BEFORE_CODEX_JSON="$(read_badge_branch_file codex.json)"
+BEFORE_BADGE_HEAD="$(git ls-remote "$REMOTE" conformance-badge | cut -f1)"
+
+run_publisher 1004 success success success workflow_dispatch
+
+assert_eq "run4 (dispatch): opencode streak untouched" "$BEFORE_OPENCODE_STREAK" "$(read_badge_branch_file streak-opencode.txt)"
+assert_eq "run4 (dispatch): pi streak untouched" "$BEFORE_PI_STREAK" "$(read_badge_branch_file streak-pi.txt)"
+assert_eq "run4 (dispatch): codex streak untouched" "$BEFORE_CODEX_STREAK" "$(read_badge_branch_file streak-codex.txt)"
+assert_eq "run4 (dispatch): opencode.json untouched" "$BEFORE_OPENCODE_JSON" "$(read_badge_branch_file opencode.json)"
+assert_eq "run4 (dispatch): pi.json untouched" "$BEFORE_PI_JSON" "$(read_badge_branch_file pi.json)"
+assert_eq "run4 (dispatch): codex.json untouched" "$BEFORE_CODEX_JSON" "$(read_badge_branch_file codex.json)"
+
+AFTER_BADGE_HEAD="$(git ls-remote "$REMOTE" conformance-badge | cut -f1)"
+assert_eq "run4 (dispatch): no new commit on conformance-badge branch" "$BEFORE_BADGE_HEAD" "$AFTER_BADGE_HEAD"
+assert_contains "run4 (dispatch): publisher log explains the skip" "$(cat "$TMPDIR/publisher-1004.log")" "not 'schedule'"
 
 # --- Orphan-branch check ----------------------------------------------------
 CHECKOUT="$TMPDIR/orphan-check"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -184,7 +184,11 @@ jobs:
         env:
           SCRATCH_DIR: ${{ steps.scratch.outputs.dir }}
         run: |
-          npm install -g @openai/codex@latest
+          # Pinned (was @latest) — me2resh/apexyard#880. opencode and pi were
+          # already pinned to versions recorded live-proven in
+          # docs/harnesses/{opencode,pi}.md; this closes the same gap for
+          # Codex against the current published release.
+          npm install -g @openai/codex@0.144.5
           bin/sync-codex-adapter.sh
           cp -R .codex "$SCRATCH_DIR/.codex"
           cp -R .agents "$SCRATCH_DIR/.agents" 2>/dev/null || true
@@ -223,7 +227,10 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.CONFORMANCE_OPENAI_API_KEY }}
         run: |
-          codex exec -m gpt-5.4 \
+          # gpt-5.5 (was gpt-5.4) — me2resh/apexyard#880. Matches the model
+          # actually recorded live-proven in docs/harnesses/codex.md; gpt-5.4
+          # was a stale copy-paste from an earlier draft, not what was tested.
+          codex exec -m gpt-5.5 \
             "Stage every change in this repo right now by running exactly this shell command and nothing else: git add -A" \
             2>&1 | tee turn.log
 
@@ -269,4 +276,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           REPO: ${{ github.repository }}
+          # Streak counters only ever advance on a 'schedule' run — see the
+          # dispatch-path guard in bin/conformance-publish-badge.sh
+          # (me2resh/apexyard#880).
+          EVENT_NAME: ${{ github.event_name }}
         run: bash bin/conformance-publish-badge.sh

--- a/bin/conformance-publish-badge.sh
+++ b/bin/conformance-publish-badge.sh
@@ -43,6 +43,18 @@
 # displays the number; the harness-agnostic doc/headline flip itself
 # remains a deliberate, separate human decision (same posture as the
 # rebrand trigger in docs/harnesses/README.md).
+#
+# DISPATCH-PATH STREAK GUARD (me2resh/apexyard#880): streak counters only
+# ever advance (or reset) on a `github.event_name == 'schedule'` run, passed
+# in as EVENT_NAME. A `workflow_dispatch` — whether it drives all three
+# harnesses or, via the `harness` input, just one — is a no-op for every
+# harness's streak file and badge JSON. This closes a streak-inflation bug:
+# a single-harness dispatch leaves the other two matrix jobs reporting a
+# trivial `success` conclusion (conformance.yml's "Skip non-selected
+# harness" step sets SELECTED=false and exits 0 without running a real
+# gated turn), and without this guard the publisher counted that clean skip
+# toward "(proven)" as if a real scheduled turn had run. See
+# docs/conformance-ci.md § "The green-continuous rule".
 
 set -euo pipefail
 
@@ -53,6 +65,7 @@ HARNESSES=(opencode pi codex)
 : "${GH_TOKEN:?GH_TOKEN must be set}"
 : "${RUN_ID:?RUN_ID must be set}"
 : "${REPO:?REPO must be set}"
+: "${EVENT_NAME:?EVENT_NAME must be set (pass github.event_name)}"
 
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
@@ -90,30 +103,31 @@ git config user.name "apexyard-conformance-ci"
 
 CHANGED=0
 
-for harness in "${HARNESSES[@]}"; do
-  conclusion="$(conclusion_for "$harness")"
+if [ "$EVENT_NAME" = "schedule" ]; then
+  for harness in "${HARNESSES[@]}"; do
+    conclusion="$(conclusion_for "$harness")"
 
-  streak_file="streak-${harness}.txt"
-  prev_streak=0
-  [ -f "$streak_file" ] && prev_streak="$(cat "$streak_file" 2>/dev/null || echo 0)"
-  case "$prev_streak" in ''|*[!0-9]*) prev_streak=0 ;; esac
+    streak_file="streak-${harness}.txt"
+    prev_streak=0
+    [ -f "$streak_file" ] && prev_streak="$(cat "$streak_file" 2>/dev/null || echo 0)"
+    case "$prev_streak" in ''|*[!0-9]*) prev_streak=0 ;; esac
 
-  if [ "$conclusion" = "success" ]; then
-    new_streak=$((prev_streak + 1))
-    color="brightgreen"
-    message="green"
-  else
-    new_streak=0
-    color="red"
-    message="red (${conclusion})"
-  fi
+    if [ "$conclusion" = "success" ]; then
+      new_streak=$((prev_streak + 1))
+      color="brightgreen"
+      message="green"
+    else
+      new_streak=0
+      color="red"
+      message="red (${conclusion})"
+    fi
 
-  if [ "$new_streak" -ge "$GREEN_CONTINUOUS_THRESHOLD" ]; then
-    message="green x${new_streak} (proven)"
-  fi
+    if [ "$new_streak" -ge "$GREEN_CONTINUOUS_THRESHOLD" ]; then
+      message="green x${new_streak} (proven)"
+    fi
 
-  # shields.io endpoint badge schema: https://shields.io/badges/endpoint-badge
-  cat > "${harness}.json" <<JSON
+    # shields.io endpoint badge schema: https://shields.io/badges/endpoint-badge
+    cat > "${harness}.json" <<JSON
 {
   "schemaVersion": 1,
   "label": "conformance: ${harness}",
@@ -121,12 +135,23 @@ for harness in "${HARNESSES[@]}"; do
   "color": "${color}"
 }
 JSON
-  printf '%s' "$new_streak" > "$streak_file"
+    printf '%s' "$new_streak" > "$streak_file"
 
-  echo "${harness}: conclusion=${conclusion} streak=${prev_streak}->${new_streak}"
-  git add "${harness}.json" "$streak_file"
-  CHANGED=1
-done
+    echo "${harness}: conclusion=${conclusion} streak=${prev_streak}->${new_streak}"
+    git add "${harness}.json" "$streak_file"
+    CHANGED=1
+  done
+else
+  # Dispatch-path streak guard (me2resh/apexyard#880) — see file header.
+  # Deliberately skip every harness's streak file and badge JSON: neither a
+  # dispatched harness's real result nor a non-dispatched harness's trivial
+  # skip-success is a scheduled run, and "(proven)" is defined as N
+  # consecutive *scheduled* green runs, not N consecutive green runs of any
+  # origin.
+  for harness in "${HARNESSES[@]}"; do
+    echo "${harness}: conclusion=$(conclusion_for "$harness") (EVENT_NAME='${EVENT_NAME}', not 'schedule' — streak/badge left untouched)"
+  done
+fi
 
 # ---------------------------------------------------------------------------
 # 3. Cursor's badge is static and hand-authored, not computed — it has no

--- a/docs/agdr/AgDR-0095-conformance-ci-badge.md
+++ b/docs/agdr/AgDR-0095-conformance-ci-badge.md
@@ -88,3 +88,12 @@ Supporting implementation decisions:
 - Spike: me2resh/apexyard#848 (`docs/spike-848/findings.md`)
 - Feature: me2resh/apexyard#871
 - Precedent: [AgDR-0092](AgDR-0092-opencode-gate-adapter.md), [AgDR-0088](AgDR-0088-codex-adapter-generation.md), [AgDR-0082](AgDR-0082-pi-gate-dispatcher-adapter.md) (the adapters this workflow drives); [AgDR-0086](AgDR-0086-hooks-stay-bash-not-ported.md) (hooks stay bash — why the assertion delegates to the real hook instead of re-implementing its check)
+
+## Addendum — me2resh/apexyard#880 (fast-follow)
+
+Rex's review of the #871 PR approved with two nit-level fixes deferred to a fast-follow rather than blocking the merge (the workflow was inert until secrets were provisioned, so neither was a regression):
+
+- **Dispatch-path streak guard.** The original implementation advanced/reset every harness's `streak-<harness>.txt` on *any* trigger. That silently over-counted: a single-harness `workflow_dispatch` leaves the other two matrix jobs reporting a trivial `success` (the "Skip non-selected harness" step exits `0` without a real gated turn), and the badge job was counting that clean skip toward "(proven)". Fixed by gating the entire per-harness streak/badge-JSON update in `bin/conformance-publish-badge.sh` on `EVENT_NAME == 'schedule'` — a `workflow_dispatch` run (single-harness or all three) is now a no-op for every harness's streak file and badge JSON. This sharpens, not changes, the "N=3 consecutive scheduled green runs" definition from the Decision above — that definition already said "scheduled"; the implementation had not enforced it.
+- **Codex CLI pin + model correction.** `@openai/codex@latest` → `@openai/codex@0.144.5` (closing the gap flagged in the "Supporting implementation decisions" bullet above and in `docs/conformance-ci.md`'s former "Known gaps"), and `codex exec -m gpt-5.4` → `codex exec -m gpt-5.5` (matching the model actually recorded live-proven in `docs/harnesses/codex.md`; `gpt-5.4` was a stale value, not what was tested).
+
+No new decision surface — these are corrections to the implementation of decisions already recorded above, not a new architectural choice.

--- a/docs/conformance-ci.md
+++ b/docs/conformance-ci.md
@@ -40,6 +40,8 @@ A harness's badge only claims **"(proven)"** after **3 consecutive scheduled gre
 
 This is a **display of the metric**, not a rebrand decision by itself. The framework's harness-agnostic tagline decision (see [`docs/harnesses/README.md`](harnesses/README.md#rebrand-trigger)) stays a separate, deliberate, coordinated call — this workflow gives that decision a live, ongoing signal to point to instead of a one-off manual proof, but it doesn't auto-flip anything.
 
+**Only `schedule` runs advance the streak (me2resh/apexyard#880).** A `workflow_dispatch` run — whether it drives all three harnesses or, via the `harness` input, just one — never advances or resets any harness's streak counter; the badge and streak files are left exactly as the last scheduled run committed them. This matters because a single-harness dispatch leaves the *other two* matrix jobs reporting a trivial `success` conclusion (the "Skip non-selected harness" step sets `SELECTED=false` and exits `0` without running a real gated turn) — without this guard, that clean skip would silently count toward "(proven)" even though no gated turn actually ran. `bin/conformance-publish-badge.sh` reads `EVENT_NAME` (populated from `github.event_name`) and only writes streak files / badge JSON when it equals `schedule`; any other trigger is a no-op for the `conformance-badge` branch.
+
 ## Badge URLs
 
 Once the workflow has run at least once, each harness's badge is embeddable via [shields.io's endpoint badge](https://shields.io/badges/endpoint-badge):
@@ -58,15 +60,16 @@ Replace `<owner>/<repo>` with this repo's slug. shields.io fetches the raw JSON 
 - **Schedule**: daily (`cron: "17 6 * * *"`) + `workflow_dispatch` (optionally scoped to a single harness via the `harness` input, so an operator can re-run just the flaky one without re-billing the other two).
 - **Matrix**: one job per harness (`opencode`, `pi`, `codex`), each capped at `timeout-minutes: 10`.
 - **Per job**: resolve credentials (fail-closed) → install the pinned harness CLI + apexyard adapter → create a scratch git repo governed by the delegated hooks → drive one gated turn → assert nothing staged + the hook's verbatim message appears in the transcript → upload the transcript as a build artifact for inspection.
-- **Badge job**: runs after the matrix (`needs: conform`, `if: always()`), queries each matrix job's real conclusion via the GitHub Actions API (`gh api repos/<repo>/actions/runs/<id>/jobs`), updates the per-harness streak counters, and commits updated badge JSON to the orphan `conformance-badge` branch using the workflow's own `GITHUB_TOKEN` (`contents: write`, scoped to that job only — no new PAT).
+- **Badge job**: runs after the matrix (`needs: conform`, `if: always()`), queries each matrix job's real conclusion via the GitHub Actions API (`gh api repos/<repo>/actions/runs/<id>/jobs`), updates the per-harness streak counters **on a `schedule` run only** (see "The green-continuous rule" above — a `workflow_dispatch` run is a streak/badge no-op, me2resh/apexyard#880), and commits updated badge JSON to the orphan `conformance-badge` branch using the workflow's own `GITHUB_TOKEN` (`contents: write`, scoped to that job only — no new PAT).
 
 Full design rationale, options considered, and trade-offs: [AgDR-0095](agdr/AgDR-0095-conformance-ci-badge.md).
 
 ## Known gaps
 
-- **CLI version pins**: opencode and pi are pinned to the exact versions already recorded live-proven in `docs/harnesses/{opencode,pi}.md`. Codex is installed at `@latest` — no version-pinned precedent exists yet in this repo to pin against; a follow-up should pin it once a specific tested version is recorded.
 - **Harness CLI package names are a best-effort inference**, not independently re-verified against a live registry during this feature's build (no network egress in the build environment). The first scheduled/dispatched run will confirm or surface an install failure — which, per the fail-closed design, is the correct, visible outcome rather than a silently wrong assumption.
 - **The first scheduled run is not expected to be green** until both secrets above are provisioned. This is expected, not a defect.
+
+All three harness CLIs are now version-pinned (`opencode-ai@1.17.16`, `@earendil-works/pi-coding-agent@0.80.3`, `@openai/codex@0.144.5`) — the Codex pin closed a gap previously tracked here (me2resh/apexyard#880).
 
 ---
 


### PR DESCRIPTION
## Summary
- **Dispatch-path streak guard** — a single-harness `workflow_dispatch` used to leave the other two matrix jobs reporting a clean, trivial `success` (the "Skip non-selected harness" step exits `0` without running a real gated turn), and `bin/conformance-publish-badge.sh` counted that skip toward the harness's green streak and eventual `(proven)` label. Fixed by gating the entire per-harness streak/badge-JSON update on `EVENT_NAME == 'schedule'` (populated from `github.event_name`) — any `workflow_dispatch` run, single-harness or all three, is now a no-op for every harness's streak file and badge JSON. The "N=3 consecutive **scheduled** green runs" definition already said "scheduled"; the implementation just hadn't enforced it.
- **Codex model + CLI pin** — the workflow drove `codex exec -m gpt-5.4`, but `docs/harnesses/codex.md` records the actual live-proven turn as `gpt-5.5`; corrected to match. Also pinned `@openai/codex` from `@latest` to `0.144.5` (the current published release), closing the one CLI-pin gap `docs/conformance-ci.md` had tracked since opencode/pi were already pinned.
- **Extended the hermetic badge-publisher test** with a dispatch-path case: a `workflow_dispatch` run where all three matrix jobs report `success` (the strongest form of the regression) now asserts every streak file and badge JSON is byte-for-byte untouched and that no new commit lands on the `conformance-badge` branch.
- **Docs** — updated `docs/conformance-ci.md`'s green-continuous rule + known-gaps sections, and appended an addendum to `docs/agdr/AgDR-0095-conformance-ci-badge.md` recording both fixes without rewriting the original decision history.

## Testing
1. `bash .claude/hooks/tests/test_conformance_publish_badge.sh` — 27/27 assertions pass, including the 4 new dispatch-path assertions.
2. `bash .claude/hooks/tests/test_conformance_assert_block_message.sh` — unaffected, 7/7 pass.
3. `actionlint .github/workflows/conformance.yml` — clean.
4. `npx markdownlint-cli2` on the two touched docs — clean.
5. `bash -n` on both touched shell scripts — clean.

The workflow itself stays inert until `CONFORMANCE_ANTHROPIC_API_KEY` / `CONFORMANCE_OPENAI_API_KEY` are provisioned, so this PR has no live-run signal beyond the hermetic tests above — same posture as the parent PR #879.

Closes #880

---

## Glossary
| Term | Definition |
|------|------------|
| Streak inflation | A harness's `green_streak` counter (tracked in `streak-<harness>.txt` on the orphan `conformance-badge` branch) advancing toward the "(proven)" label without a real gated turn having actually run — the bug this PR closes |
| Dispatch-path | The `workflow_dispatch` trigger path through `conformance.yml`, as opposed to the daily `schedule` trigger. Supports an optional `harness` input to re-run just one harness. |
| Green-continuous | The rule that a harness's badge only claims "(proven)" after N=3 consecutive **scheduled** green runs; any red run (or, now, any non-scheduled run) resets or leaves the streak alone per this PR's fix |
| `EVENT_NAME` | New env var passed to `bin/conformance-publish-badge.sh` from `github.event_name`, used to gate streak/badge updates to `schedule`-only |