### PR TITLE
feat(#913): onboarding JIT glossary asides (guided-mode)

### DIFF
--- a/.claude/hooks/_lib-onboarding-glossary-seen.sh
+++ b/.claude/hooks/_lib-onboarding-glossary-seen.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# _lib-onboarding-glossary-seen.sh — shared helpers for the onboarding
+# just-in-time glossary asides: the per-session seen-set marker
+# (.claude/session/onboarding-glossary-seen) and the glossary.md term
+# lookup the asides slice content from.
+#
+# Ticket: me2resh/apexyard#913 (increment-2 M5 — teach-in-context glossary
+# + just-in-time asides). Technical design:
+# docs/technical-designs/onboarding-increment-2.md § D1/D3/D7.
+#
+# THIS LIB IS GATED ON, NOT RESPONSIBLE FOR, DEPTH MODE. #914's
+# _lib-onboarding-depth-mode.sh owns the .claude/session/onboarding-depth-mode
+# marker (derivation, override, transparency). This lib only READS that
+# marker (via depth_mode_read) to decide whether an aside should fire at
+# all — it never writes it. D7's safe default (absent marker -> terse ->
+# depth_mode_read echoes "terse") makes this correctness-safe regardless
+# of whether #914's writer has run yet in a given session.
+#
+# Functions (sourced; do not exec this file directly):
+#   glossary_seen_marker_path()
+#       Echoes the resolved seen-set marker path for the current ops
+#       root. Empty string if there's no git toplevel at all. Same
+#       ops-root resolution as _lib-onboarding-depth-mode.sh (pin-first,
+#       walk-up fallback, via _lib-ops-root.sh when present).
+#   glossary_seen_has(term_key)
+#       Returns 0 (true) if term_key is already present in the seen-set
+#       marker (newline-delimited term keys), 1 otherwise. A missing or
+#       empty marker always returns 1 (nothing seen yet).
+#   glossary_seen_add(term_key)
+#       Appends term_key to the seen-set marker, creating it if absent.
+#       Idempotent: a no-op if the key is already present (never writes a
+#       duplicate line). Refuses (prints to stderr, returns 1, no write)
+#       an empty term_key.
+#   glossary_term_body(term_key)
+#       Pure read, no session-marker I/O: slices ONE term's plain-language
+#       definition out of docs/onboarding/glossary.md by its `<!-- term:
+#       ... -->` key-comment (D1's read contract — comma-separated
+#       surface spellings resolve to one entry, e.g. "issue" and "ticket"
+#       both hit the same section). Echoes the definition paragraph
+#       (trimmed, blank lines collapsed, the "**Example**:" line and
+#       anything after it excluded — asides are a short parenthetical,
+#       not the full entry). Echoes nothing and returns 1 if the term
+#       isn't found or the asset is missing. Resolved relative to the git
+#       toplevel — glossary.md is tracked framework content living in the
+#       SAME repo as this lib, not per-fork session state, so it needs no
+#       ops-root indirection the way the two session markers do.
+#   glossary_maybe_aside(term_key)
+#       The full D3 firing algorithm, composed:
+#         1. Gate on mode first (reads .claude/session/onboarding-depth-mode
+#            via #914's depth_mode_read). Not "guided" -> echo nothing,
+#            return 1, seen-set untouched. This is what makes terse mode's
+#            "zero asides" structural rather than a formatting choice.
+#         2. Seen-set check -- key already present -> echo nothing,
+#            return 1 (term already glossed this session).
+#         3. Slice the term's body via glossary_term_body. Empty/unknown
+#            term -> echo nothing, return 1, seen-set untouched.
+#         4. Record the key in the seen-set, echo the sliced body, return
+#            0. The caller (the agent, in-flow) composes this into ONE
+#            short inline parenthetical the first time it uses the term
+#            toward the adopter -- this function supplies gating +
+#            source content, never inline prose formatting.
+#
+# CONTRACT (the "presentation only" invariant, same as #914's lib): this
+# lib touches ONLY the glossary-seen marker file and reads (never writes)
+# the depth-mode marker + docs/onboarding/glossary.md. It never reads or
+# writes anything under `.claude/session/reviews/`, never touches a
+# `*-rex.approved` / `*-ceo.approved` / `*-security.approved` /
+# `*-architecture.approved` marker, and never edits a gate, permission, or
+# role-boundary file. See `.claude/hooks/tests/test_glossary_asides.sh`'s
+# invariant case.
+
+# Don't run twice in the same shell.
+[ -n "${_LIB_ONBOARDING_GLOSSARY_SEEN_SOURCED:-}" ] && return 0
+_LIB_ONBOARDING_GLOSSARY_SEEN_SOURCED=1
+
+_GLOSSARY_SEEN_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -f "$_GLOSSARY_SEEN_LIB_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$_GLOSSARY_SEEN_LIB_DIR/_lib-ops-root.sh"
+fi
+
+if [ -f "$_GLOSSARY_SEEN_LIB_DIR/_lib-onboarding-depth-mode.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$_GLOSSARY_SEEN_LIB_DIR/_lib-onboarding-depth-mode.sh"
+fi
+
+glossary_seen_marker_path() {
+  local repo_root root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [ -z "$repo_root" ]; then
+    echo ""
+    return 0
+  fi
+  root="$repo_root"
+  if command -v resolve_ops_root >/dev/null 2>&1; then
+    root=$(resolve_ops_root "$repo_root")
+    [ -n "$root" ] || root="$repo_root"
+  fi
+  echo "$root/.claude/session/onboarding-glossary-seen"
+  return 0
+}
+
+glossary_seen_has() {
+  local term_key="$1" marker
+  [ -n "$term_key" ] || return 1
+  marker=$(glossary_seen_marker_path)
+  [ -n "$marker" ] && [ -f "$marker" ] || return 1
+  grep -qxF "$term_key" "$marker" 2>/dev/null
+}
+
+glossary_seen_add() {
+  local term_key="$1" marker
+  if [ -z "$term_key" ]; then
+    echo "glossary_seen_add: refusing to add an empty term key" >&2
+    return 1
+  fi
+  marker=$(glossary_seen_marker_path)
+  if [ -z "$marker" ]; then
+    echo "glossary_seen_add: could not resolve marker path (no git toplevel)" >&2
+    return 1
+  fi
+  if glossary_seen_has "$term_key"; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$marker")"
+  printf '%s\n' "$term_key" >> "$marker"
+  return 0
+}
+
+glossary_term_body() {
+  local term_key="$1" asset
+  [ -n "$term_key" ] || return 1
+
+  asset="docs/onboarding/glossary.md"
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -f "$CLAUDE_PROJECT_DIR/$asset" ]; then
+    asset="$CLAUDE_PROJECT_DIR/$asset"
+  elif ! [ -f "$asset" ]; then
+    local repo_root
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+    [ -n "$repo_root" ] && [ -f "$repo_root/$asset" ] && asset="$repo_root/$asset"
+  fi
+  [ -f "$asset" ] || return 1
+
+  local body
+  body=$(awk -v key="$term_key" '
+    /^<!-- term: /{
+      line = $0
+      sub(/^<!-- term: /, "", line)
+      sub(/ *-->$/, "", line)
+      n = split(line, keys, ",")
+      match_found = 0
+      for (i = 1; i <= n; i++) {
+        k = keys[i]
+        gsub(/^[ \t]+|[ \t]+$/, "", k)
+        if (k == key) { match_found = 1 }
+      }
+      capture = match_found
+      next
+    }
+    capture && /^\*\*Example\*\*:/ { capture = 0; next }
+    capture && /^#/ { capture = 0; next }
+    capture && /^---/ { capture = 0; next }
+    capture { buf = buf $0 "\n" }
+    END { printf "%s", buf }
+  ' "$asset")
+
+  # Trim leading/trailing blank lines and collapse internal newlines to
+  # single spaces, so the caller gets one clean sentence-block, not a
+  # multi-line blob with markdown line-wrap artifacts.
+  body=$(printf '%s' "$body" | awk 'NF{$1=$1; print}' | tr '\n' ' ' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+  [ -n "$body" ] || return 1
+  printf '%s' "$body"
+  return 0
+}
+
+glossary_maybe_aside() {
+  local term_key="$1" mode body
+  [ -n "$term_key" ] || return 1
+
+  mode="terse"
+  if command -v depth_mode_read >/dev/null 2>&1; then
+    mode=$(depth_mode_read)
+  fi
+  [ "$mode" = "guided" ] || return 1
+
+  if glossary_seen_has "$term_key"; then
+    return 1
+  fi
+
+  body=$(glossary_term_body "$term_key") || return 1
+  [ -n "$body" ] || return 1
+
+  glossary_seen_add "$term_key" || return 1
+  printf '%s' "$body"
+  return 0
+}

--- a/.claude/hooks/clear-onboarding-glossary-seen-marker.sh
+++ b/.claude/hooks/clear-onboarding-glossary-seen-marker.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# SessionStart hook: clear any stale onboarding glossary-seen marker from a
+# previous session.
+#
+# The marker at .claude/session/onboarding-glossary-seen tracks which of
+# the five core glossary terms have already been surfaced as a
+# just-in-time aside this session (terse/guided depth mode — see
+# docs/technical-designs/onboarding-increment-2.md § D3, ticket
+# me2resh/apexyard#913). It is per-session by design: a returning adopter
+# should get the refresher again, not have it silently suppressed by a
+# seen-set left over from a previous, unrelated session. If a flow is
+# interrupted mid-session (terminal closed, agent killed), the marker can
+# be left behind, silently carrying a prior session's "already explained"
+# state into the next one.
+#
+# This hook runs at SessionStart and removes the marker if present, so
+# every session starts with a clean slate — the next /onboard run
+# re-glosses each term on its first encounter, per the design's
+# per-session (not per-fork) scope.
+#
+# Silent on the no-marker path (the common case). Logs a one-line note to
+# stderr when clearing a stale marker so the operator sees what happened.
+# Same shape as clear-bootstrap-marker.sh / clear-active-reviewer-marker.sh
+# / clear-onboarding-depth-mode-marker.sh.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# Walk up to find the apexyard fork root. Honours both the v2
+# `.apexyard-fork` marker and the legacy v1 anchor.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT=""
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+  ROOT=$(resolve_ops_root "$REPO_ROOT")
+else
+  cur="$REPO_ROOT"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    if [ -f "$cur/.apexyard-fork" ]; then
+      ROOT="$cur"
+      break
+    fi
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      ROOT="$cur"
+      break
+    fi
+    parent=$(dirname "$cur"); [ "$parent" = "$cur" ] && break; cur="$parent"
+  done
+fi
+
+if [ -z "$ROOT" ]; then
+  exit 0
+fi
+
+MARKER="$ROOT/.claude/session/onboarding-glossary-seen"
+if [ -f "$MARKER" ]; then
+  stale_count=$(wc -l < "$MARKER" 2>/dev/null | tr -d '[:space:]')
+  [ -n "$stale_count" ] || stale_count="(unreadable)"
+  rm -f "$MARKER"
+  echo "ApexYard: cleared stale onboarding glossary-seen marker ($stale_count term(s)) from a previous session." >&2
+fi
+
+exit 0

--- a/.claude/hooks/tests/test_clear_onboarding_glossary_seen_marker.sh
+++ b/.claude/hooks/tests/test_clear_onboarding_glossary_seen_marker.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/clear-onboarding-glossary-seen-marker.sh
+#
+# SessionStart hook (me2resh/apexyard#913) that sweeps a stale
+# .claude/session/onboarding-glossary-seen marker left behind by an
+# interrupted session, mirroring clear-bootstrap-marker.sh /
+# clear-onboarding-depth-mode-marker.sh. A stale marker would otherwise
+# silently carry a prior session's "already glossed" seen-set into the
+# next one, denying a returning adopter the per-session refresher the
+# design's D3 explicitly calls for
+# (docs/technical-designs/onboarding-increment-2.md § D3).
+#
+# Each case builds an isolated sandbox repo, optionally seeds the marker,
+# runs the hook from inside the sandbox, and asserts marker-file state +
+# stderr content.
+#
+# Exit 0 means all cases passed. Exit 1 on any failure (all cases still run).
+
+set -u
+
+export APEXYARD_OPS_DISABLE_PIN=1
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/clear-onboarding-glossary-seen-marker.sh"
+LIB_OPS_ROOT="$(cd "$(dirname "$0")/.." && pwd)/_lib-ops-root.sh"
+
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$LIB_OPS_ROOT" ]; then
+  echo "FAIL: _lib-ops-root.sh not found at $LIB_OPS_ROOT" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    touch onboarding.yaml apexyard.projects.yaml
+    git add onboarding.yaml apexyard.projects.yaml
+    git commit -q -m "init"
+  )
+  mkdir -p "$sb/.claude/hooks" "$sb/.claude/session"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/clear-onboarding-glossary-seen-marker.sh"
+  cp "$LIB_OPS_ROOT" "$sb/.claude/hooks/_lib-ops-root.sh"
+  chmod +x "$sb/.claude/hooks/clear-onboarding-glossary-seen-marker.sh"
+  echo "$sb"
+}
+
+# run_hook <sandbox> <expect_grep|""> <case_name>
+run_hook() {
+  local sb="$1" expect_grep="$2" case_name="$3"
+  local stderr_file
+  stderr_file=$(mktemp)
+  (
+    cd "$sb" || exit 1
+    "$sb/.claude/hooks/clear-onboarding-glossary-seen-marker.sh" 2>"$stderr_file"
+  )
+  local rc=$?
+  local ok=1
+
+  if [ "$rc" != "0" ]; then
+    echo "FAIL [$case_name]: exit $rc (expected 0)" >&2
+    ok=0
+  fi
+
+  if [ -z "$expect_grep" ]; then
+    if [ -s "$stderr_file" ]; then
+      echo "FAIL [$case_name]: expected silent, got stderr" >&2
+      ok=0
+    fi
+  else
+    if ! grep -qE "$expect_grep" "$stderr_file"; then
+      echo "FAIL [$case_name]: stderr did not match /$expect_grep/" >&2
+      ok=0
+    fi
+  fi
+
+  if [ "$ok" = "1" ]; then
+    PASS=$((PASS+1))
+    echo "PASS [$case_name]"
+  else
+    sed 's/^/    stderr: /' "$stderr_file" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="$FAILED_CASES $case_name"
+  fi
+  rm -f "$stderr_file"
+}
+
+# -------------------- CASE 1: no marker present — silent no-op --------------------
+case1() {
+  local sb
+  sb=$(make_sandbox)
+  run_hook "$sb" "" "no-marker-silent"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 2: stale seen-set with 2 terms present — cleared + logged --------------------
+case2() {
+  local sb
+  sb=$(make_sandbox)
+  local marker="$sb/.claude/session/onboarding-glossary-seen"
+  printf 'ticket\nmerge\n' > "$marker"
+  run_hook "$sb" "cleared stale onboarding glossary-seen marker \\(2 term" "stale-seen-set-cleared"
+  if [ -f "$marker" ]; then
+    echo "FAIL [stale-seen-set-cleared]: marker file still present after sweep" >&2
+    FAIL=$((FAIL+1))
+    PASS=$((PASS-1))
+  fi
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 3: stale seen-set with 1 term present — cleared + logged --------------------
+case3() {
+  local sb
+  sb=$(make_sandbox)
+  local marker="$sb/.claude/session/onboarding-glossary-seen"
+  printf 'branch\n' > "$marker"
+  run_hook "$sb" "cleared stale onboarding glossary-seen marker \\(1 term" "stale-single-term-cleared"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 4: idempotent — running twice is still silent the 2nd time --------------------
+case4() {
+  local sb
+  sb=$(make_sandbox)
+  local marker="$sb/.claude/session/onboarding-glossary-seen"
+  printf 'ci\n' > "$marker"
+  run_hook "$sb" "cleared stale onboarding glossary-seen marker" "idempotent-first-sweep"
+  run_hook "$sb" "" "idempotent-second-sweep-silent"
+  rm -rf "$sb"
+}
+
+case1
+case2
+case3
+case4
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_glossary_asides.sh
+++ b/.claude/hooks/tests/test_glossary_asides.sh
@@ -1,0 +1,395 @@
+#!/bin/bash
+# Unit tests for .claude/hooks/_lib-onboarding-glossary-seen.sh
+#
+# Ticket: me2resh/apexyard#913 (increment-2 M5 — teach-in-context glossary
+# + just-in-time asides). Technical design:
+# docs/technical-designs/onboarding-increment-2.md § D1/D3/D7.
+#
+# Coverage (per the design's Testing Strategy for #913 t4):
+#   - terse mode -> zero asides, seen-set untouched
+#   - guided mode, first mention of a term -> aside fires, key recorded
+#   - guided mode, second mention of the SAME term -> no aside (already
+#     seen), seen-set unchanged
+#   - unknown term key -> no aside, seen-set untouched
+#   - glossary_term_body slices the right section and excludes the
+#     **Example**: line (asides are a short parenthetical, not the whole
+#     entry)
+#   - INVARIANT: exercising the aside path for all five terms across both
+#     modes never writes a gate/permission/approval marker
+#     (`.claude/session/reviews/**`, `*-rex.approved`, `*-ceo.approved`,
+#     `*-security.approved`, `*-architecture.approved`) — the same
+#     mechanical guard #914's test_depth_mode.sh established for design
+#     § "Depth mode is presentation only"
+#
+# Each case builds an isolated sandbox repo (with a real docs/onboarding/
+# glossary.md fixture), sources the lib inside it, and asserts
+# stdout/return-code/file-state. Exit 0 means all cases passed. Exit 1 on
+# any failure (all cases still run).
+
+set -u
+
+export APEXYARD_OPS_DISABLE_PIN=1
+
+HOOKS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB_SRC="$HOOKS_DIR/_lib-onboarding-glossary-seen.sh"
+DEPTH_MODE_LIB_SRC="$HOOKS_DIR/_lib-onboarding-depth-mode.sh"
+LIB_OPS_ROOT="$HOOKS_DIR/_lib-ops-root.sh"
+REPO_ROOT="$(cd "$HOOKS_DIR/../.." && pwd)"
+GLOSSARY_SRC="$REPO_ROOT/docs/onboarding/glossary.md"
+
+if [ ! -f "$LIB_SRC" ]; then
+  echo "FAIL: lib not found at $LIB_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$DEPTH_MODE_LIB_SRC" ]; then
+  echo "FAIL: _lib-onboarding-depth-mode.sh not found at $DEPTH_MODE_LIB_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$LIB_OPS_ROOT" ]; then
+  echo "FAIL: _lib-ops-root.sh not found at $LIB_OPS_ROOT" >&2
+  exit 1
+fi
+if [ ! -f "$GLOSSARY_SRC" ]; then
+  echo "FAIL: docs/onboarding/glossary.md not found at $GLOSSARY_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    touch onboarding.yaml apexyard.projects.yaml
+    git add onboarding.yaml apexyard.projects.yaml
+    git commit -q -m "init"
+  )
+  mkdir -p "$sb/.claude/hooks" "$sb/.claude/session" "$sb/docs/onboarding"
+  cp "$LIB_SRC" "$sb/.claude/hooks/_lib-onboarding-glossary-seen.sh"
+  cp "$DEPTH_MODE_LIB_SRC" "$sb/.claude/hooks/_lib-onboarding-depth-mode.sh"
+  cp "$LIB_OPS_ROOT" "$sb/.claude/hooks/_lib-ops-root.sh"
+  cp "$GLOSSARY_SRC" "$sb/docs/onboarding/glossary.md"
+  echo "$sb"
+}
+
+# assert_eq <case_name> <expected> <actual>
+assert_eq() {
+  local case_name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS+1))
+    echo "PASS [$case_name]"
+  else
+    echo "FAIL [$case_name]: expected '$expected', got '$actual'" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="$FAILED_CASES $case_name"
+  fi
+}
+
+# assert_true <case_name> <bash-condition-as-string, already evaluated 0/1>
+assert_rc0() {
+  local case_name="$1" rc="$2"
+  if [ "$rc" = "0" ]; then
+    PASS=$((PASS+1))
+    echo "PASS [$case_name]"
+  else
+    echo "FAIL [$case_name]: expected rc 0, got rc $rc" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="$FAILED_CASES $case_name"
+  fi
+}
+
+assert_rc1() {
+  local case_name="$1" rc="$2"
+  if [ "$rc" = "1" ]; then
+    PASS=$((PASS+1))
+    echo "PASS [$case_name]"
+  else
+    echo "FAIL [$case_name]: expected rc 1, got rc $rc" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="$FAILED_CASES $case_name"
+  fi
+}
+
+# ============================================================
+# terse mode -> zero asides, seen-set untouched (the critical case)
+# ============================================================
+
+case_terse_zero_asides() {
+  local sb out rc
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    printf '%s' "terse" > .claude/session/onboarding-depth-mode
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-glossary-seen.sh
+
+    out=$(glossary_maybe_aside "ticket"); rc=$?
+    echo "$out:$rc"
+  ) > "$sb/out.txt"
+
+  assert_eq "terse-no-aside-empty-output" ":1" "$(cat "$sb/out.txt")"
+
+  if [ -f "$sb/.claude/session/onboarding-glossary-seen" ]; then
+    echo "FAIL [terse-seen-set-untouched]: seen-set marker created in terse mode" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES terse-seen-set-untouched"
+  else
+    PASS=$((PASS+1)); echo "PASS [terse-seen-set-untouched]"
+  fi
+  rm -rf "$sb"
+}
+
+# Absent depth-mode marker entirely (safe default -> terse, D7).
+case_absent_marker_defaults_terse() {
+  local sb out rc
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-glossary-seen.sh
+    out=$(glossary_maybe_aside "merge"); rc=$?
+    echo "$out:$rc"
+  ) > "$sb/out.txt"
+
+  assert_eq "absent-marker-defaults-terse-no-aside" ":1" "$(cat "$sb/out.txt")"
+  rm -rf "$sb"
+}
+
+# ============================================================
+# guided mode — first mention fires, records the key
+# ============================================================
+
+case_guided_first_mention() {
+  local sb out rc seen
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    printf '%s' "guided" > .claude/session/onboarding-depth-mode
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-glossary-seen.sh
+    out=$(glossary_maybe_aside "ticket"); rc=$?
+    echo "$out"
+    echo "RC:$rc"
+  ) > "$sb/out.txt"
+
+  rc=$(grep '^RC:' "$sb/out.txt" | cut -d: -f2)
+  body=$(grep -v '^RC:' "$sb/out.txt")
+
+  assert_rc0 "guided-first-mention-fires" "$rc"
+
+  if [ -n "$body" ]; then
+    PASS=$((PASS+1)); echo "PASS [guided-first-mention-nonempty-body]"
+  else
+    echo "FAIL [guided-first-mention-nonempty-body]: expected non-empty aside body" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES guided-first-mention-nonempty-body"
+  fi
+
+  # Body must not contain the Example line — asides are a short
+  # parenthetical, not the whole glossary entry.
+  if printf '%s' "$body" | grep -q '\*\*Example\*\*'; then
+    echo "FAIL [guided-aside-excludes-example]: aside body leaked the Example line" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES guided-aside-excludes-example"
+  else
+    PASS=$((PASS+1)); echo "PASS [guided-aside-excludes-example]"
+  fi
+
+  seen=$(cat "$sb/.claude/session/onboarding-glossary-seen" 2>/dev/null)
+  assert_eq "guided-first-mention-key-recorded" "ticket" "$seen"
+
+  rm -rf "$sb"
+}
+
+# ============================================================
+# guided mode — second mention of the SAME term is suppressed
+# ============================================================
+
+case_guided_second_mention_suppressed() {
+  local sb rc1 rc2 seen_after
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    printf '%s' "guided" > .claude/session/onboarding-depth-mode
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-glossary-seen.sh
+    glossary_maybe_aside "merge" >/dev/null; echo "rc1=$?"
+    glossary_maybe_aside "merge" >/dev/null; echo "rc2=$?"
+  ) > "$sb/out.txt"
+
+  rc1=$(grep '^rc1=' "$sb/out.txt" | cut -d= -f2)
+  rc2=$(grep '^rc2=' "$sb/out.txt" | cut -d= -f2)
+
+  assert_rc0 "guided-second-mention-first-call-fires" "$rc1"
+  assert_rc1 "guided-second-mention-suppressed" "$rc2"
+
+  seen_after=$(cat "$sb/.claude/session/onboarding-glossary-seen" 2>/dev/null | wc -l | tr -d '[:space:]')
+  assert_eq "guided-second-mention-no-duplicate-key" "1" "$seen_after"
+
+  rm -rf "$sb"
+}
+
+# guided mode — different terms each get their own aside, in order.
+case_guided_multiple_distinct_terms() {
+  local sb seen
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    printf '%s' "guided" > .claude/session/onboarding-depth-mode
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-glossary-seen.sh
+    glossary_maybe_aside "ticket" >/dev/null
+    glossary_maybe_aside "branch" >/dev/null
+    glossary_maybe_aside "ticket" >/dev/null   # repeat — must not re-add
+  )
+
+  seen=$(cat "$sb/.claude/session/onboarding-glossary-seen" 2>/dev/null | tr '\n' ',')
+  assert_eq "guided-multiple-terms-recorded-once-each" "ticket,branch," "$seen"
+  rm -rf "$sb"
+}
+
+# ============================================================
+# unknown term key — no aside, no seen-set write
+# ============================================================
+
+case_unknown_term() {
+  local sb out rc
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    printf '%s' "guided" > .claude/session/onboarding-depth-mode
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-glossary-seen.sh
+    out=$(glossary_maybe_aside "nonexistent-term"); rc=$?
+    echo "$out:$rc"
+  ) > "$sb/out.txt"
+
+  assert_eq "unknown-term-no-aside" ":1" "$(cat "$sb/out.txt")"
+
+  if [ -f "$sb/.claude/session/onboarding-glossary-seen" ]; then
+    echo "FAIL [unknown-term-seen-set-untouched]: seen-set created for an unknown term" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES unknown-term-seen-set-untouched"
+  else
+    PASS=$((PASS+1)); echo "PASS [unknown-term-seen-set-untouched]"
+  fi
+  rm -rf "$sb"
+}
+
+# ============================================================
+# glossary_term_body — comma-key aliasing (issue vs ticket -> same entry)
+# ============================================================
+
+case_term_body_alias() {
+  local sb issue_body ticket_body
+  sb=$(make_sandbox)
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-glossary-seen.sh
+    printf '%s\n' "$(glossary_term_body "issue")"
+    echo "---SPLIT---"
+    printf '%s\n' "$(glossary_term_body "ticket")"
+  ) > "$sb/out.txt"
+
+  issue_body=$(sed -n '1,/^---SPLIT---$/p' "$sb/out.txt" | sed '$d')
+  ticket_body=$(sed -n '/^---SPLIT---$/,$p' "$sb/out.txt" | tail -n +2)
+
+  assert_eq "term-body-alias-issue-eq-ticket" "$issue_body" "$ticket_body"
+
+  if [ -n "$issue_body" ]; then
+    PASS=$((PASS+1)); echo "PASS [term-body-alias-nonempty]"
+  else
+    echo "FAIL [term-body-alias-nonempty]: expected non-empty body for 'issue'/'ticket'" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES term-body-alias-nonempty"
+  fi
+  rm -rf "$sb"
+}
+
+# ============================================================
+# INVARIANT: exercising the aside path never writes a gate/approval
+# marker anywhere in the sandbox — mirrors #914's
+# case_invariant_no_gate_marker in test_depth_mode.sh.
+# ============================================================
+
+case_invariant_no_gate_marker() {
+  local sb
+  sb=$(make_sandbox)
+
+  (
+    cd "$sb" || exit 1
+    # shellcheck source=/dev/null
+    . .claude/hooks/_lib-onboarding-glossary-seen.sh
+
+    # Terse pass first (should be fully inert).
+    printf '%s' "terse" > .claude/session/onboarding-depth-mode
+    for t in issue pr merge branch ci; do
+      glossary_maybe_aside "$t" >/dev/null
+    done
+
+    # Now flip to guided and exercise all five terms, twice each.
+    printf '%s' "guided" > .claude/session/onboarding-depth-mode
+    for t in issue pr merge branch ci; do
+      glossary_maybe_aside "$t" >/dev/null
+      glossary_maybe_aside "$t" >/dev/null
+    done
+  )
+
+  # -- Assertion 1: .claude/session/reviews/ was never created --
+  if [ -d "$sb/.claude/session/reviews" ]; then
+    echo "FAIL [invariant-no-reviews-dir]: .claude/session/reviews/ exists after exercising glossary-aside functions" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES invariant-no-reviews-dir"
+  else
+    PASS=$((PASS+1)); echo "PASS [invariant-no-reviews-dir]"
+  fi
+
+  # -- Assertion 2: no gate/approval marker file exists anywhere in the sandbox --
+  local hits
+  hits=$(find "$sb" -type f \( \
+      -name "*-rex.approved" -o \
+      -name "*-ceo.approved" -o \
+      -name "*-security.approved" -o \
+      -name "*-architecture.approved" \
+    \) 2>/dev/null)
+  if [ -n "$hits" ]; then
+    echo "FAIL [invariant-no-approval-marker-anywhere]: found $hits" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="$FAILED_CASES invariant-no-approval-marker-anywhere"
+  else
+    PASS=$((PASS+1)); echo "PASS [invariant-no-approval-marker-anywhere]"
+  fi
+
+  # -- Assertion 3: the ONLY files under .claude/session/ are the two
+  #    markers this run legitimately touches — no surprise state.
+  local session_files expected
+  session_files=$(cd "$sb/.claude/session" && find . -type f | sed 's|^\./||' | sort | tr '\n' ',')
+  expected="onboarding-depth-mode,onboarding-glossary-seen,"
+  assert_eq "invariant-only-expected-session-files" "$expected" "$session_files"
+
+  # -- Assertion 4: all five terms ended up recorded exactly once each. --
+  local seen_count
+  seen_count=$(wc -l < "$sb/.claude/session/onboarding-glossary-seen" 2>/dev/null | tr -d '[:space:]')
+  assert_eq "invariant-five-terms-recorded-once-each" "5" "$seen_count"
+
+  rm -rf "$sb"
+}
+
+case_terse_zero_asides
+case_absent_marker_defaults_terse
+case_guided_first_mention
+case_guided_second_mention_suppressed
+case_guided_multiple_distinct_terms
+case_unknown_term
+case_term_body_alias
+case_invariant_no_gate_marker
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,10 @@
           },
           {
             "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/clear-onboarding-glossary-seen-marker.sh\"'"
+          },
+          {
+            "type": "command",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/clear-issue-skill-marker.sh\"'"
           },
           {

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -32,12 +32,17 @@ below for derivation, and "Depth mode override + transparency" for the
 mid-session override (FR-6) and the "what mode am I in?" affordance
 (FR-9).
 
-The **per-term teach-in-context glossary + just-in-time asides** (#913)
-and the **ambient any-session lookup + full `/tutorial` glossary render**
-(#915) are sibling tickets, not yet built as of this ticket — guided mode
-here provides generic narration only. This flow already gates on the
-shared `.claude/session/onboarding-depth-mode` marker (D7's safe default:
-absent → terse), so #913's asides need no rework once they land.
+**The per-term teach-in-context glossary + just-in-time asides (#913) are
+now wired into this flow.** In guided mode, the first time this skill
+uses one of the five core terms — issue/ticket, PR, merge, branch, CI —
+toward the adopter, it weaves in a short inline parenthetical explaining
+it, once per term per session (design § D3). See "Just-in-time glossary
+asides" below for the mechanism. Terse mode sees zero asides — this is
+structural, not a formatting choice (the same `$mode` gate Step 3.5
+derives). The **ambient any-session lookup + full `/tutorial` glossary
+render** (#915) is still a sibling ticket, not yet built as of this
+ticket — asking "what's a merge?" outside a guided `/onboard` run isn't
+wired up yet.
 
 ## Path resolution
 
@@ -255,6 +260,55 @@ This satisfies FR-9: it reads the marker (default `terse` if absent) and
 states the current mode plus how to switch. Answering this question is a
 **read** — it never writes anything.
 
+### Just-in-time glossary asides (#913 — design § D3)
+
+From Step 3.5 onward, any time you are about to use one of the five core
+terms — **issue/ticket, PR, merge, branch, CI** — toward the adopter for
+the first time this session, check whether a short plain-language aside
+is due and, if so, weave it into your sentence as a single parenthetical.
+This can fire at any later step — most commonly Step 4 (the branch talks
+about the repo and may reach for "issue"/"ticket"), Step 5 (the guided
+first win names "ticket", "PR", "merge", "branch", "CI" directly in the
+"idea → ticket → PR → review → merge" framing), and the closing message.
+Don't wait for a dedicated "glossary step" — call this the first time you
+reach for the term, wherever that happens to be.
+
+Source the shared helper (it reads the depth-mode marker internally via
+`_lib-onboarding-depth-mode.sh`'s `depth_mode_read` — no separate mode
+check needed):
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-onboarding-glossary-seen.sh"
+aside=$(glossary_maybe_aside "ticket")   # term key: issue|ticket, pr, merge, branch, ci
+rc=$?
+```
+
+- **`$rc` is `1`, `$aside` empty** — say the term plainly, no aside. This
+  is the common path: terse mode (the design's structural "zero asides"),
+  the term already glossed once this session, or an unmapped term.
+- **`$rc` is `0`** — `$aside` holds that term's plain-language definition,
+  already sliced to exclude the glossary's "**Example**:" line (a short
+  paragraph, not the whole entry). Compress it into ONE short
+  parenthetical, right where you use the term:
+
+  ```
+  …I've opened a ticket for this (a ticket is just a tracked to-do item
+  we can both refer back to by number).
+  ```
+
+  Keep it to a single sentence — this is a per-term gloss, not the
+  generic "why this matters" framing Step 3.5 already adds in guided
+  mode; the two are complementary, never merge them into one longer
+  aside.
+
+Never hand-craft your own explanation for a term instead of calling the
+helper — the seen-set (`.claude/session/onboarding-glossary-seen`) is
+what guarantees "once per term, per session" is actually true, and it
+only updates through `glossary_maybe_aside`/`glossary_seen_add`. Terse
+mode's output is byte-for-byte unaffected by this section — the helper's
+mode gate is the same one Step 3.5 wrote, so a terse session renders
+exactly as it did before #913 landed.
+
 ### 4. Phase 3 — handover-vs-new-project branch
 
 Ask directly:
@@ -412,16 +466,24 @@ re-run-offer exits, and on any decline/cancel path. Never leave it set.
 5. **The tour content lives in one file.** Never inline or paraphrase
    `docs/onboarding/capability-tour.md` — both `/onboard` and `/tutorial`
    read the same asset verbatim.
-6. **Per-term glossary asides (#913) and the ambient any-session lookup +
-   full `/tutorial` glossary render (#915) are sibling tickets, not part
-   of this flow yet.** Guided mode here is generic "why this matters"
-   narration only — never invent per-term definitions or fabricate a
-   glossary lookup ahead of #913/#915 landing.
+6. **Per-term glossary asides (#913) are wired in; the ambient
+   any-session lookup + full `/tutorial` glossary render (#915) is still
+   a sibling ticket, not part of this flow yet.** In guided mode, gloss a
+   term via `glossary_maybe_aside` (see "Just-in-time glossary asides"
+   above) the first time you use it toward the adopter — never invent a
+   per-term definition by hand, and never fabricate a glossary lookup
+   outside a guided `/onboard`/`/tutorial` run ahead of #915 landing.
 7. **Only ever write the depth-mode marker via the shared helper**
    (`_lib-onboarding-depth-mode.sh`'s `depth_mode_write`) — never hand-edit
    `.claude/session/onboarding-depth-mode` with a raw `echo`/redirect.
    This keeps derivation, override, and the invariant test all going
    through one code path.
+8. **Only ever touch the glossary-seen marker via the shared helper**
+   (`_lib-onboarding-glossary-seen.sh`'s `glossary_seen_add` /
+   `glossary_maybe_aside`) — never hand-edit
+   `.claude/session/onboarding-glossary-seen` with a raw `echo`/redirect.
+   This is what keeps "once per term, per session" mechanically true and
+   testable (`.claude/hooks/tests/test_glossary_asides.sh`).
 
 ---
 

--- a/docs/onboarding/glossary.md
+++ b/docs/onboarding/glossary.md
@@ -1,0 +1,96 @@
+# ApexYard Plain-Language Glossary
+
+Five core SDLC terms explained in one to three plain-language sentences
+each — no jargon used to define another piece of jargon. This is the
+**single shared asset** three surfaces read from, never duplicated: the
+just-in-time asides in `/onboard` (guided mode, one term at a time), the
+full re-entry render in `/tutorial`, and the any-session on-demand lookup
+(`.claude/rules/glossary-lookup.md`). See
+`docs/technical-designs/onboarding-increment-2.md` § D1 (AgDR-0100).
+
+**Read contract** — every consumer of this file relies on this exact
+shape, so keep it if you edit an entry:
+
+- One term per stable `###` heading.
+- The heading's very first line is a greppable key comment
+  `<!-- term: <key>[,<key>...] -->` — comma-separated surface spellings
+  that all resolve to the same entry (e.g. "issue" and "ticket" both map
+  to the first section below).
+- Body: 1–3 plain-language sentences. No word inside a definition may be
+  jargon unless it is inlined right there or is itself one of these five
+  terms (D6 — Consistency).
+- `/tutorial` renders the whole file, top to bottom, unchanged. The
+  just-in-time asides and the on-demand lookup slice exactly one section
+  by its `term:` key. No consumer ever re-types or paraphrases this prose
+  elsewhere.
+
+---
+
+## Terms
+
+### issue / ticket
+
+<!-- term: issue,ticket -->
+
+A ticket (GitHub calls it an "issue") is a tracked to-do item with its own
+number, like `#42`. It's where the team writes down what needs to happen,
+follows the discussion, and links the pull request that eventually does
+the work — so anyone can look up "what was #42 about?" months later.
+
+**Example**: when `/feature` files a ticket for you, it's a real page on
+GitHub you can open, comment on, and refer back to by that number.
+
+### PR (pull request)
+
+<!-- term: pr -->
+
+A PR is a proposed change to the code, packaged up for review before it
+becomes part of the project. It shows exactly what would change (line by
+line) alongside a description of what and why, so a reviewer can decide
+whether it's safe to bring in.
+
+**Example**: finishing a ticket's work opens a PR; nothing from it reaches
+the main codebase until that PR is reviewed and merged.
+
+### merge
+
+<!-- term: merge -->
+
+Merging is the moment a PR's changes are actually folded into the main
+codebase — the point of no casual return. Because of that, a merge only
+happens after both an automated reviewer and a human have explicitly
+approved that exact version of the change; nothing merges on a vague
+"looks good, go ahead."
+
+**Example**: `gh pr merge` is blocked until the two approvals above both
+match the PR's current state — a fresh commit after approval means
+approving again first.
+
+### branch
+
+<!-- term: branch -->
+
+A branch is a parallel, separate copy of the code where a change can be
+built and tested without touching the version everyone else is using. Once
+the work on a branch is ready, it becomes a PR asking to bring those
+changes back into the main line.
+
+**Example**: starting a ticket creates a branch named after it (like
+`feature/#42-add-login`), so the in-progress work stays isolated until
+it's reviewed.
+
+### CI (continuous integration)
+
+<!-- term: ci -->
+
+CI is an automated check that runs every time a PR is opened or updated —
+it builds the code, runs the tests, and reports back pass or fail before
+any human review even starts. A PR with a failing CI check ("red CI")
+never gets merged, regardless of how small the change looks.
+
+**Example**: pushing a new commit to an open PR re-runs CI automatically,
+so a fix you just made gets verified before anyone re-reviews it.
+
+---
+
+*Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*


### PR DESCRIPTION
## Summary

- **New shared glossary asset (`docs/onboarding/glossary.md`)** — one
  plain-language definition each for issue/ticket, PR, merge, branch, and
  CI, written in the framework's voice with real one-paragraph
  definitions (not stubs). Structured as one term per `###` heading with
  a greppable `<!-- term: -->` key comment, so this single file is what
  the just-in-time asides below, the future full `/tutorial` render, and
  the future on-demand lookup (#915) all read from — never duplicated
  prose across three surfaces.
- **`_lib-onboarding-glossary-seen.sh`** — the mechanical guts of "explain
  each term once per session, in guided mode only." `glossary_maybe_aside`
  composes the design's D3 firing algorithm: gate on #914's depth-mode
  marker first (not guided → no aside, seen-set untouched — this is what
  makes terse mode's "zero asides" structural rather than a formatting
  choice), then check the per-session seen-set, then slice the term's
  definition out of `glossary.md` (excluding its "**Example**:" line —
  asides are a short parenthetical, not the whole entry) and record it as
  seen.
- **`/onboard` now weaves in the asides** — the first time the guided-mode
  flow uses one of the five terms toward the adopter, it adds a short
  inline parenthetical (e.g. "…I've opened a ticket for this (a ticket is
  just a tracked to-do item we can both refer back to by number)."). This
  can fire at any step after depth mode is derived — most commonly the
  handover/new-project branch and the guided first win's "idea → ticket →
  PR → review → merge" framing. Terse-mode output is byte-for-byte
  unaffected — same safe-default gate #914 already established.
- **`clear-onboarding-glossary-seen-marker.sh`** — a new SessionStart
  sweep (wired into `.claude/settings.json` right after #914's
  `clear-onboarding-depth-mode-marker.sh`) so an interrupted session can't
  leave a stale seen-set behind and silently deny a returning adopter the
  per-session refresher the design calls for.

## Design

Builds against the merged increment-2 technical design
(`docs/technical-designs/onboarding-increment-2.md` § D1/D3/D7,
AgDR-0100/AgDR-0101). This PR covers ticket #913's ownership only:
authoring `glossary.md`, the guided-mode aside path in `/onboard`, the
seen-set marker + its clear-hook, and the test suite. It does **not**
touch `/tutorial`, does not write the depth-mode marker (only reads it
via #914's `_lib-onboarding-depth-mode.sh`), and does not add
`.claude/rules/glossary-lookup.md` — those are #915's scope per the D7
build-seam contract.

## Testing

- `bash -n` on all four new/changed shell scripts — clean.
- `python3 -c "import json; json.load(...)"` on `.claude/settings.json` —
  valid JSON.
- `npx markdownlint-cli2` (repo's own `.markdownlint.json`) on
  `docs/onboarding/glossary.md` and the changed `SKILL.md` — 0 errors.
- New `.claude/hooks/tests/test_glossary_asides.sh` (19 cases, all
  passing): terse mode → zero asides + seen-set untouched (the critical
  case); absent depth-mode marker defaults to terse (D7 safe default);
  guided first mention fires + records the key; guided second mention of
  the *same* term is suppressed with no duplicate seen-set entry; two
  different terms each gloss once; an unknown term key produces no aside
  and no seen-set write; `glossary_term_body` resolves "issue" and
  "ticket" to the identical entry (comma-key aliasing) and excludes the
  Example line; and an invariant case mirroring #914's — exercising all
  five terms across both modes never creates
  `.claude/session/reviews/`, never writes a `*-rex.approved` /
  `*-ceo.approved` / `*-security.approved` / `*-architecture.approved`
  marker anywhere in the sandbox, and only the two expected files exist
  under `.claude/session/` afterward.
- New `.claude/hooks/tests/test_clear_onboarding_glossary_seen_marker.sh`
  (5 cases, all passing): no-marker silent no-op, stale multi-term and
  single-term markers cleared + logged, idempotent re-run.
- Re-ran #914's own suites unmodified to confirm no regression:
  `test_depth_mode.sh` (25/25 pass) and
  `test_clear_onboarding_depth_mode_marker.sh` (5/5 pass).
- `test_settings_wrappers_silent_noop.sh` (the framework's SessionStart
  hook-wrapper invariant guard) — 4/4 pass, confirming the new hook entry
  in `settings.json` follows the same guarded-`exec` pattern as every
  other wrapper.
- `git diff upstream/dev --stat` shows only the seven files this ticket
  owns (per the design's D7 surface inventory) — no stray edits into
  `/tutorial` or any #914/#915-owned file.

Refs #913

---

## Glossary

| Term | Definition |
|------|------------|
| JIT (just-in-time) aside | A short inline explanation shown at the moment a term is first used, instead of a separate glossary lookup step. |
| Seen-set | A per-session record of which glossary terms have already been explained, so each one is glossed at most once. |
| Term-key aliasing | Two or more surface spellings of a concept (e.g. "issue" and "ticket") that both resolve to the same glossary entry via a shared `<!-- term: -->` key. |
| Safe default | The design's rule that an absent or unset session marker falls back to the least-surprising behavior (here: absent depth mode → terse → zero asides) so a partial or out-of-order build never leaks unwanted output. |
| Invariant test | A test asserting something never happens across a whole exercised code path (here: no gate/approval marker is ever written by the glossary-aside machinery), not just that a specific input produces a specific output. |
