### PR TITLE
fix(#943): reconcile installed Codex adapters on /update (carry-forward of #944)

### DIFF
--- a/.claude/hooks/check-upstream-drift.sh
+++ b/.claude/hooks/check-upstream-drift.sh
@@ -36,19 +36,23 @@ fi
 
 cd "$REPO_ROOT" || exit 0
 
-# Bootstrap generated Codex adapters after a framework update. The /update
-# skill is itself generated under .agents/, so an adopter invoking a pre-fix
-# copy cannot execute reconciliation instructions that only arrived in the
-# newly merged canonical skill. Existing Codex hook wiring already delegates
-# this SessionStart hook to .claude/hooks/, giving the first restart a stable
-# path to install the refreshed skill. The generator owns detection and is a
-# silent no-op for uninstalled/partial adapters. Startup stays advisory: warn
-# on failure, but never block the session.
+# Warn (never mutate) when an installed Codex adapter looks stale. SessionStart
+# is a boot-time hook that runs on every session, so it must never write to
+# the tree itself — reconciliation is a deliberate, explicit action owned by
+# `/update` (via `bin/sync-codex-adapter.sh --reconcile-installed`) or a manual
+# operator run. This hook only runs the generator's read-only
+# `--check-installed` mode (no writes, ever) and prints a one-line advisory
+# nudge on drift. The generator owns installation detection and is a silent
+# no-op for uninstalled adapters. Startup stays advisory: warn on drift or
+# failure, but never block the session, and never touch the working tree.
 CODEX_RECONCILER="$REPO_ROOT/bin/sync-codex-adapter.sh"
 if [ -f "$CODEX_RECONCILER" ]; then
+  _CODEX_TO=""
+  if command -v timeout >/dev/null 2>&1; then _CODEX_TO="timeout -k 2 5"
+  elif command -v gtimeout >/dev/null 2>&1; then _CODEX_TO="gtimeout -k 2 5"; fi
   ADAPTER_ERROR=""
-  if ! ADAPTER_ERROR=$(bash "$CODEX_RECONCILER" --reconcile-installed 2>&1 >/dev/null); then
-    echo "ApexYard: installed Codex adapter could not be refreshed; run bash bin/sync-codex-adapter.sh --reconcile-installed." >&2
+  if ! ADAPTER_ERROR=$($_CODEX_TO bash "$CODEX_RECONCILER" --check-installed 2>&1 >/dev/null); then
+    echo "ApexYard: installed Codex adapter may be stale — run bash bin/sync-codex-adapter.sh --reconcile-installed." >&2
     [ -n "$ADAPTER_ERROR" ] && printf '%s\n' "$ADAPTER_ERROR" >&2
   fi
 fi

--- a/.claude/hooks/check-upstream-drift.sh
+++ b/.claude/hooks/check-upstream-drift.sh
@@ -36,6 +36,23 @@ fi
 
 cd "$REPO_ROOT" || exit 0
 
+# Bootstrap generated Codex adapters after a framework update. The /update
+# skill is itself generated under .agents/, so an adopter invoking a pre-fix
+# copy cannot execute reconciliation instructions that only arrived in the
+# newly merged canonical skill. Existing Codex hook wiring already delegates
+# this SessionStart hook to .claude/hooks/, giving the first restart a stable
+# path to install the refreshed skill. The generator owns detection and is a
+# silent no-op for uninstalled/partial adapters. Startup stays advisory: warn
+# on failure, but never block the session.
+CODEX_RECONCILER="$REPO_ROOT/bin/sync-codex-adapter.sh"
+if [ -f "$CODEX_RECONCILER" ]; then
+  ADAPTER_ERROR=""
+  if ! ADAPTER_ERROR=$(bash "$CODEX_RECONCILER" --reconcile-installed 2>&1 >/dev/null); then
+    echo "ApexYard: installed Codex adapter could not be refreshed; run bash bin/sync-codex-adapter.sh --reconcile-installed." >&2
+    [ -n "$ADAPTER_ERROR" ] && printf '%s\n' "$ADAPTER_ERROR" >&2
+  fi
+fi
+
 # Bail if no upstream remote — either this IS the upstream repo, or the fork
 # owner hasn't run `git remote add upstream …` yet. Either case: silent.
 if ! git remote | grep -qx upstream; then

--- a/.claude/hooks/tests/test_check_upstream_drift.sh
+++ b/.claude/hooks/tests/test_check_upstream_drift.sh
@@ -159,9 +159,11 @@ case_squash_no_changelog() {
   rm -rf "$up" "$(dirname "$fk")"
 }
 
-# CASE 6: an installed pre-manifest Codex adapter is refreshed through the
-# canonical SessionStart hook after new framework skills land.
-case_codex_bootstrap_refresh() {
+# CASE 6: an installed pre-manifest Codex adapter has drifted (new framework
+# skills landed). The SessionStart hook must WARN about the drift but must
+# NEVER mutate the tree itself — reconciliation is owned exclusively by an
+# explicit `/update` or a manual `--reconcile-installed` run.
+case_codex_bootstrap_warns_without_mutating() {
   local up; up=$(make_upstream)
   local fk; fk=$(make_fork "$up")
   (
@@ -175,20 +177,25 @@ case_codex_bootstrap_refresh() {
     mkdir -p .claude/skills/tutorial
     printf '%s\n' '# newly synced tutorial skill' > .claude/skills/tutorial/SKILL.md
   )
-  run_hook_from "$fk" >/tmp/_upstream_drift_codex_bootstrap.out
-  if [ -f "$fk/.codex/apexyard-adapter.json" ] \
-    && grep -q '# newly synced tutorial skill' "$fk/.agents/skills/tutorial/SKILL.md"; then
-    echo "PASS [SessionStart refreshes a legacy Codex adapter]"
+  local output
+  output=$(run_hook_from "$fk")
+  if echo "$output" | grep -q 'Codex adapter may be stale' \
+    && [ ! -e "$fk/.codex/apexyard-adapter.json" ] \
+    && [ ! -e "$fk/.agents/skills/tutorial" ]; then
+    echo "PASS [SessionStart warns on Codex adapter drift without mutating the tree]"
     PASS=$((PASS+1))
   else
-    echo "FAIL [SessionStart refreshes a legacy Codex adapter]" >&2
+    echo "FAIL [SessionStart warns on Codex adapter drift without mutating the tree]" >&2
+    echo "  output=$output" >&2
+    echo "  manifest exists=$([ -e "$fk/.codex/apexyard-adapter.json" ] && echo yes || echo no)" >&2
+    echo "  tutorial skill copied=$([ -e "$fk/.agents/skills/tutorial" ] && echo yes || echo no)" >&2
     FAIL=$((FAIL+1)); FAILED="${FAILED}codex-bootstrap "
   fi
   rm -rf "$up" "$(dirname "$fk")"
 }
 
-# CASE 7: carrying the reconciler without a detected installation must not
-# create Codex-specific files for another harness.
+# CASE 7: carrying the checker without a detected installation must not
+# create Codex-specific files for another harness, and must stay silent.
 case_codex_bootstrap_uninstalled_noop() {
   local up; up=$(make_upstream)
   local fk; fk=$(make_fork "$up")
@@ -208,8 +215,8 @@ case_codex_bootstrap_uninstalled_noop() {
   rm -rf "$up" "$(dirname "$fk")"
 }
 
-# CASE 8: startup reconciliation failure is visible but advisory. The session
-# hook must still return zero.
+# CASE 8: a failure inside the staleness check itself is visible but
+# advisory. The session hook must still return zero and must not mutate.
 case_codex_bootstrap_failure_warns_without_blocking() {
   local up; up=$(make_upstream)
   local fk; fk=$(make_fork "$up")
@@ -228,12 +235,13 @@ SH
   output=$(run_hook_from "$fk")
   rc=$?
   if [ "$rc" -eq 0 ] \
-    && echo "$output" | grep -q 'installed Codex adapter could not be refreshed' \
-    && echo "$output" | grep -q 'synthetic reconciliation failure'; then
-    echo "PASS [SessionStart warns without blocking on reconciliation failure]"
+    && echo "$output" | grep -q 'Codex adapter may be stale' \
+    && echo "$output" | grep -q 'synthetic reconciliation failure' \
+    && [ ! -e "$fk/.codex/apexyard-adapter.json" ]; then
+    echo "PASS [SessionStart warns without blocking or mutating on check failure]"
     PASS=$((PASS+1))
   else
-    echo "FAIL [SessionStart warns without blocking on reconciliation failure] rc=$rc output=$output" >&2
+    echo "FAIL [SessionStart warns without blocking or mutating on check failure] rc=$rc output=$output" >&2
     FAIL=$((FAIL+1)); FAILED="${FAILED}codex-failure "
   fi
   rm -rf "$up" "$(dirname "$fk")"
@@ -244,7 +252,7 @@ case_merge_commit_caught_up
 case_genuinely_behind
 case_fork_ahead
 case_squash_no_changelog
-case_codex_bootstrap_refresh
+case_codex_bootstrap_warns_without_mutating
 case_codex_bootstrap_uninstalled_noop
 case_codex_bootstrap_failure_warns_without_blocking
 

--- a/.claude/hooks/tests/test_check_upstream_drift.sh
+++ b/.claude/hooks/tests/test_check_upstream_drift.sh
@@ -11,6 +11,7 @@
 set -u
 
 HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/check-upstream-drift.sh"
+GENERATOR_SRC="$(cd "$(dirname "$0")/../../.." && pwd)/bin/sync-codex-adapter.sh"
 PASS=0
 FAIL=0
 FAILED=""
@@ -158,11 +159,94 @@ case_squash_no_changelog() {
   rm -rf "$up" "$(dirname "$fk")"
 }
 
+# CASE 6: an installed pre-manifest Codex adapter is refreshed through the
+# canonical SessionStart hook after new framework skills land.
+case_codex_bootstrap_refresh() {
+  local up; up=$(make_upstream)
+  local fk; fk=$(make_fork "$up")
+  (
+    cd "$fk" || exit 1
+    mkdir -p bin .claude/skills/status .claude/agents
+    cp "$GENERATOR_SRC" bin/sync-codex-adapter.sh
+    printf '%s\n' '{"hooks":{}}' > .claude/settings.json
+    printf '%s\n' '# old status skill' > .claude/skills/status/SKILL.md
+    bash bin/sync-codex-adapter.sh >/dev/null
+    rm .codex/apexyard-adapter.json
+    mkdir -p .claude/skills/tutorial
+    printf '%s\n' '# newly synced tutorial skill' > .claude/skills/tutorial/SKILL.md
+  )
+  run_hook_from "$fk" >/tmp/_upstream_drift_codex_bootstrap.out
+  if [ -f "$fk/.codex/apexyard-adapter.json" ] \
+    && grep -q '# newly synced tutorial skill' "$fk/.agents/skills/tutorial/SKILL.md"; then
+    echo "PASS [SessionStart refreshes a legacy Codex adapter]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [SessionStart refreshes a legacy Codex adapter]" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}codex-bootstrap "
+  fi
+  rm -rf "$up" "$(dirname "$fk")"
+}
+
+# CASE 7: carrying the reconciler without a detected installation must not
+# create Codex-specific files for another harness.
+case_codex_bootstrap_uninstalled_noop() {
+  local up; up=$(make_upstream)
+  local fk; fk=$(make_fork "$up")
+  (
+    cd "$fk" || exit 1
+    mkdir -p bin
+    cp "$GENERATOR_SRC" bin/sync-codex-adapter.sh
+  )
+  run_hook_from "$fk" >/tmp/_upstream_drift_codex_uninstalled.out
+  if [ ! -e "$fk/.agents" ] && [ ! -e "$fk/.codex" ]; then
+    echo "PASS [SessionStart leaves an uninstalled Codex adapter absent]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [SessionStart leaves an uninstalled Codex adapter absent]" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}codex-uninstalled "
+  fi
+  rm -rf "$up" "$(dirname "$fk")"
+}
+
+# CASE 8: startup reconciliation failure is visible but advisory. The session
+# hook must still return zero.
+case_codex_bootstrap_failure_warns_without_blocking() {
+  local up; up=$(make_upstream)
+  local fk; fk=$(make_fork "$up")
+  (
+    cd "$fk" || exit 1
+    mkdir -p bin .agents/skills .codex/agents
+    printf '%s\n' '{}' > .codex/hooks.json
+    cat > bin/sync-codex-adapter.sh <<'SH'
+#!/bin/bash
+echo "synthetic reconciliation failure" >&2
+exit 7
+SH
+    chmod +x bin/sync-codex-adapter.sh
+  )
+  local output rc
+  output=$(run_hook_from "$fk")
+  rc=$?
+  if [ "$rc" -eq 0 ] \
+    && echo "$output" | grep -q 'installed Codex adapter could not be refreshed' \
+    && echo "$output" | grep -q 'synthetic reconciliation failure'; then
+    echo "PASS [SessionStart warns without blocking on reconciliation failure]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [SessionStart warns without blocking on reconciliation failure] rc=$rc output=$output" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}codex-failure "
+  fi
+  rm -rf "$up" "$(dirname "$fk")"
+}
+
 case_squash_caught_up
 case_merge_commit_caught_up
 case_genuinely_behind
 case_fork_ahead
 case_squash_no_changelog
+case_codex_bootstrap_refresh
+case_codex_bootstrap_uninstalled_noop
+case_codex_bootstrap_failure_warns_without_blocking
 
 echo ""
 echo "==================================="

--- a/.claude/hooks/tests/test_sync_codex_adapter.sh
+++ b/.claude/hooks/tests/test_sync_codex_adapter.sh
@@ -275,6 +275,68 @@ for missing in skills agents hooks; do
   assert_no_file "$PARTIAL/.codex/apexyard-adapter.json" "partial shape missing $missing gets no manifest"
 done
 
+# Reconciliation must never follow generated-output symlinks outside the repo.
+# Each fixture carries a complete legacy shape, redirects one owned path to an
+# external sentinel, and proves the generator rejects it before mutation.
+assert_symlink_escape_rejected() {
+  local kind="$1" fixture="$TMPROOT/symlink-$1" external="$TMPROOT/external-$1"
+  mkdir -p "$fixture/.agents/skills" "$fixture/.codex/agents" "$external"
+  cp -R "$TMPROOT/.claude" "$fixture/.claude"
+  printf '{}\n' > "$fixture/.codex/hooks.json"
+  printf '%s\n' 'outside must survive' > "$external/sentinel.txt"
+
+  case "$kind" in
+    agents-root)
+      rmdir "$fixture/.agents/skills" "$fixture/.agents"
+      mkdir -p "$external/skills"
+      ln -s "$external" "$fixture/.agents"
+      ;;
+    codex-root)
+      rmdir "$fixture/.codex/agents"
+      rm "$fixture/.codex/hooks.json"
+      rmdir "$fixture/.codex"
+      mkdir -p "$external/agents"
+      printf '{}\n' > "$external/hooks.json"
+      ln -s "$external" "$fixture/.codex"
+      ;;
+    skills-child)
+      rmdir "$fixture/.agents/skills"
+      ln -s "$external" "$fixture/.agents/skills"
+      ;;
+    agents-child)
+      rmdir "$fixture/.codex/agents"
+      ln -s "$external" "$fixture/.codex/agents"
+      ;;
+    hooks-child)
+      rm "$fixture/.codex/hooks.json"
+      printf '{}\n' > "$external/hooks.json"
+      ln -s "$external/hooks.json" "$fixture/.codex/hooks.json"
+      ;;
+    manifest-child)
+      printf '%s\n' '{"adapter":"apexyard-codex","schema":1}' > "$external/manifest.json"
+      ln -s "$external/manifest.json" "$fixture/.codex/apexyard-adapter.json"
+      ;;
+  esac
+
+  if bash "$SCRIPT" --root "$fixture" --reconcile-installed >/tmp/_codex_adapter_symlink.out 2>&1; then
+    mark_fail "symlinked $kind is rejected" "expected non-zero exit"
+  elif grep -q 'refusing Codex adapter output through symlink' /tmp/_codex_adapter_symlink.out; then
+    mark_pass "symlinked $kind is rejected"
+  else
+    mark_fail "symlinked $kind is rejected" "$(cat /tmp/_codex_adapter_symlink.out)"
+  fi
+
+  if [ "$(cat "$external/sentinel.txt")" = 'outside must survive' ]; then
+    mark_pass "symlinked $kind cannot mutate external sentinel"
+  else
+    mark_fail "symlinked $kind cannot mutate external sentinel" "sentinel changed or missing"
+  fi
+}
+
+for symlink_kind in agents-root codex-root skills-child agents-child hooks-child manifest-child; do
+  assert_symlink_escape_rejected "$symlink_kind"
+done
+
 # A detected install with an invalid canonical config must fail loudly.
 FAILROOT="$TMPROOT/failing-install"
 mkdir -p "$FAILROOT/.agents/skills" "$FAILROOT/.codex/agents"

