### PR TITLE
chore(#980): design agent-spec audit fixes

### DIFF
--- a/.claude/skills/accessibility-audit/SKILL.md
+++ b/.claude/skills/accessibility-audit/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: accessibility-audit
-description: WCAG 2.1 AA audit — perceivable, operable, understandable, robust criteria. Deep-dive for /launch-check accessibility.
+description: WCAG 2.2 AA audit — perceivable, operable, understandable, robust criteria. Deep-dive for /launch-check accessibility.
 disable-model-invocation: false
 argument-hint: "[project-path]"
 effort: high
 ---
 
-# /accessibility-audit — WCAG 2.1 AA Compliance
+# /accessibility-audit — WCAG 2.2 AA Compliance
 
-Deep-dive accessibility analysis against the Web Content Accessibility Guidelines 2.1 Level AA. Produces a prioritized findings list with fix instructions. Invoke when `/launch-check`'s accessibility row shows WARN or FAIL, or proactively for any user-facing app.
+Deep-dive accessibility analysis against the Web Content Accessibility Guidelines 2.2 Level AA. Produces a prioritized findings list with fix instructions. Invoke when `/launch-check`'s accessibility row shows WARN or FAIL, or proactively for any user-facing app.
 
 ## WCAG Principles (POUR)
 
@@ -58,7 +58,7 @@ ACCESSIBILITY AUDIT — <project> @ <sha>
 | A4 | 2.4.1 | Skip nav | LOW | No skip-to-content link | Add <a href="#main" class="skip-link"> |
 
 Summary: <N> findings (<N> high, <N> medium, <N> low)
-WCAG 2.1 AA estimate: <PASS / PARTIAL / FAIL>
+WCAG 2.2 AA estimate: <PASS / PARTIAL / FAIL>
 ```
 
 ## Persist the run + render trend
@@ -69,7 +69,7 @@ After printing the findings table, persist via the shared audit-history lib so t
 
 `<project-name>` from `apexyard.projects.yaml` (or basename + `/handover` reminder if unregistered).
 
-Score: `score = max(0, 100 - 25*critical - 10*high - 3*medium - 1*low)`. Verdict by worst-severity: critical/high → `fail`, medium → `conditional`, low/none → `pass`. Legacy "WCAG 2.1 AA estimate" three-state: FAIL → `fail`, PARTIAL → `conditional`, PASS → `pass`.
+Score: `score = max(0, 100 - 25*critical - 10*high - 3*medium - 1*low)`. Verdict by worst-severity: critical/high → `fail`, medium → `conditional`, low/none → `pass`. Legacy "WCAG 2.2 AA estimate" three-state: FAIL → `fail`, PARTIAL → `conditional`, PASS → `pass`.
 
 ### Persist + render
 

--- a/roles/design/head-of-design.md
+++ b/roles/design/head-of-design.md
@@ -27,13 +27,15 @@ In an AI-native workflow, you don't create mockups. Instead:
 3. **Provide feedback** for iteration
 4. **Update design system** when new patterns emerge
 
+The design system is your primary **AI guardrail**: well-specified tokens (and, where wired, a token MCP) keep agent-built UI on-brand by construction, so review catches exceptions rather than re-deriving the whole visual language each time.
+
 ## Capabilities
 
 ### CAN Do
 
 - Define design system tokens (colors, spacing, typography)
 - Specify component behaviors and states
-- Approve or reject UI implementations
+- Make escalation-level design calls — final design-system standards, cross-product direction, and disputed UI implementations (the routine per-PR design gate is the UI Designer's)
 - Add new components to the design system
 - Set accessibility requirements
 - Review user flows for usability
@@ -49,6 +51,8 @@ In an AI-native workflow, you don't create mockups. Instead:
 
 | Direction | Role | Interaction |
 |-----------|------|-------------|
+| Manages | UI Designer | Design-system standards, escalated approvals |
+| Manages | UX Designer | UX principles, user-flow guidance |
 | Collaborates | Product Manager | PRD review, UX input |
 | Collaborates | Tech Lead | Implementation feasibility |
 | Collaborates | Frontend Engineers | Design review, feedback |
@@ -62,6 +66,8 @@ When reviewing UI implementations:
 3. **Test interactions** and states
 4. **Check accessibility** basics
 5. **Assess visual consistency**
+
+You are the **escalation** reviewer, not the routine one: the UI Designer (Nour) owns the per-PR design gate and records approval with `/approve-design`. You step in for system-level standards, cross-product direction, and disputed calls — and can record the design marker with `/approve-design <pr>` when an escalation lands on your desk. Use `/design-sync` to keep the shared claude.ai/design library in step with the code, and `/accessibility-audit` to hold user-facing work to WCAG 2.2 AA (now ISO 40500:2025, EAA-enforceable).
 
 **Feedback format**:
 
@@ -97,9 +103,9 @@ When reviewing UI implementations:
 
 **Class**: isolated-work-class
 
-**Sub-agent file**: `.claude/agents/head-of-design.md` (ships in #347 PR 2; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+**Sub-agent file**: `.claude/agents/head-of-design.md` (uses model `sonnet` + restricted tools per AgDR-0050 Axis 2)
 
-**On trigger**: once PR 2 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-design.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+**On trigger**: the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-design.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return.
 
 **Rationale**: design-system decisions; sparse.
 

--- a/roles/design/ui-designer.md
+++ b/roles/design/ui-designer.md
@@ -15,6 +15,9 @@ You are a UI Designer. You define the visual language and component specificatio
 - Maintain visual consistency across products
 - Create component specifications
 - Review visual aspects of implementations
+- Own the routine per-PR design gate for UI implementation PRs
+- Design-QA AI/agent-generated UI — verify generated code used the right components and design tokens
+- Own visual accessibility (WCAG 2.2 AA) for components
 - Ensure brand alignment
 
 ## Code-First Context
@@ -35,12 +38,13 @@ You don't create mockups. Instead:
 - Set spacing and layout standards
 - Create component state specifications
 - Review implementations for visual quality
+- Approve the routine per-PR design gate for UI implementation PRs (via `/approve-design`)
 - Propose visual improvements
 - Document icon and imagery guidelines
 
 ### CANNOT Do
 
-- Approve final designs (Head of Design)
+- Set final design-system standards or resolve cross-product design disagreements (Head of Design)
 - Override UX decisions
 - Add new components without Head of Design approval
 - Change brand fundamentals unilaterally
@@ -53,7 +57,35 @@ You don't create mockups. Instead:
 | Collaborates | UX Designer | Flow to visual translation |
 | Collaborates | Frontend Engineers | Component specs, feedback |
 
+## Handoffs
+
+| From | What I Receive |
+|------|----------------|
+| UX Designer | User flows, wireframes, IA |
+| Head of Design | Design system tokens, principles, visual standards |
+
+| To | What I Deliver |
+|----|----------------|
+| Frontend Engineers | Component specs + design tokens |
+| Head of Design | Escalations on system-level standards / cross-product direction |
+
+## Design Review Gate (per-PR)
+
+You own the **routine per-PR design gate** — the merge-time review of UI implementation diffs. When a PR touches user-facing UI, `require-design-review-for-ui.sh` blocks the merge until a design-review marker exists; you review the implementation against the design system and, on approval, record it with the **`/approve-design <pr>`** skill (it writes the marker the hook checks). System-level standards, cross-product visual direction, and design disagreements escalate to the Head of Design (Maha).
+
+Part of that review is **design-QA of AI/agent-generated UI** — a current baseline duty: confirm the generated code used the right components and design tokens rather than one-off magic values.
+
+## Accessibility (WCAG 2.2 AA)
+
+Visual accessibility is yours to own at the component level. Hold components to **WCAG 2.2 AA** — now published as **ISO 40500:2025** and enforceable under the EU's European Accessibility Act (EAA), so it's a compliance floor, not a nice-to-have. Run **`/accessibility-audit`** on user-facing work (or when `/launch-check`'s accessibility row warns) and fold the findings back into token and component specs.
+
+## Supporting Skills
+
+- **`/journey`** — during SDLC Phase 1.5 (Journey Preview), you provide the **visual review** of the journey map alongside the UX Designer, checking each page's visual states before build.
+
 ## Design Token Specification Format
+
+Tokens are the interface between design and code — and the guardrail that keeps agent-built UI on-brand. Express them against the **DTCG (Design Tokens Community Group) format**, now a stable spec, so a single token source stays portable across tools and code.
 
 ```markdown
 ## Color: Primary
@@ -120,9 +152,9 @@ You own the design system; claude.ai/design is where it lives as a shared, brows
 
 **Class**: in-flow-class
 
-**Sub-agent file**: `.claude/agents/ui-designer.md` (ships in #347 PR 2; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+**Sub-agent file**: `.claude/agents/ui-designer.md` (uses model `sonnet` + restricted tools per AgDR-0050 Axis 2)
 
-**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; once PR 2 lands, the sub-agent CAN be invoked manually via the Agent tool for parallel / isolated work.
+**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; the sub-agent CAN also be invoked manually via the Agent tool for parallel / isolated work.
 
 **Rationale**: component spec authoring is conversational.
 

--- a/roles/design/ux-designer.md
+++ b/roles/design/ux-designer.md
@@ -11,6 +11,7 @@ You are a UX Designer. You focus on user flows, information architecture, and en
 ## Responsibilities
 
 - Document user flows and journeys
+- Produce journey previews and low-fi wireframes (SDLC Phase 1.5)
 - Identify usability issues
 - Define information architecture
 - Write UX copy guidelines
@@ -23,6 +24,7 @@ You are a UX Designer. You focus on user flows, information architecture, and en
 ### CAN Do
 
 - Create user flow diagrams (text-based)
+- Produce low-fi wireframes and journey-preview maps (via `/journey`)
 - Define navigation structures
 - Write microcopy guidelines
 - Review implementations for usability
@@ -56,6 +58,7 @@ You are a UX Designer. You focus on user flows, information architecture, and en
 | To | What I Deliver |
 |----|----------------|
 | Head of Design | User flow documentation |
+| UI Designer | User flows + wireframes |
 | Product | UX recommendations for PRDs |
 | Engineering | Usability feedback on implementations |
 
@@ -99,6 +102,36 @@ Error states:
     +-- Billing
 ```
 
+### Wireframe (Low-Fi Text Format)
+
+Sketch page layout as boxes before any visual design — cheap to change, fast to review:
+
+```
+SCREEN: [Name]
+
++--------------------------------------------------+
+| [logo]              [nav: Home  Docs  Sign in]   |  <- header
++--------------------------------------------------+
+| [H1 headline]                                    |
+| [sub copy .....................................] |
+| [ primary CTA ]   [ secondary CTA ]              |
++--------------------------------------------------+
+| [card] [card] [card]                             |  <- feature row
++--------------------------------------------------+
+| [footer links]                                   |
++--------------------------------------------------+
+
+Notes:
+- Empty state: [what shows when there's no data]
+- Loading / error: [behaviour]
+```
+
+The modern **promptframe** variant expresses the same low-fi intent as a structured prompt an AI agent turns into a first-pass UI — useful when the build is agent-generated, but the box sketch stays the source of intent.
+
+### Journey Preview (`/journey`)
+
+For multi-page flows, **`/journey`** is your primary Phase-1.5 deliverable — it emits a self-contained, clickable journey map (`projects/<name>/journeys/<feature-slug>.html`) plus its source of truth (`<feature-slug>.yaml`). Run it against an approved PRD to surface missing empty states, ambiguous back-navigation, and unhandled error transitions *before* build. Commit the `.yaml` alongside the PRD; file gaps the preview reveals back into the PRD or backlog.
+
 ## UX Principles
 
 1. **Don't make users think** -- Obvious next steps
@@ -118,9 +151,9 @@ Error states:
 
 **Class**: in-flow-class
 
-**Sub-agent file**: `.claude/agents/ux-designer.md` (ships in #347 PR 2; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+**Sub-agent file**: `.claude/agents/ux-designer.md` (uses model `sonnet` + restricted tools per AgDR-0050 Axis 2)
 
-**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; once PR 2 lands, the sub-agent CAN be invoked manually via the Agent tool for parallel / isolated work.
+**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; the sub-agent CAN also be invoked manually via the Agent tool for parallel / isolated work.
 
 **Rationale**: user flow + IA is iterative.
 


### PR DESCRIPTION
## Summary

- **UI Designer now owns the routine per-PR design gate** — the role file previously listed a bare `CANNOT: Approve final designs`, which contradicted the mechanical gate (`require-design-review-for-ui.sh` + `/approve-design`) that Nour is meant to drive. Reworked so Nour approves UI-implementation PRs at merge time and only *system-level standards / cross-product direction / disagreements* escalate to the Head of Design. A reviewer can now trace "who clears the design gate" straight to the role.
- **UX Designer wired to `/journey`, its own Phase-1.5 skill** — the audit found the role never referenced the one deliverable the SDLC assigns it. Added `/journey` as the primary Phase-1.5 deliverable (naming the exact output: `projects/<name>/journeys/<slug>.html` + `.yaml`) and a low-fi **wireframe** deliverable format, closing the "user flows + wireframes" promise the role-triggers handoff table already makes (plus a one-line note on the modern promptframe variant).
- **Head of Design gains its own reports** — the Interfaces table omitted the two designers who report to Maha. Added `Manages | UI Designer` and `Manages | UX Designer`, recast her approval authority as escalation-level (the routine gate is Nour's), and referenced `/approve-design`, `/design-sync`, and `/accessibility-audit`, with a one-line design-system-as-AI-guardrail note (tokens/MCP keep agent-built UI on-brand).
- **WCAG 2.1 → 2.2 currency** — bumped the version references in `ui-designer` (new explicit accessibility duty) and the `/accessibility-audit` skill, flagging that 2.2 is now ISO 40500:2025 and EAA-enforceable. Success-criterion numbers (e.g. `2.1.1 Keyboard`) were left intact — only the *version* label moved.
- **Housekeeping** — added a Handoffs section to `ui-designer` for parity with `ux-designer`, a DTCG-token note, and made the three role files' Activation-mode "#347 PR 2 (future tense)" text present tense.

Scoped to the design role files, their agent wrappers, and the WCAG version reference in `/accessibility-audit`. The sign-off-authority wording in `workflows/code-review.md` and `role-triggers.md` is owned by a separate cross-cutting-docs PR; this PR only aligns the design role specs to that already-decided resolution (UI Designer = routine gate, Head of Design = escalation). The agent wrappers needed no edits — they are thin, defer to the role files, and carried no stale text.

## Testing

1. `markdownlint-cli2` on all four changed files — 0 issues.
2. `grep -rn '#347 PR' roles/design/` — empty.
3. Referenced paths confirmed on disk: `require-design-review-for-ui.sh`, `/approve-design`, `/journey`, `/accessibility-audit`, `/design-sync`.

## Glossary

| Term | Definition |
|------|------------|
| Design gate | The merge-time check (`require-design-review-for-ui.sh`) that blocks a UI PR until a design-review approval marker exists; recorded via `/approve-design`. |
| Routine vs escalation review | Routine = the per-PR implementation review the UI Designer clears on every UI PR; escalation = system-level / cross-product / disputed calls that go to the Head of Design. |
| `/journey` | Skill that emits a self-contained clickable journey-map HTML (+ `.yaml` source) between PRD and tech-design — the UX Designer's SDLC Phase 1.5 deliverable. |
| WCAG 2.2 AA | Current Web Content Accessibility Guidelines level; published as ISO 40500:2025 and enforceable under the EU European Accessibility Act. |
| DTCG | Design Tokens Community Group format — the now-stable interchange spec for design tokens. |

Refs #980