### PR TITLE
fix(#1019): strip trailing CR from config_get so Windows multi-line reads work

### DIFF
--- a/.claude/hooks/_lib-read-config.sh
+++ b/.claude/hooks/_lib-read-config.sh
@@ -167,9 +167,14 @@ config_get() {
     # EVERY read is affected, single-value included. Command substitution
     # strips trailing NEWLINES only, so `$(printf 'gh\r\n')` is `gh\r` — the
     # CR survives. Do not gate this strip to iterating filters on the belief
-    # that scalar reads are safe: ~60 single-value reads would silently
+    # that scalar reads are safe: ~40 single-value reads would silently
     # regress, among them `.tracker.kind` and the `$`-anchored
-    # `.tracker.id_pattern`, where a trailing CR breaks the match.
+    # `.tracker.id_pattern`, where a trailing CR breaks the match. (Order of
+    # magnitude, not an exact census: two independent sweeps counted 38 and 39
+    # scalar production reads against 20 and 22 iterating ones, the spread
+    # depending on whether `config_get_or` and double-quoted filters are
+    # included. Only the scalar half is at risk from that hypothetical
+    # gating.)
     #
     # A MULTI-line filter (e.g. `.branch.type_whitelist[]`) is merely where
     # the damage became VISIBLE rather than where it was unique: callers join

--- a/.claude/hooks/_lib-read-config.sh
+++ b/.claude/hooks/_lib-read-config.sh
@@ -162,15 +162,23 @@ config_get() {
     #
     # The trailing-CR strip is for Windows (Git Bash / MSYS2), where the native
     # jq.exe writes stdout through a text-mode CRT handle and rewrites every
-    # emitted \n into \r\n. A SINGLE-value filter is unharmed — command
-    # substitution strips the one trailing newline and takes the \r with it —
-    # but a MULTI-line filter (e.g. `.branch.type_whitelist[]`) leaves a \r
-    # baked into every line except the last. Callers that join with
-    # `paste -sd'|' -` then build an alternation containing stray carriage
-    # returns, which can never match a real branch name or PR title, so the
-    # validators block every branch and PR on Windows. Ten hooks read
-    # multi-line config values, so the fix belongs here rather than at each
-    # call site. See me2resh/apexyard#1019.
+    # emitted \n into \r\n.
+    #
+    # EVERY read is affected, single-value included. Command substitution
+    # strips trailing NEWLINES only, so `$(printf 'gh\r\n')` is `gh\r` — the
+    # CR survives. Do not gate this strip to iterating filters on the belief
+    # that scalar reads are safe: ~60 single-value reads would silently
+    # regress, among them `.tracker.kind` and the `$`-anchored
+    # `.tracker.id_pattern`, where a trailing CR breaks the match.
+    #
+    # A MULTI-line filter (e.g. `.branch.type_whitelist[]`) is merely where
+    # the damage became VISIBLE rather than where it was unique: callers join
+    # with `paste -sd'|' -`, building an alternation with carriage returns
+    # inside it that can never match a real branch name or PR title — and
+    # since the branch/PR validators BLOCK, Windows adopters could not create
+    # a compliant branch or PR at all. Ten hooks read multi-line config
+    # values, so the fix belongs here rather than at each call site.
+    # See me2resh/apexyard#1019.
     #
     # Deliberately surgical: this removes a CR only at end-of-line, not every
     # CR in the stream. A `tr -d '\r'` would also corrupt a config value that

--- a/.claude/hooks/_lib-read-config.sh
+++ b/.claude/hooks/_lib-read-config.sh
@@ -26,6 +26,12 @@
 # ------------------------------------------------------------------------------
 # Internal state: cache merged config per-process so repeated reads are cheap.
 # ------------------------------------------------------------------------------
+# `_CR` holds a literal carriage return, used by config_get to strip the CRLF
+# line endings Windows (Git Bash / MSYS2) jq.exe emits. Defined as a real
+# character rather than a `\r` escape because BSD/macOS sed does not interpret
+# `\r` in a regex — the escape form would silently no-op on macOS and leave the
+# bug half-fixed. See me2resh/apexyard#1019.
+_CR=$(printf '\r')
 _CONFIG_CACHE=""
 _CONFIG_WARNED_NO_JQ=""
 _CONFIG_ROOT_CACHE=""
@@ -147,7 +153,24 @@ config_get() {
     # document and config_get returns empty for EVERY key, silently dropping all
     # project-config overrides (incl. split-portfolio portfolio.* paths).
     # See me2resh/apexyard#629.
-    printf '%s' "$_CONFIG_CACHE" | jq -r "$filter" 2>/dev/null
+    #
+    # The trailing-CR strip is for Windows (Git Bash / MSYS2), where the native
+    # jq.exe writes stdout through a text-mode CRT handle and rewrites every
+    # emitted \n into \r\n. A SINGLE-value filter is unharmed — command
+    # substitution strips the one trailing newline and takes the \r with it —
+    # but a MULTI-line filter (e.g. `.branch.type_whitelist[]`) leaves a \r
+    # baked into every line except the last. Callers that join with
+    # `paste -sd'|' -` then build an alternation containing stray carriage
+    # returns, which can never match a real branch name or PR title, so the
+    # validators block every branch and PR on Windows. Ten hooks read
+    # multi-line config values, so the fix belongs here rather than at each
+    # call site. See me2resh/apexyard#1019.
+    #
+    # Deliberately surgical: this removes a CR only at end-of-line, not every
+    # CR in the stream. A `tr -d '\r'` would also corrupt a config value that
+    # legitimately contains a carriage return mid-string. `$_CR` holds a real
+    # CR character because BSD/macOS sed does not interpret a `\r` escape.
+    printf '%s' "$_CONFIG_CACHE" | jq -r "$filter" 2>/dev/null | sed "s/${_CR}\$//"
   else
     return 0
   fi

--- a/.claude/hooks/_lib-read-config.sh
+++ b/.claude/hooks/_lib-read-config.sh
@@ -28,9 +28,15 @@
 # ------------------------------------------------------------------------------
 # `_CR` holds a literal carriage return, used by config_get to strip the CRLF
 # line endings Windows (Git Bash / MSYS2) jq.exe emits. Defined as a real
-# character rather than a `\r` escape because BSD/macOS sed does not interpret
-# `\r` in a regex — the escape form would silently no-op on macOS and leave the
-# bug half-fixed. See me2resh/apexyard#1019.
+# character rather than writing `s/\r$//` because `\r` is NOT specified by POSIX
+# as a BRE escape — whether sed expands it, matches a literal `r`, or errors is
+# implementation-defined. GNU sed and current macOS/BSD sed both happen to
+# expand it, but relying on that is relying on an accident: a sed that treats
+# `\r` as a literal `r` would silently strip the last character off any value
+# ending in `r` (`…-reviewer` -> `…-reviewe`) — a wrong-value bug, not a
+# no-op, and one that only shows up on whichever platform we didn't test.
+# A real CR byte is unambiguous on every implementation.
+# See me2resh/apexyard#1019.
 _CR=$(printf '\r')
 _CONFIG_CACHE=""
 _CONFIG_WARNED_NO_JQ=""
@@ -169,7 +175,8 @@ config_get() {
     # Deliberately surgical: this removes a CR only at end-of-line, not every
     # CR in the stream. A `tr -d '\r'` would also corrupt a config value that
     # legitimately contains a carriage return mid-string. `$_CR` holds a real
-    # CR character because BSD/macOS sed does not interpret a `\r` escape.
+    # CR byte rather than a `\r` escape — see its definition above for why the
+    # escape form is not portable.
     printf '%s' "$_CONFIG_CACHE" | jq -r "$filter" 2>/dev/null | sed "s/${_CR}\$//"
   else
     return 0

--- a/.claude/hooks/_lib-read-config.sh
+++ b/.claude/hooks/_lib-read-config.sh
@@ -167,14 +167,16 @@ config_get() {
     # EVERY read is affected, single-value included. Command substitution
     # strips trailing NEWLINES only, so `$(printf 'gh\r\n')` is `gh\r` — the
     # CR survives. Do not gate this strip to iterating filters on the belief
-    # that scalar reads are safe: ~40 single-value reads would silently
+    # that scalar reads are safe: dozens of single-value reads would silently
     # regress, among them `.tracker.kind` and the `$`-anchored
-    # `.tracker.id_pattern`, where a trailing CR breaks the match. (Order of
-    # magnitude, not an exact census: two independent sweeps counted 38 and 39
-    # scalar production reads against 20 and 22 iterating ones, the spread
-    # depending on whether `config_get_or` and double-quoted filters are
-    # included. Only the scalar half is at risk from that hypothetical
-    # gating.)
+    # `.tracker.id_pattern`, where a trailing CR breaks the match. ("Dozens"
+    # is deliberate. Three independent sweeps produced three different counts
+    # — the figure moves with the scope swept (`.claude/hooks/` vs all
+    # production `.sh` vs including docs) and with how call forms are matched.
+    # Roughly 40 under `.claude/hooks/`, more repo-wide. No exact census is
+    # stated here because none of the three reproduced, and the argument does
+    # not need one: what matters is that the scalar half is large and would
+    # regress silently.)
     #
     # A MULTI-line filter (e.g. `.branch.type_whitelist[]`) is merely where
     # the damage became VISIBLE rather than where it was unique: callers join

--- a/.claude/hooks/tests/test_config_get_strips_cr.sh
+++ b/.claude/hooks/tests/test_config_get_strips_cr.sh
@@ -5,13 +5,22 @@
 # returns, even when the underlying jq emits CRLF line endings.
 #
 # The bug: on Windows (Git Bash / MSYS2) the native jq.exe writes stdout through
-# a text-mode CRT handle, silently rewriting every \n it emits into \r\n. A
-# SINGLE-value filter is unharmed — command substitution strips the one trailing
-# newline and takes the \r with it — but a MULTI-line filter (e.g.
-# `.branch.type_whitelist[]`) leaves a \r baked into every line except the last.
-# Callers that join with `paste -sd'|' -` then build a regex alternation
-# containing stray carriage returns, which can never match a real branch name or
-# PR title. Since validate-branch-name.sh and validate-pr-create.sh BLOCK on
+# a text-mode CRT handle, silently rewriting every \n it emits into \r\n.
+#
+# EVERY read is affected, and every line is affected. Command substitution
+# strips trailing NEWLINES only, so a scalar read of `gh\r\n` yields `gh\r`, and
+# a 3-element read yields three CRs with the last element ending `chore\r`
+# (both od-verified). Cases 4 and 5 below exist because of exactly this: each
+# FAILS against the unfixed lib, which is direct evidence that scalar reads and
+# the final line are harmed. Do not reintroduce the tempting "scalars and the
+# last line are safe" story — it is false, and acting on it by gating the strip
+# to iterating filters would silently regress ~40 scalar production reads,
+# `.tracker.kind` and the `$`-anchored `.tracker.id_pattern` among them.
+#
+# A MULTI-line filter is where the damage became VISIBLE, not where it was
+# unique: callers join with `paste -sd'|' -`, building a regex alternation with
+# carriage returns inside it that can never match a real branch name or PR
+# title. Since validate-branch-name.sh and validate-pr-create.sh BLOCK on
 # failure, Windows adopters could not create a compliant branch or PR at all.
 # Ten hooks read multi-line config values, so the fix lives in config_get.
 #
@@ -145,12 +154,33 @@ check "mid-string carriage return is preserved, not stripped" "1" "$inner"
 # on whichever platform we cannot run. Assert it at the SOURCE level instead,
 # which works on every platform because it never executes sed at all.
 lib="$HOOK_DIR/_lib-read-config.sh"
-if grep -nE "sed[^|]*['\"]s/\\\\r" "$lib" >/dev/null 2>&1; then
-  found="yes"
+
+# 8a — the file must exist. Without this the two greps below both "pass"
+# vacuously on a bad $HOOK_DIR, and a test that cannot find its target while
+# reporting success is worse than no test at all.
+[ -f "$lib" ] && lib_found="yes" || lib_found="no"
+check "the lib under test was actually located" "yes" "$lib_found"
+
+# 8b — POSITIVE control. The negative grep in 8c is narrow: a `\r` escape can
+# hide from it behind a line continuation, a variable, or `-e`. Asserting the
+# canonical form is PRESENT is spelling-agnostic, so any rewrite that drops
+# `${_CR}` fails here even if it evades 8c.
+if grep -q 'sed "s/${_CR}' "$lib" 2>/dev/null; then
+  canonical="yes"
 else
-  found="no"
+  canonical="no"
 fi
-check "config_get's sed uses a real CR byte, not a \\r escape" "no" "$found"
+check "config_get still strips via the \${_CR} byte" "yes" "$canonical"
+
+# 8c — negative control. Catches the direct `s/\r$//` rewrite. Note this
+# deliberately does NOT flag `sed $'s/\r$//'`: ANSI-C quoting expands to a real
+# CR byte before sed ever sees it, which satisfies the same contract as $_CR.
+if grep -nE "sed[^|]*['\"]s/\\\\r" "$lib" >/dev/null 2>&1; then
+  escaped="yes"
+else
+  escaped="no"
+fi
+check "config_get's sed uses a real CR byte, not a \\r escape" "no" "$escaped"
 
 echo
 echo "==================================="

--- a/.claude/hooks/tests/test_config_get_strips_cr.sh
+++ b/.claude/hooks/tests/test_config_get_strips_cr.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Regression test for me2resh/apexyard#1019.
+#
+# `config_get` must return plain \n-delimited text with no embedded carriage
+# returns, even when the underlying jq emits CRLF line endings.
+#
+# The bug: on Windows (Git Bash / MSYS2) the native jq.exe writes stdout through
+# a text-mode CRT handle, silently rewriting every \n it emits into \r\n. A
+# SINGLE-value filter is unharmed — command substitution strips the one trailing
+# newline and takes the \r with it — but a MULTI-line filter (e.g.
+# `.branch.type_whitelist[]`) leaves a \r baked into every line except the last.
+# Callers that join with `paste -sd'|' -` then build a regex alternation
+# containing stray carriage returns, which can never match a real branch name or
+# PR title. Since validate-branch-name.sh and validate-pr-create.sh BLOCK on
+# failure, Windows adopters could not create a compliant branch or PR at all.
+# Ten hooks read multi-line config values, so the fix lives in config_get.
+#
+# macOS/Linux jq never emits CRLF, so the bug is latent here and a naive test
+# would pass on the OLD code too — proving nothing. This test therefore forces
+# the Windows behaviour with a stub `jq` earlier on PATH that appends \r to every
+# line, exactly as jq.exe does. That reproduces the failure on the old code and
+# passes only on the fixed code.
+
+set -u
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+check() { # check <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS + 1)); printf 'PASS [%s]\n' "$1"
+  else
+    FAIL=$((FAIL + 1)); printf 'FAIL [%s]\n  expected: %s\n  actual:   %s\n' "$1" "$2" "$3"
+  fi
+}
+
+mkdir -p "$TMP/.claude"
+: > "$TMP/.apexyard-fork"
+
+cat > "$TMP/.claude/project-config.defaults.json" <<'JSON'
+{
+  "branch": { "type_whitelist": ["feature", "fix", "chore"] },
+  "tracker": { "kind": "gh" }
+}
+JSON
+
+# --- Stub jq that mimics Windows jq.exe -------------------------------------
+# Wraps the real jq and rewrites every emitted \n into \r\n. awk is used rather
+# than `sed 's/$/\r/'` because BSD/macOS sed does not interpret a \r escape.
+REAL_JQ="$(command -v jq 2>/dev/null)"
+if [ -z "$REAL_JQ" ]; then
+  echo "SKIP: jq not installed — cannot simulate the Windows CRLF path"
+  exit 0
+fi
+
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/jq" <<EOF
+#!/usr/bin/env bash
+"$REAL_JQ" "\$@" | awk '{ printf "%s\r\n", \$0 }'
+EOF
+chmod +x "$TMP/bin/jq"
+
+PATH="$TMP/bin:$PATH"
+export PATH
+
+cd "$TMP" || exit 1
+# APEXYARD_OPS_DISABLE_PIN: without this the session ops-root pin wins over the
+# temp fixture and config_get reads the REAL repo config, so every assertion
+# below would silently test the wrong file.
+export APEXYARD_OPS_DISABLE_PIN=1
+unset _CONFIG_CACHE _CONFIG_ROOT_CACHE 2>/dev/null || true
+# shellcheck source=/dev/null
+. "$HOOK_DIR/_lib-read-config.sh"
+
+# --- 1. multi-line output carries no CR ---------------------------------------
+raw="$(config_get '.branch.type_whitelist[]')"
+cr_count="$(printf '%s' "$raw" | tr -dc '\r' | wc -c | tr -d ' ')"
+check "multi-line config_get output contains no carriage return" "0" "$cr_count"
+
+# --- 2. the joined alternation is usable --------------------------------------
+# This is the shape validate-branch-name.sh and validate-pr-create.sh build.
+types="$(config_get '.branch.type_whitelist[]' | paste -sd'|' -)"
+check "joined alternation is clean" "feature|fix|chore" "$types"
+
+# --- 3. the alternation actually matches a real branch name -------------------
+# The user-visible symptom: with \r present this regex matched nothing, so the
+# validators rejected every branch.
+branch="feature/GH-1019-example"
+if printf '%s' "$branch" | grep -qE "^(${types})/"; then
+  matched="yes"
+else
+  matched="no"
+fi
+check "a valid branch name matches the built alternation" "yes" "$matched"
+
+# --- 4. single-value lookups still work (no over-stripping) -------------------
+check "single-value lookup unaffected" "gh" "$(config_get '.tracker.kind')"
+
+# --- 5. a value containing an INTERNAL carriage return is preserved -----------
+# The strip is deliberately anchored to end-of-line so it cannot corrupt a
+# legitimate mid-string CR. A blanket `tr -d '\r'` would fail this case.
+cat > "$TMP/.claude/project-config.json" <<'JSON'
+{ "custom": { "value": "before\rafter" } }
+JSON
+# Assign empty rather than `unset` — the lib reads these under `set -u`, so
+# unsetting them here makes it abort with "unbound variable" instead of reloading.
+_CONFIG_CACHE=""
+_CONFIG_ROOT_CACHE=""
+inner="$(config_get '.custom.value' | tr -dc '\r' | wc -c | tr -d ' ')"
+check "mid-string carriage return is preserved, not stripped" "1" "$inner"
+
+echo
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/tests/test_config_get_strips_cr.sh
+++ b/.claude/hooks/tests/test_config_get_strips_cr.sh
@@ -48,7 +48,10 @@ JSON
 
 # --- Stub jq that mimics Windows jq.exe -------------------------------------
 # Wraps the real jq and rewrites every emitted \n into \r\n. awk is used rather
-# than `sed 's/$/\r/'` because BSD/macOS sed does not interpret a \r escape.
+# than `sed 's/$/\r/'` because POSIX does not specify `\r` as a sed escape on
+# either side of the substitution — expanding it is an implementation extension,
+# not a guarantee. awk's `printf "\r"` is specified, so the stub behaves the same
+# everywhere. (Same reasoning as the `_CR` definition in _lib-read-config.sh.)
 REAL_JQ="$(command -v jq 2>/dev/null)"
 if [ -z "$REAL_JQ" ]; then
   echo "SKIP: jq not installed — cannot simulate the Windows CRLF path"
@@ -98,12 +101,31 @@ check "a valid branch name matches the built alternation" "yes" "$matched"
 # --- 4. single-value lookups still work (no over-stripping) -------------------
 check "single-value lookup unaffected" "gh" "$(config_get '.tracker.kind')"
 
-# --- 5. a value containing an INTERNAL carriage return is preserved -----------
+# --- 5. the LAST line of a multi-line read is not damaged ---------------------
+# The strip runs on every line, including the final one. Check the last element
+# arrives whole rather than clipped — a strip that ate one byte too many would
+# still produce CR-free output and so would pass checks 1 and 2 unnoticed.
+last="$(config_get '.branch.type_whitelist[]' | tail -n1)"
+check "last element of a multi-line read is intact" "chore" "$last"
+
+# --- 6. a value ending in a literal 'r' survives ------------------------------
+# The reason `_CR` holds a real CR byte instead of the string `\r`: POSIX does
+# not specify `\r` as a BRE escape, so an implementation is free to read it as a
+# literal `r`. Under such a sed, `s/\r$//` would silently truncate every value
+# ending in 'r' — 'reviewer' -> 'reviewe'. That is a wrong VALUE, not a no-op,
+# and it would sail past every other check in this file. This case pins it.
+cat > "$TMP/.claude/project-config.json" <<'JSON'
+{ "custom": { "value": "before\rafter", "ends_in_r": "active-reviewer" } }
+JSON
+# Assign empty rather than `unset` — the lib reads these under `set -u`, so
+# unsetting them here makes it abort with "unbound variable" instead of reloading.
+_CONFIG_CACHE=""
+_CONFIG_ROOT_CACHE=""
+check "value ending in a literal 'r' is not truncated" "active-reviewer" "$(config_get '.custom.ends_in_r')"
+
+# --- 7. a value containing an INTERNAL carriage return is preserved -----------
 # The strip is deliberately anchored to end-of-line so it cannot corrupt a
 # legitimate mid-string CR. A blanket `tr -d '\r'` would fail this case.
-cat > "$TMP/.claude/project-config.json" <<'JSON'
-{ "custom": { "value": "before\rafter" } }
-JSON
 # Assign empty rather than `unset` — the lib reads these under `set -u`, so
 # unsetting them here makes it abort with "unbound variable" instead of reloading.
 _CONFIG_CACHE=""

--- a/.claude/hooks/tests/test_config_get_strips_cr.sh
+++ b/.claude/hooks/tests/test_config_get_strips_cr.sh
@@ -155,26 +155,44 @@ check "mid-string carriage return is preserved, not stripped" "1" "$inner"
 # which works on every platform because it never executes sed at all.
 lib="$HOOK_DIR/_lib-read-config.sh"
 
-# 8a — the file must exist. Without this the two greps below both "pass"
-# vacuously on a bad $HOOK_DIR, and a test that cannot find its target while
-# reporting success is worse than no test at all.
+# 8a — the file must exist. Without this, 8c "passes" vacuously on a bad
+# $HOOK_DIR: a negative grep finds no `\r` escape in a file it cannot open, and
+# a test that misses its target while reporting success is worse than no test.
+# 8b does NOT share that failure — a positive control cannot pass vacuously,
+# which is the structural reason to have one. 8a is therefore about 8c.
 [ -f "$lib" ] && lib_found="yes" || lib_found="no"
 check "the lib under test was actually located" "yes" "$lib_found"
 
 # 8b — POSITIVE control. The negative grep in 8c is narrow: a `\r` escape can
 # hide from it behind a line continuation, a variable, or `-e`. Asserting the
 # canonical form is PRESENT is spelling-agnostic, so any rewrite that drops
-# `${_CR}` fails here even if it evades 8c.
-if grep -q 'sed "s/${_CR}' "$lib" 2>/dev/null; then
+# `${_CR}` fails here even if it evades 8c. Unlike 8c it cannot pass vacuously.
+#
+# Matched against the whole PIPELINE, not just `sed "s/${_CR}`, because a
+# file-scoped anchor is satisfied by any mention anywhere — including one of the
+# comments in this very block, which would let a rewritten sed call slip past
+# while the suite stayed green.
+#
+# `-F` (fixed string) is deliberate, not laziness: as a BRE, the `{` in
+# `${_CR}` is undefined behaviour, and at least one grep implementation
+# (ugrep 7.5) returns zero matches for the pattern form — which would make this
+# control silently vacuous. That is precisely the class of bug this PR exists to
+# fix, so the guard must not be built on it.
+if grep -qF 'jq -r "$filter" 2>/dev/null | sed "s/${_CR}' "$lib" 2>/dev/null; then
   canonical="yes"
 else
   canonical="no"
 fi
 check "config_get still strips via the \${_CR} byte" "yes" "$canonical"
 
-# 8c — negative control. Catches the direct `s/\r$//` rewrite. Note this
-# deliberately does NOT flag `sed $'s/\r$//'`: ANSI-C quoting expands to a real
-# CR byte before sed ever sees it, which satisfies the same contract as $_CR.
+# 8c — negative control. Catches the direct `s/\r$//` rewrite.
+#
+# It ALSO flags `sed $'s/\r$//'`, which is a false positive in principle: ANSI-C
+# quoting expands to a real CR byte before sed ever sees it, so that form is
+# actually portable and satisfies the same contract as $_CR. Accepted knowingly
+# — nobody writes it here, and the failure direction is safe: it forces a human
+# to look rather than waving a `\r` through. (An earlier revision of this
+# comment claimed the opposite — that 8c does not flag it. It does.)
 if grep -nE "sed[^|]*['\"]s/\\\\r" "$lib" >/dev/null 2>&1; then
   escaped="yes"
 else

--- a/.claude/hooks/tests/test_config_get_strips_cr.sh
+++ b/.claude/hooks/tests/test_config_get_strips_cr.sh
@@ -109,11 +109,16 @@ last="$(config_get '.branch.type_whitelist[]' | tail -n1)"
 check "last element of a multi-line read is intact" "chore" "$last"
 
 # --- 6. a value ending in a literal 'r' survives ------------------------------
-# The reason `_CR` holds a real CR byte instead of the string `\r`: POSIX does
-# not specify `\r` as a BRE escape, so an implementation is free to read it as a
-# literal `r`. Under such a sed, `s/\r$//` would silently truncate every value
-# ending in 'r' — 'reviewer' -> 'reviewe'. That is a wrong VALUE, not a no-op,
-# and it would sail past every other check in this file. This case pins it.
+# Asserts the behavioural contract: a value ending in 'r' comes back whole.
+#
+# Be precise about what this does and does not catch, because the obvious
+# reading is wrong. On a CONFORMING sed this passes whether the code uses
+# `$_CR` or a literal `\r`, so it does NOT catch a maintainer swapping one for
+# the other — case 8 below exists for that. What it catches is a sed that reads
+# `\r` as a literal 'r' (POSIX leaves that undefined), which we can only reach
+# by sabotaging `_CR` to the string `r` — and note it then fails via the CR
+# SURVIVING, not via truncation, since the stub leaves the value as
+# 'active-reviewer\r' and `s/r$//` cannot match a trailing CR.
 cat > "$TMP/.claude/project-config.json" <<'JSON'
 { "custom": { "value": "before\rafter", "ends_in_r": "active-reviewer" } }
 JSON
@@ -132,6 +137,20 @@ _CONFIG_CACHE=""
 _CONFIG_ROOT_CACHE=""
 inner="$(config_get '.custom.value' | tr -dc '\r' | wc -c | tr -d ' ')"
 check "mid-string carriage return is preserved, not stripped" "1" "$inner"
+
+# --- 8. the source does not rely on a `\r` escape inside sed ------------------
+# The realistic regression is a maintainer "simplifying" `sed "s/${_CR}\$//"`
+# into `sed 's/\r$//'`. Every runtime check above passes on a conforming sed,
+# so no behavioural test on this machine can catch it — it would only surface
+# on whichever platform we cannot run. Assert it at the SOURCE level instead,
+# which works on every platform because it never executes sed at all.
+lib="$HOOK_DIR/_lib-read-config.sh"
+if grep -nE "sed[^|]*['\"]s/\\\\r" "$lib" >/dev/null 2>&1; then
+  found="yes"
+else
+  found="no"
+fi
+check "config_get's sed uses a real CR byte, not a \\r escape" "no" "$found"
 
 echo
 echo "==================================="


### PR DESCRIPTION
## Summary

- **Windows adopters currently cannot create a compliant branch or PR at all.** On Git Bash / MSYS2 the native `jq.exe` writes stdout through a text-mode CRT handle and rewrites every `\n` it emits into `\r\n`. Callers joining a multi-line value with `paste -sd'|' -` build a regex alternation containing stray carriage returns, which can never match a real branch name or PR title. Since `validate-branch-name.sh` and `validate-pr-create.sh` **block** rather than warn, the effect is a hard stop on every branch and PR.

- **Every read is affected, single-value included — and an earlier revision of this PR claimed otherwise.** Command substitution strips trailing **newlines** only, so `$(printf 'gh\r\n')` is `gh\r` (od-verified in `bash` and `sh`), and that surviving CR breaks any `$`-anchored match. This correction matters practically: acting on the old claim by gating the strip to iterating filters would silently regress dozens of scalar reads, `.tracker.kind` and the `$`-anchored `.tracker.id_pattern` among them. The multi-line case is where the damage became **visible**, not where it was unique.

- **The blast radius is five times what the report described.** @Manito2z named those two validators; **ten** hooks read multi-line config values, including `require-active-ticket.sh`, `block-main-push.sh`, `validate-commit-format.sh`, `require-agdr-for-arch-pr.sh` and `block-private-refs-in-public-repos.sh`. That is why the fix belongs in `config_get` rather than at each call site — patching the two named validators would have left eight consumers silently broken.

- **The strip is deliberately anchored to end-of-line, not global.** A blanket `tr -d '\r'` would also corrupt a config value that legitimately contains a mid-string carriage return. Case 7 pins that distinction, so a future "simplification" to `tr -d` fails the suite instead of silently changing behaviour.

- **`_CR` holds a real carriage-return byte rather than a `\r` escape, and the reason has been corrected.** An earlier revision justified it by claiming BSD/macOS `sed` does not interpret `\r` — that is **false**; current macOS `sed` interprets it fine. The real reason is portability: POSIX does not specify `\r` as a `sed` escape on either side of a substitution, so an implementation may read it as a literal `r`. Under such a `sed`, `s/\r$//` would silently truncate any value ending in 'r' (`active-reviewer` → `active-reviewe`) — a wrong **value**, not a no-op, appearing only on the platform we cannot test.

## Why this is safe for existing adopters

**Strictly a no-op on macOS and Linux.** `jq` there emits no carriage returns, so the `sed` stage has nothing to match and passes every line through unchanged. Verified directly: stdout is byte-identical across nine filters before and after.

## Testing

`.claude/hooks/tests/test_config_get_strips_cr.sh` — ten assertions:

| # | Assertion |
|---|---|
| 1 | multi-line output contains no carriage return |
| 2 | the joined alternation is clean (`feature\|fix\|chore`) |
| 3 | a real branch name actually matches that alternation — the user-visible symptom |
| 4 | single-value lookups are correct (no over-stripping) |
| 5 | the **last** line of a multi-line read is intact — a strip eating one byte too far would still be CR-free and pass 1 and 2 |
| 6 | a value ending in a literal 'r' is returned whole |
| 7 | a **mid-string** carriage return is preserved, not stripped |
| 8a | the lib under test was actually located — without this **8c** passes vacuously on a bad path (8b cannot; a positive control never does) |
| 8b | **positive control**: the canonical `${_CR}` strip is still present, matched across the whole pipeline via `grep -qF` — catches rewrites that evade 8c |
| 8c | **negative control**: no `\r` escape inside `sed` — a source-level check |

macOS/Linux `jq` never emits CRLF, so a naive test would pass on the broken code too and prove nothing. The test therefore forces the Windows behaviour with a **stub `jq` earlier on `PATH`** that appends `\r` to every line, exactly as `jq.exe` does.

**Verified in both directions:**

Eight variants, each measured rather than reasoned about:

```
the fix                              :  PASS 10  FAIL 0
the UNFIXED lib (strip removed)      :  PASS  2  FAIL 8
_CR sabotaged to the literal 'r'     :  PASS  3  FAIL 7
sed swapped to a literal \r escape    :  PASS  8  FAIL 2
${_CR} swapped for a shell variable  :  PASS  3  FAIL 7
the lib file absent entirely         :  PASS  2  FAIL 8
\x0d escape, anchor kept in a comment :  PASS  9  FAIL 1
split line, anchor kept in a comment  :  PASS  8  FAIL 2
```

The last three rows are why case 8 has three parts. The realistic regression is a maintainer simplifying `sed "s/${_CR}$//"` into `sed 's/\r$//'` — and because macOS `sed` handles `\r` correctly, **no behavioural test on this machine can detect it**; every runtime case stays green. 8c catches the direct rewrite, 8b catches the rewrites that hide from 8c behind a variable or a line continuation, and 8a exists because without it a bad `$HOOK_DIR` made **8c** pass vacuously — a test that cannot find its target while reporting success is worse than no test. 8b is immune to that by construction: a positive control cannot pass when the file is missing, which is precisely why the pair is worth having.

8b is also deliberately whitespace-exact (`grep -qF` against the full pipeline), so reformatting the real `config_get` line — a hoist to a variable, an extra space — will false-fail it. That brittleness is accepted on purpose: the failure direction is safe and it names the exact line, which beats a loose pattern that a rewrite can slip past.

The controls do not all fail distinct subsets — the `\r`-escape row and the split-line row both fail exactly {8b, 8c}. They are still worth running separately: they reach that same failure by different routes, and a guard that only survives the route its author imagined is the failure mode this whole section exists to document.

Worth noting how invisible the underlying bug is: case 4 fails on the old code with `expected: gh, actual: gh`. Identical to the eye, different to the shell, because of a trailing `\r` you cannot see in any output.

Also confirmed: the sibling `test_config_get_backslash_escape.sh` still passes, and `shellcheck -x -S warning` is clean on both files.

### Review history

Five rounds of review found **eight false factual claims** in this PR's own prose — plus one unsupportable number — all in trust-chain code where a maintainer could act on them:

1. "BSD/macOS `sed` does not interpret `\r`" — it does.
2. "A single-value filter is unharmed" — it isn't; the CR survives command substitution.
3. "…a `\r` on every line **except the last**" — it's on the last line too (`chore\r`).
4. Case 6's comment claimed to pin truncation — it actually fails via CR survival.
5. "~60 scalar reads" — unsupportable. Three sweeps produced three different counts, and review disproved the stated cause of the spread. Now "dozens", with no census claimed.
6. The 8a comment: "both greps pass vacuously on a bad path" — only 8c does; a positive control structurally cannot.
7. The 8c comment: "deliberately does NOT flag `sed $'s/\r$//'`" — it does. The reasoning was right, the behaviour claim inverted.
8. Misattributing #6 and #7 to the fix for #4 when they came from the fix for #2 — disclosed below but, until now, never counted.
9. …then #6 again, corrected in the code but left standing in this PR body (see below).

Two patterns are worth naming. **#2 and #3 sat in a header directly above tests that disprove them** — cases 4 and 5 fail on the unfixed lib precisely because scalar reads and the final line are affected. The evidence was in the same file as the claim.

And **#6 and #7 were introduced by the fix for #2** (commit `64ff5ca`) — the remediation of a false-comment finding shipped two more false comments. (Item 8: an earlier revision misattributed them to the fix for #4, `7e349e7`, which introduced neither. Corrected after review traced all five commits.) That is the strongest argument for the source-level guards: prose describing behaviour drifts from behaviour, and only an executable check notices.

Finding #6 then did it once more, at one further remove: it was corrected in the code comment and left standing **in this document**, which for a time asserted the falsehood, the correction, and the note that it had been retired — all at once. Fixed above. The lesson is not "write more carefully"; it is that a claim about code belongs in a test, where it either holds or fails, rather than in prose, where it can be wrong indefinitely and still read well.

Recording this rather than quietly fixing it, because the pattern is the interesting failure here, not the CRLF bug: the code was right in every round and the stated justification was wrong in every round. In trust-chain code a confident, wrong comment is the more dangerous artifact — it survives review, gets believed, and licenses a future "simplification" that reintroduces the bug.

Refs #1019

---

## Glossary

| Term | Definition |
|------|------------|
| CRLF | The Windows line ending `\r\n`, versus `\n` on Unix. The stray `\r` is what contaminates the values here. |
| Text-mode CRT handle | The Windows C-runtime stdout mode that silently translates `\n` to `\r\n` on write — why `jq.exe` differs from `jq` without either being wrong |
| Alternation | A regex `(a\|b\|c)` built here by joining config values with `paste -sd'\|' -`; one stray `\r` makes the whole pattern unmatchable |
| MSYS2 / Git Bash | The POSIX-emulation environment most Windows developers run these hooks under; it provides a Unix shell but native Windows binaries on `PATH` |
| No-op | A change with no observable effect on a given platform — here, the entire fix on macOS and Linux |
| BRE | Basic Regular Expression, the dialect `sed` uses by default. POSIX leaves the meaning of `\r` in a BRE undefined, which is the whole reason `_CR` holds a real byte. |
| Source-level assertion | A test that inspects the code text rather than running it — used here to catch a regression that is invisible at runtime on conforming platforms |
