### PR TITLE
chore(#997): narrow AgDR rule from "any technical decision" to material ones

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -149,7 +149,7 @@ Examples that **do not** trigger the heuristic:
 
 ### 7. Technical Decisions (AgDR) — ⛔ BLOCKING CHECK
 
-**You MUST detect and enforce AgDR for any technical decisions.**
+**You MUST detect and enforce AgDR for *material* technical decisions** — architectural, hard to reverse, or cross-cutting. Routine implementation choices that are reversible inside this PR (local naming, extracting a helper, control flow, test structure, using an API from a dependency already in the manifest) do **NOT** need an AgDR and must not be flagged. See `.claude/rules/agdr-decisions.md` § "The threshold" for the full line, including the two non-negotiable rails: security / trust-chain / migration decisions are always material, and genuine ambiguity rounds **up**.
 
 #### How to detect technical decisions in code
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -169,7 +169,7 @@ Scan the diff for these patterns:
 #### Enforcement rules
 
 1. **Check if AgDR exists** — look for `AgDR` or `agdr` links in the PR description
-2. **If a decision is detected but NO AgDR is linked** → **REQUEST CHANGES** with this template:
+2. **If a *material* decision is detected but NO AgDR is linked** → **REQUEST CHANGES** with this template. (Material per `.claude/rules/agdr-decisions.md` § "The threshold" — do NOT request changes for a routine choice reversible inside this PR.)
 
 ```markdown
 ## ⛔ AgDR Required
@@ -823,7 +823,7 @@ Report the failure in plain text with the exact command the caller needs to run.
 4. **Don't nitpick style** — that's what linters are for
 5. **First review** — a human approver does the second review before merge
 6. **Glossary is mandatory** — request changes if missing
-7. **AgDR enforcement is BLOCKING** — if you detect a technical decision without an AgDR link:
+7. **AgDR enforcement is BLOCKING** — if you detect a **material** technical decision (architectural, hard to reverse, or cross-cutting per `.claude/rules/agdr-decisions.md` § "The threshold") without an AgDR link:
    - DO NOT approve the PR
    - REQUEST CHANGES with the specific decisions you detected
    - List what needs to be documented

--- a/.claude/rules/agdr-decisions.md
+++ b/.claude/rules/agdr-decisions.md
@@ -1,51 +1,65 @@
-# Technical Decisions — AgDR Required
+# Technical Decisions — AgDR Required for *Material* Decisions
 
-**HARD STOP**: before making any technical decision, run `/decide` and create an Agent Decision Record (AgDR).
+**HARD STOP**: before making a **material** technical decision — one that is architectural, hard to reverse, or cross-cutting — run `/decide` and create an Agent Decision Record (AgDR).
 
-## Trigger Patterns — STOP if you catch yourself doing these
+The word doing the work is **material**. An earlier version of this rule said "before making any technical decision," which read as *every* implementation choice: which helper to extract, how to shape a loop, what to name a module. That bar is unmeetable, and trying to meet it produces the failure mode this framework already named elsewhere — ceremony that costs more than the work it guards. Worse, it compounds: every AgDR written lands a file under `docs/agdr/**`, which re-fires the Tech Lead activation trigger (and, for a migration AgDR, the Solution Architect trigger too), so an over-broad AgDR rule manufactures exactly the role-handover churn [`role-triggers.md`](role-triggers.md) and [`right-size-ceremony.md`](right-size-ceremony.md) exist to prevent. See me2resh/apexyard#995 and #997.
 
-If you are about to:
+This rule is the decision-record sibling of [`right-size-ceremony.md`](right-size-ceremony.md): same instinct (match the ceremony to the blast radius), applied to *recording* rather than *reviewing*.
 
-- Say "I'll use X" or "Let's go with X" → STOP, run `/decide` first
-- Compare "X vs Y" or "X or Y" → STOP, run `/decide` first
-- Choose a library, framework, or tool → STOP, run `/decide` first
-- Pick an implementation approach → STOP, run `/decide` first
-- Make an architectural choice → STOP, run `/decide` first
+## The threshold
 
-## Real-Time Decision Detection
+A decision needs an AgDR when **any** of these is true:
 
-Before writing any code or config, scan your planned response for:
+| Signal | Because |
+|--------|---------|
+| It adds a **new dependency, library, framework, or technology** | Someone inherits the maintenance, licensing, and upgrade cost |
+| It creates a **new service, bounded context, or external integration** | It changes the system's shape and its failure modes |
+| It changes the **data model or schema** | Migrations are expensive and data loss is not reversible |
+| It touches a **security-relevant control** — auth, crypto, secrets, the trust chain | Getting it wrong is the costliest class of wrong |
+| It designs **CI/CD, release, or infrastructure** | It's the machinery everything else ships through |
+| It adopts a **pattern repo-wide or cross-cutting** | Reversing it later means touching everything at once |
+| It is **hard to reverse** — externally visible, shared-state, or expensive to undo | The record is the only cheap artifact left afterwards |
 
-| Pattern in your response | Decision type | Action |
-|--------------------------|---------------|--------|
-| "I'll create a workflow that…"          | CI/CD design | `/decide` |
-| "We'll use GitHub Actions / CircleCI…"  | CI platform | `/decide` |
-| "The keystore will be stored in…"       | Security/infra | `/decide` |
-| Adding dependencies to build files       | Library choice | `/decide` |
-| Creating new architecture (modules, layers) | Architecture | `/decide` |
-| "I'll implement the X pattern…"         | Design pattern | `/decide` |
-| Setting up signing / release / deployment | Release strategy | `/decide` |
+A decision does **not** need an AgDR when it is a routine implementation choice, reversible inside a single PR:
 
-**Test yourself**: if someone asked "why did you choose X over Y?", would you need to explain trade-offs? If yes → `/decide` first.
+- Local naming — variables, functions, files, modules
+- Whether to extract a helper, split a function, or inline something
+- Control flow, error-handling shape, or how a loop is written
+- Test structure, fixture layout, or which assertions to make
+- Calling an API from a dependency **already in the manifest** (adding the dependency is material; using it is not)
+- One-off refactors, formatting, and comment or doc wording
 
-## Self-Check Before the Build Phase
+**The practical test:** *would a competent teammate six months from now be confused, or repeat expensive work, because this reasoning wasn't written down?* If yes, `/decide`. If they'd just read the code and move on, write the code.
+
+The older heuristic — "if someone asked why you chose X over Y, would you need to explain trade-offs?" — is **too sensitive on its own**, because almost every line of code has an unexplained alternative. Use it only *after* the threshold table above already says the decision is material; it helps you write a better AgDR, it does not decide whether you need one.
+
+## The two rails (unchanged, non-negotiable)
+
+Narrowing the rule does not narrow the rails from [`right-size-ceremony.md`](right-size-ceremony.md):
+
+1. **Security, trust chain, and migrations are never exempt.** A decision touching `.claude/hooks/**`, `.claude/settings.json`, auth, crypto, secrets, or a migration is material regardless of how small the diff is. A one-line change to a merge gate is exactly where you want the record.
+2. **Ambiguity rounds up.** If you genuinely can't tell whether a decision is material, write the AgDR. The tolerated failure is an occasional unnecessary record — never a silently unrecorded architectural call.
+
+## Self-check before the Build phase
 
 ```
-[ ] Did I make any technical decisions?     YES → AgDR exists for each?
-[ ] Did I choose between options?           YES → AgDR exists?
-[ ] No AgDR for a decision I made?          → Create it NOW before proceeding
+[ ] Did I make a decision that meets the threshold above?   YES → AgDR exists for each?
+[ ] Is it security / trust-chain / migration related?       YES → material, no exceptions (rail 1)
+[ ] Am I unsure whether it's material?                      → round UP, write it (rail 2)
+[ ] Material decision made with no AgDR?                    → create it NOW before proceeding
 ```
 
-## Self-Check During Implementation
+## Self-check during implementation
 
 ```
-[ ] Am I about to write code that introduces a new pattern?   → STOP, /decide
-[ ] Am I adding new dependencies?                             → STOP, /decide
-[ ] Am I creating CI/CD or infra config?                      → STOP, /decide
-[ ] Am I designing something that has alternatives?           → STOP, /decide
+[ ] Am I adding a new dependency, service, integration, or technology?  → /decide
+[ ] Am I changing a data model, schema, or a security control?          → /decide
+[ ] Am I designing CI/CD, release, or infra?                            → /decide
+[ ] Am I adopting a pattern across the whole repo?                      → /decide
+[ ] Is this a routine choice reversible in this PR?                     → just write the code
 ```
 
-## What `/decide` Does
+## What `/decide` does
 
 Creates an **Agent Decision Record** (AgDR) that captures:
 
@@ -55,12 +69,20 @@ Creates an **Agent Decision Record** (AgDR) that captures:
 
 **AgDRs are stored at**: `{project}/docs/agdr/AgDR-NNNN-{slug}.md`. Each project has its own folder and its own ID sequence.
 
-## Enforcement
+Before drafting one, run `/agdr search <term>` — the portfolio may have already settled this, and re-litigating a decided call is its own kind of waste.
 
-1. **Real-time self-check** — scan every response for decision patterns before writing code
-2. **Workflow gate** — AgDR required before the Build phase for new features
-3. **Code Reviewer** — flags PRs with architecture changes that don't link an AgDR
-4. **Pre-commit hook** — warns if architecture files changed without an AgDR reference
+## Enforcement — and the honest limits of it
+
+| Layer | What it actually does |
+|-------|----------------------|
+| **Self-discipline** | The threshold above, applied before writing code. The primary mechanism. |
+| **Workflow gate** | AgDR required before the Build phase for new features (Gate 2, [`workflow-gates.md`](workflow-gates.md)). |
+| **Code Reviewer (Rex)** | Flags PRs with architecture changes that don't link an AgDR. |
+| **Pre-commit hooks** | `require-agdr-for-arch-changes.sh` / `require-agdr-for-arch-pr.sh`. |
+
+The hooks are **deliberately narrow** — they fire only on `infrastructure/**`, `*.tf` / `*.tfvars`, `Dockerfile*` / `docker-compose*`, and `.github/workflows/**`, and their own header says why: *"Deliberately NARROW. Dependency bumps and API schema changes are NOT included — too noisy, not all changes need an AgDR."*
+
+That narrowness is correct, and this rule is now written to match it. A rule far broader than anything anyone would actually enforce doesn't produce more records — it produces ignored prose, and it burns the agent's ceremony budget on decisions nobody needed written down. The threshold above is wider than the hooks (it covers dependencies, data models, and cross-cutting patterns the hooks can't see) but it is no longer unbounded. Adopters who want a broader mechanical net can extend `.claude/project-config.json` → `.architecture_paths`.
 
 ---
 

--- a/.claude/rules/agdr-decisions.md
+++ b/.claude/rules/agdr-decisions.md
@@ -80,9 +80,21 @@ Before drafting one, run `/agdr search <term>` — the portfolio may have alread
 | **Code Reviewer (Rex)** | Flags PRs with architecture changes that don't link an AgDR. |
 | **Pre-commit hooks** | `require-agdr-for-arch-changes.sh` / `require-agdr-for-arch-pr.sh`. |
 
-The hooks are **deliberately narrow** — they fire only on `infrastructure/**`, `*.tf` / `*.tfvars`, `Dockerfile*` / `docker-compose*`, and `.github/workflows/**`, and their own header says why: *"Deliberately NARROW. Dependency bumps and API schema changes are NOT included — too noisy, not all changes need an AgDR."*
+The two hooks fire at different moments and on **different, deliberately bounded** path sets — neither is a catch-all for "any decision":
 
-That narrowness is correct, and this rule is now written to match it. A rule far broader than anything anyone would actually enforce doesn't produce more records — it produces ignored prose, and it burns the agent's ceremony budget on decisions nobody needed written down. The threshold above is wider than the hooks (it covers dependencies, data models, and cross-cutting patterns the hooks can't see) but it is no longer unbounded. Adopters who want a broader mechanical net can extend `.claude/project-config.json` → `.architecture_paths`.
+| Hook | Fires on | Default trigger set |
+|------|----------|---------------------|
+| `require-agdr-for-arch-changes.sh` | `git commit`, against the **staged** diff | `*.tf`, `*.tfvars`, `docker-compose*.yml`, `Dockerfile*`, `.github/workflows/**` |
+| `require-agdr-for-arch-pr.sh` | `gh pr create`, against the **PR** diff | `**/domain/**`, `**/infrastructure/**`, `**/migrations/**`, `infrastructure/**`, `template.yaml`, `**/*.tf(vars)`, `.github/workflows/**` — **plus dependency *additions*** to `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `Gemfile` |
+
+Two details worth knowing, because both are easy to get wrong from the comments alone:
+
+- The commit-time hook **deliberately omits a bare `infrastructure/` directory pattern** (its `ARCH_GLOBS` excludes it even though an older header comment mentions it). Testing found it false-positived on `docs/infrastructure/notes.md` and `src/types/infrastructure/foo.ts` — the word is ambiguous between IaC and library code. Terraform is caught unambiguously via `\.tf$` at any depth instead. CDK / Pulumi projects using plain `.ts` / `.py` under `infrastructure/` should override via `.architecture_paths`.
+- Only the **PR-time** hook watches dependency manifests, and only for *additions* — a version bump of something already present does not trigger it.
+
+Both are configurable: `.architecture_paths` for the commit-time hook, `.agdr_trigger_paths[]` / `.agdr_trigger_dep_files[]` for the PR-time one, and `<!-- agdr: not-applicable -->` in a PR body bypasses the PR gate with a visible warning.
+
+That bounded shape is correct, and this rule is now written to match its spirit. A rule far broader than anything anyone would actually enforce doesn't produce more records — it produces ignored prose, and it burns the agent's ceremony budget on decisions nobody needed written down. The threshold above is still **wider** than the hooks, deliberately: it covers new technologies, security controls, and cross-cutting patterns that no path glob can see. But it is no longer unbounded.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ Every PR must include:
 
 ### Technical Decisions
 
-Before making significant technical decisions (new libraries, architecture changes, implementation approaches), create an Agent Decision Record (AgDR):
+Before making a **material** technical decision — one that is architectural, hard to reverse, or cross-cutting (a new dependency or technology, a new service or integration, a data-model or schema change, a security-relevant control, CI/CD or infra design, a repo-wide pattern) — create an Agent Decision Record (AgDR). Routine implementation choices that are reversible inside one PR do **not** need one. Full threshold, the two rails, and the "does NOT need an AgDR" list: @.claude/rules/agdr-decisions.md
 
 Template: @templates/agdr.md
 

--- a/docs/agdr/AgDR-0108-agdr-materiality-threshold.md
+++ b/docs/agdr/AgDR-0108-agdr-materiality-threshold.md
@@ -1,0 +1,52 @@
+# AgDR Materiality Threshold — Record Material Decisions, Not Every Decision
+
+> In the context of an over-broad decision-recording rule that demanded an AgDR before *any* technical decision, facing a real user reporting "infinite loops of AgDRs then backend then devops and zero progress", I decided to replace the blanket trigger with an explicit materiality threshold plus a concrete exemption list, to restore "make progress by default" without losing the durable record of architectural calls, accepting that a small number of borderline decisions will now go unrecorded unless the ambiguity-rounds-up rail catches them.
+
+## Context
+
+`.claude/rules/agdr-decisions.md` opened with **"HARD STOP: before making any technical decision, run `/decide`"** and listed triggers including *"Pick an implementation approach"* and *"Am I about to write code that introduces a new pattern?"*. Read literally, that covers nearly every implementation choice.
+
+Three things made this actively harmful rather than merely verbose:
+
+1. **It compounded the role-handover loop.** Every AgDR lands a file under `docs/agdr/**`, which re-fires the Tech Lead activation trigger (and, for migration AgDRs, the Solution Architect trigger too). So the AgDR rule *manufactured* the exact churn that [AgDR-0107](AgDR-0107-right-size-ceremony.md) and me2resh/apexyard#995 were fixing. The three issues are one disease.
+2. **The prose was far broader than its own enforcement.** The mechanical hooks are bounded path sets (`require-agdr-for-arch-changes.sh` on `*.tf`/Dockerfile/compose/workflows; `require-agdr-for-arch-pr.sh` on `**/domain/**`, `**/migrations/**`, `template.yaml`, IaC paths, and dependency *additions*). `CLAUDE.md` already said "significant". Only the rule file said "any".
+3. **A rule nobody can satisfy is a rule nobody follows.** An unmeetable bar doesn't produce more records; it produces ignored prose and spends the session's finite ceremony budget on decisions nobody needed written down.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Leave as-is** | Zero risk of under-recording; no work | Keeps feeding the reported loop; the bar stays unmeetable and therefore ignored in practice |
+| **Delete the rule; rely on hooks alone** | Maximally cheap; hooks are already well-scoped | Loses the decisions no path glob can see — new technologies, security controls, cross-cutting patterns. Hooks match paths, not judgment |
+| **Narrow the prose to the hooks' exact path set** | Perfectly consistent prose↔mechanism | Under-covers: a new technology or auth model introduced in ordinary source files would need no record |
+| **Materiality threshold + explicit exemption list** (chosen) | Restores progress-by-default; keeps judgment-based coverage wider than globs; rails prevent the dangerous failure | Requires an agent to make a judgement call; borderline cases depend on rail 2 |
+
+## Decision
+
+Chosen: **an explicit materiality threshold plus a concrete "does NOT need an AgDR" list**, because the failure modes are asymmetric and the rails make the remaining risk cheap.
+
+An AgDR is required when a decision is architectural, hard to reverse, or cross-cutting: a new dependency / technology, a new service or external integration, a data-model or schema change, a security-relevant control, CI/CD-release-infra design, or a pattern adopted repo-wide. It is **not** required for routine choices reversible inside a single PR: local naming, extracting a helper, control flow, test structure, or calling an API from a dependency already in the manifest.
+
+Two rails from AgDR-0107 carry over unchanged and are non-negotiable:
+
+1. **Security, trust chain, and migrations are never exempt** — regardless of diff size.
+2. **Ambiguity rounds up** — if you can't tell, write the record.
+
+The old *"could you explain the trade-off?"* heuristic is demoted from a trigger to a **writing aid**. As a trigger it over-fires by construction, because almost every line of code has an unexplained alternative.
+
+Deliberately **not** in scope: any change to hook, gate, or marker logic. This narrows guidance only. Notably, `require-agdr-for-arch-pr.sh` still prints the old "any technical decision" phrasing in its agent-facing block message — that file is rail-1 trust chain (`.claude/hooks/**`) and must be corrected on the Heavy path with the Security Auditor, not tacked onto a prose change.
+
+## Consequences
+
+- Routine implementation work no longer triggers an AgDR, so it no longer triggers the downstream Tech Lead / Solution Architect activations that produced the reported handover loop.
+- The threshold remains **wider than the hooks** by design — it covers judgment-visible decisions (technology, security posture, cross-cutting patterns) that no path glob can detect. Prose and mechanism are now consistent in *spirit* without pretending to be identical in *scope*.
+- Rex's blocking AgDR check was narrowed to match; leaving it at the old bar would have silently cancelled this change at review time.
+- Residual risk: a genuinely material decision judged "routine" and left unrecorded. Mitigated by rail 2, the unchanged mechanical hooks, and Rex's review pass. The tolerated failure is an occasional unnecessary AgDR — never a silently unrecorded architectural call.
+- This AgDR exists because the new rule, applied to itself, says it should: changing the portfolio's decision-recording policy is cross-cutting. AgDR-0107 was scoped to *review* tiering; the *recording* threshold is a distinct policy call, so it gets its own record rather than inheriting one.
+
+## Artifacts
+
+- me2resh/apexyard#997 — the ticket
+- me2resh/apexyard#998 — this PR
+- [AgDR-0107](AgDR-0107-right-size-ceremony.md) — right-size-ceremony, the review-tiering sibling
+- me2resh/apexyard#995 / #996 — the role-trigger convergence fix this change stops undermining

--- a/docs/rule-audit.md
+++ b/docs/rule-audit.md
@@ -82,7 +82,7 @@ Columns:
 
 | rule | source | enforced by | mechanizable? | proposed hook / reason advisory |
 |------|--------|-------------|---------------|---------------------------------|
-| HARD STOP — run `/decide` before any technical decision | `.claude/rules/agdr-decisions.md § Trigger Patterns` | prose (self-discipline) | no | trigger patterns are chat-output phrases; linting assistant prose was rejected for the same reason as in `ticket-vocabulary.md` [^self-discipline] |
+| HARD STOP — run `/decide` before a **material** technical decision (architectural, hard to reverse, or cross-cutting) | `.claude/rules/agdr-decisions.md § The threshold` | prose (self-discipline) | no | the threshold is a judgment about blast radius, not a lintable chat-output phrase; linting assistant prose was rejected for the same reason as in `ticket-vocabulary.md` [^self-discipline]. Narrowed from "any technical decision" in [#997][997] — the blanket form manufactured the AgDR→Tech-Lead→Solution-Architect handover churn fixed in [#995][995] |
 | AgDR required for architecture / infra commits | `.claude/rules/agdr-decisions.md § Enforcement` | `require-agdr-for-arch-changes.sh` | yes | mechanized (AgDR-0001); narrow default path list, project-config override via `.architecture_paths` |
 | AgDR required at PR time when diff touches architecture paths OR adds a new dependency | `.claude/rules/agdr-decisions.md § Enforcement` | `require-agdr-for-arch-pr.sh` | yes | mechanized ([#112][112]); fires on `gh pr create`, config via `.agdr_trigger_paths[]` + `.agdr_trigger_dep_files[]`; skip marker `<!-- agdr: not-applicable -->` bypasses with a visible warning |
 | Extend default `architecture_paths` to cover SAM / Helm / K8s / Serverless Framework | — | — | deferred | [#25][25] — default list is deliberately narrow; follow-up broadens safely |
@@ -202,3 +202,5 @@ The spread confirms what AgDR-0001 set out to make true: the **high-blast-radius
 [107]: https://github.com/me2resh/apexyard/issues/107
 [110]: https://github.com/me2resh/apexyard/issues/110
 [112]: https://github.com/me2resh/apexyard/issues/112
+[995]: https://github.com/me2resh/apexyard/issues/995
+[997]: https://github.com/me2resh/apexyard/issues/997


### PR DESCRIPTION
## Summary

- **Closes the last leg of the over-process fix** that #994 (right-size-ceremony) and #996 (role-trigger convergence) started. `agdr-decisions.md` opened with *"HARD STOP: before making **any** technical decision"* and listed triggers like *"Pick an implementation approach"* and *"Am I about to write code that introduces a new pattern?"* — a bar that covers essentially every implementation choice a person makes.
- **This rule was actively feeding the loop we just fixed.** Every AgDR written lands a file under `docs/agdr/**`, which re-fires the Tech Lead activation trigger (and, for migration AgDRs, the Solution Architect trigger too). So an over-broad AgDR rule *manufactures* the AgDR → backend → devops churn the reporting user described. Narrowing it is what stops #996's fix from being undermined by the rule sitting next to it.
- **The load-bearing finding: the prose demanded far more than anything actually enforced.** The two hooks are bounded and fire at different moments — `require-agdr-for-arch-changes.sh` at commit time on `*.tf`/`*.tfvars`, `Dockerfile*`, `docker-compose*`, `.github/workflows/**`; `require-agdr-for-arch-pr.sh` at PR-create time on `**/domain/**`, `**/infrastructure/**`, `**/migrations/**`, `infrastructure/**`, `template.yaml`, IaC globs, **plus dependency *additions*** to `package.json` / `pyproject.toml` / `Cargo.toml` / `go.mod` / `Gemfile`. `CLAUDE.md` already said *"significant"*. Only the rule file said **any**. A rule far broader than anything anyone would enforce doesn't produce more records — it produces ignored prose and burns the ceremony budget. This aligns the prose to reality, and documents both hooks accurately (including that the commit-time hook *deliberately omits* a bare `infrastructure/` pattern because it false-positived on `docs/infrastructure/notes.md` — a drift that survives only in a stale header comment).
- **What the rule now says** — an explicit **materiality threshold** (new dependency/technology, new service or integration, data-model or schema change, security-relevant control, CI/CD-release-infra design, repo-wide pattern, anything hard to reverse) sitting next to a concrete **"does NOT need an AgDR"** list (local naming, extracting a helper, control flow, test structure, calling an API from a dependency already in the manifest). The old *"could you explain the trade-off?"* heuristic is demoted to a **writing aid** rather than a trigger, because almost every line of code has an unexplained alternative — which is precisely why it over-fired.
- **Both safety rails survive intact**: security / trust chain / migrations are **never** exempt regardless of diff size, and genuine ambiguity **rounds up** to writing the record. The tolerated failure stays "an occasional unnecessary AgDR", never "a silently unrecorded architectural call."
- **Rex's blocking check was narrowed to match** — `code-reviewer.md` § 7, its enforcement rule 2, and Rules #7 all said *"a technical decision"* unqualified, which would have kept flagging PRs at the old bar and quietly cancelled this change. Its detection table was already material-shaped and is untouched.
- **AgDR-0108 records the policy call.** Applying the new rule to itself: changing the portfolio's decision-*recording* policy is cross-cutting, and AgDR-0107 is scoped to review *tiering* — a distinct call, so it gets its own record rather than inheriting one.

## Testing

1. **No mechanical behaviour changed** — the diff is prose plus one new AgDR. No hook, `settings.json`, gate, or marker logic.
2. `npx markdownlint-cli2` — **0 issues**; CI markdownlint, hook test suite, Analyze, and Verify Ticket ID all green.
3. Hook trigger sets in the new table were **re-derived from source** (`ARCH_GLOBS` and `TRIGGER_PATHS` / `TRIGGER_DEP_FILES`), not from header comments — the first revision of this PR was misled by a stale comment, which is exactly why the rule now documents the drift.
4. All intra-repo links verified to resolve; `[995]` / `[997]` reference-style link definitions added to `docs/rule-audit.md` per that file's convention.

**Deliberately deferred to #999** (Heavy path — `.claude/hooks/**` is rail-1 trust chain, so it needs the Security Auditor, not a tack-on to a prose PR): `require-agdr-for-arch-pr.sh` still prints the old "any technical decision" wording in its agent-facing block message, plus two dangling citations and the stale header comment that caused the detour above.

Fixes #997

---

## Glossary

| Term | Definition |
|------|------------|
| AgDR | Agent Decision Record — the lightweight decision log written to `docs/agdr/AgDR-NNNN-*.md`, capturing options considered and why one won. |
| Materiality threshold | The line separating decisions worth a durable record (architectural, hard to reverse, cross-cutting) from routine choices reversible inside a single PR. The core of this change. |
| Prose↔hook gap | When a written rule demands far more than its mechanical enforcement checks. The gap this PR closes. |
| Documented drift | A comment describing behaviour the code no longer has — here, the commit-time hook's `infrastructure/**` mention, recorded as known but still live enough to mislead this PR's first revision. |
| Safety rails | From right-size-ceremony: (1) security / trust-chain / migration never takes the lighter path; (2) ambiguity rounds up a tier. |
| Ceremony budget | The finite tolerance a session has for process steps before they crowd out the work — the resource an over-broad rule spends without buying safety. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KGiYPZB3US1LrQ9GS9vXe