--- a/.claude/hooks/tests/test_sync_codex_adapter.sh
+++ b/.claude/hooks/tests/test_sync_codex_adapter.sh
@@ -337,6 +337,42 @@ for symlink_kind in agents-root codex-root skills-child agents-child hooks-child
   assert_symlink_escape_rejected "$symlink_kind"
 done
 
+# Drift detection (and reconciliation) is scoped to adapter-owned paths only.
+# A hand-authored file living alongside generated output under .codex/ or
+# .agents/ — a native Codex config.toml, an operator scratch file — must
+# never be reported as drift, and must never be deleted by reconciliation.
+# Before this scoping, a whole-tree `diff -qr` would misreport such a file as
+# drift, which made --reconcile-installed's own post-write verification fail
+# even though every owned path was perfectly in sync — a false-positive hard
+# failure on /update's strict path.
+SCOPED="$TMPROOT/scoped-owned-paths"
+mkdir -p "$SCOPED/.agents/skills" "$SCOPED/.codex/agents"
+cp -R "$TMPROOT/.claude" "$SCOPED/.claude"
+bash "$SCRIPT" --root "$SCOPED" >/dev/null 2>&1
+printf '%s\n' 'hand-authored, not adapter output' > "$SCOPED/.codex/config.toml"
+mkdir -p "$SCOPED/.agents/notes"
+printf '%s\n' 'operator scratch file' > "$SCOPED/.agents/notes/todo.md"
+
+if bash "$SCRIPT" --root "$SCOPED" --check >/tmp/_codex_adapter_scoped_check.out 2>&1; then
+  mark_pass "--check ignores non-owned files under .codex/ and .agents/"
+else
+  mark_fail "--check ignores non-owned files under .codex/ and .agents/" "$(cat /tmp/_codex_adapter_scoped_check.out)"
+fi
+
+if bash "$SCRIPT" --root "$SCOPED" --check-installed >/tmp/_codex_adapter_scoped_check_installed.out 2>&1; then
+  mark_pass "--check-installed ignores non-owned files (no false-positive staleness)"
+else
+  mark_fail "--check-installed ignores non-owned files (no false-positive staleness)" "$(cat /tmp/_codex_adapter_scoped_check_installed.out)"
+fi
+
+if bash "$SCRIPT" --root "$SCOPED" --reconcile-installed >/tmp/_codex_adapter_scoped_reconcile.out 2>&1; then
+  mark_pass "--reconcile-installed succeeds with non-owned files present (no false-positive failure)"
+else
+  mark_fail "--reconcile-installed succeeds with non-owned files present (no false-positive failure)" "$(cat /tmp/_codex_adapter_scoped_reconcile.out)"
+fi
+assert_contains "$SCOPED/.codex/config.toml" "hand-authored, not adapter output" "reconciliation leaves a hand-authored .codex file untouched"
+assert_contains "$SCOPED/.agents/notes/todo.md" "operator scratch file" "reconciliation leaves a hand-authored .agents file untouched"
+
 # A detected install with an invalid canonical config must fail loudly.
 FAILROOT="$TMPROOT/failing-install"
 mkdir -p "$FAILROOT/.agents/skills" "$FAILROOT/.codex/agents"
@@ -354,6 +390,20 @@ if bash "$SCRIPT" --root "$TMPROOT" --check >/tmp/_codex_adapter_check_drift.out
   mark_fail "--check detects drift" "expected non-zero exit"
 else
   mark_pass "--check detects drift"
+fi
+
+# --check-installed is the read-only counterpart used by the SessionStart
+# advisory: it must catch real owned-path drift (same fixture the --check
+# assertion above just proved is stale) without writing anything.
+if bash "$SCRIPT" --root "$TMPROOT" --check-installed >/tmp/_codex_adapter_check_installed_drift.out 2>&1; then
+  mark_fail "--check-installed detects real owned-path drift" "expected non-zero exit"
+else
+  mark_pass "--check-installed detects real owned-path drift"
+fi
+if grep -q "New source line." "$TMPROOT/.agents/skills/status/SKILL.md" 2>/dev/null; then
+  mark_fail "--check-installed does not write the drifted change to generated output" "generated output was mutated"
+else
+  mark_pass "--check-installed does not write the drifted change to generated output"
 fi
 
 echo

--- a/.claude/hooks/tests/test_sync_codex_adapter.sh
+++ b/.claude/hooks/tests/test_sync_codex_adapter.sh
@@ -30,6 +30,11 @@ assert_no_dir() {
   [ ! -d "$path" ] && mark_pass "$label" || mark_fail "$label" "unexpected directory $path"
 }
 
