### PR TITLE
docs(#1015): AgDR-0109 — marker-write gate is a backstop; activate AgDR-0104 deferred meta-gate

### DIFF
--- a/docs/agdr/AgDR-0109-marker-write-gate-is-a-backstop.md
+++ b/docs/agdr/AgDR-0109-marker-write-gate-is-a-backstop.md
@@ -38,6 +38,8 @@ AgDR-0104 deferred its CI meta-gate pending "a third *independent* incident" —
 
 Different session, not degraded, different root causes. **`here-doc` appears verbatim in AgDR-0104's list of unbounded expressions** — the class recurred exactly where it was predicted. The trigger has fired.
 
+**On the count, taken at its strictest.** A reader could argue AgDR-0104's own "n=2 are correlated" collapses #962 and #965 into a single data point, making today only the *second* independent incident rather than the third. Two things answer that. First, today supplies **two** further bypasses (interpreter heredoc and BSD `sed -i`) with distinct root causes, so even on the collapsing reading the count reaches three. Second, and more to the point, the deferral's stated purpose was to wait until the class was *proven to recur* rather than to reach an arbitrary tally — and a bypass landing on a construct AgDR-0104 had already listed by name, inside the fix for the previous bypass, is stronger proof of recurrence than a third unrelated incident would have been. The condition is met on either reading.
+
 ### The cost being paid meanwhile
 
 In one session the blocking behaviour produced roughly **fourteen false positives**: a read-only `grep` whose *pattern string* contained the trigger words; an `rm` cleanup; an `echo` whose prose mentioned them; the sanctioned reviewer's own sign-off write **with the session marker correctly set**; and a command that merely declared a variable named `MARKER_HOME` — the name the framework's own agent spec recommends. Reviewers worked around it by base64-encoding literals and splitting filenames across `printf` calls.
@@ -64,7 +66,15 @@ Chosen: **E.** Three parts, in order.
 
 **2. Block only on a confidently-resolved marker target; warn on ambiguity.** When the hook resolves a write target to a marker path, block — that is the #843 shape and it works. When it cannot resolve role and PR (`detected role: unresolved, pr: unresolved`), emit the advisory banner and exit 0.
 
-This is not a weakening dressed as a fix. Failing open on ambiguity is *correct for a backstop* and wrong only for THE control — which, per part 1, this is not. It converts every false positive observed today into a warning while leaving the case that motivated blocking fully gated. A build agent writing a literal marker path is still blocked; a reviewer grepping for the word is not.
+This is not a weakening dressed as a fix. It converts every false positive observed today into a warning while leaving the case that motivated blocking fully gated. A build agent writing a literal marker path is still blocked; a reviewer grepping for the word is not.
+
+**Reconciling this with AgDR-0104's fail-closed instruction.** AgDR-0104 § Decision directs: *"Fix #962 and #965 fail-closed (a gate that can't evaluate its precondition must **block**, not allow)"* — and **#962 is this very hook**. Resting on the backstop label alone would be too thin, since the labelling requirement came from AgDR-0104 in the same breath; relabelling would then look like a way to escape its own instruction.
+
+The reconciliation is not the label, it is **what the precondition is about**. In #965 the merge gate could not evaluate whether the *protected action* was authorised, and allowed it anyway — an unverified merge proceeded. That is what "must block" governs: never admit the protected action without verifying it.
+
+This hook's ambiguity is a different question one level up. When it cannot resolve a role and PR, it does not know whether the command **is a marker write at all** — not whether an established marker write is authorised. Failing open there **declines jurisdiction**; it does not admit an unverified action. The evidence is unanimous: every false positive enumerated above — a `grep`, an `rm`, an `echo`, a bare variable declaration — was not a marker write. Blocking them protected nothing, because there was no protected action present to protect.
+
+So AgDR-0104's rule is preserved exactly where it applies. A command that *does* resolve to a marker target is the protected action, and it still blocks, fail-closed. Ambiguity about whether the action exists is not the same as ambiguity about whether it is authorised, and only the latter is what "must block, not allow" was written for.
 
 **3. Activate AgDR-0104's deferred CI meta-gate.** Its trigger has fired on its own stated terms. A trust-chain hook must ship with a paired **adversarial** test — one that attempts bypass shapes, not merely asserts the happy path. Seed it with the shapes now known: interpreter heredocs, BSD vs GNU `sed -i`, variable indirection (#962) — and the false-positive direction too, because a gate can fail by over-firing and today it mostly did.
 
