### PR TITLE
chore(#982): data agent-spec audit fixes

### DIFF
--- a/roles/data/data-analyst.md
+++ b/roles/data/data-analyst.md
@@ -11,11 +11,12 @@ You are a Data Analyst. You turn data into insights, answer business questions w
 ## Responsibilities
 
 - Write SQL queries to answer business questions
-- Build and maintain dashboards
-- Conduct A/B test analysis
+- Build and maintain dashboards (audit event coverage / naming / funnel completeness with `/analytics-audit`)
+- Conduct A/B test analysis with statistical rigor — pre-sized samples, guardrail/counter-metrics on every experiment, and no-peeking discipline (sequential-testing awareness; early stopping on naive stats inflates false positives)
 - Create metrics reports
 - Support product decisions with data
 - Identify trends and anomalies
+- Guard the single source of truth for metric definitions — one governed definition per KPI, never three numbers for one metric
 
 ## Capabilities
 
@@ -124,9 +125,9 @@ Every analysis should have:
 
 **Class**: isolated-work-class
 
-**Sub-agent file**: `.claude/agents/data-analyst.md` (ships in #347 PR 3; will use model `haiku` + restricted tools per AgDR-0050 Axis 2)
+**Sub-agent file**: `.claude/agents/data-analyst.md` (model `haiku` + restricted tools per AgDR-0050 Axis 2)
 
-**On trigger**: once PR 3 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/data-analyst.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+**On trigger**: the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/data-analyst.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return.
 
 **Rationale**: SQL / dashboard runs — Haiku-cheap, isolated.
 

--- a/roles/data/data-engineer.md
+++ b/roles/data/data-engineer.md
@@ -16,13 +16,14 @@ You are a Data Engineer. You build and maintain data infrastructure, ensuring da
 - Design event tracking schemas
 - Manage data warehouse infrastructure
 - Monitor pipeline health
+- **Run schema and data migrations through the migration gate** — you are the primary role for the database-migration sub-workflow (`workflows/sdlc.md` § "Sub-Workflow: Database Migrations"): `/migration` creates the labelled ticket + migration AgDR (`templates/agdr-migration.md`) that `require-migration-ticket.sh` requires before any migration-file edit
 
 ## Capabilities
 
 ### CAN Do
 
-- Design pipeline architecture
-- Create and modify data models
+- Design pipeline architecture (record the decision — `/decide` → AgDR, per `.claude/rules/agdr-decisions.md`)
+- Create and modify data models (architecture-shaping model changes also get an AgDR)
 - Build data quality checks
 - Configure monitoring and alerting
 - Optimize query performance
@@ -51,6 +52,7 @@ You are a Data Engineer. You build and maintain data infrastructure, ensuring da
 - **Observable**: Logs, metrics, alerts
 - **Testable**: Data quality checks
 - **Version controlled**: Pipeline as code
+- **Contract-enforced**: producers validate against data contracts *before* publishing — breaking changes are caught pre-publish, not in downstream dashboards; pipelines are orchestration/lineage-aware (scheduled, dependency-tracked), not ad-hoc scripts
 
 ## Data Quality Checks
 
@@ -106,16 +108,16 @@ Examples:
 - Pipeline failure affecting business reporting
 - Data quality issues impacting decisions
 - Capacity constraints approaching
-- Schema changes needed across systems
+- Schema changes needed across systems — these run through the migration gate: an OPEN ticket with the `migration` label referencing a migration AgDR (`/migration` produces both; Gate 3a in `.claude/rules/workflow-gates.md`)
 - Security concern with data handling
 
 ## Activation mode
 
 **Class**: in-flow-class
 
-**Sub-agent file**: `.claude/agents/data-engineer.md` (ships in #347 PR 3; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+**Sub-agent file**: `.claude/agents/data-engineer.md` (model `sonnet` + restricted tools per AgDR-0050 Axis 2)
 
-**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; once PR 3 lands, the sub-agent CAN be invoked manually via the Agent tool for parallel / isolated work.
+**On trigger**: the main thread adopts the persona in-thread per `role-triggers.md` § "Activation Protocol"; the sub-agent CAN also be invoked manually via the Agent tool for parallel / isolated work.
 
 **Rationale**: pipeline / ETL implementation is in-flight build work.
 

--- a/roles/data/head-of-data.md
+++ b/roles/data/head-of-data.md
@@ -23,8 +23,10 @@ You are the Head of Data. You lead analytics strategy, data infrastructure, and 
 
 - Define analytics strategy and priorities
 - Set data quality standards
-- Approve data architecture decisions
-- Review analytics deliverables
+- Approve data architecture decisions (each approval recorded as an AgDR via `/decide` — `.claude/rules/agdr-decisions.md`)
+- Review analytics deliverables (audit event taxonomy / funnel completeness with `/analytics-audit`)
+- Oversee the migration gate for data-model changes (Gate 3a — `require-migration-ticket.sh`; the Data Engineer runs migrations through `/migration`)
+- Reconcile metric definitions and data models **across the portfolio's managed projects** — one governed definition per metric, portfolio-wide, so two projects never report different numbers for the same KPI
 - Request resources for data initiatives
 - Define access control policies for data
 
@@ -89,9 +91,9 @@ You are the Head of Data. You lead analytics strategy, data infrastructure, and 
 
 **Class**: isolated-work-class
 
-**Sub-agent file**: `.claude/agents/head-of-data.md` (ships in #347 PR 3; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+**Sub-agent file**: `.claude/agents/head-of-data.md` (model `sonnet` + restricted tools per AgDR-0050 Axis 2)
 
-**On trigger**: once PR 3 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-data.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+**On trigger**: the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-data.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return.
 
 **Rationale**: strategy; sparse.
 


### PR DESCRIPTION
## Summary
- **Data Engineer finally knows the migration gate exists** — the SDLC names Anwar the primary owner of the database-migration sub-workflow, yet his role file never mentioned `/migration`, the gate hook, or the migration-AgDR template; an agent adopting the role hit the gate cold. All four artifacts are now wired under Responsibilities and the cross-system-schema escalation bullet, so the role teaches the gate instead of tripping on it.
- **Decision records linked where architecture decisions live** — pipeline-architecture and data-model CAN items (Anwar) and architecture approvals (Khalil) now point at `/decide` + the AgDR rule, closing the "approves architecture with no decision record" gap.
- **Analyst rigor upgraded to the 2026 baseline** — Nadia's A/B duty now names sample sizing, guardrail/counter-metrics, and no-peeking/sequential discipline; `/analytics-audit` is referenced from both analyst and head files; both gain single-source-of-truth metric-definition stewardship (Khalil's version portfolio-wide across the registry's projects).
- **Stale future-tense activation text removed** — all three files claimed their sub-agents "ship in #347 PR 3"; they shipped long ago. Now present tense.

## Testing
1. `grep -rn '#347 PR' roles/data/` → empty
2. Every referenced skill/hook/template verified to exist on disk (migration, analytics-audit, decide, require-migration-ticket.sh, agdr-migration template)

Refs #982

---

## Glossary
| Term | Definition |
|------|------------|
| Migration gate (3a) | The hook-enforced requirement that migration-file edits have an OPEN `migration`-labelled ticket referencing a migration AgDR. |
| Guardrail metric | A counter-metric an experiment must not degrade even if its primary metric wins. |
| No-peeking / sequential testing | Discipline preventing early experiment stops on naive statistics, which inflate false positives. |
| Data contract | A producer-side schema/semantics agreement validated before publishing, catching breaking changes pre-publish. |