+assert_no_file() {
+  local path="$1" label="$2"
+  [ ! -f "$path" ] && mark_pass "$label" || mark_fail "$label" "unexpected file $path"
+}
+
 assert_contains() {
   local path="$1" pattern="$2" label="$3"
   grep -F "$pattern" "$path" >/dev/null 2>&1 && mark_pass "$label" || mark_fail "$label" "missing pattern [$pattern] in $path"
@@ -124,6 +129,7 @@ fi
 assert_file "$TMPROOT/.agents/skills/status/SKILL.md" "skill mirror exists"
 assert_file "$TMPROOT/.codex/hooks.json" "hooks.json mirror exists"
 assert_file "$TMPROOT/.codex/agents/backend-engineer.toml" "agent TOML exists"
+assert_file "$TMPROOT/.codex/apexyard-adapter.json" "adapter ownership manifest exists"
 assert_no_dir "$TMPROOT/.codex/hooks" "adapter does not copy hook scripts"
 
 assert_contains "$TMPROOT/.agents/skills/status/SKILL.md" ".agents/skills/status/briefing.sh" "skill rewrites skill paths"
@@ -137,6 +143,16 @@ assert_contains "$TMPROOT/.codex/agents/backend-engineer.toml" 'name = "backend-
 assert_contains "$TMPROOT/.codex/agents/backend-engineer.toml" 'model = "gpt-5.4"' "agent TOML maps Claude model to Codex model"
 assert_contains "$TMPROOT/.codex/agents/backend-engineer.toml" ".claude/rules/workflow-gates.md" "agent instructions preserve rule paths"
 assert_not_contains "$TMPROOT/.codex/agents/backend-engineer.toml" "---" "agent TOML excludes YAML frontmatter"
+
+if jq -e '
+  .adapter == "apexyard-codex"
+  and .schema == 1
+  and .generated_from == ".claude"
+' "$TMPROOT/.codex/apexyard-adapter.json" >/dev/null; then
+  mark_pass "adapter ownership manifest has the expected schema"
+else
+  mark_fail "adapter ownership manifest has the expected schema" "$(cat "$TMPROOT/.codex/apexyard-adapter.json")"
+fi
 
 if jq -e '.. | objects | select(has("if"))' "$TMPROOT/.codex/hooks.json" >/dev/null; then
   mark_fail "hooks.json omits unsupported if fields" "found handler-level if metadata"
@@ -202,6 +218,73 @@ if bash "$SCRIPT" --root "$TMPROOT" --check >/tmp/_codex_adapter_check.out 2>&1;
   mark_pass "--check passes when generated output is current"
 else
   mark_fail "--check passes when generated output is current" "$(cat /tmp/_codex_adapter_check.out)"
+fi
+
+# The manifest participates in drift detection just like skills, agents, and
+# hooks. Restore it through normal generation after proving the drift signal.
+printf '{"adapter":"apexyard-codex","schema":999,"generated_from":".claude"}\n' \
+  > "$TMPROOT/.codex/apexyard-adapter.json"
+if bash "$SCRIPT" --root "$TMPROOT" --check >/tmp/_codex_adapter_manifest_drift.out 2>&1; then
+  mark_fail "--check detects ownership-manifest drift" "expected non-zero exit"
+else
+  mark_pass "--check detects ownership-manifest drift"
+fi
+bash "$SCRIPT" --root "$TMPROOT" >/dev/null 2>&1
+
+# A pre-manifest adapter is recognised only when all three legacy surfaces
+# exist. Reconciliation refreshes stale skills and writes the durable marker.
+rm "$TMPROOT/.codex/apexyard-adapter.json"
+printf '\nLegacy refresh line.\n' >> "$TMPROOT/.claude/skills/status/SKILL.md"
+if bash "$SCRIPT" --root "$TMPROOT" --reconcile-installed >/tmp/_codex_adapter_legacy.out 2>&1; then
+  mark_pass "--reconcile-installed refreshes a complete legacy adapter"
+else
+  mark_fail "--reconcile-installed refreshes a complete legacy adapter" "$(cat /tmp/_codex_adapter_legacy.out)"
+fi
+assert_file "$TMPROOT/.codex/apexyard-adapter.json" "legacy reconciliation writes ownership manifest"
+assert_contains "$TMPROOT/.agents/skills/status/SKILL.md" "Legacy refresh line." "legacy reconciliation refreshes skills"
+
+# No install means no harness-specific output is created.
+NOINSTALL="$TMPROOT/no-install"
+mkdir -p "$NOINSTALL"
+cp -R "$TMPROOT/.claude" "$NOINSTALL/.claude"
+if bash "$SCRIPT" --root "$NOINSTALL" --reconcile-installed >/tmp/_codex_adapter_noinstall.out 2>&1; then
+  mark_pass "--reconcile-installed is a no-op when Codex is not installed"
+else
+  mark_fail "--reconcile-installed is a no-op when Codex is not installed" "$(cat /tmp/_codex_adapter_noinstall.out)"
+fi
+assert_no_dir "$NOINSTALL/.agents" "uninstalled fork keeps .agents absent"
+assert_no_dir "$NOINSTALL/.codex" "uninstalled fork keeps .codex absent"
+
+# Every two-of-three partial legacy shape remains untouched. This prevents a
+# user-owned .agents or .codex tree from being claimed by ApexYard.
+for missing in skills agents hooks; do
+  PARTIAL="$TMPROOT/partial-$missing"
+  mkdir -p "$PARTIAL/.agents/skills" "$PARTIAL/.codex/agents"
+  cp -R "$TMPROOT/.claude" "$PARTIAL/.claude"
+  printf '{}\n' > "$PARTIAL/.codex/hooks.json"
+  case "$missing" in
+    skills) rmdir "$PARTIAL/.agents/skills" "$PARTIAL/.agents" ;;
+    agents) rmdir "$PARTIAL/.codex/agents" ;;
+    hooks)  rm "$PARTIAL/.codex/hooks.json" ;;
+  esac
+  if bash "$SCRIPT" --root "$PARTIAL" --reconcile-installed >/tmp/_codex_adapter_partial.out 2>&1; then
+    mark_pass "partial legacy shape missing $missing is ignored"
+  else
+    mark_fail "partial legacy shape missing $missing is ignored" "$(cat /tmp/_codex_adapter_partial.out)"
+  fi
+  assert_no_file "$PARTIAL/.codex/apexyard-adapter.json" "partial shape missing $missing gets no manifest"
+done
+
+# A detected install with an invalid canonical config must fail loudly.
+FAILROOT="$TMPROOT/failing-install"
+mkdir -p "$FAILROOT/.agents/skills" "$FAILROOT/.codex/agents"
+cp -R "$TMPROOT/.claude" "$FAILROOT/.claude"
+printf '{}\n' > "$FAILROOT/.codex/hooks.json"
+printf '{ invalid json\n' > "$FAILROOT/.claude/settings.json"
+if bash "$SCRIPT" --root "$FAILROOT" --reconcile-installed >/tmp/_codex_adapter_failure.out 2>&1; then
+  mark_fail "--reconcile-installed propagates generation failure" "expected non-zero exit"
+else
+  mark_pass "--reconcile-installed propagates generation failure"
 fi
 
 printf '\nNew source line.\n' >> "$TMPROOT/.claude/skills/status/SKILL.md"

--- a/.claude/hooks/tests/test_update_codex_adapter_reconcile.sh
+++ b/.claude/hooks/tests/test_update_codex_adapter_reconcile.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Contract test for /update's installed Codex adapter reconciliation (#943).
+#
+# /update is a markdown skill, so this test pins its documented shell recipe
+# and verifies the two required call sites remain ordered around the
+# already-current and post-sync success paths.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+GENERATOR="$ROOT/bin/sync-codex-adapter.sh"
+SKILL="$ROOT/.claude/skills/update/SKILL.md"
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/update-codex-reconcile.XXXXXX")
+trap 'rm -rf "$TMPROOT"' EXIT
+
+PASS=0
+FAIL=0
+FAILED=""
+
+pass() { echo "  ok   $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL $1: $2" >&2; FAIL=$((FAIL+1)); FAILED="$FAILED $1"; }
+
+build_root() {
+  local root="$TMPROOT/$1"
+  mkdir -p "$root/.claude/skills/update" "$root/.claude/agents"
+  printf '%s\n' '# update fixture' > "$root/.claude/skills/update/SKILL.md"
+  printf '%s\n' '{"hooks":{}}' > "$root/.claude/settings.json"
+  printf '%s\n' "$root"
+}
+
+run_recipe() {
+  local root="$1"
+  shift
+  (
+    cd "$root" || exit 1
+    DRY_RUN=0
+    SKIP_ADAPTER_SYNC=0
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --dry-run) DRY_RUN=1 ;;
+        --skip-adapter-sync) SKIP_ADAPTER_SYNC=1 ;;
+      esac
+      shift
+    done
+
+    reconcile_installed_codex_adapter() {
+      if [ "$SKIP_ADAPTER_SYNC" = "1" ]; then
+        echo "Codex adapter reconciliation skipped (--skip-adapter-sync)."
+        return 0
+      fi
+      if [ "$DRY_RUN" = "1" ]; then
+        echo "DRY-RUN: would reconcile an installed Codex adapter."
+        return 0
+      fi
+
+      local script="$GENERATOR"
+      if [ ! -f "$script" ]; then
+        echo "Codex adapter reconciliation failed: missing $script" >&2
+        return 1
+      fi
+      bash "$script" --root "$root" --reconcile-installed
+    }
+
+    reconcile_installed_codex_adapter
+  )
+}
+
+echo "== /update Codex adapter reconciliation"
+
+NOINSTALL=$(build_root no-install)
+if run_recipe "$NOINSTALL" >/tmp/_update_codex_noinstall.out 2>&1; then
+  pass "uninstalled fork exits successfully"
+else
+  fail "uninstalled fork exits successfully" "$(cat /tmp/_update_codex_noinstall.out)"
+fi
+if [ ! -e "$NOINSTALL/.agents" ] && [ ! -e "$NOINSTALL/.codex" ]; then
+  pass "uninstalled fork remains untouched"
+else
+  fail "uninstalled fork remains untouched" "adapter directories were created"
+fi
+
+STALE=$(build_root stale-install)
+bash "$GENERATOR" --root "$STALE" >/dev/null
+printf '%s\n' '# newly synced update content' >> "$STALE/.claude/skills/update/SKILL.md"
+if run_recipe "$STALE" >/tmp/_update_codex_stale.out 2>&1 \
+  && grep -q '# newly synced update content' "$STALE/.agents/skills/update/SKILL.md"; then
+  pass "already-current recipe refreshes a stale installed skill"
+else
+  fail "already-current recipe refreshes a stale installed skill" "$(cat /tmp/_update_codex_stale.out)"
+fi
+
+DRY=$(build_root dry-run)
+bash "$GENERATOR" --root "$DRY" >/dev/null
+printf '%s\n' '# dry-run source drift' >> "$DRY/.claude/skills/update/SKILL.md"
+if run_recipe "$DRY" --dry-run >/tmp/_update_codex_dry.out 2>&1 \
+  && ! grep -q '# dry-run source drift' "$DRY/.agents/skills/update/SKILL.md"; then
+  pass "--dry-run reports intent without refreshing output"
+else
+  fail "--dry-run reports intent without refreshing output" "$(cat /tmp/_update_codex_dry.out)"
+fi
+
+SKIP=$(build_root skip-sync)
+bash "$GENERATOR" --root "$SKIP" >/dev/null
+printf '%s\n' '# skipped source drift' >> "$SKIP/.claude/skills/update/SKILL.md"
+if run_recipe "$SKIP" --skip-adapter-sync >/tmp/_update_codex_skip.out 2>&1 \
+  && ! grep -q '# skipped source drift' "$SKIP/.agents/skills/update/SKILL.md"; then
+  pass "--skip-adapter-sync leaves installed output unchanged"
+else
+  fail "--skip-adapter-sync leaves installed output unchanged" "$(cat /tmp/_update_codex_skip.out)"
+fi
+
+BROKEN=$(build_root broken-install)
+bash "$GENERATOR" --root "$BROKEN" >/dev/null
+printf '%s\n' '{ invalid json' > "$BROKEN/.claude/settings.json"
+if run_recipe "$BROKEN" >/tmp/_update_codex_broken.out 2>&1; then
+  fail "explicit reconciliation propagates generator failure" "expected non-zero exit"
+else
+  pass "explicit reconciliation propagates generator failure"
+fi
+
+call_count=$(grep -c '^reconcile_installed_codex_adapter ||' "$SKILL")
+early_call=$(grep -n '^reconcile_installed_codex_adapter ||' "$SKILL" | head -n 1 | cut -d: -f1)
+current_report=$(grep -n 'echo "Fork is up to date with upstream/main' "$SKILL" | head -n 1 | cut -d: -f1)
+late_heading=$(grep -n '^### 8d\. Reconcile an installed Codex adapter' "$SKILL" | cut -d: -f1)
+final_heading=$(grep -n '^### 9\. Final state' "$SKILL" | cut -d: -f1)
+
+if [ "$call_count" -eq 2 ]; then
+  pass "skill has exactly two strict reconciliation call sites"
+else
+  fail "skill has exactly two strict reconciliation call sites" "found $call_count"
+fi
+if [ -n "$early_call" ] && [ -n "$current_report" ] && [ "$early_call" -lt "$current_report" ]; then
+  pass "already-current path reconciles before reporting success"
+else
+  fail "already-current path reconciles before reporting success" "call=$early_call report=$current_report"
+fi
+if [ -n "$late_heading" ] && [ -n "$final_heading" ] && [ "$late_heading" -lt "$final_heading" ]; then
+  pass "post-sync reconciliation precedes final success report"
+else
+  fail "post-sync reconciliation precedes final success report" "reconcile=$late_heading final=$final_heading"
+fi
+if grep -q -- '--skip-adapter-sync) SKIP_ADAPTER_SYNC=1' "$SKILL"; then
+  pass "skill parser handles --skip-adapter-sync"
+else
+  fail "skill parser handles --skip-adapter-sync" "parse case missing"
+fi
+
+echo
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:$FAILED" >&2
+  exit 1
+fi

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update
 description: Sync the ApexYard fork with upstream — preview, merge-or-rebase on a sync branch, walk per-version migrations.
