### PR TITLE
fix(#995): role-trigger banners fire once/session + converge, not per-edit

### DIFF
--- a/.claude/hooks/detect-role-trigger.sh
+++ b/.claude/hooks/detect-role-trigger.sh
@@ -103,6 +103,59 @@ agent_slug_for() {
 }
 
 # ---------------------------------------------------------------------------
+# Session-scoped, once-per-role de-dupe (me2resh/apexyard#995).
+#
+# The path/label triggers fire on EVERY matching Edit/Write/Bash. Before
+# this guard a single multi-layer unit of work (backend code → an AgDR →
+# a CI file) re-emitted a role-activation banner on each edit, and the
+# agent, reading each banner as an instruction, kept switching persona /
+# opening ceremony mid-task instead of finishing the unit — the "infinite
+# role-handover loop, zero progress" a real user reported (#995).
+#
+# This makes each role's banner fire AT MOST ONCE per Claude Code session.
+# The marker is keyed on CLAUDE_CODE_SESSION_ID, so a new session starts
+# fresh with NO new SessionStart hook and NO settings.json change (keeps
+# this a Standard-tier advisory hook, not a trust-chain edit). It is
+# self-cleaning: each call sweeps markers left by other sessions, so the
+# dir can't grow without bound.
+#
+# Fail-open by design: no session id, no REPO_ROOT, or an unwritable
+# session dir all degrade to the pre-#995 always-fire behaviour. A banner
+# is advisory — over-surfacing on a broken environment is strictly safer
+# than silently swallowing role activation.
+#
+# Returns 0 = already fired this session (SKIP the banner);
+#         1 = first time / fail-open (FIRE the banner).
+# ---------------------------------------------------------------------------
+role_banner_already_fired() {
+  local file="$1"
+  local sid="${CLAUDE_CODE_SESSION_ID:-}"
+  [ -z "$sid" ] && return 1          # no session id → always fire (fail-open)
+  [ -z "$REPO_ROOT" ] && return 1    # no repo root → always fire (fail-open)
+
+  local dir="$REPO_ROOT/.claude/session/role-fired"
+  mkdir -p "$dir" 2>/dev/null || return 1   # can't record → always fire
+
+  # Self-clean: drop markers from any prior/other session so the dir
+  # doesn't accumulate across sessions (no SessionStart sweep needed).
+  local f
+  for f in "$dir"/*; do
+    [ -e "$f" ] || continue
+    case "${f##*/}" in
+      "${sid}__"*) : ;;              # keep this session's markers
+      *) rm -f "$f" 2>/dev/null ;;   # sweep other sessions'
+    esac
+  done
+
+  local slug marker
+  slug=$(printf '%s' "$file" | tr '/ ' '__')
+  marker="$dir/${sid}__${slug}"
+  [ -e "$marker" ] && return 0        # already fired this session → skip
+  : > "$marker" 2>/dev/null || return 1  # can't write → fail-open, fire
+  return 1                            # first time → fire
+}
+
+# ---------------------------------------------------------------------------
 # Helper: emit one class-aware banner line. Multiple triggers in a single
 # call can fire multiple banners.
 #