@@ -84,5 +94,6 @@ The tests written in each of the three rounds all covered the shapes their autho
 - Ticket: me2resh/apexyard#1015
 - Live bypasses closed by PR #1011 (round 2) — this decision is about the gate's design, not those two fixes
 - Supersedes the deferral in [AgDR-0104](AgDR-0104-trust-chain-controls-vs-backstops.md) § Consequences ("CI meta-gate, trigger: a 3rd independent bypass incident")
+- **Qualifies** [AgDR-0104](AgDR-0104-trust-chain-controls-vs-backstops.md) § Decision step 1 — *"Fix #962 and #965 fail-closed (a gate that can't evaluate its precondition must block, not allow)"* — as it applies to **#962 / this hook only**. The instruction stands unchanged where the precondition concerns whether a *resolved* protected action is authorised; it does not extend to ambiguity about whether a protected action is present at all. See § Decision part 2 for the reasoning. **#965 and the merge gate are untouched by this qualification.**
 - Re-affirms [AgDR-0062](AgDR-0062-rex-marker-authenticity.md)'s accepted exposure and its rejection of the structured-marker and posted-review options
 - Related: [AgDR-0075](AgDR-0075-code-reviewer-local-marker-is-gate-signal.md) (the local marker is the gate signal), #962, #965, #843, #1000

