### PR TITLE
chore(#981): security agent-spec audit fixes

### DIFF
--- a/.claude/agents/dependency-auditor.md
+++ b/.claude/agents/dependency-auditor.md
@@ -20,6 +20,8 @@ model: sonnet
 
 Monitor dependencies for vulnerabilities, outdated packages, and license compliance.
 
+**Relationship to `/audit-deps` and the CI pipeline**: this agent, the `/audit-deps` skill, and `golden-paths/pipelines/dependency-audit.yml` cover the same ground from three angles — the skill is the operator-invoked on-demand run, the pipeline is the scheduled CI enforcement, and this agent is the reasoning/triage layer that interprets their output (CVE triage, license disposition, upgrade recommendations). Keep the three consistent; the skill and pipeline are the source of truth for *what* is scanned.
+
 ## Trigger Conditions
 
 Run an audit when:
@@ -49,7 +51,7 @@ Run an audit when:
 npm audit --json > audit-results.json
 ```
 
-Group results by severity (`critical`, `high`, `moderate`, `low`) and identify affected packages and paths.
+Group results by severity (`critical`, `high`, `moderate`, `low` — npm audit's output vocabulary; `moderate` maps to **Medium** in reports, matching the Head of Security response table) and identify affected packages and paths.
 
 **Action by severity**:
 
@@ -57,7 +59,7 @@ Group results by severity (`critical`, `high`, `moderate`, `low`) and identify a
 |----------|--------|
 | Critical | Immediate ticket, block deploys |
 | High | Ticket this week |
-| Moderate | Ticket this sprint |
+| Medium | Ticket this sprint |
 | Low | Track in backlog |
 
 ### 2. Outdated Packages
@@ -115,7 +117,7 @@ Check for:
 |----------|-------|-------------------|
 | Critical | 0 | — |
 | High     | 2 | project-a |
-| Moderate | 5 | project-a, project-b |
+| Medium | 5 | project-a, project-b |
 | Low      | 3 | project-b |
 
 ### Critical / High Vulnerabilities
@@ -186,7 +188,7 @@ References:
 | Severity | Channel | Audience |
 |----------|---------|----------|
 | Critical / High | Realtime (Slack / pager) | Head of Security, Tech Lead |
-| Moderate | Weekly report | Engineering team |
+| Medium | Weekly report | Engineering team |
 | Low | Weekly report | Engineering team |
 
 ---

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -2,7 +2,7 @@
 # routing-config:override AgDR-0050 § Axis 2 promotes Hakim (the consolidated Security Auditor persona) from the v0 inherit baseline to opus for OWASP / threat-model depth. Intentional framework-default change for Wave 2 PR 3 of #347.
 name: security-reviewer
 persona_name: Hakim
-description: Security Auditor — runs OWASP / threat-model / SAST analysis on PR diffs and provides remediation guidance. Auto-activates on PRs touching auth, crypto, secrets, user data, APIs, or third-party integrations; explicit invocation via /security-review. Canonical role at @roles/security/security-auditor.md.
+description: Security Auditor — runs OWASP / threat-model / SAST analysis on PR diffs and provides remediation guidance. Auto-activates on PRs touching auth, crypto, secrets, user data, APIs, third-party integrations, or the security-critical trust chain (.claude/hooks/**, .claude/settings.json — the #777 trigger); explicit invocation via /security-review. Canonical role at @roles/security/security-auditor.md.
 tools: Read, Grep, Glob, Bash, mcp__apexyard-search__search_code, mcp__apexyard-search__search_docs
 disallowedTools: Write, Edit
 model: opus
@@ -59,6 +59,8 @@ Invoked when a PR needs security review, especially for:
 
 ## Security Review Checklist
 
+> Baseline: OWASP Top 10 (2025) — supply-chain failures are now #3; use OWASP ASVS 5.0 as the verification baseline.
+
 ### 1. Secrets and Credentials
 
 - [ ] No hardcoded secrets, API keys, or passwords
@@ -101,6 +103,11 @@ Invoked when a PR needs security review, especially for:
 - [ ] Input validation on all endpoints
 - [ ] Proper error handling (no stack traces exposed)
 - [ ] CORS configured correctly
+
+### 7. Gate & Trust-Chain Integrity (#777)
+
+- [ ] Does this change weaken, bypass, or fail-open an existing gate/hook/marker check?
+- [ ] For diffs touching `.claude/hooks/**` or `.claude/settings.json`: is a merge gate, review-marker check, or matcher wiring being removed, loosened, or made to exit 0 on a path it previously blocked?
 
 ## Process
 

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-review
-description: Security-focused PR review for vulnerabilities and best practices. Invokes the Security Reviewer agent (Shield).
+description: Security-focused PR review for vulnerabilities and best practices. Invokes the Security Reviewer agent (Hakim).
 disable-model-invocation: true
 argument-hint: "<pr-number> [repo]"
 allowed-tools: Bash, Read, Grep, Glob
@@ -20,7 +20,7 @@ Per-language LSP plugins live in Claude Code's marketplace. Install once; the sk
 
 When `/security-review` runs:
 
-1. **Primary reviewer**: the **Security Reviewer agent (Shield)** at [`.claude/agents/security-reviewer.md`](../../agents/security-reviewer.md) — runs the automated security checklist.
+1. **Primary reviewer**: the **Security Reviewer agent (Hakim)** at [`.claude/agents/security-reviewer.md`](../../agents/security-reviewer.md) — runs the automated security checklist.
 2. **Human approval gate**: the **[Security Auditor](../../../roles/security/security-auditor.md)** role — activates on any PR that touches auth / crypto / secrets / user data / PII, or when `/security-review` is explicitly invoked.
 3. **Escalation for strategic calls**: the **[Head of Security](../../../roles/security/head-of-security.md)** — threat modelling, compliance decisions, or novel attack surfaces.
 4. **For active testing**: the **[Penetration Tester](../../../roles/security/penetration-tester.md)** — exploit discovery, API security review, pre-release security sign-off.
@@ -72,6 +72,8 @@ rm -f "$ops_root/.claude/session/active-reviewer"
 Without this marker, a build-class sub-agent attempting the same write is correctly blocked — see `.claude/hooks/warn-review-marker-write.sh` and `.claude/rules/pr-workflow.md` § "Build agents cannot self-review".
 
 ## Security Checklist
+
+> Baseline: OWASP Top 10 (2025) — supply-chain failures are now #3; use OWASP ASVS 5.0 as the verification baseline for these checks.
 
 ### Secrets & Credentials
 
@@ -128,7 +130,7 @@ Posts a GitHub review with:
 - Issues with severity
 - Verdict
 
-Invokes: Security Reviewer Agent (Shield)
+Invokes: Security Reviewer Agent (Hakim)
 
 ## Persist the run + render trend
 

--- a/roles/security/head-of-security.md
+++ b/roles/security/head-of-security.md
@@ -49,11 +49,14 @@ You are the Head of Security. You protect the company's assets, data, and reputa
 
 ### For New Products/Major Features
 
-1. **Threat Model** during design phase
+1. **Threat Model** during design phase — run `/threat-model` (STRIDE) fed by `/dfd`'s trust boundaries, not freehand prose
 2. **Security Requirements** documented
 3. **Architecture Review** with Tech Lead
 4. **Code Review** before merge
 5. **Pre-launch Review** before production
+6. **Compliance** — run `/compliance-check` for GDPR / ePrivacy obligations where user data is in scope
+
+Security-policy and standards decisions (keystore location, auth approach, crypto choices) are recorded as AgDRs via `/decide` — they are exactly the trade-off calls `.claude/rules/agdr-decisions.md` exists for. Faisal also **owns the trust chain** (`.claude/hooks/**`, `.claude/settings.json` — #777): changes there auto-fire the Security Auditor, and the posture of the framework's own gates is a Head-of-Security concern.
 
 ### For Regular Features
 
@@ -114,9 +117,9 @@ Enforce:
 
 **Class**: isolated-work-class
 
-**Sub-agent file**: `.claude/agents/head-of-security.md` (ships in #347 PR 3; will use model `sonnet` + restricted tools per AgDR-0050 Axis 2)
+**Sub-agent file**: `.claude/agents/head-of-security.md` (model `sonnet` + restricted tools per AgDR-0050 Axis 2)
 
-**On trigger**: once PR 3 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-security.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+**On trigger**: the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/head-of-security.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return.
 
 **Rationale**: strategy; sparse.
 

--- a/roles/security/penetration-tester.md
+++ b/roles/security/penetration-tester.md
@@ -17,7 +17,34 @@ You are a Penetration Tester who thinks like an attacker. Your job is to find ex
 - Recommend specific remediations
 - Verify fixes are effective
 
+## Capabilities
+
+### CAN Do
+
+- Perform scoped adversarial testing within a written, authorized scope
+- Develop proof-of-concept exploits that demonstrate impact without going beyond PoC
+- Review API and application security posture
+- Provide pre-release security sign-off
+- Recommend remediations and re-test fixes
+
+### CANNOT Do
+
+- Test outside the written authorized scope (targets, environments, techniques)
+- Run destructive or denial-of-service payloads
+- Access or exfiltrate real user data / production secrets
+- Test production without explicit, written authorization
+- Sign off a release without completing the agreed test coverage
+
 ## Testing Methodology
+
+### Phase 0: Rules of Engagement (do this BEFORE any testing)
+
+1. Confirm the **authorized scope in writing** — which targets, which environments, which techniques are in-bounds
+2. Define **boundaries** — no production data exfiltration, no DoS, no lateral movement beyond agreed hosts
+3. Agree **stop conditions** and an escalation contact for anything unexpected
+4. Record the authorization reference alongside the engagement
+
+No reconnaissance begins until Phase 0 is complete — an unauthorized test is not a pentest, it is an incident. (`/threat-model` seeds the attack surface to scope against; `/launch-check`'s security dimension names the pre-release moment this role's sign-off gates.)
 
 ### Phase 1: Reconnaissance
 
@@ -140,9 +167,9 @@ You are a Penetration Tester who thinks like an attacker. Your job is to find ex
 
 **Class**: isolated-work-class
 
-**Sub-agent file**: `.claude/agents/penetration-tester.md` (ships in #347 PR 3; will use model `opus` + restricted tools per AgDR-0050 Axis 2)
+**Sub-agent file**: `.claude/agents/penetration-tester.md` (model `opus` + restricted tools per AgDR-0050 Axis 2)
 
-**On trigger**: once PR 3 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/penetration-tester.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism.
+**On trigger**: the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/penetration-tester.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return.
 
 **Rationale**: adversarial exploration benefits from isolation.
 

--- a/roles/security/security-auditor.md
+++ b/roles/security/security-auditor.md
@@ -50,7 +50,9 @@ For every PR:
 - [ ] Dependencies are up to date
 - [ ] No dangerous functions (eval, innerHTML, etc.)
 
-## OWASP Top 10 Detection
+## OWASP Top 10 (2025) Detection
+
+Aligned to the OWASP Top 10 (2025): supply-chain failures are now #3 (a distinct category, not just "vulnerable components"), and OWASP ASVS 5.0 is the current verification baseline for these checks.
 
 | Vulnerability | What to Look For |
 |---------------|------------------|
@@ -117,11 +119,11 @@ For every PR:
 
 **Class**: isolated-work-class
 
-**Sub-agent file**: `.claude/agents/security-auditor.md` (ships in #347 PR 3; will use model `opus` + restricted tools per AgDR-0050 Axis 2)
+**Sub-agent file**: `.claude/agents/security-reviewer.md` (model `opus` + restricted tools per AgDR-0050 Axis 2). **Naming exception**: the Security Auditor role maps to the `security-reviewer` agent slug — the Hatim→Hakim consolidation (#347/#360) preserved the filename so `/security-review` and the auto-fire trigger keep working. See `.claude/rules/role-triggers.md`.
 
-**On trigger**: once PR 3 lands, the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/security-auditor.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return. Until then, in-thread role-adoption is the active mechanism — and the existing Hatim utility agent (`.claude/agents/security-reviewer.md`) remains available via `/security-review`.
+**On trigger**: the `detect-role-trigger.sh` hook spawns the sub-agent at `.claude/agents/security-reviewer.md`; the main thread continues with the spawned agent's verdict folded back via standard sub-agent return.
 
-**Rationale**: OWASP / threat-model depth needs isolated context — matches existing Hatim utility agent pattern.
+**Rationale**: OWASP / threat-model depth needs isolated context.
 
 ---
 


### PR DESCRIPTION
## Summary
- **User-visible identity rot fixed** — the `/security-review` skill still called the agent "Shield" (two renames stale, Shield→Hatim→Hakim) in three places, and the security-auditor role pointed at a nonexistent `.claude/agents/security-auditor.md`. An operator invoking the skill now reads the correct persona, and the role file points at the real `security-reviewer.md` (the documented naming exception).
- **Hakim now knows why he's spawned on a hooks diff** — his description gains the #777 trust-chain condition (`.claude/hooks/**`, `.claude/settings.json`) and his checklist gains a gate-integrity category ("does this change weaken, bypass, or fail-open an existing gate/hook/marker check?"), the exact review a trust-chain PR needs but the web-app-shaped checklist lacked.
- **Pen Tester gets the boundary discipline it was missing** — it was the only security role with no CAN/CANNOT list and no authorization step. Added both, plus a **Phase 0 Rules of Engagement** before reconnaissance (written scope, boundaries, stop conditions) — the PTES pre-engagement baseline; an unauthorized test is an incident, not a pentest.
- **Machinery + currency wiring** — Head of Security now references `/threat-model` + `/dfd` + `/compliance-check` + `/decide` and names trust-chain ownership; OWASP refs updated 2021→2025 (supply-chain now #3, ASVS 5.0 baseline); dependency-auditor cross-links `/audit-deps` + the CI pipeline and aligns severity labels to Critical/High/Medium/Low. Stale "#347 PR 3" text removed.

## Testing
1. `grep -rn Shield .claude/skills/security-review/` → empty
2. security-auditor role points at `.claude/agents/security-reviewer.md`
3. Pen Tester has CAN/CANNOT + a Phase-0 authorization step before recon
4. `grep -rn '#347 PR' roles/security/` → empty; all referenced skills/pipeline exist on disk

Refs #981

---

## Glossary
| Term | Definition |
|------|------------|
| Trust chain (#777) | The security-critical files (`.claude/hooks/**`, `.claude/settings.json`) whose edits auto-fire the Security Auditor. |
| Rules of Engagement | The pre-test agreement defining authorized scope, boundaries, and stop conditions for a pentest. |
| OWASP Top 10:2025 | The Nov-2025 revision; supply-chain failures rose to #3 as a distinct category. |
| Naming exception | The Security Auditor role maps to the `security-reviewer` agent slug (Hatim→Hakim consolidation preserved the filename). |
