### PR TITLE
chore(#984): cross-cutting agent-spec audit fixes

### DIFF
--- a/.claude/rules/role-triggers.md
+++ b/.claude/rules/role-triggers.md
@@ -17,10 +17,10 @@ ApexYard ships **20 role definitions** in `roles/{department}/`. They are not al
 | **Head of Product** | `roles/product/head-of-product.md` | Roadmap prioritization · feasibility call · strategic product decision · resource allocation across products |
 | **Product Manager** | `roles/product/product-manager.md` | PRD creation · user-story breakdown · acceptance-criteria authoring · sprint planning |
 | **Product Analyst** | `roles/product/product-analyst.md` | Market research · competitive analysis · metric investigation · data-driven product call |
-| **Head of Design** | `roles/design/head-of-design.md` | Design-system changes · UX principles decision · cross-project visual standards |
+| **Head of Design** | `roles/design/head-of-design.md` | Design-system changes · UX principles decision · cross-project visual standards · escalation from a UI Designer (design gate) |
 | **UI Designer** | `roles/design/ui-designer.md` | Visual design · component specifications · design tokens · pixel-level work |
 | **UX Designer** | `roles/design/ux-designer.md` | User flows · information architecture · usability review · wireframing |
-| **Head of Security** | `roles/security/head-of-security.md` | Security strategy · threat model · compliance call · cross-project security architecture |
+| **Head of Security** | `roles/security/head-of-security.md` | Security strategy · threat model · compliance call · cross-project security architecture · escalation from a Security Auditor (strategy / compliance / repeated-pattern concern) |
 | **Security Auditor** | `roles/security/security-auditor.md` | **PR touches auth / crypto / user data / secrets** · **the security-critical trust chain (`.claude/hooks/**`, `.claude/settings.json`) — #777** · SAST findings · OWASP review · dependency vulnerability |
 | **Penetration Tester** | `roles/security/penetration-tester.md` | Active testing · exploit discovery · API security review · pre-release security sign-off |
 | **Head of Data** | `roles/data/head-of-data.md` | Analytics strategy · data governance · reporting architecture · cross-project data modelling |
@@ -46,6 +46,10 @@ Head of Product → Product Manager → Head of Design / UX Designer / UI Design
 ```
 
 Each handoff is explicit. The handing-off role delivers the artefact defined in its role file (PRD, tech design, PR, test plan, etc.); the receiving role reads it and moves forward.
+
+### On inbound escalation
+
+When a Head-class role is activated by an escalation named in the Activation Table — Tech Lead → Head of Engineering, UI Designer → Head of Design, Security Auditor → Head of Security — it acknowledges the escalation in its activation marker (naming the escalating role and the reason). It then makes the call within its CAN scope, or escalates further if the decision exceeds that scope, and hands the decision back to the escalating role so work resumes where it paused. Each Head's own role file defines the receiving-side specifics — what it decides, what it escalates onward, and the artefact it returns.
 
 ### How to signal activation
 
@@ -125,11 +129,20 @@ Roles deliver concrete artefacts at each handoff point. These are the contracts 
 | Head of Design → UX/UI Designer | Design system tokens + principles |
 | UX Designer → UI Designer | User flows + wireframes |
 | UI Designer → Frontend Engineer | Component specs + design tokens |
+| UI Designer → Head of Design | Escalated design call (design-system change · cross-product visual standard · design disagreement · no UI Designer available) |
 | Tech Lead → Backend / Frontend Engineer | Technical design + task breakdown |
 | Backend / Frontend Engineer → QA Engineer | Testable build + PR |
-| Security Auditor → Tech Lead | Security findings + required fixes |
+| Security Auditor → Tech Lead | Security findings + required fixes (remediation is engineering work) |
+| Security Auditor → Head of Security | Strategy / compliance / cross-project escalation + repeated-pattern concern |
 | QA Engineer → Product Manager | AC verification sign-off |
 | Platform Engineer → SRE | Production deployment + runbook |
+
+### Two authority splits worth calling out
+
+Two of the rows above encode a **practitioner-reviews / head-escalates** split — the same shape as code review (Rex → Head of Engineering) and design-artifact review (Tariq → Head of Engineering):
+
+- **UI design gate.** The **UI Designer (Nour)** owns the routine per-PR design gate: she reviews the implementation diff, and her approval is recorded through the design-approval flow (`/approve-design`, gated by `require-design-review-for-ui.sh`). The **Head of Design (Maha)** is the escalation path, not the default reviewer — a design-system change, a cross-product visual standard, a disagreement on a design call, or no UI Designer available. Making the Head the routine reviewer would bottleneck every UI PR on the org's most senior designer; recorded as AgDR-0106.
+- **Security escalation.** A **Security Auditor's findings + required fixes go to the Tech Lead** — remediation is engineering work. **Strategy, compliance, cross-project concerns, and repeated-pattern signals escalate to the Head of Security (Faisal)** instead. Both legs are real and non-overlapping: the Tech Lead fixes the diff, the Head of Security owns the posture.
 
 ## Aspirational → Real
 

--- a/docs/agdr/AgDR-0106-ui-design-gate-authority.md
+++ b/docs/agdr/AgDR-0106-ui-design-gate-authority.md
@@ -1,0 +1,48 @@
+---
+id: AgDR-0106
+timestamp: 2026-07-22T00:00:00Z
+agent: claude (Tech Lead — Hisham)
+model: claude-opus-4-8[1m]
+trigger: user-prompt
+status: executed
+---
+
+# UI design-gate authority: UI Designer owns the routine gate, Head of Design is the escalation
+
+> In the context of an agent-spec audit ([#984](https://github.com/me2resh/apexyard/issues/984)) finding three shared docs disagreeing on who holds UI merge sign-off — the design role files said Head of Design while `workflows/code-review.md` assigned the conditional design reviewer to the UI Designer — facing a genuine ambiguity in who reviews a routine UI PR versus who owns the design system, we decided the **UI Designer (Nour) owns the routine per-PR design gate and the Head of Design (Maha) is the escalation path**, to achieve a single consistent authority statement across `role-triggers.md`, `workflows/code-review.md`, and the design role files, accepting that a UI PR whose design concern genuinely exceeds a practitioner's scope now takes one extra hop to the Head of Design.
+
+## Context
+
+- The audit surfaced a three-doc contradiction: `roles/design/*` implied the Head of Design signs off UI PRs, while `workflows/code-review.md` already listed the **UI Designer** as the conditional design reviewer and `workflows/sdlc.md` named the UI Designer as the design gate. Readers couldn't tell who actually holds the merge-blocking `require-design-review-for-ui.sh` gate.
+- ApexYard already runs a **practitioner-reviews / head-escalates** shape everywhere else: Rex (Code Reviewer) does the routine code review and escalates architecture calls to the Head of Engineering; Tariq (Solution Architect) reviews design artifacts and escalates to the Head of Engineering. UI design review is the same shape with no reason to differ.
+- The `/approve-design` skill and `require-design-review-for-ui.sh` gate are the mechanical surface; they record a per-PR design approval, which is a routine, per-diff act — the kind of work a practitioner reviewer owns, not the org's most senior designer.
+- A parallel ticket (#980) aligns the design **role files** to this same resolution; this AgDR + the shared-docs edits ([#984](https://github.com/me2resh/apexyard/issues/984)) own the cross-cutting docs side.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A — Head of Design owns all UI sign-off** | Single senior owner; strong consistency of taste | Bottlenecks every UI PR on the org's most senior designer; contradicts `workflows/code-review.md`'s existing conditional-reviewer assignment; breaks the practitioner-reviews shape used for code (Rex) and design artifacts (Tariq) |
+| **B — UI Designer owns routine gate, Head of Design escalation (chosen)** | Mirrors Rex/Tariq → Head-of-Engineering; keeps routine review fast; matches the existing code-review.md + sdlc.md wording; leaves a clear escalation for design-system / cross-product / disagreement cases | One extra hop when a routine UI PR turns out to carry a design-system-level concern |
+
+## Decision
+
+Chosen: **Option B — UI Designer owns the routine per-PR design gate; Head of Design is the escalation path**, because it matches the practitioner-reviews / head-escalates pattern already used for code review (Rex → Head of Engineering) and design-artifact review (Tariq → Head of Engineering), keeps routine UI review off the most senior designer's desk, and aligns with the wording `workflows/code-review.md` and `workflows/sdlc.md` already carried.
+
+Concretely:
+
+- **UI Designer (Nour)** — reviews the implementation diff on any UI-touching PR and records approval via `/approve-design` (the `require-design-review-for-ui.sh` merge gate). This is the routine, per-PR design gate.
+- **Head of Design (Maha)** — the escalation path, not the default reviewer: design-system changes, cross-product visual standards, disagreements on a design call, or when no UI Designer is available.
+
+## Consequences
+
+- One authority statement now holds across `.claude/rules/role-triggers.md` (activation table, handoff table, and the "Two authority splits" note), `workflows/code-review.md` (Roles table + Approval Requirements), and — via #980 — the design role files.
+- A `UI Designer → Head of Design` escalation leg is added to the role-triggers handoff table, and the Head of Design activation row now names "escalation from a UI Designer (design gate)".
+- The generic "On inbound escalation" convention (added to role-triggers.md § Activation Protocol) covers the receiving side: the Head of Design acknowledges the escalation in its activation marker, decides within scope or escalates further, and hands the call back.
+- No mechanical change to `require-design-review-for-ui.sh` — the gate already records a per-PR design approval regardless of which designer supplies it; this AgDR fixes the *documented authority*, not the hook.
+
+## Artifacts
+
+- [#984](https://github.com/me2resh/apexyard/issues/984) — the audit ticket
+- PR: `chore(#984): cross-cutting agent-spec audit fixes`
+- Edited: `.claude/rules/role-triggers.md`, `workflows/code-review.md`

--- a/workflows/code-review.md
+++ b/workflows/code-review.md
@@ -13,8 +13,8 @@ Code review is a **role-activated** workflow. The roles below activate automatic
 | **Author** | Creates PR, responds to feedback. The engineer who wrote the code: [Backend Engineer](../roles/engineering/backend-engineer.md) or [Frontend Engineer](../roles/engineering/frontend-engineer.md). | `roles/engineering/{backend,frontend}-engineer.md` |
 | **Code Reviewer agent (Rex)** | Automated first-pass review on every commit. Checks architecture, tests, security, AgDR, glossary. | `.claude/agents/code-reviewer.md` |
 | **Tech Lead reviewer** | Human approval gate. Signs off on architecture, design patterns, team conventions. | [`roles/engineering/tech-lead.md`](../roles/engineering/tech-lead.md) |
-| **Security Auditor** (conditional) | Activates when the PR diff touches `**/auth/**`, `**/crypto/**`, `**/secrets/**`, `.env*`, or similar. | [`roles/security/security-auditor.md`](../roles/security/security-auditor.md) |
-| **UI Designer** (conditional) | Activates when the PR diff touches UI components, design tokens, or visible layout. | [`roles/design/ui-designer.md`](../roles/design/ui-designer.md) |
+| **Security Auditor** (conditional) | Activates when the PR diff touches `**/auth/**`, `**/crypto/**`, `**/secrets/**`, `.env*`, or similar. Findings + required fixes hand off to the Tech Lead; strategy / compliance / repeated-pattern concerns escalate to the [Head of Security](../roles/security/head-of-security.md). | [`roles/security/security-auditor.md`](../roles/security/security-auditor.md) |
+| **UI Designer** (conditional) | Owns the **routine per-PR design gate** — activates when the PR diff touches UI components, design tokens, or visible layout, reviews the implementation diff, and records approval via `/approve-design`. The [Head of Design](../roles/design/head-of-design.md) is the **escalation path** (design-system changes, cross-product visual standards, disagreements, no UI Designer available), not the routine reviewer. See AgDR-0106. | [`roles/design/ui-designer.md`](../roles/design/ui-designer.md) |
 | **QA Engineer** | Not a reviewer — takes over at the QA phase after merge to verify acceptance criteria. | [`roles/engineering/qa-engineer.md`](../roles/engineering/qa-engineer.md) |
 
 ---
@@ -159,6 +159,7 @@ QUESTION:   "Why did you choose Map over Object here?"
 | Standard feature | 1 (Tech Lead or Senior) |
 | Infrastructure | 1 + Platform Engineer |
 | Security-related | 1 + Security review |
+| UI change | 1 + UI Designer (routine design gate; Head of Design on escalation) |
 | Architecture change | Head of Engineering |
 
 ---


### PR DESCRIPTION
## Summary
- **The UI sign-off contradiction is resolved and recorded (AgDR-0106)** — three docs disagreed on who holds UI merge sign-off; now one authority statement holds everywhere: the UI Designer owns the routine per-PR design gate (approval via the design-approval flow), the Head of Design is the escalation path (design-system changes, cross-product standards, disagreements, no UI designer available). Mirrors the practitioner-reviews/head-escalates shape Rex and Tariq already use.
- **The Security-Auditor escalation chain finally has both legs** — findings + required fixes keep flowing to the Tech Lead (remediation is engineering work), and the previously-unwired second leg now routes strategy/compliance/repeated-pattern escalations to the Head of Security, matching the claim its agent description has carried all along. Trigger table, handoff table, and prose agree.
- **Heads get a defined receiving side** — a short "On inbound escalation" convention in role-triggers.md § Activation Protocol says what a Head does when a table-named escalation arrives (acknowledge in the marker, decide within CAN scope or escalate further, hand back).
- Sibling PR #986 aligned the design role files to the same authority resolution; this PR owns the shared-docs side.

## Testing
1. Authority statement reads identically in meaning across role-triggers.md and workflows/code-review.md
2. Both Security-Auditor handoff legs present, non-overlapping
3. `grep -rn '#347 PR' roles/architecture/` → empty

Refs #984

---

## Glossary
| Term | Definition |
|------|------------|
| Design gate | The merge-blocking requirement that UI-touching PRs carry a designer's per-PR approval marker. |
| Practitioner-reviews / head-escalates | The authority shape where a working-level reviewer owns routine review and the department Head handles escalations only. |
| Inbound escalation | An escalation a Head-class role *receives* from a subordinate role, per the activation table. |