-argument-hint: "[--dry-run] [--rebase] [--from-version vN.N.N] [--skip-migrations]"
+argument-hint: "[--dry-run] [--rebase] [--from-version vN.N.N] [--skip-migrations] [--skip-adapter-sync]"
 allowed-tools: Bash, Read, Write, Edit
 ---
 
@@ -40,6 +40,7 @@ Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projec
 /update --dry-run                    # preview only, don't touch anything
 /update --from-version v1.2.0        # override the version anchor (use when fork anchor is missing/wrong)
 /update --skip-migrations            # files-only sync; do NOT run the per-version migration chain
+/update --skip-adapter-sync          # do not refresh an already-installed Codex adapter
 /update --from-dev                   # (hidden) pull from upstream/dev — pre-release; expect breakage
 ```
 
@@ -51,6 +52,7 @@ Defaults match today's single-fork layout (`./apexyard.projects.yaml`, `./projec
 | `--dry-run` | Run the preview step only. Print the commit delta and exit; no fetch-after-preview, no branch creation, no merge. **Does NOT execute migrations** — only previews the planned chain. |
 | `--from-version vN.N.N` | Explicit version-anchor override. Use when `.claude/framework-version` is missing (legacy fork pre-v1.4.0) OR you've manually rolled back and the anchor is stale. The chain is built against this value instead of the file. Refuses if the value doesn't match `vMAJOR.MINOR.PATCH`. |
 | `--skip-migrations` | Sync the framework files but DO NOT run the per-version migration chain. Prints an advisory warning naming each skipped pair and reminding the operator that the migrations can be replayed later with `bash .claude/migrations/<pair>.sh`. The anchor file IS still advanced to the new release tag, so subsequent runs won't re-offer the same migrations. Use sparingly — the chain is the point. |
+| `--skip-adapter-sync` | Do not refresh an already-installed Codex adapter. Detection is installation-based, not harness-session-based: without this flag, `/update` reconciles only a manifest-backed or complete legacy ApexYard Codex adapter and leaves uninstalled forks untouched. Intended as a troubleshooting escape hatch. |
 | `--from-dev` | **Hidden / opt-in.** Sync from `upstream/dev` (pre-release work) instead of the latest `upstream/main` tag. Prints a `⚠ PRE-RELEASE SYNC` banner BEFORE any fetch/state-mutation. Same sync-branch + conflict-resolution flow; branch is named `chore/sync-upstream-dev` (or `chore/#<TICKET>-sync-upstream-dev` if a tracking issue is supplied). Intended for the framework maintainer (testing pre-release work on another machine) and for adopters who explicitly want to validate an upcoming framework change. **Not** in the skill's `description` frontmatter on purpose — `/help` should not surface it, since the adopter contract is tagged releases (see AgDR-0007 release-cut model). Combinable with `--rebase` and `--dry-run`. **When `--from-dev` is set, the migration chain is automatically skipped** — pre-release work doesn't have a release tag to anchor against. |
 
 ## Output
