### PR TITLE
fix(#951): portfolio_validate flags projects_dir/workspace_dir resolving inside the fork

### DIFF
--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -403,41 +403,41 @@ portfolio_validate() {
     fi
   fi
 
-  # Fork-containment check — see me2resh/apexyard#951.
+  # Fork-containment check — see me2resh/apexyard#951 (and #952 for the
+  # false-positive fix below).
   #
-  # The checks above compare RAW resolved paths (simple string
-  # concatenation — see _portfolio_resolve) against root_real. A
-  # `../` depth mismatch in a projects_dir/workspace_dir override can
-  # still exist on disk (a real, but WRONG, directory) while landing
-  # right back INSIDE the ops fork rather than the intended sibling
-  # portfolio repo — the plain existence check earlier in this
-  # function passes, so the misconfig stays silent and subsequent
-  # writes (clones, docs, registry edits) land in the wrong tree.
+  # A projects_dir/workspace_dir override that's meant to point at the
+  # sibling portfolio repo but has the wrong `../` depth (or a missing
+  # leading `../`) can resolve to a real, but WRONG, directory INSIDE the
+  # ops fork. The plain existence check earlier in this function passes —
+  # the decoy dir genuinely exists — so the misconfig stays silent and
+  # subsequent writes (clones, docs, registry edits) land in the wrong
+  # tree. Close that gap by resolving each dir to its canonical
+  # (`cd && pwd -P`) form and flagging if it lands inside.
   #
-  # Close that gap by resolving projects_dir to its canonical
-  # (`cd && pwd -P`) form and checking fork-containment on THAT, in
-  # addition to the raw check above. workspace_dir already gets this
-  # canonical treatment via $wd_real earlier in this function.
+  # GATE ON THE RESOLVED LOCATION, NOT on portfolio_is_v2 (#952). Flag only
+  # when a dir resolves INSIDE the ops fork at a NON-DEFAULT location. The
+  # in-fork DEFAULTS ($root/projects, $root/workspace) are correct
+  # single-fork behaviour and must never be flagged; a sibling-intended
+  # override with the wrong `../` depth (or a missing leading `../`) lands
+  # inside the fork at some OTHER path, which is the misconfig #951 catches.
   #
-  # Conservative by design: only fires in a confirmed v2-oriented
-  # setup — the `.apexyard-fork` marker is present, OR registry /
-  # projects_dir already resolve outside the fork (the same
-  # v2-oriented signal #373 uses above). A plain single-fork (v1)
-  # setup with untouched in-fork defaults never reaches this branch,
-  # so it can't false-positive there.
+  # The old `portfolio_is_v2` gate false-positived because single-fork forks
+  # ALSO carry the `.apexyard-fork` marker (it's written on every /setup,
+  # single-fork or split), so the marker can't tell a legit in-fork default
+  # from a sibling-intended override — see #952. Comparing the resolved path
+  # against the canonical default location is immune to that ambiguity and
+  # needs no (root-resolution-sensitive) config-key read.
   local pd_real
   pd_real=$(cd "$projects_dir" 2>/dev/null && pwd -P) || pd_real="$projects_dir"
+  if ! _outside_fork "$pd_real" && [ "$pd_real" != "$root_real/projects" ]; then
+    echo "broken: split-portfolio v2 misconfig — portfolio.projects_dir resolved to $projects_dir, which is INSIDE the ops fork ($root_real) rather than the sibling private-portfolio repo. Check for a '../' depth mismatch (or a missing leading '../') in .claude/project-config.json's portfolio.projects_dir override. See me2resh/apexyard#951."
+    return 1
+  fi
 
-  if portfolio_is_v2 || _outside_fork "$registry" || _outside_fork "$projects_dir"; then
-    if ! _outside_fork "$pd_real"; then
-      echo "broken: split-portfolio v2 misconfig — portfolio.projects_dir resolved to $projects_dir, which is INSIDE the ops fork ($root_real) rather than the sibling private-portfolio repo. Check for a '../' depth mismatch in .claude/project-config.json's portfolio.projects_dir override. See me2resh/apexyard#951."
-      return 1
-    fi
-
-    if ! _outside_fork "$wd_real"; then
-      echo "broken: split-portfolio v2 misconfig — portfolio.workspace_dir resolved to $workspace_dir, which is INSIDE the ops fork ($root_real) rather than the sibling private-portfolio repo. Check for a '../' depth mismatch in .claude/project-config.json's portfolio.workspace_dir override. See me2resh/apexyard#951."
-      return 1
-    fi
+  if ! _outside_fork "$wd_real" && [ "$wd_real" != "$root_real/workspace" ]; then
+    echo "broken: split-portfolio v2 misconfig — portfolio.workspace_dir resolved to $workspace_dir, which is INSIDE the ops fork ($root_real) rather than the sibling private-portfolio repo. Check for a '../' depth mismatch (or a missing leading '../') in .claude/project-config.json's portfolio.workspace_dir override. See me2resh/apexyard#951."
+    return 1
   fi
 
   case "$onboarding" in

--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -403,6 +403,43 @@ portfolio_validate() {
     fi
   fi
 
+  # Fork-containment check — see me2resh/apexyard#951.
+  #
+  # The checks above compare RAW resolved paths (simple string
+  # concatenation — see _portfolio_resolve) against root_real. A
+  # `../` depth mismatch in a projects_dir/workspace_dir override can
+  # still exist on disk (a real, but WRONG, directory) while landing
+  # right back INSIDE the ops fork rather than the intended sibling
+  # portfolio repo — the plain existence check earlier in this
+  # function passes, so the misconfig stays silent and subsequent
+  # writes (clones, docs, registry edits) land in the wrong tree.
+  #
+  # Close that gap by resolving projects_dir to its canonical
+  # (`cd && pwd -P`) form and checking fork-containment on THAT, in
+  # addition to the raw check above. workspace_dir already gets this
+  # canonical treatment via $wd_real earlier in this function.
+  #
+  # Conservative by design: only fires in a confirmed v2-oriented
+  # setup — the `.apexyard-fork` marker is present, OR registry /
+  # projects_dir already resolve outside the fork (the same
+  # v2-oriented signal #373 uses above). A plain single-fork (v1)
+  # setup with untouched in-fork defaults never reaches this branch,
+  # so it can't false-positive there.
+  local pd_real
+  pd_real=$(cd "$projects_dir" 2>/dev/null && pwd -P) || pd_real="$projects_dir"
+
+  if portfolio_is_v2 || _outside_fork "$registry" || _outside_fork "$projects_dir"; then
+    if ! _outside_fork "$pd_real"; then
+      echo "broken: split-portfolio v2 misconfig — portfolio.projects_dir resolved to $projects_dir, which is INSIDE the ops fork ($root_real) rather than the sibling private-portfolio repo. Check for a '../' depth mismatch in .claude/project-config.json's portfolio.projects_dir override. See me2resh/apexyard#951."
+      return 1
+    fi
+
+    if ! _outside_fork "$wd_real"; then
+      echo "broken: split-portfolio v2 misconfig — portfolio.workspace_dir resolved to $workspace_dir, which is INSIDE the ops fork ($root_real) rather than the sibling private-portfolio repo. Check for a '../' depth mismatch in .claude/project-config.json's portfolio.workspace_dir override. See me2resh/apexyard#951."
+      return 1
+    fi
+  fi
+
   case "$onboarding" in
     "$root"/*|"$root")
       # In-fork path — leave it to onboarding-check.sh.

--- a/.claude/hooks/tests/test_portfolio_paths.sh
+++ b/.claude/hooks/tests/test_portfolio_paths.sh
@@ -218,6 +218,76 @@ exit 1
 rm -rf "$SB" "$SIB"
 
 # ---------------------------------------------------------------------------
+# Case 2c (#951): v2 marker present + projects_dir override resolves to a
+# REAL BUT WRONG directory INSIDE the ops fork (the `../` depth-mismatch
+# bug). The plain existence check alone would pass here — the decoy dir
+# genuinely exists — so validate() must additionally catch fork-containment.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+touch "$SB/.apexyard-fork"
+# Decoy dir: shares a name with what the sibling portfolio SHOULD be, but
+# lives inside the fork because the override below is missing its leading
+# "../" — exactly the layout mismatch #951 describes.
+mkdir -p "$SB/sibling-portfolio/projects"
+cat > "$SB/.claude/project-config.json" <<'JSON'
+{
+  "portfolio": {
+    "projects_dir": "sibling-portfolio/projects"
+  }
+}
+JSON
+run_case "v2 (#951): projects_dir resolves inside the fork → broken" "$SB" '
+out=$(portfolio_validate 2>&1)
+rc=$?
+case "$out" in
+  *"projects_dir"*"INSIDE the ops fork"*)
+    [ "$rc" -ne 0 ] && exit 0
+    echo "rc was 0 even though fork-containment message printed: $out"
+    exit 1
+    ;;
+esac
+echo "expected fork-containment message, got rc=$rc out=$out"
+exit 1
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 2d (#951): v2 marker present + projects_dir AND workspace_dir both
+# correctly resolve to the sibling private-portfolio repo → OK. Proves the
+# new check doesn't false-positive on a correctly configured v2 fork.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+touch "$SB/.apexyard-fork"
+SIB=$(mktemp -d)
+SIB=$(cd "$SIB" && pwd -P)
+mkdir -p "$SIB/projects" "$SIB/workspace"
+cat > "$SB/.claude/project-config.json" <<JSON
+{
+  "portfolio": {
+    "projects_dir": "$SIB/projects",
+    "workspace_dir": "$SIB/workspace"
+  }
+}
+JSON
+run_case "v2 (#951): correctly configured sibling projects_dir/workspace_dir → OK" "$SB" '
+if portfolio_validate >/dev/null 2>&1; then exit 0; else echo "validate failed: $(portfolio_validate)"; exit 1; fi
+'
+rm -rf "$SB" "$SIB"
+
+# ---------------------------------------------------------------------------
+# Case 2e (#951): v1 single-fork, no .apexyard-fork marker, untouched in-fork
+# defaults for projects_dir/workspace_dir → still OK. Proves the new
+# fork-containment check is conservative and doesn't fire on a plain v1
+# single-fork setup where in-fork defaults are correct.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+run_case "v1 (#951): untouched in-fork defaults, no marker → OK (no false positive)" "$SB" '
+if portfolio_is_v2; then echo "expected v1 (no marker) for this fixture"; exit 1; fi
+if portfolio_validate >/dev/null 2>&1; then exit 0; else echo "validate failed: $(portfolio_validate)"; exit 1; fi
+'
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
 # Case 3: relative override resolves against fork root
 # ---------------------------------------------------------------------------
 SB=$(make_fork)


### PR DESCRIPTION
## Summary

- **Closes the silent-misconfig gap `portfolio_validate()` had for split-portfolio v2 forks** — it only checked that `projects_dir`/`workspace_dir` existed, were readable, and parsed as YAML. A `../` depth mismatch in a v2 override (e.g. one `../` too few) can resolve to a directory that genuinely exists but sits **inside the ops fork** instead of the intended sibling private-portfolio repo — the existence check passes, so nothing ever surfaces the mistake, and subsequent portfolio writes (clones, docs, registry edits) silently land in the wrong tree.
- **Adds a fork-containment check**, gated conservatively so it can't false-positive on plain v1 single-fork setups: it fires only when the `.apexyard-fork` marker is present, or when `registry`/`projects_dir` already resolve outside the fork (the same v2-oriented signal the existing `#373` asymmetry check uses). When it fires, it canonicalizes `projects_dir` via `cd && pwd -P` (the same technique already used for `workspace_dir`'s `$wd_real`) before checking containment — closing the specific gap where the existing raw string-prefix check can miss a `../`-mangled path that still happens to land inside the fork.
- **Stays inside `portfolio_validate()` only** — a sibling PR (#945) is separately fixing `_portfolio_resolve`/`portfolio_workspace_dir` canonicalization in the same file; this PR doesn't touch either function to minimize overlap.

## Testing

Added three new cases to `.claude/hooks/tests/test_portfolio_paths.sh` (mirrors the existing `#373` partial-v2 test style):

1. **v2 marker present + `projects_dir` resolves inside the fork (the `../` mismatch bug)** — a decoy directory is created *inside* the fork sharing the name the sibling repo should have had, with a `projects_dir` override missing its leading `../`. `portfolio_validate()` now reports `broken: ... projects_dir ... INSIDE the ops fork ...` and returns non-zero.
2. **v2 marker present + `projects_dir`/`workspace_dir` correctly resolve to the sibling repo** — validates OK, proving no false positive on a correctly configured v2 fork.
3. **v1 single-fork, no marker, untouched in-fork defaults** — validates OK, proving the check is conservative and doesn't fire on the common case.

Local run:

```
$ bash .claude/hooks/tests/test_portfolio_paths.sh
...
PASS: v2 (#951): projects_dir resolves inside the fork → broken
PASS: v2 (#951): correctly configured sibling projects_dir/workspace_dir → OK
PASS: v1 (#951): untouched in-fork defaults, no marker → OK (no false positive)
...
===== test_portfolio_paths.sh =====
Passed: 42
Failed: 0
```

Also ran the full `test_split_portfolio_v2_migration.sh` suite (23/25 pass) to check for regressions — the 2 failures (`validate post-state`, `post-v2 ops_root`) are **pre-existing on `upstream/dev`**, reproduced identically with `git stash` before applying this change, and are environment artifacts (macOS `/tmp` vs `/private/var` path resolution in the sandbox), not caused by this fix.

`shellcheck -x .claude/hooks/_lib-portfolio-paths.sh` reports no issues.

`bash .claude/hooks/run-hook-tests.sh` does not exist in this checkout, so it was not run.

Refs #951

## Glossary

| Term | Definition |
|------|------------|
| Split-portfolio v2 | Layout where framework files stay in the public ops fork and company-private data (registry, projects, onboarding, workspace) lives in a sibling private repo, marked by an `.apexyard-fork` file at the fork root. |
| `portfolio_validate()` | A `SessionStart`-invoked sanity check (via `check-portfolio-config.sh`) that verifies the portfolio's resolved paths (registry, `projects_dir`, `ideas_backlog`, `onboarding`, `workspace_dir`) are usable, surfacing misconfiguration before a portfolio-aware skill fails with a vaguer error later. |
| Fork-containment | Whether a resolved path lives inside the ops-fork's own directory tree vs. outside it (e.g. in a sibling repo). A v2 fork's `projects_dir`/`workspace_dir` are expected to be OUTSIDE the fork; this PR adds the check that flags when they aren't. |
| Canonicalization (`cd && pwd -P`) | Resolving a path (including any `../` segments) to its real, absolute, symlink-free form, so string-prefix comparisons against the fork root are accurate. |

**Trust-chain note**: this PR touches `.claude/hooks/**`, so it's expected to trigger the Security Auditor (Hakim) review per the trust-chain trigger in `.claude/rules/role-triggers.md` (#777).
