### PR TITLE
fix(#887): scope pr_base_repo resolution in fork checkouts

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -52,6 +52,11 @@ Invoked when a PR needs security review, especially for:
 - Data storage changes
 - Third-party integrations
 
+## Input
+
+- PR number or URL — `{number}` below
+- Repository (any repository the user authorises) — `{repo}` below, threaded in by the invoking skill (`/security-review <pr> [repo]`). Never re-derive this from an unscoped `gh pr view {number} --json headRepository` call — see the resolution section's `#887` note.
+
 ## Security Review Checklist
 
 ### 1. Secrets and Credentials
@@ -111,7 +116,7 @@ Invoked when a PR needs security review, especially for:
 4. Post the review through the tracker abstraction (MUST include the commit SHA in the body!)
 ```
 
-Resolve the ops fork root **pin-first** (the SAME strategy the merge gate uses — `_lib-ops-root.sh::resolve_ops_root`) so you can source `_lib-tracker.sh`, then resolve the PR/MR **host (base) repo** and submit. `_lib-tracker.sh` lives at `<ops_fork_root>/.claude/hooks/`; inside a `workspace/<project>/` clone, `git rev-parse --show-toplevel` is the project clone, NOT the ops fork — so resolve pin-first. (This agent writes **no** gate marker, so it needs only `_lib-tracker.sh`, not `_lib-review-markers.sh`.)
+Resolve the ops fork root **pin-first** (the SAME strategy the merge gate uses — `_lib-ops-root.sh::resolve_ops_root`) so you can source `_lib-tracker.sh` AND `_lib-review-markers.sh` (needed for `pr_base_repo`, below), then resolve the PR/MR **host (base) repo** and submit. Both libs live at `<ops_fork_root>/.claude/hooks/`; inside a `workspace/<project>/` clone, `git rev-parse --show-toplevel` is the project clone, NOT the ops fork — so resolve pin-first. (This agent writes **no** gate marker, so it does not need `review_marker_path` — only `pr_base_repo` from `_lib-review-markers.sh`.)
 
 ```bash
 # 1. Pin-first ops-root resolution (points at the real ops fork regardless of cwd).
@@ -138,17 +143,38 @@ fi
 LIB_HOME="${OPS_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 # shellcheck source=/dev/null
 . "$LIB_HOME/.claude/hooks/_lib-tracker.sh"
+# shellcheck source=/dev/null
+. "$LIB_HOME/.claude/hooks/_lib-review-markers.sh"
 
-# 2. Resolve the PR/MR HOST (base) repo — where the review must be POSTED and the
-# repo tracker_review_submit selects its adapter from. On a cross-fork PR this
-# differs from the fork (posting to the fork fails: the PR lives on the base).
-# gh pr view has no baseRepository field, but the PR URL is ALWAYS on the base
-# repo — parse owner/repo from it (works for gh /pull/ and glab
-# /-/merge_requests/, incl. nested GitLab groups). Falls back to headRepository.
-PR_HOST_REPO=$(gh pr view {number} --json url --jq '.url' 2>/dev/null | sed -E 's#^https?://[^/]+/(.+)/(pull|-/merge_requests)/[0-9].*#\1#')
-[ -z "$PR_HOST_REPO" ] && PR_HOST_REPO=$(gh pr view {number} --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+# 2. Resolve the repo YOU already know hosts this PR — that is how you got
+# {number} in the first place (the `{repo}` input above, when the invoking
+# skill threaded it through). NEVER re-derive this via an unscoped
+# `gh pr view {number} --json headRepository` call: that call (a) reads the
+# WRONG field for this purpose (the PR's head/fork, not its base) and (b) is
+# itself an unscoped, ambient-resolved gh query — the exact class of bug #887
+# fixed (gh's ambient default prefers the parent/upstream, which is wrong for
+# a same-repo fork PR opened against the fork's own main). When {repo} wasn't
+# threaded through, fall back to the CURRENT checkout's own remote — a
+# deterministic, non-ambient source of truth — never to a second gh guess.
+REPO="{repo}"
+if [ -z "$REPO" ] || [ "$REPO" = "{repo}" ]; then
+  origin_url=$(git remote get-url origin 2>/dev/null)
+  origin_url="${origin_url%.git}"
+  REPO=$(printf '%s' "$origin_url" | sed -E 's#^(https?://[^/]+/|git@[^:]+:)##')
+fi
 
-# 3. Write the review to a temp body-file and submit through the abstraction.
+# 3. Resolve the PR/MR HOST (base) repo — where the review must be POSTED and
+# the repo tracker_review_submit selects its adapter from. On a cross-fork PR
+# this differs from the fork (posting to the fork fails: the PR lives on the
+# base). `pr_base_repo` (in _lib-review-markers.sh) REQUIRES the explicit
+# $REPO above and scopes its gh query to it — NEVER gh's ambient/parent-
+# preferring default (#887). Scoping to the repo you already know hosts the
+# PR is authoritative, not a guess: a PR object only resolves through its own
+# base repo's API path, so passing the wrong repo here fails closed instead
+# of silently posting to an unrelated repo's PR of the same number.
+PR_HOST_REPO=$(pr_base_repo {number} "$REPO")
+
+# 4. Write the review to a temp body-file and submit through the abstraction.
 # A file (not inline text) is the uniform path: gh takes --body-file, glab reads
 # the file into an MR note, custom exposes it via $TRACKER_REVIEW_BODY_FILE.
 REVIEW_BODY_FILE=$(mktemp)

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -611,7 +611,9 @@ resolve_ci_status_glab() {
 #   1b. `glab api projects/<owner>%2F<repo>/merge_requests/<N>/merge ...` — repo
 #       from the URL-encoded project path (#767)
 #   2. `gh pr merge ... --repo <owner>/<repo> ...`        — repo from --repo flag
-#   3. Falls back to `gh pr view --json headRepository`   — current branch's PR
+#   3. Falls back to `gh pr view --json headRepository`, scoped to the
+#      checkout's own `origin` remote when resolvable (#887) — current
+#      branch's PR
 #
 # Returns empty if the repo cannot be determined.
 extract_repo_from_command() {
@@ -662,11 +664,31 @@ extract_repo_from_command() {
 
   # 3. Last resort: ask the forge which repo the current branch's PR/MR belongs
   #    to. Forge-aware (#764): a glab command falls back to `glab repo view`.
+  #
+  #    gh side (#887): an UNSCOPED `gh pr view --json headRepository` trusts
+  #    gh's ambient default-repo resolution, which prefers a remote literally
+  #    named "upstream" over "origin" when both exist — exactly the fork
+  #    layout this framework's own hooks use (origin=fork, upstream=canonical).
+  #    On a same-repo fork PR (opened against the fork's own main) that
+  #    ambient default silently targets the WRONG (parent) repo instead of
+  #    failing, the same class of bug `pr_base_repo` was fixed against in
+  #    #765/#898. Resolve the checkout's OWN repo from its `origin` remote
+  #    FIRST — deterministic, not a guess — and scope the gh query to it;
+  #    only fall through to the unscoped call when origin itself can't be
+  #    resolved at all (e.g. no git remote configured), so single-remote
+  #    checkouts keep working exactly as before.
   if [ -z "$repo" ]; then
     if [ "$(_forge_from_command "$cmd")" = glab ]; then
       repo=$(glab repo view --output json 2>/dev/null | jq -r '.full_name // empty' 2>/dev/null)
     else
-      repo=$(gh pr view --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+      local origin_repo
+      origin_repo=$(git remote get-url origin 2>/dev/null | sed -E 's#\.git$##; s#^(https?://[^/]+/|git@[^:]+:)##')
+      if [ -n "$origin_repo" ]; then
+        repo=$(gh pr view --repo "$origin_repo" --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+      fi
+      if [ -z "$repo" ]; then
+        repo=$(gh pr view --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+      fi
     fi
   fi
 

--- a/.claude/hooks/tests/test_extract_repo_fork_scoping.sh
+++ b/.claude/hooks/tests/test_extract_repo_fork_scoping.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# test_extract_repo_fork_scoping.sh — regression coverage for the #887
+# same-repo-fork-PR class of bug in `extract_repo_from_command`'s gh
+# "last resort" fallback (_lib-extract-pr.sh).
+#
+# #898 already fixed `pr_base_repo` (see test_pr_base_repo.sh) by requiring
+# an explicit <repo> arg instead of trusting gh's ambient default. The
+# follow-up review on #887 found the SAME unscoped-gh-query pattern still
+# alive in extract_repo_from_command's step-3 fallback: when a merge command
+# carries neither `--repo`/`-R` nor a parseable API path, the function asks
+# gh "which repo does the current branch's PR belong to" via a BARE
+# `gh pr view --json headRepository` — no `--repo`. In a fork checkout with
+# both `origin` (the fork) and `upstream` (the canonical parent) configured,
+# gh's ambient default-repo resolution prefers a remote literally named
+# "upstream" over "origin" — so that bare call can succeed with the WRONG
+# repo instead of failing, exactly like the original pr_base_repo bug.
+#
+# The fix: resolve the checkout's OWN repo from its `origin` remote FIRST
+# (deterministic, not a guess) and scope the gh query to it; the unscoped
+# ambient call is now only a last-last-resort for the rare case where origin
+# itself can't be resolved (no git remote at all).
+#
+# gh is mocked via a file-driven stub (same shape as test_pr_base_repo.sh):
+# scoped to the CORRECT (origin) repo → succeeds with the right answer;
+# called WITHOUT --repo at all → returns a deliberately WRONG answer, so the
+# test fails loudly if the fix ever regresses to the unscoped call.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+LIB="$SRC_ROOT/.claude/hooks/_lib-extract-pr.sh"
+# shellcheck source=/dev/null
+. "$LIB"
+
+PASS=0; FAIL=0; FAILED=""
+assert_eq() { # <label> <want> <got>
+  if [ "$2" = "$3" ]; then PASS=$((PASS+1));
+  else echo "FAIL [$1]: want [$2] got [$3]" >&2; FAIL=$((FAIL+1)); FAILED="${FAILED}$1 "; fi
+}
+
+MOCKBIN=$(mktemp -d)
+cat > "$MOCKBIN/gh" <<'EOF'
+#!/bin/bash
+# mock gh (--repo-aware, #887-aware):
+#   - --repo == ORIGIN_REPO_EXPECT  → success, prints "$CORRECT_REPO".
+#   - --repo == anything else       → fails (gh 404).
+#   - --repo omitted                → prints "$WRONG_REPO" if set (models
+#                                      gh's ambient/parent-preferring default
+#                                      resolving successfully to the WRONG
+#                                      repo). A fixed implementation must
+#                                      never hit this branch when an origin
+#                                      remote is configured.
+repo=""
+scoped=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) repo="$2"; scoped=1; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ "$scoped" -eq 0 ]; then
+  if [ -n "${WRONG_REPO:-}" ]; then printf '%s' "$WRONG_REPO"; exit 0; fi
+  exit 1
+fi
+if [ "$repo" != "${ORIGIN_REPO_EXPECT:-}" ]; then exit 1; fi
+printf '%s' "${CORRECT_REPO:-}"
+EOF
+chmod +x "$MOCKBIN/gh"
+export PATH="$MOCKBIN:$PATH"
+
+# Build a real git repo with BOTH an `origin` (fork) and `upstream` (parent)
+# remote — the exact layout that triggers gh's ambient parent-preference.
+SBX=$(mktemp -d)
+(
+  cd "$SBX" || exit 1
+  git init -q
+  git remote add origin https://github.com/atlas-apex/apexyard.git
+  git remote add upstream https://github.com/me2resh/apexyard.git
+)
+
+# --- 1. THE #887 REGRESSION GUARD -----------------------------------------
+# A merge-ish command with no --repo/-R and no parseable API path forces the
+# step-3 "last resort" gh path. Scoped-to-origin succeeds with the CORRECT
+# repo; the ambient/unscoped branch (if ever hit) would return WRONG_REPO.
+GOT1=$(
+  cd "$SBX" || exit 1
+  export ORIGIN_REPO_EXPECT="atlas-apex/apexyard"
+  export CORRECT_REPO="atlas-apex/apexyard"
+  export WRONG_REPO="me2resh/apexyard"
+  extract_repo_from_command "gh pr merge --squash"
+)
+assert_eq "#887 same-repo-fork: origin-scoped call wins over ambient parent-preferring default" \
+  "atlas-apex/apexyard" "$GOT1"
+
+# --- 2. No origin remote resolvable → falls through to the unscoped call --
+# (the only remaining path that hits gh's ambient default — by design, since
+# there is nothing deterministic left to scope to).
+SBX_NOREMOTE=$(mktemp -d)
+(
+  cd "$SBX_NOREMOTE" || exit 1
+  git init -q
+)
+GOT2=$(
+  cd "$SBX_NOREMOTE" || exit 1
+  export WRONG_REPO="ambient/fallback"
+  extract_repo_from_command "gh pr merge --squash"
+)
+assert_eq "no origin remote → last-last-resort ambient call still fires" \
+  "ambient/fallback" "$GOT2"
+
+# --- 3. --repo flag still takes priority over the step-3 fallback entirely,
+#        (regression check: the new origin-scoping must not shadow step 2).
+GOT3=$(
+  cd "$SBX" || exit 1
+  unset ORIGIN_REPO_EXPECT CORRECT_REPO WRONG_REPO 2>/dev/null
+  extract_repo_from_command "gh pr merge 42 --repo explicit/repo --squash"
+)
+assert_eq "explicit --repo flag still wins (step 2 unaffected)" "explicit/repo" "$GOT3"
+
+rm -rf "$MOCKBIN" "$SBX" "$SBX_NOREMOTE"
+echo "=========================================="
+if [ "$FAIL" -eq 0 ]; then
+  echo "PASS: $PASS  FAIL: 0"; exit 0
+else
+  echo "PASS: $PASS  FAIL: $FAIL  (failed: $FAILED)"; exit 1
+fi

--- a/.claude/hooks/tests/test_warn_stale_review_markers.sh
+++ b/.claude/hooks/tests/test_warn_stale_review_markers.sh
@@ -358,6 +358,85 @@ case9() {
   rm -rf "$sb"
 }
 
+# -------- CASE 10: #887 same-repo-fork-PR — gh calls must be origin-scoped --------
+# A fork checkout with BOTH `origin` (the fork) and `upstream` (the canonical
+# parent) configured — the exact layout that makes gh's ambient default-repo
+# resolution prefer "upstream" over "origin" (see me2resh/apexyard#887, and
+# the follow-up fix to `pr_base_repo` in #765/#898). This stub returns the
+# CORRECT PR data only when `gh pr view` is scoped with `--repo <origin>`;
+# an unscoped call returns a deliberately WRONG PR number/repo/SHA, so the
+# test fails loudly if the hook ever regresses to trusting gh's ambient
+# default instead of the checkout's own origin remote.
+write_gh_stub_fork_aware() {
+  local sb="$1" origin_repo="$2" correct_num="$3" correct_sha="$4"
+  cat > "$sb/bin/gh" <<STUB
+#!/bin/bash
+args="\$*"
+origin_repo="$origin_repo"
+correct_num="$correct_num"
+correct_sha="$correct_sha"
+STUB
+  cat >> "$sb/bin/gh" <<'STUB_TAIL'
+scoped=0
+repo=""
+prev=""
+for a in $args; do
+  if [ "$prev" = "--repo" ]; then repo="$a"; scoped=1; fi
+  prev="$a"
+done
+if [ "$scoped" -eq 1 ] && [ "$repo" = "$origin_repo" ]; then
+  case "$args" in
+    *"--json number"*)         echo "$correct_num"; exit 0 ;;
+    *"headRefOid"*)            echo "$correct_sha"; exit 0 ;;
+    *"headRepository"*)        echo "$origin_repo"; exit 0 ;;
+  esac
+  exit 0
+fi
+if [ "$scoped" -eq 1 ]; then
+  # Scoped to a repo other than origin — gh would 404 in reality.
+  exit 1
+fi
+# UNSCOPED call: models gh's ambient parent-preferring default resolving
+# successfully but WRONGLY. A fixed hook must never reach this branch when
+# an origin remote is configured.
+case "$args" in
+  *"--json number"*)   echo "999"; exit 0 ;;
+  *"headRefOid"*)      echo "wrongsha0000000000000000000000000000wrong"; exit 0 ;;
+  *"headRepository"*)  echo "me2resh/apexyard"; exit 0 ;;
+esac
+exit 1
+STUB_TAIL
+  chmod +x "$sb/bin/gh"
+}
+
+case10() {
+  local sb
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    git remote add origin https://github.com/atlas-apex/apexyard.git
+    git remote add upstream https://github.com/me2resh/apexyard.git
+  )
+  local sha
+  sha=$(printf '9%.0s' {1..40})
+  write_gh_stub_fork_aware "$sb" "atlas-apex/apexyard" "42" "$sha"
+  # Stale marker keyed on the CORRECT (origin) repo/PR — the hook must
+  # resolve PR_NUMBER=42 and PR_REPO=atlas-apex/apexyard via the origin-
+  # scoped gh calls, find this marker, and flag it stale against the
+  # correct (scoped) HEAD SHA — never the "999"/"wrongsha…" ambient answers.
+  local old_sha
+  old_sha=$(printf '0%.0s' {1..40})
+  local rex_marker
+  rex_marker=$(review_marker_path "atlas-apex/apexyard" 42 rex "$sb")
+  echo "$old_sha" > "$rex_marker"
+  local marker_basename
+  marker_basename=$(basename "$rex_marker")
+  run_hook "$sb" "$(push_json_success)" \
+    "Stale review marker: ${marker_basename}.*now 9999999" \
+    "887-same-repo-fork-origin-scoped"
+  rm -rf "$sb"
+}
+
 # Run all cases.
 case1
 case2