@@ -127,15 +180,29 @@ agent_slug_for() {
 # ---------------------------------------------------------------------------
 emit_banner() {
   local role="$1" file="$2" reason="$3"
+
+  # Session-scoped de-dupe (#995): a role's banner surfaces at most once
+  # per session, so a multi-edit unit of work doesn't re-trigger a
+  # handover on every file. Advisory — the underlying tool call always
+  # proceeds regardless.
+  if role_banner_already_fired "$file"; then
+    return 0
+  fi
+
   local class agent_slug
   class=$(lookup_role_class "$file")
   agent_slug=$(agent_slug_for "$file")
 
+  # Both banners are ADVISORY and carry a convergence guard (#995): they
+  # name the role that OWNS this kind of work, but explicitly tell the
+  # agent NOT to switch persona / open new ceremony mid-task. Roles hand
+  # off at phase boundaries, not on every edit — the counter-force that
+  # keeps "make progress by default" the default.
   if [ "$class" = "isolated-work-class" ]; then
-    printf 'ROLE TRIGGER: %s activates per .claude/rules/role-triggers.md (%s). Isolated-work-class — SPAWN the sub-agent via the Agent tool with subagent_type: %s. Canonical role at %s, agent wrapper at .claude/agents/%s.md. Per AgDR-0050 § Axis 6.\n' \
+    printf 'ROLE TRIGGER: %s owns this kind of work per .claude/rules/role-triggers.md (%s) [advisory, once/session]. If you are STARTING a discrete, isolatable task, you MAY spawn it via the Agent tool with subagent_type: %s (canonical role at %s, wrapper at .claude/agents/%s.md). But if you are MID-TASK and making progress, do NOT switch persona or open new ceremony on this edit — finish the current unit first; roles hand off at phase boundaries, not per file. Per AgDR-0050 § Axis 6 + #995.\n' \
       "$role" "$reason" "$agent_slug" "$file" "$agent_slug" >&2
   else
-    printf 'ROLE TRIGGER: %s activates per .claude/rules/role-triggers.md (%s). In-flow-class — adopt the persona IN-THREAD. Read %s before continuing. Per AgDR-0050 § Axis 6.\n' \
+    printf 'ROLE TRIGGER: %s owns this kind of work per .claude/rules/role-triggers.md (%s) [advisory, once/session]. If helpful, read %s to adopt its lens in-thread. But if you are MID-TASK and making progress, do NOT switch persona or open new ceremony on this edit — finish the current unit first; roles hand off at phase boundaries, not per file. Per AgDR-0050 § Axis 6 + #995.\n' \
       "$role" "$reason" "$file" >&2
   fi
 }

--- a/.claude/hooks/tests/test_detect_role_trigger.sh
+++ b/.claude/hooks/tests/test_detect_role_trigger.sh
@@ -432,7 +432,9 @@ dedup_edit() {
   local sid="$1" path="$2" input
   input=$(jq -nc --arg p "$path" \
     '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
-  ( printf '%s' "$input" | ( cd "$DEDUP_REPO" && CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" ) ) 2>&1 >/dev/null
+  # Capture stderr (the banner), discard stdout. The brace-group form keeps the
+  # redirection order unambiguous (shellcheck SC2069).
+  { printf '%s' "$input" | ( cd "$DEDUP_REPO" && CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" ) >/dev/null; } 2>&1
 }
 
 assert_dedup() {

--- a/.claude/hooks/tests/test_detect_role_trigger.sh
+++ b/.claude/hooks/tests/test_detect_role_trigger.sh
@@ -16,6 +16,13 @@
 
 set -u
 
+# The session-scoped de-dupe (#995) keys on CLAUDE_CODE_SESSION_ID. Unset it
+# for the per-case tests below so each invocation is in the fail-open
+# always-fire mode — deterministic and independent of whatever ambient
+# session happens to be running this test. Section (7) sets its own id to
+# exercise the de-dupe explicitly.
+unset CLAUDE_CODE_SESSION_ID
+
 SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 HOOK="$SRC_ROOT/.claude/hooks/detect-role-trigger.sh"
 
@@ -232,67 +239,82 @@ else
 fi
 
 # --- (4) HYBRID class-aware banner — AgDR-0050 § Axis 6 (Wave 2 PR 5) --------
-# Each banner now includes either "Isolated-work-class — SPAWN the sub-agent"
-# or "In-flow-class — adopt the persona IN-THREAD" depending on the matched
-# role's **Class** value in its role file. Verifies the class lookup actually
-# fires + the security-auditor → security-reviewer slug exception.
+# Each banner is now ADVISORY with a convergence guard (#995): isolated-work
+# roles carry "you MAY spawn it ... subagent_type: <slug>", in-flow roles carry
+# "read <file> to adopt its lens in-thread", and BOTH carry "do NOT switch
+# persona ... finish the current unit first". Verifies the class lookup fires +
+# the security-auditor → security-reviewer slug exception.
 
-# 4a. Security Auditor (isolated-work-class) — banner instructs SPAWN with
+# 4a. Security Auditor (isolated-work-class) — banner offers SPAWN with
 #     subagent_type: security-reviewer (NOT security-auditor; the
 #     Hatim→Hakim consolidation in PR #360 kept the filename).
 in=$(jq -nc \
   --arg p "src/auth/login.ts" \
   '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
-run_case "hybrid class-aware: Security Auditor → isolated-work-class banner" 0 \
-  "Isolated-work-class.*subagent_type: security-reviewer" "$in"
+run_case "hybrid class-aware: Security Auditor → spawn-offer banner" 0 \
+  "MAY spawn.*subagent_type: security-reviewer" "$in"
 
-# 4b. Platform Engineer (in-flow-class) — banner instructs in-thread
+# 4b. Platform Engineer (in-flow-class) — banner offers in-thread lens
 #     adoption. The CI/CD diff path triggers this role.
 in=$(jq -nc \
   --arg p ".github/workflows/ci.yml" \
   '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
-run_case "hybrid class-aware: Platform Engineer → in-flow-class banner" 0 \
-  "Platform Engineer.*In-flow-class.*adopt the persona IN-THREAD" "$in"
+run_case "hybrid class-aware: Platform Engineer → in-thread-lens banner" 0 \
+  "Platform Engineer.*adopt its lens in-thread" "$in"
 
-# 4c. Tech Lead (isolated-work-class) — banner instructs SPAWN with
+# 4c. Tech Lead (isolated-work-class) — banner offers SPAWN with
 #     subagent_type: tech-lead. Triggered by edits under docs/agdr/.
 in=$(jq -nc \
   --arg p "docs/agdr/AgDR-0099-example.md" \
   '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
-run_case "hybrid class-aware: Tech Lead → isolated-work-class banner" 0 \
-  "Tech Lead.*Isolated-work-class.*subagent_type: tech-lead" "$in"
+run_case "hybrid class-aware: Tech Lead → spawn-offer banner" 0 \
+  "Tech Lead.*subagent_type: tech-lead" "$in"
 
-# 4d. QA Engineer (isolated-work-class) — banner instructs SPAWN with
+# 4d. QA Engineer (isolated-work-class) — banner offers SPAWN with
 #     subagent_type: qa-engineer. Triggered by `gh issue edit --add-label qa`.
 in=$(jq -nc \
   --arg c "gh issue edit 42 --add-label qa" \
   '{hook_event_name:"PreToolUse", tool_name:"Bash", tool_input:{command:$c}}')
-run_case "hybrid class-aware: QA Engineer → isolated-work-class banner" 0 \
-  "QA Engineer.*Isolated-work-class.*subagent_type: qa-engineer" "$in"
+run_case "hybrid class-aware: QA Engineer → spawn-offer banner" 0 \
+  "QA Engineer.*subagent_type: qa-engineer" "$in"
 
-# 4e. Prompted Backend Engineer (in-flow-class) — banner instructs
-#     in-thread adoption.
+# 4e. Prompted Backend Engineer (in-flow-class) — banner offers in-thread
+#     lens adoption.
 in=$(jq -nc \
   --arg prm "act as the backend engineer and refactor this handler" \
   '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
-run_case "hybrid class-aware: Backend Engineer prompted → in-flow-class banner" 0 \
-  "Backend Engineer.*In-flow-class.*adopt the persona IN-THREAD" "$in"
+run_case "hybrid class-aware: Backend Engineer prompted → in-thread-lens banner" 0 \
+  "Backend Engineer.*adopt its lens in-thread" "$in"
 
-# 4f. Prompted UX Designer (in-flow-class) — banner instructs in-thread
+# 4f. Prompted UX Designer (in-flow-class) — banner offers in-thread lens
 #     adoption.
 in=$(jq -nc \
   --arg prm "put on your UX Designer hat for this flow review" \
   '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
-run_case "hybrid class-aware: UX Designer prompted → in-flow-class banner" 0 \
-  "Ux Designer.*In-flow-class.*adopt the persona IN-THREAD" "$in"
+run_case "hybrid class-aware: UX Designer prompted → in-thread-lens banner" 0 \
+  "Ux Designer.*adopt its lens in-thread" "$in"
 
-# 4g. Prompted Pen Tester (isolated-work-class) — banner instructs SPAWN
+# 4g. Prompted Pen Tester (isolated-work-class) — banner offers SPAWN
 #     with subagent_type: penetration-tester.
 in=$(jq -nc \
   --arg prm "as the pen tester, dry-run an exploit on the new endpoint" \
   '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
-run_case "hybrid class-aware: Pen Tester prompted → isolated-work-class banner" 0 \
-  "Pen Tester.*Isolated-work-class.*subagent_type: penetration-tester" "$in"
+run_case "hybrid class-aware: Pen Tester prompted → spawn-offer banner" 0 \
+  "Pen Tester.*subagent_type: penetration-tester" "$in"
+
+# 4h. Convergence guard (#995): EVERY banner tells the agent not to switch
+#     persona / open ceremony mid-task. Assert it on both an isolated-work
+#     and an in-flow banner.
+in=$(jq -nc \
+  --arg p "src/auth/login.ts" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "convergence guard present (isolated-work banner) [#995]" 0 \
+  "do NOT switch persona.*finish the current unit first" "$in"
+in=$(jq -nc \
+  --arg p ".github/workflows/ci.yml" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "convergence guard present (in-flow banner) [#995]" 0 \
+  "do NOT switch persona.*finish the current unit first" "$in"
 
 # --- (5) Solution Architect (Tariq) — design-artifact triggers --------------
 
@@ -332,15 +354,15 @@ run_case "path trigger: migration AgDR also fires Solution Architect" 0 \
 in=$(jq -nc \
   --arg p "projects/foo/docs/technical-design-x.md" \
   '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
-run_case "hybrid class-aware: Solution Architect → isolated-work-class banner" 0 \
-  "Solution Architect.*Isolated-work-class.*subagent_type: solution-architect" "$in"
+run_case "hybrid class-aware: Solution Architect → spawn-offer banner" 0 \
+  "Solution Architect.*subagent_type: solution-architect" "$in"
 
 # 5f. Prompted "as the Solution Architect" → Solution Architect banner.
 in=$(jq -nc \
   --arg prm "as the solution architect, review the proposed design" \
   '{hook_event_name:"UserPromptSubmit", prompt:$prm}')
 run_case "prompt trigger: 'as the solution architect' fires Solution Architect" 0 \
-  "Solution Architect.*Isolated-work-class.*subagent_type: solution-architect" "$in"
+  "Solution Architect.*subagent_type: solution-architect" "$in"
 
 # 5g. An ordinary source file does NOT fire the Solution Architect.
 in=$(jq -nc \
@@ -390,6 +412,67 @@ else
   echo "PASS [prompt trigger: build prompt does not fire The Contrarian]"
   PASS=$((PASS+1))
 fi
+
+# --- (7) Session-scoped once-per-role de-dupe (#995) -------------------------
+# The bug: path/label triggers re-fired on every edit, so a multi-layer unit
+# of work re-triggered a role handover per file → the infinite-loop symptom.
+# The fix fires each role's banner at most once per CLAUDE_CODE_SESSION_ID.
+# These run in a throwaway git repo so REPO_ROOT (and the role-fired marker
+# dir) resolve there, never polluting the real session dir.
+
+DEDUP_REPO=$(mktemp -d)
+( cd "$DEDUP_REPO" && git init -q )
+
+SID_A="test-session-aaa-995"
+SID_B="test-session-bbb-995"
+
+# dedup_edit <sid> <path> — fire an Edit-trigger with a given session id under
+# DEDUP_REPO; echoes stderr (the banner, if any). Empty sid → fail-open path.
+dedup_edit() {
+  local sid="$1" path="$2" input
+  input=$(jq -nc --arg p "$path" \
+    '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+  ( printf '%s' "$input" | ( cd "$DEDUP_REPO" && CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" ) ) 2>&1 >/dev/null
+}
+
+assert_dedup() {
+  local label="$1" expect="$2" out="$3"
+  if [ "$expect" = "fire" ]; then
+    if [ -n "$out" ]; then echo "PASS [$label]"; PASS=$((PASS+1));
+    else echo "FAIL [$label]: expected a banner, got silence" >&2; FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "; fi
+  else
+    if [ -z "$out" ]; then echo "PASS [$label]"; PASS=$((PASS+1));
+    else echo "FAIL [$label]: expected silence, got: ${out:0:120}" >&2; FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "; fi
+  fi
+}
+
+# 7a. First Security-Auditor edit in session A → fires.
+assert_dedup "dedup 7a: first auth edit (session A) fires" fire \
+  "$(dedup_edit "$SID_A" "src/auth/login.ts")"
+
+# 7b. A DIFFERENT file that maps to the SAME role (Security Auditor) in the
+#     same session → silent. This is the exact loop scenario: many files, one
+#     role, one banner.
+assert_dedup "dedup 7b: second same-role edit (session A) is silent" silent \
+  "$(dedup_edit "$SID_A" "packages/api/src/auth/jwt.ts")"
+
+# 7c. A DIFFERENT role in the same session still fires — de-dupe is per-role,
+#     not a global once-per-session mute.
+assert_dedup "dedup 7c: different role (session A) still fires" fire \
+  "$(dedup_edit "$SID_A" ".github/workflows/ci.yml")"
+
+# 7d. The original role in a NEW session fires again — de-dupe is session-scoped.
+assert_dedup "dedup 7d: same role in a new session fires again" fire \
+  "$(dedup_edit "$SID_B" "src/auth/login.ts")"
+
+# 7e. Fail-open: with no session id, repeated same-role edits BOTH fire
+#     (degrades to pre-#995 always-fire, since a banner is advisory).
+assert_dedup "dedup 7e-i: no session id — first edit fires" fire \
+  "$(dedup_edit "" "src/auth/login.ts")"
+assert_dedup "dedup 7e-ii: no session id — second edit ALSO fires (fail-open)" fire \
+  "$(dedup_edit "" "src/auth/login.ts")"
+
+rm -rf "$DEDUP_REPO"
 
 # --- Summary -----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- **Kills the "infinite role-handover loop" a real user reported** — driving multi-layer work, the agent kept ping-ponging AgDR → backend → devops with zero progress. Root cause (`/debug`): `detect-role-trigger.sh` re-emitted an *imperative* role-activation banner on **every** matching Edit/Write/Bash, and the agent obeyed each one and switched persona mid-task. The framework had a strong "activate the right role on every action" force and **no** counter-force toward "make progress."
- **Session-scoped, once-per-role de-dupe in `emit_banner`** — each role's banner now surfaces at most once per `CLAUDE_CODE_SESSION_ID`, so a single unit of work that touches several files no longer re-triggers a handover per file. The marker lives under `.claude/session/role-fired/` and is **self-cleaning** (each call sweeps other sessions' markers) — so there's **no new SessionStart hook and no `settings.json` change**, keeping this a Standard-tier advisory hook rather than a trust-chain edit. Fail-open: no session id / no repo root / unwritable dir all degrade to the old always-fire behaviour, because a banner is advisory and over-surfacing beats silently swallowing role activation on a broken environment.
- **Both banners reworded from imperative to advisory + convergence** — they still name the role that owns the work and offer the spawn / in-thread-lens, but now explicitly add: *"if you are MID-TASK and making progress, do NOT switch persona or open new ceremony on this edit — finish the current unit first; roles hand off at phase boundaries, not per file."* This is the missing counter-force; it's what actually breaks the loop behaviourally even when a banner does fire.
- **Deliberately the smallest change that reduces process** — the reported disease is over-ceremony, so the fix removes push (imperative → advisory) and removes repetition (per-edit → once/session) rather than adding any new gate. No merge-gate, credential, or marker logic is touched. A follow-up (separate PR) will narrow `agdr-decisions.md`'s per-decision HARD-STOP, which compounds the same churn.

## Testing
1. `bash .claude/hooks/tests/test_detect_role_trigger.sh` — **50/50 pass** (44 existing + 6 new).
2. New section (7) proves the de-dupe in a throwaway git repo: first same-role edit fires, a second file mapping to the *same* role is silent, a *different* role still fires (per-role, not a global mute), the same role in a *new* session fires again (session-scoped), and with no session id repeated edits both fire (fail-open).
3. Existing per-case tests run with `CLAUDE_CODE_SESSION_ID` unset (always-fire mode) so they stay deterministic regardless of the ambient session; class-aware assertions updated for the advisory wording, plus two new cases asserting the convergence guard is present on both banner shapes.

Fixes #995

---

## Glossary
| Term | Definition |
|------|------------|
| Role-trigger banner | The advisory stderr note `detect-role-trigger.sh` prints when a diff/prompt matches a role's activation condition. Advisory only — never blocks the tool call. |
| Convergence guard | The new "finish the current unit before switching roles / opening ceremony" instruction — the counter-force to the framework's "activate the right role" push. |
| Session-scoped de-dupe | Firing each role's banner at most once per Claude Code session, keyed on `CLAUDE_CODE_SESSION_ID`, via a self-cleaning marker under `.claude/session/role-fired/`. |
| Fail-open | When the de-dupe can't record state (no session id / no repo root / unwritable dir) it degrades to always-firing, since a swallowed advisory is worse than a repeated one. |
| Standard-tier (vs trust-chain) | Per right-size-ceremony (#994): this hook is an advisory banner, not a merge gate / marker lib / `settings.json` matcher, so it doesn't require the security-auditor trust-chain treatment. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KGiYPZB3US1LrQ9GS9vXe
