### PR TITLE
feat(#929): SessionStart search advisory probes MCP reachability

### DIFF
--- a/.claude/hooks/_lib-premium-hook.sh
+++ b/.claude/hooks/_lib-premium-hook.sh
@@ -100,6 +100,35 @@
 #       (works because presence checks run via `eval` in THIS shell, not a
 #       child process — unlike the payload, they inherit this lib's functions.)
 #
+#   premium_hook_probe <feature_key> <presence_check_cmd> <probe_cmd> [default_enabled]
+#       A cheap, bounded LIVENESS check (me2resh/apexyard#929) — for callers
+#       that need to know whether a premium component can actually RESPOND
+#       right now, not just whether it's installed, before deciding what to
+#       advertise. Same GATE 1 (feature flag) / GATE 2 (presence) semantics
+#       as premium_hook_run, and the same timeout-guarded child-process
+#       execution shape, but instead of always returning 0 it returns a
+#       three-way result the caller branches on:
+#         0  REACHABLE     — gate passed AND probe_cmd exited 0 in time.
+#         1  UNREACHABLE    — gate passed but probe_cmd exited non-zero or
+#                            was killed for hanging past the timeout.
+#         2  NOT_APPLICABLE — feature disabled/unconfigured, presence check
+#                            failed, or required args are missing. Same
+#                            "nothing to report on" case premium_hook_run
+#                            treats as a silent no-op.
+#       probe_cmd should be side-effect-free and fast (a liveness check,
+#       not the real premium work) — see reindex-on-session-start.sh for
+#       the worked example (probes `apexyard-search doctor` before nudging
+#       a reindex).
+#
+# Tunables (env):
+#   PREMIUM_HOOK_PROBE_TIMEOUT_SECS   max seconds a premium_hook_probe call
+#                                     spends before killing the probe and
+#                                     treating it as UNREACHABLE (default 5 —
+#                                     short on purpose; a liveness check
+#                                     should be fast even when the caller's
+#                                     own premium_hook_run payload is allowed
+#                                     a longer PREMIUM_HOOK_TIMEOUT_SECS)
+#
 # Source-guard: safe to source more than once in the same shell (idempotent,
 # matches the pattern in _lib-ops-root.sh).
 
@@ -296,4 +325,49 @@ premium_hook_run() {
 
   # ALWAYS 0 — a premium hook can never block or break its caller.
   return 0
+}
+
+# ------------------------------------------------------------------------------
+# Public: premium_hook_probe <feature_key> <presence_check_cmd> <probe_cmd> [default_enabled]
+#   See header for full semantics. Unlike premium_hook_run, this function's
+#   return code IS the signal — 0 (reachable) / 1 (unreachable) /
+#   2 (not applicable) — so callers can branch on it. It still never lets a
+#   hanging probe run unbounded: same timeout-guarded child-process shape as
+#   premium_hook_run, just with its own (shorter-by-default) timeout knob.
+# ------------------------------------------------------------------------------
+premium_hook_probe() {
+  local feature_key="${1:-}"
+  local presence_cmd="${2:-}"
+  local probe_cmd="${3:-}"
+  local default_enabled="${4:-true}"
+
+  # Nothing to probe -> not applicable, same as premium_hook_run's "nothing
+  # to run" early-out.
+  [ -n "$feature_key" ] || return 2
+  [ -n "$probe_cmd" ] || return 2
+
+  # GATE 1: feature flag. Absent/disabled -> not applicable, zero latency.
+  premium_feature_enabled "$feature_key" "$default_enabled" || return 2
+
+  # GATE 2: component presence, when the caller supplied a check.
+  if [ -n "$presence_cmd" ]; then
+    ( eval "$presence_cmd" ) >/dev/null 2>&1 || return 2
+  fi
+
+  # LIVENESS CHECK: timeout-guarded child process, same fallback order as
+  # premium_hook_run (GNU `timeout`, then macOS `gtimeout`, else unbounded).
+  local timeout_secs to
+  timeout_secs="${PREMIUM_HOOK_PROBE_TIMEOUT_SECS:-5}"
+  to=""
+  if command -v timeout >/dev/null 2>&1; then
+    to="timeout -k 2 ${timeout_secs}"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    to="gtimeout -k 2 ${timeout_secs}"
+  fi
+
+  # shellcheck disable=SC2086
+  if $to bash -c "$probe_cmd"; then
+    return 0
+  fi
+  return 1
 }

--- a/.claude/hooks/reindex-on-session-start.sh
+++ b/.claude/hooks/reindex-on-session-start.sh
@@ -7,15 +7,33 @@
 #   - --if-stale:    the CLI no-ops when the index is still fresh, so the common
 #                    case (just reindexed) costs essentially nothing.
 #
+# REACHABILITY, NOT JUST PRESENCE (me2resh/apexyard#929): before nudging a
+# reindex, this hook now probes whether apexyard-search can actually RESPOND
+# — `command -v apexyard-search` only proves the binary is on PATH, not that
+# invoking it works. A binary that's present but broken (missing a runtime
+# dependency, a stale venv, whatever) used to be treated identically to a
+# healthy install: the reindex payload would run, silently fail, and an agent
+# would assume search was live when it was quietly falling back to grep+Read
+# the whole session. The probe closes that gap with a fast, bounded,
+# side-effect-free `apexyard-search doctor` call (an index-health report that
+# always exits 0 when it runs cleanly) via `premium_hook_probe`:
+#   - REACHABLE      -> unchanged behaviour, opportunistic reindex runs.
+#   - UNREACHABLE     -> one honest stderr line ("configured but not
+#                        reachable — falling back to grep+Read") INSTEAD of
+#                        the reindex nudge. Still exits 0 — advisory only.
+#   - NOT_APPLICABLE  -> unchanged silent no-op (not configured / disabled).
+#
 # SAFE SHAPE: retrofitted onto the shared premium-hook harness
-# (_lib-premium-hook.sh, me2resh/apexyard#890) — behaviour-preserving, not a
-# redesign. This hook NEVER blocks session start and ALWAYS exits 0. Every
-# failure mode is a silent no-op:
+# (_lib-premium-hook.sh, me2resh/apexyard#890) — behaviour-preserving except
+# for the #929 reachability branch above. This hook NEVER blocks session
+# start and ALWAYS exits 0. Every failure mode is a silent no-op or an
+# advisory line, never a block:
 #   - apexyard-search not on PATH  (MCP not installed)         -> no-op
 #   - index already fresh          (--if-stale short-circuits) -> no-op
 #   - APEXYARD_OPS_ROOT / _PORTFOLIO_ROOT unset                -> no-op (CLI errs, swallowed)
 #   - reindex slower than the timeout                          -> killed, no-op
 #   - APEXYARD_SEARCH_REINDEX_DISABLE set                      -> no-op
+#   - reachability probe fails or hangs past its own timeout   -> honest stderr note, no reindex nudge
 #
 # Why "search" defaults enabled=true (see _lib-premium-hook.sh's
 # `default_enabled` param): this hook historically gated ONLY on
@@ -30,6 +48,7 @@
 # Tunables (env):
 #   APEXYARD_SEARCH_STALE_AFTER       staleness threshold in seconds (default 86400 = 24h)
 #   APEXYARD_SEARCH_REINDEX_TIMEOUT   max seconds to spend before giving up (default 25)
+#   APEXYARD_SEARCH_PROBE_TIMEOUT     max seconds for the reachability probe (default 5)
 #   APEXYARD_SEARCH_REINDEX_DISABLE   non-empty -> skip entirely
 
 set -u
@@ -46,19 +65,40 @@ HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 STALE_AFTER="${APEXYARD_SEARCH_STALE_AFTER:-86400}"
 
-# Map this hook's own timeout tunable onto the harness's generic one. Read
-# by premium_hook_run in _lib-premium-hook.sh (sourced above into this same
-# shell, not a child process) — shellcheck can't see the cross-file read, so
-# it flags this as unused; it isn't.
+# Map this hook's own timeout tunables onto the harness's generic ones. Read
+# by premium_hook_run / premium_hook_probe in _lib-premium-hook.sh (sourced
+# above into this same shell, not a child process) — shellcheck can't see
+# the cross-file read, so it flags these as unused; they aren't.
 # shellcheck disable=SC2034
 PREMIUM_HOOK_TIMEOUT_SECS="${APEXYARD_SEARCH_REINDEX_TIMEOUT:-25}"
+# shellcheck disable=SC2034
+PREMIUM_HOOK_PROBE_TIMEOUT_SECS="${APEXYARD_SEARCH_PROBE_TIMEOUT:-5}"
 
-# Payload preserves the exact prior command + redirection (discard stdout,
-# and — same as before the retrofit — stderr rides along into the same
-# redirect since `2>&1` dups onto the already-redirected stdout). Swallowing
-# the exit code and the timeout guard are the harness's job now.
-PAYLOAD="apexyard-search reindex --incremental --if-stale=\"${STALE_AFTER}\" >/dev/null 2>&1"
-
-premium_hook_run "search" "command -v apexyard-search" "$PAYLOAD" "true"
+# (#929) Reachability probe BEFORE the reindex nudge. `apexyard-search
+# doctor` is the right probe command: it's a fast, side-effect-free report
+# (index-health JSON) that always exits 0 on a healthy CLI — so a non-zero
+# exit or a hang here means the CLI itself can't respond, not that the index
+# merely needs rebuilding.
+premium_hook_probe "search" "command -v apexyard-search" "apexyard-search doctor >/dev/null 2>&1" "true"
+case $? in
+  0)
+    # REACHABLE -> unchanged behaviour. Payload preserves the exact prior
+    # command + redirection (discard stdout, and — same as before the
+    # retrofit — stderr rides along into the same redirect since `2>&1`
+    # dups onto the already-redirected stdout). Swallowing the exit code
+    # and the timeout guard are the harness's job.
+    PAYLOAD="apexyard-search reindex --incremental --if-stale=\"${STALE_AFTER}\" >/dev/null 2>&1"
+    premium_hook_run "search" "command -v apexyard-search" "$PAYLOAD" "true"
+    ;;
+  1)
+    # UNREACHABLE -> configured but can't respond right now. One honest
+    # line instead of a reindex nudge that can't succeed; still advisory,
+    # never blocks session start.
+    echo "[apexyard-search] search is configured but not reachable right now — falling back to grep+Read for this session. (#929)" >&2
+    ;;
+  *)
+    # NOT_APPLICABLE (2) -> not configured / disabled. Unchanged silent no-op.
+    ;;
+esac
 
 exit 0

