### PR TITLE
fix(#977): fail closed on unresolved target PR in warn-review-marker-write indirect path

### DIFF
--- a/.claude/hooks/tests/test_warn_review_marker_write.sh
+++ b/.claude/hooks/tests/test_warn_review_marker_write.sh
@@ -60,6 +60,16 @@
 #                 (without the #974 fix, both sides of the kind comparison
 #                 resolve to "" and the write would be incorrectly ALLOWED)
 #
+# #977 test (per-PR binding on the indirect path — see the hook's #977 guard):
+#   (27) Bash   → indirect write whose ROLE resolves (rex) but whose PR does
+#                 NOT (variable PR arg), + an active-reviewer marker for a
+#                 DIFFERENT specific PR                            → BLOCKED, exit 2
+#                 (without #977, TARGET_PR="" skips the PR check and the write
+#                 matches the wrong-PR active-reviewer marker → wrongly ALLOWED)
+#   (28) Bash   → indirect write where BOTH role and PR resolve (literal PR,
+#                 the sanctioned idiom), matching active-reviewer marker
+#                                                                  → ALLOWED, exit 0 (no regression)
+#
 # Exit 0 if all cases pass; 1 on failure.
 
 set -u
@@ -525,6 +535,49 @@ case26() {
   rm -rf "$sb"
 }
 
+# ---------------------------------------------------------------------------
+# (27) Bash → #962 INDIRECT write whose ROLE resolves (rex) but whose PR does
+#      NOT (review_marker_path called with a variable PR, so _extract_marker_pr
+#      recovers no literal digit), paired with an active-reviewer marker for a
+#      DIFFERENT, specific PR → BLOCKED (#977).
+#
+#      Before #977: role rex matched the marker's kind; TARGET_PR was empty so
+#      the PR-equality check was SKIPPED; TARGET_REPO is empty on the indirect
+#      path so the repo check was skipped too — the write incorrectly matched
+#      the pr=42 active-reviewer marker and was ALLOWED. #977 fails closed on an
+#      unresolved TARGET_PR, so the gate's per-PR binding holds on this path.
+# ---------------------------------------------------------------------------
+case27() {
+  local sb; sb=$(make_sandbox)
+  # Active reviewer is authorised for PR 42 specifically.
+  printf '%s\n' "${REPO}#42:rex" > "$sb/.claude/session/active-reviewer"
+  # Indirect marker write: review_marker_path is called with a VARIABLE PR
+  # ("$PR") so the PR number can't be recovered; role 'rex' is a literal arg so
+  # it resolves. The redirection makes it a genuine write.
+  # shellcheck disable=SC2016 # deliberate literal — not real expansion here
+  local cmd='REX_MARKER=$(review_marker_path "$REPO" "$PR" rex "$MARKER_HOME"); printf "%s" sha123 > "$REX_MARKER"'
+  run_hook "$sb" "Bash indirect write, role resolves + PR unresolved, active-reviewer for different PR -> BLOCKED (#977)" \
+    "$(bash_json "$cmd")" 2 "BLOCKED"
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (28) Bash → #962 INDIRECT write where BOTH role and PR resolve (a LITERAL PR
+#      in the review_marker_path call, matching the sanctioned reviewers'
+#      documented idiom), against a matching active-reviewer marker → ALLOWED
+#      (exit 0). Confirms #977's fail-closed guard does NOT regress the
+#      legitimate reviewer flow.
+# ---------------------------------------------------------------------------
+case28() {
+  local sb; sb=$(make_sandbox)
+  printf '%s\n' "${REPO}#42:rex" > "$sb/.claude/session/active-reviewer"
+  # shellcheck disable=SC2016 # deliberate literal — not real expansion here
+  local cmd='REX_MARKER=$(review_marker_path "$REPO" 42 rex "$MARKER_HOME"); printf "%s" sha123 > "$REX_MARKER"'
+  run_hook "$sb" "Bash indirect write, role+PR both resolve, matching active-reviewer -> ALLOWED (#977 no regression)" \
+    "$(bash_json "$cmd")" 0
+  rm -rf "$sb"
+}
+
 case1
 case2
 case3
@@ -551,6 +604,8 @@ case23
 case24
 case25
 case26
+case27
+case28
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/.claude/hooks/warn-review-marker-write.sh
+++ b/.claude/hooks/warn-review-marker-write.sh
@@ -414,7 +414,18 @@ _active_reviewer_allows() {
 
   [ -n "$c_kind" ] || return 1
   [ "$c_kind" = "$MARKER_TYPE" ] || return 1
-  [ -n "$TARGET_PR" ] && [ "$c_pr" != "$TARGET_PR" ] && return 1
+  # Fail closed when the write's target PR can't be resolved from the marker
+  # filename (#977). A marker path whose prefix carries no PR number (e.g. a
+  # non-qualified `foo-rex.approved`, or a variable-derived name that matched
+  # the marker regex but resolved no digits) leaves TARGET_PR empty. Skipping
+  # the PR-equality check there would let such a write match ANY active-reviewer
+  # marker of the same kind — regardless of which PR that review is for —
+  # breaking the gate's per-PR binding on the indirect path. The sanctioned
+  # reviewer flow always writes a repo/PR-qualified marker (via
+  # review_marker_path), so its TARGET_PR always resolves; failing closed here
+  # costs the legitimate path nothing. Mirrors the empty-kind guard shape above.
+  [ -n "$TARGET_PR" ] || return 1
+  [ "$c_pr" != "$TARGET_PR" ] && return 1
   # Repo check only when the target filename encodes a repo (post-#485
   # qualified marker). Legacy bare markers, and #962 indirect writes where
   # the repo couldn't be recovered, skip this comparison.


### PR DESCRIPTION
## Summary

- **Closes the per-PR-binding hole on the indirect resolution path** — on the #962 indirect path, the marker-write gate resolved the write's *role* (rex/security/architecture) but could leave the target PR number unresolved (when the marker-path helper is called with a variable PR arg). The old PR-equality check was written as `[ -n "$TARGET_PR" ] && [ "$c_pr" != "$TARGET_PR" ]`, so an empty target PR **skipped the check entirely** — and since the repo is also unrecoverable on that path, a resolved-role write matched *any* authorised session marker of the same kind, no matter which PR that review was actually for. The gate's "this approval is only valid for the PR it names" property silently didn't hold there.
- **The fix is a one-line fail-closed guard** — add a non-empty check on the target PR before the equality test, so an unresolved PR now BLOCKS instead of matching a different PR's marker. Mirrors the empty-kind guard shape from #974.
- **No impact on the legitimate reviewer flow** — the sanctioned reviewer idiom always passes a *literal* PR number to the marker-path helper (`code-reviewer.md:699`, `solution-architect.md:236`), so the PR extractor always resolves it. Verified before writing the guard, per the ticket's request. The empty-PR case only arises for a forged/malformed write using a variable PR — exactly what should fail closed.
- **Two regression tests** — case27 drives the exact hole (indirect write, role resolves, PR unresolved, authorised marker present for a *different* PR → BLOCKED) and case28 is the no-regression companion (both role and PR resolve, matching marker → still ALLOWED). Full suite: 30/30 assertions green.

## Testing

1. `bash .claude/hooks/tests/test_warn_review_marker_write.sh` → `PASS: 30 FAIL: 0`
2. `bash -n .claude/hooks/warn-review-marker-write.sh` → clean

Low practical exploitability (needs a concurrent same-kind active review in flight), pre-existing since #962, flagged by Hakim during the #975 review as a follow-up — worth closing so the gate's per-PR binding literally holds on the indirect path.

Closes #977

---

## Glossary

| Term | Definition |
|------|------------|
| authorised session marker | `.claude/session/active-reviewer`, one line `<owner>/<repo>#<pr>:<kind>`, that the orchestrator writes just before spawning the sanctioned reviewer to authorise its marker write. |
| indirect path | The #962 detection branch that catches a marker write whose target is built via a shell variable/function instead of a literal filename. |
| per-PR binding | The property that a review-approval marker is valid only for the specific PR it names — the thing this fix restores on the indirect path. |
| fail closed | Deny by default when a needed fact (here, the target PR) can't be resolved, rather than skipping the check and allowing. |
