### PR TITLE
feat(#914): onboarding depth adaptivity — terse vs guided + override

### DIFF
--- a/.claude/hooks/_lib-onboarding-depth-mode.sh
+++ b/.claude/hooks/_lib-onboarding-depth-mode.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# _lib-onboarding-depth-mode.sh — shared helpers for the onboarding depth-mode
+# session marker (.claude/session/onboarding-depth-mode ∈ {terse, guided}).
+#
+# Ticket: me2resh/apexyard#914 (increment-2 M6 — depth adaptivity: terse vs
+# guided + override + transparency). Technical design:
+# docs/technical-designs/onboarding-increment-2.md § D2/D7.
+#
+# THE SIGNAL VS THE MODE — two distinct things (design § D2). Increment 1
+# captured `.claude/session/onboarding-tech-level` ∈ {engineer, non-engineer,
+# ambiguous} — the *inference input*. This lib owns the separate, effective
+# *rendering setting* the adopter can flip: `.claude/session/
+# onboarding-depth-mode` ∈ {terse, guided}. This lib never writes the
+# tech-level signal file — only reads it as a one-time derivation input.
+#
+# Functions (sourced; do not exec this file directly):
+#   depth_mode_marker_path()
+#       Echoes the resolved marker path for the current ops root. Empty
+#       string if there's no git toplevel at all.
+#   depth_mode_read()
+#       Echoes the current depth mode: terse | guided.
+#       SAFE DEFAULT (D2/D7): an absent, unreadable, or unrecognised
+#       marker echoes "terse" — never blocks, never guesses guided. This
+#       is what makes the #913/#914 parallel build correctness-safe: even
+#       if #913's asides land before this ticket's mode-writer, an unset
+#       marker renders terse (zero asides).
+#   depth_mode_write(mode)
+#       Writes "terse" or "guided" to the marker. Rejects any other value
+#       (prints to stderr, returns 1, no write) — the marker must only
+#       ever hold one of the two canonical values.
+#   depth_mode_derive_from_signal(signal)
+#       Pure mapping, no I/O: engineer->terse, non-engineer->guided.
+#       Anything else (ambiguous / empty / unrecognised) prints nothing
+#       and returns 1 — the caller must ask a fresh low-friction question
+#       (inc-1 D5) rather than silently defaulting to guided.
+#   depth_mode_classify_override(phrase)
+#       Pure mapping, no I/O: classifies a plain-language phrase against
+#       the two override families named in design § D2 and echoes
+#       terse | guided | "" (no match). Case-insensitive substring match.
+#   depth_mode_report()
+#       Echoes the FR-9 transparency sentence for the CURRENT marker
+#       value (reads via depth_mode_read — default terse). Read-only.
+#
+# CONTRACT (the "presentation only" invariant): this lib touches ONLY the
+# depth-mode marker file. It never reads or writes anything under
+# `.claude/session/reviews/`, never touches a `*-rex.approved` /
+# `*-ceo.approved` / `*-security.approved` / `*-architecture.approved`
+# marker, and never edits a gate, permission, or role-boundary file. See
+# `.claude/hooks/tests/test_depth_mode.sh`'s invariant case — the
+# mechanical guard for design § "Depth mode is presentation only".
+
+# Don't run twice in the same shell.
+[ -n "${_LIB_ONBOARDING_DEPTH_MODE_SOURCED:-}" ] && return 0
+_LIB_ONBOARDING_DEPTH_MODE_SOURCED=1
+
+_DEPTH_MODE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -f "$_DEPTH_MODE_LIB_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$_DEPTH_MODE_LIB_DIR/_lib-ops-root.sh"
+fi
+
+depth_mode_marker_path() {
+  local repo_root root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [ -z "$repo_root" ]; then
+    echo ""
+    return 0
+  fi
+  root="$repo_root"
+  if command -v resolve_ops_root >/dev/null 2>&1; then
+    root=$(resolve_ops_root "$repo_root")
+    [ -n "$root" ] || root="$repo_root"
+  fi
+  echo "$root/.claude/session/onboarding-depth-mode"
+  return 0
+}
+
+depth_mode_read() {
+  local marker value
+  marker=$(depth_mode_marker_path)
+  if [ -n "$marker" ] && [ -f "$marker" ]; then
+    value=$(tr -d '[:space:]' < "$marker" 2>/dev/null)
+    case "$value" in
+      terse|guided)
+        echo "$value"
+        return 0
+        ;;
+    esac
+  fi
+  # Safe default (D2 / D7): absent, unreadable, or unrecognised -> terse.
+  echo "terse"
+  return 0
+}
+
+depth_mode_write() {
+  local mode="$1" marker
+  case "$mode" in
+    terse|guided) ;;
+    *)
+      echo "depth_mode_write: invalid mode '$mode' (must be terse|guided) — refusing to write" >&2
+      return 1
+      ;;
+  esac
+  marker=$(depth_mode_marker_path)
+  if [ -z "$marker" ]; then
+    echo "depth_mode_write: could not resolve marker path (no git toplevel)" >&2
+    return 1
+  fi
+  mkdir -p "$(dirname "$marker")"
+  printf '%s' "$mode" > "$marker"
+  return 0
+}
+
+depth_mode_derive_from_signal() {
+  local signal="$1"
+  case "$signal" in
+    engineer)
+      echo "terse"
+      return 0
+      ;;
+    non-engineer)
+      echo "guided"
+      return 0
+      ;;
+    *)
+      # ambiguous / empty / unrecognised — caller must ask, not guess.
+      return 1
+      ;;
+  esac
+}
+
+depth_mode_classify_override() {
+  local phrase="$1" lower
+  lower=$(printf '%s' "$phrase" | tr '[:upper:]' '[:lower:]')
+
+  case "$lower" in
+    *"explain more"*|*"explain things more"*|*"explain it more"*|*"i don't know these terms"*|*"i dont know these terms"*)
+      echo "guided"
+      return 0
+      ;;
+  esac
+
+  case "$lower" in
+    *"skip the explanations"*|*"skip explanations"*|*"be terse"*|*"i know this already"*|*"i already know this"*)
+      echo "terse"
+      return 0
+      ;;
+  esac
+
+  echo ""
+  return 0
+}
+
+depth_mode_report() {
+  local mode
+  mode=$(depth_mode_read)
+  if [ "$mode" = "guided" ]; then
+    echo "Guided — I explain terms in plain language as they come up. Say \"be terse\" to switch."
+  else
+    echo "Terse — I skip the plain-language explanations. Say \"explain more\" to switch to guided."
+  fi
+  return 0
+}

