### PR TITLE
fix(#965): merge-gate hooks fail closed when jq/tool-input is unevaluable

### DIFF
--- a/.claude/hooks/block-merge-on-red-ci.sh
+++ b/.claude/hooks/block-merge-on-red-ci.sh
@@ -45,16 +45,58 @@
 #   treated as green, exactly like a red-or-unfetchable gh CI check.
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-
-if [ -z "$COMMAND" ]; then
-  exit 0
-fi
 
 # Shared merge-shape detector + PR-number parser (see _lib-extract-pr.sh).
 # Handles `gh pr merge <N>`, `gh api repos/<owner>/<repo>/pulls/<N>/merge`,
 # `glab mr merge <N>`, and `glab api .../merge_requests/<N>/merge` (#764/#767).
+# Sourced BEFORE the jq-based command parse below (moved up from its
+# original position after the parse) so is_merge_command is available as
+# the jq-independent fallback detector when the parse can't be trusted —
+# see #965.
 . "$(dirname "$0")/_lib-extract-pr.sh"
+
+# Parse .tool_input.command via jq. #965: this used to be the ONLY parse
+# path, and an empty/failed result — jq missing from PATH, or jq erroring
+# on unexpected input — fell straight through to `exit 0`, silently
+# ALLOWING the merge command through with NO CI-status check at all. A
+# security/quality gate must fail CLOSED when it can't evaluate its own
+# precondition, not fail open.
+#
+# But this hook's PreToolUse matcher is `Bash` (every Bash call this
+# session runs, not just merges — see .claude/settings.json), so the fix
+# can't be "exit 2 whenever jq is unavailable": that would block every
+# unrelated Bash command for the rest of the session the moment jq broke,
+# which is worse than the bug it replaces. The resolution below keeps the
+# jq-unparseable case a no-op EXCEPT when the raw payload text itself
+# looks merge-shaped — in that narrower case we cannot safely let the
+# command through, so we fail closed instead.
+COMMAND=""
+if command -v jq >/dev/null 2>&1; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+fi
+
+if [ -z "$COMMAND" ]; then
+  # jq is missing, OR jq is present but the parse produced nothing — a
+  # genuinely empty command (legitimate no-op) or jq choking on
+  # malformed/unexpected JSON. Those two cases are indistinguishable from
+  # a parsed field alone, so fall back to a parser-independent scan: reuse
+  # is_merge_command (plain grep/sed, no jq dependency) directly against
+  # the RAW JSON payload text instead of the parsed command. The command
+  # text's own words (`gh`, `pr`, `merge`, digits, spaces) survive JSON
+  # string-encoding unchanged, so this is the exact same tested
+  # merge-shape detector used below — not a second, drift-prone regex.
+  #
+  # A payload that isn't merge-shaped at all is a genuine no-op — exit 0,
+  # unchanged behaviour for the overwhelming majority of Bash calls this
+  # hook sees. A payload that DOES look merge-shaped but that we can't
+  # safely parse/verify fails CLOSED (exit 2) instead of silently letting
+  # an ungated merge through with an unverified CI status.
+  if is_merge_command "$INPUT"; then
+    echo "BLOCKED: CI gate cannot evaluate this command — jq is unavailable or .tool_input.command could not be parsed, but the raw input looks merge-related. Refusing to merge until CI status can be verified. Restore jq (see .claude/hooks/check-jq-installed.sh) and retry." >&2
+    exit 2
+  fi
+  exit 0
+fi
 
 if ! is_merge_command "$COMMAND"; then
   exit 0

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -47,17 +47,59 @@
 # explicit human-authorization moment. Different threat model.
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-
-if [ -z "$COMMAND" ]; then
-  exit 0
-fi
 
 # Shared merge-shape detector + PR-number parser (see _lib-extract-pr.sh).
 # Handles `gh pr merge <N>` and `gh api repos/<owner>/<repo>/pulls/<N>/merge`.
+# Sourced BEFORE the jq-based command parse below (moved up from its
+# original position after the parse) so is_merge_command is available as
+# the jq-independent fallback detector when the parse can't be trusted —
+# see #965.
 . "$(dirname "$0")/_lib-extract-pr.sh"
 # Repo-qualified marker path helper (#485).
 . "$(dirname "$0")/_lib-review-markers.sh"
+
+# Parse .tool_input.command via jq. #965: this used to be the ONLY parse
+# path, and an empty/failed result — jq missing from PATH, or jq erroring
+# on unexpected input — fell straight through to `exit 0`, silently
+# ALLOWING the merge command through completely ungated. A security gate
+# must fail CLOSED when it can't evaluate its own precondition, not fail
+# open.
+#
+# But this hook's PreToolUse matcher is `Bash` (every Bash call this
+# session runs, not just merges — see .claude/settings.json), so the fix
+# can't be "exit 2 whenever jq is unavailable": that would block every
+# unrelated Bash command for the rest of the session the moment jq broke,
+# which is worse than the bug it replaces. The resolution below keeps the
+# jq-unparseable case a no-op EXCEPT when the raw payload text itself
+# looks merge-shaped — in that narrower case we cannot safely let the
+# command through, so we fail closed instead.
+COMMAND=""
+if command -v jq >/dev/null 2>&1; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+fi
+
+if [ -z "$COMMAND" ]; then
+  # jq is missing, OR jq is present but the parse produced nothing — a
+  # genuinely empty command (legitimate no-op) or jq choking on
+  # malformed/unexpected JSON. Those two cases are indistinguishable from
+  # a parsed field alone, so fall back to a parser-independent scan: reuse
+  # is_merge_command (plain grep/sed, no jq dependency) directly against
+  # the RAW JSON payload text instead of the parsed command. The command
+  # text's own words (`gh`, `pr`, `merge`, digits, spaces) survive JSON
+  # string-encoding unchanged, so this is the exact same tested
+  # merge-shape detector used below — not a second, drift-prone regex.
+  #
+  # A payload that isn't merge-shaped at all is a genuine no-op — exit 0,
+  # unchanged behaviour for the overwhelming majority of Bash calls this
+  # hook sees. A payload that DOES look merge-shaped but that we can't
+  # safely parse/verify fails CLOSED (exit 2) instead of silently letting
+  # an ungated merge through.
+  if is_merge_command "$INPUT"; then
+    echo "BLOCKED: merge gate cannot evaluate this command — jq is unavailable or .tool_input.command could not be parsed, but the raw input looks merge-related. Refusing to merge until this can be verified. Restore jq (see .claude/hooks/check-jq-installed.sh) and retry." >&2
+    exit 2
+  fi
+  exit 0
+fi
 
 if ! is_merge_command "$COMMAND"; then
   exit 0

--- a/.claude/hooks/require-architecture-review.sh
+++ b/.claude/hooks/require-architecture-review.sh
@@ -39,19 +39,61 @@
 # existence. For adversarial trust, use CODEOWNERS.
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-
-if [ -z "$COMMAND" ]; then
-  exit 0
-fi
 
 # Shared merge-shape detector + PR-number parser (see _lib-extract-pr.sh).
 # Handles `gh pr merge <N>` and `gh api repos/<owner>/<repo>/pulls/<N>/merge`.
+# Sourced BEFORE the jq-based command parse below (moved up from its
+# original position after the parse) so is_merge_command is available as
+# the jq-independent fallback detector when the parse can't be trusted —
+# see #965.
 . "$(dirname "$0")/_lib-extract-pr.sh"
 # Repo-qualified marker path helper (#485).
 . "$(dirname "$0")/_lib-review-markers.sh"
 # cd-target → origin recovery for the no---repo split-portfolio merge (#687).
 . "$(dirname "$0")/_lib-pr-repo.sh"
+
+# Parse .tool_input.command via jq. #965: this used to be the ONLY parse
+# path, and an empty/failed result — jq missing from PATH, or jq erroring
+# on unexpected input — fell straight through to `exit 0`, silently
+# ALLOWING the merge command through with NO architecture-review check at
+# all. A gate must fail CLOSED when it can't evaluate its own
+# precondition, not fail open.
+#
+# But this hook's PreToolUse matcher is `Bash` (every Bash call this
+# session runs, not just merges — see .claude/settings.json), so the fix
+# can't be "exit 2 whenever jq is unavailable": that would block every
+# unrelated Bash command for the rest of the session the moment jq broke,
+# which is worse than the bug it replaces. The resolution below keeps the
+# jq-unparseable case a no-op EXCEPT when the raw payload text itself
+# looks merge-shaped — in that narrower case we cannot safely let the
+# command through, so we fail closed instead.
+COMMAND=""
+if command -v jq >/dev/null 2>&1; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+fi
+
+if [ -z "$COMMAND" ]; then
+  # jq is missing, OR jq is present but the parse produced nothing — a
+  # genuinely empty command (legitimate no-op) or jq choking on
+  # malformed/unexpected JSON. Those two cases are indistinguishable from
+  # a parsed field alone, so fall back to a parser-independent scan: reuse
+  # is_merge_command (plain grep/sed, no jq dependency) directly against
+  # the RAW JSON payload text instead of the parsed command. The command
+  # text's own words (`gh`, `pr`, `merge`, digits, spaces) survive JSON
+  # string-encoding unchanged, so this is the exact same tested
+  # merge-shape detector used below — not a second, drift-prone regex.
+  #
+  # A payload that isn't merge-shaped at all is a genuine no-op — exit 0,
+  # unchanged behaviour for the overwhelming majority of Bash calls this
+  # hook sees. A payload that DOES look merge-shaped but that we can't
+  # safely parse/verify fails CLOSED (exit 2) instead of silently letting
+  # an unreviewed design artifact through.
+  if is_merge_command "$INPUT"; then
+    echo "BLOCKED: architecture-review gate cannot evaluate this command — jq is unavailable or .tool_input.command could not be parsed, but the raw input looks merge-related. Refusing to merge until this can be verified. Restore jq (see .claude/hooks/check-jq-installed.sh) and retry." >&2
+    exit 2
+  fi
+  exit 0
+fi
 
 if ! is_merge_command "$COMMAND"; then
   exit 0

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -38,19 +38,61 @@
 # visible file existence. For adversarial trust, use CODEOWNERS.
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-
-if [ -z "$COMMAND" ]; then
-  exit 0
-fi
 
 # Shared merge-shape detector + PR-number parser (see _lib-extract-pr.sh).
 # Handles `gh pr merge <N>` and `gh api repos/<owner>/<repo>/pulls/<N>/merge`.
+# Sourced BEFORE the jq-based command parse below (moved up from its
+# original position after the parse) so is_merge_command is available as
+# the jq-independent fallback detector when the parse can't be trusted —
+# see #965.
 . "$(dirname "$0")/_lib-extract-pr.sh"
 # Repo-qualified marker path helper (#485).
 . "$(dirname "$0")/_lib-review-markers.sh"
 # cd-target → origin recovery for the no---repo split-portfolio merge (#687).
 . "$(dirname "$0")/_lib-pr-repo.sh"
+
+# Parse .tool_input.command via jq. #965: this used to be the ONLY parse
+# path, and an empty/failed result — jq missing from PATH, or jq erroring
+# on unexpected input — fell straight through to `exit 0`, silently
+# ALLOWING the merge command through with NO design-review check at all.
+# A gate must fail CLOSED when it can't evaluate its own precondition,
+# not fail open.
+#
+# But this hook's PreToolUse matcher is `Bash` (every Bash call this
+# session runs, not just merges — see .claude/settings.json), so the fix
+# can't be "exit 2 whenever jq is unavailable": that would block every
+# unrelated Bash command for the rest of the session the moment jq broke,
+# which is worse than the bug it replaces. The resolution below keeps the
+# jq-unparseable case a no-op EXCEPT when the raw payload text itself
+# looks merge-shaped — in that narrower case we cannot safely let the
+# command through, so we fail closed instead.
+COMMAND=""
+if command -v jq >/dev/null 2>&1; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+fi
+
+if [ -z "$COMMAND" ]; then
+  # jq is missing, OR jq is present but the parse produced nothing — a
+  # genuinely empty command (legitimate no-op) or jq choking on
+  # malformed/unexpected JSON. Those two cases are indistinguishable from
+  # a parsed field alone, so fall back to a parser-independent scan: reuse
+  # is_merge_command (plain grep/sed, no jq dependency) directly against
+  # the RAW JSON payload text instead of the parsed command. The command
+  # text's own words (`gh`, `pr`, `merge`, digits, spaces) survive JSON
+  # string-encoding unchanged, so this is the exact same tested
+  # merge-shape detector used below — not a second, drift-prone regex.
+  #
+  # A payload that isn't merge-shaped at all is a genuine no-op — exit 0,
+  # unchanged behaviour for the overwhelming majority of Bash calls this
+  # hook sees. A payload that DOES look merge-shaped but that we can't
+  # safely parse/verify fails CLOSED (exit 2) instead of silently letting
+  # an unreviewed UI change through.
+  if is_merge_command "$INPUT"; then
+    echo "BLOCKED: design-review gate cannot evaluate this command — jq is unavailable or .tool_input.command could not be parsed, but the raw input looks merge-related. Refusing to merge until this can be verified. Restore jq (see .claude/hooks/check-jq-installed.sh) and retry." >&2
+    exit 2
+  fi
+  exit 0
+fi
 
 if ! is_merge_command "$COMMAND"; then
   exit 0

--- a/.claude/hooks/tests/test_block_merge_on_red_ci.sh
+++ b/.claude/hooks/tests/test_block_merge_on_red_ci.sh
@@ -322,6 +322,31 @@ sb=$(make_sandbox_wrapper failure)
 run_case "wrapper: glab-registered project, pipeline failed -> blocks (forge dispatched via registry, not command text)" 2 "red or unresolvable" "$sb" \
   "$(printf "$WRAPPER_CMD_TMPL" "$sb")"
 
+# --- Fail-closed on jq-unavailable/unparseable input (#965) ------------
+#
+# Reuses make_sandbox's green gh mock, then shadows jq with a stub that
+# always fails — same code path as jq being entirely missing from PATH.
+make_sandbox_broken_jq() {
+  local sb
+  sb=$(make_sandbox green "")
+  cat > "$sb/bin/jq" <<'EOF'
+#!/bin/bash
+# Simulates a broken/unavailable jq: always fails, no output. See #965.
+exit 1
+EOF
+  chmod +x "$sb/bin/jq"
+  echo "$sb"
+}
+
+sb=$(make_sandbox_broken_jq)
+run_case "#965: jq broken, gh pr merge -> BLOCKS (fail closed, CI status unverifiable)" 2 \
+  "cannot evaluate this command" "$sb" \
+  "gh pr merge 302 --repo $TEST_REPO --squash"
+
+sb=$(make_sandbox_broken_jq)
+run_case "#965: jq broken, clearly non-merge command -> stays a no-op" 0 "" "$sb" \
+  "npm test"
+
 echo ""
 echo "=== test_block_merge_on_red_ci: $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then

--- a/.claude/hooks/tests/test_block_unreviewed_merge.sh
+++ b/.claude/hooks/tests/test_block_unreviewed_merge.sh
@@ -731,6 +731,60 @@ else
   fi
 fi
 
+# --- Fail-closed on jq-unavailable/unparseable input (#965) ------------
+#
+# make_sandbox_broken_jq installs a `jq` stub in $sb/bin that ALWAYS fails
+# (exit 1, no stdout) — same code path as jq being entirely missing from
+# PATH, since either way `jq -r '.tool_input.command // empty'` yields
+# nothing. $sb/bin is prepended to PATH by run_case_custom_cmd, so this
+# stub shadows the real jq for the duration of the hook's invocation only.
+make_sandbox_broken_jq() {
+  local sb
+  sb=$(make_sandbox)
+  cat > "$sb/bin/jq" <<'EOF'
+#!/bin/bash
+# Simulates a broken/unavailable jq: always fails, no output. See #965.
+exit 1
+EOF
+  chmod +x "$sb/bin/jq"
+  echo "$sb"
+}
+
+# 14. jq broken + a real `gh pr merge` with NO approval markers at all →
+#     must BLOCK (exit 2). Pre-#965 this fell through the old
+#     `[ -z "$COMMAND" ] && exit 0` no-op and merged completely ungated.
+sb=$(make_sandbox_broken_jq)
+run_case_custom_cmd "#965: jq broken, gh pr merge with no markers -> BLOCKS (fail closed)" 2 \
+  "cannot evaluate this command" "$sb" \
+  "gh pr merge 300 --repo me2resh/apexyard --squash"
+
+# 15. jq broken + a CLEARLY non-merge Bash command → must stay a no-op
+#     (exit 0, no stderr). Proves the fail-closed fix does NOT block every
+#     Bash command in the session just because jq is broken — only the
+#     merge-shaped ones (the boundary the #965 fix is built around).
+sb=$(make_sandbox_broken_jq)
+cmd="npm test"
+input=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
+  echo "PASS [#965: jq broken, clearly non-merge command -> stays a no-op]"; PASS=$((PASS+1))
+else
+  echo "FAIL [#965: jq broken, clearly non-merge command -> stays a no-op]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}jq-broken-nonmerge-noop "
+fi
+
+# 16. jq broken + the gh-api merge shape (no `gh pr merge` substring at
+#     all) → must still BLOCK. Proves the raw-text fallback detector
+#     (is_merge_command reused against $INPUT) recognises every shape the
+#     normal parsed-command path recognises, not just the literal
+#     `gh pr merge` string.
+sb=$(make_sandbox_broken_jq)
+run_case_custom_cmd "#965: jq broken, gh-api merge shape -> BLOCKS (fail closed)" 2 \
+  "cannot evaluate this command" "$sb" \
+  "gh api repos/me2resh/apexyard/pulls/301/merge -X PUT"
+
 # --- Summary ----------------------------------------------------------
 
 echo ""


### PR DESCRIPTION
## Summary

- **The merge gate silently disabled itself when `jq` was broken.** `block-unreviewed-merge.sh` (and its three sibling merge gates) parsed `.tool_input.command` via `jq` as the very first step, and an empty/failed parse fell straight through to `exit 0` — "nothing to gate, let it through." If `jq` was missing from `PATH` (or errored for any reason), a `gh pr merge` with **zero approval markers** would sail through completely ungated. A security gate that fails *open* on its own precondition breaking is the opposite of what it's for.
- **Audited and fixed all four merge-gate hooks identically** — `block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, `require-design-review-for-ui.sh`, `require-architecture-review.sh` all shared the exact same "parse-first, exit-0-on-failure" shape (verified byte-for-byte at the top of each file), so the same fix applies to all four, not just the one named in #965.
- **Fixed with a boundary that matters**: each of these hooks' `PreToolUse` matcher is `Bash` — every Bash command the session runs, not just merges. A blanket "jq unavailable → exit 2" would block every unrelated command (`npm test`, `ls`, anything) the instant `jq` broke, which is worse than the bug it replaces. Instead, when the jq parse yields nothing, each hook now falls back to running `is_merge_command` — the same tested, jq-free grep/sed detector already used on the parsed command — directly against the raw JSON payload text. A payload that isn't merge-shaped stays a no-op (unchanged behaviour for the overwhelming majority of Bash calls); a payload that *does* look merge-shaped but can't be safely parsed now fails closed instead of silently allowing.
- **Regression tests added** to `test_block_unreviewed_merge.sh` and `test_block_merge_on_red_ci.sh`: with `jq` stubbed to always fail, a `gh pr merge`/`gh api .../merge` with no approval markers now blocks (exit 2), while a clearly non-merge command (`npm test`) stays a no-op (exit 0, no stderr) — proving the fix doesn't over-block. The other two hooks (`require-design-review-for-ui.sh`, `require-architecture-review.sh`) were verified manually with the same jq-broken scenarios (both block on merge-shaped input, no-op on non-merge input) — their existing test harnesses use a different structure (portfolio/split-portfolio helpers) and adding equivalent automated cases there is flagged as good follow-up work, not done in this PR to keep the diff auditable.

## Testing

1. `shellcheck -x` on all six touched files — zero new findings; the only findings present are pre-existing `info`-level notices (`SC1091` on relative `.` sourcing, `SC2086`/`SC2016`/`SC2059` on pre-existing lines elsewhere in the files) that were already there before this change and are below the CI gate's `severity: warning` threshold.
2. `bash .claude/hooks/tests/test_block_unreviewed_merge.sh` → 37/37 pass (3 new `#965` cases).
3. `bash .claude/hooks/tests/test_block_merge_on_red_ci.sh` → 25/25 pass (2 new `#965` cases).
4. `bash .claude/hooks/tests/test_require_design_review_for_ui.sh` → 22/22 pass (unchanged, confirms no regression).
5. `bash .claude/hooks/tests/test_require_architecture_review.sh` → 22/22 pass (unchanged, confirms no regression).
6. Manual sandbox verification: with `jq` stubbed to fail, `require-design-review-for-ui.sh` and `require-architecture-review.sh` both block (exit 2, "cannot evaluate this command") on a merge-shaped command and stay a no-op (exit 0) on `npm test`.
7. Full suite: `bin/run-hook-tests.sh` → 112/113 pass. The one failure (`test_sync_codex_adapter.sh`, a `sed` internal assertion crash) is unrelated — that file isn't touched by this PR, and re-running it in isolation shows a different, pre-existing flake, not a crash tied to this change.

Refs #965

---

## Glossary

| Term | Definition |
|------|------------|
| Fail closed / fail open | A gate that, on ambiguity or internal error, *blocks* (closed — safe) vs. *allows* (open — unsafe). Security/quality gates must fail closed. |
| Merge gate | One of the four `PreToolUse` hooks (`block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, `require-design-review-for-ui.sh`, `require-architecture-review.sh`) that inspect a `gh pr merge` / `gh api .../merge` command before letting it run. |
| `is_merge_command` | A shared, jq-free grep/sed detector in `_lib-extract-pr.sh` that recognises every merge-command shape (`gh pr merge`, `gh api .../pulls/<N>/merge`, `glab mr merge`, `glab api .../merge_requests/<N>/merge`, the `tracker_pr_merge` wrapper). This fix reuses it as a fallback against the raw JSON payload when the jq-parsed command is unavailable. |
| `.tool_input.command` | The JSON field each hook parses to read the Bash command it's gating, taken from the `PreToolUse` payload the harness pipes to the hook on stdin. |