--- a/docs/agdr/AgDR-0109-marker-write-gate-is-a-backstop.md
+++ b/docs/agdr/AgDR-0109-marker-write-gate-is-a-backstop.md
@@ -1,0 +1,88 @@
+---
+id: AgDR-0109
+timestamp: 2026-07-25T10:00:00Z
+agent: claude (orchestrator)
+model: claude-opus-5
+trigger: user-prompt
+status: executed
+---
+
+# The marker-write gate is a backstop, not the control — block only on a resolved target, and activate the deferred meta-gate
+
+> In the context of [AgDR-0104](AgDR-0104-trust-chain-controls-vs-backstops.md) deferring its anti-rot CI meta-gate "until a third *independent* incident proves the class recurs", facing exactly that third incident — two previously-unknown bypasses of `warn-review-marker-write.sh` found during review of the fix for the *previous* bypass — I decided to **label that hook a backstop per AgDR-0104, narrow its blocking behaviour to confidently-resolved marker targets while ambiguity warns instead of blocks, and activate the deferred CI meta-gate** — to achieve a gate that stops obstructing the flow it protects without re-opening the induced-impersonation hole that made it blocking, accepting that a determined actor can still reach the file locally because the real control is the per-PR human approval plus the merge-gate SHA check.
+
+## Context
+
+`warn-review-marker-write.sh` decides whether to block by pattern-matching the **text** of a Bash command to infer write intent. Its history is three rounds deep on one hook:
+
+| Round | Change | Outcome |
+|---|---|---|
+| [#962](https://github.com/me2resh/apexyard/issues/962) → PR #970 | Narrowed from literal path matching toward resolved targets | Incomplete; false positives persisted |
+| [#1000](https://github.com/me2resh/apexyard/issues/1000) → PR #1011 | Narrowed to actual write intent | **Introduced two new bypasses** |
+| PR #1011 round 2 | Closed both | Pending re-review |
+
+AgDR-0062 shipped this hook deliberately as **advisory — "exit 0 always"** — accepting that "the rex marker remains technically forgeable while every merge has a human-in-the-loop CEO nod." It was promoted to **blocking** in [#843](https://github.com/me2resh/apexyard/issues/843) after build-class sub-agents were observed writing their own approval markers (PRs #835, #842). That promotion addressed a real, exercised failure — it was not gratuitous.
+
+AgDR-0104 then established the framing this decision applies:
+
+> "a security gate implemented as regex/substring matching over bash command *text* **cannot be made sound** — the ways to express a path (`$VAR`, `$(…)`, concat, **here-doc**, symlink, `printf`) are unbounded."
+
+and required every trust-chain hook be labelled *THE control* or *a backstop to a server-side gate*. That labelling was never applied to this hook.
+
+### The third incident
+
+AgDR-0104 deferred its CI meta-gate pending "a third *independent* incident" — its n=2 (#962, #965) being correlated, from one API-degraded session. During review of PR #1011, the code reviewer constructed and confirmed two new bypasses:
+
+1. **Interpreter heredoc.** `python3 <<EOF` / `node <<EOF` / `bash <<EOF` with the write in the body — old hook blocked, new logic allowed. Heredoc bodies were stripped as *data*, but for an interpreter the body is *code naming the destination*; such writes also yield no extractable target, so the fallback ran with its only evidence removed.
+2. **Mis-extracted target.** BSD-form `sed -i '' s/a/b/ <file>` returned the sed *expression* as the target; literal and non-matching, it was treated as conclusive and suppressed the fallback. Demonstrated rewriting a stale sign-off into a valid current-HEAD one, defeating the "new commits invalidate approval" property.
+
+Different session, not degraded, different root causes. **`here-doc` appears verbatim in AgDR-0104's list of unbounded expressions** — the class recurred exactly where it was predicted. The trigger has fired.
+
+### The cost being paid meanwhile
+
+In one session the blocking behaviour produced roughly **fourteen false positives**: a read-only `grep` whose *pattern string* contained the trigger words; an `rm` cleanup; an `echo` whose prose mentioned them; the sanctioned reviewer's own sign-off write **with the session marker correctly set**; and a command that merely declared a variable named `MARKER_HOME` — the name the framework's own agent spec recommends. Reviewers worked around it by base64-encoding literals and splitting filenames across `printf` calls.
+
+Two of those matter more than the count. A gate that **blocks its own review** pressures reviewers into obfuscation habits indistinguishable from evasion. And a gate that fires on the **framework's own documented variable name** is mis-tuned by its own standard.
+
+Every one of those false positives shared a signature: the hook reported `detected role: unresolved, pr: unresolved`. It blocked while unable to identify any marker at all.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A — Status quo (block on ambiguity)** | No work; maximally cautious in one direction | ~14 false positives/session; blocks the sanctioned reviewer and the documented cleanup step; drives obfuscation; three rounds of whack-a-mole and counting |
+| **B — Revert fully to advisory (AgDR-0062's original)** | Removes all false positives; restores the recorded design | Re-opens the induced-impersonation hole #843 shipped to close — a real, twice-exercised failure, not hypothetical |
+| **C — Structure the Rex marker** (CEO-marker style fields) | Raises the forgery bar | **Rejected by AgDR-0062**: "a determined build agent can still type out the fields; gives false confidence" |
+| **D — Require a posted forge review at HEAD** | Server-side, unforgeable locally | **Deferred by AgDR-0062/0104**: unsatisfiable in single-account setups, would block every merge |
+| **E — Backstop labelling + resolved-target blocking + meta-gate (chosen)** | Keeps the block where it demonstrably works (a resolved marker target — the #843 shape); removes it where it only ever produced noise (unresolvable commands); applies AgDR-0104's required labelling; activates its deferred fixed point | Ambiguous-but-genuine forgery attempts now warn rather than block — accepted, because this is a backstop and the real control lies elsewhere |
+
+## Decision
+
+Chosen: **E.** Three parts, in order.
+
+**1. Label `warn-review-marker-write.sh` a BACKSTOP, not THE control.** AgDR-0104 requires the label and its own reasoning forces the answer: a hook pattern-matching bash text "cannot be made sound," so it cannot be the thing integrity rests on. The control is, and remains, the per-PR human approval plus `block-unreviewed-merge.sh`'s SHA comparison against the forge-reported HEAD. Record the label in the hook header so the next contributor inherits the framing rather than re-deriving it.
+
+**2. Block only on a confidently-resolved marker target; warn on ambiguity.** When the hook resolves a write target to a marker path, block — that is the #843 shape and it works. When it cannot resolve role and PR (`detected role: unresolved, pr: unresolved`), emit the advisory banner and exit 0.
+
+This is not a weakening dressed as a fix. Failing open on ambiguity is *correct for a backstop* and wrong only for THE control — which, per part 1, this is not. It converts every false positive observed today into a warning while leaving the case that motivated blocking fully gated. A build agent writing a literal marker path is still blocked; a reviewer grepping for the word is not.
+
+**3. Activate AgDR-0104's deferred CI meta-gate.** Its trigger has fired on its own stated terms. A trust-chain hook must ship with a paired **adversarial** test — one that attempts bypass shapes, not merely asserts the happy path. Seed it with the shapes now known: interpreter heredocs, BSD vs GNU `sed -i`, variable indirection (#962) — and the false-positive direction too, because a gate can fail by over-firing and today it mostly did.
+
+The tests written in each of the three rounds all covered the shapes their author had thought of, which is definitionally the set not containing the next bypass. Only an adversarial pairing changes that.
+
+## Consequences
+
+- The ~14 false positives per session collapse to warnings; the sanctioned reviewer stops being blocked by the gate it is reviewing, and reviewers stop needing base64 workarounds that read as evasion.
+- The #843 induced-impersonation case stays blocked. A build agent naming a marker path literally — the observed failure — is unaffected.
+- **Accepted exposure:** a build agent that reaches a marker through indirection the extractor cannot resolve now gets a warning instead of a block. This is the exposure AgDR-0062 already accepted, re-affirmed deliberately rather than inherited: the per-PR human nod is the control, and the merge gate independently validates the SHA against forge-reported HEAD.
+- Every future trust-chain hook costs one adversarial test. Intended; the alternative is a fourth round.
+- AgDR-0104's deferred item is discharged. Its other deferral — compliance mapping, trigger-attached to an adopter request — is untouched.
+- The honest-naming correction stands: absent a separate reviewer identity this is **structured self-review plus an audit trail**, not separation of duties. Narrowing a backstop does not change that claim, because the backstop was never what supported it.
+
+## Artifacts
+
+- Ticket: me2resh/apexyard#1015
+- Live bypasses closed by PR #1011 (round 2) — this decision is about the gate's design, not those two fixes
+- Supersedes the deferral in [AgDR-0104](AgDR-0104-trust-chain-controls-vs-backstops.md) § Consequences ("CI meta-gate, trigger: a 3rd independent bypass incident")
+- Re-affirms [AgDR-0062](AgDR-0062-rex-marker-authenticity.md)'s accepted exposure and its rejection of the structured-marker and posted-review options
+- Related: [AgDR-0075](AgDR-0075-code-reviewer-local-marker-is-gate-signal.md) (the local marker is the gate signal), #962, #965, #843, #1000


### PR DESCRIPTION
## Summary

- **AgDR-0104's deferral trigger has fired, and this records what follows.** That decision deferred its anti-rot CI meta-gate "until a third *independent* incident proves the class recurs" — its n=2 were correlated, from one API-degraded session. Reviewing PR #1011 (the fix for #1000, itself a follow-up to #962/#970) surfaced **two previously-unknown bypasses of the same gate**, in a different, undegraded session. One is the `here-doc` shape AgDR-0104 had already listed by name among the unbounded ways to express a path. The class recurred exactly where it was predicted, so the trigger is satisfied on its own stated terms.

- **Labels `warn-review-marker-write.sh` a backstop, not THE control** — a label AgDR-0104 required for every trust-chain hook but which was never applied to this one. Its own reasoning forces the answer: a hook that pattern-matches bash command text "cannot be made sound," so integrity cannot rest on it. The control is the per-PR human approval plus the merge gate's SHA comparison against forge-reported HEAD. Recording the label means the next contributor inherits the framing instead of re-deriving it on round four.

- **Narrows blocking to confidently-resolved targets; ambiguity warns instead.** Every false positive observed today — roughly fourteen in one session — shared one signature: the hook reported `detected role: unresolved, pr: unresolved`, blocking while unable to identify any marker at all. It blocked a read-only `grep` whose *pattern string* contained the trigger words, an `rm` cleanup, an `echo` whose prose mentioned them, the sanctioned reviewer's own sign-off write with the session marker correctly set, and a command that merely declared a variable named `MARKER_HOME` — the name the framework's own agent spec recommends. Failing open on ambiguity is correct *for a backstop* and wrong only for THE control, which this is not. The #843 induced-impersonation case — a build agent naming a marker path literally — stays fully blocked.

- **Activates the deferred CI meta-gate:** a trust-chain hook must ship with a paired *adversarial* test that attempts bypass shapes, not one that asserts the happy path. Each of the three prior rounds shipped tests covering the shapes its author had thought of, which is definitionally the set that does not contain the next bypass. That is why the same hook has now been "fixed" three times and the third fix introduced two new holes.

- **Deliberately does not re-open settled ground.** AgDR-0062 already considered and rejected structuring the Rex marker ("a determined build agent can still type out the fields; gives false confidence") and deferred requiring a posted forge review (unsatisfiable in a single-account setup, where it would block every merge). The exposure AgDR-0062 accepted is re-affirmed here **deliberately**, with today's evidence, rather than inherited by default.

## Why this is a decision record and not a bug fix

The two live bypasses are already closed by PR #1011 round 2. This PR changes no code. It exists because the *pattern* — three rounds of narrowing on one hook, each shipping tests, the third introducing two fresh bypasses while the same heuristic blocked legitimate work fourteen times — is not something another patch fixes. AgDR-0104 anticipated exactly this and set a trigger. Landing the record is what stops round four being discovered rather than prevented.

## Testing

Documentation only — no code, no hooks, no gate logic touched. Verify by reading `docs/agdr/AgDR-0109-marker-write-gate-is-a-backstop.md` against the two decisions it builds on:

1. `docs/agdr/AgDR-0104-trust-chain-controls-vs-backstops.md` § Consequences — confirm the deferred CI meta-gate names "a 3rd independent bypass incident" as its trigger.
2. `docs/agdr/AgDR-0062-rex-marker-authenticity.md` § Options Considered — confirm the structured-marker and posted-review options were rejected there, so this record re-affirms rather than re-litigates them.

Refs #1015

---

## Glossary

| Term | Definition |
|------|------------|
| Trust chain | The hooks enforcing security-critical SDLC properties — merge gates, review-marker writes, the tracker and marker libraries |
| Control vs backstop | AgDR-0104's distinction: *THE control* sits where it can see structured state (e.g. a forge-reported HEAD SHA); a *backstop* is a best-effort local nudge sitting behind a real server-side gate |
| Adversarial test | A test that actively tries to defeat a control, rather than confirming it works on inputs its author already had in mind |
| Fail-open / fail-closed | Whether a gate that cannot evaluate its precondition allows or denies. Failing open is defensible for a backstop and not for a control |
| Induced impersonation | The #843 failure: a build agent, unable to spawn the real reviewer, writes the reviewer's approval marker itself — satisfying the gate's filename while defeating its intent |
| Structured self-review | One identity both authoring and reviewing, with a recorded audit trail — a real property, but strictly weaker than separation of duties, which needs a second identity |