--- a/.claude/hooks/clear-onboarding-depth-mode-marker.sh
+++ b/.claude/hooks/clear-onboarding-depth-mode-marker.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# SessionStart hook: clear any stale onboarding depth-mode marker from a
+# previous session.
+#
+# The marker at .claude/session/onboarding-depth-mode signals to /onboard
+# and /tutorial the adopter's effective rendering depth (terse | guided —
+# see docs/technical-designs/onboarding-increment-2.md § D2, ticket
+# me2resh/apexyard#914). It is per-session by design: a returning adopter
+# should get depth re-derived (or re-asked) fresh, not silently inherit a
+# stale mode from a previous, unrelated session. If a flow is interrupted
+# mid-session (terminal closed, agent killed), the marker can be left
+# behind, silently carrying a prior session's depth choice into the next
+# one.
+#
+# This hook runs at SessionStart and removes the marker if present, so
+# every session starts with a clean slate — the next /onboard or /tutorial
+# run derives (or asks) fresh, per the design's D2 safe default (absent
+# marker -> terse).
+#
+# Silent on the no-marker path (the common case). Logs a one-line note to
+# stderr when clearing a stale marker so the operator sees what happened.
+# Same shape as clear-bootstrap-marker.sh / clear-active-reviewer-marker.sh
+# / clear-issue-skill-marker.sh.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# Walk up to find the apexyard fork root. Honours both the v2
+# `.apexyard-fork` marker and the legacy v1 anchor.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT=""
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  ROOT=$(resolve_ops_root "$REPO_ROOT")
+else
+  cur="$REPO_ROOT"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/.apexyard-fork" ]; then
+      ROOT="$cur"
+      break
+    fi
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      ROOT="$cur"
+      break
+    fi
+    parent=$(dirname "$cur"); [ "$parent" = "$cur" ] && break; cur="$parent"
+  done
+fi
+
+if [ -z "$ROOT" ]; then
+  exit 0
+fi
+
+MARKER="$ROOT/.claude/session/onboarding-depth-mode"
+if [ -f "$MARKER" ]; then
+  stale_value=$(tr -d '[:space:]' < "$MARKER" 2>/dev/null || echo "(unreadable)")
+  rm -f "$MARKER"
+  echo "ApexYard: cleared stale onboarding depth-mode marker (was: $stale_value) from a previous session." >&2
+fi
+
+exit 0

