### PR TITLE
fix(#964): resync prefix-whitelist fallback + task skill to shipped defaults

### DIFF
--- a/.claude/hooks/tests/test_validate_issue_structure.sh
+++ b/.claude/hooks/tests/test_validate_issue_structure.sh
@@ -476,6 +476,36 @@ run_case "Framework-shaped [Feature], no active-issue-skill marker → still blo
 rm -f "$TMPDIR/fork/.apexyard-fork"
 
 # ---------------------------------------------------------------------------
+# Drift guard (me2resh/apexyard#964)
+#
+# The hook carries an INLINE fallback whitelist for bare checkouts that predate
+# config (`PREFIX_WHITELIST="Feature Bug ..."`). That fallback is a hand-copied
+# mirror of `.ticket.prefix_whitelist` in project-config.defaults.json and had
+# silently drifted (missing Prototype/Investigation/Migration/Idea) — so a
+# `[Migration]`/`[Idea]` ticket filed on a config-less checkout was wrongly
+# rejected. This assertion fails loudly the next time the two lists diverge,
+# instead of leaving the drift to be discovered by a mis-rejected ticket.
+# ---------------------------------------------------------------------------
+DEFAULTS_JSON="$REPO_ROOT/.claude/project-config.defaults.json"
+# The hook's inline fallback: grep the assignment, strip to the quoted value,
+# then normalise whitespace → newline-per-token → sort.
+fallback_sorted=$(
+  grep -E 'PREFIX_WHITELIST="[^"]+"' "$HOOK" \
+    | sed -E 's/.*PREFIX_WHITELIST="([^"]+)".*/\1/' \
+    | tr ' ' '\n' | grep -v '^$' | sort
+)
+defaults_sorted=$(jq -r '.ticket.prefix_whitelist[]' "$DEFAULTS_JSON" | sort)
+if [ "$fallback_sorted" = "$defaults_sorted" ]; then
+  echo "PASS: inline fallback whitelist matches .ticket.prefix_whitelist in defaults"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: inline fallback whitelist has drifted from .ticket.prefix_whitelist" >&2
+  echo "  hook fallback : $(echo "$fallback_sorted" | tr '\n' ' ')" >&2
+  echo "  defaults json : $(echo "$defaults_sorted" | tr '\n' ' ')" >&2
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
 # Result
 # ---------------------------------------------------------------------------
 

--- a/.claude/hooks/validate-issue-structure.sh
+++ b/.claude/hooks/validate-issue-structure.sh
@@ -189,7 +189,7 @@ fi
 # Inline defaults for bare checkouts predating apexyard#109. Mirror the
 # shipped .claude/project-config.defaults.json so behaviour is identical.
 if [ -z "$PREFIX_WHITELIST" ]; then
-  PREFIX_WHITELIST="Feature Bug Chore Refactor Testing CI Docs Spike"
+  PREFIX_WHITELIST="Feature Bug Chore Refactor Testing CI Docs Spike Prototype Investigation Migration Idea"
 fi
 SKIP_MARKER="${SKIP_MARKER:-<!-- validate-issue-structure: skip -->}"
 # Framework-filing skills that file upstream with their own body template

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -136,7 +136,7 @@ Substitute the gathered inputs into the resolved template (or the inline heredoc
 Here's the ticket I'll create:
 
 ---
-**[{Chore|Refactor|Test|CI}] {title}**
+**[{Chore|Refactor|Testing|CI}] {title}**
 
 ## Driver
 {why this work is needed}


### PR DESCRIPTION
## Summary
- **Resynced the config-less fallback whitelist** — `validate-issue-structure.sh` carries an inline `PREFIX_WHITELIST` for bare checkouts that predate project config; it had silently drifted to 8 entries, missing `Prototype`, `Investigation`, `Migration`, and `Idea`. On such a checkout a perfectly valid `[Migration]` or `[Idea]` ticket was rejected as an unknown prefix. Now mirrors the full 12-entry `.ticket.prefix_whitelist`.
- **Fixed the task skill's own example** — `task/SKILL.md` line 139 rendered the prefix menu as `{Chore|Refactor|Test|CI}`, but the whitelist entry is `Testing`, not `Test`. The skill was demonstrating a prefix its own validator rejects. Corrected to `Testing`.
- **Added a drift-guard test** — a static assertion that the hook's inline fallback string equals `.ticket.prefix_whitelist` in `project-config.defaults.json`. The next time the two lists diverge, CI fails loudly instead of leaving the drift to be discovered by a mis-rejected ticket (which is exactly how this bug surfaced).

## Testing
1. `bash .claude/hooks/tests/test_validate_issue_structure.sh` — 35/35 pass, including the new `inline fallback whitelist matches .ticket.prefix_whitelist` case.
2. `shellcheck .claude/hooks/validate-issue-structure.sh .claude/hooks/tests/test_validate_issue_structure.sh` — clean on the changed lines (two pre-existing style nits on untouched lines 62/88 remain).

Refs #964

---

## Glossary
| Term | Definition |
|------|------------|
| Prefix whitelist | The set of accepted `[Prefix]` ticket-title tokens (`Feature`, `Bug`, `Migration`, …) that `validate-issue-structure.sh` allows when a ticket is filed. |
| Inline fallback | A hard-coded copy of the whitelist the hook uses when it can't read `project-config.defaults.json` (a bare checkout with no config). |
| Drift | Two copies of the same list diverging over time because one was updated and the hand-copied mirror wasn't. |
| Drift guard | A test that asserts the two copies are identical, so a future divergence fails CI instead of silently mis-behaving. |
