### PR TITLE
fix(#945): canonicalize resolved portfolio paths so ticket-gate prefix match works

### DIFF
--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -89,25 +89,116 @@ _portfolio_root() {
 }
 
 # ------------------------------------------------------------------------------
+# Internal: canonicalize an ABSOLUTE path to its logical, `/../`-free,
+# symlink-resolved form — WITHOUT requiring the leaf to already exist.
+#
+# Why this exists (me2resh/apexyard#945): callers of the public resolvers
+# below (require-active-ticket.sh, require-migration-ticket.sh) compare a
+# tool-supplied FILE_PATH against e.g. `portfolio_workspace_dir()` via a
+# shell `case "$FILE_PATH" in "$WORKSPACE_DIR"/*)` prefix match. FILE_PATH
+# arrives already normalised (no literal ".." component). Before this fix,
+# a split-portfolio v2 adopter whose `portfolio.workspace_dir` override was
+# a RELATIVE sibling path (e.g. "../<fork>-portfolio/workspace") got a
+# resolved value that still contained a literal "/../" segment — e.g.
+# "/Users/x/apexyard/../apexyard-portfolio/workspace" — because the old
+# `_portfolio_resolve` just string-concatenated `$root/$p` with no
+# normalisation. That literal "/../" never appears in a real FILE_PATH, so
+# the prefix match silently failed and the per-project ticket marker
+# (Tier 0/1) was ignored — legitimate edits got blocked (or fell through
+# to the wrong tier).
+#
+# Algorithm mirrors `_resolve_real_path()` in require-active-ticket.sh:
+# walk up to the nearest EXISTING ancestor, physically resolve it via
+# `cd ... && pwd -P` (which both collapses ".." and follows symlinks),
+# then re-append whatever tail doesn't exist yet literally — a tail that
+# doesn't exist yet cannot itself be a symlink or contain an unresolved
+# "..", since dirname/basename already stripped those out of the walked
+# portion. This is the same "realpath -m without depending on GNU
+# coreutils" trick, needed because macOS/BSD doesn't guarantee GNU
+# realpath's -m/-e flags are available.
+#
+# Fails soft: if $p can't be resolved for any reason (cd denied, etc.),
+# echoes the original input unchanged rather than an empty/broken path —
+# unlike require-active-ticket.sh's fail-CLOSED security check, a
+# portfolio path resolver has no "block on doubt" contract to uphold.
+# ------------------------------------------------------------------------------
+_portfolio_canonicalize() {
+  local p="$1" dir tail=""
+  case "$p" in
+    /*) : ;;
+    *) echo "$p"; return 0 ;;  # not absolute — nothing to canonicalize
+  esac
+
+  dir="$p"
+  while [ -n "$dir" ] && [ "$dir" != "/" ] && [ ! -e "$dir" ]; do
+    if [ -z "$tail" ]; then
+      tail="$(basename "$dir")"
+    else
+      tail="$(basename "$dir")/$tail"
+    fi
+    dir="$(dirname "$dir")"
+  done
+
+  if [ ! -e "$dir" ]; then
+    echo "$p"
+    return 0
+  fi
+
+  if [ -d "$dir" ]; then
+    dir="$(cd "$dir" 2>/dev/null && pwd -P)"
+  else
+    # $dir resolved to an existing FILE (not a directory) partway through
+    # the walk — canonicalize its parent and re-append its own basename.
+    local parent
+    parent="$(cd "$(dirname "$dir")" 2>/dev/null && pwd -P)"
+    if [ -n "$parent" ]; then
+      dir="$parent/$(basename "$dir")"
+    else
+      dir=""
+    fi
+  fi
+
+  if [ -z "$dir" ]; then
+    echo "$p"
+    return 0
+  fi
+
+  if [ -n "$tail" ]; then
+    if [ "$dir" = "/" ]; then
+      printf '%s%s' "$dir" "$tail"
+    else
+      printf '%s/%s' "$dir" "$tail"
+    fi
+  else
+    printf '%s' "$dir"
+  fi
+}
+
+# ------------------------------------------------------------------------------
 # Internal: resolve a possibly-relative path against the ops-fork root.
-# Outputs an absolute path. If the input is already absolute, echo as-is.
+# Outputs an absolute, canonical (symlink-free, `/../`-free) path. If the
+# input is already absolute, it is still canonicalized — an absolute
+# override in project-config.json could itself carry a relative segment
+# (e.g. "$SIBLING/../other").
 # ------------------------------------------------------------------------------
 _portfolio_resolve() {
-  local p="$1"
+  local p="$1" abs
   case "$p" in
-    /*) echo "$p" ;;
+    /*) abs="$p" ;;
     *)
       local root
       root=$(_portfolio_root)
       if [ -n "$root" ]; then
         # Strip leading ./ for tidier output.
-        echo "$root/${p#./}"
+        abs="$root/${p#./}"
       else
         # No root — return the literal so caller can detect.
         echo "$p"
+        return 0
       fi
       ;;
   esac
+  _portfolio_canonicalize "$abs"
 }
 
 # ------------------------------------------------------------------------------

--- a/.claude/hooks/tests/test_portfolio_paths.sh
+++ b/.claude/hooks/tests/test_portfolio_paths.sh
@@ -688,6 +688,134 @@ if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; e
 '
 rm -rf "$SB"
 
+# ---------------------------------------------------------------------------
+# Case 25 (#945): a RELATIVE split-portfolio v2 override that itself carries
+# a literal ".." segment (e.g. "../<fork>-portfolio/workspace" — the exact
+# shape a split-portfolio v2 adopter configures when the private sibling
+# repo lives next to the ops fork) must resolve to a canonical, `/../`-free
+# absolute path. Every other override test in this file pre-resolves its
+# sibling path via `cd ... && pwd` before writing it into project-config.json
+# (so it never exercises the buggy concatenation branch); this case
+# deliberately writes the RAW relative-with-".." string, which is what
+# actually reaches `_portfolio_resolve` in the field.
+# ---------------------------------------------------------------------------
+SB=$(make_fork)
+SIBROOT=$(mktemp -d)
+SIBROOT=$(cd "$SIBROOT" && pwd -P)
+mkdir -p "$SIBROOT/apexyard-portfolio/workspace"
+# Re-root the sandbox so "$SB/.." really is $SIBROOT (the literal ".."
+# override below must land on a real, existing sibling directory).
+rm -rf "$SB"
+SB="$SIBROOT/apexyard"
+mkdir -p "$SB"
+(
+  cd "$SB" || exit 1
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "test"
+  touch onboarding.yaml
+  cat > apexyard.projects.yaml <<'YAML'
+version: 1
+projects:
+  - name: example
+    repo: example/example
+YAML
+  mkdir -p projects
+  cat > projects/ideas-backlog.md <<'MD'
+# Ideas Backlog
+MD
+  mkdir -p .claude/hooks
+  cp "$LIB_SRC" .claude/hooks/_lib-portfolio-paths.sh
+  cp "$CONFIG_LIB_SRC" .claude/hooks/_lib-read-config.sh
+  cp "$DEFAULTS_SRC" .claude/project-config.defaults.json
+  cat > .claude/project-config.json <<'JSON'
+{
+  "portfolio": {
+    "workspace_dir": "../apexyard-portfolio/workspace"
+  }
+}
+JSON
+  git add -A
+  git commit -q -m "test fixture (#945)"
+)
+run_case "#945: relative override with a literal '..' resolves /../-free" "$SB" '
+r=$(portfolio_workspace_dir)
+expected="'"$SIBROOT"'/apexyard-portfolio/workspace"
+case "$r" in
+  *"/../"*) echo "still contains a literal /../ segment: $r"; exit 1 ;;
+esac
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+run_case "#945: end-to-end — FILE_PATH under the resolved workspace now matches the gate's prefix check" "$SB" '
+WORKSPACE_DIR=$(portfolio_workspace_dir)
+# FILE_PATH is built independently from the CANONICAL sibling root
+# ($SIBROOT, captured before this subshell via cd + plain pwd -P), NOT by
+# concatenating $WORKSPACE_DIR — this mirrors reality, where the harness
+# hands the hook an already fully-resolved absolute path with no literal
+# ".." in it, regardless of how WORKSPACE_DIR itself was computed. Deriving
+# FILE_PATH from $WORKSPACE_DIR would make this assertion pass trivially
+# even on the unfixed code (both sides would carry the same literal
+# "/../", so the prefix match "works" for the wrong reason).
+FILE_PATH="'"$SIBROOT"'/apexyard-portfolio/workspace/exampleproj/src/app.ts"
+case "$FILE_PATH" in
+  "$WORKSPACE_DIR"/*) exit 0 ;;
+esac
+echo "FILE_PATH ($FILE_PATH) did not match WORKSPACE_DIR prefix ($WORKSPACE_DIR) — Tier-0/1 marker would be silently ignored"
+exit 1
+'
+rm -rf "$SIBROOT"
+
+# ---------------------------------------------------------------------------
+# Case 26 (#945): same relative-".." override, but the leaf directory does
+# NOT exist yet (the common split-portfolio v2 state before the first
+# managed-project clone lands in workspace/). Canonicalization must still
+# collapse the ".." without requiring the leaf to exist.
+# ---------------------------------------------------------------------------
+SIBROOT=$(mktemp -d)
+SIBROOT=$(cd "$SIBROOT" && pwd -P)
+mkdir -p "$SIBROOT/apexyard-portfolio"   # sibling root exists; workspace/ leaf does not
+SB="$SIBROOT/apexyard"
+mkdir -p "$SB"
+(
+  cd "$SB" || exit 1
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "test"
+  touch onboarding.yaml
+  cat > apexyard.projects.yaml <<'YAML'
+version: 1
+projects:
+  - name: example
+    repo: example/example
+YAML
+  mkdir -p projects
+  cat > projects/ideas-backlog.md <<'MD'
+# Ideas Backlog
+MD
+  mkdir -p .claude/hooks
+  cp "$LIB_SRC" .claude/hooks/_lib-portfolio-paths.sh
+  cp "$CONFIG_LIB_SRC" .claude/hooks/_lib-read-config.sh
+  cp "$DEFAULTS_SRC" .claude/project-config.defaults.json
+  cat > .claude/project-config.json <<'JSON'
+{
+  "portfolio": {
+    "workspace_dir": "../apexyard-portfolio/workspace"
+  }
+}
+JSON
+  git add -A
+  git commit -q -m "test fixture (#945, no leaf yet)"
+)
+run_case "#945: relative override with '..' resolves /../-free even when the leaf dir does not exist yet" "$SB" '
+r=$(portfolio_workspace_dir)
+expected="'"$SIBROOT"'/apexyard-portfolio/workspace"
+case "$r" in
+  *"/../"*) echo "still contains a literal /../ segment: $r"; exit 1 ;;
+esac
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+rm -rf "$SIBROOT"
+
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

- **Fixed the root cause of #945** — `_portfolio_resolve()` in `_lib-portfolio-paths.sh` (the function behind `portfolio_workspace_dir`, `portfolio_projects_dir`, and every other `portfolio.*` config resolver) built its output by string-concatenating a relative override onto the ops-fork root, with no normalisation step. A split-portfolio v2 adopter whose `portfolio.workspace_dir` is a relative sibling path — the documented shape, e.g. `"../<fork>-portfolio/workspace"` — got back a resolved value that still contained a literal `/../` segment (e.g. `/Users/x/apexyard/../apexyard-portfolio/workspace`).
- **Why that broke the ticket gate** — `require-active-ticket.sh` and `require-migration-ticket.sh` compare a tool-supplied `FILE_PATH` (always arrives pre-normalised by the harness — no `..` component) against the resolved workspace dir via a shell `case "$FILE_PATH" in "$WORKSPACE_DIR"/*)` prefix match. A literal `/../` never shows up in a real `FILE_PATH`, so the match silently failed. Concretely, the per-project ticket marker (Tier 0/1 in the resolution order) was ignored, and legitimate edits either got blocked outright or fell through to the wrong tier — the exact symptom reported in #945.
- **The fix** — added `_portfolio_canonicalize()`, an existence-tolerant canonicalizer: it walks up to the nearest existing ancestor, physically resolves it with `cd ... && pwd -P` (which both collapses `..` and follows symlinks), and re-appends whatever tail doesn't exist yet literally. This mirrors the trick `require-active-ticket.sh`'s own `_resolve_real_path()` already uses, and deliberately avoids depending on GNU `realpath -m`/`-e` (not guaranteed present on macOS/BSD). `_portfolio_resolve()` now runs every computed path through it — both the relative-join branch and the absolute-passthrough branch — so the fix applies once, at the resolution boundary, and every caller (`portfolio_workspace_dir`, `portfolio_projects_dir`, `portfolio_registry`, `portfolio_onboarding_path`, `portfolio_custom_skills_dir`, `portfolio_custom_handbooks_dir`, `portfolio_agent_routing`) benefits without needing its own fix.
- **Why this seam, not the gate** — canonicalizing at `_portfolio_resolve()` fixes every caller uniformly instead of patching `require-active-ticket.sh`'s prefix check alone (which would leave `require-migration-ticket.sh` and any future caller with the same bug). I checked every existing caller (`require-active-ticket.sh`, `require-migration-ticket.sh`, `print-portfolio-primer.sh`, `_lib-multi-repo-trace.sh`, `maintain-docs-index.sh`, `_lib-audit-history.sh`) — none of them depend on the exact non-canonical string; they either do prefix comparisons (which this fix repairs) or pass the value to `cd`/`ls`/`find` (which already tolerate `/../` transparently). `portfolio_validate()` in the same file is untouched — that function is owned by a sibling PR (#951).

## Testing

Added three new cases to `.claude/hooks/tests/test_portfolio_paths.sh` (existing suite; I did not create a new file):

1. **`#945: relative override with a literal '..' resolves /../-free`** — sets `portfolio.workspace_dir` to the raw string `"../apexyard-portfolio/workspace"` against a fixture where the sibling directory genuinely exists next to the fork root (every *other* override test in this file pre-resolves the sibling path via `cd && pwd` before writing it into config, so none of them actually exercised the buggy relative-with-`..` concatenation branch — this one deliberately does).
2. **`#945: end-to-end — FILE_PATH under the resolved workspace now matches the gate's prefix check`** — builds a `FILE_PATH` independently from the known-canonical sibling root (not derived from `$WORKSPACE_DIR` itself, which would trivially "pass" even on the buggy code since both sides would carry the same literal `/../`), then asserts the `case "$FILE_PATH" in "$WORKSPACE_DIR"/*)` prefix match — the actual gate logic — now succeeds.
3. **`#945: relative override with '..' resolves /../-free even when the leaf dir does not exist yet`** — same shape, but the `workspace/` leaf hasn't been created yet (the common split-portfolio v2 state before the first managed-project clone), proving the canonicalizer's existence-tolerant walk works without requiring the full path to exist.

I verified all three tests actually catch the regression (not vacuously true) by temporarily reverting only `_lib-portfolio-paths.sh` and re-running:

```
$ git stash push -- .claude/hooks/_lib-portfolio-paths.sh
$ bash .claude/hooks/tests/test_portfolio_paths.sh 2>&1 | tail -10
FAIL: #945: relative override with a literal '..' resolves /../-free
  output: still contains a literal /../ segment: /private/var/.../apexyard/../apexyard-portfolio/workspace
FAIL: #945: end-to-end — FILE_PATH under the resolved workspace now matches the gate's prefix check
FAIL: #945: relative override with '..' resolves /../-free even when the leaf dir does not exist yet
  output: still contains a literal /../ segment: /private/var/.../apexyard/../apexyard-portfolio/workspace

===== test_portfolio_paths.sh =====
Passed: 39
Failed: 3
$ git stash pop
```

With the fix restored, the full suite is green:

```
$ bash .claude/hooks/tests/test_portfolio_paths.sh 2>&1 | tail -6
PASS: #945: relative override with a literal '..' resolves /../-free
PASS: #945: end-to-end — FILE_PATH under the resolved workspace now matches the gate's prefix check
PASS: #945: relative override with '..' resolves /../-free even when the leaf dir does not exist yet

===== test_portfolio_paths.sh =====
Passed: 42
Failed: 0
```

I also ran the broader hook-test suite for anything touching `_lib-portfolio-paths.sh` or the two ticket gates it feeds, to check for regressions: `test_require_active_ticket_bash.sh` (78/78), `test_require_migration_ticket.sh` (26/26), `test_portfolio_agent_routing.sh` (6/6), `test_print_portfolio_primer.sh` (3/3), `test_audit_history.sh` (11/11), `test_maintain_docs_index.sh` (33/33), `test_handover_clone_prompt.sh` (18/18) — all pass.

Three unrelated test files (`test_ops_root.sh`, `test_split_portfolio_v2_migration.sh`, `test_workspace_tracker_resolution.sh`) show pre-existing failures in this sandbox — I confirmed by stashing my change and re-running them, and they fail identically with or without this diff, so they're not a regression introduced here (looks like an environment/CWD quirk unrelated to this fix).

`shellcheck -x .claude/hooks/_lib-portfolio-paths.sh` is clean.

Refs #945

---

## Glossary

| Term | Definition |
|------|------------|
| Canonicalize | Resolve a path to one unambiguous absolute form — no `..`/`.` segments, no symlinks left unresolved. Two different-looking path strings can name the same file; canonicalizing makes them compare equal as strings too. |
| Existence-tolerant | A canonicalization approach that doesn't require the full path to exist on disk — it resolves as much of the path as physically exists (walking up to the nearest real ancestor) and reattaches the rest literally, since a not-yet-created tail can't itself be a symlink. |
| Prefix match | A shell `case "$x" in "$y"/*)` check used here to test "is `$x` a path underneath directory `$y`?" — purely a string comparison, so both sides must already be in the same normalised form or the match silently fails. |
| Split-portfolio v2 | An apexyard deployment mode where company config (`onboarding.yaml`, `apexyard.projects.yaml`, `workspace/`) lives in a private sibling repo next to the public framework fork, instead of inside the fork itself. |
| Tier 0/1 ticket marker | The per-worktree / per-project active-ticket marker files `require-active-ticket.sh` checks (in order) before falling back to the ops-level marker or blocking the edit outright. |
