### PR TITLE
fix(#962): gate marker writes on the resolved target, not a literal path match

### DIFF
--- a/.claude/hooks/tests/test_warn_review_marker_write.sh
+++ b/.claude/hooks/tests/test_warn_review_marker_write.sh
@@ -33,6 +33,24 @@
 #   (18) Write  → legacy bare-number marker filename, no marker  → BLOCKED, exit 2
 #   (19) Write  → legacy bare-number marker filename, matching pr+kind → ALLOWED, exit 0 (repo check skipped)
 #
+# #962 test matrix (resolved-target detection — see the hook's own #962
+# header comment for the false-negative/false-positive bugs this closes):
+#   (20) Bash   → variable-indirected write (review_marker_path + "$REX_MARKER"
+#                 redirect), no active-reviewer marker            → BLOCKED, exit 2
+#   (21) Bash   → same indirected write, WITH matching active-reviewer marker
+#                                                                  → ALLOWED, exit 0
+#   (22) Bash   → literal-path READ (cat) of a rex marker, no active-reviewer
+#                                                                  → silent, exit 0 (NOT blocked — false-positive fix)
+#   (23) Bash   → indirected tee write (review_marker_path + tee "$REX_MARKER"),
+#                 no active-reviewer marker                       → BLOCKED, exit 2
+#   (24) Bash   → fully ambiguous indirected write (mentions
+#                 .claude/session/reviews/ but no resolvable role), WITH an
+#                 active-reviewer marker present for a DIFFERENT kind
+#                                                                  → BLOCKED, exit 2 (fail-closed on total ambiguity)
+#   (25) Bash   → _lib-detect-bash-write.sh missing (graceful fallback):
+#                 literal-path READ (cat) of a rex marker, no active-reviewer
+#                                                                  → BLOCKED, exit 2 (conservative pre-#962 fallback, not a bypass)
+#
 # Exit 0 if all cases pass; 1 on failure.
 
 set -u
@@ -44,6 +62,7 @@ export APEXYARD_OPS_DISABLE_PIN=1
 HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/warn-review-marker-write.sh"
 LIB_OPS_ROOT="$(cd "$(dirname "$0")/.." && pwd)/_lib-ops-root.sh"
 LIB_MARKERS="$(cd "$(dirname "$0")/.." && pwd)/_lib-review-markers.sh"
+LIB_BDW="$(cd "$(dirname "$0")/.." && pwd)/_lib-detect-bash-write.sh"
 
 if [ ! -f "$HOOK_SRC" ]; then
   echo "FAIL: hook not found: $HOOK_SRC" >&2
@@ -59,6 +78,10 @@ if [ ! -f "$LIB_OPS_ROOT" ]; then
 fi
 if [ ! -f "$LIB_MARKERS" ]; then
   echo "FAIL: _lib-review-markers.sh not found at $LIB_MARKERS" >&2
+  exit 1
+fi
+if [ ! -f "$LIB_BDW" ]; then
+  echo "FAIL: _lib-detect-bash-write.sh not found at $LIB_BDW" >&2
   exit 1
 fi
 
@@ -88,7 +111,17 @@ make_sandbox() {
   mkdir -p "$sb/.claude/hooks" "$sb/.claude/session/reviews"
   cp "$HOOK_SRC" "$sb/.claude/hooks/warn-review-marker-write.sh"
   cp "$LIB_OPS_ROOT" "$sb/.claude/hooks/_lib-ops-root.sh"
+  cp "$LIB_BDW" "$sb/.claude/hooks/_lib-detect-bash-write.sh"
   chmod +x "$sb/.claude/hooks/warn-review-marker-write.sh"
+  echo "$sb"
+}
+
+# Build a sandbox with _lib-detect-bash-write.sh DELETED — used by case24 to
+# verify the graceful literal-substring-only fallback when the library is
+# missing (#962).
+make_sandbox_no_bdw_lib() {
+  local sb; sb=$(make_sandbox)
+  rm -f "$sb/.claude/hooks/_lib-detect-bash-write.sh"
   echo "$sb"
 }
 
@@ -362,6 +395,101 @@ case19() {
   rm -rf "$sb"
 }
 
+# ---------------------------------------------------------------------------
+# (20) Bash → variable-indirected write, no active-reviewer marker → BLOCKED
+#      (#962: the documented reviewer idiom — a `review_marker_path` call
+#      assigned to a variable, then redirected into — used to evade the
+#      literal-substring detector entirely. See make_indirect_rex_write().)
+# ---------------------------------------------------------------------------
+make_indirect_rex_write() {
+  # Builds: REX_MARKER=$(review_marker_path "me2resh/apexyard" 42 rex "$MARKER_HOME"); printf '%s' sha123 > "$REX_MARKER"
+  # The role ("rex") and PR ("42") arguments are literal — matching the real
+  # reviewers' documented usage (code-reviewer.md / solution-architect.md) —
+  # but the eventual write TARGET ("$REX_MARKER") never appears as a literal
+  # path anywhere in the command text.
+  # shellcheck disable=SC2016 # deliberate — the $VARs must stay literal text
+  # for the hook to scan (the whole point of this indirection test case).
+  printf 'REX_MARKER=$(review_marker_path "%s" 42 rex "$MARKER_HOME"); printf '"'"'%%s'"'"' sha123 > "$REX_MARKER"' "$REPO"
+}
+
+case20() {
+  local sb; sb=$(make_sandbox)
+  run_hook "$sb" "Bash indirected write (review_marker_path var), no marker -> BLOCKED (#962)" \
+    "$(bash_json "$(make_indirect_rex_write)")" 2 "BLOCKED"
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (21) Bash → same indirected write WITH matching active-reviewer marker
+#      → ALLOWED
+# ---------------------------------------------------------------------------
+case21() {
+  local sb; sb=$(make_sandbox)
+  printf '%s\n' "${REPO}#42:rex" > "$sb/.claude/session/active-reviewer"
+  run_hook "$sb" "Bash indirected write, matching active-reviewer -> ALLOWED (#962)" \
+    "$(bash_json "$(make_indirect_rex_write)")" 0
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (22) Bash → literal-path READ (cat) of a rex marker, no active-reviewer
+#      → silent, exit 0 (#962 false-positive fix: a plain read must NOT be
+#      blocked just because the literal marker path appears in the text)
+# ---------------------------------------------------------------------------
+case22() {
+  local sb; sb=$(make_sandbox)
+  local marker; marker=$(review_marker_path "$REPO" 42 rex "$sb")
+  run_hook "$sb" "Bash cat (read) of literal rex marker path -> NOT blocked (#962)" \
+    "$(bash_json "cat ${marker}")" 0
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (23) Bash → indirected TEE write, no active-reviewer marker → BLOCKED
+#      (tee/redirect variant of the #962 indirection idiom)
+# ---------------------------------------------------------------------------
+case23() {
+  local sb; sb=$(make_sandbox)
+  local cmd
+  # shellcheck disable=SC2016 # deliberate — literal text, not real expansion
+  cmd=$(printf 'REX_MARKER=$(review_marker_path "%s" 42 rex "$MARKER_HOME"); echo sha123 | tee "$REX_MARKER"' "$REPO")
+  run_hook "$sb" "Bash indirected tee write, no marker -> BLOCKED (#962)" \
+    "$(bash_json "$cmd")" 2 "BLOCKED"
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (24) Bash → fully ambiguous indirected write (mentions .claude/session/
+#      reviews/ but the role can't be resolved to any of rex/ceo/security/
+#      architecture), WITH an active-reviewer marker present for a
+#      DIFFERENT kind → still BLOCKED. Demonstrates fail-closed-on-total-
+#      ambiguity (#962 requirement 3): an unresolved role can never match a
+#      real active-reviewer marker's kind field, by construction.
+# ---------------------------------------------------------------------------
+case24() {
+  local sb; sb=$(make_sandbox)
+  printf '%s\n' "${REPO}#42:security" > "$sb/.claude/session/active-reviewer"
+  # shellcheck disable=SC2016 # deliberate — literal text, not real expansion
+  local cmd='DIR="$MARKER_HOME/.claude/session/reviews"; printf "%s" sha123 > "$DIR/mystery.approved"'
+  run_hook "$sb" "Bash fully ambiguous indirected write -> BLOCKED (#962 fail-closed)" \
+    "$(bash_json "$cmd")" 2 "BLOCKED"
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (25) Bash → _lib-detect-bash-write.sh missing: literal-path READ (cat) of a
+#      rex marker, no active-reviewer marker → BLOCKED (conservative pre-#962
+#      fallback — re-applies the known false-positive-on-read limitation
+#      rather than silently bypassing the gate when the library is absent).
+# ---------------------------------------------------------------------------
+case25() {
+  local sb; sb=$(make_sandbox_no_bdw_lib)
+  local marker; marker=$(review_marker_path "$REPO" 42 rex "$sb")
+  run_hook "$sb" "Bash cat (read) of literal rex marker, lib missing -> BLOCKED (graceful fallback)" \
+    "$(bash_json "cat ${marker}")" 2 "BLOCKED"
+  rm -rf "$sb"
+}
+
 case1
 case2
 case3
@@ -381,6 +509,12 @@ case16
 case17
 case18
 case19
+case20
+case21
+case22
+case23
+case24
+case25
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/.claude/hooks/warn-review-marker-write.sh
+++ b/.claude/hooks/warn-review-marker-write.sh
@@ -36,22 +36,60 @@
 # ever see an active-reviewer marker set for its own PR — is blocked with a
 # message telling it to stop and hand back to the orchestrator.
 #
-# KNOWN LIMITATION (scope of the block, honestly stated)
-# ------------------------------------------------------
-# This gate fires only when the LITERAL marker path (e.g. a `*-rex.approved`
-# suffix) appears in the Write tool's file_path or in the Bash command text —
-# it inherits the `_is_marker_target` match surface that predates #843. The
-# sanctioned reviewers write the marker via a shell VARIABLE
-# (`printf '%s\n' "$SHA" > "$REX_MARKER"`, path from `review_marker_path`),
-# where the literal suffix never appears in the command text; a shell hook
-# cannot expand that variable to know the target, so the variable form is NOT
-# intercepted. Consequence: this blocks the common "just create the file"
-# literal-path forgery vector (real value), but an agent that forges by
-# copying the reviewers' own documented variable-form idiom is NOT stopped by
-# this hook. So #843 *narrows* the induced-impersonation surface; it does not
-# claim to mechanically block every forgery. The load-bearing defences remain
-# the per-PR CEO nod (`/approve-merge`) and the orchestrator running a real,
-# separate reviewer pass — this gate is a backstop, not a complete fence.
+# #962 — RESOLVED-TARGET DETECTION (closes the prior KNOWN LIMITATION)
+# ----------------------------------------------------------------------
+# #843's detection matched the LITERAL marker suffix as a plain substring of
+# the Bash command TEXT. Two consequences fell out of that:
+#
+#   1. FALSE NEGATIVE (security-relevant): the sanctioned reviewers' own
+#      documented idiom builds the marker path via a shell variable —
+#      `REX_MARKER=$(review_marker_path "$REPO" "$PR" rex "$MARKER_HOME")`
+#      then `printf '%s\n' "$SHA" > "$REX_MARKER"` — where the literal
+#      `-rex.approved` suffix never appears anywhere in the command text.
+#      A build agent forging by copying that exact idiom evaded the gate
+#      entirely: no active-reviewer marker required, no block.
+#   2. FALSE POSITIVE: a harmless READ of a marker path that happens to
+#      spell out the literal filename (`cat .claude/session/reviews/…
+#      -security.approved`) tripped the same substring match and was
+#      wrongly refused, even though nothing was being written.
+#
+# THE FIX: detect on the RESOLVED WRITE, not a literal-path substring —
+# reusing `_lib-detect-bash-write.sh` (the same helper require-active-
+# ticket.sh's Bash matcher already uses for the identical class of problem,
+# see me2resh/apexyard#151):
+#
+#   - `bash_command_appears_to_write` distinguishes a genuine write
+#     (redirection, tee, sed -i, an embedded interpreter with a write
+#     keyword, …) from a plain read (cat/grep/head) — closing the false
+#     positive. A literal-path match is now gated ONLY when the command is
+#     also an actual write.
+#   - When the command performs a write but carries no literal marker path,
+#     `_is_marker_plausible_indirect` looks for the documented indirection
+#     idiom itself — a `review_marker_path` call, a `.claude/session/
+#     reviews/` mention, an `active-reviewer` mention, or a write target
+#     whose variable NAME follows the established *_MARKER convention
+#     (REX_MARKER, CEO_MARKER, SECURITY_MARKER, ARCH_MARKER, …). Any of
+#     those, combined with a real write, is treated as a plausible marker
+#     write and gated — closing the false negative.
+#   - Best-effort role (`_extract_marker_role`) and PR-number
+#     (`_extract_marker_pr`) extraction reads the SAME `review_marker_path`
+#     call's own positional arguments — the role and PR-number arguments
+#     are conventionally literal in the reviewers' documented usage (see
+#     code-reviewer.md / solution-architect.md), even though the RESULT of
+#     the call is assigned to a variable. When the role can't be resolved
+#     at all, the write is still gated — no literal `c_kind` in a
+#     well-formed `active-reviewer` marker can ever equal an unresolved
+#     empty string, so an unresolvable marker write FAILS CLOSED by
+#     construction rather than by a special case.
+#
+# This does NOT weaken the pre-#962 literal-path detection — it remains the
+# first check tried, unchanged — it only (a) requires that check to
+# co-occur with an actual write (fixing the read false-positive) and (b)
+# adds a second, indirection-aware detection path alongside it (fixing the
+# write false-negative). If `_lib-detect-bash-write.sh` is missing for any
+# reason, this hook falls back to the original #843 literal-substring-only
+# behaviour (conservative — the pre-existing false-positive-on-read
+# limitation re-applies, but nothing new is weakened).
 #
 # *-ceo.approved KEEPS its original #728 advisory-only behaviour (never
 # blocks) — it has its own structured-field defence in
@@ -62,7 +100,12 @@
 # `843-rex.approved` with no `<owner>__<repo>__` prefix) are still
 # recognised — the repo component of the active-reviewer check is skipped
 # for those (can't recover a repo from a bare filename), but the pr + kind
-# match still applies.
+# match still applies. The same skip-when-unresolvable philosophy extends
+# to #962's indirect-resolution path: when the PR number or repo can't be
+# recovered from the command text, that comparison is skipped, but kind
+# (rex vs security vs architecture) is ALWAYS required to match — and an
+# unresolved kind can never match, so under-resolution fails closed, not
+# open.
 #
 # THREAT MODEL: same as every other marker in this framework (see
 # .claude/rules/pr-workflow.md). Local session state, gitignored, converts
@@ -72,15 +115,19 @@
 # the marker directly used to be. The mechanical gate exists to remove the
 # INDUCED failure mode (auto-code-review.sh's banner telling a build agent
 # to do the impossible), not to defend against a deliberately adversarial
-# agent.
+# agent. #962's resolved-target detection narrows the surface further but
+# makes the same non-claim: a sufficiently adversarial agent that avoids
+# every keyword/naming signal this hook looks for is not mechanically
+# stopped — the load-bearing defences remain the per-PR human-approver nod
+# and the orchestrator running a real, separate reviewer pass.
 #
 # #873 trimmed the BLOCKED banner's orchestrator branch: since the sanctioned
-# reviewer writes the marker via the variable form (untouched by this gate,
-# see KNOWN LIMITATION above), the only caller who ever lands on this banner
-# is doing a literal-path write — the induced-forgery case. Printing a
-# copy-pasteable `printf > active-reviewer` recipe there handed a working
-# marker-set command to the agent we least want holding one. The banner now
-# points the orchestrator at the matching skill (/code-review,
+# reviewer writes the marker via the variable form (now DETECTED by #962,
+# see above — no longer a blind spot), the only caller who used to land on
+# this banner via a literal-path write was doing the induced-forgery case.
+# Printing a copy-pasteable `printf > active-reviewer` recipe there handed a
+# working marker-set command to the agent we least want holding one. The
+# banner points the orchestrator at the matching skill (/code-review,
 # /security-review, /design-review) instead — same skills that already own
 # the marker's set/clear lifecycle (see auto-code-review.sh's #843 banner for
 # the sibling fix this mirrors).
@@ -89,8 +136,8 @@
 #   matcher: Write    (catches direct file writes)
 #   matcher: Bash     (catches shell redirections, echo >, printf, tee, etc.)
 #
-# References: #728, #843, #873, AgDR-0062, .claude/rules/pr-workflow.md
-#             § "Build agents cannot self-review"
+# References: #728, #843, #873, #957, #962, AgDR-0062, AgDR-0104,
+#             .claude/rules/pr-workflow.md § "Build agents cannot self-review"
 
 set -u
 
@@ -98,6 +145,18 @@ INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Source the bash-write detector (#962). Same helper require-active-
+# ticket.sh's Bash matcher uses for the identical "does this command
+# actually write" question — see me2resh/apexyard#151. Missing library is
+# handled gracefully: fall back to the pre-#962 literal-substring-only
+# behaviour rather than bricking the hook (HAVE_BDW_LIB=0 below).
+HAVE_BDW_LIB=0
+if [ -f "$HOOK_DIR/_lib-detect-bash-write.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-detect-bash-write.sh"
+  HAVE_BDW_LIB=1
+fi
 
 _is_marker_target() {
   local text="$1"
@@ -109,12 +168,73 @@ _is_marker_target() {
   echo "$text" | grep -qE '\.claude/session/reviews/[^[:space:]"'"'"']+-(rex|ceo|security|architecture)\.approved'
 }
 
+# _is_marker_plausible_indirect COMMAND (#962)
+#
+# True when COMMAND performs a write with no literal marker path in sight,
+# but still plausibly targets a review marker via the documented
+# indirection idiom:
+#   REX_MARKER=$(review_marker_path "$REPO" "$PR" rex "$MARKER_HOME")
+#   printf '%s\n' "$SHA" > "$REX_MARKER"
+#
+# Signals (any one is sufficient):
+#   - a `review_marker_path` call anywhere in the command
+#   - a literal `.claude/session/reviews/` directory mention (without a full
+#     matched filename — e.g. a directory-only reference, or a path built
+#     via concatenation rather than a single contiguous literal)
+#   - a literal `active-reviewer` mention
+#   - a write-target-shaped variable name following the established
+#     *_MARKER convention this codebase's reviewers use (REX_MARKER,
+#     CEO_MARKER, SECURITY_MARKER, ARCH_MARKER, ARCHITECTURE_MARKER, …)
+_is_marker_plausible_indirect() {
+  local text="$1"
+  if echo "$text" | grep -qE 'review_marker_path|\.claude/session/reviews/|active-reviewer'; then
+    return 0
+  fi
+  echo "$text" | grep -qiE '\$\{?[a-z_]*marker[a-z_]*\}?'
+}
+
+# _extract_marker_role COMMAND (#962)
+#
+# Best-effort role extraction from a `review_marker_path <repo> <pr> <role>
+# [marker_home]` call embedded in COMMAND. The call's own arguments are
+# conventionally literal in the reviewers' documented usage even when the
+# call's RESULT is assigned to a variable (see code-reviewer.md,
+# solution-architect.md) — so the role can be recovered even though the
+# eventual write target cannot. Echoes rex|ceo|security|architecture, or
+# nothing if no such call (or no recognisable role argument) is found.
+_extract_marker_role() {
+  local cmd="$1" call
+  call=$(echo "$cmd" | grep -oE 'review_marker_path[^;&|)]*' | head -1)
+  [ -z "$call" ] && return 1
+  echo "$call" | grep -oE '\b(rex|ceo|security|architecture)\b' | head -1
+}
+
+# _extract_marker_pr COMMAND (#962)
+#
+# Best-effort PR-number extraction from the SAME `review_marker_path` call
+# — the {number} positional argument is conventionally a literal integer at
+# the point a reviewer or skill actually invokes it (a placeholder filled in
+# with the real PR number, per code-reviewer.md / solution-architect.md).
+# Echoes the first bare digit-run found in the call, or nothing.
+_extract_marker_pr() {
+  local cmd="$1" call
+  call=$(echo "$cmd" | grep -oE 'review_marker_path[^;&|)]*' | head -1)
+  [ -z "$call" ] && return 1
+  echo "$call" | grep -oE '\b[0-9]+\b' | head -1
+}
+
 MATCHED=0
 MARKER_TYPE=""
 TARGET=""
+TARGET_PR=""
+TARGET_REPO=""
+RESOLVED_VIA="literal"   # "literal" | "indirect" — which detection path matched
 
 case "$TOOL_NAME" in
   Write)
+    # Write's file_path is always a literal, harness-resolved string — never
+    # a shell expression a variable could hide — so the read/write ambiguity
+    # and indirection concerns below don't apply here. Unchanged from #843.
     FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
     if _is_marker_target "$FILE_PATH"; then
       MATCHED=1
@@ -123,9 +243,40 @@ case "$TOOL_NAME" in
     ;;
   Bash)
     COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-    if _is_marker_target "$COMMAND"; then
-      MATCHED=1
-      TARGET=$(echo "$COMMAND" | grep -oE '\.claude/session/reviews/[^[:space:]"'"'"']+-(rex|ceo|security|architecture)\.approved' | head -1)
+
+    if [ "$HAVE_BDW_LIB" = "1" ]; then
+      IS_WRITE=1
+      bash_command_appears_to_write "$COMMAND" || IS_WRITE=0
+
+      if [ "$IS_WRITE" = "1" ] && _is_marker_target "$COMMAND"; then
+        # Literal marker path present AND this command actually performs a
+        # write — not just a read that happens to mention the path (#962
+        # fix for the false-positive half of the bug: a bare `cat`/`grep`/
+        # `head` on a literal marker path is no longer blocked).
+        MATCHED=1
+        TARGET=$(echo "$COMMAND" | grep -oE '\.claude/session/reviews/[^[:space:]"'"'"']+-(rex|ceo|security|architecture)\.approved' | head -1)
+        RESOLVED_VIA="literal"
+      elif [ "$IS_WRITE" = "1" ] && _is_marker_plausible_indirect "$COMMAND"; then
+        # No literal path in the command text, but it performs a write AND
+        # plausibly targets a review marker via variable/function
+        # indirection (#962 fix for the false-negative half of the bug) —
+        # e.g. REX_MARKER=$(review_marker_path ...); printf ... > "$REX_MARKER"
+        MATCHED=1
+        RESOLVED_VIA="indirect"
+        MARKER_TYPE=$(_extract_marker_role "$COMMAND")
+        TARGET_PR=$(_extract_marker_pr "$COMMAND")
+        TARGET="<resolved via variable/function indirection; detected role: ${MARKER_TYPE:-unresolved}, pr: ${TARGET_PR:-unresolved}>"
+      fi
+    else
+      # Library unavailable — fall back to the pre-#962 literal-substring
+      # check with no read/write distinction (conservative: re-applies the
+      # known false-positive-on-read limitation, but doesn't newly weaken
+      # anything that was previously caught).
+      if _is_marker_target "$COMMAND"; then
+        MATCHED=1
+        TARGET=$(echo "$COMMAND" | grep -oE '\.claude/session/reviews/[^[:space:]"'"'"']+-(rex|ceo|security|architecture)\.approved' | head -1)
+        RESOLVED_VIA="literal"
+      fi
     fi
     ;;
 esac
@@ -134,8 +285,10 @@ if [ "$MATCHED" != "1" ]; then
   exit 0
 fi
 
-MARKER_BASENAME=$(basename "$TARGET")
-MARKER_TYPE=$(printf '%s' "$MARKER_BASENAME" | sed -E 's/^.*-(rex|ceo|security|architecture)\.approved$/\1/')
+if [ "$RESOLVED_VIA" = "literal" ]; then
+  MARKER_BASENAME=$(basename "$TARGET")
+  MARKER_TYPE=$(printf '%s' "$MARKER_BASENAME" | sed -E 's/^.*-(rex|ceo|security|architecture)\.approved$/\1/')
+fi
 
 # --- Configurable human-approver DISPLAY title (me2resh/apexyard#957) ---
 # DISPLAY ONLY: substitutes the printed word for the human per-PR merge
@@ -181,7 +334,8 @@ BANNER
   exit 0
 fi
 
-# --- rex / security / architecture: BLOCKING gate on the active-reviewer marker (#843). ---
+# --- rex / security / architecture (or an unresolved #962 indirect role):
+#     BLOCKING gate on the active-reviewer marker. ---
 
 # Resolve MARKER_HOME the same way every other review-marker hook does
 # (ops fork root, not necessarily the current repo's git toplevel — see
@@ -197,21 +351,36 @@ MARKER_HOME="${OPS_ROOT:-${REPO_ROOT:-.}}"
 
 ACTIVE_REVIEWER_MARKER="$MARKER_HOME/.claude/session/active-reviewer"
 
-# Parse the (repo, pr) this write targets from the marker's own filename.
-# Repo-qualified (post-#485): <owner>__<repo>__<pr>-<role>.approved
-# Legacy bare:                <pr>-<role>.approved
-PREFIX="${MARKER_BASENAME%-${MARKER_TYPE}.approved}"
-if printf '%s' "$PREFIX" | grep -qE '^[0-9]+$'; then
-  TARGET_PR="$PREFIX"
-  TARGET_REPO=""
-else
-  TARGET_PR=$(printf '%s' "$PREFIX" | grep -oE '[0-9]+$')
-  TARGET_REPO=$(printf '%s' "$PREFIX" | sed -E "s/__${TARGET_PR}\$//" | sed 's/__/\//')
+if [ "$RESOLVED_VIA" = "literal" ]; then
+  # Parse the (repo, pr) this write targets from the marker's own filename.
+  # Repo-qualified (post-#485): <owner>__<repo>__<pr>-<role>.approved
+  # Legacy bare:                <pr>-<role>.approved
+  PREFIX="${MARKER_BASENAME%-${MARKER_TYPE}.approved}"
+  if printf '%s' "$PREFIX" | grep -qE '^[0-9]+$'; then
+    TARGET_PR="$PREFIX"
+    TARGET_REPO=""
+  else
+    TARGET_PR=$(printf '%s' "$PREFIX" | grep -oE '[0-9]+$')
+    TARGET_REPO=$(printf '%s' "$PREFIX" | sed -E "s/__${TARGET_PR}\$//" | sed 's/__/\//')
+  fi
 fi
+# else (RESOLVED_VIA=indirect): TARGET_PR was already best-effort set (may
+# be empty) by _extract_marker_pr above; TARGET_REPO stays empty — a repo
+# slug is essentially never a literal argument to review_marker_path in
+# real usage (always a variable), so there's nothing reliable to recover.
+# Same "skip when unresolvable" fallback the legacy bare-marker-filename
+# case already uses below.
 
 _active_reviewer_allows() {
   # Returns 0 (allow) iff the active-reviewer marker exists and its
   # <repo>#<pr>:<kind> content matches this write's (repo, pr, role).
+  #
+  # Fail-closed by construction (#962): when MARKER_TYPE is empty (the role
+  # couldn't be resolved at all — total ambiguity on an indirect write), no
+  # well-formed active-reviewer marker can ever have an empty kind field, so
+  # `[ "$c_kind" = "$MARKER_TYPE" ]` can never succeed here. No special case
+  # is needed to reject the fully-unresolved case — the existing equality
+  # check already fails closed on it.
   [ -f "$ACTIVE_REVIEWER_MARKER" ] || return 1
   local content
   content=$(tr -d '[:space:]' < "$ACTIVE_REVIEWER_MARKER" 2>/dev/null)
@@ -231,7 +400,8 @@ _active_reviewer_allows() {
   [ "$c_kind" = "$MARKER_TYPE" ] || return 1
   [ -n "$TARGET_PR" ] && [ "$c_pr" != "$TARGET_PR" ] && return 1
   # Repo check only when the target filename encodes a repo (post-#485
-  # qualified marker). Legacy bare markers skip this comparison.
+  # qualified marker). Legacy bare markers, and #962 indirect writes where
+  # the repo couldn't be recovered, skip this comparison.
   if [ -n "$TARGET_REPO" ] && [ -n "$c_repo" ] && [ "$c_repo" != "$TARGET_REPO" ]; then
     return 1
   fi
@@ -257,12 +427,12 @@ cat >&2 <<MSG
 [apexyard] BLOCKED: Unauthorized review-marker write
 ======================================================================
 
-You are about to write a *-${MARKER_TYPE}.approved review marker with no
+You are about to write a *-${MARKER_TYPE:-<unresolved>}.approved review marker with no
 matching active-reviewer session marker.
 
 Target:  ${TARGET}
 Expected active-reviewer marker: ${ACTIVE_REVIEWER_MARKER}
-  (must contain: <owner>/<repo>#${TARGET_PR:-<pr>}:${MARKER_TYPE})
+  (must contain: <owner>/<repo>#${TARGET_PR:-<pr>}:${MARKER_TYPE:-<role>})
 
 This marker may ONLY be written by the sanctioned reviewer agent for this
 role (code-reviewer / security-reviewer / solution-architect), immediately


### PR DESCRIPTION
## Summary

- **Closes the false negative that let a build agent self-approve a review marker** — `warn-review-marker-write.sh` (the #843 blocking gate) matched the literal `-rex.approved`/`-security.approved`/`-architecture.approved` suffix as a plain substring of the Bash command text. The sanctioned reviewers' own documented idiom — `REX_MARKER=$(review_marker_path "$REPO" "$PR" rex "$MARKER_HOME"); printf '%s\n' "$SHA" > "$REX_MARKER"` — never puts that literal suffix anywhere in the command text, so a build agent copying that exact idiom evaded the gate entirely: no `active-reviewer` marker required, no block. This was exercised on a live PR, not hypothetical. The fix detects on the **resolved write**, reusing `_lib-detect-bash-write.sh` (the same helper `require-active-ticket.sh`'s Bash matcher already uses for the identical class of problem, #151) plus a plausibility check for the `review_marker_path`/`*_MARKER` indirection idiom.
- **Closes the paired false positive** — a harmless `cat`/`grep` read of a marker path that happens to spell out the literal filename used to trip the same substring match and get wrongly refused. A literal-path match is now gated only when the command also performs an actual write (`bash_command_appears_to_write`), so reads pass through silently.
- **Best-effort role/PR extraction from the indirection idiom** — `review_marker_path`'s role and PR-number arguments are conventionally literal in the reviewers' own documented usage even though the call's *result* is assigned to a variable, so the marker's kind (rex/security/architecture) and target PR can usually still be recovered and checked against the `active-reviewer` marker exactly as before.
- **Fails closed on total ambiguity, by construction, not by a special case** — when the role genuinely can't be resolved (a write clearly touching `.claude/session/reviews/` with no recognisable role marker), the gate still blocks: no well-formed `active-reviewer` marker can ever have an empty `kind` field, so the existing equality check already rejects it.
- **Graceful degrade, not a silent bypass, if the write-detection library is ever missing** — falls back to the pre-#962 literal-substring-only check (conservative: the old false-positive-on-read limitation re-applies, but nothing that was previously caught is weakened).

## Testing

- Added 6 new cases to `.claude/hooks/tests/test_warn_review_marker_write.sh` (cases 20–25) covering: a variable-indirected write with no `active-reviewer` marker (BLOCKED), the same write with a matching marker (ALLOWED), a literal-path `cat` read (NOT blocked — the false-positive fix), an indirected `tee` write (BLOCKED), a fully ambiguous indirected write even with a wrong-kind `active-reviewer` marker present (BLOCKED — fail-closed), and the graceful library-missing fallback (BLOCKED, conservative).
- Full suite run: `.claude/hooks/tests/test_warn_review_marker_write.sh` → **27/27 PASS** (19 pre-existing + 6 new).
- Full repo hook suite: `bin/run-hook-tests.sh` → **111/113 PASS**. The 2 failures (`test_pr_create_gate_anchor.sh`, `test_sync_codex_adapter.sh`) are pre-existing on `upstream/dev` and untouched by this diff — confirmed via `git diff --name-only upstream/dev`, which shows only the two files this PR touches.
- `shellcheck -x` on both touched files: clean (0 findings) after adding targeted `# shellcheck disable=SC2016` comments on three lines in the test file where `$VAR` must deliberately stay unexpanded literal text (that's the whole point of the indirection test cases). The hook file carries one pre-existing `SC2295` info-level finding, unchanged from `upstream/dev` — confirmed identical via a side-by-side shellcheck run against the upstream copy.

Refs #962

---

## Glossary

| Term | Definition |
|------|------------|
| Review marker | A gitignored local file at `.claude/session/reviews/<owner>__<repo>__<pr>-<role>.approved` that records a reviewer's (Rex/Hakim/Tariq) or the human approver's sign-off on a specific PR + commit SHA. Merge gates check these files exist and match HEAD before allowing a merge. |
| `active-reviewer` marker | A one-line session file (`<owner>/<repo>#<pr>:<kind>`) the orchestrator writes immediately before spawning a sanctioned reviewer agent. `warn-review-marker-write.sh` requires this marker to exist and match before it allows a `*-rex.approved`/`*-security.approved`/`*-architecture.approved` write — the mechanism that stops a build agent from writing its own approval. |
| Resolved-target detection | Determining what a shell command actually writes to by analysing its structure (redirection operators, `tee`, in-place editors, etc.) rather than searching the command's raw text for a literal substring. The fix in this PR switches the hook from the latter to the former. |
| Fail-closed | When the system can't determine whether an action is authorized, it defaults to blocking rather than allowing. This PR's ambiguous-role case (§ "fails closed on total ambiguity") is fail-closed: an unresolvable marker role can never match a real approval, so it's blocked by construction. |