--- a/.claude/hooks/tests/test_clear_onboarding_depth_mode_marker.sh
+++ b/.claude/hooks/tests/test_clear_onboarding_depth_mode_marker.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/clear-onboarding-depth-mode-marker.sh
+#
+# SessionStart hook (me2resh/apexyard#914) that sweeps a stale
+# .claude/session/onboarding-depth-mode marker left behind by an
+# interrupted session, mirroring clear-bootstrap-marker.sh /
+# clear-active-reviewer-marker.sh. A stale marker would otherwise
+# silently carry a prior session's depth choice (terse|guided) into the
+# next one, instead of the design's per-session derive-or-ask contract
+# (docs/technical-designs/onboarding-increment-2.md § D2).
+#
+# Each case builds an isolated sandbox repo, optionally seeds the marker,
+# runs the hook from inside the sandbox, and asserts marker-file state +
+# stderr content.
+#
+# Exit 0 means all cases passed. Exit 1 on any failure (all cases still run).
+
+set -u
+
+export APEXYARD_OPS_DISABLE_PIN=1
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/clear-onboarding-depth-mode-marker.sh"
+LIB_OPS_ROOT="$(cd "$(dirname "$0")/.." && pwd)/_lib-ops-root.sh"
+
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$LIB_OPS_ROOT" ]; then
+  echo "FAIL: _lib-ops-root.sh not found at $LIB_OPS_ROOT" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    touch onboarding.yaml apexyard.projects.yaml
+    git add onboarding.yaml apexyard.projects.yaml
+    git commit -q -m "init"
+  )
+  mkdir -p "$sb/.claude/hooks" "$sb/.claude/session"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/clear-onboarding-depth-mode-marker.sh"
+  cp "$LIB_OPS_ROOT" "$sb/.claude/hooks/_lib-ops-root.sh"
+  chmod +x "$sb/.claude/hooks/clear-onboarding-depth-mode-marker.sh"
+  echo "$sb"
+}
+
+# run_hook <sandbox> <expect_grep|""> <case_name>
+run_hook() {
+  local sb="$1" expect_grep="$2" case_name="$3"
+  local stderr_file
+  stderr_file=$(mktemp)
+  (
+    cd "$sb" || exit 1
+    "$sb/.claude/hooks/clear-onboarding-depth-mode-marker.sh" 2>"$stderr_file"
+  )
+  local rc=$?
+  local ok=1
+
+  if [ "$rc" != "0" ]; then
+    echo "FAIL [$case_name]: exit $rc (expected 0)" >&2
+    ok=0
+  fi
+
+  if [ -z "$expect_grep" ]; then
+    if [ -s "$stderr_file" ]; then
+      echo "FAIL [$case_name]: expected silent, got stderr" >&2
+      ok=0
+    fi
+  else
+    if ! grep -qE "$expect_grep" "$stderr_file"; then
+      echo "FAIL [$case_name]: stderr did not match /$expect_grep/" >&2
+      ok=0
+    fi
+  fi
+
+  if [ "$ok" = "1" ]; then
+    PASS=$((PASS+1))
+    echo "PASS [$case_name]"
+  else
+    sed 's/^/    stderr: /' "$stderr_file" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="$FAILED_CASES $case_name"
+  fi
+  rm -f "$stderr_file"
+}
+
+# -------------------- CASE 1: no marker present — silent no-op --------------------
+case1() {
+  local sb
+  sb=$(make_sandbox)
+  run_hook "$sb" "" "no-marker-silent"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 2: stale "guided" marker present — cleared + logged --------------------
+case2() {
+  local sb
+  sb=$(make_sandbox)
+  local marker="$sb/.claude/session/onboarding-depth-mode"
+  printf '%s' "guided" > "$marker"
+  run_hook "$sb" "cleared stale onboarding depth-mode marker.*was: guided" "stale-guided-marker-cleared"
+  if [ -f "$marker" ]; then
+    echo "FAIL [stale-guided-marker-cleared]: marker file still present after sweep" >&2
+    FAIL=$((FAIL+1))
+    PASS=$((PASS-1))
+  fi
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 3: stale "terse" marker present — cleared + logged --------------------
+case3() {
+  local sb
+  sb=$(make_sandbox)
+  local marker="$sb/.claude/session/onboarding-depth-mode"
+  printf '%s' "terse" > "$marker"
+  run_hook "$sb" "cleared stale onboarding depth-mode marker.*was: terse" "stale-terse-marker-cleared"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 4: idempotent — running twice is still silent the 2nd time --------------------
+case4() {
+  local sb
+  sb=$(make_sandbox)
+  local marker="$sb/.claude/session/onboarding-depth-mode"
+  printf '%s' "guided" > "$marker"
+  run_hook "$sb" "cleared stale onboarding depth-mode marker" "idempotent-first-sweep"
+  run_hook "$sb" "" "idempotent-second-sweep-silent"
+  rm -rf "$sb"
+}
+
+case1
+case2
+case3
+case4
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_depth_mode.sh
+++ b/.claude/hooks/tests/test_depth_mode.sh
@@ -1,0 +1,368 @@
+#!/bin/bash
+# Unit tests for .claude/hooks/_lib-onboarding-depth-mode.sh
+#
+# Ticket: me2resh/apexyard#914 (increment-2 M6 — depth adaptivity: terse vs
+# guided + override + transparency). Technical design:
+# docs/technical-designs/onboarding-increment-2.md § D2/D7.
+#
+# Coverage (per the design's Testing Strategy for #914 t6):
+#   - derivation from each `onboarding-tech-level` signal value
+#   - depth_mode_read's safe default (absent/garbage marker -> terse)
+#   - override phrase classification (both families + no-match)
+#   - FR-9 transparency report text for both modes
+#   - INVARIANT: exercising every depth-mode function never writes a
+#     gate/permission/approval marker (`.claude/session/reviews/**`,
+#     `*-rex.approved`, `*-ceo.approved`, `*-security.approved`,
+#     `*-architecture.approved`) — the mechanical guard for design
+#     § "Depth mode is presentation only"
+#
+# Each case builds an isolated sandbox repo, sources the lib inside it,
+# and asserts stdout/return-code/file-state. Exit 0 means all cases
+# passed. Exit 1 on any failure (all cases still run).
+
+set -u
+
+export APEXYARD_OPS_DISABLE_PIN=1
+
+LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-onboarding-depth-mode.sh"
+LIB_OPS_ROOT="$(cd "$(dirname "$0")/.." && pwd)/_lib-ops-root.sh"
+
+if [ ! -f "$LIB_SRC" ]; then
+  echo "FAIL: lib not found at $LIB_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$LIB_OPS_ROOT" ]; then
+  echo "FAIL: _lib-ops-root.sh not found at $LIB_OPS_ROOT" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    touch onboarding.yaml apexyard.projects.yaml
+    git add onboarding.yaml apexyard.projects.yaml
+    git commit -q -m "init"
+  )
+  mkdir -p "$sb/.claude/hooks" "$sb/.claude/session"
+  cp "$LIB_SRC" "$sb/.claude/hooks/_lib-onboarding-depth-mode.sh"
+  cp "$LIB_OPS_ROOT" "$sb/.claude/hooks/_lib-ops-root.sh"
+  echo "$sb"
+}
+
+# assert_eq <case_name> <expected> <actual>
+assert_eq() {
+  local case_name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS+1))
+    echo "PASS [$case_name]"
+  else
+    echo "FAIL [$case_name]: expected '$expected', got '$actual'" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="$FAILED_CASES $case_name"
+  fi
+}
+
+# assert_rc <case_name> <expected_rc> <actual_rc>
+assert_rc() {
+  local case_name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS+1))
+    echo "PASS [$case_name]"
+  else
+    echo "FAIL [$case_name]: expected rc $expected, got rc $actual" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="$FAILED_CASES $case_name"
+  fi
+}
+
+# ============================================================
+# derive_from_signal — pure mapping
+# ============================================================
+
+case_derive() {
+  local sb out rc
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-depth-mode.sh
+
+    out=$(depth_mode_derive_from_signal "engineer"); rc=$?
+    echo "engineer:$out:$rc"
+
+    out=$(depth_mode_derive_from_signal "non-engineer"); rc=$?
+    echo "non-engineer:$out:$rc"
+
+    out=$(depth_mode_derive_from_signal "ambiguous"); rc=$?
+    echo "ambiguous:$out:$rc"
+
+    out=$(depth_mode_derive_from_signal ""); rc=$?
+    echo "empty:$out:$rc"
+  ) > "$sb/derive.out"
+
+  assert_eq "derive-engineer-to-terse" "engineer:terse:0" "$(sed -n '1p' "$sb/derive.out")"
+  assert_eq "derive-non-engineer-to-guided" "non-engineer:guided:0" "$(sed -n '2p' "$sb/derive.out")"
+  assert_eq "derive-ambiguous-fails-no-guess" "ambiguous::1" "$(sed -n '3p' "$sb/derive.out")"
+  assert_eq "derive-empty-fails-no-guess" "empty::1" "$(sed -n '4p' "$sb/derive.out")"
+
+  rm -rf "$sb"
+}
+
+# ============================================================
+# depth_mode_read — safe default
+# ============================================================
+
+case_read_default() {
+  local sb out
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-depth-mode.sh
+    depth_mode_read
+  ) > "$sb/read1.out"
+  assert_eq "read-absent-marker-defaults-terse" "terse" "$(cat "$sb/read1.out")"
+
+  mkdir -p "$sb/.claude/session"
+  printf 'guided' > "$sb/.claude/session/onboarding-depth-mode"
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-depth-mode.sh
+    depth_mode_read
+  ) > "$sb/read2.out"
+  assert_eq "read-guided-marker-reflected" "guided" "$(cat "$sb/read2.out")"
+
+  printf 'garbage-value' > "$sb/.claude/session/onboarding-depth-mode"
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-depth-mode.sh
+    depth_mode_read
+  ) > "$sb/read3.out"
+  assert_eq "read-garbage-marker-safe-default-terse" "terse" "$(cat "$sb/read3.out")"
+
+  rm -rf "$sb"
+}
+
+# ============================================================
+# depth_mode_write — writes + rejects invalid values
+# ============================================================
+
+case_write() {
+  local sb rc
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-depth-mode.sh
+    depth_mode_write "guided"
+  )
+  assert_eq "write-guided-persists" "guided" "$(cat "$sb/.claude/session/onboarding-depth-mode" 2>/dev/null)"
+
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-depth-mode.sh
+    depth_mode_write "terse"
+  )
+  assert_eq "write-terse-overwrites" "terse" "$(cat "$sb/.claude/session/onboarding-depth-mode" 2>/dev/null)"
+
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-depth-mode.sh
+    depth_mode_write "chaotic-neutral" 2>/dev/null
+  )
+  rc=$?
+  assert_rc "write-invalid-mode-rejected-rc1" "1" "$rc"
+  assert_eq "write-invalid-mode-does-not-overwrite" "terse" "$(cat "$sb/.claude/session/onboarding-depth-mode" 2>/dev/null)"
+
+  rm -rf "$sb"
+}
+
+# ============================================================
+# depth_mode_classify_override — phrase families (design § D2)
+# ============================================================
+
+case_classify_override() {
+  local sb
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-depth-mode.sh
+
+    echo "guided1:$(depth_mode_classify_override "actually, explain things more")"
+    echo "guided2:$(depth_mode_classify_override "Explain more please")"
+    echo "guided3:$(depth_mode_classify_override "honestly I don't know these terms")"
+    echo "terse1:$(depth_mode_classify_override "skip the explanations")"
+    echo "terse2:$(depth_mode_classify_override "just be terse")"
+    echo "terse3:$(depth_mode_classify_override "I know this already")"
+    echo "none1:$(depth_mode_classify_override "what does this PR do")"
+    echo "none2:$(depth_mode_classify_override "")"
+  ) > "$sb/classify.out"
+
+  assert_eq "override-explain-things-more-guided" "guided1:guided" "$(sed -n '1p' "$sb/classify.out")"
+  assert_eq "override-explain-more-guided" "guided2:guided" "$(sed -n '2p' "$sb/classify.out")"
+  assert_eq "override-dont-know-terms-guided" "guided3:guided" "$(sed -n '3p' "$sb/classify.out")"
+  assert_eq "override-skip-explanations-terse" "terse1:terse" "$(sed -n '4p' "$sb/classify.out")"
+  assert_eq "override-be-terse-terse" "terse2:terse" "$(sed -n '5p' "$sb/classify.out")"
+  assert_eq "override-know-this-already-terse" "terse3:terse" "$(sed -n '6p' "$sb/classify.out")"
+  assert_eq "override-unrelated-phrase-no-match" "none1:" "$(sed -n '7p' "$sb/classify.out")"
+  assert_eq "override-empty-phrase-no-match" "none2:" "$(sed -n '8p' "$sb/classify.out")"
+
+  rm -rf "$sb"
+}
+
+# ============================================================
+# depth_mode_report — FR-9 transparency text
+# ============================================================
+
+case_report() {
+  local sb
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-depth-mode.sh
+    depth_mode_report
+  ) > "$sb/report_default.out"
+
+  if grep -qi "^Terse" "$sb/report_default.out" && grep -qi "explain more" "$sb/report_default.out"; then
+    PASS=$((PASS+1)); echo "PASS [report-default-terse-mentions-switch-phrase]"
+  else
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES report-default-terse-mentions-switch-phrase"
+    echo "FAIL [report-default-terse-mentions-switch-phrase]: $(cat "$sb/report_default.out")" >&2
+  fi
+
+  mkdir -p "$sb/.claude/session"
+  printf 'guided' > "$sb/.claude/session/onboarding-depth-mode"
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-depth-mode.sh
+    depth_mode_report
+  ) > "$sb/report_guided.out"
+
+  if grep -qi "^Guided" "$sb/report_guided.out" && grep -qi "be terse" "$sb/report_guided.out"; then
+    PASS=$((PASS+1)); echo "PASS [report-guided-mentions-switch-phrase]"
+  else
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES report-guided-mentions-switch-phrase"
+    echo "FAIL [report-guided-mentions-switch-phrase]: $(cat "$sb/report_guided.out")" >&2
+  fi
+
+  rm -rf "$sb"
+}
+
+# ============================================================
+# INVARIANT — depth mode never touches a gate/permission/approval marker
+#
+# Exercises derive -> write -> override -> report end-to-end (a full
+# simulated session), then asserts NOTHING under .claude/session/reviews/
+# exists and no *-rex.approved / *-ceo.approved / *-security.approved /
+# *-architecture.approved file exists anywhere in the sandbox. This is
+# the mechanical guard for design § "Depth mode is presentation only".
+# ============================================================
+
+case_invariant_no_gate_marker() {
+  local sb
+  sb=$(make_sandbox)
+
+  # Seed an inc-1 tech-level signal, same as /onboard would have written.
+  printf 'non-engineer' > "$sb/.claude/session/onboarding-tech-level"
+
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-depth-mode.sh
+
+    # 1. Derive from the seeded signal (non-engineer -> guided).
+    signal=$(cat .claude/session/onboarding-tech-level)
+    mode=$(depth_mode_derive_from_signal "$signal") || mode="terse"
+    depth_mode_write "$mode"
+
+    # 2. Adopter asks a transparency question.
+    depth_mode_report >/dev/null
+
+    # 3. Adopter overrides mid-session.
+    new_mode=$(depth_mode_classify_override "actually, be terse from now on")
+    [ -n "$new_mode" ] && depth_mode_write "$new_mode"
+
+    # 4. Adopter asks again post-override.
+    depth_mode_report >/dev/null
+
+    # 5. An ambiguous/ill-formed override attempt — must not write anything odd.
+    depth_mode_classify_override "hmm not sure" >/dev/null
+  )
+
+  # -- Assertion 1: the .claude/session/reviews/ directory was never created --
+  if [ -d "$sb/.claude/session/reviews" ]; then
+    echo "FAIL [invariant-no-reviews-dir]: .claude/session/reviews/ exists after exercising depth-mode functions" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES invariant-no-reviews-dir"
+  else
+    PASS=$((PASS+1)); echo "PASS [invariant-no-reviews-dir]"
+  fi
+
+  # -- Assertion 2: no gate/approval marker file exists anywhere in the sandbox --
+  local hits
+  hits=$(find "$sb" -type f \( \
+      -name "*-rex.approved" -o \
+      -name "*-ceo.approved" -o \
+      -name "*-security.approved" -o \
+      -name "*-architecture.approved" \
+    \) 2>/dev/null)
+  if [ -n "$hits" ]; then
+    echo "FAIL [invariant-no-approval-marker-anywhere]: found $hits" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES invariant-no-approval-marker-anywhere"
+  else
+    PASS=$((PASS+1)); echo "PASS [invariant-no-approval-marker-anywhere]"
+  fi
+
+  # -- Assertion 3: the ONLY files under .claude/session/ are the depth-mode
+  #    marker itself and the pre-seeded tech-level signal — no surprise state.
+  local session_files
+  session_files=$(cd "$sb/.claude/session" && find . -type f | sed 's|^\./||' | sort | tr '\n' ',')
+  local expected="onboarding-depth-mode,onboarding-tech-level,"
+  if [ "$session_files" = "$expected" ]; then
+    PASS=$((PASS+1)); echo "PASS [invariant-only-expected-session-files]"
+  else
+    echo "FAIL [invariant-only-expected-session-files]: expected '$expected', got '$session_files'" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES invariant-only-expected-session-files"
+  fi
+
+  # -- Assertion 4: the final mode reflects the override (terse), proving the
+  #    override path actually took effect during the same run as the checks
+  #    above (not just a no-op that happened to leave no marker).
+  local final_mode
+  final_mode=$(cat "$sb/.claude/session/onboarding-depth-mode" 2>/dev/null)
+  assert_eq "invariant-override-took-effect" "terse" "$final_mode"
+
+  rm -rf "$sb"
+}
+
+case_derive
+case_read_default
+case_write
+case_classify_override
+case_report
+case_invariant_no_gate_marker
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,10 @@
           },
           {
             "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/clear-onboarding-depth-mode-marker.sh\"'"
+          },
+          {
+            "type": "command",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/clear-issue-skill-marker.sh\"'"
           },
           {

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -10,17 +10,34 @@ allowed-tools: Bash, Read, Write, Skill
 # /onboard — Guided First-Run Onboarding
 
 This is increment 1 of the guided-onboarding walking skeleton (technical
-design: `docs/technical-designs/onboarding-increment-1.md`, ticket #910).
+design: `docs/technical-designs/onboarding-increment-1.md`, ticket #910),
+now layered with increment 2's **depth adaptivity** (technical design:
+`docs/technical-designs/onboarding-increment-2.md` § D2/D7, ticket #914).
 `/onboard` is a **thin orchestrator + router**, not a replacement for
 `/setup` or `/handover` — it sequences those two skills (plus `/feature`)
 behind a capability tour and an explicit branch. It never edits `/setup`,
 `/handover`, or `/feature`; their direct and scripted behaviour stays
 byte-for-byte unchanged (see AgDR-0097).
 
-Ships **terse mode only** in this increment — the teach-in-context glossary
-and terse/guided depth adaptivity are increment 2 (#911 and beyond). This
-flow *captures* a technical-level signal (D5) but does not yet branch
-rendering on it.
+**This flow now renders in one of two depth modes — `terse` or `guided`
+— off a single shared session marker, not a forked skill** (US-5/FR-6).
+Terse renders every step exactly as increment 1 did (byte-for-byte
+identical output — NFR Backward-compat). Guided adds one short
+"why this matters" framing sentence after each major step. Depth mode
+changes **only** explanatory narration — it never changes which gate
+fires, which approval is required, or any role boundary (the
+"presentation only" invariant, mechanically guarded by
+`.claude/hooks/tests/test_depth_mode.sh`'s invariant case). See Step 3.5
+below for derivation, and "Depth mode override + transparency" for the
+mid-session override (FR-6) and the "what mode am I in?" affordance
+(FR-9).
+
+The **per-term teach-in-context glossary + just-in-time asides** (#913)
+and the **ambient any-session lookup + full `/tutorial` glossary render**
+(#915) are sibling tickets, not yet built as of this ticket — guided mode
+here provides generic narration only. This flow already gates on the
+shared `.claude/session/onboarding-depth-mode` marker (D7's safe default:
+absent → terse), so #913's asides need no rework once they land.
 
 ## Path resolution
 
@@ -135,17 +152,108 @@ tools vs. a vague or absent description). Infer silently:
 
   Answer maps to `engineer` (used before) or `non-engineer` (new to it).
 
-Record the captured signal — this is a one-line seam for increment 2, not a
-rendering switch yet (increment 1 is terse-only regardless of the signal):
+Record the captured signal — increment 2 (#914) now acts on this
+immediately, in the very next step:
 
 ```bash
 mkdir -p .claude/session && echo "$SIGNAL" > .claude/session/onboarding-tech-level
 ```
 
 Where `$SIGNAL` is `engineer`, `non-engineer`, or `ambiguous` (if neither
-signal was usable). Never block on this — a wrong guess costs nothing since
-increment 1 doesn't act on it, and increment 2's reversibility NFR lets the
-adopter override in plain language whenever depth adaptivity ships.
+signal was usable). Never block on this — a wrong guess costs little,
+since the adopter can override the derived depth mode in plain language
+at any point (NFR Reversibility — see "Depth mode override + transparency"
+below).
+
+### 3.5 Depth mode derivation (#914 — design § D2)
+
+Immediately after writing the tech-level signal above, derive the
+session's effective **depth mode** — the setting that actually controls
+rendering verbosity for the rest of THIS flow, and for any later
+`/tutorial` run this session (D2's signal-vs-mode split: the tech-level
+signal is the *inference input*; depth mode is the *effective setting*
+the adopter can flip).
+
+Source the shared helper and derive from the signal just captured:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-onboarding-depth-mode.sh"
+mode=$(depth_mode_derive_from_signal "$SIGNAL") || mode=""
+```
+
+- `$SIGNAL` is `engineer` → `$mode` is `terse`.
+- `$SIGNAL` is `non-engineer` → `$mode` is `guided`.
+- `$SIGNAL` is `ambiguous` (the derive call fails, `$mode` is empty) —
+  this shouldn't normally happen here since Step 3's fallback question
+  already resolved `engineer`/`non-engineer`, but handle it defensively:
+  ask the SAME one-line fallback question from Step 3 if you haven't
+  already, map the answer (`engineer`→`terse`, `non-engineer`→`guided`),
+  and set `$mode` directly. Never leave `$mode` empty.
+
+Write it:
+
+```bash
+depth_mode_write "$mode"
+```
+
+From this point on, render the rest of `/onboard` **in `$mode`**:
+
+- **`terse`** — render every remaining step exactly as increment 1 did.
+  No framing sentences, no "why this matters" narration. Output is
+  byte-for-byte identical to increment 1 (NFR Backward-compat).
+- **`guided`** — after each major step (capability tour, the `/setup`
+  handoff, the handover/new-project branch, the guided first win), add
+  ONE short plain-language "why this matters" sentence before moving on.
+  Keep it to a single sentence — this is generic narration, not a
+  per-term glossary aside (that's #913's job once it lands; this flow
+  already gates on the same `$mode` marker, so no rework is needed here).
+
+Depth mode is overridable for the rest of this session from any later
+step — see "Depth mode override + transparency" immediately below.
+
+### Depth mode override + transparency (design § D2, FR-6/FR-9)
+
+At any point after Step 3.5 (including during Steps 4–6), before writing
+your own response, check the adopter's last message for two things:
+
+**1. An override phrase.** Classify it with the shared helper:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-onboarding-depth-mode.sh"
+new_mode=$(depth_mode_classify_override "$ADOPTER_MESSAGE")
+```
+
+If `$new_mode` is `guided` or `terse`, write it immediately and confirm in
+one line, then continue the flow at the new depth from your very next
+render (NFR Reversibility — no config file touched, effect is instant,
+lossless):
+
+```bash
+[ -n "$new_mode" ] && depth_mode_write "$new_mode"
+```
+
+```
+Switching to guided — I'll explain terms as they come up.
+```
+
+```
+Switching to terse — I'll skip the plain-language explanations.
+```
+
+If `$new_mode` is empty, the message wasn't an override — continue
+normally.
+
+**2. A transparency question** ("what mode am I in?" or equivalent).
+Answer plainly using the helper's canned report — don't hand-write a new
+sentence each time:
+
+```bash
+depth_mode_report
+```
+
+This satisfies FR-9: it reads the marker (default `terse` if absent) and
+states the current mode plus how to switch. Answering this question is a
+**read** — it never writes anything.
 
 ### 4. Phase 3 — handover-vs-new-project branch
 
@@ -266,13 +374,11 @@ Want to try filing your first ticket? It's a real GitHub issue, not a demo
 
 ### 6. Closing
 
-Always end with a pointer to the standalone re-entry point (even though
-`/tutorial` ships in #911 — name it now so the reference lands with the
-first PR that needs it):
+Always end with a pointer to the standalone re-entry point:
 
 ```
 Come back anytime with /tutorial to replay this tour — it works on any
-fork state and never changes anything.
+fork state and never changes anything. Your depth mode carries over.
 ```
 
 ### 7. Clear the bootstrap marker (REQUIRED — every exit path)
@@ -294,12 +400,28 @@ re-run-offer exits, and on any decline/cancel path. Never leave it set.
    real repo target, decline honestly (Step 5).
 3. **One question at a time.** Same conversational rule as `/setup`,
    `/handover`, and `/feature`.
-4. **Terse mode only, this increment.** Don't add glossary asides or
-   depth-adaptive rendering — that's increment 2 (#911+). Capture the
-   technical-level signal; don't act on it yet.
+4. **Depth mode changes rendering only, never a gate.** Terse vs guided
+   controls explanatory narration alongside `/onboard`'s output — it must
+   NEVER change which gate fires, which approval is required, or any role
+   boundary. If you catch yourself about to skip a real gate/permission
+   check because the adopter is in guided mode (or add one because
+   they're in terse), that's a bug — stop and render the SAME underlying
+   gate, just described at the current mode's verbosity (design §
+   "Depth mode is presentation only"; mechanically guarded by
+   `.claude/hooks/tests/test_depth_mode.sh`'s invariant case).
 5. **The tour content lives in one file.** Never inline or paraphrase
    `docs/onboarding/capability-tour.md` — both `/onboard` and `/tutorial`
    read the same asset verbatim.
+6. **Per-term glossary asides (#913) and the ambient any-session lookup +
+   full `/tutorial` glossary render (#915) are sibling tickets, not part
+   of this flow yet.** Guided mode here is generic "why this matters"
+   narration only — never invent per-term definitions or fabricate a
+   glossary lookup ahead of #913/#915 landing.
+7. **Only ever write the depth-mode marker via the shared helper**
+   (`_lib-onboarding-depth-mode.sh`'s `depth_mode_write`) — never hand-edit
+   `.claude/session/onboarding-depth-mode` with a raw `echo`/redirect.
+   This keeps derivation, override, and the invariant test all going
+   through one code path.
 
 ---
 

--- a/.claude/skills/tutorial/SKILL.md
+++ b/.claude/skills/tutorial/SKILL.md
@@ -11,13 +11,22 @@ allowed-tools: Read, Bash
 
 This is ticket #911 (M3) of the guided-onboarding walking skeleton (technical
 design: `docs/technical-designs/onboarding-increment-1.md`, § D3/D4 and the
-"Standalone `/tutorial` Reusability Spec"). `/tutorial` is a **standalone,
-read-only re-entry point** to the same capability tour `/onboard` shows on
-first run — for the adopter who skipped it, missed it, or just wants to see
-it again without faking a fresh fork.
+"Standalone `/tutorial` Reusability Spec"), now layered with increment 2's
+**depth adaptivity** (technical design:
+`docs/technical-designs/onboarding-increment-2.md` § D2/D5/D7, ticket #914).
+`/tutorial` is a **standalone, read-only re-entry point** to the same
+capability tour `/onboard` shows on first run — for the adopter who
+skipped it, missed it, or just wants to see it again without faking a
+fresh fork.
 
-Ships **tour-only** in this increment. The teach-in-context glossary (US-4)
-is increment 2 and is **out of scope here**.
+**This ticket (#914) wires `/tutorial` onto the shared depth-mode marker**
+so it renders the tour in the adopter's current `terse`/`guided` mode
+(one short "why this matters" sentence per section in guided mode; bare,
+byte-for-byte unchanged rendering in terse — NFR Backward-compat). The
+**full teach-in-context glossary render** (US-6 in full — `/tutorial`
+growing to show all five glossary terms) is **#915** and still out of
+scope here; this ticket only makes the mechanism ready so #915 needs no
+rework once it lands (D7).
 
 ## What this skill does NOT do
 
@@ -32,14 +41,62 @@ never:
   for `/onboard` and the SessionStart hook, not for this skill)
 - Runs any part of the `/setup` or `/handover` flows
 - Writes to `apexyard.projects.yaml` or any other registry
-- Touches the active-ticket marker or any other session state required for
-  its own function (it may read `.claude/session/onboarding-tech-level` if
-  present, purely to pick a rendering nuance — never required)
+- Touches the active-ticket marker or the bootstrap marker
 
-Zero side effects. Running `/tutorial` should leave `git status` exactly as
-it was before the command ran.
+**One deliberate, narrow exception (design § D5):** this skill MAY both
+read and write the depth-mode marker
+(`.claude/session/onboarding-depth-mode`) — deriving or asking a mode, and
+honouring a plain-language override mid-`/tutorial`, is "solicited"
+teaching (the adopter is running `/tutorial` on purpose), not a side
+effect the increment-1 contract forbids. It may also read
+`.claude/session/onboarding-tech-level` if present, purely as a
+derivation input — this skill never writes that file.
+
+Zero OTHER side effects. Running `/tutorial` should leave `git status`
+exactly as it was before the command ran, aside from the gitignored
+depth-mode marker under `.claude/session/`.
 
 ## Process
+
+### 0. Resolve depth mode (design § D2/D5)
+
+Before rendering, resolve the session's depth mode:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-onboarding-depth-mode.sh"
+mode=$(depth_mode_read)
+```
+
+If a mode is already set this session (from an earlier `/onboard` run, or
+an earlier `/tutorial` invocation), `depth_mode_read` returns it —
+`terse` or `guided` — and you're done; skip to Step 1.
+
+If no mode marker exists yet (a cold `/tutorial` on a fork that never ran
+`/onboard`), try to derive one from the increment-1 tech-level signal, if
+present:
+
+```bash
+signal=$(cat .claude/session/onboarding-tech-level 2>/dev/null || echo "")
+mode=$(depth_mode_derive_from_signal "$signal") || mode=""
+```
+
+If `$mode` is still empty (no usable signal), this is a **solicited** flow
+(the adopter ran `/tutorial` on purpose), so it's fine to ask — use the
+SAME one-line fallback question increment-1's `/onboard` D5 uses:
+
+```
+Quick one — have you used git/GitHub before, or is this new to you?
+```
+
+Map the answer (`engineer`→`terse`, `non-engineer`→`guided`), then write
+it:
+
+```bash
+depth_mode_write "$mode"
+```
+
+Never block the tour on this — if the adopter doesn't want to answer,
+default to `terse` (the safe default, design § D2/D7) and proceed.
 
 ### 1. Read the shared tour asset
 
@@ -74,9 +131,17 @@ Do not fabricate tour content as a fallback.
 ### 2. Render the tour
 
 Print the file's content (the "What's a role?" / "What's a skill?" /
-"What's a gate?" sections plus the "How the loop works" closer). No
-depth-mode branching this increment — increment 1 is terse-only everywhere,
-including here (matches `/onboard`'s D5 scope caveat).
+"What's a gate?" sections plus the "How the loop works" closer), rendered
+in the `$mode` resolved in Step 0:
+
+- **`terse`** — render exactly as increment 1 did: no framing, no
+  extra sentences. Byte-for-byte identical to a terse-mode run
+  (NFR Backward-compat).
+- **`guided`** — after the tour content, add ONE short plain-language
+  "why this matters" sentence (e.g. tying the roles/skills/gates tour
+  back to what the adopter will actually see day to day). Keep it to a
+  single sentence — this is generic framing, not the per-term glossary
+  render (that's #915's job; this ticket only wires the mode mechanism).
 
 Open with a one-line frame so the adopter knows this is a replay, not a
 first-run flow:
@@ -88,7 +153,23 @@ Replaying the ApexYard capability tour — the same 60-second orientation
 
 Then render the tour content.
 
-### 3. Close
+### 3. Depth mode override + transparency (design § D2, FR-6/FR-9)
+
+Same handling as `/onboard`'s — before rendering, and at any later point
+this session, check the adopter's message for an override phrase or a
+transparency question:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-onboarding-depth-mode.sh"
+new_mode=$(depth_mode_classify_override "$ADOPTER_MESSAGE")
+[ -n "$new_mode" ] && depth_mode_write "$new_mode"
+```
+
+Confirm a switch in one line (`Switching to guided — …` /
+`Switching to terse — …`), same as `/onboard`. For "what mode am I in?",
+answer with `depth_mode_report` — a read, never a write.
+
+### 4. Close
 
 End with a short pointer back to normal work — no branch, no follow-up
 questions, no first-win prompt (that's `/onboard`'s job, not this skill's):
@@ -104,16 +185,23 @@ free of side effects.
    fresh every invocation; never inline, cache, or hand-copy its prose into
    this skill file. If the tour content needs to change, it changes in one
    place and both `/onboard` and `/tutorial` pick it up automatically.
-2. **No side effects, ever.** No writes to `onboarding.yaml`, the registry,
-   the active-ticket marker, or the bootstrap marker. If a future increment
-   needs `/tutorial` to record something, that's a new design decision, not
-   an assumption to make here.
+2. **No side effects, except the depth-mode marker.** No writes to
+   `onboarding.yaml`, the registry, the active-ticket marker, or the
+   bootstrap marker — ever. The ONE exception is
+   `.claude/session/onboarding-depth-mode` (design § D5): deriving,
+   asking, writing, or overriding it is in-contract "solicited" teaching,
+   and it's the only marker this skill may write. Always write it through
+   the shared helper (`_lib-onboarding-depth-mode.sh`'s `depth_mode_write`)
+   — never a raw `echo`/redirect.
 3. **Works on any fork state.** Configured, fresh, or pre-dating this
    feature entirely — the read-and-render behaviour must be identical in
-   all three. Do not branch on `fresh_fork_state()`.
-4. **Tour-only, this increment.** No glossary rendering, no on-demand term
-   lookup — increment 2 territory (see the technical design's Non-Goals and
-   Open Questions).
+   all three (aside from depth-mode rendering, which depends on the
+   marker/signal, not fork state). Do not branch on `fresh_fork_state()`.
+4. **Tour + depth-mode rendering only, this ticket (#914).** No per-term
+   glossary asides (that's #913) and no full glossary render or ambient
+   on-demand lookup (that's #915) — sibling tickets, not yet built. The
+   depth-mode marker this ticket wires is the shared mechanism both will
+   read/extend without rework (D7).
 
 ---
 


### PR DESCRIPTION
## Summary

- **`/onboard` and `/tutorial` now render in one of two depth modes — `terse` or `guided` — off a single shared session marker, not a forked skill.** Terse renders byte-for-byte identical to increment 1's output; guided adds one short "why this matters" sentence per major step. This is the increment-2 depth-adaptivity ticket (#914), built to the merged technical design's § D2/D7.
- **New shared library `_lib-onboarding-depth-mode.sh`** owns the `.claude/session/onboarding-depth-mode` marker as a deliberately separate signal from increment-1's `onboarding-tech-level` file — the design's rationale is that conflating "what we inferred" with "what the adopter chose" would corrupt the recorded inference the moment someone overrides their mode. The library is a small, pure-function shell API (`depth_mode_derive_from_signal`, `depth_mode_read`, `depth_mode_write`, `depth_mode_classify_override`, `depth_mode_report`) precisely so the mode logic is bash-unit-testable instead of living only in agent-followed prose.
- **Plain-language override takes effect immediately, mid-session** — "explain more" / "explain things more" / "I don't know these terms" flips to guided; "skip the explanations" / "be terse" / "I know this already" flips to terse. No config file is touched; the switch is instantaneous and lossless.
- **"What mode am I in?" (FR-9)** reads the marker (default `terse` if absent) and reports the mode plus how to switch it — a pure read, never a write.
- **New SessionStart hook `clear-onboarding-depth-mode-marker.sh`** (wired into `.claude/settings.json`) sweeps a stale depth-mode marker left by an interrupted session, mirroring the existing `clear-active-reviewer-marker.sh` / `clear-bootstrap-marker.sh` pattern — so a returning adopter always gets depth re-derived or re-asked fresh, never inherits a stale choice.
- **The safe default is `terse` (absent marker → terse → zero extra narration).** This is what makes the sibling ticket #913 (per-term glossary asides) correctness-safe to build in either order — even if #913's asides land before this ticket, an unset marker renders exactly as increment 1 did.
- **The load-bearing invariant: depth mode is presentation-only.** `test_depth_mode.sh` includes an explicit invariant case that exercises derive → write → override → report end-to-end and asserts nothing under `.claude/session/reviews/` was created and no `*-rex.approved` / `*-ceo.approved` / `*-security.approved` / `*-architecture.approved` marker exists anywhere in the sandbox afterward — the mechanical guard that depth mode can never change a gate, permission, or role boundary.

## Testing

1. `bash .claude/hooks/tests/test_depth_mode.sh` — 25/25 pass: signal derivation (`engineer`→terse, `non-engineer`→guided, ambiguous/empty→ask-don't-guess), `depth_mode_read`'s safe default (absent/garbage marker→terse), override phrase classification for both families plus no-match, FR-9 report text for both modes, and the no-gate-marker invariant.
2. `bash .claude/hooks/tests/test_clear_onboarding_depth_mode_marker.sh` — 5/5 pass: no-marker silent no-op, stale `guided`/`terse` marker cleared + logged, idempotent second sweep.
3. `bash bin/run-hook-tests.sh` — full framework suite: 110 tests discovered (108 pre-existing + this PR's 2 new files), 109 pass. The 1 failure (`test_sync_codex_adapter.sh`) is pre-existing and unrelated — verified by stashing this PR's changes and re-running against clean `upstream/dev` (same failure, same hardcoded-path root cause, before this PR touched anything).
4. `bash -n` on both new shell scripts — clean.
5. `npx markdownlint-cli2` (using the repo's `.markdownlint.json`) on both touched `.md` files — 0 errors.
6. `python3 -c "import json; json.load(open('.claude/settings.json'))"` — valid JSON after the SessionStart hook insertion; diff is a clean 4-line addition, no reformatting.
7. Manual diff review — `git diff --stat` confirms the change is scoped to exactly the surfaces the design's Surface Inventory names for #914 (the two skills, the new lib, the new hook, `settings.json`'s SessionStart wiring, and the two new tests). No touch to `/setup`, `/handover`, `/feature`, `capability-tour.md`, or any gate/permission file.

Closes #914

---

## Glossary

| Term | Definition |
|------|------------|
| Depth mode | The effective onboarding rendering setting (`terse` or `guided`) stored in `.claude/session/onboarding-depth-mode` — controls how much plain-language narration `/onboard` and `/tutorial` add, nothing else. |
| Tech-level signal | Increment 1's `.claude/session/onboarding-tech-level` marker (`engineer` / `non-engineer` / `ambiguous`) — the one-time inference input this ticket derives depth mode from. A signal, not a setting; never overwritten by an override. |
| Safe default | The design's correctness guarantee that an absent depth-mode marker always renders `terse` — protects the primary engineer persona and makes the #913/#914 parallel build order-independent. |
| Invariant test | The mechanical guard in `test_depth_mode.sh` proving depth-mode code paths never write a gate/permission/approval marker — the "presentation only" security story made testable. |
| Session marker | A gitignored per-session state file under `.claude/session/` — swept at SessionStart so nothing leaks between unrelated sessions. |
