### PR TITLE
fix(#886): judge all bash write targets, not just the first

### DIFF
--- a/.claude/hooks/_lib-detect-bash-write.sh
+++ b/.claude/hooks/_lib-detect-bash-write.sh
@@ -119,8 +119,21 @@ _bdw_starts_with_git_subcommand() {
 # ------------------------------------------------------------------------------
 
 # 1. Redirection.
+#
+# The leading-context class `[^|<&]` excludes a `>` that's part of `2>&1`
+# fd-dup or immediately follows a pipe/heredoc marker. But `[^|<&]` REQUIRES
+# a character before `>` to exist at all — a command (or, after #886's
+# segment split, a SEGMENT) that BEGINS with `>` has no preceding character,
+# so the original pattern silently failed to match at position 0. That's
+# the exact shape a no-space chained write produces: splitting
+# `echo a > /tmp/ok;> .gitignore` on `;` yields a second segment of
+# `> .gitignore` — starting with `>` — and the un-anchored pattern dropped
+# it entirely (apexyard#886 Hakim security-review finding, PR #926).
+# `(^|[^|<&])` adds "start of string/segment" as an equally-valid leading
+# context, closing that hole while leaving the `2>&1` / `<<EOF` exclusions
+# intact (neither of those ever begins a segment with a bare `>`).
 _bdw_match_redirection() {
-  echo "$1" | grep -qE '[^|<&]>>?[[:space:]]+[^[:space:]&|;]+'
+  echo "$1" | grep -qE '(^|[^|<&])>>?[[:space:]]+[^[:space:]&|;]+'
 }
 
 # 2. tee.
@@ -401,8 +414,15 @@ bash_extract_write_target() {
 
   # Output redirection: capture the first target after > or >>.
   # Strip leading number for cases like `2> file`.
+  #
+  # (^|[^|<&]) — see the identical note on _bdw_match_redirection above
+  # (apexyard#886/#926): a command that BEGINS with `>` (e.g. the second
+  # half of `echo a > /tmp/ok;> .gitignore` once split on `;`) has no
+  # character before the `>`, so the un-anchored `[^|<&]>...` silently
+  # failed to match at position 0. Anchoring on start-of-string closes
+  # that hole without loosening the `2>&1` / heredoc exclusions.
   local target
-  target=$(echo "$cmd" | grep -oE '[^|<&]>>?[[:space:]]+[^[:space:]&|;]+' \
+  target=$(echo "$cmd" | grep -oE '(^|[^|<&])>>?[[:space:]]+[^[:space:]&|;]+' \
                 | head -n 1 \
                 | sed -E 's/^[^>]*>>?[[:space:]]+//')
   if [ -n "$target" ]; then
@@ -513,11 +533,21 @@ _bdw_targets_from_segment() {
   local line target tee_tail
 
   # ALL redirection targets in this segment (not just the first).
+  #
+  # (^|[^|<&]) — apexyard#886/#926 (Hakim security review, PR #926): a
+  # segment produced by bash_extract_write_targets' top-level split can
+  # itself BEGIN with `>` — e.g. splitting `echo a > /tmp/ok;> .gitignore`
+  # on `;` yields a second segment of `> .gitignore`. The un-anchored
+  # `[^|<&]>...` requires a character before `>` to exist, so it silently
+  # dropped every no-space-after-separator redirection (`;>`, `&&>`, `|>`,
+  # `||>`). Anchoring on start-of-segment closes that hole while leaving
+  # the `2>&1` / heredoc exclusions untouched (neither begins a segment
+  # with a bare `>`).
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     target=$(printf '%s\n' "$line" | sed -E 's/^[^>]*>>?[[:space:]]+//')
     [ -n "$target" ] && _bdw_strip_quotes "$target"
-  done < <(printf '%s\n' "$seg" | grep -oE '[^|<&]>>?[[:space:]]+[^[:space:]&|;]+')
+  done < <(printf '%s\n' "$seg" | grep -oE '(^|[^|<&])>>?[[:space:]]+[^[:space:]&|;]+')
 
   # ALL tee operands in this segment — `tee a b c` names three targets, not
   # one; the original single-target extractor only ever returned "a".

--- a/.claude/hooks/_lib-detect-bash-write.sh
+++ b/.claude/hooks/_lib-detect-bash-write.sh
@@ -132,8 +132,24 @@ _bdw_starts_with_git_subcommand() {
 # `(^|[^|<&])` adds "start of string/segment" as an equally-valid leading
 # context, closing that hole while leaving the `2>&1` / `<<EOF` exclusions
 # intact (neither of those ever begins a segment with a bare `>`).
+#
+# COMPLETE operator alternation (apexyard#886/#926 round 3 — Hakim's
+# adversarial re-hunt): the pattern above only modelled `>` / `>>` (and,
+# via the leading-context class, `n>` / `n>>` for an fd number). It missed
+# two more real, destructive write operators:
+#   - `&>` / `&>>`  — redirect BOTH stdout and stderr to a file (a write).
+#     Matched by a dedicated `&>>?` alternative: `&` immediately followed
+#     by `>` is unambiguous — it never appears in `2>&1` or `>&2` (there
+#     the `&` comes AFTER the `>`, not before), so this can't collide with
+#     the fd-dup exclusion the leading-context class protects.
+#   - `>|` / `>>|`  — force-clobber (override `set -o noclobber`), also a
+#     write. Modelled by an optional trailing `\|?` on the existing `>>?`.
+# Both are added as alternatives / suffixes to the SAME anchored pattern,
+# not new logic — `2>&1`, `>&2`, `<`, `<<EOF`, `<<<` are all still excluded
+# by the same mechanisms as before (mandatory whitespace immediately after
+# the operator; `&` only recognised when it precedes `>`, never follows).
 _bdw_match_redirection() {
-  echo "$1" | grep -qE '(^|[^|<&])>>?[[:space:]]+[^[:space:]&|;]+'
+  echo "$1" | grep -qE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]+[^[:space:]&|;]+'
 }
 
 # 2. tee.
@@ -412,8 +428,9 @@ bash_extract_write_target() {
   local cmd="$1"
   [ -z "$cmd" ] && return 0
 
-  # Output redirection: capture the first target after > or >>.
-  # Strip leading number for cases like `2> file`.
+  # Output redirection: capture the first target after >, >>, &>, &>>, >|,
+  # or >>|. Strip leading number/ampersand for cases like `2> file` /
+  # `&> file`.
   #
   # (^|[^|<&]) — see the identical note on _bdw_match_redirection above
   # (apexyard#886/#926): a command that BEGINS with `>` (e.g. the second
@@ -421,10 +438,18 @@ bash_extract_write_target() {
   # character before the `>`, so the un-anchored `[^|<&]>...` silently
   # failed to match at position 0. Anchoring on start-of-string closes
   # that hole without loosening the `2>&1` / heredoc exclusions.
+  #
+  # `&>>?` and the trailing `\|?` (apexyard#886/#926 round 3) extend the
+  # same anchored pattern to the full write-redirect operator set — see
+  # the comment on _bdw_match_redirection for why `&>` can't collide with
+  # `2>&1`/`>&2` fd-dup exclusion. The strip sed's `[^>]*` prefix already
+  # swallows a leading `&` the same way it swallows a leading digit or
+  # space, so no separate strip pattern is needed for `&>`/`&>>`; the
+  # trailing `\|?` addition handles `>|`/`>>|`.
   local target
-  target=$(echo "$cmd" | grep -oE '(^|[^|<&])>>?[[:space:]]+[^[:space:]&|;]+' \
+  target=$(echo "$cmd" | grep -oE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]+[^[:space:]&|;]+' \
                 | head -n 1 \
-                | sed -E 's/^[^>]*>>?[[:space:]]+//')
+                | sed -E 's/^[^>]*>>?\|?[[:space:]]+//')
   if [ -n "$target" ]; then
     target="${target%\"}"; target="${target#\"}"
     target="${target%\'}"; target="${target#\'}"
@@ -532,7 +557,9 @@ _bdw_targets_from_segment() {
   local seg="$1"
   local line target tee_tail
 
-  # ALL redirection targets in this segment (not just the first).
+  # ALL redirection targets in this segment (not just the first) — covers
+  # every write-redirect operator: >, >>, >|, >>|, &>, &>>, and n>/n>> (an
+  # fd-numbered redirect, e.g. `2> err.log`, IS a write to err.log).
   #
   # (^|[^|<&]) — apexyard#886/#926 (Hakim security review, PR #926): a
   # segment produced by bash_extract_write_targets' top-level split can
@@ -543,11 +570,20 @@ _bdw_targets_from_segment() {
   # `||>`). Anchoring on start-of-segment closes that hole while leaving
   # the `2>&1` / heredoc exclusions untouched (neither begins a segment
   # with a bare `>`).
+  #
+  # `&>>?` and the trailing `\|?` (apexyard#886/#926 round 3): Hakim's
+  # adversarial re-hunt found this pattern still missed `&>`/`&>>`
+  # (redirect-both-streams) and `>|`/`>>|` (force-clobber) — both real
+  # destructive writes. `&>` is unambiguous against `2>&1`/`>&2` fd-dup
+  # because the `&` precedes the `>` here, never follows it. `>|`/`>>|`
+  # need the SEGMENT to still contain the literal `|` — see
+  # bash_extract_write_targets' clobber-protection step, which shields
+  # these operators from the later bare-`|` (pipe) split.
   while IFS= read -r line; do
     [ -z "$line" ] && continue
-    target=$(printf '%s\n' "$line" | sed -E 's/^[^>]*>>?[[:space:]]+//')
+    target=$(printf '%s\n' "$line" | sed -E 's/^[^>]*>>?\|?[[:space:]]+//')
     [ -n "$target" ] && _bdw_strip_quotes "$target"
-  done < <(printf '%s\n' "$seg" | grep -oE '(^|[^|<&])>>?[[:space:]]+[^[:space:]&|;]+')
+  done < <(printf '%s\n' "$seg" | grep -oE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]+[^[:space:]&|;]+')
 
   # ALL tee operands in this segment — `tee a b c` names three targets, not
   # one; the original single-target extractor only ever returned "a".
@@ -596,6 +632,19 @@ bash_extract_write_targets() {
   local cmd="$1"
   [ -z "$cmd" ] && return 0
 
+  # Protect the force-clobber redirect operators (`>|`, `>>|`) BEFORE the
+  # pipe split below (apexyard#886/#926 round 3, Hakim security review). A
+  # real bash tokenizer lexes `>|`/`>>|` as ONE operator — never as `>`
+  # followed by a separate pipe — so `cmd >| file` / `cmd >>| file` must
+  # not be torn apart at the `|` embedded in the operator itself. Replace
+  # them with placeholders first, run the normal &&/||/;/| split, then
+  # restore the placeholders inside whichever segment(s) still hold them.
+  # Longest-match-first: protect `>>|` before `>|` so `>>|` isn't half-eaten
+  # by the `>|` substitution (`>>|` contains `>|` as a substring).
+  local split="$cmd"
+  split="${split//>>|/@@APEXYARD_CLOBBER_APPEND@@}"
+  split="${split//>|/@@APEXYARD_CLOBBER@@}"
+
   # Split into segments on top-level separators (&&, ||, ;, |) using bash
   # parameter-expansion substitution, NOT sed: BSD sed (macOS's default,
   # non-GNU) does not treat `\n` in the replacement text as a literal
@@ -604,11 +653,15 @@ bash_extract_write_targets() {
   # shipped broken had this been caught only on Linux CI). Order matters:
   # replace the two-character separators BEFORE the single-character ones
   # so `&&` / `||` aren't first flattened into two lone `&` / `|` splits.
-  local split="$cmd"
   split="${split//&&/$'\n'}"
   split="${split//||/$'\n'}"
   split="${split//;/$'\n'}"
   split="${split//|/$'\n'}"
+
+  # Restore the protected clobber operators inside whichever segment(s)
+  # now contain the placeholder.
+  split="${split//@@APEXYARD_CLOBBER_APPEND@@/>>|}"
+  split="${split//@@APEXYARD_CLOBBER@@/>|}"
 
   local seg
   {

--- a/.claude/hooks/_lib-detect-bash-write.sh
+++ b/.claude/hooks/_lib-detect-bash-write.sh
@@ -167,6 +167,88 @@ _bdw_match_redirection() {
   echo "$1" | grep -qE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]*[^[:space:]&|;]+'
 }
 
+# ------------------------------------------------------------------------------
+# Internal: _bdw_split_top_level COMMAND
+#
+# Splits COMMAND into top-level segments on &&, ||, ;, | — echoed one per
+# line via stdout. THE canonical segmentation for this whole library:
+# both DETECTION (_bdw_match_redirection_any_segment, below) and
+# EXTRACTION (bash_extract_write_targets) call this SAME function, so
+# they cannot disagree about where one command ends and the next begins
+# (apexyard#886/#926 round 5 — Hakim security review; see that helper's
+# comment for why divergence was the actual structural bug behind rounds
+# 1-5 of this operator class, not "yet another missed operator").
+#
+# Protects the force-clobber operators (`>|`, `>>|`) from being torn
+# apart by the bare-`|` split — a real bash tokenizer lexes them as ONE
+# operator, never as `>` followed by a separate pipe — via a
+# placeholder-and-restore step. Uses bash parameter-expansion
+# substitution, NOT sed, for the split itself: BSD sed (macOS's default,
+# non-GNU) does not honour `\n` in replacement text as a literal newline,
+# so a sed-based split would silently no-op on a stock Mac.
+# ------------------------------------------------------------------------------
+_bdw_split_top_level() {
+  local cmd="$1"
+  [ -z "$cmd" ] && return 0
+
+  local split="$cmd"
+  # Longest-match-first: protect >>| before >| so >>| isn't half-eaten by
+  # the >| substitution (>>| contains >| as a substring).
+  split="${split//>>|/@@APEXYARD_CLOBBER_APPEND@@}"
+  split="${split//>|/@@APEXYARD_CLOBBER@@}"
+
+  # Two-character separators BEFORE single-character ones, so && / ||
+  # aren't first flattened into two lone & / | splits.
+  split="${split//&&/$'\n'}"
+  split="${split//||/$'\n'}"
+  split="${split//;/$'\n'}"
+  split="${split//|/$'\n'}"
+
+  split="${split//@@APEXYARD_CLOBBER_APPEND@@/>>|}"
+  split="${split//@@APEXYARD_CLOBBER@@/>|}"
+
+  printf '%s\n' "$split"
+}
+
+# ------------------------------------------------------------------------------
+# Internal: _bdw_match_redirection_any_segment COMMAND
+#
+# THE STRUCTURAL FIX for apexyard#886/#926 round 5 (Hakim security
+# review). Runs _bdw_match_redirection on EACH top-level segment of
+# COMMAND (via _bdw_split_top_level) instead of on the whole, unsplit
+# command.
+#
+# Why this was the actual bug, not another missed operator: DETECTION
+# (bash_command_appears_to_write, via this helper's predecessor) used to
+# call _bdw_match_redirection on the WHOLE command. EXTRACTION
+# (bash_extract_write_targets) already split into segments FIRST, then
+# anchored `^` per segment. For `false ||> src/app.ts` — a real,
+# truncating write — the `>` is immediately preceded by `|` (from `||`).
+# On the whole, unsplit string, `[^|<&]` (needed to exclude `2>&1`/`>&2`
+# fd-dup) EXCLUDES that `|`-preceded `>` from matching, and it isn't at
+# `^` either (it's preceded by `|`), so detection said "not a write" —
+# false negative, exit 0, no ticket. Extraction, meanwhile, split on `||`
+# first, leaving `> src/app.ts` as its own segment where the `>` sits at
+# `^` — which the anchor DOES match — so extraction correctly found the
+# target. Detection and extraction disagreed; that disagreement, not the
+# `|`/`||` operator itself, was the root cause across rounds 1-5 (`;>`
+# survived only because `;` isn't excluded by the leading-context class;
+# `&&>` survived only by coincidentally containing the substring `&>`;
+# `|>`/`||>`/`||>|` had no such rescue). Splitting BEFORE matching, with
+# the SAME segmentation function extraction already uses, means the two
+# paths can't diverge again — this is the fix, not one more operator
+# added to the alternation.
+# ------------------------------------------------------------------------------
+_bdw_match_redirection_any_segment() {
+  local cmd="$1" seg
+  [ -z "$cmd" ] && return 1
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+    _bdw_match_redirection "$seg" && return 0
+  done < <(_bdw_split_top_level "$cmd")
+  return 1
+}
+
 # 2. tee.
 _bdw_match_tee() {
   echo "$1" | grep -qE '\btee\b'
@@ -348,7 +430,11 @@ bash_command_appears_to_write() {
   local cmd="$1"
   [ -z "$cmd" ] && return 1
 
-  _bdw_match_redirection     "$cmd" && return 0
+  # Segment-aware (apexyard#886/#926 round 5) — see
+  # _bdw_match_redirection_any_segment for why matching the WHOLE, unsplit
+  # command here (as this used to) missed `|`/`||`-adjacent redirects
+  # (`false ||> file`, `echo x |> file`).
+  _bdw_match_redirection_any_segment "$cmd" && return 0
   _bdw_match_tee             "$cmd" && return 0
   _bdw_match_sed_inplace     "$cmd" && return 0
   _bdw_match_awk_inplace     "$cmd" && return 0
@@ -395,7 +481,12 @@ bash_command_is_deletion_only() {
   fi
 
   # Any other content-writing pattern alongside rm → not deletion-only.
-  _bdw_match_redirection    "$cmd" && return 1
+  # Segment-aware (apexyard#886/#926 round 5) — same reasoning as
+  # bash_command_appears_to_write: matching the whole, unsplit command
+  # here would miss `rm x; false ||> src/app.ts` (a real write hiding
+  # behind a `|`/`||`-adjacent redirect), wrongly classifying it as
+  # deletion-only and exempting it from the ticket gate.
+  _bdw_match_redirection_any_segment "$cmd" && return 1
   _bdw_match_tee            "$cmd" && return 1
   _bdw_match_sed_inplace    "$cmd" && return 1
   _bdw_match_awk_inplace    "$cmd" && return 1
@@ -438,6 +529,14 @@ bash_command_is_deletion_only() {
 #   - cmd with multiple redirects
 #   - paths constructed from variables
 #   - tar -x (target is a directory, often implicit)
+#   - `cmd <> file` (read-write open, apexyard#886/#926 round 5): known,
+#     accepted, OUT-OF-SCOPE gap — exotic, non-truncating (unlike every
+#     operator this file DOES model, `<>` opens for read+write WITHOUT
+#     truncating existing content, so it's a materially different risk
+#     shape), and not adjacent to any of the &&/||/;/| separators this
+#     library segments on, so the round-5 structural fix doesn't reach
+#     it either. Tracked as a separate follow-up rather than folded into
+#     this operator-class close.
 # ------------------------------------------------------------------------------
 bash_extract_write_target() {
   local cmd="$1"
@@ -666,47 +765,22 @@ _bdw_targets_from_segment() {
 # extractable targets produces no output at all — callers must treat
 # "nothing on stdout" as the same fail-closed/categorical case that empty
 # bash_extract_write_target output signals today.
+#
+# Segmentation is delegated to _bdw_split_top_level (apexyard#886/#926
+# round 5) — the SAME function bash_command_appears_to_write's
+# _bdw_match_redirection_any_segment uses, so detection and extraction
+# share one source of truth for "where does one command end and the next
+# begin" and can't drift apart again.
 # ------------------------------------------------------------------------------
 bash_extract_write_targets() {
   local cmd="$1"
   [ -z "$cmd" ] && return 0
-
-  # Protect the force-clobber redirect operators (`>|`, `>>|`) BEFORE the
-  # pipe split below (apexyard#886/#926 round 3, Hakim security review). A
-  # real bash tokenizer lexes `>|`/`>>|` as ONE operator — never as `>`
-  # followed by a separate pipe — so `cmd >| file` / `cmd >>| file` must
-  # not be torn apart at the `|` embedded in the operator itself. Replace
-  # them with placeholders first, run the normal &&/||/;/| split, then
-  # restore the placeholders inside whichever segment(s) still hold them.
-  # Longest-match-first: protect `>>|` before `>|` so `>>|` isn't half-eaten
-  # by the `>|` substitution (`>>|` contains `>|` as a substring).
-  local split="$cmd"
-  split="${split//>>|/@@APEXYARD_CLOBBER_APPEND@@}"
-  split="${split//>|/@@APEXYARD_CLOBBER@@}"
-
-  # Split into segments on top-level separators (&&, ||, ;, |) using bash
-  # parameter-expansion substitution, NOT sed: BSD sed (macOS's default,
-  # non-GNU) does not treat `\n` in the replacement text as a literal
-  # newline, so a `sed 's/;/\n/g'`-style split silently no-ops on a stock
-  # macOS box (the #886 bug this was first written to fix would have
-  # shipped broken had this been caught only on Linux CI). Order matters:
-  # replace the two-character separators BEFORE the single-character ones
-  # so `&&` / `||` aren't first flattened into two lone `&` / `|` splits.
-  split="${split//&&/$'\n'}"
-  split="${split//||/$'\n'}"
-  split="${split//;/$'\n'}"
-  split="${split//|/$'\n'}"
-
-  # Restore the protected clobber operators inside whichever segment(s)
-  # now contain the placeholder.
-  split="${split//@@APEXYARD_CLOBBER_APPEND@@/>>|}"
-  split="${split//@@APEXYARD_CLOBBER@@/>|}"
 
   local seg
   {
     while IFS= read -r seg; do
       [ -z "$seg" ] && continue
       _bdw_targets_from_segment "$seg"
-    done <<< "$split"
+    done < <(_bdw_split_top_level "$cmd")
   } | awk '!seen[$0]++'
 }

--- a/.claude/hooks/_lib-detect-bash-write.sh
+++ b/.claude/hooks/_lib-detect-bash-write.sh
@@ -146,10 +146,25 @@ _bdw_starts_with_git_subcommand() {
 #     write. Modelled by an optional trailing `\|?` on the existing `>>?`.
 # Both are added as alternatives / suffixes to the SAME anchored pattern,
 # not new logic — `2>&1`, `>&2`, `<`, `<<EOF`, `<<<` are all still excluded
-# by the same mechanisms as before (mandatory whitespace immediately after
-# the operator; `&` only recognised when it precedes `>`, never follows).
+# by the same mechanisms as before (whitespace after the operator is now
+# OPTIONAL — see the #886/#926 round-4 note below — but the exclusions
+# don't rely on mandatory whitespace; they rely on `&` only being
+# recognised when it precedes `>`, never follows).
+#
+# Whitespace after the operator is OPTIONAL (apexyard#886/#926 round 4 —
+# Hakim's adversarial re-hunt): bash accepts ZERO whitespace between a
+# redirect operator and its target (`echo hi>file`, `echo b 2>file`,
+# `echo b>>file`, `echo b>|file`, `echo b&>file` are all valid, real
+# writes) — the mandatory `[[:space:]]+` here silently dropped every one
+# of them. Relaxed to `[[:space:]]*` (zero-or-more). This does NOT open a
+# new false-positive surface for `2>&1`/`>&2`/`1>&2` (fd-dup): after the
+# operator matches, the target class `[^[:space:]&|;]+` still EXCLUDES
+# `&` — so when the very next character is `&` (as in all three fd-dup
+# forms), the target can't start there regardless of how much whitespace
+# came before it. The whitespace requirement was never what excluded
+# fd-dup; the target character class was and still is.
 _bdw_match_redirection() {
-  echo "$1" | grep -qE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]+[^[:space:]&|;]+'
+  echo "$1" | grep -qE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]*[^[:space:]&|;]+'
 }
 
 # 2. tee.
@@ -446,10 +461,16 @@ bash_extract_write_target() {
   # swallows a leading `&` the same way it swallows a leading digit or
   # space, so no separate strip pattern is needed for `&>`/`&>>`; the
   # trailing `\|?` addition handles `>|`/`>>|`.
+  #
+  # `[[:space:]]*` (apexyard#886/#926 round 4): whitespace between the
+  # operator and the target is optional in real bash (`echo hi>file`,
+  # `2>file`, `>>file`, `>|file`, `&>file` are all valid writes) — see the
+  # matching note on _bdw_match_redirection for why this doesn't loosen
+  # the fd-dup exclusion (the target class still rejects a leading `&`).
   local target
-  target=$(echo "$cmd" | grep -oE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]+[^[:space:]&|;]+' \
+  target=$(echo "$cmd" | grep -oE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]*[^[:space:]&|;]+' \
                 | head -n 1 \
-                | sed -E 's/^[^>]*>>?\|?[[:space:]]+//')
+                | sed -E 's/^[^>]*>>?\|?[[:space:]]*//')
   if [ -n "$target" ]; then
     target="${target%\"}"; target="${target#\"}"
     target="${target%\'}"; target="${target#\'}"
@@ -579,11 +600,18 @@ _bdw_targets_from_segment() {
   # need the SEGMENT to still contain the literal `|` — see
   # bash_extract_write_targets' clobber-protection step, which shields
   # these operators from the later bare-`|` (pipe) split.
+  #
+  # `[[:space:]]*` (apexyard#886/#926 round 4): a FOURTH re-hunt found the
+  # mandatory whitespace after the operator was itself a bypass — bash
+  # accepts zero whitespace (`echo hi>file`, `2>file`, `&>file`, `>|file`
+  # are all real writes). Relaxed to optional; the target class
+  # `[^[:space:]&|;]+` still rejects a leading `&`, so `2>&1`/`>&2`
+  # (fd-dup) stay correctly unmatched regardless of spacing.
   while IFS= read -r line; do
     [ -z "$line" ] && continue
-    target=$(printf '%s\n' "$line" | sed -E 's/^[^>]*>>?\|?[[:space:]]+//')
+    target=$(printf '%s\n' "$line" | sed -E 's/^[^>]*>>?\|?[[:space:]]*//')
     [ -n "$target" ] && _bdw_strip_quotes "$target"
-  done < <(printf '%s\n' "$seg" | grep -oE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]+[^[:space:]&|;]+')
+  done < <(printf '%s\n' "$seg" | grep -oE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]*[^[:space:]&|;]+')
 
   # ALL tee operands in this segment — `tee a b c` names three targets, not
   # one; the original single-target extractor only ever returned "a".
@@ -605,6 +633,17 @@ _bdw_targets_from_segment() {
         continue
       fi
       skip_flags=0
+      # Stop consuming tee's operand list once a redirection operator
+      # token appears (Rex review, PR #926): `tee a b 2> err.log` — the
+      # `2>` starts a shell redirect of tee's OWN stdout/stderr, not
+      # another tee file argument. Without this, naive whitespace
+      # word-splitting would emit the operator token itself (e.g. the
+      # literal string "2>") as a spurious "target". Not a bypass either
+      # way — the real redirect target ("err.log") is still independently
+      # captured by the redirection-matching loop above, so this only
+      # tightens the gate (fail-closed on a garbage path) rather than
+      # missing anything.
+      printf '%s' "$target" | grep -qE '^[0-9]*(>>?|<<?)' && break
       [ -n "$target" ] && _bdw_strip_quotes "$target"
     done
   fi

--- a/.claude/hooks/_lib-detect-bash-write.sh
+++ b/.claude/hooks/_lib-detect-bash-write.sh
@@ -18,8 +18,11 @@
 # Usage:
 #   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-detect-bash-write.sh"
 #   if bash_command_appears_to_write "$COMMAND"; then
-#     target=$(bash_extract_write_target "$COMMAND")
-#     # ... apply gate, optionally with target-aware path exemptions
+#     targets=$(bash_extract_write_targets "$COMMAND")
+#     # ... apply gate to EVERY line of $targets — see #886. Judging only
+#     # the first target lets a command that ALSO writes an out-of-repo
+#     # path first (`echo x > /tmp/a; echo y > src/app.ts`) slip its
+#     # second, in-repo target past a gate that only looked at target #1.
 #   fi
 #
 # Exposed functions:
@@ -27,11 +30,27 @@
 #       returns 0 if the command appears to write to a file, 1 otherwise
 #
 #   bash_extract_write_target COMMAND
-#       echoes the target path if extractable, empty string otherwise.
-#       Best-effort — only handles the simple cases (echo > file,
-#       tee file, sed -i ... file, cp src dst, curl -o file). Embedded
-#       interpreters (python -c, node -e, ruby -e, perl -e, php -r,
-#       go run, deno, bun) return empty.
+#       echoes the FIRST target path if extractable, empty string
+#       otherwise. Best-effort — only handles the simple cases (echo >
+#       file, tee file, sed -i ... file, cp src dst, curl -o file).
+#       Embedded interpreters (python -c, node -e, ruby -e, perl -e,
+#       php -r, go run, deno, bun) return empty.
+#
+#       Kept for backward compatibility with existing single-target
+#       call sites and tests. New gate consumers should prefer
+#       bash_extract_write_targets (plural, below) — a command can name
+#       more than one write target, and judging only the first is a
+#       gate-bypass surface (#886).
+#
+#   bash_extract_write_targets COMMAND
+#       echoes EVERY extractable write target, one per line, deduplicated.
+#       Splits the command on top-level separators (&&, ||, ;, |) so each
+#       chained command is considered independently, and within a segment
+#       captures every redirection (`cmd > a; cmd2 > b` inside one
+#       segment, e.g. from a heredoc) and every tee operand (`tee a b c`
+#       names three targets). Same misses as bash_extract_write_target —
+#       an unparseable segment contributes nothing, never a fabricated
+#       target.
 
 # ------------------------------------------------------------------------------
 # Public: bash_command_appears_to_write COMMAND
@@ -462,4 +481,110 @@ bash_extract_write_target() {
 
   # No target extractable.
   return 0
+}
+
+# ------------------------------------------------------------------------------
+# Internal: _bdw_strip_quotes ARG — trim one layer of matching quotes.
+# ------------------------------------------------------------------------------
+_bdw_strip_quotes() {
+  local t="$1"
+  t="${t%\"}"; t="${t#\"}"
+  t="${t%\'}"; t="${t#\'}"
+  printf '%s\n' "$t"
+}
+
+# ------------------------------------------------------------------------------
+# Internal: _bdw_targets_from_segment SEGMENT
+#
+# Extracts ALL write targets from a single command segment (a segment is
+# one command with no top-level &&, ||, ;, | separators — see
+# bash_extract_write_targets below for how segments are produced).
+#
+# Unlike bash_extract_write_target's single-shot "first match wins" walk,
+# this captures EVERY redirection and EVERY tee operand in the segment
+# (both families support naming more than one target: `cmd > a 2> b`,
+# `tee a b c`), then falls back to bash_extract_write_target for the
+# remaining single-target families (sed -i, cp/mv, curl -o, wget -O) —
+# correct here because a segment is one command invocation, so "first
+# match" and "only match" coincide for those families.
+# ------------------------------------------------------------------------------
+_bdw_targets_from_segment() {
+  local seg="$1"
+  local line target tee_tail
+
+  # ALL redirection targets in this segment (not just the first).
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    target=$(printf '%s\n' "$line" | sed -E 's/^[^>]*>>?[[:space:]]+//')
+    [ -n "$target" ] && _bdw_strip_quotes "$target"
+  done < <(printf '%s\n' "$seg" | grep -oE '[^|<&]>>?[[:space:]]+[^[:space:]&|;]+')
+
+  # ALL tee operands in this segment — `tee a b c` names three targets, not
+  # one; the original single-target extractor only ever returned "a".
+  #
+  # NOTE: extraction deliberately uses grep (not sed) for the `\btee\b`
+  # word-boundary match. BSD sed (macOS's default, non-GNU) silently does
+  # NOT support `\b` in its regex engine — a `sed -E 's/^.*\btee\b.../'`
+  # here would no-op on a stock Mac and this bug would ship invisible on
+  # this exact platform. grep's `\b` support is fine (BSD grep is
+  # GNU-compatible on this point); the strip-the-"tee"-token step below
+  # uses plain anchored parameter expansion instead of sed, sidestepping
+  # the incompatibility entirely.
+  if printf '%s\n' "$seg" | grep -qE '\btee\b'; then
+    tee_tail=$(printf '%s\n' "$seg" | grep -oE '\btee\b[[:space:]].*' | head -n 1)
+    tee_tail="${tee_tail#tee}"
+    local skip_flags=1
+    for target in $tee_tail; do
+      if [ "$skip_flags" = "1" ] && printf '%s' "$target" | grep -qE '^-'; then
+        continue
+      fi
+      skip_flags=0
+      [ -n "$target" ] && _bdw_strip_quotes "$target"
+    done
+  fi
+
+  # sed -i / cp / mv / curl -o / wget -O: single-target families. Reusing
+  # the existing single-shot extractor on just THIS segment is correct —
+  # a segment is one command, so "first match in the segment" IS "the
+  # match". (This may re-emit a redirection/tee target already captured
+  # above; bash_extract_write_targets dedupes the combined output.)
+  target=$(bash_extract_write_target "$seg")
+  [ -n "$target" ] && printf '%s\n' "$target"
+}
+
+# ------------------------------------------------------------------------------
+# Public: bash_extract_write_targets COMMAND
+#
+# See the header comment block at the top of this file for the contract.
+# Returns via stdout (one target per line); no meaningful exit-code
+# contract beyond "ran".  An empty COMMAND or a command with zero
+# extractable targets produces no output at all — callers must treat
+# "nothing on stdout" as the same fail-closed/categorical case that empty
+# bash_extract_write_target output signals today.
+# ------------------------------------------------------------------------------
+bash_extract_write_targets() {
+  local cmd="$1"
+  [ -z "$cmd" ] && return 0
+
+  # Split into segments on top-level separators (&&, ||, ;, |) using bash
+  # parameter-expansion substitution, NOT sed: BSD sed (macOS's default,
+  # non-GNU) does not treat `\n` in the replacement text as a literal
+  # newline, so a `sed 's/;/\n/g'`-style split silently no-ops on a stock
+  # macOS box (the #886 bug this was first written to fix would have
+  # shipped broken had this been caught only on Linux CI). Order matters:
+  # replace the two-character separators BEFORE the single-character ones
+  # so `&&` / `||` aren't first flattened into two lone `&` / `|` splits.
+  local split="$cmd"
+  split="${split//&&/$'\n'}"
+  split="${split//||/$'\n'}"
+  split="${split//;/$'\n'}"
+  split="${split//|/$'\n'}"
+
+  local seg
+  {
+    while IFS= read -r seg; do
+      [ -z "$seg" ] && continue
+      _bdw_targets_from_segment "$seg"
+    done <<< "$split"
+  } | awk '!seen[$0]++'
 }

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -42,6 +42,15 @@
 # machine config, /tmp scratch files. See the "Out-of-governance
 # exemption" block below for the fail-closed resolution rules (symlinks
 # resolved before judging; unresolvable/ambiguous targets stay gated).
+#
+# ALL write targets are judged, not just the first (apexyard#886): a Bash
+# command can name more than one write target (`echo a > /tmp/x; echo b >
+# src/app.ts`, `tee /tmp/a src/b.ts`). The gate pipeline below is wrapped
+# in a function and invoked ONCE PER EXTRACTED TARGET (see the dispatch
+# section at the bottom); the command as a whole only passes if EVERY
+# target independently clears the gate. Judging only the first target
+# let a command that also names an out-of-governance target FIRST slip an
+# in-repo target past a gate that stopped looking after target #1.
 
 # Resolve PATH to its canonical, symlink-free absolute form. Walks up to
 # the nearest EXISTING ancestor, physically resolves it (`pwd -P`, which
@@ -93,11 +102,492 @@ _resolve_real_path() {
   fi
 }
 
+# ------------------------------------------------------------------------------
+# _ratc_evaluate_target FILE_PATH TOOL_NAME
+#
+# Runs the full ticket-gate pipeline for ONE candidate write target:
+# variable-target exemptions, REPO_ROOT/REL_PATH normalisation, path-prefix
+# exemptions, ops-root discovery, the out-of-governance exemption
+# (#883/#885), the bootstrap-skill exemption, and marker resolution
+# (tier 0 per-worktree / tier 1 per-project / tier 2 ops fallback).
+#
+# Returns 0 if this target is exempt OR a matching ticket marker is found.
+# Returns 2 (and prints a BLOCKED message to stderr) if this target
+# requires an active ticket that isn't set.
+#
+# #886: called ONCE PER EXTRACTED BASH WRITE TARGET by the dispatch section
+# below — not just the first. All local state (REPO_ROOT, OPS_ROOT,
+# PROJECT, the markers, ...) is scoped to this function so each call is
+# independent; nothing leaks between targets.
+# ------------------------------------------------------------------------------
+_ratc_evaluate_target() {
+  local FILE_PATH="$1"
+  local TOOL_NAME="$2"
+
+  # Variable target (e.g. `cat > "$VAR"`): the extractor returns the literal
+  # shell-variable token. Exempt a temp-dir var, and a BARE whole-target variable
+  # (`$CEO`, `${marker}` — unresolvable, in practice a .claude/ scratch path). A
+  # variable WITH a concatenated path tail (`$PWD/src/app.ts`, `$D/app.ts`,
+  # `$HOME/work/src/x.ts`) is NOT exempt — that path could be tracked source, and
+  # the old blanket `$*` exemption let such a write dodge the ticket gate (#582
+  # review: fail-open on a security gate). A var+tail target isn't bare and isn't
+  # absolute, so it falls through to the ticket gate below and blocks — which is
+  # the safe direction. (We deliberately do NOT expand $PWD/$HOME here: that adds
+  # nothing for blocking and tripped a /var↔/private/var symlink mismatch.)
+  case "$FILE_PATH" in
+    '$TMPDIR'/*|'${TMPDIR}'/*|'$TMP'/*|'${TMP}'/*) return 0 ;;  # temp dir → outside the repo
+  esac
+  # Bare whole-target variable only (no path/extension tail) → exempt.
+  if printf '%s' "$FILE_PATH" | grep -qE '^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$'; then
+    return 0
+  fi
+
+  if [ -z "$FILE_PATH" ] && [ "$TOOL_NAME" != "Bash" ]; then
+    return 0
+  fi
+
+  # Normalise to repo-relative path when possible.
+  #
+  # BUG #744 FIX: derive REPO_ROOT from the FILE_PATH's directory, NOT the
+  # hook's CWD. The harness can fire with any CWD (e.g. /tmp, the ops root,
+  # a totally unrelated directory). Using `git rev-parse --show-toplevel`
+  # from the hook process's CWD returns the WRONG root whenever the CWD
+  # differs from the file's actual git repo — which breaks the OPS_ROOT
+  # walk-up and causes the per-project marker to be missed, blocking edits
+  # even when /start-ticket set a valid marker (#744, #745).
+  #
+  # Resolution order:
+  #   1. FILE_PATH is set and absolute: run git in the file's nearest existing
+  #      ancestor directory.  Works for new files (dirname of a not-yet-created
+  #      path still points at the parent dir).
+  #   2. FILE_PATH is set but relative (Bash write-target extracted from the
+  #      command): relative paths are relative to the process CWD, so fall
+  #      back to the legacy CWD-based git rev-parse — same behaviour as before.
+  #   3. FILE_PATH is empty (Bash command, no extractable target): CWD-based
+  #      fallback as before.
+  local REPO_ROOT="" _fp_dir _wt_gd _wt_gcd _main_root REL_PATH
+  if [ -n "$FILE_PATH" ]; then
+    case "$FILE_PATH" in
+      /*)
+        # Absolute path — find the nearest existing ancestor directory.
+        # dirname works on non-existent files; the while loop handles the
+        # case where the new file's parent dir doesn't exist yet.
+        _fp_dir="$(dirname "$FILE_PATH")"
+        while [ -n "$_fp_dir" ] && [ "$_fp_dir" != "/" ] && [ ! -d "$_fp_dir" ]; do
+          _fp_dir="$(dirname "$_fp_dir")"
+        done
+        if [ -d "$_fp_dir" ]; then
+          REPO_ROOT=$(git -C "$_fp_dir" rev-parse --show-toplevel 2>/dev/null)
+          # When the file's repo is a LINKED git worktree the worktree dir
+          # inherits the main branch's files — including anchor files like
+          # onboarding.yaml / apexyard.projects.yaml.  The OPS_ROOT walk-up
+          # below would then stop at the worktree instead of the real ops
+          # fork.  Detect a linked worktree (absolute git-dir ≠ common-dir)
+          # and replace REPO_ROOT with the main-checkout root (dirname of
+          # the common-dir, i.e. parent of the main .git dir).  This keeps
+          # the walk-up anchored to the actual ops fork while leaving the
+          # later per-worktree branch detection (which re-reads git from
+          # _fdir) unaffected.
+          if [ -n "$REPO_ROOT" ]; then
+            _wt_gd=$(git -C "$_fp_dir" rev-parse --absolute-git-dir 2>/dev/null)
+            _wt_gcd=$(git -C "$_fp_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+            if [ -n "$_wt_gd" ] && [ -n "$_wt_gcd" ] && [ "$_wt_gd" != "$_wt_gcd" ]; then
+              _main_root=$(dirname "$_wt_gcd")
+              [ -d "$_main_root" ] && REPO_ROOT="$_main_root"
+            fi
+          fi
+        fi
+        ;;
+      *)
+        # Relative path (Bash write-target): resolve against CWD.
+        REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+        ;;
+    esac
+  fi
+  # Fallback: FILE_PATH empty (Bash command, no extractable target).
+  if [ -z "$REPO_ROOT" ]; then
+    REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+  fi
+  REL_PATH="$FILE_PATH"
+  if [ -n "$REPO_ROOT" ] && [ -n "$FILE_PATH" ]; then
+    case "$FILE_PATH" in
+      "$REPO_ROOT"/*) REL_PATH="${FILE_PATH#$REPO_ROOT/}" ;;
+    esac
+  fi
+
+  # NOTE: the narrow "Bash absolute path outside REPO_ROOT" exemption that
+  # used to live here (#569) has been superseded by the out-of-governance
+  # exemption below (apexyard#883), which covers BOTH Bash and Edit/Write/
+  # MultiEdit, resolves symlinks before judging, and checks the actual
+  # governance boundaries (ops root + registered workspaces) rather than
+  # just "outside the nearest git repo". See that block for the full design.
+
+  # Exempt paths.
+  #
+  # Each path-prefix exemption is matched in both REL_PATH (repo-relative)
+  # and absolute (*/path/*) forms. Absolute-path fallthrough happens when
+  # FILE_PATH points outside REPO_ROOT (e.g. agent worktrees whose
+  # git-toplevel differs from the outer apexyard tree); in that case the
+  # strip above is a no-op and REL_PATH stays absolute. The existing
+  # `*.md` pattern already crosses `/`, so absolute-match via a `*/…`
+  # prefix is a known-good shape — #56 extends the same trick to the
+  # path-prefix exemptions.
+  #
+  # Skipped entirely when FILE_PATH is empty (Bash command writes to an
+  # unextractable target — e.g. `python -c '...write...'`). Those fall
+  # through to the ticket gate; the bootstrap-skill exemption below covers
+  # the legitimate use case (/setup writing to fork-root files via Bash).
+  if [ -n "$REL_PATH" ]; then
+    case "$REL_PATH" in
+      .claude/*|.claude|*/.claude/*|*/.claude) return 0 ;;
+      docs/*|docs|*/docs/*|*/docs) return 0 ;;
+      TODO.md|README.md|MEMORY.md|CLAUDE.md) return 0 ;;
+    esac
+    # Note: `projects/*/docs/*` is subsumed by `*/docs/*` above (shell case `*`
+    # crosses `/`), so no separate arm needed. Per-project apexyard docs are
+    # matched by the generic docs-in-any-subtree pattern.
+    case "$REL_PATH" in
+      *.md) return 0 ;;
+    esac
+  fi
+
+  # Discover the ops root. Walk up from REPO_ROOT looking for either the
+  # v2 `.apexyard-fork` marker (split-portfolio v2 layout) OR the legacy
+  # v1 anchor (onboarding.yaml + apexyard.projects.yaml). Stop at /. If
+  # not found, OPS_ROOT stays empty and we treat the REPO_ROOT itself as
+  # the marker home (pre-#41 behaviour).
+  #
+  # Guard change (#744/#745): the lib-based resolver is always invoked when
+  # the lib is available — even when REPO_ROOT is empty. This matters for
+  # split-portfolio v2 where the workspace is a sibling repo with no git
+  # history: REPO_ROOT is empty (no git in the sibling dir) but the
+  # session-pin resolver in _lib-ops-root.sh can still locate the ops fork
+  # from the pin written at session-start, regardless of start dir.
+  local HOOK_DIR OPS_ROOT="" r parent
+  HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+  if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$HOOK_DIR/_lib-ops-root.sh"
+    # Pass REPO_ROOT as the walk-up start dir when available; the pin
+    # resolver ignores the start dir and uses the session pin directly.
+    OPS_ROOT=$(resolve_ops_root "${REPO_ROOT:-}")
+  elif [ -n "$REPO_ROOT" ]; then
+    # Inline walk-up fallback when the lib is absent (e.g. minimal test
+    # sandboxes that only copy the core libs).
+    r="$REPO_ROOT"
+    while [ -n "$r" ] && [ "$r" != "/" ]; do
+      if [ -f "$r/.apexyard-fork" ]; then
+        OPS_ROOT="$r"
+        break
+      fi
+      if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
+        OPS_ROOT="$r"
+        break
+      fi
+      parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
+    done
+  fi
+
+  local MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
+  MARKER_HOME="${MARKER_HOME:-.}"
+
+  # Resolve the workspace dir for the per-project marker resolution below.
+  # Defaults to $OPS_ROOT/workspace; split-portfolio v2 adopters override
+  # via portfolio.workspace_dir to point at their private sibling repo.
+  local WORKSPACE_DIR="$OPS_ROOT/workspace" resolved_ws
+  if [ -n "$OPS_ROOT" ] && [ -f "$HOOK_DIR/_lib-portfolio-paths.sh" ] && [ -f "$HOOK_DIR/_lib-read-config.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$HOOK_DIR/_lib-read-config.sh"
+    # shellcheck source=/dev/null
+    . "$HOOK_DIR/_lib-portfolio-paths.sh"
+    resolved_ws=$(portfolio_workspace_dir 2>/dev/null)
+    if [ -n "$resolved_ws" ]; then
+      WORKSPACE_DIR="$resolved_ws"
+    fi
+  fi
+
+  # --- Out-of-governance exemption (apexyard#883) -------------------------
+  #
+  # A write TARGET that is outside every governed tree — the ops fork
+  # itself AND every registered workspace/<project> clone — AND not inside
+  # ANY git repository at all is outside this gate's jurisdiction. Applies
+  # to BOTH Bash-detected writes and Edit/Write/MultiEdit tool calls (the
+  # earlier #569 exemption was Bash-only, which left Edit-tool writes to
+  # e.g. ~/.zshrc gated with no legitimate way to satisfy the gate on forks
+  # with GitHub Issues disabled — the exact bug reported in #883).
+  #
+  # Fail-closed directions (deliberate):
+  #   - An unresolvable FILE_PATH (empty — a Bash target the extractor
+  #     couldn't identify) is NEVER exempted here; it falls through to the
+  #     ticket gate below, unchanged from before this change.
+  #   - Relative paths (a Bash write-target like `src/app.ts`) resolve
+  #     against the hook's CWD before judging.
+  #   - Symlinks are resolved to their real path before judging (via
+  #     _resolve_real_path above), so a symlink living under $HOME that
+  #     POINTS INTO a governed tree does not slip through as "outside" it.
+  #   - Being inside SOME git repository that is neither the ops fork nor a
+  #     registered workspace project does NOT exempt the write on its own —
+  #     the ops-root/workspace boundaries are checked EXPLICITLY (not
+  #     merely inferred from "is this a git repo"), because a
+  #     split-portfolio workspace project is governed even when its clone
+  #     isn't itself a git repository (e.g. a docs-only project, or a test
+  #     fixture that never ran `git init`).
+  #   - RAW-AND-RESOLVED containment (security review finding on #885,
+  #     apexyard PR #885 — Hakim/security-reviewer): checking ops-root and
+  #     workspace containment ONLY on the symlink-resolved target has a
+  #     mirror-image hole to the one `_resolve_real_path` fixes. If a
+  #     REGISTERED workspace/<project> entry is ITSELF a symlink whose real
+  #     target lives OUTSIDE workspace/ in a non-git directory
+  #     (`workspace/proj -> /some/nongit/dir`), resolving the target
+  #     "escapes" the workspace boundary the same way the fix escapes a
+  #     symlink-into-repo attack — the RESOLVED path no longer sits under
+  #     WORKSPACE_DIR, so the naive single-check reads it as ungoverned and
+  #     wrongly exempts it. The fix: evaluate ops-root/workspace
+  #     containment against BOTH the RAW (pre-resolution) absolute target
+  #     AND the fully resolved target, using the SAME canonicalized
+  #     boundary anchors for both comparisons (only the anchors are
+  #     canonicalized once; the raw target itself is deliberately left
+  #     symlink-unresolved so a governed raw path can't be laundered away
+  #     by a symlink further down it). A path counts as governed — and
+  #     therefore NOT exempt — if EITHER the raw or the resolved check
+  #     lands inside ops-root or workspace. Exemption requires ALL FOUR
+  #     containment checks below (raw-ops, raw-ws, resolved-ops,
+  #     resolved-ws) to say "outside", plus the git-repo probe to say "not
+  #     in a repo".
+  if [ -n "$FILE_PATH" ]; then
+    local _og_abs_target _og_real_target
+    case "$FILE_PATH" in
+      /*) _og_abs_target="$FILE_PATH" ;;
+      *)  _og_abs_target="$PWD/$FILE_PATH" ;;
+    esac
+    _og_real_target="$(_resolve_real_path "$_og_abs_target")"
+    if [ -n "$_og_real_target" ]; then
+      local _og_in_ops_raw=0
+      local _og_in_ws_raw=0
+      local _og_in_ops_res=0
+      local _og_in_ws_res=0
+      local _og_in_git=0
+      local _og_real_ops="" _og_real_ws="" _og_probe
+
+      # Canonicalize the boundary anchors ONCE — used as the comparison
+      # basis for both the raw-target check and the resolved-target check.
+      # This keeps the two checks internally consistent even when OPS_ROOT
+      # was resolved via a non-canonical path (e.g. a CWD-based walk-up
+      # that never ran through `pwd -P`).
+      if [ -n "$OPS_ROOT" ]; then
+        _og_real_ops="$(cd "$OPS_ROOT" 2>/dev/null && pwd -P)"
+      fi
+      if [ -n "$WORKSPACE_DIR" ] && [ -d "$WORKSPACE_DIR" ]; then
+        _og_real_ws="$(cd "$WORKSPACE_DIR" 2>/dev/null && pwd -P)"
+      fi
+
+      # RAW check — the pre-resolution absolute target against the
+      # canonical boundary. Catches a registered workspace/<project> that
+      # is itself a symlink pointing OUTSIDE workspace/: the raw path
+      # still literally names the governed workspace/<project> location,
+      # even though resolving it lands elsewhere.
+      if [ -n "$_og_real_ops" ]; then
+        case "$_og_abs_target" in
+          "$_og_real_ops") _og_in_ops_raw=1 ;;
+          "$_og_real_ops"/*) _og_in_ops_raw=1 ;;
+        esac
+      fi
+      if [ -n "$_og_real_ws" ]; then
+        case "$_og_abs_target" in
+          "$_og_real_ws") _og_in_ws_raw=1 ;;
+          "$_og_real_ws"/*) _og_in_ws_raw=1 ;;
+        esac
+      fi
+
+      # RESOLVED check — the symlink-resolved target against the same
+      # canonical boundary. Catches a symlink OUTSIDE any governed tree
+      # that POINTS INTO one (the original #883 defense).
+      if [ -n "$_og_real_ops" ]; then
+        case "$_og_real_target" in
+          "$_og_real_ops") _og_in_ops_res=1 ;;
+          "$_og_real_ops"/*) _og_in_ops_res=1 ;;
+        esac
+      fi
+      if [ -n "$_og_real_ws" ]; then
+        case "$_og_real_target" in
+          "$_og_real_ws") _og_in_ws_res=1 ;;
+          "$_og_real_ws"/*) _og_in_ws_res=1 ;;
+        esac
+      fi
+
+      # Nearest-existing-ancestor git-repo probe on the REAL (symlink-
+      # resolved) target — catches any git repo, governed or not. A single
+      # probe suffices for both raw and resolved forms: directory
+      # traversal (`-d`, `git -C`) transparently follows symlinks at the
+      # OS level regardless of which path string reaches the location, so
+      # raw-path traversal and resolved-path traversal of the SAME logical
+      # target always land on the same physical directory.
+      _og_probe="$_og_real_target"
+      while [ -n "$_og_probe" ] && [ "$_og_probe" != "/" ] && [ ! -d "$_og_probe" ]; do
+        _og_probe="$(dirname "$_og_probe")"
+      done
+      if [ -n "$_og_probe" ] && [ -d "$_og_probe" ] \
+         && git -C "$_og_probe" rev-parse --show-toplevel >/dev/null 2>&1; then
+        _og_in_git=1
+      fi
+
+      if [ "$_og_in_ops_raw" = 0 ] && [ "$_og_in_ws_raw" = 0 ] \
+         && [ "$_og_in_ops_res" = 0 ] && [ "$_og_in_ws_res" = 0 ] \
+         && [ "$_og_in_git" = 0 ]; then
+        return 0
+      fi
+    fi
+  fi
+
+  # Bootstrap-skill exemption (apexyard#150): skills like /setup,
+  # /handover, /update, /split-portfolio run BEFORE any ticket can exist
+  # (no portfolio configured yet, no projects registered). They write a
+  # marker at .claude/session/active-bootstrap with the skill name on
+  # entry; this hook reads the marker, looks up the configured
+  # bootstrap_skills list, and exits 0 if the active skill is on the list.
+  #
+  # The marker is cleared at SessionStart by clear-bootstrap-marker.sh so
+  # a stale marker from an interrupted session can't carry over.
+  local BOOTSTRAP_MARKER active_bootstrap
+  BOOTSTRAP_MARKER="$MARKER_HOME/.claude/session/active-bootstrap"
+  if [ -f "$BOOTSTRAP_MARKER" ]; then
+    active_bootstrap=$(tr -d '[:space:]' < "$BOOTSTRAP_MARKER" 2>/dev/null)
+    if [ -n "$active_bootstrap" ]; then
+      # Source the config reader and look up bootstrap_skills.
+      if [ -f "$MARKER_HOME/.claude/hooks/_lib-read-config.sh" ]; then
+        # shellcheck source=/dev/null
+        . "$MARKER_HOME/.claude/hooks/_lib-read-config.sh"
+        if command -v config_get >/dev/null 2>&1; then
+          # `config_get '.ticket.bootstrap_skills[]'` outputs one skill per
+          # line. Use grep -wF for whole-word, fixed-string match.
+          if config_get '.ticket.bootstrap_skills[]' 2>/dev/null | grep -qwF "$active_bootstrap"; then
+            return 0
+          fi
+        fi
+      fi
+    fi
+  fi
+
+  # Per-project resolution (apexyard#41): if FILE_PATH points under the
+  # resolved workspace dir, we look for a per-project marker at
+  # .claude/session/tickets/<project>. This keeps per-project session state
+  # keyed by the managed-project name and localised in the ops fork
+  # (gitignored), instead of the pre-#41 scheme that relied on a
+  # .claude/session/ inside each managed-project clone.
+  #
+  # Split-portfolio v2 (#242): WORKSPACE_DIR may resolve to a sibling
+  # private repo path (e.g. ../<fork>-portfolio/workspace) instead of the
+  # default $OPS_ROOT/workspace; both shapes are handled here.
+  local PROJECT="" tail
+  if [ -n "$WORKSPACE_DIR" ]; then
+    case "$FILE_PATH" in
+      "$WORKSPACE_DIR"/*)
+        tail="${FILE_PATH#$WORKSPACE_DIR/}"
+        PROJECT="${tail%%/*}"
+        ;;
+    esac
+  fi
+  # Belt-and-suspenders: also recognise the literal $OPS_ROOT/workspace/
+  # shape, in case workspace_dir is overridden but a tool produced an
+  # absolute path under the in-fork legacy location.
+  if [ -z "$PROJECT" ] && [ -n "$OPS_ROOT" ]; then
+    case "$FILE_PATH" in
+      "$OPS_ROOT"/workspace/*)
+        tail="${FILE_PATH#$OPS_ROOT/workspace/}"
+        PROJECT="${tail%%/*}"
+        ;;
+    esac
+  fi
+
+  # Tier 0 — per-worktree marker (#513): when two agents are fanned out on the
+  # SAME managed project in parallel git worktrees, each must declare its ticket
+  # independently or they collide on the shared per-project file (last-writer-wins,
+  # silent wrong-ticket pass). A branch-scoped marker at
+  # tickets/<project>/<safe-branch> is resolved BEFORE the per-project tier.
+  # Single-agent / non-worktree flows have no such marker and fall straight
+  # through to the per-project tier — no behaviour change. Note: tickets/<project>
+  # is a FILE in single-agent mode and a DIRECTORY in worktree mode; the `-f`
+  # tests below distinguish them, so the two tiers never conflict.
+  local PER_WORKTREE_MARKER="" WT_BRANCH SAFE_BRANCH _fdir _gd _gcd
+  if [ -n "$PROJECT" ]; then
+    # Branch: prefer the harness-set env var (populated at worktree spawn). Else
+    # only treat the file's repo as worktree-scoped when it's a LINKED worktree,
+    # detected by comparing the ABSOLUTE git-dir against the ABSOLUTE common-dir
+    # (they differ only in a linked worktree). This matches /start-ticket's
+    # write-side detection exactly — no read/write asymmetry — and the absolute
+    # forms avoid the false positive where, in the main checkout from a subdir,
+    # `--git-dir` is absolute but `--git-common-dir` is relative.
+    WT_BRANCH="${CLAUDE_WORKTREE_BRANCH:-}"
+    if [ -z "$WT_BRANCH" ]; then
+      _fdir=$(dirname "$FILE_PATH")
+      _gd=$(git -C "$_fdir" rev-parse --absolute-git-dir 2>/dev/null)
+      _gcd=$(git -C "$_fdir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+      if [ -n "$_gd" ] && [ "$_gd" != "$_gcd" ]; then
+        WT_BRANCH=$(git -C "$_fdir" branch --show-current 2>/dev/null)
+      fi
+    fi
+    if [ -n "$WT_BRANCH" ]; then
+      SAFE_BRANCH="${WT_BRANCH//\//__}"   # '/' → '__' for a filesystem-safe segment
+      PER_WORKTREE_MARKER="$MARKER_HOME/.claude/session/tickets/$PROJECT/$SAFE_BRANCH"
+      if [ -f "$PER_WORKTREE_MARKER" ]; then
+        return 0
+      fi
+    fi
+  fi
+
+  local PER_PROJECT_MARKER=""
+  if [ -n "$PROJECT" ]; then
+    PER_PROJECT_MARKER="$MARKER_HOME/.claude/session/tickets/$PROJECT"
+    if [ -f "$PER_PROJECT_MARKER" ]; then
+      return 0
+    fi
+  fi
+
+  # Fallback: the ops-level current-ticket marker. This is the pre-#41
+  # location and still honoured for ops-repo framework edits, and as a
+  # safety net for any file we couldn't map to a specific project.
+  local FALLBACK_MARKER="$MARKER_HOME/.claude/session/current-ticket"
+  if [ -f "$FALLBACK_MARKER" ]; then
+    return 0
+  fi
+
+  # Nothing found — emit a guide that names both possibilities.
+  cat >&2 <<MSG
+BLOCKED: No active ticket set for this session.
+
+ApexYard requires a ticket BEFORE any code changes (workflow-gates rule #3,
+pre-build gate, "one ticket at a time").
+
+To unblock:
+
+  1. Create or find the ticket (GitHub Issue in the project's own repo):
+       gh issue create --repo <owner/repo> --title "..."
+  2. Declare it for this session — run the /start-ticket skill with the
+     issue number (or pass owner/repo#number to pin it). The skill writes
+     a per-project marker if the ticket's repo matches a registered
+     managed project, otherwise falls back to the ops-level marker.
+  3. Retry the edit
+
+Markers looked up for this path (in order):
+$([ -n "$PER_WORKTREE_MARKER" ] && echo "  per-worktree: $PER_WORKTREE_MARKER")
+$([ -n "$PER_PROJECT_MARKER" ] && echo "  per-project:  $PER_PROJECT_MARKER")
+  ops fallback: $FALLBACK_MARKER
+
+Target: ${FILE_PATH:-<unextractable Bash write target>}
+
+Exempt paths (no ticket required): .claude/, docs/, projects/*/docs/, *.md
+MSG
+  return 2
+}
+
+# ------------------------------------------------------------------------------
+# Dispatch
+# ------------------------------------------------------------------------------
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
 
-# Bash-tool path: extract the target file from the command if it appears
+# Bash-tool path: extract the target file(s) from the command if it appears
 # to be a write. Closes the bypass surface where Bash file-writes
 # (`echo > file`, `tee file`, `sed -i ... file`, `python -c
 # 'pathlib.Path(...).write_text(...)'`, etc.) routed around the
@@ -131,460 +621,34 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     exit 0
   fi
 
-  # Try to extract a target path so we can apply the same path-based
-  # exemptions (.claude/, docs/, *.md). If extraction fails, FILE_PATH
-  # stays empty and the gate is applied categorically.
-  FILE_PATH=$(bash_extract_write_target "$COMMAND")
+  # Extract ALL write targets (#886) — not just the first. A command can
+  # name more than one (`echo a > /tmp/x; echo b > src/app.ts`, `tee a b
+  # c`); judging only the first let the rest slip past the gate whenever
+  # the first happened to be exempt.
+  ALL_TARGETS=$(bash_extract_write_targets "$COMMAND")
 
-  # Variable target (e.g. `cat > "$VAR"`): the extractor returns the literal
-  # shell-variable token. Exempt a temp-dir var, and a BARE whole-target variable
-  # (`$CEO`, `${marker}` — unresolvable, in practice a .claude/ scratch path). A
-  # variable WITH a concatenated path tail (`$PWD/src/app.ts`, `$D/app.ts`,
-  # `$HOME/work/src/x.ts`) is NOT exempt — that path could be tracked source, and
-  # the old blanket `$*` exemption let such a write dodge the ticket gate (#582
-  # review: fail-open on a security gate). A var+tail target isn't bare and isn't
-  # absolute, so it falls through to the ticket gate below and blocks — which is
-  # the safe direction. (We deliberately do NOT expand $PWD/$HOME here: that adds
-  # nothing for blocking and tripped a /var↔/private/var symlink mismatch.)
-  case "$FILE_PATH" in
-    '$TMPDIR'/*|'${TMPDIR}'/*|'$TMP'/*|'${TMP}'/*) exit 0 ;;  # temp dir → outside the repo
-  esac
-  # Bare whole-target variable only (no path/extension tail) → exempt.
-  if printf '%s' "$FILE_PATH" | grep -qE '^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$'; then
-    exit 0
+  if [ -z "$ALL_TARGETS" ]; then
+    # No target extractable at all — categorical fail-closed gate, same
+    # as the pre-#886 empty-FILE_PATH behaviour (single call, FILE_PATH="").
+    _ratc_evaluate_target "" "Bash"
+    exit $?
   fi
-fi
 
-if [ -z "$FILE_PATH" ] && [ "$TOOL_NAME" != "Bash" ]; then
+  # AND semantics: the command as a whole passes only if EVERY extracted
+  # target independently clears the gate. Stop at (and report) the first
+  # target that doesn't — the overall verdict is already "block" at that
+  # point, so there's nothing to gain from evaluating the rest.
+  while IFS= read -r _tgt; do
+    [ -z "$_tgt" ] && continue
+    if ! _ratc_evaluate_target "$_tgt" "Bash"; then
+      exit 2
+    fi
+  done <<< "$ALL_TARGETS"
+
   exit 0
 fi
 
-# Normalise to repo-relative path when possible.
-#
-# BUG #744 FIX: derive REPO_ROOT from the FILE_PATH's directory, NOT the
-# hook's CWD. The harness can fire with any CWD (e.g. /tmp, the ops root,
-# a totally unrelated directory). Using `git rev-parse --show-toplevel`
-# from the hook process's CWD returns the WRONG root whenever the CWD
-# differs from the file's actual git repo — which breaks the OPS_ROOT
-# walk-up and causes the per-project marker to be missed, blocking edits
-# even when /start-ticket set a valid marker (#744, #745).
-#
-# Resolution order:
-#   1. FILE_PATH is set and absolute: run git in the file's nearest existing
-#      ancestor directory.  Works for new files (dirname of a not-yet-created
-#      path still points at the parent dir).
-#   2. FILE_PATH is set but relative (Bash write-target extracted from the
-#      command): relative paths are relative to the process CWD, so fall
-#      back to the legacy CWD-based git rev-parse — same behaviour as before.
-#   3. FILE_PATH is empty (Bash command, no extractable target): CWD-based
-#      fallback as before.
-REPO_ROOT=""
-if [ -n "$FILE_PATH" ]; then
-  case "$FILE_PATH" in
-    /*)
-      # Absolute path — find the nearest existing ancestor directory.
-      # dirname works on non-existent files; the while loop handles the
-      # case where the new file's parent dir doesn't exist yet.
-      _fp_dir="$(dirname "$FILE_PATH")"
-      while [ -n "$_fp_dir" ] && [ "$_fp_dir" != "/" ] && [ ! -d "$_fp_dir" ]; do
-        _fp_dir="$(dirname "$_fp_dir")"
-      done
-      if [ -d "$_fp_dir" ]; then
-        REPO_ROOT=$(git -C "$_fp_dir" rev-parse --show-toplevel 2>/dev/null)
-        # When the file's repo is a LINKED git worktree the worktree dir
-        # inherits the main branch's files — including anchor files like
-        # onboarding.yaml / apexyard.projects.yaml.  The OPS_ROOT walk-up
-        # below would then stop at the worktree instead of the real ops
-        # fork.  Detect a linked worktree (absolute git-dir ≠ common-dir)
-        # and replace REPO_ROOT with the main-checkout root (dirname of
-        # the common-dir, i.e. parent of the main .git dir).  This keeps
-        # the walk-up anchored to the actual ops fork while leaving the
-        # later per-worktree branch detection (which re-reads git from
-        # _fdir) unaffected.
-        if [ -n "$REPO_ROOT" ]; then
-          _wt_gd=$(git -C "$_fp_dir" rev-parse --absolute-git-dir 2>/dev/null)
-          _wt_gcd=$(git -C "$_fp_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
-          if [ -n "$_wt_gd" ] && [ -n "$_wt_gcd" ] && [ "$_wt_gd" != "$_wt_gcd" ]; then
-            _main_root=$(dirname "$_wt_gcd")
-            [ -d "$_main_root" ] && REPO_ROOT="$_main_root"
-          fi
-        fi
-      fi
-      ;;
-    *)
-      # Relative path (Bash write-target): resolve against CWD.
-      REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-      ;;
-  esac
-fi
-# Fallback: FILE_PATH empty (Bash command, no extractable target).
-if [ -z "$REPO_ROOT" ]; then
-  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-fi
-REL_PATH="$FILE_PATH"
-if [ -n "$REPO_ROOT" ] && [ -n "$FILE_PATH" ]; then
-  case "$FILE_PATH" in
-    "$REPO_ROOT"/*) REL_PATH="${FILE_PATH#$REPO_ROOT/}" ;;
-  esac
-fi
-
-# NOTE: the narrow "Bash absolute path outside REPO_ROOT" exemption that
-# used to live here (#569) has been superseded by the out-of-governance
-# exemption below (apexyard#883), which covers BOTH Bash and Edit/Write/
-# MultiEdit, resolves symlinks before judging, and checks the actual
-# governance boundaries (ops root + registered workspaces) rather than
-# just "outside the nearest git repo". See that block for the full design.
-
-# Exempt paths.
-#
-# Each path-prefix exemption is matched in both REL_PATH (repo-relative)
-# and absolute (*/path/*) forms. Absolute-path fallthrough happens when
-# FILE_PATH points outside REPO_ROOT (e.g. agent worktrees whose
-# git-toplevel differs from the outer apexyard tree); in that case the
-# strip on lines 43-45 is a no-op and REL_PATH stays absolute. The
-# existing `*.md` pattern already crosses `/`, so absolute-match via a
-# `*/…` prefix is a known-good shape — #56 extends the same trick to the
-# path-prefix exemptions.
-#
-# Skipped entirely when FILE_PATH is empty (Bash command writes to an
-# unextractable target — e.g. `python -c '...write...'`). Those fall
-# through to the ticket gate; the bootstrap-skill exemption below covers
-# the legitimate use case (/setup writing to fork-root files via Bash).
-if [ -n "$REL_PATH" ]; then
-  case "$REL_PATH" in
-    .claude/*|.claude|*/.claude/*|*/.claude) exit 0 ;;
-    docs/*|docs|*/docs/*|*/docs) exit 0 ;;
-    TODO.md|README.md|MEMORY.md|CLAUDE.md) exit 0 ;;
-  esac
-  # Note: `projects/*/docs/*` is subsumed by `*/docs/*` above (shell case `*`
-  # crosses `/`), so no separate arm needed. Per-project apexyard docs are
-  # matched by the generic docs-in-any-subtree pattern.
-  case "$REL_PATH" in
-    *.md) exit 0 ;;
-  esac
-fi
-
-# Discover the ops root. Walk up from REPO_ROOT looking for either the
-# v2 `.apexyard-fork` marker (split-portfolio v2 layout) OR the legacy
-# v1 anchor (onboarding.yaml + apexyard.projects.yaml). Stop at /. If
-# not found, OPS_ROOT stays empty and we treat the REPO_ROOT itself as
-# the marker home (pre-#41 behaviour).
-#
-# Guard change (#744/#745): the lib-based resolver is always invoked when
-# the lib is available — even when REPO_ROOT is empty. This matters for
-# split-portfolio v2 where the workspace is a sibling repo with no git
-# history: REPO_ROOT is empty (no git in the sibling dir) but the
-# session-pin resolver in _lib-ops-root.sh can still locate the ops fork
-# from the pin written at session-start, regardless of start dir.
-HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-OPS_ROOT=""
-if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
-  # shellcheck source=/dev/null
-  . "$HOOK_DIR/_lib-ops-root.sh"
-  # Pass REPO_ROOT as the walk-up start dir when available; the pin
-  # resolver ignores the start dir and uses the session pin directly.
-  OPS_ROOT=$(resolve_ops_root "${REPO_ROOT:-}")
-elif [ -n "$REPO_ROOT" ]; then
-  # Inline walk-up fallback when the lib is absent (e.g. minimal test
-  # sandboxes that only copy the core libs).
-  r="$REPO_ROOT"
-  while [ -n "$r" ] && [ "$r" != "/" ]; do
-    if [ -f "$r/.apexyard-fork" ]; then
-      OPS_ROOT="$r"
-      break
-    fi
-    if [ -f "$r/onboarding.yaml" ] && [ -f "$r/apexyard.projects.yaml" ]; then
-      OPS_ROOT="$r"
-      break
-    fi
-    parent=$(dirname "$r"); [ "$parent" = "$r" ] && break; r="$parent"
-  done
-fi
-
-MARKER_HOME="${OPS_ROOT:-$REPO_ROOT}"
-MARKER_HOME="${MARKER_HOME:-.}"
-
-# Resolve the workspace dir for the per-project marker resolution below.
-# Defaults to $OPS_ROOT/workspace; split-portfolio v2 adopters override
-# via portfolio.workspace_dir to point at their private sibling repo.
-WORKSPACE_DIR="$OPS_ROOT/workspace"
-if [ -n "$OPS_ROOT" ] && [ -f "$HOOK_DIR/_lib-portfolio-paths.sh" ] && [ -f "$HOOK_DIR/_lib-read-config.sh" ]; then
-  # shellcheck source=/dev/null
-  . "$HOOK_DIR/_lib-read-config.sh"
-  # shellcheck source=/dev/null
-  . "$HOOK_DIR/_lib-portfolio-paths.sh"
-  resolved_ws=$(portfolio_workspace_dir 2>/dev/null)
-  if [ -n "$resolved_ws" ]; then
-    WORKSPACE_DIR="$resolved_ws"
-  fi
-fi
-
-# --- Out-of-governance exemption (apexyard#883) -------------------------
-#
-# A write TARGET that is outside every governed tree — the ops fork
-# itself AND every registered workspace/<project> clone — AND not inside
-# ANY git repository at all is outside this gate's jurisdiction. Applies
-# to BOTH Bash-detected writes and Edit/Write/MultiEdit tool calls (the
-# earlier #569 exemption was Bash-only, which left Edit-tool writes to
-# e.g. ~/.zshrc gated with no legitimate way to satisfy the gate on forks
-# with GitHub Issues disabled — the exact bug reported in #883).
-#
-# Fail-closed directions (deliberate):
-#   - An unresolvable FILE_PATH (empty — a Bash target the extractor
-#     couldn't identify) is NEVER exempted here; it falls through to the
-#     ticket gate below, unchanged from before this change.
-#   - Relative paths (a Bash write-target like `src/app.ts`) resolve
-#     against the hook's CWD before judging.
-#   - Symlinks are resolved to their real path before judging (via
-#     _resolve_real_path above), so a symlink living under $HOME that
-#     POINTS INTO a governed tree does not slip through as "outside" it.
-#   - Being inside SOME git repository that is neither the ops fork nor a
-#     registered workspace project does NOT exempt the write on its own —
-#     the ops-root/workspace boundaries are checked EXPLICITLY (not
-#     merely inferred from "is this a git repo"), because a
-#     split-portfolio workspace project is governed even when its clone
-#     isn't itself a git repository (e.g. a docs-only project, or a test
-#     fixture that never ran `git init`).
-#   - RAW-AND-RESOLVED containment (security review finding on #885,
-#     apexyard PR #885 — Hakim/security-reviewer): checking ops-root and
-#     workspace containment ONLY on the symlink-resolved target has a
-#     mirror-image hole to the one `_resolve_real_path` fixes. If a
-#     REGISTERED workspace/<project> entry is ITSELF a symlink whose real
-#     target lives OUTSIDE workspace/ in a non-git directory
-#     (`workspace/proj -> /some/nongit/dir`), resolving the target
-#     "escapes" the workspace boundary the same way the fix escapes a
-#     symlink-into-repo attack — the RESOLVED path no longer sits under
-#     WORKSPACE_DIR, so the naive single-check reads it as ungoverned and
-#     wrongly exempts it. The fix: evaluate ops-root/workspace
-#     containment against BOTH the RAW (pre-resolution) absolute target
-#     AND the fully resolved target, using the SAME canonicalized
-#     boundary anchors for both comparisons (only the anchors are
-#     canonicalized once; the raw target itself is deliberately left
-#     symlink-unresolved so a governed raw path can't be laundered away
-#     by a symlink further down it). A path counts as governed — and
-#     therefore NOT exempt — if EITHER the raw or the resolved check
-#     lands inside ops-root or workspace. Exemption requires ALL FOUR
-#     containment checks below (raw-ops, raw-ws, resolved-ops,
-#     resolved-ws) to say "outside", plus the git-repo probe to say "not
-#     in a repo".
-if [ -n "$FILE_PATH" ]; then
-  case "$FILE_PATH" in
-    /*) _og_abs_target="$FILE_PATH" ;;
-    *)  _og_abs_target="$PWD/$FILE_PATH" ;;
-  esac
-  _og_real_target="$(_resolve_real_path "$_og_abs_target")"
-  if [ -n "$_og_real_target" ]; then
-    _og_in_ops_raw=0
-    _og_in_ws_raw=0
-    _og_in_ops_res=0
-    _og_in_ws_res=0
-    _og_in_git=0
-
-    # Canonicalize the boundary anchors ONCE — used as the comparison
-    # basis for both the raw-target check and the resolved-target check.
-    # This keeps the two checks internally consistent even when OPS_ROOT
-    # was resolved via a non-canonical path (e.g. a CWD-based walk-up
-    # that never ran through `pwd -P`).
-    _og_real_ops=""
-    if [ -n "$OPS_ROOT" ]; then
-      _og_real_ops="$(cd "$OPS_ROOT" 2>/dev/null && pwd -P)"
-    fi
-    _og_real_ws=""
-    if [ -n "$WORKSPACE_DIR" ] && [ -d "$WORKSPACE_DIR" ]; then
-      _og_real_ws="$(cd "$WORKSPACE_DIR" 2>/dev/null && pwd -P)"
-    fi
-
-    # RAW check — the pre-resolution absolute target against the
-    # canonical boundary. Catches a registered workspace/<project> that
-    # is itself a symlink pointing OUTSIDE workspace/: the raw path
-    # still literally names the governed workspace/<project> location,
-    # even though resolving it lands elsewhere.
-    if [ -n "$_og_real_ops" ]; then
-      case "$_og_abs_target" in
-        "$_og_real_ops") _og_in_ops_raw=1 ;;
-        "$_og_real_ops"/*) _og_in_ops_raw=1 ;;
-      esac
-    fi
-    if [ -n "$_og_real_ws" ]; then
-      case "$_og_abs_target" in
-        "$_og_real_ws") _og_in_ws_raw=1 ;;
-        "$_og_real_ws"/*) _og_in_ws_raw=1 ;;
-      esac
-    fi
-
-    # RESOLVED check — the symlink-resolved target against the same
-    # canonical boundary. Catches a symlink OUTSIDE any governed tree
-    # that POINTS INTO one (the original #883 defense).
-    if [ -n "$_og_real_ops" ]; then
-      case "$_og_real_target" in
-        "$_og_real_ops") _og_in_ops_res=1 ;;
-        "$_og_real_ops"/*) _og_in_ops_res=1 ;;
-      esac
-    fi
-    if [ -n "$_og_real_ws" ]; then
-      case "$_og_real_target" in
-        "$_og_real_ws") _og_in_ws_res=1 ;;
-        "$_og_real_ws"/*) _og_in_ws_res=1 ;;
-      esac
-    fi
-
-    # Nearest-existing-ancestor git-repo probe on the REAL (symlink-
-    # resolved) target — catches any git repo, governed or not. A single
-    # probe suffices for both raw and resolved forms: directory
-    # traversal (`-d`, `git -C`) transparently follows symlinks at the
-    # OS level regardless of which path string reaches the location, so
-    # raw-path traversal and resolved-path traversal of the SAME logical
-    # target always land on the same physical directory.
-    _og_probe="$_og_real_target"
-    while [ -n "$_og_probe" ] && [ "$_og_probe" != "/" ] && [ ! -d "$_og_probe" ]; do
-      _og_probe="$(dirname "$_og_probe")"
-    done
-    if [ -n "$_og_probe" ] && [ -d "$_og_probe" ] \
-       && git -C "$_og_probe" rev-parse --show-toplevel >/dev/null 2>&1; then
-      _og_in_git=1
-    fi
-
-    if [ "$_og_in_ops_raw" = 0 ] && [ "$_og_in_ws_raw" = 0 ] \
-       && [ "$_og_in_ops_res" = 0 ] && [ "$_og_in_ws_res" = 0 ] \
-       && [ "$_og_in_git" = 0 ]; then
-      exit 0
-    fi
-  fi
-fi
-
-# Bootstrap-skill exemption (apexyard#150): skills like /setup,
-# /handover, /update, /split-portfolio run BEFORE any ticket can exist
-# (no portfolio configured yet, no projects registered). They write a
-# marker at .claude/session/active-bootstrap with the skill name on
-# entry; this hook reads the marker, looks up the configured
-# bootstrap_skills list, and exits 0 if the active skill is on the list.
-#
-# The marker is cleared at SessionStart by clear-bootstrap-marker.sh so
-# a stale marker from an interrupted session can't carry over.
-BOOTSTRAP_MARKER="$MARKER_HOME/.claude/session/active-bootstrap"
-if [ -f "$BOOTSTRAP_MARKER" ]; then
-  active_bootstrap=$(tr -d '[:space:]' < "$BOOTSTRAP_MARKER" 2>/dev/null)
-  if [ -n "$active_bootstrap" ]; then
-    # Source the config reader and look up bootstrap_skills.
-    if [ -f "$MARKER_HOME/.claude/hooks/_lib-read-config.sh" ]; then
-      # shellcheck source=/dev/null
-      . "$MARKER_HOME/.claude/hooks/_lib-read-config.sh"
-      if command -v config_get >/dev/null 2>&1; then
-        # `config_get '.ticket.bootstrap_skills[]'` outputs one skill per
-        # line. Use grep -wF for whole-word, fixed-string match.
-        if config_get '.ticket.bootstrap_skills[]' 2>/dev/null | grep -qwF "$active_bootstrap"; then
-          exit 0
-        fi
-      fi
-    fi
-  fi
-fi
-
-# Per-project resolution (apexyard#41): if FILE_PATH points under the
-# resolved workspace dir, we look for a per-project marker at
-# .claude/session/tickets/<project>. This keeps per-project session state
-# keyed by the managed-project name and localised in the ops fork
-# (gitignored), instead of the pre-#41 scheme that relied on a
-# .claude/session/ inside each managed-project clone.
-#
-# Split-portfolio v2 (#242): WORKSPACE_DIR may resolve to a sibling
-# private repo path (e.g. ../<fork>-portfolio/workspace) instead of the
-# default $OPS_ROOT/workspace; both shapes are handled here.
-PROJECT=""
-if [ -n "$WORKSPACE_DIR" ]; then
-  case "$FILE_PATH" in
-    "$WORKSPACE_DIR"/*)
-      tail="${FILE_PATH#$WORKSPACE_DIR/}"
-      PROJECT="${tail%%/*}"
-      ;;
-  esac
-fi
-# Belt-and-suspenders: also recognise the literal $OPS_ROOT/workspace/
-# shape, in case workspace_dir is overridden but a tool produced an
-# absolute path under the in-fork legacy location.
-if [ -z "$PROJECT" ] && [ -n "$OPS_ROOT" ]; then
-  case "$FILE_PATH" in
-    "$OPS_ROOT"/workspace/*)
-      tail="${FILE_PATH#$OPS_ROOT/workspace/}"
-      PROJECT="${tail%%/*}"
-      ;;
-  esac
-fi
-
-# Tier 0 — per-worktree marker (#513): when two agents are fanned out on the
-# SAME managed project in parallel git worktrees, each must declare its ticket
-# independently or they collide on the shared per-project file (last-writer-wins,
-# silent wrong-ticket pass). A branch-scoped marker at
-# tickets/<project>/<safe-branch> is resolved BEFORE the per-project tier.
-# Single-agent / non-worktree flows have no such marker and fall straight
-# through to the per-project tier — no behaviour change. Note: tickets/<project>
-# is a FILE in single-agent mode and a DIRECTORY in worktree mode; the `-f`
-# tests below distinguish them, so the two tiers never conflict.
-PER_WORKTREE_MARKER=""
-if [ -n "$PROJECT" ]; then
-  # Branch: prefer the harness-set env var (populated at worktree spawn). Else
-  # only treat the file's repo as worktree-scoped when it's a LINKED worktree,
-  # detected by comparing the ABSOLUTE git-dir against the ABSOLUTE common-dir
-  # (they differ only in a linked worktree). This matches /start-ticket's
-  # write-side detection exactly — no read/write asymmetry — and the absolute
-  # forms avoid the false positive where, in the main checkout from a subdir,
-  # `--git-dir` is absolute but `--git-common-dir` is relative.
-  WT_BRANCH="${CLAUDE_WORKTREE_BRANCH:-}"
-  if [ -z "$WT_BRANCH" ]; then
-    _fdir=$(dirname "$FILE_PATH")
-    _gd=$(git -C "$_fdir" rev-parse --absolute-git-dir 2>/dev/null)
-    _gcd=$(git -C "$_fdir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
-    if [ -n "$_gd" ] && [ "$_gd" != "$_gcd" ]; then
-      WT_BRANCH=$(git -C "$_fdir" branch --show-current 2>/dev/null)
-    fi
-  fi
-  if [ -n "$WT_BRANCH" ]; then
-    SAFE_BRANCH="${WT_BRANCH//\//__}"   # '/' → '__' for a filesystem-safe segment
-    PER_WORKTREE_MARKER="$MARKER_HOME/.claude/session/tickets/$PROJECT/$SAFE_BRANCH"
-    if [ -f "$PER_WORKTREE_MARKER" ]; then
-      exit 0
-    fi
-  fi
-fi
-
-PER_PROJECT_MARKER=""
-if [ -n "$PROJECT" ]; then
-  PER_PROJECT_MARKER="$MARKER_HOME/.claude/session/tickets/$PROJECT"
-  if [ -f "$PER_PROJECT_MARKER" ]; then
-    exit 0
-  fi
-fi
-
-# Fallback: the ops-level current-ticket marker. This is the pre-#41
-# location and still honoured for ops-repo framework edits, and as a
-# safety net for any file we couldn't map to a specific project.
-FALLBACK_MARKER="$MARKER_HOME/.claude/session/current-ticket"
-if [ -f "$FALLBACK_MARKER" ]; then
-  exit 0
-fi
-
-# Nothing found — emit a guide that names both possibilities.
-cat >&2 <<MSG
-BLOCKED: No active ticket set for this session.
-
-ApexYard requires a ticket BEFORE any code changes (workflow-gates rule #3,
-pre-build gate, "one ticket at a time").
-
-To unblock:
-
-  1. Create or find the ticket (GitHub Issue in the project's own repo):
-       gh issue create --repo <owner/repo> --title "..."
-  2. Declare it for this session — run the /start-ticket skill with the
-     issue number (or pass owner/repo#number to pin it). The skill writes
-     a per-project marker if the ticket's repo matches a registered
-     managed project, otherwise falls back to the ops-level marker.
-  3. Retry the edit
-
-Markers looked up for this path (in order):
-$([ -n "$PER_WORKTREE_MARKER" ] && echo "  per-worktree: $PER_WORKTREE_MARKER")
-$([ -n "$PER_PROJECT_MARKER" ] && echo "  per-project:  $PER_PROJECT_MARKER")
-  ops fallback: $FALLBACK_MARKER
-
-Exempt paths (no ticket required): .claude/, docs/, projects/*/docs/, *.md
-MSG
-exit 2
+# Non-Bash tool call (Edit/Write/MultiEdit): a single, explicit file_path —
+# no multi-target concern, one evaluation.
+_ratc_evaluate_target "$FILE_PATH" "$TOOL_NAME"
+exit $?

--- a/.claude/hooks/require-migration-ticket.sh
+++ b/.claude/hooks/require-migration-ticket.sh
@@ -35,17 +35,40 @@
 #
 # The config is read from `<ops_root>/.claude/project-config.json` if
 # present, otherwise defaults below apply.
+#
+# ALL write targets are judged, not just the first (apexyard#886): a Bash
+# command can name more than one write target (`echo x > /tmp/scratch.sql
+# && echo y > db/migrations/002_add.sql`). Judging only the first target
+# let a command whose first target wasn't migration-shaped slip a later,
+# genuinely migration-shaped target past this gate entirely. See the
+# target-resolution loop below (after is_migration_path is defined) for
+# how every extracted target gets checked.
+
+# Exempt meta / docs / example files — these never need a migration
+# ticket regardless of path. Applied PER TARGET (not just once against
+# the first extracted target) so a meta-exempt target can't shadow a
+# genuinely migration-shaped target named later in the same command.
+_rmt_is_meta_exempt() {
+  case "$1" in
+    */.claude/*|*/.claude|*/docs/*|*/docs) return 0 ;;
+    *.md|*.example) return 0 ;;
+  esac
+  # Note: `*/projects/*/docs/*` is subsumed by `*/docs/*` above (shell case
+  # `*` crosses `/`), so no separate arm is needed.
+  return 1
+}
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
 
-# Bash-tool path: if the command writes, try to extract the target so we
-# can apply the migration-path matcher to it. If extraction fails (e.g.
-# `python -c '…write_text("file"…)…'`), FILE_PATH stays empty and the
-# hook exits 0 — the migration gate is path-specific, so an
-# unextractable target falls outside the gate's scope.
+# Bash-tool path: if the command writes, collect ALL extractable targets so
+# every one can be checked against the migration-path matcher below — not
+# just the first (#886). If extraction finds nothing at all (e.g.
+# `python -c '…write_text("file"…)…'`), the migration gate is path-specific
+# by design and falls outside its scope, same as before this change.
 # See me2resh/apexyard#151 + _lib-detect-bash-write.sh for the detector.
+BASH_TARGETS=""
 if [ "$TOOL_NAME" = "Bash" ]; then
   COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
   [ -z "$COMMAND" ] && exit 0
@@ -57,26 +80,28 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     if ! bash_command_appears_to_write "$COMMAND"; then
       exit 0
     fi
-    FILE_PATH=$(bash_extract_write_target "$COMMAND")
+    BASH_TARGETS=$(bash_extract_write_targets "$COMMAND")
   else
     # Library missing — fall back to no-op rather than bricking the hook.
     exit 0
   fi
+
+  if [ -z "$BASH_TARGETS" ]; then
+    exit 0
+  fi
+  # Resolved to the gate-worthy target further down, once is_migration_path
+  # is defined — see the resolution loop after that function.
+  FILE_PATH=""
 fi
 
-if [ -z "$FILE_PATH" ]; then
-  exit 0
+if [ "$TOOL_NAME" != "Bash" ]; then
+  if [ -z "$FILE_PATH" ]; then
+    exit 0
+  fi
+  if _rmt_is_meta_exempt "$FILE_PATH"; then
+    exit 0
+  fi
 fi
-
-# --------- Exempt meta / docs / example files ---------
-# These never need a migration ticket regardless of path, so short-circuit
-# before doing any network calls.
-case "$FILE_PATH" in
-  */.claude/*|*/.claude|*/docs/*|*/docs) exit 0 ;;
-  *.md|*.example) exit 0 ;;
-esac
-# Note: `*/projects/*/docs/*` is subsumed by `*/docs/*` above (shell case `*`
-# crosses `/`), so no separate arm is needed.
 
 # --------- Discover ops root ---------
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -175,7 +200,29 @@ is_migration_path() {
   return 1
 }
 
-if ! is_migration_path "$FILE_PATH"; then
+# --------- Resolve which target (if any) is migration-shaped ---------
+# #886: for a Bash command, check EVERY extracted target — not just the
+# first — skipping any that are meta-exempt, and gate on the first one
+# that matches a migration-path pattern. For a non-Bash tool call there is
+# only ever the one FILE_PATH (already meta-exemption-checked above).
+if [ "$TOOL_NAME" = "Bash" ]; then
+  RESOLVED_TARGET=""
+  while IFS= read -r _tgt; do
+    [ -z "$_tgt" ] && continue
+    _rmt_is_meta_exempt "$_tgt" && continue
+    if is_migration_path "$_tgt"; then
+      RESOLVED_TARGET="$_tgt"
+      break
+    fi
+  done <<< "$BASH_TARGETS"
+
+  if [ -z "$RESOLVED_TARGET" ]; then
+    # No target in this command matches a migration path — other hooks
+    # handle the standard ticket check.
+    exit 0
+  fi
+  FILE_PATH="$RESOLVED_TARGET"
+elif ! is_migration_path "$FILE_PATH"; then
   # Not a migration file — other hooks handle the standard ticket check.
   exit 0
 fi

--- a/.claude/hooks/tests/test_detect_bash_write.sh
+++ b/.claude/hooks/tests/test_detect_bash_write.sh
@@ -257,6 +257,35 @@ assert_targets "tee -a with multiple file operands" \
 assert_targets "three semicolon-chained redirects" \
   "echo a > /tmp/x; echo b > /tmp/y; echo c > src/app.ts"                             "/tmp/x,/tmp/y,src/app.ts"
 
+# #886/#926 (Hakim security-review finding): NO-SPACE separator+redirection.
+# Splitting on the separator can leave a segment that BEGINS with `>` —
+# e.g. `;> .gitignore` splits into a second segment of `> .gitignore`. The
+# original leading-context regex `[^|<&]>...` required a character before
+# `>` to exist at all, so it silently dropped the target at position 0.
+# These are Hakim's exact repro strings from the PR #926 review.
+assert_targets "no-space semicolon then redirect" \
+  "echo a > /tmp/ok;> .gitignore"                                                     "/tmp/ok,.gitignore"
+assert_targets "no-space semicolon+redirect with trailing command" \
+  "echo a > /tmp/ok;> .gitignore cat /etc/hostname"                                   "/tmp/ok,.gitignore"
+assert_targets "no-space && then redirect" \
+  "echo a > /tmp/ok&&> .gitignore"                                                    "/tmp/ok,.gitignore"
+assert_targets "no-space | then redirect" \
+  "echo a > /tmp/ok|> .gitignore"                                                     "/tmp/ok,.gitignore"
+assert_targets "no-space || then redirect" \
+  "echo a > /tmp/ok||> .gitignore"                                                    "/tmp/ok,.gitignore"
+
+# Sanity: the anchored fix must not turn 2>&1 (fd-dup) or a heredoc into a
+# false-positive redirection target.
+if bash_command_appears_to_write "make build 2>&1"; then
+  echo "FAIL [targets/2>&1 must not be treated as a write]" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}targets/fd-dup-false-positive "
+else
+  echo "PASS [targets/2>&1 correctly not a write]"
+  PASS=$((PASS+1))
+fi
+assert_targets "heredoc still extracts correctly (no regression)" \
+  "$(printf 'cat > /tmp/x <<EOF\nhi\nEOF')"                                           "/tmp/x"
+
 # Duplicate targets across segments collapse to one entry.
 got_dup=$(bash_extract_write_targets "echo a > /tmp/x; echo b > /tmp/x" | wc -l | tr -d ' ')
 if [ "$got_dup" = "1" ]; then

--- a/.claude/hooks/tests/test_detect_bash_write.sh
+++ b/.claude/hooks/tests/test_detect_bash_write.sh
@@ -219,6 +219,58 @@ assert_not_deletion_only "rm + tee"                 "rm a | tee b"
 assert_not_deletion_only "redirect only (no rm)"    "echo x > file.ts"
 assert_not_deletion_only "cp only"                  "cp a b"
 
+# --- bash_extract_write_targets (#886) — ALL targets, not just the first ---
+
+assert_targets() {
+  local label="$1" cmd="$2" want="$3"
+  local got
+  got=$(bash_extract_write_targets "$cmd" | sort | tr '\n' ',' )
+  local want_sorted
+  want_sorted=$(printf '%s' "$want" | tr ',' '\n' | sort | tr '\n' ',')
+  if [ "$got" = "$want_sorted" ]; then
+    echo "PASS [targets/$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [targets/$label]: cmd=$cmd  want=[$want_sorted]  got=[$got]" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}targets/${label} "
+  fi
+}
+
+# Single-target commands still return exactly one target (no regression
+# vs. the singular bash_extract_write_target).
+assert_targets "single redirect"          "echo hi > /tmp/x"                          "/tmp/x"
+assert_targets "single in-repo redirect"  "echo hi > src/app.ts"                      "src/app.ts"
+assert_targets "single tee"               "echo x | tee /tmp/x"                       "/tmp/x"
+assert_targets "single cp"                "cp src.txt /tmp/dst.txt"                   "/tmp/dst.txt"
+
+# THE #886 bypass shape: an out-of-repo (or otherwise exempt) target FIRST,
+# an in-repo target SECOND — both must be present in the extracted set so a
+# consumer can gate on the second even though the first would exempt alone.
+assert_targets "semicolon-chained: out-of-repo then in-repo" \
+  "echo a > /tmp/x; echo b > src/app.ts"                                              "/tmp/x,src/app.ts"
+assert_targets "&&-chained: out-of-repo then in-repo" \
+  "cp a.txt /tmp/b.txt && echo y > src/app.ts"                                        "/tmp/b.txt,src/app.ts"
+assert_targets "tee with multiple file operands" \
+  "echo x | tee /tmp/a src/b.ts"                                                      "/tmp/a,src/b.ts"
+assert_targets "tee -a with multiple file operands" \
+  "echo x | tee -a /tmp/a src/b.ts"                                                   "/tmp/a,src/b.ts"
+assert_targets "three semicolon-chained redirects" \
+  "echo a > /tmp/x; echo b > /tmp/y; echo c > src/app.ts"                             "/tmp/x,/tmp/y,src/app.ts"
+
+# Duplicate targets across segments collapse to one entry.
+got_dup=$(bash_extract_write_targets "echo a > /tmp/x; echo b > /tmp/x" | wc -l | tr -d ' ')
+if [ "$got_dup" = "1" ]; then
+  echo "PASS [targets/duplicate targets deduped]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [targets/duplicate targets deduped]: got $got_dup lines, want 1" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}targets/dedupe "
+fi
+
+# Documented misses still contribute nothing (no fabricated targets).
+assert_targets "python -c (miss) contributes nothing" \
+  'python3 -c "open(\"/tmp/x\",\"w\").write(\"hi\")"'                                 ""
+
 echo ""
 echo "==================================="
 echo "  PASS: $PASS   FAIL: $FAIL"

--- a/.claude/hooks/tests/test_detect_bash_write.sh
+++ b/.claude/hooks/tests/test_detect_bash_write.sh
@@ -332,6 +332,56 @@ assert_targets "no-space '>&2' fd-dup — still not a write target" \
 assert_targets "no-space '2>&1' fd-dup — still not a write target" \
   "make build 2>&1;true"                                                              ""
 
+# #886/#926 round 5 (Hakim's fifth adversarial re-hunt — the STRUCTURAL
+# root of the whole series): `|`/`||`-adjacent redirects. Detection
+# (bash_command_appears_to_write) used to run the redirection matcher on
+# the WHOLE, unsplit command, where a `|`-preceded `>` is excluded by the
+# leading-context class and isn't at `^` either — so `|>`/`||>`/`||>|`
+# were never even recognised as writes, let alone extracted. Extraction
+# already split first, so it found the target correctly — detection and
+# extraction DISAGREED. This block proves EXTRACTION already returns the
+# right target for these (it did before round 5 too); the real fix is in
+# the DETECTION-level test block further down, which is where the
+# structural bug actually lived.
+assert_targets "'||>' after a false command (Hakim repro)" \
+  "false ||> src/app.ts"                                                             "src/app.ts"
+assert_targets "'||>|' force-clobber after a false command (Hakim repro)" \
+  "false ||>| src/app.ts"                                                            "src/app.ts"
+assert_targets "'|>' after echo (Hakim repro)" \
+  "echo x |> src/app.ts"                                                             "src/app.ts"
+
+# Detection-level proof: bash_command_appears_to_write must ALSO recognise
+# these — this is the assertion that actually discriminates round 5 from
+# rounds 1-4, since it's the DETECTION path (not extraction) that had the
+# structural bug.
+assert_appears_to_write() {
+  local label="$1" cmd="$2"
+  if bash_command_appears_to_write "$cmd"; then
+    echo "PASS [detect/$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [detect/$label]: bash_command_appears_to_write missed: $cmd" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}detect/${label} "
+  fi
+}
+assert_appears_to_write "'||>' detected as a write (Hakim repro)"    "false ||> src/app.ts"
+assert_appears_to_write "'||>|' detected as a write (Hakim repro)"   "false ||>| src/app.ts"
+assert_appears_to_write "'|>' detected as a write (Hakim repro)"     "echo x |> src/app.ts"
+
+# Sanity: the deletion-only classifier had the identical structural bug at
+# its own direct _bdw_match_redirection call site — `rm x; false ||> y`
+# would have been wrongly classified as deletion-only (content-writing
+# hiding behind a |-adjacent redirect), exempting it from the ticket gate.
+assert_not_deletion_only "rm + '||>' hides a real write (round 5)" \
+  "rm old.ts; false ||> src/app.ts"
+
+# Sanity: the round-5 fix must NOT false-positive on fd-dup / read forms
+# that also happen to be pipe-adjacent.
+assert_targets "'| cmd 2>&1' pipe then fd-dup — not a write" \
+  "echo x | cat 2>&1"                                                                 ""
+assert_targets "'|| cmd >&2' or-chain then fd-dup — not a write" \
+  "false || echo err >&2"                                                             ""
+
 # Sanity: the broadened operator set must NOT false-positive on fd-duplication
 # forms, which look superficially similar (`&` and `>` both present) but mean
 # something entirely different — redirecting one fd to ANOTHER fd, not to a

--- a/.claude/hooks/tests/test_detect_bash_write.sh
+++ b/.claude/hooks/tests/test_detect_bash_write.sh
@@ -286,6 +286,54 @@ fi
 assert_targets "heredoc still extracts correctly (no regression)" \
   "$(printf 'cat > /tmp/x <<EOF\nhi\nEOF')"                                           "/tmp/x"
 
+# #886/#926 round 3 (Hakim adversarial re-hunt): the operator alternation
+# only modelled >, >>, and n> — it missed &>/&>> (redirect BOTH streams to
+# a file) and >|/>>| (force-clobber, noclobber override). Both are real,
+# destructive truncating writes. Hakim's exact repros:
+assert_targets "&> redirects both streams to a file (Hakim repro)" \
+  "echo hi &> .gitignore"                                                            ".gitignore"
+# NOTE: unlike the other rows in this block, `&>>` happens to extract
+# correctly even under the PRE-round-3 regex — not via the dedicated `&>>?`
+# alternative this fix adds, but by coincidence: the pattern's leading-context
+# class `[^|<&]` doesn't exclude `>` itself, so the SECOND `>` in `&>>` reads
+# the FIRST `>` as valid (non-excluded) leading context and matches anyway.
+# Kept here as a correctness/coverage check (it must still pass post-fix),
+# not a fail-pre/pass-post discriminator like the bare `&>` row above it.
+assert_targets "&>> append-both-streams to a file" \
+  "echo hi &>> .gitignore"                                                           ".gitignore"
+assert_targets ">| force-clobber after no-space semicolon (Hakim repro)" \
+  "echo a > /tmp/ok;>| db/migrations/006.sql"                                         "/tmp/ok,db/migrations/006.sql"
+assert_targets ">>| force-clobber-append variant" \
+  "echo a > /tmp/ok;>>| db/migrations/006.sql"                                        "/tmp/ok,db/migrations/006.sql"
+assert_targets ">| with a space after the separator (not just no-space)" \
+  "echo a > /tmp/ok; >| db/migrations/006.sql"                                        "/tmp/ok,db/migrations/006.sql"
+
+# Sanity: the broadened operator set must NOT false-positive on fd-duplication
+# forms, which look superficially similar (`&` and `>` both present) but mean
+# something entirely different — redirecting one fd to ANOTHER fd, not to a
+# file. Order in "&"/">"" matters: &> is `&` THEN `>` (a write); these forms
+# have `>` THEN `&` (a dup) and must stay unmatched.
+assert_targets "2>&1 fd-dup — not a write target" \
+  "make build 2>&1"                                                                   ""
+assert_targets ">&2 fd-dup — not a write target" \
+  "echo err >&2"                                                                      ""
+assert_targets "1>&2 fd-dup — not a write target" \
+  "cmd 1>&2"                                                                          ""
+if bash_command_appears_to_write "echo err >&2"; then
+  echo "FAIL [targets/>&2 must not be detected as appears_to_write]" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}targets/fd-dup-appears-to-write "
+else
+  echo "PASS [targets/>&2 correctly not detected as a write]"
+  PASS=$((PASS+1))
+fi
+
+# Sanity: reads / heredocs / herestrings must still be untouched by the
+# broadened operator set.
+assert_targets "< plain read redirection — not a write" \
+  "cat < /tmp/x"                                                                      ""
+assert_targets "<<< herestring — not a write" \
+  "cat <<< 'hello'"                                                                   ""
+
 # Duplicate targets across segments collapse to one entry.
 got_dup=$(bash_extract_write_targets "echo a > /tmp/x; echo b > /tmp/x" | wc -l | tr -d ' ')
 if [ "$got_dup" = "1" ]; then

--- a/.claude/hooks/tests/test_detect_bash_write.sh
+++ b/.claude/hooks/tests/test_detect_bash_write.sh
@@ -308,6 +308,30 @@ assert_targets ">>| force-clobber-append variant" \
 assert_targets ">| with a space after the separator (not just no-space)" \
   "echo a > /tmp/ok; >| db/migrations/006.sql"                                        "/tmp/ok,db/migrations/006.sql"
 
+# #886/#926 round 4 (Hakim's fourth adversarial re-hunt): ZERO whitespace
+# between the operator and its target. Bash accepts this for every
+# operator — the mandatory `[[:space:]]+` this pattern used through round 3
+# silently dropped all five of these real, destructive writes. Hakim's
+# exact repros:
+assert_targets "no-space '>' (Hakim repro)" \
+  "echo hi>src/migrations/001.sql"                                                    "src/migrations/001.sql"
+assert_targets "no-space 'n>' fd-numbered (Hakim repro)" \
+  "echo a > /tmp/ok; echo b 2>src/migrations/001.sql"                                 "/tmp/ok,src/migrations/001.sql"
+assert_targets "no-space '>>' (Hakim repro)" \
+  "echo a > /tmp/ok; echo b>>src/migrations/001.sql"                                  "/tmp/ok,src/migrations/001.sql"
+assert_targets "no-space '>|' (Hakim repro)" \
+  "echo a > /tmp/ok; echo b>|src/migrations/001.sql"                                  "/tmp/ok,src/migrations/001.sql"
+assert_targets "no-space '&>' (Hakim repro)" \
+  "echo a > /tmp/ok; echo b&>src/migrations/001.sql"                                  "/tmp/ok,src/migrations/001.sql"
+
+# Sanity: relaxing whitespace to optional must NOT open a new false-positive
+# surface on fd-dup forms written with NO space either — the target
+# character class (not the whitespace requirement) is what excludes them.
+assert_targets "no-space '>&2' fd-dup — still not a write target" \
+  "echo err>&2"                                                                       ""
+assert_targets "no-space '2>&1' fd-dup — still not a write target" \
+  "make build 2>&1;true"                                                              ""
+
 # Sanity: the broadened operator set must NOT false-positive on fd-duplication
 # forms, which look superficially similar (`&` and `>` both present) but mean
 # something entirely different — redirecting one fd to ANOTHER fd, not to a

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -770,6 +770,64 @@ sb=$(make_sandbox)
 in=$(jq -nc --arg c "cat < src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
 run_case "#886 sanity: plain '<' read is not gated" 0 "" "$in" "$sb"
 
+# --- #886/#926 round 4: ZERO whitespace between operator and target -----
+#
+# Hakim's fourth adversarial re-hunt: the mandatory `[[:space:]]+` after
+# the operator was itself a bypass — bash accepts ZERO whitespace between
+# a redirect operator and its target. All five of these are real,
+# destructive truncating writes that were passing (exit 0) with no ticket.
+
+# 61. `>` with no space at all, no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo hi>src/migrations/001.sql" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 no-space '>' (Hakim repro) blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 62. Same command, WITH an active ticket → ALLOWED.
+sb=$(make_sandbox)
+cat > "$sb/.claude/session/current-ticket" <<EOF
+repo=me2resh/apexyard
+number=886
+title=no-whitespace redirect operator test
+EOF
+in=$(jq -nc --arg c "echo hi>src/migrations/001.sql" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 no-space '>' allowed WITH ticket" 0 "" "$in" "$sb"
+
+# 63. `2>` (fd-numbered) with no space, no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/ok; echo b 2>src/migrations/001.sql" \
+      '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 no-space 'n>' fd-numbered blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 64. `>>` with no space, no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/ok; echo b>>src/migrations/001.sql" \
+      '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 no-space '>>' blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 65. `>|` (force-clobber) with no space, no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/ok; echo b>|src/migrations/001.sql" \
+      '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 no-space '>|' blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 66. `&>` (redirect-both-streams) with no space, no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/ok; echo b&>src/migrations/001.sql" \
+      '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 no-space '&>' blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# --- Sanity: no-space fd-dup / read forms must NOT be newly gated ------
+
+# 67. `echo err>&2` (fd-dup, NO space either) — no ticket, still ALLOWED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo err>&2" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 sanity: no-space '>&2' fd-dup is not gated" 0 "" "$in" "$sb"
+
+# 68. `make build 2>&1;true` (fd-dup, no space) — no ticket, still ALLOWED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "make build 2>&1;true" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 sanity: no-space '2>&1' fd-dup is not gated" 0 "" "$in" "$sb"
+
 # --- Summary -----------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -828,6 +828,65 @@ sb=$(make_sandbox)
 in=$(jq -nc --arg c "make build 2>&1;true" '{tool_name:"Bash", tool_input:{command:$c}}')
 run_case "#886 sanity: no-space '2>&1' fd-dup is not gated" 0 "" "$in" "$sb"
 
+# --- #886/#926 round 5: STRUCTURAL fix — |/||-adjacent redirects --------
+#
+# Hakim's fifth adversarial re-hunt found the actual root cause: DETECTION
+# (bash_command_appears_to_write) ran the redirection matcher on the
+# WHOLE, unsplit command, where a `|`-preceded `>` is excluded by the
+# leading-context class (needed for `2>&1`/`>&2`) and isn't at `^` either.
+# EXTRACTION already split first and found the target correctly —
+# detection and extraction disagreed. `;>` and `&&>` survived earlier
+# rounds by coincidence (`;` isn't excluded; `&&>` contains the substring
+# `&>`); `|`/`||` had no such rescue. These are real, truncating writes.
+
+# 69. `false ||> src/app.ts` (Hakim repro), no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "false ||> src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 '||>' after false blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 70. Same command, WITH an active ticket → ALLOWED.
+sb=$(make_sandbox)
+cat > "$sb/.claude/session/current-ticket" <<EOF
+repo=me2resh/apexyard
+number=886
+title=pipe-adjacent redirect operator test
+EOF
+in=$(jq -nc --arg c "false ||> src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 '||>' after false allowed WITH ticket" 0 "" "$in" "$sb"
+
+# 71. `false ||>| src/app.ts` (force-clobber variant, Hakim repro), no
+#     ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "false ||>| src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 '||>|' force-clobber after false blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 72. `echo x |> src/app.ts` (single-pipe variant, Hakim repro), no ticket
+#     → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo x |> src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 '|>' after echo blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 73. The deletion-only bypass: `rm old.ts; false ||> src/app.ts` — a real
+#     write hiding behind a pipe-adjacent redirect alongside an rm. Must
+#     NOT be classified as deletion-only; no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "rm old.ts; false ||> src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 rm + '||>' hides a real write, blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# --- Sanity: pipe-adjacent fd-dup / reads must NOT be newly gated -------
+
+# 74. `echo x | cat 2>&1` — pipe THEN fd-dup, no in-repo write at all →
+#     still ALLOWED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo x | cat 2>&1" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 sanity: pipe then '2>&1' fd-dup is not gated" 0 "" "$in" "$sb"
+
+# 75. `false || echo err >&2` — or-chain THEN fd-dup, no in-repo write →
+#     still ALLOWED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "false || echo err >&2" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 sanity: '||' then '>&2' fd-dup is not gated" 0 "" "$in" "$sb"
+
 # --- Summary -----------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -695,6 +695,81 @@ sb=$(make_sandbox)
 in=$(jq -nc --arg c "echo a > /tmp/ok||> .gitignore" '{tool_name:"Bash", tool_input:{command:$c}}')
 run_case "#886 no-space '||' then redirect blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
 
+# --- #886/#926 round 3: &>, &>>, >|, >>| (Hakim adversarial re-hunt) ----
+#
+# The operator alternation only modelled `>`/`>>`/`n>` — it missed
+# `&>`/`&>>` (redirect BOTH streams to a file) and `>|`/`>>|`
+# (force-clobber, noclobber override). Both are real, destructive
+# truncating writes that were passing (exit 0) with no active ticket.
+
+# 52. `&>` (redirect-both-streams) into an in-repo file, no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo hi &> .gitignore" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 '&>' redirect-both-streams blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 53. Same command, WITH an active ticket → ALLOWED.
+sb=$(make_sandbox)
+cat > "$sb/.claude/session/current-ticket" <<EOF
+repo=me2resh/apexyard
+number=886
+title=redirect-both-streams operator test
+EOF
+in=$(jq -nc --arg c "echo hi &> .gitignore" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 '&>' redirect-both-streams allowed WITH ticket" 0 "" "$in" "$sb"
+
+# 54. `&>>` (append-both-streams) into an in-repo file, no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo hi &>> .gitignore" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 '&>>' append-both-streams blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 55. `>|` (force-clobber) after a no-space `;`, out-of-repo THEN in-repo,
+#     no ticket → BLOCKED on the in-repo (migration-shaped) target. This is
+#     Hakim's exact second repro.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/ok;>| db/migrations/006.sql" \
+      '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 '>|' force-clobber blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 56. Same command, WITH an active ticket → ALLOWED (both targets clear).
+sb=$(make_sandbox)
+cat > "$sb/.claude/session/current-ticket" <<EOF
+repo=me2resh/apexyard
+number=886
+title=force-clobber operator test
+EOF
+in=$(jq -nc --arg c "echo a > /tmp/ok;>| db/migrations/006.sql" \
+      '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 '>|' force-clobber allowed WITH ticket" 0 "" "$in" "$sb"
+
+# 57. `>>|` (force-clobber-append) variant, no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/ok;>>| db/migrations/006.sql" \
+      '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 '>>|' force-clobber-append blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# --- Sanity: fd-dup / read forms must NOT be newly gated ---------------
+#
+# `>&2` / `2>&1` / `1>&2` are fd-duplication (redirecting one fd to
+# ANOTHER fd), never a file write — the broadened operator set must not
+# start treating them as write targets. `< file` is a plain read.
+
+# 58. `echo err >&2` (fd-dup only, no in-repo write) — no ticket, still
+#     ALLOWED (nothing here is a write target at all).
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo err >&2" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 sanity: '>&2' fd-dup alone is not gated" 0 "" "$in" "$sb"
+
+# 59. `make build 2>&1` — no ticket, still ALLOWED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "make build 2>&1" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 sanity: '2>&1' fd-dup alone is not gated" 0 "" "$in" "$sb"
+
+# 60. `cat < src/app.ts` — a plain READ of a tracked file, no ticket →
+#     still ALLOWED (reading is not gated; only writes are).
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "cat < src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 sanity: plain '<' read is not gated" 0 "" "$in" "$sb"
+
 # --- Summary -----------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -602,6 +602,53 @@ in=$(jq -nc --arg p "$rsb/workspace/proj/src/x.ts" '{tool_name:"Edit", tool_inpu
 run_case "#885 symlinked-out non-git workspace project allowed WITH active ticket" 0 "" "$in" "$sb"
 rm -rf "$external"
 
+# --- #886: judge ALL bash write targets, not just the first ------------
+#
+# The bypass shape: a command names an out-of-repo (or otherwise exempt)
+# target FIRST and an in-repo target SECOND. Before #886, the hook judged
+# only the first extracted target — an exempt first target let the whole
+# command through even though it also wrote somewhere gated.
+
+# 41. Multi-target: /tmp (exempt) THEN src/app.ts (gated), no ticket →
+#     BLOCKED. This is the exact bypass the #885 review surfaced.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/x; echo b > src/app.ts" \
+      '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 multi-target (out-of-repo then in-repo) blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 42. Same multi-target command, WITH an active ticket → ALLOWED (every
+#     target independently clears the gate).
+sb=$(make_sandbox)
+cat > "$sb/.claude/session/current-ticket" <<EOF
+repo=me2resh/apexyard
+number=886
+title=multi-target bash write test
+EOF
+in=$(jq -nc --arg c "echo a > /tmp/x; echo b > src/app.ts" \
+      '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 multi-target (out-of-repo then in-repo) allowed WITH ticket" 0 "" "$in" "$sb"
+
+# 43. Regression: a SINGLE out-of-repo target (no second target) remains
+#     exempt — the per-target loop must not become stricter than before
+#     for the plain single-target case.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/x" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 regression: single out-of-repo target still exempt" 0 "" "$in" "$sb"
+
+# 44. Regression: a SINGLE in-repo target (no other target) remains gated
+#     w/o a ticket — same as before #886.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > src/app.ts" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 regression: single in-repo target still blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 45. tee naming BOTH an out-of-repo and an in-repo file in one invocation
+#     (`tee /tmp/a src/b.ts`) — both are targets of the SAME command, no
+#     ticket → BLOCKED on the in-repo one.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo x | tee /tmp/a src/b.ts" \
+      '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 tee with out-of-repo + in-repo operands blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
 # --- Summary -----------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -649,6 +649,52 @@ in=$(jq -nc --arg c "echo x | tee /tmp/a src/b.ts" \
       '{tool_name:"Bash", tool_input:{command:$c}}')
 run_case "#886 tee with out-of-repo + in-repo operands blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
 
+# --- #886/#926: NO-SPACE separator+redirection (Hakim security-review) --
+#
+# `echo a > /tmp/ok;> .gitignore` — after splitting on `;`, the second
+# segment is `> .gitignore`, which BEGINS with `>`. The pre-fix regex
+# `[^|<&]>...` required a character before `>` to exist, so this second,
+# in-repo target was silently dropped and the whole command exempted on
+# the first (out-of-repo) target alone. These are Hakim's exact repro
+# strings, now expected to BLOCK.
+
+# 46. No-space `;` then redirect, no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/ok;> .gitignore" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 no-space ';' then redirect blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 47. Same command, WITH an active ticket → ALLOWED (both targets clear).
+sb=$(make_sandbox)
+cat > "$sb/.claude/session/current-ticket" <<EOF
+repo=me2resh/apexyard
+number=886
+title=no-space redirection bypass test
+EOF
+in=$(jq -nc --arg c "echo a > /tmp/ok;> .gitignore" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 no-space ';' then redirect allowed WITH ticket" 0 "" "$in" "$sb"
+
+# 48. No-space `;` + redirect with a trailing command appended, no ticket
+#     → BLOCKED (the trailing `cat /etc/hostname` must not swallow the
+#     dropped target or change the verdict).
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/ok;> .gitignore cat /etc/hostname" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 no-space ';' + redirect with trailing command blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 49. No-space `&&` then redirect, no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/ok&&> .gitignore" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 no-space '&&' then redirect blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 50. No-space `|` then redirect, no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/ok|> .gitignore" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 no-space '|' then redirect blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
+# 51. No-space `||` then redirect, no ticket → BLOCKED.
+sb=$(make_sandbox)
+in=$(jq -nc --arg c "echo a > /tmp/ok||> .gitignore" '{tool_name:"Bash", tool_input:{command:$c}}')
+run_case "#886 no-space '||' then redirect blocked w/o ticket" 2 "BLOCKED" "$in" "$sb"
+
 # --- Summary -----------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_require_migration_ticket.sh
+++ b/.claude/hooks/tests/test_require_migration_ticket.sh
@@ -117,6 +117,22 @@ run_hook() {
   [ "$rc" = "$expected_rc" ]
 }
 
+# Run the hook (Bash tool) against a synthetic shell command; check exit code.
+# #886: used to prove the hook judges EVERY extracted write target, not
+# just the first — a command naming a non-migration path FIRST and a
+# migration path SECOND must still hit the migration gate on the second.
+run_hook_bash() {
+  local sb="$1" command="$2" expected_rc="$3"
+  local input rc
+  input=$(jq -nc --arg c "$command" '{tool_name:"Bash", tool_input:{command:$c}}')
+  (
+    cd "$sb" || exit 99
+    PATH="$sb/bin:$PATH" .claude/hooks/require-migration-ticket.sh <<<"$input" >/dev/null 2>&1
+  )
+  rc=$?
+  [ "$rc" = "$expected_rc" ]
+}
+
 MIG="migrations/001_add_table.sql"   # matches */migrations/*.sql
 GH_OPEN_OK='
 if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
@@ -497,6 +513,38 @@ if run_hook "$SB" "$SB/$MIG" 0; then
   record_pass "guard: #-prefixed number passes and is shell-safe (printf %q escapes #)"
 else
   record_fail "guard: #-prefixed number passes and is shell-safe (printf %q escapes #)"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 16: #886 — Bash command names a NON-migration target FIRST and a
+# migration-path target SECOND. With an OPEN, labelled, AgDR-linked ticket
+# → allow (0). Before #886, the hook judged only the first extracted
+# target (src/app.ts, not migration-shaped) and exited 0 without ever
+# consulting the tracker for the second target — this proves the second
+# target is now the one that drives the gate.
+# =============================================================================
+SB=$(make_fork)
+set_marker "$SB" test-org/test-repo 42
+install_mock "$SB" gh "$GH_OPEN_OK"
+if run_hook_bash "$SB" "echo x > src/app.ts; echo y > ./$MIG" 0; then
+  record_pass "#886 bash: non-migration target then migration target, valid ticket → allow"
+else
+  record_fail "#886 bash: non-migration target then migration target, valid ticket → allow"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 17: #886 — same shape, but NO active-ticket marker at all → block (2).
+# Confirms Gate 1 fires for the migration-shaped SECOND target even though
+# the FIRST target in the command is an ordinary source file.
+# =============================================================================
+SB=$(make_fork)
+install_mock "$SB" gh 'exit 99'
+if run_hook_bash "$SB" "echo x > src/app.ts; echo y > ./$MIG" 2; then
+  record_pass "#886 bash: non-migration target then migration target, no ticket → block"
+else
+  record_fail "#886 bash: non-migration target then migration target, no ticket → block"
 fi
 rm -rf "$SB"
 

--- a/.claude/hooks/tests/test_require_migration_ticket.sh
+++ b/.claude/hooks/tests/test_require_migration_ticket.sh
@@ -613,6 +613,23 @@ fi
 rm -rf "$SB"
 
 # =============================================================================
+# Case 22: #886/#926 round 5 (Hakim's fifth adversarial re-hunt — the
+# STRUCTURAL fix). DETECTION (bash_command_appears_to_write) used to run
+# the redirection matcher on the WHOLE, unsplit command; a `|`-preceded
+# `>` (from `||`) is excluded by the leading-context class and isn't at
+# `^` either, so `false ||> ./migrations/...` was never even recognised
+# as a write. No ticket → block (2).
+# =============================================================================
+SB=$(make_fork)
+install_mock "$SB" gh 'exit 99'
+if run_hook_bash "$SB" "false ||> ./$MIG" 2; then
+  record_pass "#886 bash: '||>' directly into migration target, no ticket → block"
+else
+  record_fail "#886 bash: '||>' directly into migration target, no ticket → block"
+fi
+rm -rf "$SB"
+
+# =============================================================================
 # Summary
 # =============================================================================
 echo

--- a/.claude/hooks/tests/test_require_migration_ticket.sh
+++ b/.claude/hooks/tests/test_require_migration_ticket.sh
@@ -567,6 +567,36 @@ fi
 rm -rf "$SB"
 
 # =============================================================================
+# Case 19: #886/#926 round 3 (Hakim adversarial re-hunt) — `&>` (redirect
+# BOTH stdout and stderr to a file) directly into a migration path. The
+# pre-round-3 operator alternation only modelled `>`/`>>`/`n>`; it missed
+# `&>` entirely. No ticket → block (2).
+# =============================================================================
+SB=$(make_fork)
+install_mock "$SB" gh 'exit 99'
+if run_hook_bash "$SB" "echo x &> ./$MIG" 2; then
+  record_pass "#886 bash: '&>' directly into migration target, no ticket → block"
+else
+  record_fail "#886 bash: '&>' directly into migration target, no ticket → block"
+fi
+rm -rf "$SB"
+
+# =============================================================================
+# Case 20: #886/#926 round 3 — `>|` (force-clobber) after a no-space `;`,
+# non-migration target FIRST, migration target SECOND. Same shape as case
+# 18 but with the force-clobber operator instead of a plain redirect. No
+# ticket → block (2).
+# =============================================================================
+SB=$(make_fork)
+install_mock "$SB" gh 'exit 99'
+if run_hook_bash "$SB" "echo x > src/app.ts;>| ./$MIG" 2; then
+  record_pass "#886 bash: '>|' force-clobber into migration target, no ticket → block"
+else
+  record_fail "#886 bash: '>|' force-clobber into migration target, no ticket → block"
+fi
+rm -rf "$SB"
+
+# =============================================================================
 # Summary
 # =============================================================================
 echo

--- a/.claude/hooks/tests/test_require_migration_ticket.sh
+++ b/.claude/hooks/tests/test_require_migration_ticket.sh
@@ -597,6 +597,22 @@ fi
 rm -rf "$SB"
 
 # =============================================================================
+# Case 21: #886/#926 round 4 (Hakim's fourth adversarial re-hunt) — ZERO
+# whitespace between the operator and the migration-path target:
+# `echo x > src/app.ts;>./migrations/...` (no space after the `;>`). The
+# mandatory whitespace requirement this pattern used through round 3 was
+# itself a bypass — bash accepts zero whitespace here. No ticket → block (2).
+# =============================================================================
+SB=$(make_fork)
+install_mock "$SB" gh 'exit 99'
+if run_hook_bash "$SB" "echo x > src/app.ts;>./$MIG" 2; then
+  record_pass "#886 bash: no-space '>' into migration target, no ticket → block"
+else
+  record_fail "#886 bash: no-space '>' into migration target, no ticket → block"
+fi
+rm -rf "$SB"
+
+# =============================================================================
 # Summary
 # =============================================================================
 echo

--- a/.claude/hooks/tests/test_require_migration_ticket.sh
+++ b/.claude/hooks/tests/test_require_migration_ticket.sh
@@ -549,6 +549,24 @@ fi
 rm -rf "$SB"
 
 # =============================================================================
+# Case 18: #886/#926 (Hakim security-review finding) — NO-SPACE `;` then
+# redirect into a migration path: `echo x > src/app.ts;> ./migrations/...`.
+# After splitting on `;`, the second segment BEGINS with `>` (no space
+# between the separator and the redirection) — the pre-fix regex required
+# a character before `>` to exist, so this migration-shaped target was
+# silently dropped and the command passed through ungated. No ticket →
+# block (2).
+# =============================================================================
+SB=$(make_fork)
+install_mock "$SB" gh 'exit 99'
+if run_hook_bash "$SB" "echo x > src/app.ts;> ./$MIG" 2; then
+  record_pass "#886 bash: no-space ';' into migration target, no ticket → block"
+else
+  record_fail "#886 bash: no-space ';' into migration target, no ticket → block"
+fi
+rm -rf "$SB"
+
+# =============================================================================
 # Summary
 # =============================================================================
 echo


### PR DESCRIPTION
## Summary

- **Extended the bash write-target extractor to return ALL targets, not just the first** — `_lib-detect-bash-write.sh` gains `bash_extract_write_targets` (plural), which splits a Bash command on top-level separators (`&&`, `||`, `;`, `|`) and captures every redirection and every `tee` operand across those segments, instead of the existing `bash_extract_write_target`'s first-match-wins walk. The singular function is kept unchanged for backward compatibility with its existing call sites and tests.
- **Closed the gate-bypass surface confirmed by the #885 review** — `require-active-ticket.sh` and `require-migration-ticket.sh` used to extract only the FIRST write target from a Bash command and judge the whole command on that one path alone. A command naming an out-of-governance target first and an in-repo (or migration-shaped) target second was silently exempted, because the gate never looked past target #1. Both hooks now evaluate every extracted target: `require-active-ticket.sh` uses AND semantics (the command only passes if every target independently clears the gate — variable exemptions, out-of-governance exemption, path-prefix exemptions, then the ticket-marker lookup); `require-migration-ticket.sh` scans every target for the first one that's both non-meta-exempt and migration-shaped, then gates on that one.
- **Refactored `require-active-ticket.sh`'s single-target pipeline into `_ratc_evaluate_target()`** so it can be invoked once per extracted target with fully isolated local state (`REPO_ROOT`, `OPS_ROOT`, `PROJECT`, markers, the `#883`/`#885` out-of-governance symlink-containment checks) — nothing leaks between targets, and the existing single-target behaviour is unchanged when a command names only one write target.
- **New regression tests prove the fix is load-bearing** — the added multi-target cases (semicolon-chained, `&&`-chained, `tee` with multiple file operands) fail against the pre-fix hooks and pass against the fix; single-target cases are unchanged, confirming no regression to the existing exemption behaviour.

## Testing

1. `bash -n` on every changed hook file — all pass.
2. `.claude/hooks/tests/test_detect_bash_write.sh` — 108/108 pass (11 new `bash_extract_write_targets` cases added, covering multi-target chains, `tee` with multiple operands, dedup, and the documented interpreter misses).
3. `.claude/hooks/tests/test_require_active_ticket_bash.sh` — 48/48 pass (5 new `#886` cases: multi-target blocked w/o ticket, multi-target allowed with ticket, single out-of-repo target still exempt, single in-repo target still blocked, `tee` with mixed operands blocked).
4. `.claude/hooks/tests/test_require_migration_ticket.sh` — 21/21 pass (2 new `#886` cases covering a non-migration target followed by a migration-shaped target, with and without an active ticket).
5. Verified all five new tests are load-bearing: stashing the hook fixes (keeping only the new tests) reproduces exactly the expected failures against the pre-fix hooks, confirming the tests actually exercise the bypass.
6. Pre-existing, unrelated test failures (`test_workspace_tracker_resolution.sh`, `test_ops_root.sh`, two cases in `test_split_portfolio_v2_migration.sh`) were confirmed to fail identically with this branch's changes stashed out — not caused by this PR.

Closes #886

---

## Glossary

| Term | Definition |
|------|------------|
| Write-target extraction | `_lib-detect-bash-write.sh`'s parse of a Bash command's redirections/`tee`/`sed -i`/etc. into concrete file-path targets, used by the ticket and migration gates to decide whether a write needs to be judged. |
| Gate-bypass surface | A way a mechanically-enforced rule (here, the ticket-first gate) can be satisfied on paper while the underlying intent (every governed write requires an active ticket) is violated. |
| AND semantics (ticket gate) | The command as a whole only passes `require-active-ticket.sh` if EVERY extracted write target independently clears the gate — a single exempt target no longer excuses the rest. |
| Out-of-governance exemption (#883/#885) | The existing symlink-aware, raw-and-resolved containment check that decides whether a write target sits entirely outside the ops fork and every registered workspace project (and therefore doesn't need a ticket). Reused unchanged per-target by this PR. |
