### PR TITLE
fix(#955): parse GitLab /-/work_items/N issue URLs in tracker_create

### DIFF
--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -569,7 +569,12 @@ tracker_state() {
 # dedicated extractor in their own adapter (Part C), not this numeric helper.
 _tracker_extract_ref_url() {
   local raw="$1" url ref
-  url=$(printf '%s\n' "$raw" | grep -oE 'https?://[^[:space:]]+' | grep -E '/issues/[0-9]+' | head -1)
+  # Match both the legacy `/-/issues/N` form and GitLab's current
+  # `/-/work_items/N` issue URL shape (me2resh/apexyard#955) — a glab adopter
+  # whose `glab issue create` prints the work_items form would otherwise get
+  # an empty parse and a false "creation failed". The trailing-numeric ref
+  # extraction below already handles both.
+  url=$(printf '%s\n' "$raw" | grep -oE 'https?://[^[:space:]]+' | grep -E '/(issues|work_items)/[0-9]+' | head -1)
   if [ -z "$url" ]; then
     return 1
   fi

--- a/.claude/hooks/tests/test_tracker_create.sh
+++ b/.claude/hooks/tests/test_tracker_create.sh
@@ -175,6 +175,42 @@ else
   echo "SKIP: tracker_create glab per-project case (no yq / python3+PyYAML)"
 fi
 
+# Case 4b (#955) — glab prints the modern `/-/work_items/N` issue URL form.
+# _tracker_extract_ref_url must parse it (previously only matched /issues/N).
+if [ "$HAVE_YAML" = yes ]; then
+  SB2b=$(make_sandbox "version: 1
+projects:
+  - name: gl
+    repo: g/p
+    tracker:
+      kind: glab")
+  cat > "$SB2b/bin/glab" <<'EOF'
+#!/bin/bash
+if [ "$1" = "issue" ] && [ "$2" = "create" ]; then
+  echo "Creating issue in g/p..."
+  echo "https://gitlab.com/g/p/-/work_items/77"
+fi
+EOF
+  chmod +x "$SB2b/bin/glab"
+  printf 'glab body\n' > "$SB2b/body.md"
+  (
+    cd "$SB2b" || exit 1
+    # shellcheck source=/dev/null
+    . "$SB2b/.claude/hooks/_lib-tracker.sh"
+    tracker_clear_cache
+    out=$(PATH="$SB2b/bin:$PATH" tracker_create "g/p" "GL title" "$SB2b/body.md")
+    printf '%s\t%s\n' \
+      "$(printf '%s' "$out" | jq -r '.ref // empty' 2>/dev/null)" \
+      "$(printf '%s' "$out" | jq -r '.url // empty' 2>/dev/null)"
+  ) > "$SB2b/result"
+  IFS=$'\t' read -r r_ref r_url < "$SB2b/result"
+  assert_eq "tracker_create glab work_items → ref parsed"  "77" "$r_ref"
+  assert_eq "tracker_create glab work_items → url parsed"  "https://gitlab.com/g/p/-/work_items/77" "$r_url"
+  rm -rf "$SB2b"
+else
+  echo "SKIP: tracker_create glab work_items case (no yq / python3+PyYAML)"
+fi
+
 # Case 5 — per-project custom create_command. The title/body pass via ENV
 # ($TRACKER_TITLE / $TRACKER_BODY_FILE), never string-substituted — so a title
 # full of shell metacharacters cannot inject. (needs a YAML parser.)


### PR DESCRIPTION
## Summary

- **Fixed false "creation failed" for every GitLab adopter** — `_tracker_extract_ref_url` matched only `/issues/[0-9]+` URLs, so when `glab issue create` returns GitLab's current `https://…/-/work_items/N` issue-URL form the parse came back empty and `tracker_create` reported *failure* even though the issue was created. This hit every ticket-creating skill (`/task`, `/feature`, `/bug`, `/tickets-batch`, …) on any `tracker.kind: glab` project, and invited duplicate re-attempts.
- **One-line pattern broadening** — `grep -E '/(issues|work_items)/[0-9]+'`. The trailing-numeric ref extraction (`grep -oE '[0-9]+$'`) already handled both URL forms, so no other change was needed.
- **Test coverage** — added a `work_items` case to `test_tracker_create.sh` proving both the ref (`77`) and the full URL parse; the existing `/-/issues/N` case stays green (backward-compatible).

## Testing

1. `bash .claude/hooks/tests/test_tracker_create.sh` — all pass, including the 2 new `work_items` assertions
2. `shellcheck -x .claude/hooks/_lib-tracker.sh` — clean

Refs #955

Reported with the exact fix by @AbdElrahmaN31 — thank you.

_Touches `.claude/hooks/**` (trust chain); Security Auditor (Hakim) review expected in addition to Rex._

## Glossary

| Term | Definition |
|------|------------|
| `tracker_create` | Framework abstraction that creates a ticket in a project's configured tracker (gh/glab/custom) and returns normalised `{ref,url}` JSON. |
| Work item URL | GitLab's current canonical issue URL form (`/-/work_items/N`), which superseded the older `/-/issues/N` form. |
