### PR TITLE
fix(#950): warn when portfolio/config libs are sourced under zsh

### DIFF
--- a/.claude/hooks/_lib-read-config.sh
+++ b/.claude/hooks/_lib-read-config.sh
@@ -59,6 +59,18 @@ _config_repo_root() {
   # file in .claude/hooks/, so locate it via BASH_SOURCE — not via
   # `git rev-parse` (which would defeat the whole point of this fix).
   local lib_dir
+  # zsh-safe warning (me2resh/apexyard#950): these helpers are #!/bin/bash and
+  # rely on ${BASH_SOURCE[0]} for self-location, which is a bash-only feature —
+  # it is EMPTY under zsh, so an operator who `source`s this lib in an
+  # interactive zsh shell (a common manual config-verification move during
+  # setup) would silently resolve to the wrong dir and chase a phantom bug.
+  # Emit a one-line advisory so the failure is loud, not silent. (A real zsh
+  # self-location expansion was rejected — this file has other bash-only
+  # constructs that don't source cleanly under zsh anyway, so "run it under
+  # bash" is the honest guidance.)
+  if [ -n "${ZSH_VERSION:-}" ]; then
+    printf 'apexyard: source the .claude/hooks/_lib-*.sh helpers under bash, not zsh — path resolution is unreliable under zsh. Wrap manual checks in `bash -c '"'"'...'"'"'`.\n' >&2
+  fi
   lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   if [ -f "$lib_dir/_lib-ops-root.sh" ]; then
     # shellcheck source=/dev/null


### PR DESCRIPTION
## Summary

- **Loud advisory instead of silent wrong-resolution under zsh** — `_lib-read-config.sh` self-locates via `${BASH_SOURCE[0]}`, a bash-only feature that is empty under zsh. An operator who `source`s these helpers in an interactive zsh shell to verify config/portfolio path resolution (the setup-guide snippet does exactly this) would otherwise silently resolve to the wrong directory and chase a phantom bug. The config-root resolver now emits a one-line advisory under zsh — "source these under bash" — so the failure is loud, not silent. Shipped hooks are all `#!/bin/bash` and are unaffected; this only bites manual sourcing.
- **Why warn-only rather than a zsh-native self-location fix** — a real zsh expansion (`${(%):-%x}`) was tried and rejected: shellcheck (which parses everything as bash) errors on the nested zsh-only form (SC2298), and the file has other bash-only constructs that don't source cleanly under zsh anyway. "Run it under bash" is the honest, robust guidance, and it can't hang or break shellcheck.

## Testing

1. `shellcheck -x .claude/hooks/_lib-read-config.sh` — clean
2. bash: `. _lib-read-config.sh && config_get_or …` resolves as before (no regression)
3. zsh: `zsh -c '. _lib-read-config.sh; config_get_or .x def'` — the advisory fires when the resolver runs (the exact manual-verification path)

Refs #950

_Touches `.claude/hooks/**` (trust chain); Security Auditor (Hakim) review expected in addition to Rex._

## Glossary

| Term | Definition |
|------|------------|
| `${BASH_SOURCE[0]}` | Bash array holding the currently-sourced file's path; used for self-location. Empty under zsh. |
| Self-location | A sourced library resolving its own directory so it can find sibling files regardless of the caller's cwd. |