--- a/.claude/hooks/tests/test_lib_premium_hook.sh
+++ b/.claude/hooks/tests/test_lib_premium_hook.sh
@@ -288,6 +288,145 @@ YAML
   rm -rf "$sb"
 }
 
+# ---------------------------------------------------------------------------
+# Case 7 (#929): premium_hook_probe — feature disabled -> NOT_APPLICABLE (2),
+# same "nothing to report on" outcome premium_hook_run treats as a silent
+# no-op, but as its own distinguishable return code so callers can branch.
+# ---------------------------------------------------------------------------
+test_probe_not_applicable_when_feature_disabled() {
+  local sb rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  cat > "$sb/features.yaml" <<'YAML'
+search:
+  enabled: false
+YAML
+
+  # shellcheck source=/dev/null
+  ( cd "$sb" && . "$LIB" && premium_hook_probe "search" "true" "true" "true" ); rc=$?
+
+  if [ "$rc" -eq 2 ]; then
+    mark_pass "premium_hook_probe: feature disabled -> NOT_APPLICABLE (2)"
+  else
+    mark_fail "probe not applicable when feature disabled" "rc=$rc"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 8 (#929): premium_hook_probe — feature enabled but presence check
+# fails (component absent) -> NOT_APPLICABLE (2).
+# ---------------------------------------------------------------------------
+test_probe_not_applicable_when_component_absent() {
+  local sb rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+
+  # shellcheck source=/dev/null
+  ( cd "$sb" && . "$LIB" && premium_hook_probe "search" "false" "true" "true" ); rc=$?
+
+  if [ "$rc" -eq 2 ]; then
+    mark_pass "premium_hook_probe: component absent -> NOT_APPLICABLE (2)"
+  else
+    mark_fail "probe not applicable when component absent" "rc=$rc"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 9 (#929): premium_hook_probe — gate passes AND probe_cmd exits 0 ->
+# REACHABLE (0).
+# ---------------------------------------------------------------------------
+test_probe_reachable_returns_zero() {
+  local sb rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+
+  # shellcheck source=/dev/null
+  ( cd "$sb" && . "$LIB" && premium_hook_probe "search" "true" "true" "true" ); rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    mark_pass "premium_hook_probe: gate passes + probe succeeds -> REACHABLE (0)"
+  else
+    mark_fail "probe reachable" "rc=$rc"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 10 (#929): premium_hook_probe — gate passes but probe_cmd exits
+# non-zero -> UNREACHABLE (1), distinguishable from NOT_APPLICABLE (2).
+# ---------------------------------------------------------------------------
+test_probe_unreachable_on_failure() {
+  local sb rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+
+  # shellcheck source=/dev/null
+  ( cd "$sb" && . "$LIB" && premium_hook_probe "search" "true" "exit 1" "true" ); rc=$?
+
+  if [ "$rc" -eq 1 ]; then
+    mark_pass "premium_hook_probe: probe_cmd exits 1 -> UNREACHABLE (1)"
+  else
+    mark_fail "probe unreachable on failure" "rc=$rc"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 11 (#929): premium_hook_probe — a hanging probe_cmd is killed by its
+# OWN (shorter-by-default) timeout knob and treated as UNREACHABLE (1), not
+# left to hang or fall back to the general payload timeout. Skips gracefully
+# if neither `timeout` nor `gtimeout` exists.
+# ---------------------------------------------------------------------------
+test_probe_hanging_is_bounded_and_unreachable() {
+  local sb start end elapsed rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+
+  if ! command -v timeout >/dev/null 2>&1 && ! command -v gtimeout >/dev/null 2>&1; then
+    echo "  SKIP: neither timeout nor gtimeout is installed on this machine"
+    rm -rf "$sb"
+    return 0
+  fi
+
+  start=$(date +%s)
+  # shellcheck source=/dev/null
+  ( cd "$sb" && export PREMIUM_HOOK_PROBE_TIMEOUT_SECS=1 && . "$LIB" && premium_hook_probe "search" "true" "sleep 30" "true" )
+  rc=$?
+  end=$(date +%s)
+  elapsed=$((end - start))
+
+  if [ "$rc" -eq 1 ] && [ "$elapsed" -lt 10 ]; then
+    mark_pass "premium_hook_probe: hanging probe killed within its own timeout -> UNREACHABLE (elapsed=${elapsed}s)"
+  else
+    mark_fail "probe hanging is bounded and unreachable" "rc=$rc elapsed=${elapsed}s"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 12 (#929): premium_hook_probe — missing feature_key or missing
+# probe_cmd -> NOT_APPLICABLE (2), never a shell error.
+# ---------------------------------------------------------------------------
+test_probe_missing_required_args_not_applicable() {
+  local sb rc1 rc2
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+
+  # shellcheck source=/dev/null
+  ( cd "$sb" && . "$LIB" && premium_hook_probe "" "true" "true" "true" ); rc1=$?
+  # shellcheck source=/dev/null
+  ( cd "$sb" && . "$LIB" && premium_hook_probe "search" "true" "" "true" ); rc2=$?
+
+  if [ "$rc1" -eq 2 ] && [ "$rc2" -eq 2 ]; then
+    mark_pass "premium_hook_probe: missing feature_key / probe_cmd -> NOT_APPLICABLE (2)"
+  else
+    mark_fail "probe missing required args" "rc1=$rc1 rc2=$rc2"
+  fi
+  rm -rf "$sb"
+}
+
 test_feature_absent_is_silent_noop
 test_feature_absent_defaults_to_enabled_when_asked
 test_feature_explicitly_false_overrides_default_true
@@ -297,6 +436,12 @@ test_throwing_payload_is_swallowed
 test_hanging_payload_is_killed_and_swallowed
 test_missing_required_args_are_silent_noop
 test_premium_feature_enabled_standalone
+test_probe_not_applicable_when_feature_disabled
+test_probe_not_applicable_when_component_absent
+test_probe_reachable_returns_zero
+test_probe_unreachable_on_failure
+test_probe_hanging_is_bounded_and_unreachable
+test_probe_missing_required_args_not_applicable
 
 echo ""
 echo "Passed: $PASS  Failed: $FAIL"

--- a/.claude/hooks/tests/test_reindex_on_session_start.sh
+++ b/.claude/hooks/tests/test_reindex_on_session_start.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 # Tests for reindex-on-session-start.sh AFTER its retrofit onto
-# _lib-premium-hook.sh (me2resh/apexyard#890). Behaviour-preservation is the
-# load-bearing property: everything this hook did before the retrofit must
-# still hold, plus the new features.yaml opt-out becomes available.
+# _lib-premium-hook.sh (me2resh/apexyard#890) AND its #929 reachability
+# probe. Behaviour-preservation is the load-bearing property for cases 1-6:
+# everything this hook did before the retrofit must still hold, plus the new
+# features.yaml opt-out. Cases 7-9 cover the #929 acceptance criteria — the
+# three reachability states (reachable / configured-unreachable / not
+# configured) the SessionStart advisory must now distinguish.
 #
 # Each case builds an isolated sandbox with a synthetic ops-fork anchor and
 # a stub `apexyard-search` binary on PATH, then runs the hook as a real
@@ -49,6 +52,25 @@ case "$mode" in
   hang) sleep 30 ;;
   *) exit 0 ;;
 esac
+EOF
+  chmod +x "$sb/bin/apexyard-search"
+}
+
+# Installs a stub `apexyard-search` on PATH (via $1/bin) whose `doctor`
+# subcommand (the #929 reachability probe) fails, while every OTHER
+# subcommand (e.g. `reindex`) would succeed if it were ever invoked — lets a
+# test prove the reindex payload is genuinely skipped, not merely also
+# failing for an unrelated reason.
+install_stub_cli_doctor_fails() {
+  local sb="$1"
+  mkdir -p "$sb/bin"
+  cat > "$sb/bin/apexyard-search" <<EOF
+#!/bin/bash
+echo "\$@" >> "$sb/bin-marker"
+if [ "\$1" = "doctor" ]; then
+  exit 1
+fi
+exit 0
 EOF
   chmod +x "$sb/bin/apexyard-search"
 }
@@ -174,7 +196,9 @@ test_cli_failure_does_not_propagate() {
 
 # ---------------------------------------------------------------------------
 # Case 6: the underlying apexyard-search hangs past the configured timeout
-# -> the hook still exits 0 promptly (bounded wall-clock).
+# -> the hook still exits 0 promptly (bounded wall-clock). Since #929, the
+# reachability probe runs BEFORE the reindex payload and hits the hanging
+# stub first — bound both timeouts so the case stays fast and deterministic.
 # ---------------------------------------------------------------------------
 test_cli_hang_is_bounded() {
   local sb start end elapsed rc
@@ -189,7 +213,7 @@ test_cli_hang_is_bounded() {
   fi
 
   start=$(date +%s)
-  run_hook_in "$sb" APEXYARD_SEARCH_REINDEX_TIMEOUT=1 >/dev/null
+  run_hook_in "$sb" APEXYARD_SEARCH_PROBE_TIMEOUT=1 APEXYARD_SEARCH_REINDEX_TIMEOUT=1 >/dev/null
   rc=$?
   end=$(date +%s)
   elapsed=$((end - start))
@@ -202,12 +226,96 @@ test_cli_hang_is_bounded() {
   rm -rf "$sb"
 }
 
+# ---------------------------------------------------------------------------
+# Case 7 (#929): reachability probe REACHABLE -> unchanged happy path. The
+# reindex still runs AND no "not reachable" degrade note is printed — proves
+# the new probe step doesn't regress (or falsely warn on) the healthy case.
+# ---------------------------------------------------------------------------
+test_reachable_probe_runs_reindex_silently() {
+  local sb out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  install_stub_cli "$sb" ok
+
+  out=$(run_hook_in "$sb")
+  rc=$?
+
+  if [ "$rc" -eq 0 ] && [ -f "$sb/bin-marker" ] && grep -q "reindex" "$sb/bin-marker" \
+    && ! echo "$out" | grep -qi "not reachable"; then
+    mark_pass "reachable probe -> reindex runs, no 'not reachable' warning (#929)"
+  else
+    mark_fail "reachable probe -> reindex runs silently" \
+      "rc=$rc out=[$out] invoked=$([ -f "$sb/bin-marker" ] && echo yes || echo no)"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 8 (#929): reachability probe UNREACHABLE (the CLI is on PATH but its
+# `doctor` subcommand fails) -> an honest degrade note is printed INSTEAD of
+# the reindex nudge, and `reindex` is never invoked. Still exits 0 (advisory
+# only, never blocks session start).
+# ---------------------------------------------------------------------------
+test_configured_but_unreachable_warns_and_skips_reindex() {
+  local sb out rc
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  install_stub_cli_doctor_fails "$sb"
+
+  out=$(run_hook_in "$sb")
+  rc=$?
+
+  if [ "$rc" -eq 0 ] && echo "$out" | grep -qi "not reachable" \
+    && [ -f "$sb/bin-marker" ] && ! grep -q "reindex" "$sb/bin-marker"; then
+    mark_pass "configured but unreachable -> honest warning, reindex skipped (#929)"
+  else
+    mark_fail "configured but unreachable -> warn + skip reindex" \
+      "rc=$rc out=[$out] marker=[$(cat "$sb/bin-marker" 2>/dev/null)]"
+  fi
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 9 (#929): a hanging `doctor` probe is bounded by its OWN timeout and
+# treated as UNREACHABLE (degrade note printed, reindex skipped) — not just
+# "no output", proving the timeout path routes through the same honest
+# message as an explicit probe failure.
+# ---------------------------------------------------------------------------
+test_hanging_probe_is_bounded_and_treated_unreachable() {
+  local sb out rc start end elapsed
+  sb=$(mktemp -d)
+  build_sandbox "$sb"
+  install_stub_cli "$sb" hang
+
+  if ! command -v timeout >/dev/null 2>&1 && ! command -v gtimeout >/dev/null 2>&1; then
+    echo "  SKIP: neither timeout nor gtimeout is installed on this machine"
+    rm -rf "$sb"
+    return 0
+  fi
+
+  start=$(date +%s)
+  out=$(run_hook_in "$sb" APEXYARD_SEARCH_PROBE_TIMEOUT=1)
+  rc=$?
+  end=$(date +%s)
+  elapsed=$((end - start))
+
+  if [ "$rc" -eq 0 ] && [ "$elapsed" -lt 15 ] && echo "$out" | grep -qi "not reachable"; then
+    mark_pass "hanging probe killed within its own timeout, treated as unreachable (elapsed=${elapsed}s) (#929)"
+  else
+    mark_fail "hanging probe bounded + unreachable" "rc=$rc elapsed=${elapsed}s out=[$out]"
+  fi
+  rm -rf "$sb"
+}
+
 test_no_cli_is_silent_noop
 test_kill_switch_is_silent_noop
 test_cli_present_no_features_yaml_still_runs
 test_features_yaml_explicit_disable_wins
 test_cli_failure_does_not_propagate
 test_cli_hang_is_bounded
+test_reachable_probe_runs_reindex_silently
+test_configured_but_unreachable_warns_and_skips_reindex
+test_hanging_probe_is_bounded_and_treated_unreachable
 
 echo ""
 echo "Passed: $PASS  Failed: $FAIL"


### PR DESCRIPTION
## Summary
- **Adds a reachability probe, not just a presence check** — `reindex-on-session-start.sh` used to gate purely on `command -v apexyard-search` (is the binary on PATH?). A binary that's present but broken (crashed dependency, stale venv, hung process) looked identical to a healthy install, so the hook would nudge a reindex that couldn't succeed and an agent would silently fall back to grep+Read without ever being told search wasn't actually working.
- **New `premium_hook_probe()` in `_lib-premium-hook.sh`** — a bounded liveness-check sibling to the existing fire-and-forget `premium_hook_run()`. Same feature-flag + presence gating, but instead of always returning 0 it returns a three-way result the caller branches on: `0` REACHABLE, `1` UNREACHABLE, `2` NOT_APPLICABLE (disabled/unconfigured). Same timeout-guarded child-process shape as `premium_hook_run`, with its own shorter default timeout (5s) since a liveness check should be fast even when the real payload gets a longer budget.
- **The hook now probes `apexyard-search doctor`** (a fast, side-effect-free index-health report that always exits 0 on a healthy CLI) before nudging a reindex. Reachable → unchanged behaviour. Unreachable → one honest stderr line ("configured but not reachable — falling back to grep+Read") instead of a reindex nudge that can't succeed. Not configured → unchanged silent no-op. Always exits 0 — still purely advisory, never blocks session start.

## Testing
1. `bash .claude/hooks/tests/test_reindex_on_session_start.sh` — 9/9 pass, including 3 new cases for the reachable / configured-unreachable / not-configured states plus a hanging-probe-is-bounded case.
2. `bash .claude/hooks/tests/test_lib_premium_hook.sh` — 15/15 pass, including 6 new cases directly exercising `premium_hook_probe`'s three-way return code and its own timeout guard.
3. `bash bin/run-hook-tests.sh` — 106/107 pass; the one failure (`test_sync_codex_adapter.sh`) is a pre-existing, unrelated environment gap (a missing `block-test.sh` fixture) — reproduced identically with this PR's changes stashed out.
4. `bash -n` on both changed hook files — clean.

Closes #929

---

## Glossary
| Term | Definition |
|------|------------|
| Reachability probe | A cheap, bounded, side-effect-free check of whether a component can actually respond right now — distinct from a presence check, which only confirms it's installed |
| `premium_hook_probe` | New shared-harness function (`_lib-premium-hook.sh`) returning a three-way liveness result: REACHABLE (0) / UNREACHABLE (1) / NOT_APPLICABLE (2) |
| `apexyard-search doctor` | An existing CLI subcommand that reports index-health (freshness) as JSON; reused here purely as a fast, always-exits-0-when-healthy liveness probe |
| Fail-soft | Degrade quietly (fall back to grep+Read) and never block, when a premium dependency is down |
