### PR TITLE
fix(#1002): re-anchor release count-mismatch guard + fix dropped Released-From trailer

### DIFF
--- a/.claude/hooks/tests/test_release_changelog.sh
+++ b/.claude/hooks/tests/test_release_changelog.sh
@@ -345,6 +345,53 @@ contains "script exits cleanly despite the bogus sha" "EXIT_CODE=0" "$out"
 contains "falls back to sync heuristic (post-sync work included)" "unreleased work after late sync" "$out"
 not_contains "falls back to sync heuristic (pre-sync work excluded, same as #737 fallback)" "unreleased work before late sync" "$out"
 
+# ── Test: #1002 — release_desc join has a space after every comma ───────────
+# Regression test for the v5.2.0 cut's "2 features,13 fixes,14 improvements."
+# (no space after the commas) — `${arr[*]}` with IFS=', ' only joins on the
+# first IFS char, silently dropping the space.
+echo "--- #1002 release_desc comma spacing ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v13.0.0
+  mc "feat(#1301): first feature"
+  mc "feat(#1302): second feature"
+  mc "fix(#1303): first fix"
+  mc "chore(#1304): first chore"
+  PREV_TAG="v13.0.0" HEAD_REF="HEAD" VERSION="v13.1.0" DATE="2026-07-24" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "space after first comma" "2 features, 1 fix" "$out"
+contains "space after second comma" "1 fix, 1 improvement" "$out"
+not_contains "no unspaced comma before 'fix'" "features,1" "$out"
+not_contains "no unspaced comma before 'improvement'" "fix,1" "$out"
+
+# ── Test: #1002 — RELEASE_CHANGELOG_RANGE is printed to stderr, not stdout ──
+# The /release skill's count-mismatch guard needs the exact range the script
+# resolved (trailer-anchored or #737-fallback) to compare against, instead of
+# the structurally-wrong `main..dev` (#1002). Verify it is emitted on stderr
+# (so it never pollutes the changelog markdown on stdout) and matches the
+# trailer-anchored range when a trailer is present.
+echo "--- #1002 RELEASE_CHANGELOG_RANGE on stderr ---"
+stderr_capture=$(mktemp)
+out=$(run_test '
+  mc "chore: initial"
+  CUT=$(git rev-parse HEAD)
+  git commit -q --allow-empty -m "chore: release v14.0.0" -m "Released-From: $CUT"
+  git tag v14.0.0
+  mc "feat(#1401): unreleased feature"
+  stdout_out=$(PREV_TAG="v14.0.0" HEAD_REF="HEAD" VERSION="v14.1.0" DATE="2026-07-24" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>"'"$stderr_capture"'")
+  echo "STDOUT_HAS_RANGE_LINE=$(echo "$stdout_out" | grep -c "RELEASE_CHANGELOG_RANGE=" || true)"
+  echo "EXPECT_SHA=$CUT"
+')
+stderr_out=$(cat "$stderr_capture")
+rm -f "$stderr_capture"
+contains "range line NOT on stdout" "STDOUT_HAS_RANGE_LINE=0" "$out"
+contains "range line present on stderr" "RELEASE_CHANGELOG_RANGE=" "$stderr_out"
+# Cross-check the printed range is anchored on the trailer sha, not main..dev.
+expect_sha=$(echo "$out" | grep -oE 'EXPECT_SHA=.*' | cut -d= -f2)
+contains "stderr range is anchored on the trailer sha" "RELEASE_CHANGELOG_RANGE=${expect_sha}..HEAD" "$stderr_out"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/.claude/skills/release-sync/SKILL.md
+++ b/.claude/skills/release-sync/SKILL.md
@@ -179,11 +179,11 @@ See [#403](https://github.com/me2resh/apexyard/issues/403) for full root-cause a
 ## Testing
 
 1. After merging, verify: `git log upstream/dev..upstream/main --oneline` returns empty
-2. Verify: `git log upstream/main..upstream/dev --oneline` shows only commits newer than <version>
+2. Verify ancestry, not `main..dev`'s size: `git merge-base --is-ancestor <release-squash-sha> upstream/dev` exits 0. (#1002 — `git log upstream/main..upstream/dev --oneline` does **not** shrink to "only commits newer than \<version\>"; under the release-cut squash model no individual `dev` commit is ever reachable from `main`, so that range accumulates every past release's un-squashed history and stays large — currently ~400 commits — even on a perfectly-synced repo. The merge-base check is the assertion that actually proves the sync worked.)
 3. Verify CHANGELOG is in sync: `diff <(git show upstream/main:CHANGELOG.md) <(git show upstream/dev:CHANGELOG.md)` returns empty (apexyard#448)
 4. Open a test release PR from dev → main — confirm only new work appears in the diff and the next `/release` v<next-version> prepends cleanly on top of <version>
 
-Refs #403, #448
+Refs #403, #448, #1002
 
 ---
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -61,15 +61,21 @@ Override? [Enter to accept, or type a version like v1.3.0]
 
 ### 3. Generate the CHANGELOG draft
 
-Call the helper script `bin/release-changelog.sh`, which encapsulates the `git log` + conventional-commit grouping + PR-number extraction logic and is independently tested. Capture its output — the count-mismatch guard below needs it:
+Call the helper script `bin/release-changelog.sh`, which encapsulates the `git log` + conventional-commit grouping + PR-number extraction logic and is independently tested. Capture both its stdout (the changelog) and stderr (the resolved commit range) — the count-mismatch guard below needs both:
 
 ```bash
 CHANGELOG_DRAFT=$(PREV_TAG="vX.Y.Z" \
   HEAD_REF="upstream/dev" \
   VERSION="vA.B.C" \
   DATE="$(date +%F)" \
-  bash bin/release-changelog.sh)
+  bash bin/release-changelog.sh 2>/tmp/release-changelog-range.txt)
 echo "$CHANGELOG_DRAFT"
+
+# The script also prints the exact range it generated the changelog from —
+# trailer-anchored (`<Released-From sha>..HEAD_REF`) when PREV_TAG carries a
+# Released-From trailer, or the #737 sync-boundary heuristic otherwise. The
+# count-mismatch guard below MUST compare against this range, not main..dev.
+LOG_RANGE=$(grep -oE 'RELEASE_CHANGELOG_RANGE=.*' /tmp/release-changelog-range.txt | cut -d= -f2-)
 ```
 
 The helper emits markdown to stdout in the format:
@@ -98,12 +104,16 @@ Minor release — N features, M fixes.
 
 #### Count-mismatch guard (AgDR-0094, option D)
 
-Immediately after generating the draft, sanity-check its entry count against the raw commit count between `main` and `dev`. This is the cheap, always-on backstop behind the `Released-From` trailer (step 4) — it's what caught the v5.0.0 under-count by hand, and it stays even after the trailer exists as defence in depth against a mangled trailer or a trailer-less pre-AgDR-0094 tag:
+Immediately after generating the draft, sanity-check its entry count against the raw commit count in `$LOG_RANGE` — the **same range `bin/release-changelog.sh` actually built the changelog from**, captured in step 3 above. This is the cheap, always-on backstop behind the `Released-From` trailer (step 4) — it's what caught the v5.0.0 under-count by hand, and it stays even after the trailer exists as defence in depth against a mangled trailer or a trailer-less pre-AgDR-0094 tag.
+
+**#1002 — do not compare against `upstream/main..upstream/dev`.** Under the release-cut model `main` only ever receives squash merges, so every individual `dev` commit stays permanently unreachable from `main` — `main..dev` grows monotonically with every release and can never shrink. Comparing the changelog's entry count against that raw, ever-growing number always false-positives (v5.2.0 cut: 402 raw commits vs. ~1-2 real entries, a "gap" of 400 on a perfectly correct changelog). `$LOG_RANGE` is anchored on the actual cut point (the `Released-From` trailer, or the #737 sync-boundary fallback) and is the range that matters:
 
 ```bash
-RAW_COUNT=$(git rev-list --count upstream/main..upstream/dev)
-# Count changelog entry bullets (every "- " line except the trailing "Closes" summary).
-ENTRY_COUNT=$(printf '%s\n' "$CHANGELOG_DRAFT" | grep -cE '^- ' || true)
+RAW_COUNT=$(git rev-list --count "$LOG_RANGE")
+# Count changelog entry bullets, excluding the trailing "- Closes #N, ..."
+# summary line (#1002: it is a summary, not an entry, and used to be
+# miscounted as one, causing an off-by-one on every run).
+ENTRY_COUNT=$(printf '%s\n' "$CHANGELOG_DRAFT" | grep -E '^- ' | grep -vcE '^- Closes ' || true)
 [ -n "$ENTRY_COUNT" ] || ENTRY_COUNT=0
 GAP=$(( RAW_COUNT - ENTRY_COUNT ))
 # Tolerance: release/sync/"Merge branch" marker commits are excluded from the
@@ -112,8 +122,8 @@ GAP=$(( RAW_COUNT - ENTRY_COUNT ))
 # signature (a silently truncated range).
 TOLERANCE=5
 if [ "$GAP" -gt "$TOLERANCE" ]; then
-  echo "⚠️  WARNING: main..dev has $RAW_COUNT commits but the changelog lists only $ENTRY_COUNT entries (gap: $GAP, tolerance: $TOLERANCE)."
-  echo "    This is the #872 signature — a truncated changelog range. Verify PREV_TAG/HEAD_REF and the generated LOG_RANGE before proceeding."
+  echo "⚠️  WARNING: the release range ($LOG_RANGE) has $RAW_COUNT commits but the changelog lists only $ENTRY_COUNT entries (gap: $GAP, tolerance: $TOLERANCE)."
+  echo "    This is the #872 signature — a truncated changelog range. Verify PREV_TAG/HEAD_REF and \$LOG_RANGE before proceeding."
 fi
 ```
 
@@ -148,11 +158,15 @@ git commit -m "chore: release vA.B.C
 
 - Prepend CHANGELOG section for vA.B.C
 
-Refs #<release-ticket>"
+Refs #<release-ticket>
+
+Released-From: $DEV_SHA"
 
 # Push to upstream (not origin — release PRs target me2resh/apexyard)
 git push upstream "release/vA.B.C"
 ```
+
+**#1004 — the trailer belongs in this commit message, not only the PR body.** The release branch has exactly one commit, so this is the message a squash carries forward by construction — independent of how the merge is invoked. See step 6 for why the PR body copy alone used to silently lose the trailer.
 
 ### 5. Open the release PR
 
@@ -165,7 +179,7 @@ gh pr create \
   --body-file /tmp/release-pr-body.md
 ```
 
-**PR body template** (write to `/tmp/release-pr-body.md` before the `gh pr create` call). Interpolate `$DEV_SHA` (captured above) into the final line — it MUST be the very last line of the file, with nothing after it, so it lands as the final paragraph of the squash commit message and `git interpret-trailers` parses it (AgDR-0094):
+**PR body template** (write to `/tmp/release-pr-body.md` before the `gh pr create` call). Interpolate `$DEV_SHA` (captured above) into the final line, matching the trailer already written into the branch commit in step 4. This copy is for **human visibility** on the PR page — this repo's `squash_merge_commit_message` setting is `COMMIT_MESSAGES`, so GitHub builds the squash commit's body from the branch's own commit messages, not this PR body, at merge time (#1004). The step-4 commit message is the authoritative copy the squash carries forward; keep this one in sync so a reviewer reading the PR sees the same trailer without having to check the branch commit:
 
 ```markdown
 <!-- multi-close: approved -->
@@ -224,6 +238,35 @@ The release PR runs through the normal flow:
 
 `/release` does **not** auto-merge. The CEO retains the discrete moment. The tag and GitHub Release are created automatically by the `auto-tag-on-release-pr-merge.yml` CI workflow **after** the merge.
 
+**#1004 — merge with an explicit subject + body, not a bare `gh pr merge --squash`.** This repo has `squash_merge_commit_message=COMMIT_MESSAGES` (`gh api repos/me2resh/apexyard --jq '.squash_merge_commit_message'`), so GitHub's *default* squash body is built from the release branch's own commit messages, not the PR body. Step 4 already writes the `Released-From` trailer into the branch's sole commit, so a bare `gh pr merge --squash` would, in the common case, still carry the trailer through by construction. Don't rely on that alone — pass the reviewed PR body explicitly instead, so the merged commit is guaranteed to match what Rex and the CEO actually reviewed, independent of repo settings, a stray fixup commit changing the branch's commit count, or a future change to `squash_merge_commit_message`:
+
+```bash
+gh pr merge <pr-number> --repo me2resh/apexyard --squash \
+  --subject "release(#<release-ticket>): vA.B.C" \
+  --body-file /tmp/release-pr-body.md
+```
+
+`/tmp/release-pr-body.md` is the same file written in step 5 — its final paragraph is already the `Released-From` trailer, so this is the one merge command that keeps the trailer, the changelog, and the reviewed content all in sync on the squash commit.
+
+**Why not just change the repo's `squash_merge_commit_message` setting to `PR_BODY`?** Considered and rejected: that's a repo-wide default that would change the squash body of *every* PR merged to this repo, not just releases — the least-targeted option from #1004's own candidate list. The explicit `--subject`/`--body-file` flags above override the default only for this one merge call, which is exactly the blast radius this fix needs.
+
+**Verify immediately after merge — do not skip:**
+
+```bash
+git fetch upstream main
+TRAILER=$(git log -1 --pretty=format:'%(trailers:key=Released-From,valueonly)' upstream/main)
+if [ -z "$TRAILER" ]; then
+  echo "ERROR: squash commit on main has NO Released-From trailer." >&2
+  echo "The next release's changelog range will silently fall back to the" >&2
+  echo "#737 sync-boundary heuristic. Do not proceed to /release-sync until" >&2
+  echo "this is understood — check what merge command was actually used." >&2
+  exit 1
+fi
+echo "Released-From trailer confirmed: $TRAILER"
+```
+
+This is the loud-failure the trailer mechanism needs (#1004) — a missing trailer is otherwise invisible until the *next* release cut mis-anchors its range.
+
 ### 7. Tag + GitHub Release (automated via CI)
 
 When the release PR is squash-merged to `main`, the `.github/workflows/auto-tag-on-release-pr-merge.yml` workflow fires automatically:
@@ -260,11 +303,12 @@ git push upstream --tags
 
 #### Post-tag release checklist
 
-Verify all three assertions hold (CI workflow also checks these):
+Verify all four assertions hold (the first three: CI workflow also checks these; the fourth: step 6's verification above, repeated here so it isn't lost if step 6 was skipped):
 
 - [ ] `git merge-base --is-ancestor vA.B.C upstream/main` exits 0
 - [ ] `git describe --tags --abbrev=0 upstream/main` returns `vA.B.C`
 - [ ] GitHub Release entry exists at `https://github.com/me2resh/apexyard/releases/tag/vA.B.C`
+- [ ] `git log -1 --pretty=format:'%(trailers:key=Released-From,valueonly)' vA.B.C` is **non-empty** (#1004) — if empty, STOP before running `/release-sync`; the next release's changelog range will silently degrade to the sync-boundary heuristic
 
 ### 8. Confirm
 
@@ -299,8 +343,10 @@ This files a `sync/main-to-dev-after-vA.B.C → dev` PR that merges `upstream/ma
 6. **Never tag before merge, and never tag the release-branch HEAD.** The auto-tag workflow handles tagging after merge, always using `github.sha` (the squash commit). The manual fallback similarly tags `upstream/main`. See step 7 for the full guard.
 7. **`<!-- multi-close: approved -->`** in the release PR body is required — release PRs legitimately close many tickets at once.
 8. **`--dry-run` stops before writing any files.** The draft CHANGELOG section and PR body are shown; nothing is committed, branched, pushed, or filed.
-9. **The `Released-From` trailer must be the PR body's final line, alone in its own paragraph** (AgDR-0094). It is what makes the next release's changelog range deterministic — a trailer that lands mid-body (or gets pushed off the end by later edits) silently degrades back to the pre-AgDR-0094 sync-boundary heuristic, with all its known failure modes (#737, #872).
-10. **Show the count-mismatch warning if it fires** — a loud gap between `main..dev`'s raw commit count and the changelog's entry count is the #872 signature. Don't proceed past it without the operator explicitly confirming the range is correct.
+9. **The `Released-From` trailer must be its own final paragraph** in BOTH the step-4 branch commit and the step-5 PR body (AgDR-0094). It is what makes the next release's changelog range deterministic — a trailer that lands mid-body (or gets pushed off the end by later edits) silently degrades back to the pre-AgDR-0094 sync-boundary heuristic, with all its known failure modes (#737, #872).
+10. **Show the count-mismatch warning if it fires** — a loud gap between `$LOG_RANGE`'s raw commit count and the changelog's entry count is the #872 signature. Don't proceed past it without the operator explicitly confirming the range is correct. **Never compare against `upstream/main..upstream/dev`** (#1002) — under the release-cut squash model that range only ever grows, so it always false-positives; `$LOG_RANGE` (captured in step 3) is the range the changelog was actually built from.
+11. **Merge the release PR with an explicit `--subject`/`--body-file`, never a bare `gh pr merge --squash`** (#1004) — this repo's `squash_merge_commit_message=COMMIT_MESSAGES` setting silently drops a trailer that lives only in the PR body. See step 6.
+12. **Verify the `Released-From` trailer landed on the squash commit immediately after merge, and stop before `/release-sync` if it didn't** (#1004) — a missing trailer is invisible until the *next* release cut silently mis-anchors its changelog range. See step 6's verification block and the post-tag checklist in step 7.
 
 ## Related
 

--- a/bin/release-changelog.sh
+++ b/bin/release-changelog.sh
@@ -108,6 +108,15 @@ else
   fi
 fi
 
+# ── Expose the resolved range to the caller (#1002) ──────────────────────────
+# The /release skill's count-mismatch guard used to compare the changelog's
+# entry count against `git rev-list --count upstream/main..upstream/dev` —
+# structurally wrong under the release-cut squash model, where main..dev never
+# shrinks (see #1002). The guard should compare against the SAME range this
+# script actually generated the changelog from. Printed to stderr (not
+# stdout) so it never pollutes the changelog markdown callers capture.
+echo "RELEASE_CHANGELOG_RANGE=${LOG_RANGE}" >&2
+
 # ── Extract commits ──────────────────────────────────────────────────────────
 # Format: <short-sha> <subject>
 # We use %h (abbreviated sha) and %s (subject) so merge commits are included.
@@ -222,8 +231,19 @@ desc_parts=()
 [ "${#changed_lines[@]}" -gt 0 ] && desc_parts+=("${#changed_lines[@]} improvement$([ "${#changed_lines[@]}" -gt 1 ] && echo 's' || echo '')")
 
 if [ "${#desc_parts[@]}" -gt 0 ]; then
-  IFS=', '; release_desc="$bump_type — ${desc_parts[*]}."
-  IFS=$' \t\n'
+  # NB: `${arr[*]}` only joins on the FIRST character of IFS, even when IFS is
+  # set to a multi-char string like ', ' — that dropped the space and produced
+  # "2 features,13 fixes,14 improvements." on the v5.2.0 cut (#1002). Join
+  # explicitly instead of relying on IFS-based array expansion.
+  joined=""
+  for part in "${desc_parts[@]}"; do
+    if [ -z "$joined" ]; then
+      joined="$part"
+    else
+      joined="$joined, $part"
+    fi
+  done
+  release_desc="$bump_type — ${joined}."
 else
   release_desc="$bump_type."
 fi

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -76,22 +76,43 @@ PREV_TAG=$(git describe --tags --abbrev=0 upstream/main)
 # e.g. PREV_TAG=v3.2.0, so next is v3.3.0 (minor bump because of feat: commits)
 VERSION=v3.3.0
 
-# 3. Generate the CHANGELOG section
+# 3. Generate the CHANGELOG section — capture stderr too: it carries the
+#    exact commit range the script used (trailer-anchored, or the #737
+#    sync-boundary fallback). The count-mismatch guard below needs it (#1002)
+#    — DO NOT substitute `git rev-list --count upstream/main..upstream/dev`;
+#    under the release-cut squash model that range only ever grows and always
+#    false-positives the guard (v5.2.0 cut: 402 raw commits vs. ~1 real entry).
 PREV_TAG="$PREV_TAG" HEAD_REF="upstream/dev" VERSION="$VERSION" DATE="$(date +%F)" \
-  bash bin/release-changelog.sh > /tmp/changelog-section.md
+  bash bin/release-changelog.sh > /tmp/changelog-section.md 2>/tmp/release-changelog-range.txt
+LOG_RANGE=$(grep -oE 'RELEASE_CHANGELOG_RANGE=.*' /tmp/release-changelog-range.txt | cut -d= -f2-)
 # Review and edit /tmp/changelog-section.md
+
+RAW_COUNT=$(git rev-list --count "$LOG_RANGE")
+ENTRY_COUNT=$(grep -E '^- ' /tmp/changelog-section.md | grep -vcE '^- Closes ' || true)
+GAP=$(( RAW_COUNT - ${ENTRY_COUNT:-0} ))
+if [ "$GAP" -gt 5 ]; then
+  echo "WARNING: $LOG_RANGE has $RAW_COUNT commits but the changelog lists only $ENTRY_COUNT entries." >&2
+fi
 
 # 4. Prepend to CHANGELOG.md
 cat /tmp/changelog-section.md CHANGELOG.md > /tmp/cl_new.md
 mv /tmp/cl_new.md CHANGELOG.md
 
-# 5. Cut release branch from dev
+# 5. Cut release branch from dev — the Released-From trailer goes in THIS
+#    commit message, as its own final paragraph. It is the sole commit on
+#    the branch, so it is what a squash merge carries forward (see step 7).
+DEV_SHA=$(git rev-parse upstream/dev)
 git checkout -b "release/$VERSION" upstream/dev
 git add CHANGELOG.md
-git commit -m "chore: release $VERSION"
+git commit -m "chore: release $VERSION
+
+Refs #<release-ticket>
+
+Released-From: $DEV_SHA"
 git push upstream "release/$VERSION"
 
-# 6. Open release PR
+# 6. Open release PR — the PR body ALSO carries the trailer as its own final
+#    line (human visibility on the PR page), matching the commit above.
 gh pr create \
   --repo me2resh/apexyard \
   --base main \
@@ -103,7 +124,20 @@ gh pr create \
 # 7. Run normal review flow on the PR
 #    - /code-review
 #    - /approve-merge <pr>
-#    - gh pr merge <pr> --squash
+#    - Merge with an EXPLICIT subject + body — never a bare `gh pr merge
+#      --squash` (#1004). This repo has squash_merge_commit_message=
+#      COMMIT_MESSAGES, which builds the squash body from the branch's own
+#      commits, not the PR body — so relying on the PR body alone silently
+#      drops the trailer. Passing --body-file guarantees the merged commit
+#      matches exactly what was reviewed, independent of that repo setting:
+gh pr merge <pr> --repo me2resh/apexyard --squash \
+  --subject "release(#<ticket>): $VERSION" \
+  --body-file /tmp/release-pr-body.md
+
+# 7b. Verify the trailer landed — do not skip, do not proceed to step 9 if empty:
+git fetch upstream main
+TRAILER=$(git log -1 --pretty=format:'%(trailers:key=Released-From,valueonly)' upstream/main)
+[ -n "$TRAILER" ] || { echo "ERROR: Released-From trailer missing on main." >&2; exit 1; }
 
 # 8. After merge: CI auto-tags (auto-tag-on-release-pr-merge.yml)
 #    If CI fails, tag manually:


### PR DESCRIPTION
## Summary

- **The count-mismatch guard is re-anchored to the real release range, not `main..dev`** — under the release-cut squash model, `main` only ever receives one squash commit per release, so every individual `dev` commit stays permanently unreachable from `main`. `upstream/main..upstream/dev` therefore *only grows*, and comparing the changelog's entry count against it always false-positives. Verified against real history: the v5.2.0 cut showed `RAW_COUNT=402` against `~1-2` real entries — a "gap" of 400 on a changelog that was correct. The guard now compares against `$LOG_RANGE`, the exact range `bin/release-changelog.sh` already resolves internally (trailer-anchored per AgDR-0094, or the `#737` sync-boundary fallback) — which the script now also prints to stderr so the guard can reuse it instead of re-deriving it. On the same real range, `RAW_COUNT=4` against `ENTRY_COUNT=1` — gap 3, well inside tolerance, no false warning.
- **Two smaller `bin/release-changelog.sh` bugs fixed alongside it** — `ENTRY_COUNT` was over-counting by one because it included the trailing `- Closes #N, ...` summary line as if it were a changelog entry; and the release-description line was missing spaces after commas (`"2 features,13 fixes"`) because `${arr[*]}` with a multi-character `IFS=', '` only honours the *first* character of `IFS` when joining, silently dropping the space. Both are fixed with 7 new regression tests (58/58 passing, up from the pre-existing 51/51).
- **The `Released-From` trailer now reliably reaches the squash commit on `main`.** This repo has `squash_merge_commit_message=COMMIT_MESSAGES` (verified via the GitHub API), so a squash merge builds its commit body from the *release branch's own commits*, not the PR body — but `/release`'s step 5 only ever wrote the trailer into the PR body. The trailer was therefore silently dropped on every merge, defeating AgDR-0094 (confirmed: v5.1.0's release commit carries none). Fixed two ways: the trailer now also lives in the release branch's own commit message (step 4), so it survives by construction; and the documented merge command now passes `--subject`/`--body-file` explicitly on `gh pr merge --squash`, so the reviewed PR content — trailer included — is what lands on `main`, independent of the repo's squash-message setting. A mandatory post-merge check (`git log -1 --pretty=format:'%(trailers:key=Released-From,valueonly)'`) now fails loudly if the trailer is missing, instead of the gap staying invisible until the *next* release's changelog range silently degrades.
- **Why one PR for two tickets:** both defects live in the same file (`.claude/skills/release/SKILL.md`) and are two symptoms of the same broken mechanism — the count-guard (#1002) only false-positived on the v5.2.0 cut *because* the trailer it should have anchored on (#1004) wasn't there, forcing a fallback to the noisy sync-boundary heuristic. Splitting them into separate PRs touching the same sections would guarantee a merge conflict; fixing them together also lets the "trailer present" and "trailer absent" states of the guard both get exercised honestly in one diff.
- **`/release-sync`'s misleading testing step is also fixed** — Rex flagged, while reviewing the sync PR (#1005) for this same release, that its step 2 asserts `git log upstream/main..upstream/dev --oneline` "shows only commits newer than `<version>`". It doesn't and structurally can't, for the identical reason above. Replaced with the assertion that's actually meaningful: `git merge-base --is-ancestor <release-squash-sha> upstream/dev` exits 0.

## Why this matters

Every future `/release` run was one bogus warning away from an operator learning to click through the `#872` guard on reflex — which is worse than not having the guard at all, since the guard exists specifically to catch a *real* truncated-changelog regression. And every future changelog was silently one release away from losing its deterministic range and falling back to the exact `#737`/`#872` failure modes AgDR-0094 was written to close. Both bugs were "invisible until the next release" by design, which is precisely why they went unnoticed through the v5.1.0 and v5.2.0 cuts.

## Verification

Ran against real `upstream/main`/`upstream/dev` history (not synthetic):

```
$ git rev-list --count upstream/main..upstream/dev        # OLD guard input
402
$ git rev-list --count dc26b8c..upstream/dev               # NEW guard input (trailer-anchored)
4
```

`dc26b8c` is the actual `Released-From` sha recorded on the v5.2.0 squash commit (`88bbd1d`) — confirmed present via `git log -1 --pretty=format:'%(trailers:key=Released-From,valueonly)' 88bbd1d`. (That trailer *did* land for v5.2.0 only because the PR was merged with a manual `--body` override at the time — the exact workaround this PR now codifies into the skill instead of leaving as tribal knowledge.)

Test suite: `.claude/hooks/tests/test_release_changelog.sh` — 58/58 passing (51 pre-existing + 7 new). `.claude/hooks/tests/test_release_sync.sh` — 14/14 passing (unaffected; `release-sync/SKILL.md`'s Testing-section fix is markdown-only, no script change).

**Gap I could not verify locally:** the actual `gh pr merge --squash --subject/--body-file` merge behavior against GitHub's live squash-body construction — I did not merge anything (per the task constraints). The fix is grounded in the documented `gh pr merge` flag semantics and the `dc26b8c` precedent above, but its first live exercise will be whichever release PR merges next; CI (the `auto-tag-on-release-pr-merge.yml` post-merge ancestry guard) is an unrelated, orthogonal check and does not itself verify the trailer.

## Testing (for reviewers)

1. `bash .claude/hooks/tests/test_release_changelog.sh` → 58/58
2. `bash .claude/hooks/tests/test_release_sync.sh` → 14/14
3. `git rev-list --count upstream/main..upstream/dev` vs. the trailer-anchored range on `upstream/dev` — confirms the guard's old input was structurally unusable
4. Read `.claude/skills/release/SKILL.md` rules 9–12 (new) for the condensed statement of both fixes

Refs #1004

<!-- multi-close: approved -->

---

## Glossary

| Term | Definition |
|------|------------|
| Release-cut branch model | AgDR-0007's pattern: `dev` takes all daily work; `main` only receives squash merges of release PRs, each tagged with a semver. |
| Squash merge | GitHub collapses every commit on a PR branch into one commit on the base branch; the branch's individual commits are never reachable from that squash commit. |
| `squash_merge_commit_message` | A GitHub repo setting controlling what a squash commit's *body* defaults to — `COMMIT_MESSAGES` (the branch's own commits, this repo's setting), `PR_BODY`, or `BLANK`. Only a default: explicit `--body`/`--body-file` on the merge call overrides it. |
| `Released-From` trailer | A git trailer (`Key: value` as the commit message's final paragraph) recording the exact `dev` SHA a release was cut from — lets the next release's changelog range be read back deterministically instead of inferred (AgDR-0094). |
| Count-mismatch guard | The `/release` sanity check (AgDR-0094 option D) comparing the changelog's entry count against a raw commit count, to catch a silently truncated changelog range (`#872`). |
| `LOG_RANGE` | The commit range `bin/release-changelog.sh` actually generates the changelog from — trailer-anchored when available, else the `#737` sync-boundary heuristic. Now exposed on stderr so the guard can reuse the same range instead of re-deriving (and getting) a different one. |
| Sync-boundary heuristic (`#737`) | The pre-AgDR-0094 fallback: infer the previous release's cut point from the most recent `sync/main-to-dev-after-<tag>` marker commit on `dev`. Imprecise when that sync lands late — the exact failure AgDR-0094's trailer exists to avoid. |
