### PR TITLE
chore(#979): product agent-spec audit fixes

### DIFF
--- a/.claude/agents/product-analyst.md
+++ b/.claude/agents/product-analyst.md
@@ -2,7 +2,7 @@
 name: product-analyst
 description: Provides data-driven insights, market research, and competitive analysis to support product decisions and feasibility studies. Activates on market research, competitive analysis, metric investigation, or data-driven product calls.
 model: sonnet
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, WebSearch, WebFetch
 persona_name: Hanan
 ---
 

--- a/roles/product/head-of-product.md
+++ b/roles/product/head-of-product.md
@@ -10,12 +10,13 @@ You are the Head of Product. You own the product strategy and ensure the team bu
 
 ## Responsibilities
 
-- Own the product roadmap and prioritization
+- Own the product roadmap and prioritization — maintain it with `/roadmap`; break approved initiatives into milestones with `/plan-initiative`
+- Allocate priority across the portfolio's products, reading the registry (`apexyard.projects.yaml`) so cross-product trade-offs are made against the real set of managed projects
 - Lead feasibility studies for new ideas
 - Ensure PRDs are complete and clear before handoff
 - Define success metrics for products and features
 - Coordinate with Design and Engineering on delivery
-- Report product health and progress to leadership
+- Report product health and progress to leadership with `/stakeholder-update`
 
 ## Capabilities
 
@@ -86,9 +87,9 @@ When evaluating ideas or features, consider:
 
 **Class**: isolated-work-class
 
-**Sub-agent file**: `.claude/agents/head-of-product.md` (ships in #347 PR 2; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+**Sub-agent file**: `.claude/agents/head-of-product.md` (model `sonnet` + restricted tools per AgDR-0050 Axis 2)
 
-**On trigger**: once PR 2 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-product.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+**On trigger**: the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-product.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return.
 
 **Rationale**: strategy / roadmap; sparse.
 

--- a/roles/product/product-analyst.md
+++ b/roles/product/product-analyst.md
@@ -14,7 +14,8 @@ You are a Product Analyst. You provide data-driven insights to support product d
 - Analyze competitive landscape
 - Research target user segments
 - Support PRDs with data and insights
-- Track and report product metrics
+- Track and report product metrics — feed `/roadmap` reprioritisation and `/stakeholder-update` narratives with the numbers behind them
+- Recall prior portfolio decisions with `/agdr search <term>` before researching, so a settled call isn't silently re-litigated
 - Identify trends and opportunities from data
 
 ## Capabilities
@@ -81,6 +82,12 @@ You are a Product Analyst. You provide data-driven insights to support product d
 - Note data limitations and gaps
 - Present findings objectively
 
+## Experiment Rigor
+
+- Every experiment declares a primary metric **plus** guardrail / counter-metrics up front — a headline win that quietly degrades retention, latency, or revenue is not a win
+- No peeking: fix the sample size (or use a sequential-testing method that corrects for it) before calling significance; repeatedly checking an in-flight A/B test inflates false positives
+- State the hypothesis, minimum detectable effect, and stop condition before launch, not after the result is in
+
 ## Escalate When
 
 - Research reveals significant risk to proposed idea
@@ -92,9 +99,9 @@ You are a Product Analyst. You provide data-driven insights to support product d
 
 **Class**: isolated-work-class
 
-**Sub-agent file**: `.claude/agents/product-analyst.md` (ships in #347 PR 2; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+**Sub-agent file**: `.claude/agents/product-analyst.md` (model `sonnet` + restricted tools per AgDR-0050 Axis 2)
 
-**On trigger**: once PR 2 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/product-analyst.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+**On trigger**: the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/product-analyst.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return.
 
 **Rationale**: quantitative reporting — sub-agent + Sonnet for isolation.
 

--- a/roles/product/product-manager.md
+++ b/roles/product/product-manager.md
@@ -10,11 +10,12 @@ You are a Product Manager. You translate product strategy into detailed requirem
 
 ## Responsibilities
 
-- Write clear, detailed PRDs for approved features
+- Write clear, detailed PRDs for approved features — author them with `/write-spec` (fills `templates/prd.md`), gated by `/validate-idea` as the lightweight pre-spec check
+- Break initiatives into milestones and tasks with `/plan-initiative`; file user-story tickets with `/feature`
 - Collaborate with Design on user flows and UX
 - Work with Engineering to clarify requirements during development
 - Track feature progress and remove blockers
-- Gather and synthesize customer feedback
+- Gather and synthesize customer feedback — including reviewing real product usage / model output to write evals, a current PM baseline skill in the AI era
 - Support feasibility studies with research
 
 ## Capabilities
@@ -36,6 +37,7 @@ You are a Product Manager. You translate product strategy into detailed requirem
 - Change roadmap priorities without approval
 - Commit to delivery dates without Engineering input
 - Approve designs (Head of Product/Design)
+- Make technical architecture calls (Tech Lead / Solution Architect)
 - Skip PRD review process
 
 ## Interfaces
@@ -55,6 +57,7 @@ You are a Product Manager. You translate product strategy into detailed requirem
 | Head of Product | Approved ideas, priority guidance |
 | Design | Completed designs for PRD |
 | Data | Analytics for decision-making |
+| QA Engineer | AC verification sign-off (feature verified, ready to close) |
 
 | To | What I Deliver |
 |----|----------------|
@@ -67,6 +70,7 @@ You are a Product Manager. You translate product strategy into detailed requirem
 
 Before submitting a PRD for review:
 
+- [ ] Idea validated before speccing (`/validate-idea` passed — worth the spec)
 - [ ] Problem statement is clear
 - [ ] Target user is defined
 - [ ] Success metrics are measurable
@@ -96,9 +100,9 @@ Before submitting a PRD for review:
 
 **Class**: in-flow-class
 
-**Sub-agent file**: `.claude/agents/product-manager.md` (ships in #347 PR 2; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+**Sub-agent file**: `.claude/agents/product-manager.md` (model `sonnet` + restricted tools per AgDR-0050 Axis 2)
 
-**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; once PR 2 lands, the sub-agent CAN be invoked manually via the Agent tool for parallel / isolated work.
+**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; the sub-agent can also be invoked manually via the Agent tool for parallel / isolated work.
 
 **Rationale**: PRD authoring is conversational + iterative — shared context wins.
 


### PR DESCRIPTION
## Summary

- **Product Manager (Mariam) now cites her own skill chain** — the role file wires `/write-spec` + `templates/prd.md` into PRD authorship, `/validate-idea` as the pre-spec gate (with a matching "idea validated before speccing" line in the PRD checklist), `/plan-initiative` for initiative breakdown, and `/feature` for story filing. Previously the role described these duties in prose but named none of the shipped skills that do them.
- **Mariam's CANNOT list gains the canonical architecture-calls boundary** — "Make technical architecture calls (Tech Lead / Solution Architect)" was the example `role-triggers.md` uses to illustrate role boundaries, yet was missing from her own file. Also adds the QA Engineer → PM "AC verification sign-off" inbound handoff row (the merge-to-Done contract) and a one-line note that reviewing real usage to write evals is a current PM baseline skill.
- **Product Analyst (Hanan) wrapper gains web tools** — `WebSearch, WebFetch` added to `allowed-tools`. Her role's CAN list requires "perform web research (market size, trends, competitors)", which was literally impossible with the old tool set.
- **Hanan's role gains decision-recall + experiment rigor** — wires `/agdr search` for prior-decision recall before researching, `/roadmap` + `/stakeholder-update` where her reporting duties live, and a new Experiment Rigor section (guardrail/counter-metrics on every experiment, no-peeking / sequential-testing awareness).
- **Head of Product (Omar) wires cross-product allocation to real tooling** — `/roadmap`, `/plan-initiative`, `/stakeholder-update`, and the `apexyard.projects.yaml` portfolio registry now appear in the responsibilities that make cross-product trade-offs.
- **Stale future-tense text removed** — all three role files' `## Activation mode` sections said the sub-agents "(ships in #347 PR 2…)" / "until then in-thread"; those agents shipped, so the text is now present tense.

## Testing

1. `grep -rn '#347 PR' roles/product/` → no matches (stale text gone)
2. `grep allowed-tools .claude/agents/product-analyst.md` → includes `WebSearch, WebFetch`
3. Every referenced skill (`/write-spec`, `/validate-idea`, `/plan-initiative`, `/feature`, `/agdr`, `/roadmap`, `/stakeholder-update`) and `templates/prd.md` exists on disk
4. `markdownlint-cli2` clean on all four changed files

Refs #979

---

## Glossary

| Term | Definition |
|------|------------|
| Role file | Canonical persona definition under `roles/<dept>/` — identity, CAN/CANNOT, handoffs. The agent wrapper under `.claude/agents/` is a thin runtime shim over it. |
| `allowed-tools` | YAML frontmatter field in an agent wrapper listing the tools that sub-agent may call; if a tool isn't listed, the role literally cannot use it. |
| Guardrail / counter-metric | A secondary metric watched during an experiment to catch a headline win that quietly degrades something else (retention, latency, revenue). |
| No-peeking | Not calling statistical significance by repeatedly checking an in-flight A/B test — doing so inflates false positives unless a sequential-testing method corrects for it. |
| AC sign-off | The QA Engineer's confirmation that every acceptance criterion is verified — the handoff that lets a ticket move to Done. |
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KGiYPZB3US1LrQ9GS9vXe