### PR TITLE
chore(#999): align .claude/hooks AgDR wording with materiality threshold

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -170,7 +170,7 @@ All path patterns use the `(^|/)` anchor so they catch **monorepo layouts** (`ba
 
 **Not in the default list (known gap):** CDK / Pulumi / generic-IaC projects that use plain `.ts` / `.py` / `.go` files inside an `infrastructure/` directory. The original draft had a generic `(^|/)infrastructure/` pattern for this, but testing showed it false-positives on `docs/infrastructure/notes.md` and `src/types/infrastructure/foo.ts` — the word "infrastructure" is ambiguous as a directory name. Projects that want CDK-style coverage should add an explicit override like `(^|/)infrastructure/.*\.(ts|py|go)$` via `.architecture_paths`.
 
-**Enforces:** `.claude/rules/agdr-decisions.md § Enforcement` — specifically the line "Pre-commit hook warns if architecture files changed without an AgDR reference", which was prose-only until this hook shipped.
+**Enforces:** `.claude/rules/agdr-decisions.md § "Enforcement — and the honest limits of it"` — this hook is the mechanical, commit-time backstop for the materiality threshold defined in § "The threshold"; the rule was prose-only until this hook shipped.
 
 ### 8. Design-review-for-UI merge gate — `require-design-review-for-ui.sh`
 

--- a/.claude/hooks/require-agdr-for-arch-changes.sh
+++ b/.claude/hooks/require-agdr-for-arch-changes.sh
@@ -4,20 +4,23 @@
 #   (a) an AgDR reference in the commit message (AgDR-NNNN / docs/agdr/AgDR-…), OR
 #   (b) a new AgDR file in the staged changes (docs/agdr/AgDR-NNNN-*.md)
 #
-# Enforces .claude/rules/agdr-decisions.md § "Pre-commit hook warns if
-# architecture files changed without an AgDR reference" — which was prose-only
-# until this hook shipped.
+# Enforces .claude/rules/agdr-decisions.md § "Enforcement — and the honest
+# limits of it" — this hook is the mechanical, commit-time half of that
+# table; the rule itself was prose-only until this hook shipped.
 #
-# What counts as "architecture":
-#   - infrastructure/**              (terraform, pulumi, cdk, cfn)
-#   - *.tf, *.tfvars                 (terraform)
+# What counts as "architecture" (a conservative proxy for the materiality
+# threshold in agdr-decisions.md § "The threshold" — CI/CD or infra design,
+# in this hook's case):
+#   - *.tf, *.tfvars                   (terraform, at any depth)
 #   - docker-compose*.yml, Dockerfile* (container orchestration)
-#   - .github/workflows/**           (CI/CD pipeline changes)
+#   - .github/workflows/**             (CI/CD pipeline changes)
 #
-# Deliberately NARROW. Dependency bumps (package.json, go.mod, etc.) and API
-# schema changes are NOT included — too noisy, not all changes need an AgDR.
-# Projects that want a broader list can override via
-# .claude/project-config.json `.architecture_paths` (a JSON array of globs).
+# Deliberately NARROW, and deliberately does NOT include a bare
+# `infrastructure/**` pattern — see the false-positive note below ARCH_GLOBS.
+# Dependency bumps (package.json, go.mod, etc.) and API schema changes are
+# also NOT included — too noisy, not all changes need an AgDR. Projects that
+# want a broader list can override via .claude/project-config.json
+# `.architecture_paths` (a JSON array of globs).
 #
 # Multi-line -m messages are handled the same way as verify-commit-refs.sh:
 # flatten newlines before sed parsing.

--- a/.claude/hooks/require-agdr-for-arch-pr.sh
+++ b/.claude/hooks/require-agdr-for-arch-pr.sh
@@ -592,11 +592,14 @@ fi
   cat <<'MSG'
 
 Why this is blocked:
-  .claude/rules/agdr-decisions.md calls /decide a HARD STOP before any
-  technical decision — library choice, architecture move, new dependency,
-  infra shape. Other HARD STOPs in the ruleset (merge approval, ticket-
-  first, migration-first) are mechanically enforced at PR time; this one
-  closes the gap.
+  .claude/rules/agdr-decisions.md § "The threshold" calls /decide a HARD
+  STOP before any MATERIAL technical decision — a new dependency/technology,
+  a new service/integration, a data-model or schema change, a security-
+  relevant control, CI/CD or infra design, a repo-wide pattern, or anything
+  hard to reverse. This PR's diff matched one of the trigger paths/dep-file
+  patterns below, which are a conservative proxy for that bar. Other HARD
+  STOPs in the ruleset (merge approval, ticket-first, migration-first) are
+  mechanically enforced at PR time; this one closes the gap.
 
 To unblock:
   1. Run /decide to walk through the decision and generate an AgDR file


### PR DESCRIPTION
## Summary
- **Un-contradicts the block message agents see most often** — `require-agdr-for-arch-pr.sh` used to tell an agent hitting the gate that `/decide` is a HARD STOP "before any technical decision"; that's the exact framing #997/#998 (AgDR-0108) demoted to a materiality threshold, so the hook was actively contradicting the rule it enforces at the moment an agent decides what to do next. It now cites `agdr-decisions.md § "The threshold"` and spells out the material triggers (new dependency/technology, new service/integration, data-model/schema change, security-relevant control, CI/CD or infra design, repo-wide pattern, anything hard to reverse).
- **Fixes two dangling citations** — `require-agdr-for-arch-changes.sh`'s header and `hooks/README.md` both pointed at `agdr-decisions.md § "Pre-commit hook warns if architecture files changed without an AgDR reference"`, a section title that no longer exists post-#998. Both now cite the current `§ "Enforcement — and the honest limits of it"` section.
- **Removes a self-contradiction inside `require-agdr-for-arch-changes.sh` itself** — its own "what counts as architecture" header comment listed `infrastructure/**` as a trigger, while the `ARCH_GLOBS` variable 50 lines below it (and the file's own later comment) deliberately excludes that pattern because of documented false-positives (`docs/infrastructure/notes.md`, `src/types/infrastructure/foo.ts`). #998 was misled by exactly this drift per the ticket; the header now matches `ARCH_GLOBS`.

**Wording only.** No trigger path, glob, exit code, or gate logic changed — verified by diff review; only comments and printed message text moved.

## Testing
1. `bash -n .claude/hooks/require-agdr-for-arch-pr.sh` / `bash -n .claude/hooks/require-agdr-for-arch-changes.sh` — both pass (no syntax breakage from the text edits).
2. `bash .claude/hooks/tests/test_require_agdr_for_arch_pr.sh` — 20/21 pass. The one failure (`spike active-ticket marker (arch change, non-spike branch + title)`) reproduces identically on a clean `upstream/dev` checkout with none of this PR's changes applied (verified via `git stash` before/after) — pre-existing, unrelated to this change.
3. No dedicated test file exists for `require-agdr-for-arch-changes.sh` (commit-time hook) or `hooks/README.md`; both are comment/prose-only edits, so nothing beyond the syntax check applies. Did not run the full `.claude/hooks/tests/` suite (avoiding a long-running command per the current session's time-budget note) — CI is the gate for the rest of the suite.

Fixes #999.

## Glossary
| Term | Definition |
|------|------------|
| Materiality threshold | The current bar from AgDR-0108/`agdr-decisions.md`: an AgDR is required for decisions that are architectural, hard to reverse, or cross-cutting — not for every reversible implementation choice. |
| `ARCH_GLOBS` | The shell variable in `require-agdr-for-arch-changes.sh` holding the actual regex patterns the commit-time hook matches against staged files — the source of truth this PR realigns the header comment to. |
| Dangling citation | A comment or message that references a section title/line that used to exist but was renamed or removed by a later change — the trap `#998` fell into when it acted on outdated section text. |
| Trust chain | `.claude/hooks/**` + `.claude/settings.json` — the merge-gate and marker machinery the framework's SDLC guarantees rest on; changes here take the Heavy review path regardless of diff size (rail 1 of right-size-ceremony). |
