### PR TITLE
fix(#931): close <> read-write + >(…) process-sub residuals in bash write-detection

### DIFF
--- a/.claude/hooks/_lib-detect-bash-write.sh
+++ b/.claude/hooks/_lib-detect-bash-write.sh
@@ -59,7 +59,13 @@
 #
 #   Redirection / pipes-to-disk
 #     - cmd > file, cmd >> file, cmd 2> file
+#     - cmd &> file, cmd >| file (force-clobber), cmd <> file (read-write
+#       open, #931)
 #     - tee
+#
+#   NOT matched as a write (deliberate exclusion, #931):
+#     - cmd >(subshell), cmd <(subshell) — process substitution. Looks
+#       adjacent to a redirect but is a command, not a file target.
 #
 #   In-place text editors
 #     - sed -i (in-place edit, GNU + BSD `''` form)
@@ -163,8 +169,46 @@ _bdw_starts_with_git_subcommand() {
 # forms), the target can't start there regardless of how much whitespace
 # came before it. The whitespace requirement was never what excluded
 # fd-dup; the target character class was and still is.
+#
+# `<>` READ-WRITE OPEN (apexyard#886/#931 round 6, closing one of the two
+# residuals #926 documented-and-deferred): `[n]<>word` opens `word` for
+# BOTH reading and writing on descriptor `n` (or fd 0 if `n` is omitted) —
+# `exec 3<> some/file`, `cmd <>file` are real, non-truncating writes that
+# every prior round's operator alternation missed entirely (the `<`
+# leading character was always excluded by the OTHER operators' own
+# leading-context class, `[^|<&]`, so `<>` was structurally invisible to
+# this pattern, not just an uncovered edge case). The new `[0-9]*<>`
+# alternative is unambiguous against every existing operator: `<>` is two
+# literal characters (`<` immediately followed by `>`), which never
+# occurs inside `<<` (heredoc), `<<<` (herestring), or any of the
+# fd-dup/`>`-based forms above (those all have `>` preceding `&`, never
+# `<` immediately preceding `>`). Chosen to DETECT rather than
+# document-as-accepted (per #931's own framing: "a write is a write") —
+# the non-truncating risk profile differs from `>`/`>>`, but the ticket
+# gate cares about "was tracked content touched", not "was it truncated".
+#
+# `>(…)` / `<(…)` PROCESS SUBSTITUTION now EXCLUDED from the target class
+# (apexyard#886/#931 round 6, closing the second #926-deferred residual):
+# `diff a >(sort)` is not a file write — `>(sort)` is process substitution,
+# a subshell whose stdin bash wires to a fifo/fd path, syntactically
+# adjacent to `>` but semantically a command, not a redirect target. The
+# prior target class `[^[:space:]&|;]+` allowed a leading `(` and so
+# happily consumed `(sort)` as if it were a filename — a fail-closed
+# (over-blocking) false positive, not a bypass, but still worth tightening
+# per #931. Splitting the target class into a first-char exclusion,
+# `[^[:space:]&|;(]`, plus the unchanged `[^[:space:]&|;]*` for the rest,
+# means the match FAILS whenever the character immediately after the
+# operator (past any optional whitespace) is `(` — process substitution
+# always starts there with zero space (`> (foo)` is not valid bash
+# redirect-to-subshell syntax; a space there is a syntax error, so
+# excluding the immediately-adjacent case costs nothing on real commands).
+# A legitimate filename that merely CONTAINS a paren not in the leading
+# position (`file(1).txt`) is untouched — only a LEADING `(` is excluded.
+# `<(…)` (process substitution on the read side) was never matched here
+# to begin with (`<` alone isn't a write operator in this file), so no
+# change was needed for that half.
 _bdw_match_redirection() {
-  echo "$1" | grep -qE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]*[^[:space:]&|;]+'
+  echo "$1" | grep -qE '(&>>?|(^|[^|<&])>>?\|?|[0-9]*<>)[[:space:]]*[^[:space:]&|;(][^[:space:]&|;]*'
 }
 
 # ------------------------------------------------------------------------------
@@ -522,6 +566,7 @@ bash_command_is_deletion_only() {
 #   - mv src /path/to/dst        → /path/to/dst (#153)
 #   - curl -o /path URL          → /path        (#153)
 #   - wget -O /path URL          → /path        (#153)
+#   - cmd <> /path/to/file       → /path/to/file (read-write open, #931)
 #
 # Does NOT handle (returns empty):
 #   - python/node/ruby/perl/php with embedded path
@@ -529,21 +574,17 @@ bash_command_is_deletion_only() {
 #   - cmd with multiple redirects
 #   - paths constructed from variables
 #   - tar -x (target is a directory, often implicit)
-#   - `cmd <> file` (read-write open, apexyard#886/#926 round 5): known,
-#     accepted, OUT-OF-SCOPE gap — exotic, non-truncating (unlike every
-#     operator this file DOES model, `<>` opens for read+write WITHOUT
-#     truncating existing content, so it's a materially different risk
-#     shape), and not adjacent to any of the &&/||/;/| separators this
-#     library segments on, so the round-5 structural fix doesn't reach
-#     it either. Tracked as a separate follow-up rather than folded into
-#     this operator-class close.
+#   - `cmd >(subshell)` / `cmd <(subshell)` process substitution: NOT a
+#     target at all (correctly excluded, #931 — see the leading-`(`
+#     exclusion note on _bdw_match_redirection above), so this returns
+#     empty for `diff a >(sort)` rather than fabricating `(sort)`.
 # ------------------------------------------------------------------------------
 bash_extract_write_target() {
   local cmd="$1"
   [ -z "$cmd" ] && return 0
 
   # Output redirection: capture the first target after >, >>, &>, &>>, >|,
-  # or >>|. Strip leading number/ampersand for cases like `2> file` /
+  # >>|, or <>. Strip leading number/ampersand for cases like `2> file` /
   # `&> file`.
   #
   # (^|[^|<&]) — see the identical note on _bdw_match_redirection above
@@ -566,8 +607,17 @@ bash_extract_write_target() {
   # `2>file`, `>>file`, `>|file`, `&>file` are all valid writes) — see the
   # matching note on _bdw_match_redirection for why this doesn't loosen
   # the fd-dup exclusion (the target class still rejects a leading `&`).
+  #
+  # `[0-9]*<>` (apexyard#886/#931 round 6): the new read-write-open
+  # alternative. The strip sed below (`^[^>]*>>?\|?[[:space:]]*`) already
+  # handles it correctly with NO changes — `[^>]*` greedily consumes the
+  # leading `<` (and any fd digit) up to the FIRST `>`, exactly the same
+  # way it already consumes a leading `&` or digit for `&>`/`2>`, so
+  # `<>file` strips down to `file` for free. The leading-`(` exclusion on
+  # the target class (apexyard#931, same round) also applies here,
+  # unchanged, for `diff a >(sort)` → no target.
   local target
-  target=$(echo "$cmd" | grep -oE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]*[^[:space:]&|;]+' \
+  target=$(echo "$cmd" | grep -oE '(&>>?|(^|[^|<&])>>?\|?|[0-9]*<>)[[:space:]]*[^[:space:]&|;(][^[:space:]&|;]*' \
                 | head -n 1 \
                 | sed -E 's/^[^>]*>>?\|?[[:space:]]*//')
   if [ -n "$target" ]; then
@@ -706,11 +756,20 @@ _bdw_targets_from_segment() {
   # are all real writes). Relaxed to optional; the target class
   # `[^[:space:]&|;]+` still rejects a leading `&`, so `2>&1`/`>&2`
   # (fd-dup) stay correctly unmatched regardless of spacing.
+  #
+  # `[0-9]*<>` and the leading-`(` target exclusion (apexyard#886/#931
+  # round 6): same two additions as _bdw_match_redirection and
+  # bash_extract_write_target above — `<>` (read-write open) is now a
+  # recognised operator (the unchanged strip-sed already handles it, since
+  # `[^>]*` swallows the leading `<`/digit the same way it swallows a
+  # leading `&`), and a leading `(` after the operator is excluded so
+  # `diff a >(sort)` (process substitution) no longer contributes the
+  # bogus target `(sort)`.
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     target=$(printf '%s\n' "$line" | sed -E 's/^[^>]*>>?\|?[[:space:]]*//')
     [ -n "$target" ] && _bdw_strip_quotes "$target"
-  done < <(printf '%s\n' "$seg" | grep -oE '(&>>?|(^|[^|<&])>>?\|?)[[:space:]]*[^[:space:]&|;]+')
+  done < <(printf '%s\n' "$seg" | grep -oE '(&>>?|(^|[^|<&])>>?\|?|[0-9]*<>)[[:space:]]*[^[:space:]&|;(][^[:space:]&|;]*')
 
   # ALL tee operands in this segment — `tee a b c` names three targets, not
   # one; the original single-target extractor only ever returned "a".

--- a/.claude/hooks/tests/test_detect_bash_write.sh
+++ b/.claude/hooks/tests/test_detect_bash_write.sh
@@ -422,6 +422,83 @@ fi
 assert_targets "python -c (miss) contributes nothing" \
   'python3 -c "open(\"/tmp/x\",\"w\").write(\"hi\")"'                                 ""
 
+# --- #931 residual 1: `<>` read-write open is now DETECTED as a write ---
+#
+# `[n]<>word` opens `word` for both reading AND writing — a real,
+# non-truncating write that every #886/#926 round missed entirely (the
+# leading `<` was always excluded by the OTHER operators' own
+# leading-context class, so `<>` was structurally invisible, not just an
+# uncovered edge case). #931 decided to DETECT rather than
+# document-as-accepted: the ticket gate cares about "was tracked content
+# touched", not "was it truncated".
+
+assert_write  "<> read-write open, fd-numbered (#931)"  "exec 3<> /tmp/x"
+assert_write  "<> read-write open, no fd, no space (#931)" "cmd <>file.txt"
+assert_write  "<> read-write open, fd + space (#931)"   "exec 3<> file.txt"
+
+assert_target "<> extracts the file target (#931)" \
+  "exec 3<> /tmp/x"                                                                   "/tmp/x"
+assert_targets "<> extracts the file target, multi-target form (#931)" \
+  "exec 3<> src/app.ts"                                                               "src/app.ts"
+
+# Sanity: `<>` must not be confused with heredoc (`<<`) or herestring
+# (`<<<`) — both contain repeated `<`, never the exact `<` immediately
+# followed by `>` this operator requires.
+assert_targets "<< heredoc still not a <> false-positive (#931)" \
+  "$(printf 'cat > /tmp/x <<EOF\nhi\nEOF')"                                           "/tmp/x"
+assert_targets "<<< herestring still not a <> false-positive (#931)" \
+  "cat <<< 'hello'"                                                                   ""
+
+# Sanity: a `<>` write hiding behind an `rm` must not be misclassified as
+# deletion-only (same shape as the round-5 `||>` sanity check above).
+assert_not_deletion_only "rm + '<>' hides a real write (#931)" \
+  "rm old.ts; exec 3<> src/app.ts"
+
+# --- #931 residual 2: `>(…)` / `<(…)` process substitution no longer
+#     over-blocked ---
+#
+# `diff a >(sort)` is NOT a file write — `>(sort)` is process substitution
+# (a subshell command wired to a fifo/fd path), syntactically adjacent to
+# `>` but semantically nothing like a redirect target. Pre-#931 the target
+# class allowed a leading `(` and so fabricated `(sort)` as if it were a
+# filename — a fail-closed (over-blocking) false positive, not a bypass,
+# but worth tightening since it needlessly blocked a common construct
+# (`diff a >(sort)`, `tee >(logger)`, etc.) behind the ticket gate.
+
+assert_read "diff with >(...) process substitution is NOT a write (#931)" \
+  "diff a >(sort)"
+assert_read "<(...) process substitution on the read side (#931, already fine)" \
+  "diff <(sort a) <(sort b)"
+
+assert_targets ">(...) process substitution contributes no target (#931)" \
+  "diff a >(sort)"                                                                    ""
+
+# The exact shape from #931's own repro: a REAL write earlier in a
+# no-space-chained command, a process-substitution tail after it — only
+# the real target must surface, and detection must still fire (because of
+# the first, real write).
+assert_appears_to_write "real write + >(...) tail still detected (#931)" \
+  "echo a > /tmp/ok;diff x >(sort)"
+assert_targets "real write + >(...) tail: only the real target surfaces (#931)" \
+  "echo a > /tmp/ok;diff x >(sort)"                                                    "/tmp/ok"
+
+# Sanity: the leading-`(` exclusion must NOT reject a legitimate filename
+# that merely CONTAINS a paren not in the leading position.
+assert_targets "filename with non-leading parens still extracts (#931)" \
+  'echo hi > "file(1).txt"'                                                           "file(1).txt"
+
+# Sanity: the process-substitution exclusion must not resurrect any
+# fd-dup / force-clobber / redirect-both-streams false-negative from
+# earlier rounds.
+assert_write  ">| force-clobber still a write alongside the new exclusion (#931)" \
+  "echo a >| /tmp/x"
+assert_write  "&> both-streams still a write alongside the new exclusion (#931)" \
+  "echo hi &> .gitignore"
+assert_read   "2>&1 fd-dup still excluded alongside the new exclusion (#931)" \
+  "make build 2>&1"
+assert_read   ">&2 fd-dup still excluded alongside the new exclusion (#931)" \
+  "echo err >&2"
+
 echo ""
 echo "==================================="
 echo "  PASS: $PASS   FAIL: $FAIL"


### PR DESCRIPTION
## Summary
- **`<>` read-write open is now detected as a write** — `[n]<>word` opens a file for both reading and writing (`exec 3<> file`, `cmd <>file`). Every prior #886/#926 hardening round missed it because the leading `<` was excluded by the *other* operators' own leading-context class, so `<>` was structurally invisible to the matcher, not just an untested edge case. Decided to detect (not document-as-accepted) per the ticket's own framing — the ticket gate cares whether tracked content was touched, not whether the write truncates.
- **`>(…)` / `<(…)` process substitution no longer fabricates a bogus write target** — `diff a >(sort)` previously matched `(sort)` as if it were a filename, needlessly gating a common, harmless construct (fail-closed over-block, never a bypass). A `>(` immediately after the operator is now excluded from the target class, while a filename that merely *contains* a non-leading paren (`file(1).txt`) still extracts correctly.
- **Both fixes are one shared regex change** — a new `[0-9]*<>` operator alternative plus a leading-`(` exclusion on the target character class — applied identically across detection (`_bdw_match_redirection`), single-target extraction (`bash_extract_write_target`), and multi-target extraction (`_bdw_targets_from_segment`), so the three paths can't disagree the way earlier #886/#926 rounds did.
- **Full #886/#926 regression matrix re-verified** — all fd-dup exclusions (`2>&1`, `>&2`, `1>&2`), force-clobber (`>|`, `>>|`), both-streams (`&>`, `&>>`), and the `|`/`||`-adjacent redirect cases from round 5 still pass unchanged.

## Testing
- `bash .claude/hooks/tests/test_detect_bash_write.sh` — 160/160 pass (142 pre-existing + 18 new rows covering `<>` detection/extraction, `>(…)`/`<(…)` exclusion, the exact chained repro from the ticket, and sanity checks that the new exclusions don't resurrect any fd-dup/force-clobber/both-streams false-negative).
- `bash .claude/hooks/tests/test_require_active_ticket_bash.sh` — 78/78 pass (unchanged, sourced-lib regression check).
- `bash .claude/hooks/tests/test_require_migration_ticket.sh` — 26/26 pass (unchanged, sourced-lib regression check).
- `bash -n` on both changed files — clean.
- `shellcheck -S warning` on both changed files plus the two hook callers (`require-active-ticket.sh`, `require-migration-ticket.sh`) — clean.

Closes #931

---

## Glossary
| Term | Definition |
|------|------------|
| `<>` (read-write open) | Bash operator (`[n]<>word`) that opens `word` for both reading and writing on descriptor `n` (or fd 0 if omitted) — a real, non-truncating write. |
| Process substitution | `>(cmd)` / `<(cmd)` — bash wires `cmd`'s stdin/stdout to a fifo/fd path and substitutes that path as an argument; it looks adjacent to a redirect but is a command, not a file target. |
| Fail-closed | Over-blocking (safe but annoying) rather than under-blocking (a real bypass). The process-substitution bug was fail-closed; the `<>` gap was a genuine miss. |
| Leading-context class | The regex character class (`[^|<&]`) used to distinguish a real redirect `>` from one that's part of `2>&1`/`>&2` (fd-dup) or a heredoc marker. |
