### PR TITLE
fix(#973): normalise JSON escapes in merge-gate raw-payload fallback

### DIFF
--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -92,6 +92,43 @@
 # `extract_repo_from_command` each gained a dedicated wrapper-arg extraction
 # step using `_extract_wrapper_arg` (quoted-or-bare positional-token parsing,
 # regex/parameter-expansion only — no `eval` of the command text, ever).
+#
+# JSON-ESCAPED SEPARATORS IN THE RAW-PAYLOAD FALLBACK (#973, a residual
+# finding from Hakim's #969 review of the #965 fix)
+# ------------------------------------------------------------------------
+# #965 (see the four call sites in block-unreviewed-merge.sh,
+# block-merge-on-red-ci.sh, require-design-review-for-ui.sh, and
+# require-architecture-review.sh) added a jq-free fallback: when jq is
+# unavailable, each hook calls `is_merge_command "$INPUT"` directly against
+# the RAW, still-JSON-encoded payload text instead of the jq-decoded
+# command string. That works because the command's own words (`gh`, `pr`,
+# `merge`, digits) survive JSON string-encoding unchanged — EXCEPT for the
+# command's *separators*, when those separators are themselves characters
+# JSON must escape: a literal tab encodes as the two-character sequence
+# `\t`, and some encoders emit `\uXXXX` or `\/` for other bytes. Those
+# two-character escape sequences are not whitespace to `grep -E`'s `\s`
+# class, so `is_merge_command`'s `\bgh\s+pr\s+merge\b` pattern silently
+# fails to match a merge command whose separators are JSON-escaped —
+# exactly while jq (the thing that would normally decode them into real
+# whitespace) is unavailable. A gate that can't evaluate its own
+# precondition must fail closed, not quietly no-op on a payload that IS
+# merge-shaped once decoded.
+#
+# `_normalize_json_escapes` (below) is a small, best-effort decoder for
+# the handful of escape shapes that matter here — NOT a full JSON string
+# parser, the same "regex/parameter-expansion only, sufficient for the
+# shapes real callers emit" discipline as `_extract_wrapper_arg` above.
+# It is called ONLY at the four hooks' raw-payload fallback call sites
+# (`is_merge_command "$(_normalize_json_escapes "$INPUT")"`), never from
+# inside `is_merge_command` itself and never on the normal jq-present
+# path: jq has ALREADY correctly decoded these same escapes for that path
+# (that's what `jq -r` does), so re-normalizing already-decoded text would
+# be redundant at best and, for the rare case of a command that legitimately
+# contains a literal backslash-t/backslash-n substring (e.g. inside a sed
+# script), actively wrong — it would corrupt real command text that jq had
+# already decoded correctly. Keeping the two paths separate is what makes
+# this change safe for the jq-present callers: their behaviour is provably
+# unchanged because they never call the new function at all.
 
 # Lazily source the tracker lib so `tracker_kind` is available for forge
 # resolution. Guarded: only source if not already defined and the lib is
@@ -170,6 +207,64 @@ _extract_wrapper_arg() {
     fi
   done
   echo ""
+}
+
+# Best-effort decode of the JSON string escapes that could hide a merge
+# command's SEPARATORS from the raw-payload fallback scan (#973). Echoes
+# the normalized text.
+#
+# Handles six literal JSON escape sequences, decoded to the real character
+# they represent: backslash-t and backslash-u0009 both decode to a tab;
+# backslash-n and backslash-u000A (either case) decode to a newline;
+# backslash-u0020 decodes to a plain space; backslash-slash decodes to a
+# plain slash.
+#
+# This is deliberately NOT a full JSON string decoder — no handling of
+# arbitrary \uXXXX code points, no awareness of escaped-backslash context
+# (a literal `\\t` — escaped backslash followed by a bare `t` — will still
+# be (mis-)decoded as a tab; that's an accepted, documented limitation, not
+# a security gap: it can only make the fallback MORE eager to treat text as
+# merge-shaped, i.e. fail closed, never a new way to evade it). Pure bash
+# parameter expansion — no eval, no external process, no regex
+# backtracking on attacker-controlled text — matching the same discipline
+# as `_extract_wrapper_arg` above.
+#
+# Callers: ONLY the four merge-gate hooks' raw-payload fallback branches
+# (`is_merge_command "$(_normalize_json_escapes "$INPUT")"`), never
+# `is_merge_command` itself and never the normal jq-present path — see the
+# file header (#973) for why mixing this into the jq-present path would be
+# unsafe.
+_normalize_json_escapes() {
+  local text="$1"
+  local tab=$'\t'
+  local nl=$'\n'
+  # Two literal backslash characters. Used as the escape-matching prefix
+  # below rather than a single backslash: bash's `${var//pattern/repl}`
+  # treats a SINGLE backslash inside an expanded pattern as a glob escape
+  # character (it would consume/escape the following char instead of
+  # matching a literal backslash), so building the pattern from a
+  # single-backslash variable silently fails to consume the backslash
+  # itself — the doubled form is what makes the pattern match one literal
+  # backslash followed by the literal marker character.
+  local bs2='\\'
+
+  local esc_u0020="${bs2}u0020"
+  local esc_u0009="${bs2}u0009"
+  local esc_u000A="${bs2}u000A"
+  local esc_u000a="${bs2}u000a"
+  local esc_slash="${bs2}/"
+  local esc_t="${bs2}t"
+  local esc_n="${bs2}n"
+
+  text="${text//$esc_u0020/ }"
+  text="${text//$esc_u0009/$tab}"
+  text="${text//$esc_u000A/$nl}"
+  text="${text//$esc_u000a/$nl}"
+  text="${text//$esc_slash//}"
+  text="${text//$esc_t/$tab}"
+  text="${text//$esc_n/$nl}"
+
+  printf '%s' "$text"
 }
 
 # Returns 0 if $1 looks like a merge command this gate should fire on.

--- a/.claude/hooks/block-merge-on-red-ci.sh
+++ b/.claude/hooks/block-merge-on-red-ci.sh
@@ -86,12 +86,21 @@ if [ -z "$COMMAND" ]; then
   # string-encoding unchanged, so this is the exact same tested
   # merge-shape detector used below — not a second, drift-prone regex.
   #
+  # #973: the command's SEPARATORS do not always survive unchanged — a
+  # literal tab (or other JSON-escaped whitespace) encodes as a
+  # multi-character escape sequence (`\t`, `\uXXXX`) that `is_merge_command`'s
+  # `\s+` regex class won't recognise as whitespace. Normalize the small set
+  # of escapes that matter BEFORE scanning, so a merge command with
+  # JSON-escaped separators is caught exactly like a space-separated one —
+  # see `_normalize_json_escapes` in _lib-extract-pr.sh for the decode and
+  # why it's only ever applied on this raw-payload path, never on COMMAND.
+  #
   # A payload that isn't merge-shaped at all is a genuine no-op — exit 0,
   # unchanged behaviour for the overwhelming majority of Bash calls this
   # hook sees. A payload that DOES look merge-shaped but that we can't
   # safely parse/verify fails CLOSED (exit 2) instead of silently letting
   # an ungated merge through with an unverified CI status.
-  if is_merge_command "$INPUT"; then
+  if is_merge_command "$(_normalize_json_escapes "$INPUT")"; then
     echo "BLOCKED: CI gate cannot evaluate this command — jq is unavailable or .tool_input.command could not be parsed, but the raw input looks merge-related. Refusing to merge until CI status can be verified. Restore jq (see .claude/hooks/check-jq-installed.sh) and retry." >&2
     exit 2
   fi

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -89,12 +89,21 @@ if [ -z "$COMMAND" ]; then
   # string-encoding unchanged, so this is the exact same tested
   # merge-shape detector used below — not a second, drift-prone regex.
   #
+  # #973: the command's SEPARATORS do not always survive unchanged — a
+  # literal tab (or other JSON-escaped whitespace) encodes as a
+  # multi-character escape sequence (`\t`, `\uXXXX`) that `is_merge_command`'s
+  # `\s+` regex class won't recognise as whitespace. Normalize the small set
+  # of escapes that matter BEFORE scanning, so a merge command with
+  # JSON-escaped separators is caught exactly like a space-separated one —
+  # see `_normalize_json_escapes` in _lib-extract-pr.sh for the decode and
+  # why it's only ever applied on this raw-payload path, never on COMMAND.
+  #
   # A payload that isn't merge-shaped at all is a genuine no-op — exit 0,
   # unchanged behaviour for the overwhelming majority of Bash calls this
   # hook sees. A payload that DOES look merge-shaped but that we can't
   # safely parse/verify fails CLOSED (exit 2) instead of silently letting
   # an ungated merge through.
-  if is_merge_command "$INPUT"; then
+  if is_merge_command "$(_normalize_json_escapes "$INPUT")"; then
     echo "BLOCKED: merge gate cannot evaluate this command — jq is unavailable or .tool_input.command could not be parsed, but the raw input looks merge-related. Refusing to merge until this can be verified. Restore jq (see .claude/hooks/check-jq-installed.sh) and retry." >&2
     exit 2
   fi

--- a/.claude/hooks/require-architecture-review.sh
+++ b/.claude/hooks/require-architecture-review.sh
@@ -83,12 +83,21 @@ if [ -z "$COMMAND" ]; then
   # string-encoding unchanged, so this is the exact same tested
   # merge-shape detector used below — not a second, drift-prone regex.
   #
+  # #973: the command's SEPARATORS do not always survive unchanged — a
+  # literal tab (or other JSON-escaped whitespace) encodes as a
+  # multi-character escape sequence (`\t`, `\uXXXX`) that `is_merge_command`'s
+  # `\s+` regex class won't recognise as whitespace. Normalize the small set
+  # of escapes that matter BEFORE scanning, so a merge command with
+  # JSON-escaped separators is caught exactly like a space-separated one —
+  # see `_normalize_json_escapes` in _lib-extract-pr.sh for the decode and
+  # why it's only ever applied on this raw-payload path, never on COMMAND.
+  #
   # A payload that isn't merge-shaped at all is a genuine no-op — exit 0,
   # unchanged behaviour for the overwhelming majority of Bash calls this
   # hook sees. A payload that DOES look merge-shaped but that we can't
   # safely parse/verify fails CLOSED (exit 2) instead of silently letting
   # an unreviewed design artifact through.
-  if is_merge_command "$INPUT"; then
+  if is_merge_command "$(_normalize_json_escapes "$INPUT")"; then
     echo "BLOCKED: architecture-review gate cannot evaluate this command — jq is unavailable or .tool_input.command could not be parsed, but the raw input looks merge-related. Refusing to merge until this can be verified. Restore jq (see .claude/hooks/check-jq-installed.sh) and retry." >&2
     exit 2
   fi

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -82,12 +82,21 @@ if [ -z "$COMMAND" ]; then
   # string-encoding unchanged, so this is the exact same tested
   # merge-shape detector used below — not a second, drift-prone regex.
   #
+  # #973: the command's SEPARATORS do not always survive unchanged — a
+  # literal tab (or other JSON-escaped whitespace) encodes as a
+  # multi-character escape sequence (`\t`, `\uXXXX`) that `is_merge_command`'s
+  # `\s+` regex class won't recognise as whitespace. Normalize the small set
+  # of escapes that matter BEFORE scanning, so a merge command with
+  # JSON-escaped separators is caught exactly like a space-separated one —
+  # see `_normalize_json_escapes` in _lib-extract-pr.sh for the decode and
+  # why it's only ever applied on this raw-payload path, never on COMMAND.
+  #
   # A payload that isn't merge-shaped at all is a genuine no-op — exit 0,
   # unchanged behaviour for the overwhelming majority of Bash calls this
   # hook sees. A payload that DOES look merge-shaped but that we can't
   # safely parse/verify fails CLOSED (exit 2) instead of silently letting
   # an unreviewed UI change through.
-  if is_merge_command "$INPUT"; then
+  if is_merge_command "$(_normalize_json_escapes "$INPUT")"; then
     echo "BLOCKED: design-review gate cannot evaluate this command — jq is unavailable or .tool_input.command could not be parsed, but the raw input looks merge-related. Refusing to merge until this can be verified. Restore jq (see .claude/hooks/check-jq-installed.sh) and retry." >&2
     exit 2
   fi

--- a/.claude/hooks/tests/test_block_merge_on_red_ci.sh
+++ b/.claude/hooks/tests/test_block_merge_on_red_ci.sh
@@ -347,6 +347,28 @@ sb=$(make_sandbox_broken_jq)
 run_case "#965: jq broken, clearly non-merge command -> stays a no-op" 0 "" "$sb" \
   "npm test"
 
+# --- Fail-closed on JSON-escaped separators in the raw-payload fallback
+#     (#973, Hakim's residual finding on the #965/#969 fix) ------------
+#
+# Same reasoning as the sibling case in test_block_unreviewed_merge.sh: a
+# merge command whose separators are JSON-escaped (a literal tab encodes
+# as the two-character sequence `\t`) is not whitespace to
+# is_merge_command's `\s+` class, so pre-#973 it evaded the raw-payload
+# fallback scan entirely while jq was unavailable to decode it. `run_case`
+# builds the payload with the real system jq (before the sandboxed
+# broken-jq stub is on PATH), so a literal tab placed in the command here
+# is correctly JSON-escaped in the resulting payload — exactly the shape
+# the fallback has to recognise without jq's help.
+sb=$(make_sandbox_broken_jq)
+tab_cmd=$'gh\tpr\tmerge 306 --repo me2resh/apexyard --squash'
+run_case "#973: jq broken, JSON-escaped-tab merge command -> BLOCKS (fail closed)" 2 \
+  "cannot evaluate this command" "$sb" "$tab_cmd"
+
+sb=$(make_sandbox_broken_jq)
+tab_nonmerge_cmd=$'echo\tnot\ta\tmerge\tcommand\tat\tall'
+run_case "#973: jq broken, JSON-escaped-tab NON-merge command -> stays a no-op" 0 "" "$sb" \
+  "$tab_nonmerge_cmd"
+
 echo ""
 echo "=== test_block_merge_on_red_ci: $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then

--- a/.claude/hooks/tests/test_block_unreviewed_merge.sh
+++ b/.claude/hooks/tests/test_block_unreviewed_merge.sh
@@ -785,6 +785,47 @@ run_case_custom_cmd "#965: jq broken, gh-api merge shape -> BLOCKS (fail closed)
   "cannot evaluate this command" "$sb" \
   "gh api repos/me2resh/apexyard/pulls/301/merge -X PUT"
 
+# --- Fail-closed on JSON-escaped separators in the raw-payload fallback
+#     (#973, Hakim's residual finding on the #965/#969 fix) ------------
+#
+# The #965 fallback (case 14 above) scans $INPUT — the RAW, still-JSON-
+# encoded payload text — directly, because jq (which would normally
+# decode it) is unavailable. That works for a normal space-separated
+# command because `gh`, `pr`, `merge` and the spaces between them survive
+# JSON string-encoding unchanged. But a command whose SEPARATORS are
+# themselves JSON-escaped (a literal tab encodes as the two-character
+# sequence `\t`) does NOT survive unchanged — those two characters are
+# not whitespace to `is_merge_command`'s `\s+` regex, so pre-#973 this
+# evaded the fallback detector entirely and the merge sailed through
+# ungated. `run_case_custom_cmd` builds the test payload with the REAL
+# system jq (`jq -nc --arg c "$cmd" ...`, called before the sandboxed
+# broken-jq stub is on PATH), so a literal tab placed in $cmd here is
+# correctly JSON-escaped to `\t` in the payload — exactly the shape the
+# broken-jq fallback then has to recognise without jq's help.
+sb=$(make_sandbox_broken_jq)
+tab_cmd=$'gh\tpr\tmerge 305 --repo me2resh/apexyard --squash'
+run_case_custom_cmd "#973: jq broken, JSON-escaped-tab merge command -> BLOCKS (fail closed)" 2 \
+  "cannot evaluate this command" "$sb" \
+  "$tab_cmd"
+
+# 18. jq broken + a clearly non-merge command whose words ALSO happen to
+#     be tab-separated (so it exercises the same JSON-escape-normalize
+#     code path) → must still stay a no-op. Proves the #973 fix doesn't
+#     turn every tab-containing payload into a false-positive block —
+#     only ones that are merge-shaped once the escapes are decoded.
+sb=$(make_sandbox_broken_jq)
+tab_nonmerge_cmd=$'echo\tnot\ta\tmerge\tcommand\tat\tall'
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c \
+  "echo '$(jq -nc --arg c "$tab_nonmerge_cmd" '{tool_name:"Bash", tool_input:{command:$c}}')' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+if [ "$got_rc" = "0" ] && [ -z "$got_stderr" ]; then
+  echo "PASS [#973: jq broken, JSON-escaped-tab NON-merge command -> stays a no-op]"; PASS=$((PASS+1))
+else
+  echo "FAIL [#973: jq broken, JSON-escaped-tab NON-merge command -> stays a no-op]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}jq-broken-tab-nonmerge-noop "
+fi
+
 # --- Summary ----------------------------------------------------------
 
 echo ""


### PR DESCRIPTION
## Summary

- **Closes the residual JSON-escape evasion Hakim found in #969** — the four merge-gate hooks (`block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, `require-design-review-for-ui.sh`, `require-architecture-review.sh`) fall back to scanning the RAW, still-JSON-encoded payload text with `is_merge_command` when jq is unavailable (#965). That works for a normal space-separated merge command because `gh`, `pr`, `merge` and the spaces between them survive JSON string-encoding unchanged — but a command whose *separators* are themselves JSON-escaped (a literal tab encodes as the two-character sequence `\t`, other bytes as `\uXXXX` or `\/`) does NOT survive unchanged, and those escape sequences are not whitespace to `is_merge_command`'s `\s+` regex. Pre-fix, a tab-separated `gh	pr	merge …` sailed through the fallback ungated while jq was broken — the exact class of gap the #965 fix was supposed to close.
- **Added a shared `_normalize_json_escapes()` helper to `_lib-extract-pr.sh`**, decoding `\t`, `\n`, `\/`, and `\uXXXX` (space/tab/newline) to their literal characters, and wired it into all four hooks' fallback call sites: `is_merge_command "$(_normalize_json_escapes "$INPUT")"`. I chose the **shared-helper** path from the two options in the ticket, not four separate per-hook fixes, because the four fallback branches are byte-identical copy-paste and a shared function is the DRY choice the file's own conventions already favor (see `_extract_wrapper_arg` for the existing "one tested helper, four callers" pattern in this same file).
- **Deliberately did NOT normalize inside `is_merge_command` itself.** `is_merge_command` has two call sites per hook: the fallback (`$INPUT`, raw JSON) and the normal path (`$COMMAND`, already jq-decoded). jq has *already* correctly decoded these same escapes on the normal path — normalizing again there would be redundant at best, and for a command that legitimately contains a literal backslash-t/backslash-n substring (e.g. inside a `sed` script), would corrupt text jq had already decoded correctly. Keeping the helper external to `is_merge_command` and calling it ONLY at the fallback sites means the normal jq-present path is provably byte-for-byte unchanged — confirmed by running the full `test_forge_aware_extract_pr.sh` suite (which exercises `is_merge_command` directly, jq-present-path style) unchanged and green.
- **Two bugs surfaced and fixed during implementation**, both interesting enough to flag: (1) bash's `${var//pattern/replacement}` treats a *single* backslash inside an expanded pattern as a glob escape character rather than a literal match target, so a naive `esc_t="\t"` pattern silently failed to consume the backslash itself — fixed by doubling the backslash in the pattern-building variable; (2) `nl=$(printf '\n')` loses the newline entirely because command substitution strips trailing newlines — fixed with ANSI-C quoting (`nl=$'\n'`) instead.
- **Regression tests added to both suites that already carry the #965 jq-broken fixtures** (`test_block_unreviewed_merge.sh`, `test_block_merge_on_red_ci.sh`): jq stubbed to fail + a JSON-escaped-tab merge command → BLOCKS, and a JSON-escaped-tab non-merge command → stays a no-op (proving the fix doesn't turn every tab-containing payload into a false positive).

## Testing

- `bash .claude/hooks/tests/test_block_unreviewed_merge.sh` — 39/39 (37 pre-existing + 2 new)
- `bash .claude/hooks/tests/test_block_merge_on_red_ci.sh` — 27/27 (25 pre-existing + 2 new)
- `bash .claude/hooks/tests/test_require_architecture_review.sh` — 22/22 (unchanged)
- `bash .claude/hooks/tests/test_require_design_review_for_ui.sh` — 22/22 (unchanged)
- `bash .claude/hooks/tests/test_forge_aware_extract_pr.sh` — 48/48 (unchanged; proves `is_merge_command`'s own behaviour is untouched)
- `shellcheck -x` on every touched file — clean (only pre-existing info-level notices, plus one new info-level SC1003 nit on the `bs2='\\'` literal, which is stylistic and doesn't affect correctness)
- `bin/run-hook-tests.sh` — 112/113 (one pre-existing, unrelated failure in `test_sync_codex_adapter.sh`, confirmed untouched by this diff; `test_pr_create_gate_anchor.sh` passes)

## Glossary

| Term | Definition |
|------|------------|
| Fail closed / fail open | A gate that can't evaluate its own precondition either blocks (fail closed — safe default for a security gate) or lets the action through (fail open — the bug class #965 fixed and #973 closes a residual gap in) |
| Raw-payload fallback | The code path in each merge-gate hook that runs when `jq` is unavailable to parse `.tool_input.command` from the PreToolUse JSON — scans the undecoded JSON text directly instead |
| `is_merge_command` | The shared detector in `_lib-extract-pr.sh` that recognises every merge-command shape (`gh pr merge`, `gh api .../pulls/<N>/merge`, `glab mr merge`, `glab api .../merge_requests/<N>/merge`, the `tracker_pr_merge` wrapper) |
| JSON string escape | The two-or-more-character sequences JSON uses to represent control characters or special bytes inside a string literal — `\t` for tab, `\n` for newline, `\/` for a forward slash, `\uXXXX` for an arbitrary code point |

Refs #973
