### PR TITLE
fix(#958): whitelist [Migration] and [Idea] ticket prefixes

### DIFF
--- a/.claude/project-config.defaults.json
+++ b/.claude/project-config.defaults.json
@@ -13,7 +13,9 @@
       "Docs",
       "Spike",
       "Prototype",
-      "Investigation"
+      "Investigation",
+      "Migration",
+      "Idea"
     ],
     "label_priority_scheme": "P0,P1,P2,P3",
     "required_sections": {


### PR DESCRIPTION
## Summary

- **`/migration` couldn't create its own ticket** — `validate-issue-structure.sh` blocks any title whose bracketed prefix isn't in `ticket.prefix_whitelist`, but the shipped default omitted `Migration` while `templates/tickets/migration.md` emits `[Migration] {{type}}: {{summary}}`. Every fresh adopter running `/migration` hit this cold: the skill's own generated title was rejected by the framework's own validator. Reported in #958.
- **Fixed the whole class, not just the reported prefix.** I audited every `templates/tickets/*.md` prefix against the whitelist and found a **second** gap the report didn't catch: `[Idea]`. `/idea` optionally creates a tracking issue, and its template emits `[Idea] {{title}}` — so it hit the identical wall. Both `Migration` and `Idea` are now whitelisted; every shipped ticket template's prefix validates.
- **Deliberately did not add `required_sections` entries for the two new prefixes.** The validator already handles a missing entry gracefully (`.required_sections["<prefix>"][]? // empty` → no section enforcement), so whitelisting alone is sufficient to unblock creation. Adding required sections would introduce *new* blocking enforcement that the reported bug never asked for and that could reject existing tickets — that's a separate judgement call worth its own ticket if the maintainer wants it.

## Testing

1. `bash .claude/hooks/tests/test_validate_issue_structure.sh` → **34 passed, 0 failed**
2. Audited every `templates/tickets/*.md` bracketed prefix against `prefix_whitelist` — no remaining gaps
3. Verified `.claude/project-config.defaults.json` still parses as valid JSON

Refs #958

Reported by @aelnemr with the correct suggested fix — thank you.

_Note: this file gates issue creation, so a Security Auditor glance is welcome, though it is not under `.claude/hooks/**` and so doesn't auto-trigger the #777 trust-chain rule._

## Glossary

| Term | Definition |
|------|------------|
| `prefix_whitelist` | The set of bracketed ticket-title prefixes (`[Feature]`, `[Bug]`, …) that `validate-issue-structure.sh` accepts before allowing issue creation. |
| `required_sections` | Per-prefix map of `## ` headings a ticket body must contain; a prefix with no entry gets no section enforcement. |
