### PR TITLE
feat(#692): Phase-0 cognitive memory scaffold

### DIFF
--- a/.claude/memory/MEMORY.example.md
+++ b/.claude/memory/MEMORY.example.md
@@ -1,0 +1,48 @@
+# Memory — EXAMPLE TEMPLATE
+
+This is the TRACKED placeholder template (committed to the repo). Your real,
+accumulated cross-session / cross-project notes live in `MEMORY.md` in this
+same directory, which is GITIGNORED and never committed — the same
+`.env.example` / `.env` convention this framework uses for `onboarding.yaml`.
+
+Copy this file to `MEMORY.md` and start filling it in locally:
+
+```bash
+cp .claude/memory/MEMORY.example.md .claude/memory/MEMORY.md
+```
+
+See `.claude/memory/README.md` for what this layer is (and isn't), and
+`docs/agdr/AgDR-0099-cognitive-memory-layer-phase0.md` for why it's structured
+this way.
+
+---
+
+## What goes here
+
+Durable, cross-session experience that's worth remembering the next time you
+(or another session) touch this portfolio — the kind of thing that would
+otherwise live in a stray notes file or someone's head. Some starting
+sections; adapt freely, this is your file:
+
+## Portfolio-wide patterns
+
+<!-- Recurring conventions, gotchas, or preferences that apply across
+     multiple managed projects. -->
+
+## Per-project notes
+
+<!-- Project-specific context worth remembering across sessions. One
+     subsection per project, e.g.: -->
+
+### `<project-name>`
+
+<!-- Notes specific to this project. -->
+
+## Recurring gotchas
+
+<!-- Things that have bitten you more than once — the "oh right, THAT
+     again" list. -->
+
+## Open questions / things to revisit
+
+<!-- Threads you want a future session to pick back up. -->

--- a/.claude/memory/README.md
+++ b/.claude/memory/README.md
@@ -1,0 +1,91 @@
+# Cognitive memory layer (Phase 0 — scaffold)
+
+This directory is a **governed, optional home for cross-session, cross-project
+experience** — the notes an adopter would otherwise bolt on outside the
+framework entirely (a stray `notes.md`, a private wiki page, tribal knowledge
+that lives in someone's head). It gives that experience one documented place
+inside apexyard's SDLC, without requiring anything to use it.
+
+This is **Phase 0** — a docs-only scaffold. It ships two markdown files, no
+code, no hooks, no new skills. See `docs/agdr/AgDR-0099-cognitive-memory-layer-phase0.md`
+for the decision record and the explicit out-of-scope list below.
+
+## What's here
+
+| Path | Tracked? | Purpose |
+|------|----------|---------|
+| `README.md` (this file) | Yes | What this layer is, what it isn't, how to use it |
+| `MEMORY.example.md` | Yes | Placeholder template — copy to `MEMORY.md` and fill in locally |
+| `USER.example.md` | Yes | Placeholder template — copy to `USER.md` and fill in locally |
+| `MEMORY.md` | **No** (gitignored) | Your real cross-project / cross-session notes — per-clone, local only |
+| `USER.md` | **No** (gitignored) | Your real operator preferences / working style notes — per-clone, local only |
+| `db/` | Yes (empty, via `.gitkeep`) | Reserved for a future structured store. Empty in Phase 0 — no database, no code reads or writes here yet. |
+
+The tracked `.example.md` files are placeholders (headings only, no real
+content) — the same `.env.example` convention this framework already uses for
+`onboarding.yaml` (see `onboarding.example.yaml` and
+`docs/agdr/AgDR-0064-onboarding-example-file-and-guard.md`). Copy an example to
+its real name and fill it in locally; the real file never gets committed.
+
+```bash
+cp .claude/memory/MEMORY.example.md .claude/memory/MEMORY.md
+cp .claude/memory/USER.example.md .claude/memory/USER.md
+```
+
+## Why not just track `MEMORY.md` / `USER.md` directly?
+
+Because this repo is typically a **public fork** that opens PRs upstream to
+`me2resh/apexyard`. Real cross-project notes — client names, internal
+decisions, adopter-specific context — belong on your machine, not in public
+git history. The example-file + gitignore split keeps the safe path the
+default, the same way `onboarding.yaml` does for company config. See
+`docs/agdr/AgDR-0099-cognitive-memory-layer-phase0.md` for the full reasoning.
+
+## What this is NOT
+
+This layer deliberately does not duplicate two things the framework and the
+harness already provide:
+
+| Compared to… | How it differs |
+|--------------|-----------------|
+| **AgDRs** (`docs/agdr/`) | An AgDR is a point-in-time technical **decision** record — what was chosen, why, what the trade-off was. This layer is for accumulating **experience** over time (what tends to work, what an adopter prefers, recurring gotchas) — it doesn't replace or duplicate a single decision's record. |
+| **Claude Code's native session memory** | The harness already maintains its own per-project, per-conversation memory (e.g. `~/.claude/projects/<project>/memory/MEMORY.md`) scoped to a single machine's Claude Code installation. This layer is apexyard's own **portfolio-governed** layer — part of the framework's tracked structure, reviewable and versionable the same way roles, rules, and skills are — not a replacement for the harness's own memory feature. Nothing here changes how the harness's native memory behaves. |
+
+## Optional and fail-soft (by construction)
+
+Nothing in the framework reads, requires, or references `.claude/memory/` at
+runtime. No hook, no skill, no `CLAUDE.md` instruction depends on its
+presence or contents. An adopter who never creates `MEMORY.md` or `USER.md`
+sees byte-for-byte identical framework behavior — this is a scaffold you can
+adopt at your own pace, not a new requirement.
+
+## Explicitly out of scope for Phase 0
+
+The original proposal (me2resh/apexyard#692) envisioned more than a docs
+scaffold. The maintainer approved Phase 0 (this directory) while explicitly
+deferring the rest to a future issue, its own AgDR, and separate maintainer
+sign-off:
+
+- A SQLite/FTS **recall engine** — a queryable store with structured search.
+- `SessionStart` / `PostToolUse` **capture hooks** — automated write-to-memory
+  behavior triggered by session events.
+- A `/learn` or similar **self-improving-skills loop** — skills that adjust
+  themselves based on accumulated memory.
+- Any new runtime dependency (Python, a database driver, etc.) to support the
+  above.
+
+None of that exists yet. This directory is the documented, governed home
+those future phases would eventually build on top of — not a preview of them.
+
+## Split-portfolio note
+
+Split-portfolio v2 adopters keep other adopter-specific content (custom
+skills, custom handbooks, `onboarding.yaml`) in a private sibling repo rather
+than the public framework fork — see `docs/multi-project.md`. Phase 0 makes
+no decision about where a real `MEMORY.md`/`USER.md` should live in that
+model; because both are already gitignored (never committed to either repo
+by default), this is a non-issue for now. A future phase that adds capture
+tooling should resolve its paths through the ops-root helper
+(`.claude/hooks/_lib-portfolio-paths.sh`) the same way every other
+portfolio-aware path in this framework does, rather than hardcoding
+`.claude/memory/`.

--- a/.claude/memory/USER.example.md
+++ b/.claude/memory/USER.example.md
@@ -1,0 +1,38 @@
+# User — EXAMPLE TEMPLATE
+
+This is the TRACKED placeholder template (committed to the repo). Your real
+operator preferences and working-style notes live in `USER.md` in this same
+directory, which is GITIGNORED and never committed — the same `.env.example`
+/ `.env` convention this framework uses for `onboarding.yaml`.
+
+Copy this file to `USER.md` and start filling it in locally:
+
+```bash
+cp .claude/memory/USER.example.md .claude/memory/USER.md
+```
+
+See `.claude/memory/README.md` for what this layer is (and isn't), and
+`docs/agdr/AgDR-0099-cognitive-memory-layer-phase0.md` for why it's structured
+this way.
+
+---
+
+## What goes here
+
+Notes about how *you* (the operator) like to work — the kind of thing a
+long-time collaborator would pick up on over time. Some starting sections;
+adapt freely, this is your file:
+
+## Communication preferences
+
+<!-- How much detail you want in updates, when to ask vs. proceed, tone
+     preferences. -->
+
+## Review habits
+
+<!-- How you like PRs described, what you always check, pet peeves. -->
+
+## Standing context
+
+<!-- Anything about your role, team, or constraints worth remembering
+     across sessions. -->

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,18 @@ onboarding.yaml
 # sensitive-topic notes that should not leak to git — keep it local.
 .claude/project-config.json
 
+# Cognitive memory layer, Phase 0 (#692). The tracked templates are
+# MEMORY.example.md / USER.example.md; your real, accumulated notes live in
+# MEMORY.md / USER.md (this repo is typically a public fork opening PRs
+# upstream — real cross-project notes must stay LOCAL). Same example-file +
+# gitignore convention as onboarding.yaml above. db/ is reserved for a future
+# structured store and stays empty (via .gitkeep) in Phase 0 — no code reads
+# or writes here yet, but any future content there is per-clone too.
+.claude/memory/MEMORY.md
+.claude/memory/USER.md
+.claude/memory/db/*
+!.claude/memory/db/.gitkeep
+
 # Claude Code per-machine settings (permission overrides, local tool config)
 .claude/settings.local.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,7 @@ Copy whichever you need into your project's `.github/workflows/`. Full details i
 | Hook wiring | `.claude/settings.json` |
 | **Per-project docs** | `projects/<name>/` |
 | **Live working copies** (gitignored) | `workspace/<name>/` |
+| **Cognitive memory layer** (optional, docs-only scaffold) | `.claude/memory/` — see [`.claude/memory/README.md`](.claude/memory/README.md) for what it is, what it isn't, and how it differs from AgDRs / Claude Code's native session memory |
 | **Topology bundles** (harness templates per service shape) | `topologies/<name>/` — see [`topologies/README.md`](topologies/README.md) |
 | CI pipelines | `golden-paths/pipelines/` |
 | Getting Started | `docs/getting-started.md` |

--- a/docs/agdr/AgDR-0099-cognitive-memory-layer-phase0.md
+++ b/docs/agdr/AgDR-0099-cognitive-memory-layer-phase0.md
@@ -1,0 +1,48 @@
+# Cognitive memory layer — Phase 0 scaffold
+
+> In the context of adopters having no single, governed home for cross-session, cross-project experience (informal notes bolted on outside the framework's governance model), facing a maintainer-approved but larger design space (a SQLite/FTS recall engine, capture/recall hooks, a `/learn` self-improving-skills loop) that deserves its own sign-off before it lands, I decided to ship only a docs-only `.claude/memory/` scaffold — a README that draws the boundary, tracked example templates, and a gitignored home for real per-clone content — to achieve a low-risk, reversible foundation that adopters can start using today, accepting that the scaffold's own functional value is latent until a future, separately-approved phase adds capture and recall.
+
+## Context
+
+me2resh/apexyard#692 originally proposed a full cognitive-memory system: a SQLite/FTS recall engine, `SessionStart`/`PostToolUse` capture hooks, and a `/learn` self-improving-skills loop, alongside the scaffold. The maintainer reviewed the proposal (2026-06-24 comment) and explicitly scoped this contribution down to **Phase 0 only** — a documented `.claude/memory/` home — deferring the engine, the hooks, and the skills to a future issue that will need its own AgDR and maintainer alignment. The maintainer's six acceptance criteria for Phase 0:
+
+1. Markdown + scaffold only — `.claude/memory/` with `MEMORY.md`, `USER.md`, `README.md`, and a gitignored `db/`. No Python, no hooks, no new skills in this PR.
+2. Optional + fail-soft by construction — nothing else may require it; its absence changes no behavior.
+3. README does the heavy lifting — what it is, that it's optional, and how it relates to (and does NOT duplicate) Claude Code's native memory + AgDRs.
+4. No new runtime dependencies; respects the ops-root resolution conventions.
+5. An AgDR recording the decision + an explicit "out of scope for now" list.
+6. No behavioral wiring — no SessionStart/PostToolUse hooks, no skill nudges, in this PR.
+
+A follow-up agent-generated Product × Tech review (2026-07-03, Omar/Hisham, advisory) additionally flagged a leak/privacy risk in a literal reading of AC 1: if `MEMORY.md` and `USER.md` themselves were tracked files (rather than the `db/` gitignore alone), any real cross-project or adopter-specific notes written into them would be committed and pushed to the public upstream fork — the exact failure mode `docs/agdr/AgDR-0064-onboarding-example-file-and-guard.md` already fixed for `onboarding.yaml` (real config leaking into public git history).
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Track `MEMORY.md` / `USER.md` directly (literal AC 1 reading), only `db/` gitignored | Matches the AC's file list most literally | Real per-adopter memory content becomes committed, public-fork content by default — the onboarding.yaml leak class this framework already fixed once |
+| Example-file + gitignore, mirroring `onboarding.example.yaml` / `onboarding.yaml` (chosen) | Safe path is the default; reuses an established, well-understood framework convention; adopters get a documented starting point without risking a public leak | The literal filenames `MEMORY.md`/`USER.md` in AC 1 are read as "the tracked artifact", not "the gitignored local file" — flagged explicitly in the PR as a deliberate interpretation, not silently reinterpreted |
+| Track real files but instruct adopters "don't put private info in them" | No new convention to learn | Relies purely on adopter discipline for a public fork; the whole point of the `.env.example` pattern this repo already uses is to not rely on discipline for this exact class of leak |
+
+## Decision
+
+Chosen: **example-file + gitignore**, matching `onboarding.example.yaml` / `onboarding.yaml`.
+
+- Track `.claude/memory/README.md` (the boundary-drawing doc), `.claude/memory/MEMORY.example.md`, `.claude/memory/USER.example.md` (placeholder templates, headings only, no real content), and `.claude/memory/db/.gitkeep` (holds the directory so `db/` exists post-clone).
+- Gitignore the real, per-clone files: `.claude/memory/MEMORY.md`, `.claude/memory/USER.md`, and any `.claude/memory/db/*` content (SQLite files, should Phase 1+ ever add them) — mirroring the `.claude/session/` and `onboarding.yaml` gitignore blocks already in `.gitignore`.
+- No hook backstop is added in this PR (unlike `block-onboarding-in-git.sh`) — Phase 0 explicitly ships **no hooks** (AC 6). If real memory content starts leaking upstream in practice, a follow-up PR can add a placeholder-diff guard the same way #517 did for onboarding — that is out of scope here.
+
+This directly satisfies AC 1 (the four named files/dirs exist, `db/` is gitignored) while resolving the ambiguity the literal wording left open, in the direction the framework's own established convention and the Product × Tech review both point.
+
+## Consequences
+
+- `.claude/memory/` ships in every fork from this PR onward: `README.md` + two `.example.md` templates + `db/.gitkeep`, all tracked; `MEMORY.md`, `USER.md`, and `db/*` (except `.gitkeep`) gitignored.
+- Nothing else in the framework reads, requires, or references these files at runtime — no `SessionStart`/`PostToolUse` hook touches them, no skill nudges an adopter toward them (AC 2, AC 6). An adopter who never looks at `.claude/memory/` sees byte-for-byte identical framework behavior.
+- The README explicitly draws the boundary against `docs/agdr/` (point-in-time technical decisions) and Claude Code's own native session memory (`~/.claude/projects/.../memory/MEMORY.md`, per-conversation) so adopters don't confuse the three.
+- Phase 1+ (recall engine, capture hooks, `/learn`) is explicitly out of scope for this AgDR and this PR. It will need its own AgDR and separate maintainer sign-off, per the maintainer's 2026-06-24 comment on #692.
+- Fork-drift surface: every adopter fork now inherits a new tracked directory. If a later phase restructures `.claude/memory/`, that adopter forks need a small migration step — kept explicitly minimal here to limit that blast radius.
+
+## Artifacts
+
+- Issue: me2resh/apexyard#692
+- Files: `.claude/memory/README.md`, `.claude/memory/MEMORY.example.md`, `.claude/memory/USER.example.md`, `.claude/memory/db/.gitkeep`, `.gitignore`, `CLAUDE.md`, `docs/agdr/AgDR-0099-cognitive-memory-layer-phase0.md`
+- Related: AgDR-0064 (onboarding example-file + gitignore convention, the pattern this decision mirrors)


### PR DESCRIPTION
## Summary

- **Docs-only `.claude/memory/` scaffold** — adds `README.md`, `MEMORY.example.md`, `USER.example.md`, and a `db/` placeholder. This is exactly the maintainer-approved Phase-0 scope from #692: a governed, optional home for cross-session/cross-project experience adopters currently bolt on outside the framework (a stray notes file, tribal knowledge), without committing to the larger recall-engine/hooks/`/learn` design that's explicitly deferred to a future issue.
- **Real memory files stay gitignored, tracked examples ship instead** — `MEMORY.example.md` / `USER.example.md` are the committed templates; `MEMORY.md` / `USER.md` are gitignored, mirroring the `onboarding.example.yaml` / `onboarding.yaml` convention (AgDR-0064). This matters because this repo is typically a public fork opening PRs upstream — tracking the real files directly would risk real cross-project notes landing in public git history, the exact class of leak AgDR-0064 already fixed once for company config.
- **README does the boundary-drawing work** — explicitly distinguishes this layer from `docs/agdr/` (point-in-time decisions) and from Claude Code's own native per-session memory, so adopters don't confuse the three or think this duplicates either.
- **Zero behavioral wiring** — no hooks, no skills, no `settings.json` changes. Verified by grepping `.claude/hooks/` and `.claude/settings.json` for any reference to `.claude/memory` — there are none, so an adopter who never touches this directory sees byte-for-byte identical framework behavior.
- **AgDR-0099** records the decision, including an explicit flag on one interpretation call: the maintainer's AC 1 literally lists `MEMORY.md`/`USER.md` as the files to create, without saying whether they're gitignored. I read that in light of AC 4 ("respects... conventions") and a follow-up agent-generated Product×Tech review that flagged the leak risk, and went with the example+gitignore pattern rather than tracking the real files. Flagging this explicitly rather than assuming it's uncontroversial.

## Testing

1. `bash bin/run-hook-tests.sh` — full hook-test suite (106 tests): **105 pass, 1 pre-existing failure** (`test_sync_codex_adapter.sh`, a self-contained test with its own temp-root fixture; its two failing assertions are about a synthetic `block-test.sh` path-resolution scenario unrelated to this PR — no memory-related content appears anywhere in that test).
2. `npx markdownlint-cli2 ".claude/memory/*.md" "docs/agdr/AgDR-0099-cognitive-memory-layer-phase0.md"` — 0 errors.
3. Fail-soft/no-op check: `grep -rl ".claude/memory" .claude/hooks/ .claude/settings.json` returns nothing — confirms no hook or wiring depends on this directory (AC 2 / AC 6 are true in practice, not just asserted in prose).
4. Gitignore behavior check: created `MEMORY.md`, `USER.md`, and a `db/test.db` locally, ran `git check-ignore -v` — all three are ignored, while `db/.gitkeep` remains tracked. Removed the scratch files afterward.
5. `git diff --stat upstream/dev..HEAD` — touches exactly the 7 files listed below; nothing else.

## Acceptance criteria (maintainer's 2026-06-24 comment on #692)

| # | AC | Status |
|---|----|--------|
| 1 | Markdown + scaffold only — `.claude/memory/` with `MEMORY.md`, `USER.md`, `README.md`, gitignored `db/`. No Python/hooks/skills. | Done, with one flagged interpretation (see Summary + AgDR-0099) |
| 2 | Optional + fail-soft — nothing else may require it | Done — verified by grep, no references anywhere in `.claude/hooks/` or `settings.json` |
| 3 | README does the heavy lifting | Done — `.claude/memory/README.md` |
| 4 | No new runtime deps; respects ops-root resolution conventions | Done — no deps added; README explicitly points a future capture-tooling phase at `_lib-portfolio-paths.sh` rather than hardcoding paths |
| 5 | AgDR recording the decision + explicit out-of-scope list | Done — `docs/agdr/AgDR-0099-cognitive-memory-layer-phase0.md` |
| 6 | No behavioral wiring — no hooks, no skill nudges | Done — verified by grep, confirmed in Testing above |

Fixes #692

---

## Glossary

| Term | Definition |
|------|------------|
| Phase 0 | The maintainer-scoped-down portion of #692's original proposal — a docs/scaffold only, deliberately excluding the recall engine, capture hooks, and `/learn` skill from the original issue. |
| Example-file + gitignore convention | The `.env.example`/`.env` pattern this framework already uses for `onboarding.yaml`: a tracked placeholder template plus a gitignored real file, so real/private content never reaches public git history by default. |
| Fail-soft | A component whose absence changes no other behavior — no hook, skill, or instruction depends on it existing. |
| AgDR | Agent Decision Record — this framework's format for recording a technical decision, its options, and its trade-offs (`docs/agdr/`). |