@@ -368,6 +447,7 @@ case6
 case7
 case8
 case9
+case10
 
 echo ""
 echo "==================================="

--- a/.claude/hooks/warn-stale-review-markers.sh
+++ b/.claude/hooks/warn-stale-review-markers.sh
@@ -91,30 +91,63 @@ if [ ! -d "$REVIEWS_DIR" ]; then
   exit 0
 fi
 
-# -------- Resolve the PR number and repo for the current branch --------
+# -------- Resolve the checkout's own repo deterministically (#887) --------
+# Never trust gh's ambient default-repo resolution for the two lookups below
+# — it prefers a remote literally named "upstream" over "origin" when both
+# exist (this framework's own fork layout), which silently misresolves to
+# the WRONG (parent) repo for a same-repo fork PR opened against the fork's
+# own main — the same class of bug `pr_base_repo` was fixed against in
+# #765/#898. Resolve from the checkout's own `origin` remote FIRST; an
+# unscoped gh call is only the last resort when origin itself can't be
+# determined (e.g. no git remote configured at all).
+_origin_url=$(git remote get-url origin 2>/dev/null)
+# Strip the `.git` suffix FIRST, then the protocol/host prefix — a single
+# combined regex here is greedy-match-prone (`[^/]+` happily absorbs a
+# literal `.git` as part of the repo-name segment since `.` isn't excluded
+# from the character class), which would silently leave a trailing `.git`
+# on the extracted repo and break every `--repo` scoped gh call below.
+ORIGIN_REPO=$(printf '%s' "$_origin_url" | sed -E 's#\.git$##; s#^(https?://[^/]+/|git@[^:]+:)##')
+
+# -------- Resolve the PR number for the current branch --------
 # `gh pr view` with no args looks up the PR for the checked-out branch.
 # If no PR exists (early push before `gh pr create`), gh exits non-zero and
 # we exit silently — this is the expected path for most first pushes.
-PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null)
+if [ -n "$ORIGIN_REPO" ]; then
+  PR_NUMBER=$(gh pr view --repo "$ORIGIN_REPO" --json number --jq '.number' 2>/dev/null)
+else
+  PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null)
+fi
 if [ -z "$PR_NUMBER" ]; then
   exit 0
 fi
 
 # Resolve the repo so we scan only markers that belong to this PR's repo (#485).
-# `gh pr view --json headRepository` returns the repo the PR targets.
-PR_REPO=$(gh pr view "$PR_NUMBER" --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
-# Fallback: derive from git remote origin if gh is offline.
-if [ -z "$PR_REPO" ]; then
-  _origin_url=$(git remote get-url origin 2>/dev/null)
-  PR_REPO=$(echo "$_origin_url" | sed -nE 's|.*[:/]([^/]+/[^/]+)(\.git)?$|\1|p')
+# `gh pr view --json headRepository` returns the repo the PR targets. Scope
+# it to ORIGIN_REPO — never unscoped (#887) — falling back to ORIGIN_REPO
+# itself (a same-repo PR's head == origin anyway) when the scoped query
+# fails or gh is offline. Only fall back to an unscoped call when origin
+# couldn't be resolved at all.
+if [ -n "$ORIGIN_REPO" ]; then
+  PR_REPO=$(gh pr view "$PR_NUMBER" --repo "$ORIGIN_REPO" --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
+  [ -z "$PR_REPO" ] && PR_REPO="$ORIGIN_REPO"
+else
+  PR_REPO=$(gh pr view "$PR_NUMBER" --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null)
 fi
 
 # -------- Resolve the PR's HEAD SHA --------
 # Prefer `gh pr view --json headRefOid` (same source-of-truth as the merge
-# gates, post-#47/#55). Fall back to local HEAD with a visible warning if
-# gh fails (offline / rate-limited / auth expired) — matches the fallback
-# behaviour in block-unreviewed-merge.sh.
-PR_HEAD=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid' 2>/dev/null)
+# gates, post-#47/#55). Scoped to ORIGIN_REPO when resolvable — never
+# unscoped (#887) — for the same reason as the two lookups above: an
+# ambient-resolved gh call can succeed against the WRONG repo on a
+# same-repo fork PR, comparing the marker against an unrelated PR's HEAD.
+# Fall back to local HEAD with a visible warning if gh fails (offline /
+# rate-limited / auth expired) — matches the fallback behaviour in
+# block-unreviewed-merge.sh.
+if [ -n "$ORIGIN_REPO" ]; then
+  PR_HEAD=$(gh pr view "$PR_NUMBER" --repo "$ORIGIN_REPO" --json headRefOid --jq '.headRefOid' 2>/dev/null)
+else
+  PR_HEAD=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid' 2>/dev/null)
+fi
 if [ -z "$PR_HEAD" ]; then
   echo "WARN: warn-stale-review-markers.sh could not resolve PR #${PR_NUMBER} HEAD via gh — falling back to local HEAD." >&2
   PR_HEAD=$(git rev-parse HEAD 2>/dev/null)


### PR DESCRIPTION
## Summary

- **Scoped the last three unscoped `gh pr view` calls in the review-posting path** — PR #898 already fixed `pr_base_repo()` itself (the marker-keying helper), but left the issue open because the maintainer found the same ambient-resolution bug alive in three other call sites. On a fork checkout with both `origin` (the fork) and `upstream` (the canonical parent) configured, gh's ambient default-repo resolution prefers a remote literally named `upstream` over `origin` — so an unscoped `gh pr view` can *succeed* against the wrong (parent) repo instead of failing, on a same-repo PR opened against the fork's own `main`.
- **`security-reviewer.md`** now threads a `{repo}` input (mirroring `code-reviewer.md`'s existing `#887` fix) and resolves the review's host repo via `pr_base_repo()` — never a raw `gh pr view {number} --json headRepository` call.
- **`_lib-extract-pr.sh`**'s `extract_repo_from_command` step-3 "last resort" now scopes its gh query to the checkout's own `origin` remote first, only falling back to the unscoped call when origin can't be resolved at all (e.g. no git remote configured) — so single-remote checkouts are unaffected.
- **`warn-stale-review-markers.sh`** — all three `gh pr view` calls in this hook (PR number, repo, HEAD SHA) now scope to the same origin-derived repo. While building the fix I also found and fixed a **latent bug in the pre-existing origin-URL parser**: its regex left a trailing `.git` on the extracted repo (greedy `[^/]+` matching), which would have silently broken every `--repo`-scoped call the moment it was actually exercised against a real remote URL — the fallback had never been hit by a real URL in any existing test.

## Testing

- `.claude/hooks/tests/test_extract_repo_fork_scoping.sh` (new) — proves `extract_repo_from_command`'s gh fallback resolves via the origin-scoped query and never falls through to gh's ambient/wrong answer when origin is configured, plus the no-origin-remote and explicit-`--repo` regression cases.
- `.claude/hooks/tests/test_warn_stale_review_markers.sh` — extended with a same-repo-fork-PR case (`origin` + `upstream` both configured) proving the hook resolves the PR number, repo, and HEAD SHA via the origin-scoped gh calls, not the ambient default.
- Full existing suite re-run: `test_extract_pr.sh`, `test_forge_aware_extract_pr.sh`, `test_pr_base_repo.sh` (untouched — confirms `pr_base_repo()` itself wasn't re-touched), `test_block_unreviewed_merge.sh`, `test_block_merge_on_red_ci.sh`, `test_require_design_review_for_ui.sh`, `test_require_architecture_review.sh`, `test_pr_hooks_cross_repo.sh`, `test_tracker_review_submit.sh` — all green.
- A handful of unrelated test files (`test_ops_root.sh`, `test_require_agdr_for_arch_pr.sh`, `test_split_portfolio_v2_migration.sh`, `test_sync_codex_adapter.sh`, `test_tracker_aware_hooks.sh`, `test_workspace_tracker_resolution.sh`) fail in this sandbox both with and without this branch's changes (confirmed via `git stash`) — pre-existing/environment-dependent, not touched by this PR.
- `bash -n` clean and `shellcheck -S warning` clean on both touched `.sh` files.

Closes #887

---

## Glossary

| Term | Definition |
|------|------------|
| `pr_base_repo()` | Helper in `_lib-review-markers.sh` that resolves a PR's canonical *base* (host) repo, given an explicit caller-supplied repo to scope its `gh` query to — the fix landed in PR #898. |
| Ambient default-repo resolution | `gh`'s behaviour of guessing which repo a repo-less command targets from the current checkout's git remotes, when no `--repo` flag is passed. |
| Same-repo fork PR | A PR whose base and head branches both live in the fork itself (as opposed to a PR filed from a fork branch against the upstream/parent repo). |
| Origin-scoped query | Resolving the target repo from the checkout's own `origin` remote *before* asking `gh`, then passing that as an explicit `--repo` — deterministic, not a guess. |
