### PR TITLE
feat(#923): /inbox reconcile flag for open issues with a merged PR

### DIFF
--- a/.claude/skills/inbox/SKILL.md
+++ b/.claude/skills/inbox/SKILL.md
@@ -133,6 +133,34 @@ Issue axis — tracker-agnostic via `tracker_list` (run per project from the reg
 tracker_list "$repo" state=open labels=blocked
 ```
 
+### 9. Reconcile — open issues that already have a merged PR (#923)
+
+> Forge axis (#711) — GitHub-only until the PR/MR abstraction lands.
+
+The sibling of the reconcile-before-build rule: that rule stops NEW drift at the spawn boundary; this section surfaces EXISTING drift that already happened. The signature is cheap and mechanical — an issue that is still `OPEN` but a merged PR already references it (`Closes #N` that didn't fire because the PR merged to `dev`, not the release branch; or `Refs #N` left open on purpose for a QA gate).
+
+Fetch **once per repo**, not once per open issue — a batched query is the whole point, both for `gh` rate limits and for wall-clock time across a portfolio:
+
+```bash
+# 1. Open issue numbers for this repo (one call).
+open_issues=$(gh issue list --repo "$repo" --state open --json number --jq '.[].number')
+
+# 2. Merged PRs for this repo, bounded so the scan stays cheap (one call).
+#    --limit 200 is a reasonable default; tighten it further with --search
+#    "merged:>=<since-date>" on a very active repo, or when --since is passed.
+gh pr list --repo "$repo" --state merged \
+  --json number,title,body,url,mergedAt --limit 200
+```
+
+Then, for each merged PR's title + body, extract issue references and classify them:
+
+- **Closing keywords** — `close[sd]?`, `fix(e[sd])?`, `resolve[sd]?` immediately followed by `#N` (case-insensitive). A match here against an issue still open is very likely a **release-cut artifact** — the PR's `Closes #N` didn't auto-fire because it merged to a non-default branch.
+- **Referencing keywords** — `refs?`, `references?`, `related to` immediately followed by `#N`. A match here is likely an **intentional QA gate** — the ticket is deliberately held open pending verification (see `workflows/sdlc.md` Phase 5) — surface it as lower-urgency than a closing-keyword match.
+
+**Conservative by construction**: only count a reference when a closing/referencing keyword sits directly next to the `#N` (not any bare number appearing anywhere in a PR body) AND `N` is in the `open_issues` set fetched in step 1. A PR that happens to mention an unrelated number, or a `#N` for an issue that's already closed, produces no flag. This is what keeps the section from ever flagging a genuinely-open or gated ticket.
+
+**Graceful degradation**: if either `gh` call fails for a repo (rate limit, auth, network), skip that repo's contribution to this section and continue — same as Rule 5 below. If a repo produces zero matches, the section is simply absent for it (Rule 4).
+
 ## Output format
 
 Group everything under headings, project-prefixed:
@@ -167,7 +195,11 @@ INBOX — 2026-04-06 09:14
 🛑 Blocked items (1)
   · billing-api#19   Waiting on API key from vendor     https://…
 
-Summary: 12 items · 3 PRs to review · 1 ready to merge · 1 blocking CI failure
+🔁 Reconcile — open issues with a merged PR (2)
+  · example-app#88   Closes-but-open · merged PR #101 (release-cut?)   https://…
+  · billing-api#31   Refs-open · merged PR #64 (QA gate?)              https://…
+
+Summary: 12 items · 3 PRs to review · 1 ready to merge · 1 blocking CI failure · 2 to reconcile
 ```
 
 If everything is empty:
@@ -184,6 +216,7 @@ If everything is empty:
 | `--since <duration>` | Only items updated in the window (e.g. `24h`, `7d`) |
 | `--project <name>` | Limit to one project from the registry |
 | `--no-mentions` | Hide the mentions section |
+| `--no-reconcile` | Hide the Reconcile section (#923) |
 
 ## Rules
 
@@ -194,6 +227,7 @@ If everything is empty:
 5. **Never error on a single project** — if one repo is unreachable, mark it `?` and continue
 6. **Always include URLs** — every row needs a clickable link
 7. **No noise** — items where you have no possible action shouldn't appear (e.g. PRs you've already approved)
+8. **Reconcile is a passive surface, not an action** — flag drift, never close/re-tag the issue or comment on the PR from this skill; the operator decides what to do with each flagged item
 
 ## Related skills
 

--- a/.claude/skills/inbox/tests/smoke.sh
+++ b/.claude/skills/inbox/tests/smoke.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# /inbox smoke test — Reconcile section (#923)
+#
+# /inbox is a prompt-driven skill: SKILL.md's bash blocks are executed by
+# Claude Code at invocation time, not by a shipped script. This smoke test
+# pins the *contract* the Reconcile section must satisfy — the same
+# contract-pinning shape used by .claude/skills/codify-rule/tests/smoke.sh
+# — plus a standalone re-implementation of the detection/classification
+# logic so the conservative-matching behaviour (no false positives on a
+# gated/genuinely-open ticket) is actually exercised, not just asserted
+# in prose.
+#
+# What this checks:
+#
+#   1. SKILL.md frontmatter sanity (name, allowed-tools unchanged).
+#   2. SKILL.md documents the Reconcile section: numbered section 9,
+#      the batched (once-per-repo, not once-per-issue) query shape,
+#      the Closes-vs-Refs distinction, graceful degradation, and the
+#      --no-reconcile filter.
+#   3. SKILL.md's output-format example includes a Reconcile row so the
+#      shape is discoverable without reading the prose.
+#   4. The detection/classification logic (extracted below as a small
+#      shell function mirroring the SKILL.md prose) correctly:
+#        a. flags an issue closed-but-open by a merged PR's "Closes #N"
+#        b. flags an issue refs-open by a merged PR's "Refs #N"
+#        c. does NOT flag a genuinely-open issue with no PR reference
+#        d. does NOT flag an issue merely mentioned in passing (no
+#           adjacent closing/referencing keyword)
+#        e. does NOT flag when the referenced issue isn't in the open set
+#
+# The skill itself is NOT executed here (no live `gh` calls) — this is a
+# contract + logic test, matching the rest of this repo's skill smoke tests.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+assert_grep() {
+  local label="$1" pattern="$2" file="$3"
+  if grep -qE "$pattern" "$file"; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (pattern: $pattern; file: $file)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (expected: $expected; actual: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Resolve the ops-fork root by walking up from this script.
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+ops_root="$script_dir"
+while [ "$ops_root" != "/" ] && [ ! -f "$ops_root/CLAUDE.md" ]; do
+  ops_root=$(dirname "$ops_root")
+done
+if [ ! -f "$ops_root/CLAUDE.md" ]; then
+  echo "FAIL: could not locate ops-fork root (CLAUDE.md missing)"
+  exit 1
+fi
+
+skill_md="$ops_root/.claude/skills/inbox/SKILL.md"
+
+echo "Smoke test: /inbox Reconcile section (#923) (ops_root=$ops_root)"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. Frontmatter sanity
+# ---------------------------------------------------------------------------
+echo "1. SKILL.md frontmatter sanity:"
+assert_grep "name: inbox"                  "^name: inbox$"                          "$skill_md"
+assert_grep "allowed-tools unchanged (read-only)" "^allowed-tools: Bash, Read, Grep, Glob$" "$skill_md"
+
+# ---------------------------------------------------------------------------
+# 2. Reconcile section contract
+# ---------------------------------------------------------------------------
+echo ""
+echo "2. Reconcile section contract:"
+assert_grep "numbered section 9 exists"          "### 9\. Reconcile"                              "$skill_md"
+assert_grep "references ticket #923"             "#923"                                            "$skill_md"
+assert_grep "batched once-per-repo framing"      "Fetch \*\*once per repo\*\*"                      "$skill_md"
+assert_grep "open-issue set fetched first"       "open_issues="                                    "$skill_md"
+assert_grep "merged-PR query present"            "gh pr list --repo \"\\\$repo\" --state merged"    "$skill_md"
+assert_grep "Closing-keyword classification"     "Closing keywords"                                "$skill_md"
+assert_grep "Referencing-keyword classification" "Referencing keywords"                            "$skill_md"
+assert_grep "release-cut artifact framing"       "release-cut artifact"                            "$skill_md"
+assert_grep "QA-gate framing"                    "intentional QA gate"                             "$skill_md"
+assert_grep "conservative-by-construction note"  "Conservative by construction"                    "$skill_md"
+assert_grep "graceful degradation note"          "Graceful degradation"                             "$skill_md"
+assert_grep "--no-reconcile filter documented"   "\-\-no-reconcile"                                 "$skill_md"
+assert_grep "Rules section: advisory-only note"  "Reconcile is a passive surface, not an action"    "$skill_md"
+
+# ---------------------------------------------------------------------------
+# 3. Output-format example includes a Reconcile row
+# ---------------------------------------------------------------------------
+echo ""
+echo "3. Output-format example:"
+assert_grep "Reconcile row in the sample output" "Reconcile — open issues with a merged PR" "$skill_md"
+
+# ---------------------------------------------------------------------------
+# 4. Detection/classification logic — exercised, not just asserted in prose
+# ---------------------------------------------------------------------------
+echo ""
+echo "4. Detection/classification logic (standalone re-implementation):"
+
+# classify <pr_text> <issue_number> <open_issues_csv>
+# Echoes "closes", "refs", or "" (no match / not conservative-eligible).
+classify() {
+  local text="$1" issue="$2" open_csv="$3"
+
+  # Not in the open set at all → never flag (regardless of PR text).
+  case ",$open_csv," in
+    *",$issue,"*) : ;;
+    *) echo ""; return ;;
+  esac
+
+  if echo "$text" | grep -qiE "(close[sd]?|fix(e[sd])?|resolve[sd]?)[^\n]{0,20}#${issue}\b"; then
+    echo "closes"
+  elif echo "$text" | grep -qiE "(refs?|references?|related to)[^\n]{0,20}#${issue}\b"; then
+    echo "refs"
+  else
+    echo ""
+  fi
+}
+
+open_set="88,31,42"
+
+result=$(classify "This PR closes #88 by fixing the race condition" "88" "$open_set")
+assert_eq "4a. Closes #N against an open issue -> classified 'closes'" "closes" "$result"
+
+result=$(classify "Refs #31 — awaiting QA sign-off before closing" "31" "$open_set")
+assert_eq "4b. Refs #N against an open issue -> classified 'refs'" "refs" "$result"
+
+result=$(classify "General cleanup, no ticket references here" "42" "$open_set")
+assert_eq "4c. No reference at all -> no flag (empty)" "" "$result"
+
+result=$(classify "See #42 for background on why this approach was chosen" "42" "$open_set")
+assert_eq "4d. Bare mention with no adjacent closing/refs keyword -> no flag" "" "$result"
+
+result=$(classify "Closes #999" "999" "$open_set")
+assert_eq "4e. Closing keyword for an issue NOT in the open set -> no flag" "" "$result"
+
+echo ""
+echo "-----------------------------------------------------------"
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,7 @@ One-line summary per skill; canonical details live in each `.claude/skills/<name
 | `/release` | (Framework-only) Cut an apexyard release — diff, bump, CHANGELOG, release PR, tag |
 | `/release-sync` | (Framework-only) Sync `main` back to `dev` after a squash-merge release so the squash commit is an ancestor of `dev`, preventing recurring merge conflicts |
 | `/projects` | List all managed projects from the registry with status |
-| `/inbox` | Items needing your attention — PRs, issues, comments, blockers |
+| `/inbox` | Items needing your attention — PRs, issues, comments, blockers, stale-ticket reconcile flags |
 | `/status` | Current snapshot — git, CI, in-progress work (use `--briefing` for 4-line shape) |
 | `/tasks` | Actionable task list across the portfolio with direct URLs, prioritised |
 | `/roadmap` | Update or create the product roadmap |


### PR DESCRIPTION
## Summary

- **`/inbox` gains a Reconcile section (§9)** — flags open issues that already have a merged PR referencing them, so stale-but-open tickets (a `Closes #N` that didn't auto-fire because the PR merged to `dev` instead of a release branch, or an intentionally-held-open QA-gate `Refs #N`) surface passively during a normal `/inbox` run instead of piling up until someone runs a manual audit.
- **Batched per-repo query, not per-issue** — fetches the repo's open-issue numbers once and its merged PRs once, then cross-references locally. This keeps the scan cheap (bounded API calls) across a portfolio instead of firing one `gh` search per open issue.
- **Conservative by construction** — only flags a reference when a closing/referencing keyword sits directly next to a `#N` *and* that `N` is actually in the open-issue set. A PR that merely mentions an unrelated number, or references an issue that's already closed, produces no flag — this is what keeps genuinely-open and intentionally-gated tickets out of the noise.
- **Distinguishes the two drift shapes** where cheaply possible — `Closes`-but-open reads as a likely release-cut artifact; `Refs`-open reads as a likely intentional QA gate (lower urgency, matches the mandatory QA-hold pattern in `workflows/sdlc.md` Phase 5).
- **Opt-out + graceful degradation** — `--no-reconcile` hides the section; a `gh` failure on one repo just skips that repo's contribution (same as the existing "never error on a single project" rule); an empty result omits the section entirely (no behaviour change for portfolios with no drift).

## Testing

1. `.claude/skills/inbox/tests/smoke.sh` — new contract + logic smoke test (mirrors the `/codify-rule` smoke-test pattern, since `/inbox` is a prompt-driven skill with no shipped runtime script). Covers: SKILL.md documents the batched query shape, the Closes/Refs distinction, graceful degradation, and the `--no-reconcile` flag; plus a standalone re-implementation of the classification logic exercising 5 cases — Closes-on-open (flag), Refs-on-open (flag), no reference (no flag), bare mention with no adjacent keyword (no flag), and closing keyword for an issue *not* in the open set (no flag). All 21 assertions pass.
2. `markdownlint-cli2` on the modified `SKILL.md` — 0 errors.
3. `shellcheck` on the new smoke test — clean.
4. `.claude/hooks/tests/test_subpack_extraction.sh` — full run, all 7 steps pass (confirms the new `tests/` subfolder under `.claude/skills/inbox/` doesn't leak into the audit-pack / safety-hooks sub-pack extraction).

Closes #923

---

## Glossary

| Term | Definition |
|------|------------|
| Reconcile flag | The new passive `/inbox` surface for open issues that already have a merged PR referencing them |
| Release-cut artifact | A `Closes #N` that didn't auto-close the issue because the PR merged to `dev`, not the release branch |
| QA-gate hold | An issue intentionally left open (`Refs #N` instead of `Closes #N`) pending QA verification, per `workflows/sdlc.md` Phase 5 |
| Forge axis (#711) | The still-open follow-up that would make `/inbox`'s PR-reading sections (including this one) tracker-agnostic beyond GitHub; until then this section is GitHub-only, same as the other PR sections |
