### PR TITLE
fix(#974): reject empty-kind active-reviewer marker in warn-review-marker-write.sh

### DIFF
--- a/.claude/hooks/tests/test_warn_review_marker_write.sh
+++ b/.claude/hooks/tests/test_warn_review_marker_write.sh
@@ -51,6 +51,15 @@
 #                 literal-path READ (cat) of a rex marker, no active-reviewer
 #                                                                  → BLOCKED, exit 2 (conservative pre-#962 fallback, not a bypass)
 #
+# #974 test (residual "total ambiguity" edge case — see the hook's #974
+# header comment):
+#   (26) Bash   → MALFORMED empty-kind active-reviewer marker
+#                 ("owner/repo#<pr>:" with nothing after the colon) +
+#                 an indirected write whose role can't be resolved to any of
+#                 rex/ceo/security/architecture                    → BLOCKED, exit 2
+#                 (without the #974 fix, both sides of the kind comparison
+#                 resolve to "" and the write would be incorrectly ALLOWED)
+#
 # Exit 0 if all cases pass; 1 on failure.
 
 set -u
@@ -490,6 +499,32 @@ case25() {
   rm -rf "$sb"
 }
 
+# ---------------------------------------------------------------------------
+# (26) Bash → MALFORMED empty-kind active-reviewer marker ("owner/repo#<pr>:"
+#      with nothing after the colon) + an indirected write whose role can't
+#      be resolved (mentions .claude/session/reviews/ but no literal
+#      rex/ceo/security/architecture token) → still BLOCKED (#974).
+#
+#      Before #974: c_kind parses to "" from the malformed marker, MARKER_TYPE
+#      resolves to "" from the unresolvable indirect write, and
+#      `[ "$c_kind" = "$MARKER_TYPE" ]` -> `[ "" = "" ]` -> true, incorrectly
+#      ALLOWING the write. #974 adds explicit non-empty guards on both sides
+#      so this can never pass.
+# ---------------------------------------------------------------------------
+case26() {
+  local sb; sb=$(make_sandbox)
+  # Malformed marker: trailing colon, nothing after it (empty kind).
+  printf '%s\n' "${REPO}#42:" > "$sb/.claude/session/active-reviewer"
+  # Same fully-ambiguous indirected write shape as case24: performs a write
+  # and mentions .claude/session/reviews/, but no literal role token appears
+  # anywhere, so _extract_marker_role (and thus MARKER_TYPE) resolves to "".
+  # shellcheck disable=SC2016 # deliberate — literal text, not real expansion
+  local cmd='DIR="$MARKER_HOME/.claude/session/reviews"; printf "%s" sha123 > "$DIR/mystery.approved"'
+  run_hook "$sb" "Bash empty-kind active-reviewer marker + unresolvable indirect write -> BLOCKED (#974)" \
+    "$(bash_json "$cmd")" 2 "BLOCKED"
+  rm -rf "$sb"
+}
+
 case1
 case2
 case3
@@ -515,6 +550,7 @@ case22
 case23
 case24
 case25
+case26
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/.claude/hooks/warn-review-marker-write.sh
+++ b/.claude/hooks/warn-review-marker-write.sh
@@ -136,7 +136,14 @@
 #   matcher: Write    (catches direct file writes)
 #   matcher: Bash     (catches shell redirections, echo >, printf, tee, etc.)
 #
-# References: #728, #843, #873, #957, #962, AgDR-0062, AgDR-0104,
+# #974 hardened _active_reviewer_allows() further: a malformed on-disk
+# active-reviewer marker (empty kind after a trailing colon) combined with
+# an unresolved indirect-write role could satisfy `[ "" = "" ]` and
+# incorrectly ALLOW the write — the exact "total ambiguity" case the #962
+# comment assumed was already fail-closed. Both sides of the kind
+# comparison are now guarded explicitly for non-empty before it runs.
+#
+# References: #728, #843, #873, #957, #962, #974, AgDR-0062, AgDR-0104,
 #             .claude/rules/pr-workflow.md § "Build agents cannot self-review"
 
 set -u
@@ -375,12 +382,20 @@ _active_reviewer_allows() {
   # Returns 0 (allow) iff the active-reviewer marker exists and its
   # <repo>#<pr>:<kind> content matches this write's (repo, pr, role).
   #
-  # Fail-closed by construction (#962): when MARKER_TYPE is empty (the role
-  # couldn't be resolved at all — total ambiguity on an indirect write), no
-  # well-formed active-reviewer marker can ever have an empty kind field, so
-  # `[ "$c_kind" = "$MARKER_TYPE" ]` can never succeed here. No special case
-  # is needed to reject the fully-unresolved case — the existing equality
-  # check already fails closed on it.
+  # #974: the #962 comment this replaced claimed fail-closed-on-empty-
+  # MARKER_TYPE was automatic — "no well-formed active-reviewer marker can
+  # ever have an empty kind field, so `[ "$c_kind" = "$MARKER_TYPE" ]` can
+  # never succeed". True for a WELL-FORMED marker, but a MALFORMED one on
+  # disk (a stray trailing colon: "owner/repo#42:" with nothing after it)
+  # parses to an empty c_kind below. Pair that with this write's own role
+  # being unresolved too (MARKER_TYPE="" — the #962 indirect path when
+  # _extract_marker_role finds no literal rex/ceo/security/architecture
+  # token in the review_marker_path(...) call), and the equality check
+  # collapses to `[ "" = "" ]` — TRUE — incorrectly ALLOWING the write.
+  # Guard both sides explicitly: an empty resolved role, on EITHER side,
+  # can never be treated as a match.
+  [ -n "$MARKER_TYPE" ] || return 1
+
   [ -f "$ACTIVE_REVIEWER_MARKER" ] || return 1
   local content
   content=$(tr -d '[:space:]' < "$ACTIVE_REVIEWER_MARKER" 2>/dev/null)
@@ -397,6 +412,7 @@ _active_reviewer_allows() {
   c_pr="${c_rest%%:*}"
   c_kind="${c_rest#*:}"
 
+  [ -n "$c_kind" ] || return 1
   [ "$c_kind" = "$MARKER_TYPE" ] || return 1
   [ -n "$TARGET_PR" ] && [ "$c_pr" != "$TARGET_PR" ] && return 1
   # Repo check only when the target filename encodes a repo (post-#485


### PR DESCRIPTION
## Summary
- **Closes the residual "total ambiguity" hole in the review-marker gate** — `warn-review-marker-write.sh`'s `_active_reviewer_allows()` compared the write's resolved role (`MARKER_TYPE`) against the active-reviewer marker's parsed kind (`c_kind`) with a plain `[ "$c_kind" = "$MARKER_TYPE" ]`. A malformed marker on disk (`owner/repo#<pr>:` with nothing after the trailing colon) parses to an empty `c_kind`; paired with an indirect Bash write whose role can't be resolved to a literal `rex`/`ceo`/`security`/`architecture` token, `MARKER_TYPE` is also empty. The comparison collapsed to `[ "" = "" ]` → true, incorrectly **allowing** a review-marker write with no real active-reviewer session behind it.
- **Made the code match the comment's own claim** — the `#962` comment on that function already asserted the gate "fails closed on total ambiguity... by construction," which was true for a well-formed marker but not for a malformed one. Both sides of the kind comparison are now explicitly guarded for non-empty before the equality check runs, so an empty resolved kind can never satisfy it on either side.
- **Added a regression test (case26)** reproducing the exact scenario — an empty-kind active-reviewer marker plus an unresolvable indirect write — and verified via a scratch revert that it fails without the fix (hook exits 0, allowing the write) and passes with it. Full suite is now 28/28 (was 27/27).

## Testing
1. `bash .claude/hooks/tests/test_warn_review_marker_write.sh` — 28/28 passing, including the new case26.
2. `shellcheck -x .claude/hooks/warn-review-marker-write.sh .claude/hooks/tests/test_warn_review_marker_write.sh` — clean (one pre-existing info-level SC2295 notice on an unrelated line, present in `upstream/dev` before this change too).
3. Manually confirmed the regression by reverting the two new guards in a scratch copy of the hook — with the guards removed, case26 fails (hook exits 0 instead of 2); restoring the guards makes it pass again.

Refs #974

---

## Glossary
| Term | Definition |
|------|------------|
| Active-reviewer marker | A one-line session file (`.claude/session/active-reviewer`, format `<owner>/<repo>#<pr>:<kind>`) the orchestrator writes immediately before spawning a sanctioned reviewer agent (Rex/Hakim/Tariq). Its presence — and matching `(repo, pr, kind)` — is what lets a build agent's own review-marker write be told apart from the real reviewer's. |
| `MARKER_TYPE` | The hook's own resolved value for *which* marker role (`rex`/`ceo`/`security`/`architecture`) the current write targets — resolved either directly from a literal file path/marker filename, or indirectly by best-effort-parsing a `review_marker_path(...)` call embedded in a Bash command that writes via a shell variable. |
| `c_kind` | The kind field parsed out of the active-reviewer marker's own file content (the part after the `:`) — this is what `MARKER_TYPE` is compared against to decide whether a write is authorized. |
| Fail closed | Security design principle: when a check can't be conclusively resolved (ambiguous, malformed, or missing input), the correct behavior is to deny/block rather than default to allow. |
| Indirect write | A Bash command that writes a review marker via a shell variable (e.g. `REX_MARKER=$(review_marker_path ...); printf ... > "$REX_MARKER"`) rather than a literal file path — the documented idiom the real reviewer agents use, and the harder case for the hook to resolve a role from. |