@@ -59,7 +61,8 @@ On success: one sync branch ready to push (e.g. `chore/#N-sync-upstream-apexyard
 
 On conflict: paused at the conflict point with per-file options (keep mine / accept upstream / open editor).
 
-On up-to-date: one line, no state change.
+On up-to-date: one line after reconciling any detected Codex adapter. Git refs
+remain unchanged, but stale generated adapter files may be refreshed.
 
 ## When NOT to use
 
@@ -79,6 +82,7 @@ FROM_DEV=0
 DRY_RUN=0
 REBASE=0
 SKIP_MIGRATIONS=0
+SKIP_ADAPTER_SYNC=0
 FROM_VERSION_OVERRIDE=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -86,6 +90,7 @@ while [ "$#" -gt 0 ]; do
     --dry-run)          DRY_RUN=1 ;;
     --rebase)           REBASE=1 ;;
     --skip-migrations)  SKIP_MIGRATIONS=1 ;;
+    --skip-adapter-sync) SKIP_ADAPTER_SYNC=1 ;;
     --from-version)     shift; FROM_VERSION_OVERRIDE="$1" ;;
     --from-version=*)   FROM_VERSION_OVERRIDE="${1#--from-version=}" ;;
   esac
@@ -167,6 +172,37 @@ if [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then
 fi
 ```
 
+#### 1d. Define installed-adapter reconciliation
+
+Detection belongs to the generator, not to the current harness session. The
+helper below refreshes only a manifest-backed ApexYard Codex adapter or the
+complete pre-manifest shape (`.agents/skills/`, `.codex/agents/`, and
+`.codex/hooks.json`). An uninstalled or partial adapter is a silent no-op.
+
+```bash
+reconcile_installed_codex_adapter() {
+  if [ "$SKIP_ADAPTER_SYNC" = "1" ]; then
+    echo "Codex adapter reconciliation skipped (--skip-adapter-sync)."
+    return 0
+  fi
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "DRY-RUN: would reconcile an installed Codex adapter."
+    return 0
+  fi
+
+  local script="$(git rev-parse --show-toplevel)/bin/sync-codex-adapter.sh"
+  if [ ! -f "$script" ]; then
+    echo "Codex adapter reconciliation failed: missing $script" >&2
+    return 1
+  fi
+  bash "$script" --reconcile-installed
+}
+```
+
+Unlike the SessionStart compatibility backstop described below, an explicit
+`/update` is strict: a detected adapter that cannot be generated and verified
+makes the update fail instead of being reported as current.
+
 ### 2. Fetch both remotes
 
 `git fetch upstream --quiet` brings down all upstream branches by default (including `upstream/dev`), so a single fetch covers both the default and the `--from-dev` target. No conditional fetch needed.
@@ -199,11 +235,20 @@ Then report. Examples:
 
 **Up-to-date (no tag drift, no commit drift):**
 
-```
-Fork is up to date with upstream/main. Nothing to sync.
+```bash
+reconcile_installed_codex_adapter || exit 1
+rm -f .claude/session/active-bootstrap
+
+echo "Fork is up to date with upstream/main. Nothing to sync."
 ```
 
 Exit 0.
+
+Any other preview path that exits 0 without creating a sync branch (for
+example, the operator declines unreleased `upstream/main` commits) MUST call
+`reconcile_installed_codex_adapter` before cleanup and exit. This closes the
+stale-adapter bug even when there is no release work to merge. `--dry-run`
+reaches the same helper but prints intent without mutating files.
 
 **No release drift, but main has moved (common, NOT actionable):**
 
@@ -866,6 +911,29 @@ Topology drift: <N projects drifted | skipped> ({…}, …)
 
 This step **always** runs after step 8b. It does NOT block the sync — drift handling is purely additive and reversible (the operator can re-run `/update` later).
 
+### 8d. Reconcile an installed Codex adapter
+
+After framework files, migrations, config offers, and topology handling have
+settled, refresh generated Codex output from the final canonical `.claude/`
+state:
+
+```bash
+reconcile_installed_codex_adapter || {
+  echo "Framework files synced, but the installed Codex adapter could not be reconciled." >&2
+  echo "Fix the generator error, then retry: bash bin/sync-codex-adapter.sh --reconcile-installed" >&2
+  exit 1
+}
+```
+
+This step is intentionally after the merge and migrations so newly added or
+rewritten skills, agents, and hooks are captured once. The first release that
+ships this behavior also carries a SessionStart compatibility backstop in
+`check-upstream-drift.sh`: a pre-fix generated `$update` cannot know these new
+instructions, but its existing Codex hook wiring already delegates that hook to
+the newly synced canonical `.claude/` file. The backstop is non-blocking and
+only bootstraps the new generated skill; explicit `/update` remains the owner of
+strict reconciliation thereafter.
+
 ### 9. Final state + next steps
 
 On clean completion, print (substituting `$UPSTREAM_REF` for the literal `upstream/main` so the operator sees the actual ref synced under `--from-dev`):
@@ -923,7 +991,7 @@ Skill done. No remote state changed.
 | No `upstream` remote | Print `git remote add` command and exit |
 | Dirty working tree | Refuse, tell user to stash/commit |
 | On non-default branch | Refuse, tell user to checkout main |
-| Already up-to-date | One-line report, exit 0 |
+| Already up-to-date | Reconcile a detected Codex adapter, then report and exit 0 |
 | Network failure on fetch | Warn, exit 1 — don't proceed on stale refs |
 | User chose rebase but has 50+ local commits | Warn about rewriting many SHAs, re-confirm |
 | Merge conflict the user aborts | Restore original branch state, delete sync branch, exit 1 |
@@ -938,6 +1006,8 @@ Skill done. No remote state changed.
 | Anchor file says `unknown` (malformed content) | Treated identically to missing — interactive prompt in step 8b. |
 | Chain has a missing link (release shipped without a migration script) | Refuse with a clear message naming the gap; advance the anchor anyway so subsequent runs don't loop on the same gap. This is a framework bug — file an issue. |
 | `--skip-migrations` passed | Chain detection runs (printed for visibility) but no `migration_run` invocations. Anchor still advances. |
+| `--skip-adapter-sync` passed | Skip adapter detection/generation on every exit path; framework sync behavior is unchanged. |
+| Codex adapter reconciliation fails during explicit `/update` | Fail non-zero and print the direct `--reconcile-installed` retry command; never report stale generated governance as current. |
 | Individual migration exits 1 (conflict) | Chain pauses. Anchor NOT advanced. Operator resolves, then re-runs `/update`. |
 | Individual migration exits 2 (hard error) | Chain aborts. Anchor NOT advanced. Print the script's stderr and exit 2. |
 | `--from-version` argument fails the semver regex | Refuse with `--from-version: expected vMAJOR.MINOR.PATCH (got 'X')`. Exit 1 before any fetch. |

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -199,9 +199,9 @@ reconcile_installed_codex_adapter() {
 }
 ```
 
-Unlike the SessionStart compatibility backstop described below, an explicit
-`/update` is strict: a detected adapter that cannot be generated and verified
-makes the update fail instead of being reported as current.
+Unlike the SessionStart advisory nudge described below, an explicit `/update`
+is strict: a detected adapter that cannot be generated and verified makes the
+update fail instead of being reported as current.
 
 ### 2. Fetch both remotes
 
@@ -926,13 +926,16 @@ reconcile_installed_codex_adapter || {
 ```
 
 This step is intentionally after the merge and migrations so newly added or
-rewritten skills, agents, and hooks are captured once. The first release that
-ships this behavior also carries a SessionStart compatibility backstop in
-`check-upstream-drift.sh`: a pre-fix generated `$update` cannot know these new
-instructions, but its existing Codex hook wiring already delegates that hook to
-the newly synced canonical `.claude/` file. The backstop is non-blocking and
-only bootstraps the new generated skill; explicit `/update` remains the owner of
-strict reconciliation thereafter.
+rewritten skills, agents, and hooks are captured once. `check-upstream-drift.sh`'s
+SessionStart hook complements this with a **read-only** advisory: on every
+session it runs the generator's `--check-installed` mode (never writes) and
+prints a one-line nudge to stderr if the installed adapter has drifted from
+what `.claude/` would generate. The nudge exists precisely because a pre-fix
+generated `$update` cannot yet know about this reconciliation step — but the
+hook only ever *warns*, it does not regenerate anything at boot. The actual
+write always happens through this explicit `/update` step (or a manual
+`bin/sync-codex-adapter.sh --reconcile-installed` run); `/update` remains the
+sole owner of strict, mutating reconciliation.
 
 ### 9. Final state + next steps
 

--- a/bin/sync-codex-adapter.sh
+++ b/bin/sync-codex-adapter.sh
@@ -60,6 +60,27 @@ CLAUDE_DIR="$ROOT/.claude"
 [ -d "$CLAUDE_DIR" ] || { echo "ERROR: .claude not found under $ROOT" >&2; exit 1; }
 [ -f "$CLAUDE_DIR/settings.json" ] || { echo "ERROR: .claude/settings.json not found" >&2; exit 1; }
 
+assert_safe_output_paths() {
+  local path
+  for path in \
+    "$ROOT/.agents" \
+    "$ROOT/.agents/skills" \
+    "$ROOT/.codex" \
+    "$ROOT/.codex/agents" \
+    "$ROOT/.codex/hooks.json" \
+    "$ROOT/.codex/apexyard-adapter.json"; do
+    if [ -L "$path" ]; then
+      echo "ERROR: refusing Codex adapter output through symlink: $path" >&2
+      return 1
+    fi
+  done
+}
+
+# The generator deletes and replaces owned output paths. Reject symlinks before
+# installation detection reads a manifest and before any mutation can escape
+# the repository through an adapter root or critical child path.
+assert_safe_output_paths || exit 1
+
 codex_adapter_installed() {
   local manifest="$ROOT/.codex/apexyard-adapter.json"
   if [ -f "$manifest" ] \

--- a/bin/sync-codex-adapter.sh
+++ b/bin/sync-codex-adapter.sh
@@ -11,10 +11,11 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CHECK=0
 CLEAN=0
 RECONCILE_INSTALLED=0
+CHECK_INSTALLED=0
 
 usage() {
   cat <<'USAGE'
-Usage: bin/sync-codex-adapter.sh [--check] [--clean] [--reconcile-installed] [--root <path>]
+Usage: bin/sync-codex-adapter.sh [--check] [--clean] [--reconcile-installed] [--check-installed] [--root <path>]
 
 Generate Codex adapter files from .claude:
   .claude/skills   -> .agents/skills
@@ -27,6 +28,11 @@ Options:
   --reconcile-installed
                 Refresh and verify an existing ApexYard Codex adapter. Silently
                 do nothing when no manifest or complete legacy adapter exists.
+  --check-installed
+                Read-only staleness check for an existing ApexYard Codex
+                adapter. Never writes; exits non-zero when the installed
+                adapter's owned paths drift from what .claude would generate.
+                Silently exits 0 when no adapter is installed.
   --root PATH   Repository root to use instead of this script's parent.
 USAGE
 }
@@ -36,6 +42,7 @@ while [ "$#" -gt 0 ]; do
     --check) CHECK=1 ;;
     --clean) CLEAN=1 ;;
     --reconcile-installed) RECONCILE_INSTALLED=1 ;;
+    --check-installed) CHECK_INSTALLED=1 ;;
     --root)
       [ "$#" -ge 2 ] || { echo "ERROR: --root requires a path" >&2; exit 2; }
       ROOT="$2"
@@ -60,17 +67,30 @@ CLAUDE_DIR="$ROOT/.claude"
 [ -d "$CLAUDE_DIR" ] || { echo "ERROR: .claude not found under $ROOT" >&2; exit 1; }
 [ -f "$CLAUDE_DIR/settings.json" ] || { echo "ERROR: .claude/settings.json not found" >&2; exit 1; }
 
+# Adapter-owned generated subpaths, relative to $ROOT. Every drift/reconcile
+# comparison in this script (symlink guard, --check, --check-installed,
+# --reconcile-installed) walks only these paths — anything else living under
+# .agents/ or .codex/ (a hand-authored Codex config.toml, a runtime cache, a
+# user-owned file) is left alone and never flagged as drift or mutated. This
+# mirrors exactly what the generator writes and removes further below.
+ADAPTER_OWNED_PATHS=(
+  ".agents/skills"
+  ".codex/agents"
+  ".codex/hooks.json"
+  ".codex/apexyard-adapter.json"
+)
+
 assert_safe_output_paths() {
-  local path
-  for path in \
-    "$ROOT/.agents" \
-    "$ROOT/.agents/skills" \
-    "$ROOT/.codex" \
-    "$ROOT/.codex/agents" \
-    "$ROOT/.codex/hooks.json" \
-    "$ROOT/.codex/apexyard-adapter.json"; do
+  local path rel
+  for path in "$ROOT/.agents" "$ROOT/.codex"; do
     if [ -L "$path" ]; then
       echo "ERROR: refusing Codex adapter output through symlink: $path" >&2
+      return 1
+    fi
+  done
+  for rel in "${ADAPTER_OWNED_PATHS[@]}"; do
+    if [ -L "$ROOT/$rel" ]; then
+      echo "ERROR: refusing Codex adapter output through symlink: $ROOT/$rel" >&2
       return 1
     fi
   done
@@ -94,6 +114,10 @@ codex_adapter_installed() {
 }
 
 if [ "$RECONCILE_INSTALLED" = "1" ] && ! codex_adapter_installed; then
+  exit 0
+fi
+
+if [ "$CHECK_INSTALLED" = "1" ] && ! codex_adapter_installed; then
   exit 0
 fi
 
@@ -229,17 +253,34 @@ if grep -R "$(printf '%s' "$ROOT" | sed 's/[.[\*^$()+?{}|]/\\&/g')" "$OUT_AGENTS
   exit 1
 fi
 
+# Compares one generated root (.agents or .codex) against its on-disk
+# counterpart, but ONLY across the owned relative paths listed in
+# ADAPTER_OWNED_PATHS that fall under $label — never a whole-tree `diff -qr`.
+# This keeps drift detection scoped to what the adapter actually generates:
+# a hand-authored Codex file living alongside the generated output (a native
+# config.toml, a runtime cache) is invisible to this check and never flagged.
 check_drift() {
-  local actual="$1" expected="$2" label="$3"
-  if [ ! -e "$actual" ]; then
-    echo "DRIFT: $label is missing; run bin/sync-codex-adapter.sh" >&2
-    return 1
-  fi
-  if ! diff -qr "$expected" "$actual" >/dev/null; then
-    echo "DRIFT: $label differs from generated output; run bin/sync-codex-adapter.sh" >&2
-    diff -qr "$expected" "$actual" >&2 || true
-    return 1
-  fi
+  local actual_root="$1" expected_root="$2" label="$3"
+  local rc=0 rel child_rel actual expected
+  for rel in "${ADAPTER_OWNED_PATHS[@]}"; do
+    case "$rel" in
+      "$label"/*) child_rel="${rel#"$label"/}" ;;
+      *) continue ;;
+    esac
+    actual="$actual_root/$child_rel"
+    expected="$expected_root/$child_rel"
+    if [ ! -e "$actual" ]; then
+      echo "DRIFT: $label/$child_rel is missing; run bin/sync-codex-adapter.sh" >&2
+      rc=1
+      continue
+    fi
+    if ! diff -qr "$expected" "$actual" >/dev/null 2>&1; then
+      echo "DRIFT: $label/$child_rel differs from generated output; run bin/sync-codex-adapter.sh" >&2
+      diff -qr "$expected" "$actual" >&2 2>&1 || true
+      rc=1
+    fi
+  done
+  return "$rc"
 }
 
 if [ "$CHECK" = "1" ]; then
@@ -249,11 +290,18 @@ if [ "$CHECK" = "1" ]; then
   exit "$rc"
 fi
 
+if [ "$CHECK_INSTALLED" = "1" ]; then
+  rc=0
+  check_drift "$ROOT/.agents" "$OUT_AGENTS" ".agents" || rc=1
+  check_drift "$ROOT/.codex" "$OUT_CODEX" ".codex" || rc=1
+  exit "$rc"
+fi
+
 if [ "$RECONCILE_INSTALLED" = "1" ] \
   && [ -e "$ROOT/.agents" ] \
   && [ -e "$ROOT/.codex" ] \
-  && diff -qr "$OUT_AGENTS" "$ROOT/.agents" >/dev/null \
-  && diff -qr "$OUT_CODEX" "$ROOT/.codex" >/dev/null; then
+  && check_drift "$ROOT/.agents" "$OUT_AGENTS" ".agents" 2>/dev/null \
+  && check_drift "$ROOT/.codex" "$OUT_CODEX" ".codex" 2>/dev/null; then
   exit 0
 fi
 

--- a/bin/sync-codex-adapter.sh
+++ b/bin/sync-codex-adapter.sh
@@ -10,10 +10,11 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CHECK=0
 CLEAN=0
+RECONCILE_INSTALLED=0
 
 usage() {
   cat <<'USAGE'
-Usage: bin/sync-codex-adapter.sh [--check] [--clean] [--root <path>]
+Usage: bin/sync-codex-adapter.sh [--check] [--clean] [--reconcile-installed] [--root <path>]
 
 Generate Codex adapter files from .claude:
   .claude/skills   -> .agents/skills
@@ -23,6 +24,9 @@ Generate Codex adapter files from .claude:
 Options:
   --check       Do not write files; fail if generated output would differ.
   --clean       Remove generated .agents/.codex before writing.
+  --reconcile-installed
+                Refresh and verify an existing ApexYard Codex adapter. Silently
+                do nothing when no manifest or complete legacy adapter exists.
   --root PATH   Repository root to use instead of this script's parent.
 USAGE
 }
@@ -31,6 +35,7 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --check) CHECK=1 ;;
     --clean) CLEAN=1 ;;
+    --reconcile-installed) RECONCILE_INSTALLED=1 ;;
     --root)
       [ "$#" -ge 2 ] || { echo "ERROR: --root requires a path" >&2; exit 2; }
       ROOT="$2"
@@ -54,6 +59,22 @@ CLAUDE_DIR="$ROOT/.claude"
 
 [ -d "$CLAUDE_DIR" ] || { echo "ERROR: .claude not found under $ROOT" >&2; exit 1; }
 [ -f "$CLAUDE_DIR/settings.json" ] || { echo "ERROR: .claude/settings.json not found" >&2; exit 1; }
+
+codex_adapter_installed() {
+  local manifest="$ROOT/.codex/apexyard-adapter.json"
+  if [ -f "$manifest" ] \
+    && grep -qE '"adapter"[[:space:]]*:[[:space:]]*"apexyard-codex"' "$manifest"; then
+    return 0
+  fi
+
+  [ -d "$ROOT/.agents/skills" ] \
+    && [ -d "$ROOT/.codex/agents" ] \
+    && [ -f "$ROOT/.codex/hooks.json" ]
+}
+
+if [ "$RECONCILE_INSTALLED" = "1" ] && ! codex_adapter_installed; then
+  exit 0
+fi
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required to generate TOML strings safely" >&2
@@ -120,6 +141,11 @@ generate_hooks_json() {
 
 copy_tree "$CLAUDE_DIR/skills" "$OUT_AGENTS/skills"
 generate_hooks_json > "$OUT_CODEX/hooks.json"
+jq -n '{
+  adapter: "apexyard-codex",
+  schema: 1,
+  generated_from: ".claude"
+}' > "$OUT_CODEX/apexyard-adapter.json"
 
 # Fail loud on a silent gate-hole (Rex, #838/#840): generate_hooks_json's jq
 # filter is written to be matcher-agnostic (it walks every event/matcher
@@ -202,6 +228,14 @@ if [ "$CHECK" = "1" ]; then
   exit "$rc"
 fi
 
+if [ "$RECONCILE_INSTALLED" = "1" ] \
+  && [ -e "$ROOT/.agents" ] \
+  && [ -e "$ROOT/.codex" ] \
+  && diff -qr "$OUT_AGENTS" "$ROOT/.agents" >/dev/null \
+  && diff -qr "$OUT_CODEX" "$ROOT/.codex" >/dev/null; then
+  exit 0
+fi
+
 if [ "$CLEAN" = "1" ]; then
   rm -rf "$ROOT/.agents" "$ROOT/.codex"
 fi
@@ -209,12 +243,24 @@ fi
 mkdir -p "$ROOT/.agents" "$ROOT/.codex"
 rm -rf "$ROOT/.agents/skills" "$ROOT/.codex/agents" "$ROOT/.codex/hooks" "$ROOT/.codex/rules" \
   "$ROOT/.codex/migrations" "$ROOT/.codex/registries" "$ROOT/.codex/hooks.json" \
-  "$ROOT/.codex/project-config.defaults.json" "$ROOT/.codex/framework-version"
+  "$ROOT/.codex/project-config.defaults.json" "$ROOT/.codex/framework-version" \
+  "$ROOT/.codex/apexyard-adapter.json"
 cp -R "$OUT_AGENTS/skills" "$ROOT/.agents/skills"
 cp -R "$OUT_CODEX/agents" "$ROOT/.codex/agents"
 cp "$OUT_CODEX/hooks.json" "$ROOT/.codex/hooks.json"
+cp "$OUT_CODEX/apexyard-adapter.json" "$ROOT/.codex/apexyard-adapter.json"
+
+if [ "$RECONCILE_INSTALLED" = "1" ]; then
+  rc=0
+  check_drift "$ROOT/.agents" "$OUT_AGENTS" ".agents" || rc=1
+  check_drift "$ROOT/.codex" "$OUT_CODEX" ".codex" || rc=1
+  [ "$rc" = "0" ] || exit "$rc"
+  echo "Reconciled installed Codex adapter from .claude."
+  exit 0
+fi
 
 echo "Generated Codex adapter from .claude:"
 echo "  .agents/skills"
 echo "  .codex/agents"
 echo "  .codex/hooks.json"
+echo "  .codex/apexyard-adapter.json"

--- a/docs/agdr/AgDR-0102-update-reconciles-installed-codex-adapter.md
+++ b/docs/agdr/AgDR-0102-update-reconciles-installed-codex-adapter.md
@@ -1,0 +1,133 @@
+# Reconcile installed Codex adapters during framework updates
+
+> In the context of `/update` synchronising ApexYard's canonical `.claude/`
+> runtime while Codex consumes generated `.agents/` and `.codex/` output,
+> facing the need to refresh existing Codex installations without creating
+> Codex files for adopters who do not use that harness, I decided to make the
+> Codex generator emit a static ownership manifest and have `/update`
+> reconcile manifest-backed or recognisable legacy installations before every
+> successful exit, to achieve automatic adapter freshness with an explicit
+> installation boundary, accepting one generated metadata file and a narrow
+> compatibility fallback for adapters created before the manifest exists.
+
+## Context
+
+- `.claude/` is the canonical ApexYard runtime; `bin/sync-codex-adapter.sh`
+  derives Codex skills, agents, and hook wiring from it under `.agents/` and
+  `.codex/`.
+- `/update` currently exits immediately when framework refs are current, so a
+  generated adapter can remain on the previous release even though no Git
+  synchronization remains to perform.
+- Unconditional generation would create Codex-specific files for adopters who
+  use only Claude Code or another harness. Detection therefore needs to answer
+  whether ApexYard owns an installed Codex adapter, not which app launched the
+  current session.
+- Existing Codex installations predate any ownership manifest, so a manifest-
+  only check would repair new installations but strand current adopters on the
+  exact stale state this change is intended to fix.
+- The `/update` skill is itself generated into `.agents/skills/update/`. An
+  adopter running a pre-fix copy cannot execute reconciliation instructions
+  that exist only in the newly merged canonical skill, so the first upgrade
+  needs a bootstrap path outside that stale prompt.
+- Existing generated Codex hook wiring already delegates the SessionStart
+  `check-upstream-drift.sh` command to its canonical `.claude/hooks/` path.
+  After a framework sync, that stable command can therefore execute newly
+  merged reconciliation logic even while `.codex/hooks.json` is stale.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Unconditionally run the Codex generator on every `/update` | Simple; every fork receives fresh Codex output | Creates `.agents/` and `.codex/` for adopters who never installed Codex support; makes harness choice implicit |
+| Infer installation only from generated directories | Repairs existing installs without new metadata | A partial or user-owned `.agents/` / `.codex/` tree is ambiguous; there is no durable ownership or schema signal |
+| Require a generated ownership manifest and ignore legacy output | Precise and extensible installation boundary | Existing pre-manifest adapters never self-heal unless operators manually regenerate once |
+| Emit a generated ownership manifest, with a complete-shape legacy fallback | Precise for future runs; repairs existing installations; leaves uninstalled forks untouched | Carries one generated metadata file and temporary compatibility logic |
+
+## Decision
+
+Chosen: **emit a generated ownership manifest and recognise the complete legacy
+Codex adapter shape as a compatibility fallback**, because `/update` needs a
+durable, harness-specific ownership signal without abandoning adapters generated
+before that signal shipped.
+
+`bin/sync-codex-adapter.sh` will emit `.codex/apexyard-adapter.json` with a
+stable adapter identifier, schema version, and canonical source. The manifest
+is generated output and participates in the existing `--check` comparison, so
+its absence or drift is reported like any other adapter output.
+
+The generator will expose an idempotent installed-only reconciliation mode so
+both `/update` and the bootstrap backstop use one detection and generation
+implementation. It is a silent no-op when no ApexYard Codex installation is
+detected and fails non-zero when generation or verification fails.
+
+`/update` will consider Codex installed when either:
+
+1. `.codex/apexyard-adapter.json` identifies the ApexYard Codex adapter; or
+2. the legacy generator's complete shape exists: `.agents/skills/`,
+   `.codex/agents/`, and `.codex/hooks.json`.
+
+On a successful framework sync, reconciliation runs after canonical files and
+migrations are settled. On the already-current path, it runs before the early
+exit. `--dry-run` remains read-only, and `--skip-adapter-sync` provides an
+explicit troubleshooting escape hatch. Reconciliation runs the generator and
+then `--check`; generation or verification failure makes `/update` fail loudly
+instead of reporting a successful update with stale governance output.
+
+For the one-time bootstrap from a pre-fix generated `$update`, the already-wired
+`check-upstream-drift.sh` SessionStart hook invokes the same installed-only
+reconciliation mode before any of its normal silent exits. This is a
+compatibility backstop, not a second implementation: once it writes the
+manifest and refreshes `$update`, future explicit updates reconcile directly.
+The hook remains silent on success/no-install, reports a concise warning on
+failure, and does not block session startup. Codex installations without
+project-hook trust cannot use this backstop and retain the documented one-time
+manual generator path.
+
+Verification is split across the existing generator smoke test and a dedicated
+`/update` reconciliation test. Together they must prove:
+
+- the manifest is generated, schema-valid, and included in `--check` drift
+  detection;
+- manifest-backed and complete-shape legacy installations are detected, while
+  an uninstalled fork and every partial legacy shape remain untouched;
+- the already-current path refreshes stale output before reporting success;
+- the post-sync path invokes the same reconciliation contract after canonical
+  files settle;
+- `--dry-run` and `--skip-adapter-sync` do not mutate adapter output; and
+- generation or verification failure propagates as a non-zero `/update`
+  result instead of being downgraded to a warning;
+- the existing SessionStart wiring reaches the canonical bootstrap call, which
+  refreshes a legacy installation, leaves an uninstalled fork untouched, and
+  warns without blocking when reconciliation fails.
+
+## Consequences
+
+- Existing Codex adopters receive new skills, agent definitions, and hook
+  wiring automatically the next time they run `/update`, including when Git is
+  already current.
+- Adopters with no detected Codex installation see no new `.agents/` or
+  `.codex/` files.
+- The first reconciliation of a legacy adapter writes the manifest, after
+  which future detection no longer relies on directory shape.
+- A pre-fix generated `$update` self-heals on the first trusted SessionStart
+  after the framework files land; untrusted Codex hook installations still
+  require the documented one-time manual generator command.
+- A user-owned partial `.agents/` or `.codex/` tree is not treated as an
+  ApexYard installation; all three legacy output surfaces must be present.
+- Generated tracked output may become dirty after reconciliation by design;
+  that is the visible update an adopter should review and commit. Ignored local
+  output refreshes without changing Git state.
+- The same manifest pattern can be adopted by other generated harness adapters
+  later, but this decision does not claim they share Codex's generation or
+  installation lifecycle.
+- `check-upstream-drift.sh` gains one local derived-file maintenance call before
+  its network/tag logic. That expands its startup responsibility slightly, but
+  reuses an already-delegated canonical execution seam and avoids permanent
+  stale-skill lockout for existing Codex adopters.
+
+## Artifacts
+
+- Ticket: [me2resh/apexyard#943](https://github.com/me2resh/apexyard/issues/943)
+- Prior decision: [AgDR-0088](AgDR-0088-codex-adapter-generation.md)
+- Generator: `bin/sync-codex-adapter.sh`
+- Update skill: `.claude/skills/update/SKILL.md`

--- a/docs/agdr/AgDR-0102-update-reconciles-installed-codex-adapter.md
+++ b/docs/agdr/AgDR-0102-update-reconciles-installed-codex-adapter.md
@@ -31,8 +31,19 @@
   needs a bootstrap path outside that stale prompt.
 - Existing generated Codex hook wiring already delegates the SessionStart
   `check-upstream-drift.sh` command to its canonical `.claude/hooks/` path.
-  After a framework sync, that stable command can therefore execute newly
-  merged reconciliation logic even while `.codex/hooks.json` is stale.
+  After a framework sync, that stable command can therefore run newly merged
+  reconciliation logic even while `.codex/hooks.json` is stale — but a
+  SessionStart hook fires on *every* session, so it must never itself mutate
+  the working tree; it can only advise the operator to run the real, explicit
+  reconciliation path.
+- Reconciliation deletes and replaces owned output paths (`.agents/skills`,
+  `.codex/agents`, `.codex/hooks.json`, `.codex/apexyard-adapter.json`). A
+  whole-tree comparison against `.agents/` or `.codex/` would misclassify any
+  hand-authored file living alongside the generated output (a native Codex
+  `config.toml`, a runtime cache) as drift, producing false-positive warnings
+  and — worse — a false-positive hard failure on `/update`'s strict path.
+  Drift detection therefore needs to be scoped to exactly the paths the
+  adapter owns, not the whole directory.
 
 ## Options Considered
 
@@ -55,16 +66,27 @@ stable adapter identifier, schema version, and canonical source. The manifest
 is generated output and participates in the existing `--check` comparison, so
 its absence or drift is reported like any other adapter output.
 
-The generator will expose an idempotent installed-only reconciliation mode so
-both `/update` and the bootstrap backstop use one detection and generation
-implementation. It is a silent no-op when no ApexYard Codex installation is
-detected and fails non-zero when generation or verification fails.
+The generator will expose an idempotent installed-only reconciliation mode
+(`--reconcile-installed`, mutating) and a companion read-only staleness check
+(`--check-installed`), so `/update`, the SessionStart advisory, and any manual
+invocation share one detection and generation implementation. Both are a
+silent no-op when no ApexYard Codex installation is detected; the mutating
+mode fails non-zero when generation or verification fails, and the read-only
+mode fails non-zero when the installed adapter has drifted, without ever
+writing to disk.
+
+Every drift comparison — `--check`, `--check-installed`, and
+`--reconcile-installed`'s own before/after checks — walks only the adapter's
+owned relative paths (`.agents/skills`, `.codex/agents`, `.codex/hooks.json`,
+`.codex/apexyard-adapter.json`), never a whole-tree `diff -qr` of `.agents/`
+or `.codex/`. A file outside that owned list is invisible to drift detection
+and is never touched by reconciliation.
 
 Because reconciliation deletes and replaces generated paths, the generator
 must reject symlinked `.agents` / `.codex` roots and symlinked owned child paths
 before reading installation metadata or mutating output. This prevents a
-repository-controlled adapter path from redirecting automatic SessionStart
-writes outside the repository.
+repository-controlled adapter path from redirecting a reconciliation write
+outside the repository.
 
 `/update` will consider Codex installed when either:
 
@@ -79,15 +101,18 @@ explicit troubleshooting escape hatch. Reconciliation runs the generator and
 then `--check`; generation or verification failure makes `/update` fail loudly
 instead of reporting a successful update with stale governance output.
 
-For the one-time bootstrap from a pre-fix generated `$update`, the already-wired
-`check-upstream-drift.sh` SessionStart hook invokes the same installed-only
-reconciliation mode before any of its normal silent exits. This is a
-compatibility backstop, not a second implementation: once it writes the
-manifest and refreshes `$update`, future explicit updates reconcile directly.
-The hook remains silent on success/no-install, reports a concise warning on
-failure, and does not block session startup. Codex installations without
-project-hook trust cannot use this backstop and retain the documented one-time
-manual generator path.
+For visibility between explicit `/update` runs, the already-wired
+`check-upstream-drift.sh` SessionStart hook invokes the generator's
+**read-only** `--check-installed` mode before any of its normal silent exits.
+This is an advisory nudge, not a second reconciliation implementation, and it
+never mutates the tree: on drift it prints a one-line warning naming
+`bin/sync-codex-adapter.sh --reconcile-installed` as the fix, wrapped in the
+same `timeout`-guarded pattern as the hook's sibling `git fetch` call so a
+hung generator invocation can't stall session startup. The hook remains
+silent on success/no-install, reports a concise warning on drift or failure,
+and does not block session startup. The actual reconciling write only ever
+happens through explicit `/update` or a manual `--reconcile-installed`
+invocation — never automatically at session boot.
 
 Verification is split across the existing generator smoke test and a dedicated
 `/update` reconciliation test. Together they must prove:
@@ -102,11 +127,15 @@ Verification is split across the existing generator smoke test and a dedicated
 - `--dry-run` and `--skip-adapter-sync` do not mutate adapter output; and
 - generation or verification failure propagates as a non-zero `/update`
   result instead of being downgraded to a warning;
-- the existing SessionStart wiring reaches the canonical bootstrap call, which
-  refreshes a legacy installation, leaves an uninstalled fork untouched, and
-  warns without blocking when reconciliation fails;
+- the existing SessionStart wiring reaches the canonical `--check-installed`
+  call, which leaves an uninstalled fork untouched, never mutates an installed
+  one, and warns without blocking when the adapter has drifted or the check
+  itself fails;
 - symlinked adapter roots and owned child paths fail before mutation, with
-  external sentinel files proving that reconciliation cannot escape the repo.
+  external sentinel files proving that reconciliation cannot escape the repo;
+- drift detection ignores files outside the adapter's owned paths (a
+  hand-authored file living alongside the generated output must not be
+  reported as drift or be at risk of deletion).
 
 ## Consequences
 
@@ -117,9 +146,10 @@ Verification is split across the existing generator smoke test and a dedicated
   `.codex/` files.
 - The first reconciliation of a legacy adapter writes the manifest, after
   which future detection no longer relies on directory shape.
-- A pre-fix generated `$update` self-heals on the first trusted SessionStart
-  after the framework files land; untrusted Codex hook installations still
-  require the documented one-time manual generator command.
+- A pre-fix generated `$update` gets a visible SessionStart nudge as soon as
+  the framework files land, but reconciliation itself still requires an
+  explicit `/update` run or a manual `--reconcile-installed` invocation — the
+  hook only ever advises, it does not self-heal the installation at boot.
 - A user-owned partial `.agents/` or `.codex/` tree is not treated as an
   ApexYard installation; all three legacy output surfaces must be present.
 - Symlinked generated roots or critical output children are rejected for every
@@ -127,13 +157,17 @@ Verification is split across the existing generator smoke test and a dedicated
 - Generated tracked output may become dirty after reconciliation by design;
   that is the visible update an adopter should review and commit. Ignored local
   output refreshes without changing Git state.
+- Drift detection and reconciliation are scoped to the adapter's owned paths
+  only, so a hand-authored file living alongside generated output under
+  `.agents/` or `.codex/` is never flagged as drift and never deleted.
 - The same manifest pattern can be adopted by other generated harness adapters
   later, but this decision does not claim they share Codex's generation or
   installation lifecycle.
-- `check-upstream-drift.sh` gains one local derived-file maintenance call before
-  its network/tag logic. That expands its startup responsibility slightly, but
-  reuses an already-delegated canonical execution seam and avoids permanent
-  stale-skill lockout for existing Codex adopters.
+- `check-upstream-drift.sh` gains one local, read-only, timeout-guarded
+  staleness check before its network/tag logic. That expands its startup
+  responsibility slightly, but the check never mutates the tree — it reuses an
+  already-delegated canonical execution seam purely to surface a warning, not
+  to perform the reconciliation itself.
 
 ## Artifacts
 

--- a/docs/agdr/AgDR-0102-update-reconciles-installed-codex-adapter.md
+++ b/docs/agdr/AgDR-0102-update-reconciles-installed-codex-adapter.md
@@ -60,6 +60,12 @@ both `/update` and the bootstrap backstop use one detection and generation
 implementation. It is a silent no-op when no ApexYard Codex installation is
 detected and fails non-zero when generation or verification fails.
 
+Because reconciliation deletes and replaces generated paths, the generator
+must reject symlinked `.agents` / `.codex` roots and symlinked owned child paths
+before reading installation metadata or mutating output. This prevents a
+repository-controlled adapter path from redirecting automatic SessionStart
+writes outside the repository.
+
 `/update` will consider Codex installed when either:
 
 1. `.codex/apexyard-adapter.json` identifies the ApexYard Codex adapter; or
@@ -98,7 +104,9 @@ Verification is split across the existing generator smoke test and a dedicated
   result instead of being downgraded to a warning;
 - the existing SessionStart wiring reaches the canonical bootstrap call, which
   refreshes a legacy installation, leaves an uninstalled fork untouched, and
-  warns without blocking when reconciliation fails.
+  warns without blocking when reconciliation fails;
+- symlinked adapter roots and owned child paths fail before mutation, with
+  external sentinel files proving that reconciliation cannot escape the repo.
 
 ## Consequences
 
@@ -114,6 +122,8 @@ Verification is split across the existing generator smoke test and a dedicated
   require the documented one-time manual generator command.
 - A user-owned partial `.agents/` or `.codex/` tree is not treated as an
   ApexYard installation; all three legacy output surfaces must be present.
+- Symlinked generated roots or critical output children are rejected for every
+  generator mode; automatic reconciliation never follows them.
 - Generated tracked output may become dirty after reconciliation by design;
   that is the visible update an adopter should review and commit. Ignored local
   output refreshes without changing Git state.

--- a/docs/codex-adapter.md
+++ b/docs/codex-adapter.md
@@ -65,15 +65,22 @@ This mode refreshes and verifies an existing ApexYard Codex adapter, but is a
 silent no-op on forks where Codex support was never installed. New
 installations are identified by `.codex/apexyard-adapter.json`; adapters from
 before that manifest are recognised only when all three generated surfaces
-exist: `.agents/skills/`, `.codex/agents/`, and `.codex/hooks.json`.
+exist: `.agents/skills/`, `.codex/agents/`, and `.codex/hooks.json`. Drift
+detection (here and in `--check` / `--check-installed`) only ever compares the
+adapter's owned paths — a hand-authored file living alongside the generated
+output under `.agents/` or `.codex/` is left alone.
 
 `/update` runs this reconciliation automatically before every successful exit,
 including the already-current path. Use `--skip-adapter-sync` only as a
-troubleshooting escape hatch. For pre-manifest installs whose old generated
-`$update` skill cannot yet contain that instruction, the already-delegated
-`check-upstream-drift.sh` SessionStart hook performs a one-time non-blocking
-refresh after framework files land. That bootstrap requires trusted project
-hooks; without hook trust, run the command above once manually.
+troubleshooting escape hatch.
+
+For pre-manifest installs whose old generated `$update` skill cannot yet
+contain that instruction, the already-delegated `check-upstream-drift.sh`
+SessionStart hook runs a **read-only** `bin/sync-codex-adapter.sh
+--check-installed` on every session and prints an advisory nudge if the
+installed adapter has drifted. This hook never writes to the tree — it only
+tells the operator to run the command above (or `/update`). It does not block
+session startup.
 
 ## Clean Regeneration
 

--- a/docs/codex-adapter.md
+++ b/docs/codex-adapter.md
@@ -17,6 +17,7 @@ The command emits:
 - `.claude/skills/` to `.agents/skills/`
 - `.claude/agents/*.md` to `.codex/agents/*.toml`
 - `.claude/settings.json` to `.codex/hooks.json`
+- adapter ownership metadata to `.codex/apexyard-adapter.json`
 
 It does **not** copy `.claude/hooks/` into `.codex/hooks/`. The generated
 `hooks.json` keeps the existing commands that exec the unmodified
@@ -53,6 +54,26 @@ bin/sync-codex-adapter.sh --check
 Use `--check` when generated adapter files are present and you want to verify
 they still match `.claude/`. It exits non-zero on drift and prints the files that
 need regeneration.
+
+## Update Reconciliation
+
+```bash
+bin/sync-codex-adapter.sh --reconcile-installed
+```
+
+This mode refreshes and verifies an existing ApexYard Codex adapter, but is a
+silent no-op on forks where Codex support was never installed. New
+installations are identified by `.codex/apexyard-adapter.json`; adapters from
+before that manifest are recognised only when all three generated surfaces
+exist: `.agents/skills/`, `.codex/agents/`, and `.codex/hooks.json`.
+
+`/update` runs this reconciliation automatically before every successful exit,
+including the already-current path. Use `--skip-adapter-sync` only as a
+troubleshooting escape hatch. For pre-manifest installs whose old generated
+`$update` skill cannot yet contain that instruction, the already-delegated
+`check-upstream-drift.sh` SessionStart hook performs a one-time non-blocking
+refresh after framework files land. That bootstrap requires trusted project
+hooks; without hook trust, run the command above once manually.
 
 ## Clean Regeneration
 

--- a/docs/harnesses/codex.md
+++ b/docs/harnesses/codex.md
@@ -24,6 +24,7 @@ Codex support is **generated** from the canonical `.claude/` runtime rather than
 - `.claude/skills/` → `.agents/skills/` (rewriting only the skill path references)
 - `.claude/agents/*.md` → `.codex/agents/*.toml`, translating model-tier labels via the shared [`.claude/harness-models.json`](../../.claude/harness-models.json) matrix (`opus`→`gpt-5.5`, `sonnet`→`gpt-5.4`, `haiku`→`gpt-5.4-mini`)
 - `.claude/settings.json` → `.codex/hooks.json`, preserving the commands that exec `$r/.claude/hooks/*.sh`
+- `.codex/apexyard-adapter.json`, identifying ApexYard-owned generated output for safe update-time reconciliation
 
 It deliberately does **not** copy the hooks, rules, migrations, or registries into `.codex/` — those stay canonical under `.claude/`. Claude Code's handler-level `if` predicates (not part of Codex's documented hook shape) are compiled into the generated shell command as a preflight filter.
 
@@ -33,7 +34,13 @@ It deliberately does **not** copy the hooks, rules, migrations, or registries in
 bin/sync-codex-adapter.sh            # generate the adapter
 bin/sync-codex-adapter.sh --check    # verify generated files still match .claude/ (non-zero on drift)
 bin/sync-codex-adapter.sh --clean    # remove generated .agents/ and .codex/ trees before regenerating
+bin/sync-codex-adapter.sh --reconcile-installed # refresh only when ApexYard's Codex adapter is installed
 ```
+
+`/update` invokes installed-only reconciliation automatically. A trusted
+SessionStart hook bootstraps legacy pre-manifest adapters after the first
+framework sync; untrusted project-hook installs need one manual
+`--reconcile-installed` run to pick up the new `$update` behavior.
 
 Tracking policy, gitignore guidance, and CI `--check` enforcement: [`docs/codex-adapter.md`](../codex-adapter.md).
 

--- a/docs/harnesses/codex.md
+++ b/docs/harnesses/codex.md
@@ -34,13 +34,16 @@ It deliberately does **not** copy the hooks, rules, migrations, or registries in
 bin/sync-codex-adapter.sh            # generate the adapter
 bin/sync-codex-adapter.sh --check    # verify generated files still match .claude/ (non-zero on drift)
 bin/sync-codex-adapter.sh --clean    # remove generated .agents/ and .codex/ trees before regenerating
-bin/sync-codex-adapter.sh --reconcile-installed # refresh only when ApexYard's Codex adapter is installed
+bin/sync-codex-adapter.sh --reconcile-installed # refresh (writes) only when ApexYard's Codex adapter is installed
+bin/sync-codex-adapter.sh --check-installed     # read-only staleness check; never writes
 ```
 
-`/update` invokes installed-only reconciliation automatically. A trusted
-SessionStart hook bootstraps legacy pre-manifest adapters after the first
-framework sync; untrusted project-hook installs need one manual
-`--reconcile-installed` run to pick up the new `$update` behavior.
+`/update` invokes installed-only reconciliation (`--reconcile-installed`)
+automatically. A SessionStart hook runs the **read-only** `--check-installed`
+mode on every session and prints an advisory nudge if a legacy or
+manifest-backed adapter has drifted — it never mutates the tree itself. Run
+`--reconcile-installed` manually (or `/update`) to pick up the new `$update`
+behavior on a pre-manifest install.
 
 Tracking policy, gitignore guidance, and CI `--check` enforcement: [`docs/codex-adapter.md`](../codex-adapter.md).
 


### PR DESCRIPTION
## Summary

Carries forward @hossam-96's #944, preserving their authorship on the core commits (`2a7891e4`, `84a27881` — both re-applied here via cherry-pick, unchanged), and adds the two review changes the panel flagged before merge:

- **Their fix (unchanged, preserved authorship)** — `/update` now reconciles an installed Codex adapter (manifest-backed or a recognizable pre-manifest legacy shape) so an existing Codex install doesn't silently drift behind `.claude/` after a sync, including on the already-current path. A symlink guard rejects a generated root or owned child path that's been redirected outside the repo before any read or write touches it.
- **Change A — the SessionStart hook no longer mutates the tree.** The original PR had `check-upstream-drift.sh` fully regenerate the Codex adapter at *every* session boot — a permanent tree mutation on every fork, every session, forever. That's too broad a blast radius for a hook that fires unconditionally. It now runs the generator's new **read-only** `--check-installed` mode and prints a one-line advisory (`Codex adapter may be stale — run bash bin/sync-codex-adapter.sh --reconcile-installed`) when the installed adapter has drifted. The actual reconciling write stays exactly where #944 put it: the explicit `/update` path (`--reconcile-installed`), or a manual run. The reconciler invocation is wrapped in the same `timeout`-guarded pattern as the hook's sibling `git fetch` call, so a hung generator can't stall session startup.
- **Change B — drift detection is scoped to the adapter's owned paths.** The generator's `--check` / `--reconcile-installed` previously ran a whole-tree `diff -qr` across `.agents/` and `.codex/`. Any non-adapter file living there — a hand-authored Codex `config.toml`, a runtime cache — was misreported as drift: a false-positive per-session warning, and worse, a false-positive **hard failure** on `/update`'s strict path (the post-write verification inside `--reconcile-installed` would fail even though every owned path was perfectly in sync). Drift detection (`--check`, the new `--check-installed`, and `--reconcile-installed`'s own before/after checks) now walks only `.agents/skills`, `.codex/agents`, `.codex/hooks.json`, and `.codex/apexyard-adapter.json` — the exact paths the generator owns and already uses for its symlink guard and cleanup list.
- **Two small wording/robustness cleanups** — `SKILL.md`'s step 8d and the hook's own comment described the backstop as "bootstrapping the new skill" (accurate for the old mutating design, stale now); reworded to describe the advisory-only behavior. The ownership manifest itself is untouched — it's still exactly the metadata file #944 designed.

## Testing

Ran all three test files touching this change, plus a syntax check on both modified scripts:

```
$ bash .claude/hooks/tests/test_sync_codex_adapter.sh
...
Passed: 57
Failed: 2   (generated hook command preserves blocking/allowing exit — pre-existing,
             unrelated to this change; confirmed failing identically on upstream/dev
             before this PR's commits, due to a missing local fixture file)

$ bash .claude/hooks/tests/test_check_upstream_drift.sh
PASS: 8   FAIL: 0

$ bash .claude/hooks/tests/test_update_codex_adapter_reconcile.sh
Passed: 10
Failed: 0
```

New/rewritten coverage added on top of #944's suite:

1. `test_check_upstream_drift.sh` — rewrote the SessionStart bootstrap case: an installed, drifted legacy adapter now gets a `Codex adapter may be stale` advisory **and the tree is provably NOT mutated** (no manifest written, no skill copied) — the prior version of this test asserted the opposite (that SessionStart *did* refresh the files), which was exactly the boot-time mutation behavior this PR removes.
2. `test_sync_codex_adapter.sh` — new "scoped-owned-paths" fixture: a hand-authored `.codex/config.toml` and `.agents/notes/todo.md` are proven to (a) never trigger `--check` / `--check-installed` drift, (b) survive `--reconcile-installed` untouched, and (c) not cause a false-positive hard failure. Also added a `--check-installed` baseline test proving it *does* catch real owned-path drift and never writes.
3. `test_update_codex_adapter_reconcile.sh` — unchanged; still passes, since `/update`'s own `--reconcile-installed` call site and contract are untouched by this PR.

## Glossary

| Term | Definition |
|------|------------|
| Codex adapter | Generated `.agents/` + `.codex/` output that lets OpenAI Codex consume ApexYard's canonical `.claude/` skills, agents, and hook wiring without a second hand-maintained copy. |
| Reconcile (installed) | Refresh a Codex adapter that's already installed in a fork, detected via an ownership manifest or a recognizable pre-manifest directory shape — as opposed to unconditionally generating one for every fork regardless of whether Codex is even in use. |
| `--check-installed` (new in this PR) | Read-only sibling of `--reconcile-installed`: same installation detection and same scoped drift comparison, but never writes to disk. Used by the SessionStart advisory. |
| Adapter-owned paths | The specific generated subpaths (`.agents/skills`, `.codex/agents`, `.codex/hooks.json`, `.codex/apexyard-adapter.json`) the generator creates and is allowed to compare/mutate — as opposed to everything else that might live under `.agents/` or `.codex/`. |
| SessionStart hook | A Claude Code hook (`check-upstream-drift.sh`) that runs once at the start of every session in a fork — hence why a mutation there has such wide blast radius. |

Refs #943

---

Trust-chain note: this PR touches `.claude/hooks/check-upstream-drift.sh` and `bin/sync-codex-adapter.sh` (a script the trust-chain hooks delegate to at session boot), so per `.claude/rules/role-triggers.md` a Security Auditor (Hakim) review is expected before merge, in addition to Rex.
