### PR TITLE
fix(#1000): narrow warn-review-marker-write.sh to actual write intent

### DIFF
--- a/.claude/hooks/tests/test_warn_review_marker_write.sh
+++ b/.claude/hooks/tests/test_warn_review_marker_write.sh
@@ -224,6 +224,14 @@ bash_json() {
   local cmd="${1//\"/\\\"}"
   printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$cmd"
 }
+# Like bash_json, but COMMAND may contain literal newlines (a real heredoc)
+# -- JSON-escapes embedded double quotes AND newlines so the payload is
+# valid JSON that decodes back to a real multi-line command (#1000-round2).
+bash_json_multiline() {
+  local cmd="${1//\"/\\\"}"
+  cmd="${cmd//$'\n'/\\n}"
+  printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$cmd"
+}
 
 # ---------------------------------------------------------------------------
 # (1) Write → rex marker, no active-reviewer marker → BLOCKED, exit 2
@@ -699,6 +707,115 @@ case34() {
   rm -rf "$sb"
 }
 
+# ---------------------------------------------------------------------------
+# (35) Bash → `python3 <<EOF` interpreter heredoc writing directly to a real
+#      rex marker, no active-reviewer marker -> BLOCKED, exit 2.
+#      #1000-round2 finding 1 (Rex's PR #1011 review): the FIRST version of
+#      this fix stripped heredoc bodies before the fallback scan, reasoning
+#      all heredoc content is data. For an INTERPRETER heredoc the body is
+#      CODE naming the destination, and interpreter writes yield no
+#      extractable target -- stripping removed the only evidence left,
+#      silently ALLOWING marker creation from scratch. Fixed by not
+#      stripping at all (see the hook's #1000-REX-ROUND-2 comment).
+# ---------------------------------------------------------------------------
+case35() {
+  local sb; sb=$(make_sandbox)
+  local marker; marker=$(review_marker_path "$REPO" 42 rex "$sb")
+  local cmd
+  cmd=$(printf 'python3 <<EOF\nopen("%s","w").write("sha123")\nEOF' "$marker")
+  run_hook "$sb" "Bash python3 heredoc write to rex marker, no marker -> BLOCKED (#1000-round2 F1)" \
+    "$(bash_json_multiline "$cmd")" 2 "BLOCKED"
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (36) Bash → `bash <<EOF` wrapping an inner `python3 -c` write to a real rex
+#      marker -> BLOCKED, exit 2. `bash` fed a heredoc isn't itself one of
+#      the shared lib's named interpreter matchers (only python/node/ruby
+#      heredoc forms are) -- this shape is caught because target extraction
+#      runs on the unstripped command and the inner write is still visible.
+#      Guards against re-introducing any body-stripping in the future.
+# ---------------------------------------------------------------------------
+case36() {
+  local sb; sb=$(make_sandbox)
+  local marker; marker=$(review_marker_path "$REPO" 42 rex "$sb")
+  local cmd
+  cmd=$(printf 'bash <<EOF\npython3 -c '"'"'open("%s","w").write("sha123")'"'"'\nEOF' "$marker")
+  run_hook "$sb" "Bash bash-heredoc wrapping python3 -c write to rex marker -> BLOCKED (#1000-round2 F2)" \
+    "$(bash_json_multiline "$cmd")" 2 "BLOCKED"
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (37) Bash → the IDENTICAL python3 -c write INLINE (no heredoc) -> BLOCKED,
+#      exit 2. Control for cases 35/36: same write, same target, no
+#      heredoc -- confirms the interpreter-write detection itself was never
+#      broken; only the (now-removed) heredoc-body strip regressed it.
+# ---------------------------------------------------------------------------
+case37() {
+  local sb; sb=$(make_sandbox)
+  local marker; marker=$(review_marker_path "$REPO" 42 rex "$sb")
+  local cmd
+  cmd=$(printf 'python3 -c '"'"'open("%s","w").write("sha123")'"'"'' "$marker")
+  run_hook "$sb" "Bash inline python3 -c write to rex marker (heredoc control) -> BLOCKED" \
+    "$(bash_json "$cmd")" 2 "BLOCKED"
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (38) Bash → BSD-form `sed -i '' s/aa/bb/ <marker>` rewriting a real rex
+#      marker's stale SHA -> BLOCKED, exit 2.
+#      #1000-round2 finding 2 (Rex's PR #1011 review): bash_extract_
+#      write_target's positional heuristic for `sed -i` assumes GNU's
+#      single-quoted-script form. BSD's two-token form (empty-string backup
+#      suffix, unquoted script) makes it return the SED EXPRESSION as "the
+#      target" -- literal, non-marker, non-variable, so the per-target loop
+#      treated it as conclusive and skipped the REAL marker file, silently
+#      ALLOWING a stale marker to be rewritten with a current SHA (defeating
+#      "new commits invalidate approval"). Fixed via IS_EXTRACTION_FRAGILE.
+# ---------------------------------------------------------------------------
+case38() {
+  local sb; sb=$(make_sandbox)
+  local marker; marker=$(review_marker_path "$REPO" 42 rex "$sb")
+  printf '%s\n' "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" > "$marker"
+  local cmd="sed -i '' s/aa/bb/ ${marker}"
+  run_hook "$sb" "Bash BSD sed -i '' mis-extracted target on rex marker -> BLOCKED (#1000-round2 finding2)" \
+    "$(bash_json "$cmd")" 2 "BLOCKED"
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (39) Bash → GNU-form `sed -i s/aa/bb/ <marker>` on a real rex marker ->
+#      BLOCKED, exit 2. Regression guard: GNU's single-token form returns
+#      EMPTY targets from bash_extract_write_target and already reached the
+#      general fallback before this fix -- confirms finding 2's fix doesn't
+#      change (or depend on masking) the already-correct GNU behaviour.
+# ---------------------------------------------------------------------------
+case39() {
+  local sb; sb=$(make_sandbox)
+  local marker; marker=$(review_marker_path "$REPO" 42 rex "$sb")
+  printf '%s\n' "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" > "$marker"
+  local cmd="sed -i s/aa/bb/ ${marker}"
+  run_hook "$sb" "Bash GNU sed -i on rex marker -> BLOCKED (regression guard)" \
+    "$(bash_json "$cmd")" 2 "BLOCKED"
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (40) Bash → `sed -i ''` editing a NON-marker file -> NOT blocked, exit 0.
+#      Negative control: IS_EXTRACTION_FRAGILE widens the fallback scan
+#      for sed -i / awk -i inplace commands, but must not turn EVERY sed -i
+#      invocation into a block -- only ones that actually touch a marker
+#      path (literal or reviews/-dir-mentioning) do.
+# ---------------------------------------------------------------------------
+case40() {
+  local sb; sb=$(make_sandbox)
+  local cmd="sed -i '' s/foo/bar/ /tmp/scratch/notes.txt"
+  run_hook "$sb" "Bash sed -i on non-marker file -> NOT blocked (negative control)" \
+    "$(bash_json "$cmd")" 0
+  rm -rf "$sb"
+}
+
 case1
 case2
 case3
@@ -733,6 +850,12 @@ case31
 case32
 case33
 case34
+case35
+case36
+case37
+case38
+case39
+case40
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/.claude/hooks/tests/test_warn_review_marker_write.sh
+++ b/.claude/hooks/tests/test_warn_review_marker_write.sh
@@ -70,6 +70,38 @@
 #                 the sanctioned idiom), matching active-reviewer marker
 #                                                                  → ALLOWED, exit 0 (no regression)
 #
+# #1000 test matrix (narrow detection to actual write intent — see the
+# hook's own #1000 header comment for the three false-positive shapes this
+# closes, and why #962/#970's resolved-target work was incomplete):
+#   (29) Bash   → `rm -f` of active-reviewer, bundled with an unrelated
+#                 command (the documented orchestrator cleanup step)
+#                                                                  → NOT blocked, exit 0
+#   (30) Bash   → purely READ-ONLY command (git show | grep) whose quoted
+#                 grep PATTERN argument contains the substring "rm -f"
+#                 (a segmentation false-positive in the shared file-mover
+#                 matcher, not a real rm)                          → NOT blocked, exit 0
+#   (31) Bash   → heredoc write to a non-marker scratch path whose BODY
+#                 content quotes "$marker" and "active-reviewer" in prose
+#                                                                  → NOT blocked, exit 0
+#   (32) Bash   → the orchestrator's documented SET step (printf > literal
+#                 active-reviewer path) — previously ALSO a false block,
+#                 since role can never resolve for a plain printf
+#                                                                  → NOT blocked, exit 0
+#   (33) Bash   → `rm` bundled with a REAL literal marker forgery in the
+#                 same command (rm -f active-reviewer; printf sha >
+#                 <real marker path>)                              → BLOCKED, exit 2
+#                 (confirms the #1000 deletion-only exemption doesn't
+#                 swallow a genuine forgery riding alongside it)
+#   (34) Bash   → `rm` of a REAL *.approved marker file (not
+#                 active-reviewer) — deliberate narrowing: deletion can
+#                 only remove evidence, it cannot forge approval content
+#                                                                  → NOT blocked, exit 0 (documented behaviour change)
+#
+# Cases (1), (3), (4), (11), (20), (21), (23) already re-verify the
+# target-based literal/indirect detection still catches every genuine
+# forgery shape after #1000's narrowing (unchanged pass/fail expectations
+# — see the top-of-file test matrix) — not duplicated here.
+#
 # Exit 0 if all cases pass; 1 on failure.
 
 set -u
@@ -578,6 +610,95 @@ case28() {
   rm -rf "$sb"
 }
 
+# ---------------------------------------------------------------------------
+# (29) Bash → `rm -f` of active-reviewer, bundled with an unrelated command
+#      (the documented orchestrator cleanup step from code-review/SKILL.md
+#      § 0) -> NOT blocked, exit 0 (#1000 point 1).
+# ---------------------------------------------------------------------------
+case29() {
+  local sb; sb=$(make_sandbox)
+  local ar="$sb/.claude/session/active-reviewer"
+  run_hook "$sb" "Bash rm -f active-reviewer bundled with unrelated command -> NOT blocked (#1000)" \
+    "$(bash_json "rm -f ${ar} && gh pr checks 996")" 0
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (30) Bash → purely READ-ONLY command (git show | grep) whose quoted grep
+#      PATTERN argument contains the substring "rm -f" — a segmentation
+#      false-positive in the shared file-mover matcher (which can't see
+#      quoting), not a real rm -> NOT blocked, exit 0 (#1000 point 1).
+# ---------------------------------------------------------------------------
+case30() {
+  local sb; sb=$(make_sandbox)
+  local cmd='git show upstream/dev:.claude/hooks/warn-review-marker-write.sh | grep -nE "approved|rm -f|active-reviewer"'
+  run_hook "$sb" "Bash read-only grep pipeline with quoted 'rm -f' substring -> NOT blocked (#1000)" \
+    "$(bash_json "$cmd")" 0
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (31) Bash → heredoc write to a non-marker scratch path whose BODY content
+#      quotes "$marker" and "active-reviewer" in prose (a review body
+#      explaining the gate, not code targeting one) -> NOT blocked, exit 0
+#      (#1000 point 2 — judge the resolved target, not the payload).
+# ---------------------------------------------------------------------------
+case31() {
+  local sb; sb=$(make_sandbox)
+  local json
+  # shellcheck disable=SC2016 # deliberate — the $marker text is literal
+  # heredoc BODY payload, not a real expansion (that's the whole point of
+  # this test case: prose content, not code).
+  json='{"tool_name":"Bash","tool_input":{"command":"cat > /tmp/scratch/review-body.md <<'"'"'EOF'"'"'\nThe hook checks the $marker token before writing the file.\nAlso mentions active-reviewer in prose.\nEOF\necho done"}}'
+  run_hook "$sb" "Bash heredoc write to scratch path, body mentions \$marker/active-reviewer -> NOT blocked (#1000)" \
+    "$json" 0
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (32) Bash → the orchestrator's documented SET step (printf > literal
+#      active-reviewer path, code-review/SKILL.md § 0) — previously ALSO a
+#      false block, since role can never resolve for a plain printf ->
+#      NOT blocked, exit 0 (#1000 point 3).
+# ---------------------------------------------------------------------------
+case32() {
+  local sb; sb=$(make_sandbox)
+  local ar="$sb/.claude/session/active-reviewer"
+  local cmd="printf '%s\n' \"${REPO}#1000:rex\" > \"${ar}\""
+  run_hook "$sb" "Bash SET step (printf > active-reviewer) -> NOT blocked (#1000)" \
+    "$(bash_json "$cmd")" 0
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (33) Bash → `rm` bundled with a REAL literal marker forgery in the same
+#      command (rm -f active-reviewer; printf sha > <real marker path>) ->
+#      BLOCKED, exit 2. Confirms the #1000 deletion-only exemption doesn't
+#      swallow a genuine forgery riding alongside an rm.
+# ---------------------------------------------------------------------------
+case33() {
+  local sb; sb=$(make_sandbox)
+  local ar="$sb/.claude/session/active-reviewer"
+  local marker; marker=$(review_marker_path "$REPO" 42 rex "$sb")
+  run_hook "$sb" "Bash rm + real marker forgery in same command -> still BLOCKED (#1000)" \
+    "$(bash_json "rm -f ${ar}; printf sha123 > ${marker}")" 2 "BLOCKED"
+  rm -rf "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# (34) Bash → `rm` of a REAL *.approved marker file (not active-reviewer) ->
+#      NOT blocked, exit 0. Deliberate, documented narrowing: deletion can
+#      only remove evidence, it cannot forge approval content (#1000).
+# ---------------------------------------------------------------------------
+case34() {
+  local sb; sb=$(make_sandbox)
+  local marker; marker=$(review_marker_path "$REPO" 42 rex "$sb")
+  : > "$marker"
+  run_hook "$sb" "Bash rm of a real *.approved marker -> NOT blocked (#1000 narrowing)" \
+    "$(bash_json "rm ${marker}")" 0
+  rm -rf "$sb"
+}
+
 case1
 case2
 case3
@@ -606,6 +727,12 @@ case25
 case26
 case27
 case28
+case29
+case30
+case31
+case32
+case33
+case34
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/.claude/hooks/warn-review-marker-write.sh
+++ b/.claude/hooks/warn-review-marker-write.sh
@@ -276,53 +276,40 @@ _is_marker_target() {
 #
 # Called two ways (both #1000):
 #   - per WRITE TARGET (a short string) — the primary, precise path
-#   - as a fallback over the whole command with heredoc bodies stripped
-#     (`_strip_heredoc_bodies`) — only when no clean literal target was
-#     found, so payload prose can't masquerade as destination code
+#   - as a fallback over the whole, UNSTRIPPED command — only when no clean
+#     literal target was found, or an extracted target is itself
+#     variable-derived
+#
+# #1000-REX-ROUND-2 (Rex's PR #1011 review, finding 3): an earlier version
+# of this fix stripped heredoc BODY content before running the fallback
+# scan, reasoning that heredoc content is always DATA, never destination-
+# determining code. That reasoning is correct for a heredoc fed to a plain
+# data-writing command (`cat > file <<EOF`) but WRONG for a heredoc fed to
+# an INTERPRETER (`python3 <<EOF`, `node <<EOF`, `bash <<EOF`) — there the
+# body IS the code that names the write destination, and interpreter
+# writes yield no extractable target in the first place (see
+# `_bdw_match_python_heredoc` / `_bdw_match_node_heredoc` / etc. in the
+# shared lib — they detect the write but extraction can't recover a
+# target). Stripping the body before the fallback ran removed the ONLY
+# evidence left to scan, so `python3 <<EOF ... open("<marker>","w")... EOF`
+# went from BLOCKED (pre-#1000) to silently ALLOWED — a marker-creation
+# bypass. Verified: removing the strip (scanning the raw, unstripped
+# command here) returns all three interpreter-heredoc shapes to BLOCKED,
+# and all 36 existing tests — including the scratchpad-heredoc false
+# positive this strip was originally written for (case 31) — still pass.
+# Case 31 was never carried by the strip: its target
+# (`/tmp/scratch/review-body.md`) is a clean, non-marker literal, so the
+# per-target loop already resolves it as conclusive and never reaches this
+# fallback at all. The strip was solving an already-solved problem while
+# opening a new one — removed rather than special-cased per interpreter,
+# since enumerating every interpreter (and `bash <<EOF` isn't even one of
+# the shared lib's named interpreter matchers) is a losing race.
 _is_marker_plausible_indirect() {
   local text="$1"
   if echo "$text" | grep -qE 'review_marker_path|\.claude/session/reviews/'; then
     return 0
   fi
   echo "$text" | grep -qiE '\$\{?[a-z_]*marker[a-z_]*\}?'
-}
-
-# _strip_heredoc_bodies TEXT (#1000)
-#
-# Removes heredoc BODY content (the lines between a `<<[-]DELIM` marker and
-# its closing DELIM line) from TEXT, keeping the marker line itself and
-# everything outside the heredoc untouched. Heredoc content is DATA a
-# command writes, never code that determines WHERE it writes — scanning it
-# for marker-shaped substrings is how a review body that merely QUOTES the
-# hook's own `$marker` token in prose used to trip the indirect-write
-# fallback scan (see #1000 header comment, point 2). Best-effort: handles
-# the common `<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF` forms. An unparseable
-# or absent heredoc is a no-op (TEXT returned unchanged).
-_strip_heredoc_bodies() {
-  local text="$1"
-  awk '
-    BEGIN { in_hd = 0; delim = "" }
-    {
-      line = $0
-      if (in_hd) {
-        check = line
-        gsub(/^\t+/, "", check)
-        if (check == delim) { in_hd = 0 }
-        next
-      }
-      if (match(line, /<<-?[[:space:]]*[\x27\x22]?[A-Za-z_][A-Za-z0-9_]*[\x27\x22]?/)) {
-        tok = substr(line, RSTART, RLENGTH)
-        d = tok
-        sub(/^<<-?[[:space:]]*/, "", d)
-        gsub(/[\x27\x22]/, "", d)
-        delim = d
-        in_hd = 1
-        print line
-        next
-      }
-      print line
-    }
-  ' <<< "$text"
 }
 
 # _extract_marker_role COMMAND (#962)
@@ -394,12 +381,26 @@ case "$TOOL_NAME" in
       fi
 
       if [ "$IS_WRITE" = "1" ]; then
-        # #1000 point 2: judge the RESOLVED WRITE TARGET(S), not the
-        # command's prose. A heredoc BODY, a --body argument, or any other
-        # payload text a command writes is DATA, never the destination.
-        SCAN_TEXT=$(_strip_heredoc_bodies "$COMMAND")
+        # #1000 point 2: judge the RESOLVED WRITE TARGET(S) first, not the
+        # command's prose — see the #1000-REX-ROUND-2 note on
+        # _is_marker_plausible_indirect for why no text-stripping happens
+        # here (heredoc-stripping was tried and reverted: it opened an
+        # interpreter-heredoc bypass without closing anything the
+        # target-based logic wasn't already closing).
         WRITE_TARGETS=$(bash_extract_write_targets "$COMMAND")
         HAS_VAR_TARGET=0
+
+        # #1000-REX-ROUND-2 finding 4: `sed -i` / `awk -i inplace` have a
+        # known-fragile positional-argument extraction heuristic (BSD
+        # `sed -i ''` in particular — see the fuller comment below, where
+        # this flag is consumed). Computed up front so it can widen BOTH
+        # the immediate literal re-check AND the general fallback trigger,
+        # not just the first — a variable-indirected marker path (case24's
+        # `$DIR/mystery.approved` shape) combined with a BSD sed -i
+        # mis-extraction would otherwise still slip past both checks.
+        IS_EXTRACTION_FRAGILE=0
+        echo "$COMMAND" | grep -qE '\bsed[[:space:]]+([^|;&]*[[:space:]])?-i\b|\bawk[[:space:]]+[^|;&]*-i[[:space:]]+inplace\b' && IS_EXTRACTION_FRAGILE=1
+
         if [ -n "$WRITE_TARGETS" ]; then
           while IFS= read -r wt; do
             [ -z "$wt" ] && continue
@@ -423,27 +424,65 @@ $WRITE_TARGETS
 EOF_TARGETS
         fi
 
-        if [ "$MATCHED" != "1" ] && { [ -z "$WRITE_TARGETS" ] || [ "$HAS_VAR_TARGET" = "1" ]; }; then
-          # Fallback broader scan — only reached when either (a) no target
-          # was extractable at all (an embedded interpreter with an opaque
-          # write target this library can't parse), or (b) at least one
+        # #1000-REX-ROUND-2 (Rex's PR #1011 review, finding 4): the
+        # "a clean literal, non-marker, non-variable extracted target is
+        # conclusive" shortcut above assumes bash_extract_write_target's
+        # positional heuristic got the target RIGHT. For `sed -i` it can
+        # be WRONG rather than merely empty: BSD's two-token form
+        # (`sed -i '' 's/a/b/' <file>`, or the unquoted `sed -i '' s/a/b/
+        # <file>`) makes the extractor return the SED EXPRESSION as "the
+        # target" — a literal, non-marker, non-variable string that then
+        # makes the extractor's wrong answer look conclusive and skips
+        # the REAL marker file the command actually mutates in place.
+        # Demonstrated: `sed -i '' s/aa/bb/ <marker>` rewrites a stale
+        # marker's SHA to the current HEAD, defeating the "new commits
+        # invalidate approval" property this whole gate exists to
+        # protect. GNU `sed -i` (single-token form) returns EMPTY targets
+        # instead and already reaches the general fallback below — this
+        # is specific to the extraction-fragile two-token form.
+        #
+        # Scoped narrowly via IS_EXTRACTION_FRAGILE (computed above from a
+        # pattern mirroring `_bdw_match_sed_inplace`/`_bdw_match_awk_
+        # inplace`, duplicated here rather than imported so the shared
+        # library stays untouched, per the #1000 blast-radius containment
+        # call) — NOT applied to every write: a plain `echo "mentions
+        # <marker path> for context" > /tmp/notes.txt` must stay allowed
+        # (#1000 point 2) — that's a real target the per-target loop
+        # already resolved as conclusive, and it isn't a sed/awk in-place
+        # edit.
+        if [ "$MATCHED" != "1" ] && [ "$IS_EXTRACTION_FRAGILE" = "1" ] && _is_marker_target "$COMMAND"; then
+          MATCHED=1
+          TARGET=$(echo "$COMMAND" | grep -oE '\.claude/session/reviews/[^[:space:]"'"'"']+-(rex|ceo|security|architecture)\.approved' | head -1)
+          RESOLVED_VIA="literal"
+        fi
+
+        if [ "$MATCHED" != "1" ] && { [ -z "$WRITE_TARGETS" ] || [ "$HAS_VAR_TARGET" = "1" ] || [ "$IS_EXTRACTION_FRAGILE" = "1" ]; }; then
+          # Fallback broader scan — only reached when (a) no target was
+          # extractable at all (an embedded interpreter with an opaque
+          # write target this library can't parse), (b) at least one
           # extracted target is itself variable-derived (e.g.
           # `$DIR/mystery.approved`, built from a variable that a PRIOR
           # statement — not the target text itself — assigns from a
           # reviews-dir literal) and so might still resolve to a marker
-          # even though the target text alone didn't say so. Runs over
-          # heredoc-stripped text so payload prose can't trip it (#1000
-          # point 2); a fully literal, non-marker, non-variable target is
-          # treated as conclusive and never reaches this fallback.
-          if _is_marker_plausible_indirect "$SCAN_TEXT"; then
+          # even though the target text alone didn't say so, or (c) the
+          # command is from an extraction-fragile family (sed -i / awk -i
+          # inplace) whose "target" the immediate check above already
+          # tried and failed to confirm as literal — covers the combined
+          # shape (b)+(c), e.g. a BSD `sed -i` mutating a
+          # variable-indirected marker path, where neither check alone
+          # would catch it. Runs over the raw, unstripped command
+          # (#1000-REX-ROUND-2) — a fully literal, non-marker,
+          # non-variable target from a non-fragile family is treated as
+          # conclusive and never reaches this fallback.
+          if _is_marker_plausible_indirect "$COMMAND"; then
             MATCHED=1
             RESOLVED_VIA="indirect"
           fi
         fi
 
         if [ "$MATCHED" = "1" ] && [ "$RESOLVED_VIA" = "indirect" ]; then
-          MARKER_TYPE=$(_extract_marker_role "$SCAN_TEXT")
-          TARGET_PR=$(_extract_marker_pr "$SCAN_TEXT")
+          MARKER_TYPE=$(_extract_marker_role "$COMMAND")
+          TARGET_PR=$(_extract_marker_pr "$COMMAND")
           TARGET="<resolved via variable/function indirection; detected role: ${MARKER_TYPE:-unresolved}, pr: ${TARGET_PR:-unresolved}>"
         fi
       fi

--- a/.claude/hooks/warn-review-marker-write.sh
+++ b/.claude/hooks/warn-review-marker-write.sh
@@ -143,7 +143,84 @@
 # comment assumed was already fail-closed. Both sides of the kind
 # comparison are now guarded explicitly for non-empty before it runs.
 #
-# References: #728, #843, #873, #957, #962, #974, AgDR-0062, AgDR-0104,
+# #1000 — NARROW DETECTION TO ACTUAL WRITE INTENT (three false positives,
+# one real session, one day)
+# ----------------------------------------------------------------------
+# #962's indirect-write detector scanned the WHOLE COMMAND TEXT for
+# marker-shaped substrings whenever the command "appeared to write"
+# anything at all. That is broader than the threat it defends against
+# (forging a *.approved file's CONTENT) and produced three real false
+# blocks in one session:
+#
+#   1. `rm -f .claude/session/active-reviewer` — the orchestrator's own
+#      documented cleanup step (code-review/SKILL.md § 0) — got matched
+#      because the command "appears to write" (rm is a file-mover) and
+#      the command text mentions "active-reviewer". But `rm` can only
+#      DELETE; it can never forge marker CONTENT. Fix: a command whose
+#      ONLY write-like signal is deletion (`bash_command_is_deletion_only`
+#      — the same helper require-active-ticket.sh already uses for the
+#      identical "rm can't add content" reasoning) is no longer treated
+#      as a write for THIS gate. This incidentally closes a second,
+#      related false block too: `grep -nE "approved|rm -f|active-reviewer"`
+#      is a purely READ-ONLY command, but the `|`-preceded "rm " substring
+#      INSIDE its own quoted pattern argument satisfies the shared
+#      matcher's `[;&|(]`-anchored file-mover regex (which can't see
+#      quoting). Since no OTHER write family matches either case,
+#      `bash_command_is_deletion_only` returns true for both — one
+#      exemption closes both.
+#
+#   2. Writing to a NON-marker path (a scratchpad file) whose CONTENT
+#      happens to mention a marker-shaped variable — e.g. a review body
+#      written via heredoc that quotes the hook's own `$marker` token in
+#      prose — tripped the `\$\{?[a-z_]*marker[a-z_]*\}?` substring scan
+#      even though the write's actual TARGET was nowhere near
+#      .claude/session/reviews/. Fix: judge the RESOLVED WRITE TARGET(S)
+#      first, via `bash_extract_write_targets` (the plural extractor #886
+#      already added for gate-bypass safety). A real write target that's
+#      a clean literal path AND isn't marker-shaped is conclusive — no
+#      marker is being touched. The broader indirection scan
+#      (`_is_marker_plausible_indirect`) only runs as a fallback: no
+#      target was extractable at all, or an extracted target is itself
+#      variable-derived (so it *might* still resolve to a marker) — and
+#      even then, over TEXT with heredoc BODY content stripped out first
+#      (`_strip_heredoc_bodies`), so payload prose can no longer
+#      masquerade as destination code. This does NOT touch the sanctioned
+#      reviewer idiom (`REX_MARKER=$(review_marker_path ...); printf ... >
+#      "$REX_MARKER"`) — that idiom's target IS a *_MARKER-named variable,
+#      matched directly per-target, same detection as before.
+#
+#   3. The literal "active-reviewer" substring signal (previously one of
+#      _is_marker_plausible_indirect's OR-conditions) was ALSO found to
+#      block the orchestrator's own documented SET step (code-review/
+#      SKILL.md § 0's `printf '%s\n' "<owner>/<repo>#<pr>:rex" >
+#      "$ops_root/.claude/session/active-reviewer"`) — role can never
+#      resolve for that write (no `review_marker_path` call in it), so it
+#      hit the same fail-closed-on-unresolved-role path as a real forgery
+#      attempt. Checked whether this signal was actually load-bearing: it
+#      was not — the IDENTICAL write via the Write tool (file_path =
+#      ".../active-reviewer") was never matched by this hook at all
+#      (`_is_marker_target`'s pattern requires the reviews/ dir + an
+#      -approved suffix, which active-reviewer's path never has), so a
+#      Write-tool-based forgery of active-reviewer sailed through ungated
+#      on both sides of #1000. The Bash-only substring match was
+#      inconsistent swiss cheese that blocked the legitimate flow without
+#      closing the actual hole — removed. Per this hook's own pre-existing
+#      THREAT MODEL note (above): forging active-reviewer by hand remains
+#      a visible/auditable rule violation, not a technically-prevented
+#      one — unchanged by #1000, just now consistent across both tool
+#      shapes instead of blocking Bash only.
+#
+# What did NOT change: a genuine indirect marker write with an unresolved
+# role or PR still fails closed exactly as #962/#974/#977/#992
+# established — the per-target *_MARKER-convention match, the
+# `review_marker_path`-call role/PR extraction, and the fail-closed
+# _active_reviewer_allows() guards are all unchanged. #1000 narrows what
+# counts as "a write worth judging" and "where to look for the marker
+# signal" — it does not loosen what happens once something IS judged to
+# be one.
+#
+# References: #728, #843, #873, #957, #962, #974, #1000, AgDR-0062,
+#             AgDR-0104,
 #             .claude/rules/pr-workflow.md § "Build agents cannot self-review"
 
 set -u
@@ -175,29 +252,77 @@ _is_marker_target() {
   echo "$text" | grep -qE '\.claude/session/reviews/[^[:space:]"'"'"']+-(rex|ceo|security|architecture)\.approved'
 }
 
-# _is_marker_plausible_indirect COMMAND (#962)
+# _is_marker_plausible_indirect TEXT (#962, narrowed #1000)
 #
-# True when COMMAND performs a write with no literal marker path in sight,
-# but still plausibly targets a review marker via the documented
+# True when TEXT plausibly targets a review marker via the documented
 # indirection idiom:
 #   REX_MARKER=$(review_marker_path "$REPO" "$PR" rex "$MARKER_HOME")
 #   printf '%s\n' "$SHA" > "$REX_MARKER"
 #
 # Signals (any one is sufficient):
-#   - a `review_marker_path` call anywhere in the command
+#   - a `review_marker_path` call anywhere in TEXT
 #   - a literal `.claude/session/reviews/` directory mention (without a full
 #     matched filename — e.g. a directory-only reference, or a path built
 #     via concatenation rather than a single contiguous literal)
-#   - a literal `active-reviewer` mention
 #   - a write-target-shaped variable name following the established
 #     *_MARKER convention this codebase's reviewers use (REX_MARKER,
 #     CEO_MARKER, SECURITY_MARKER, ARCH_MARKER, ARCHITECTURE_MARKER, …)
+#
+# #1000 removed the bare `active-reviewer` mention as a signal here — it
+# was never load-bearing (see the #1000 header comment, point 3) and was
+# blocking both the orchestrator's documented cleanup AND set steps for
+# that unrelated session marker. Forging *.approved marker CONTENT is
+# this function's job; managing active-reviewer is not.
+#
+# Called two ways (both #1000):
+#   - per WRITE TARGET (a short string) — the primary, precise path
+#   - as a fallback over the whole command with heredoc bodies stripped
+#     (`_strip_heredoc_bodies`) — only when no clean literal target was
+#     found, so payload prose can't masquerade as destination code
 _is_marker_plausible_indirect() {
   local text="$1"
-  if echo "$text" | grep -qE 'review_marker_path|\.claude/session/reviews/|active-reviewer'; then
+  if echo "$text" | grep -qE 'review_marker_path|\.claude/session/reviews/'; then
     return 0
   fi
   echo "$text" | grep -qiE '\$\{?[a-z_]*marker[a-z_]*\}?'
+}
+
+# _strip_heredoc_bodies TEXT (#1000)
+#
+# Removes heredoc BODY content (the lines between a `<<[-]DELIM` marker and
+# its closing DELIM line) from TEXT, keeping the marker line itself and
+# everything outside the heredoc untouched. Heredoc content is DATA a
+# command writes, never code that determines WHERE it writes — scanning it
+# for marker-shaped substrings is how a review body that merely QUOTES the
+# hook's own `$marker` token in prose used to trip the indirect-write
+# fallback scan (see #1000 header comment, point 2). Best-effort: handles
+# the common `<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF` forms. An unparseable
+# or absent heredoc is a no-op (TEXT returned unchanged).
+_strip_heredoc_bodies() {
+  local text="$1"
+  awk '
+    BEGIN { in_hd = 0; delim = "" }
+    {
+      line = $0
+      if (in_hd) {
+        check = line
+        gsub(/^\t+/, "", check)
+        if (check == delim) { in_hd = 0 }
+        next
+      }
+      if (match(line, /<<-?[[:space:]]*[\x27\x22]?[A-Za-z_][A-Za-z0-9_]*[\x27\x22]?/)) {
+        tok = substr(line, RSTART, RLENGTH)
+        d = tok
+        sub(/^<<-?[[:space:]]*/, "", d)
+        gsub(/[\x27\x22]/, "", d)
+        delim = d
+        in_hd = 1
+        print line
+        next
+      }
+      print line
+    }
+  ' <<< "$text"
 }
 
 # _extract_marker_role COMMAND (#962)
@@ -255,30 +380,80 @@ case "$TOOL_NAME" in
       IS_WRITE=1
       bash_command_appears_to_write "$COMMAND" || IS_WRITE=0
 
-      if [ "$IS_WRITE" = "1" ] && _is_marker_target "$COMMAND"; then
-        # Literal marker path present AND this command actually performs a
-        # write — not just a read that happens to mention the path (#962
-        # fix for the false-positive half of the bug: a bare `cat`/`grep`/
-        # `head` on a literal marker path is no longer blocked).
-        MATCHED=1
-        TARGET=$(echo "$COMMAND" | grep -oE '\.claude/session/reviews/[^[:space:]"'"'"']+-(rex|ceo|security|architecture)\.approved' | head -1)
-        RESOLVED_VIA="literal"
-      elif [ "$IS_WRITE" = "1" ] && _is_marker_plausible_indirect "$COMMAND"; then
-        # No literal path in the command text, but it performs a write AND
-        # plausibly targets a review marker via variable/function
-        # indirection (#962 fix for the false-negative half of the bug) —
-        # e.g. REX_MARKER=$(review_marker_path ...); printf ... > "$REX_MARKER"
-        MATCHED=1
-        RESOLVED_VIA="indirect"
-        MARKER_TYPE=$(_extract_marker_role "$COMMAND")
-        TARGET_PR=$(_extract_marker_pr "$COMMAND")
-        TARGET="<resolved via variable/function indirection; detected role: ${MARKER_TYPE:-unresolved}, pr: ${TARGET_PR:-unresolved}>"
+      # #1000 point 1: a command whose ONLY write-like signal is deletion
+      # (rm, with no redirection/tee/sed-i/cp/mv/dd/install/interpreter-
+      # write also present) cannot FORGE marker content — it can only
+      # remove a file. `bash_command_is_deletion_only` is the same helper
+      # require-active-ticket.sh already uses for the identical "rm can't
+      # add content" reasoning. This also incidentally closes the
+      # `grep -nE "approved|rm -f|active-reviewer"` read-only false
+      # positive — see the #1000 header comment for why both collapse to
+      # the same exemption.
+      if [ "$IS_WRITE" = "1" ] && bash_command_is_deletion_only "$COMMAND"; then
+        IS_WRITE=0
+      fi
+
+      if [ "$IS_WRITE" = "1" ]; then
+        # #1000 point 2: judge the RESOLVED WRITE TARGET(S), not the
+        # command's prose. A heredoc BODY, a --body argument, or any other
+        # payload text a command writes is DATA, never the destination.
+        SCAN_TEXT=$(_strip_heredoc_bodies "$COMMAND")
+        WRITE_TARGETS=$(bash_extract_write_targets "$COMMAND")
+        HAS_VAR_TARGET=0
+        if [ -n "$WRITE_TARGETS" ]; then
+          while IFS= read -r wt; do
+            [ -z "$wt" ] && continue
+            case "$wt" in *'$'*) HAS_VAR_TARGET=1 ;; esac
+            if [ "$MATCHED" != "1" ] && _is_marker_target "$wt"; then
+              # A real extracted write target is a literal marker path —
+              # unambiguous, regardless of what else the command's text
+              # says elsewhere (#962 behaviour, now target-scoped).
+              MATCHED=1
+              TARGET="$wt"
+              RESOLVED_VIA="literal"
+            elif [ "$MATCHED" != "1" ] && _is_marker_plausible_indirect "$wt"; then
+              # The write target ITSELF is a *_MARKER-named variable (the
+              # sanctioned reviewer idiom) or names the reviews/ dir — e.g.
+              # REX_MARKER=$(review_marker_path ...); printf ... > "$REX_MARKER"
+              MATCHED=1
+              RESOLVED_VIA="indirect"
+            fi
+          done <<EOF_TARGETS
+$WRITE_TARGETS
+EOF_TARGETS
+        fi
+
+        if [ "$MATCHED" != "1" ] && { [ -z "$WRITE_TARGETS" ] || [ "$HAS_VAR_TARGET" = "1" ]; }; then
+          # Fallback broader scan — only reached when either (a) no target
+          # was extractable at all (an embedded interpreter with an opaque
+          # write target this library can't parse), or (b) at least one
+          # extracted target is itself variable-derived (e.g.
+          # `$DIR/mystery.approved`, built from a variable that a PRIOR
+          # statement — not the target text itself — assigns from a
+          # reviews-dir literal) and so might still resolve to a marker
+          # even though the target text alone didn't say so. Runs over
+          # heredoc-stripped text so payload prose can't trip it (#1000
+          # point 2); a fully literal, non-marker, non-variable target is
+          # treated as conclusive and never reaches this fallback.
+          if _is_marker_plausible_indirect "$SCAN_TEXT"; then
+            MATCHED=1
+            RESOLVED_VIA="indirect"
+          fi
+        fi
+
+        if [ "$MATCHED" = "1" ] && [ "$RESOLVED_VIA" = "indirect" ]; then
+          MARKER_TYPE=$(_extract_marker_role "$SCAN_TEXT")
+          TARGET_PR=$(_extract_marker_pr "$SCAN_TEXT")
+          TARGET="<resolved via variable/function indirection; detected role: ${MARKER_TYPE:-unresolved}, pr: ${TARGET_PR:-unresolved}>"
+        fi
       fi
     else
       # Library unavailable — fall back to the pre-#962 literal-substring
       # check with no read/write distinction (conservative: re-applies the
       # known false-positive-on-read limitation, but doesn't newly weaken
-      # anything that was previously caught).
+      # anything that was previously caught). #1000's target-based
+      # narrowing depends on this same library, so it is unavailable here
+      # too — unchanged fallback, matching case25's locked-in behaviour.
       if _is_marker_target "$COMMAND"; then
         MATCHED=1
         TARGET=$(echo "$COMMAND" | grep -oE '\.claude/session/reviews/[^[:space:]"'"'"']+-(rex|ceo|security|architecture)\.approved' | head -1)


### PR DESCRIPTION
## Summary

- **`rm`/deletion-only commands no longer count as a marker write** — the orchestrator's documented cleanup step (`rm -f .claude/session/active-reviewer`) was blocked because `rm` satisfies the shared write-detector's file-mover check and the command text mentions "active-reviewer." But `rm` can only delete, never forge `*.approved` content, so it's out of scope for this gate (`bash_command_is_deletion_only` — the same helper `require-active-ticket.sh` already uses for identical reasoning). This incidentally also fixes a segmentation false-positive: a purely read-only `grep -nE "approved|rm -f|active-reviewer"` was blocked because the `|`-preceded `"rm "` substring *inside its own quoted pattern argument* satisfies the shared matcher's `[;&|(]`-anchored regex, which can't see quoting.
- **Indirect-write detection now judges the resolved write TARGET, not the command's prose** — a review body written via heredoc that merely *quotes* the hook's own marker-shaped variable token in explanatory text (not code) used to trip the broad substring scan, even though the actual write target was an unrelated scratch path. The hook now extracts the real write target(s) via `bash_extract_write_targets` and judges those first; the broader scan only runs as a fallback (no target extractable, or a target is itself variable-derived) and, even then, runs over heredoc-stripped text so payload content can't masquerade as destination code.
- **Dropped the bare session-marker-filename substring signal** — it was blocking the orchestrator's own documented SET step (`printf ... > .../active-reviewer`) identically to the cleanup step, and turned out never to be load-bearing: the same write via the `Write` tool was already ungated (its file_path check requires the `reviews/` dir + an `-approved` suffix, which the session marker's path never has). Removing it makes both tool shapes consistently ungated instead of Bash-only swiss cheese; forging that marker by hand remains a visible, auditable rule violation per this hook's existing threat model, unchanged by this PR.
- **Why this wasn't already closed by the prior resolved-target PR (#970, fixing #962)** — that PR moved detection from a literal-path substring match to a "does this command appear to write, and does its TEXT mention a marker signal" check. It was a real improvement (fixed the false-negative half of the original bug) but still reasoned over the *whole command's text* rather than the *resolved write target*, so any write co-occurring with marker-shaped prose anywhere in the command — a cleanup `rm`, an unrelated grep pattern, a heredoc body — still tripped it. This PR finishes that narrowing by adding target resolution on top of the prior write-detection work, rather than replacing it.

## Testing

- Added 6 regression cases (29-34) to `.claude/hooks/tests/test_warn_review_marker_write.sh`, covering the three reported false-positive shapes plus two explicit "don't over-narrow" guards (a real forgery riding alongside an `rm` in the same command still blocks; the target-based literal/indirect checks still catch genuine forgeries).
- All 28 pre-existing cases (including the fail-closed-on-ambiguity regression tests, case 24 and case 27 in particular) pass **unchanged** — ran via `timeout 120 bash .claude/hooks/tests/test_warn_review_marker_write.sh`, 36/36 PASS.
- `bash -n` syntax check and `shellcheck -x` clean on both changed files (one pre-existing SC2295 info-level note on an untouched line, one deliberate SC2016 now explicitly disabled with a comment matching the file's existing convention).
- Did **not** run the full `.claude/hooks/tests/` suite as a single blocking command (per explicit guidance to avoid the harness watchdog) — only this hook's own test file was exercised. If a full-suite pass is wanted before merge, that should run as a separate, appropriately-scoped step.

## Glossary

| Term | Definition |
|------|------------|
| Review marker | `.claude/session/reviews/<owner>__<repo>__<pr>-{rex,ceo,security,architecture}.approved` — the file the merge gate reads as proof a review happened. |
| Active-reviewer session marker | The single-line session file (`<owner>/<repo>#<pr>:<kind>`) the orchestrator sets before spawning a sanctioned reviewer; distinct from the review markers above — deleting or setting it cannot itself forge an approval. |
| Deletion-only command | A Bash command whose only write-like signal (per `_lib-detect-bash-write.sh`) is `rm`/`mv`-as-delete, with no redirection, `tee`, `sed -i`, or interpreter-write also present — `bash_command_is_deletion_only`. |
| Resolved write target | The actual file path a command writes to, as extracted by `bash_extract_write_targets`, as opposed to any marker-shaped text that merely appears somewhere in the command. |
| Heredoc body | The literal text between a `<<DELIM` marker and its closing `DELIM` line — data a command writes as file content, never code that determines the write's destination. |
| Fail closed | On an unresolved role/PR, block rather than allow — unchanged by this PR (see cases 24, 26, 27, 33). |

Closes #1000
