### PR TITLE
fix(#1017): count-guard warning text + fail-open range parse

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Write
 
 # /release — Cut an apexyard release
 
-Standardises the `dev` → `main` release flow introduced by AgDR-0007. Reads the conventional-commit log between `main` and `dev`, proposes a semver bump, **generates and writes the CHANGELOG entry**, **opens the release PR** (dev→main), and triggers the `auto-tag-on-release-pr-merge` GitHub Actions workflow that tags the squash commit and creates a GitHub Release after merge. One command drives the operator from "nothing" to "PR open, ready for Rex + CEO". The tag and GitHub Release entry are created automatically by CI when the PR merges. The release PR also records a `Released-From` trailer with the exact `dev` cut-point SHA, and the changelog step warns loudly on a large main↔dev commit-count mismatch — both close the #872 changelog-truncation gap. Design rationale: AgDR-0076, AgDR-0094.
+Standardises the `dev` → `main` release flow introduced by AgDR-0007. Reads the conventional-commit log between `main` and `dev`, proposes a semver bump, **generates and writes the CHANGELOG entry**, **opens the release PR** (dev→main), and triggers the `auto-tag-on-release-pr-merge` GitHub Actions workflow that tags the squash commit and creates a GitHub Release after merge. One command drives the operator from "nothing" to "PR open, ready for Rex + CEO". The tag and GitHub Release entry are created automatically by CI when the PR merges. The release PR also records a `Released-From` trailer with the exact `dev` cut-point SHA, and the changelog step warns loudly if commits inside the resolved changelog range aren't all making it into entries — both guard against the #872 changelog-truncation failure mode. Design rationale: AgDR-0076, AgDR-0094.
 
 This skill is **framework-only** — it's for cutting apexyard releases, not for releasing managed projects under governance. Managed projects stay trunk-based and don't have a release-cut flow.
 
@@ -76,6 +76,16 @@ echo "$CHANGELOG_DRAFT"
 # Released-From trailer, or the #737 sync-boundary heuristic otherwise. The
 # count-mismatch guard below MUST compare against this range, not main..dev.
 LOG_RANGE=$(grep -oE 'RELEASE_CHANGELOG_RANGE=.*' /tmp/release-changelog-range.txt | cut -d= -f2-)
+
+# #1017: fail CLOSED here, not at the arithmetic below. An empty/unparseable
+# $LOG_RANGE must stop the release, not silently flow into `git rev-list
+# --count ""` (whose stderr never reaches $RAW_COUNT and would let the guard
+# read a "0 commits, 0 gap" pass — AgDR-0104: "a gate that can't evaluate its
+# precondition must block, not allow").
+if [ -z "$LOG_RANGE" ]; then
+  echo "ERROR: could not read RELEASE_CHANGELOG_RANGE from bin/release-changelog.sh's stderr (see /tmp/release-changelog-range.txt). The count-mismatch guard has nothing to check against — do NOT proceed until this is resolved." >&2
+  exit 1
+fi
 ```
 
 The helper emits markdown to stdout in the format:
@@ -108,8 +118,17 @@ Immediately after generating the draft, sanity-check its entry count against the
 
 **#1002 — do not compare against `upstream/main..upstream/dev`.** Under the release-cut model `main` only ever receives squash merges, so every individual `dev` commit stays permanently unreachable from `main` — `main..dev` grows monotonically with every release and can never shrink. Comparing the changelog's entry count against that raw, ever-growing number always false-positives (v5.2.0 cut: 402 raw commits vs. ~1-2 real entries, a "gap" of 400 on a perfectly correct changelog). `$LOG_RANGE` is anchored on the actual cut point (the `Released-From` trailer, or the #737 sync-boundary fallback) and is the range that matters:
 
+**#1017 — what this guard can (and can't) still see.** `RAW_COUNT` and `ENTRY_COUNT` are now *both* derived from the same `$LOG_RANGE`, so the guard can no longer catch a truncated *range* the way it originally did — if `$LOG_RANGE` itself were too narrow, both counts would shrink together and the gap would stay small. That's an acceptable trade, not a silent regression: `$LOG_RANGE`'s anchor is exact by construction once a `Released-From` trailer exists (AgDR-0094), and step 6's post-merge check now makes a missing trailer a hard failure — so the truncated-range case is closed at its source. What the guard genuinely still catches is **classification drop-out inside a correct range**: a commit that really is inside `$LOG_RANGE` but that `bin/release-changelog.sh` didn't turn into a changelog bullet (a subject it failed to classify, a filtering bug, etc.). The warning text below describes that condition, not the old truncated-range one — say what's actually being detected, not what the guard detected before #1012 re-anchored it.
+
 ```bash
-RAW_COUNT=$(git rev-list --count "$LOG_RANGE")
+RAW_COUNT=$(git rev-list --count "$LOG_RANGE") || {
+  # #1017: fail CLOSED — don't let a `git rev-list` failure (empty or
+  # malformed $LOG_RANGE) leave $RAW_COUNT unset/empty and the arithmetic
+  # below silently treat it as 0 (GAP would go negative, no warning, guard
+  # passes quiet on exactly the precondition-failure case it exists to catch).
+  echo "ERROR: 'git rev-list --count $LOG_RANGE' failed — the count-mismatch guard cannot evaluate its precondition. Do NOT proceed; fix \$LOG_RANGE (see /tmp/release-changelog-range.txt) and rerun." >&2
+  exit 1
+}
 # Count changelog entry bullets, excluding the trailing "- Closes #N, ..."
 # summary line (#1002: it is a summary, not an entry, and used to be
 # miscounted as one, causing an off-by-one on every run).
@@ -118,12 +137,14 @@ ENTRY_COUNT=$(printf '%s\n' "$CHANGELOG_DRAFT" | grep -E '^- ' | grep -vcE '^- C
 GAP=$(( RAW_COUNT - ENTRY_COUNT ))
 # Tolerance: release/sync/"Merge branch" marker commits are excluded from the
 # changelog BY DESIGN (bin/release-changelog.sh's classify step) — a handful
-# of those is normal, not a bug. A gap much larger than that is the #872
-# signature (a silently truncated range).
+# of those is normal, not a bug. A gap much larger than that means commits
+# genuinely inside $LOG_RANGE are failing to classify into changelog entries
+# — NOT a truncated range (see the #1017 note above; $LOG_RANGE itself is
+# anchored on the Released-From trailer or the #737 fallback either way).
 TOLERANCE=5
 if [ "$GAP" -gt "$TOLERANCE" ]; then
   echo "⚠️  WARNING: the release range ($LOG_RANGE) has $RAW_COUNT commits but the changelog lists only $ENTRY_COUNT entries (gap: $GAP, tolerance: $TOLERANCE)."
-  echo "    This is the #872 signature — a truncated changelog range. Verify PREV_TAG/HEAD_REF and \$LOG_RANGE before proceeding."
+  echo "    Commits inside \$LOG_RANGE are not making it into changelog entries — read 'git log $LOG_RANGE --oneline' against the draft above and find what's missing before proceeding."
 fi
 ```
 
@@ -344,7 +365,7 @@ This files a `sync/main-to-dev-after-vA.B.C → dev` PR that merges `upstream/ma
 7. **`<!-- multi-close: approved -->`** in the release PR body is required — release PRs legitimately close many tickets at once.
 8. **`--dry-run` stops before writing any files.** The draft CHANGELOG section and PR body are shown; nothing is committed, branched, pushed, or filed.
 9. **The `Released-From` trailer must be its own final paragraph** in BOTH the step-4 branch commit and the step-5 PR body (AgDR-0094). It is what makes the next release's changelog range deterministic — a trailer that lands mid-body (or gets pushed off the end by later edits) silently degrades back to the pre-AgDR-0094 sync-boundary heuristic, with all its known failure modes (#737, #872).
-10. **Show the count-mismatch warning if it fires** — a loud gap between `$LOG_RANGE`'s raw commit count and the changelog's entry count is the #872 signature. Don't proceed past it without the operator explicitly confirming the range is correct. **Never compare against `upstream/main..upstream/dev`** (#1002) — under the release-cut squash model that range only ever grows, so it always false-positives; `$LOG_RANGE` (captured in step 3) is the range the changelog was actually built from.
+10. **Show the count-mismatch warning if it fires** — a loud gap between `$LOG_RANGE`'s raw commit count and the changelog's entry count means commits inside that range didn't make it into changelog entries (#1017 — not a truncated range; both counts derive from the same `$LOG_RANGE`, so a truncated range can no longer produce this gap). Don't proceed past it without the operator explicitly confirming the range is correct. **Never compare against `upstream/main..upstream/dev`** (#1002) — under the release-cut squash model that range only ever grows, so it always false-positives; `$LOG_RANGE` (captured in step 3) is the range the changelog was actually built from. **A `$LOG_RANGE` that fails to resolve or fails `git rev-list` must halt the release (`exit 1`), never pass silently** (#1017) — see step 3's guard.
 11. **Merge the release PR with an explicit `--subject`/`--body-file`, never a bare `gh pr merge --squash`** (#1004) — this repo's `squash_merge_commit_message=COMMIT_MESSAGES` setting silently drops a trailer that lives only in the PR body. See step 6.
 12. **Verify the `Released-From` trailer landed on the squash commit immediately after merge, and stop before `/release-sync` if it didn't** (#1004) — a missing trailer is invisible until the *next* release cut silently mis-anchors its changelog range. See step 6's verification block and the post-tag checklist in step 7.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -87,11 +87,28 @@ PREV_TAG="$PREV_TAG" HEAD_REF="upstream/dev" VERSION="$VERSION" DATE="$(date +%F
 LOG_RANGE=$(grep -oE 'RELEASE_CHANGELOG_RANGE=.*' /tmp/release-changelog-range.txt | cut -d= -f2-)
 # Review and edit /tmp/changelog-section.md
 
-RAW_COUNT=$(git rev-list --count "$LOG_RANGE")
+# #1017: fail CLOSED on a missing/unparseable range instead of letting an
+# empty $LOG_RANGE silently flow into `git rev-list --count ""` below (its
+# stderr never reaches $RAW_COUNT, so the guard would otherwise read a
+# "0 commits" pass — AgDR-0104: a gate that can't evaluate its precondition
+# must block, not allow).
+if [ -z "$LOG_RANGE" ]; then
+  echo "ERROR: RELEASE_CHANGELOG_RANGE missing from /tmp/release-changelog-range.txt — the count-mismatch guard has nothing to check. Do not proceed." >&2
+  exit 1
+fi
+RAW_COUNT=$(git rev-list --count "$LOG_RANGE") || {
+  echo "ERROR: 'git rev-list --count $LOG_RANGE' failed — cannot evaluate the count-mismatch guard. Do not proceed." >&2
+  exit 1
+}
 ENTRY_COUNT=$(grep -E '^- ' /tmp/changelog-section.md | grep -vcE '^- Closes ' || true)
-GAP=$(( RAW_COUNT - ${ENTRY_COUNT:-0} ))
+[ -n "$ENTRY_COUNT" ] || ENTRY_COUNT=0
+GAP=$(( RAW_COUNT - ENTRY_COUNT ))
 if [ "$GAP" -gt 5 ]; then
-  echo "WARNING: $LOG_RANGE has $RAW_COUNT commits but the changelog lists only $ENTRY_COUNT entries." >&2
+  # #1017: RAW_COUNT and ENTRY_COUNT both derive from $LOG_RANGE now, so this
+  # gap means commits genuinely inside the range aren't classifying into
+  # changelog entries — not a truncated range (that failure mode is closed at
+  # the trailer-anchoring source; see AgDR-0094 and step 7b below).
+  echo "WARNING: $LOG_RANGE has $RAW_COUNT commits but the changelog lists only $ENTRY_COUNT entries (some commits inside the range didn't classify into an entry)." >&2
 fi
 
 # 4. Prepend to CHANGELOG.md


### PR DESCRIPTION
## Summary

- **Re-worded the count-mismatch guard's warning so it describes what it actually detects.** After #1012 re-anchored the guard onto `$LOG_RANGE`, both `RAW_COUNT` and `ENTRY_COUNT` derive from the same range — so a truncated range (the original `#872` failure) can no longer produce a gap between them; the two numbers shrink together. What the guard genuinely still catches is *classification drop-out inside a correct range* (a commit that's really in `$LOG_RANGE` but didn't turn into a changelog bullet). The warning text, the surrounding comments, and rule 10 all said "#872 signature — a truncated changelog range" — which is precisely the thing the guard can no longer see. Fixed in both `.claude/skills/release/SKILL.md` (the automated `/release` flow) and `docs/release-process.md` (the manual fallback runbook), so an operator reading the warning gets pointed at the right investigation (read the commits in the range, not re-check `PREV_TAG`/`HEAD_REF`).
- **Made an unresolved `$LOG_RANGE` fail CLOSED instead of failing open.** If `RELEASE_CHANGELOG_RANGE` can't be parsed from `bin/release-changelog.sh`'s stderr, `$LOG_RANGE` is empty, and `git rev-list --count ""` fails — but since nothing captured that failure, `$RAW_COUNT` silently became an empty string, and `GAP=$(( RAW_COUNT - ENTRY_COUNT ))` treated it as `0`, so the guard passed quietly on exactly the case it can't evaluate. Both scripts now check `$LOG_RANGE` for empty immediately after resolving it, and guard the `git rev-list` call with `|| { …; exit 1; }`, so a missing or malformed range now halts the release with a loud, actionable message instead of reading as "no gap." This matches AgDR-0104's rail: *a gate that can't evaluate its precondition must block, not allow.*
- **Did not add a `${RAW_COUNT:-0}` default.** The issue's own draft AC suggested giving `RAW_COUNT` "the same defensive default treatment as `ENTRY_COUNT`" — but a `:-0` default is exactly the fail-open bug in disguise: it would make a `git rev-list` failure look like "0 commits" and the guard would still pass silently. `ENTRY_COUNT`'s `:-0` default is legitimate (a genuinely empty changelog is a valid state); a failed `git rev-list` on `$LOG_RANGE` is not. Explicit exit-1 checks are used instead — see Finding 2 disposition below.

## Finding-by-finding disposition (from #1017)

1. **Warning text mismatch** — real, confirmed by reading `bin/release-changelog.sh`'s classify step and the guard's own comments. Fixed.
2. **Range parse fails open** — real, confirmed by reproducing it directly (see Testing). Fixed.
3. **Cosmetic squash-body finding** and the **optional anchor-kind surfacing** enhancement from #1017 are out of scope for this PR per the task brief ("keep it minimal, don't restructure the release flow") — left for a follow-up if wanted.

## Testing

Ran the fixed guard logic against this repo's real `upstream/main`/`upstream/dev` history (not a fixture), plus the two existing release test suites.

**1. Happy path — real trailer-anchored range, guard passes correctly:**

```
$ PREV_TAG=v5.2.0 HEAD_REF=upstream/dev VERSION=v99.99.99 DATE=$(date +%F) bash bin/release-changelog.sh > /tmp/cl.md 2>/tmp/range.txt
$ cat /tmp/range.txt
RELEASE_CHANGELOG_RANGE=dc26b8c986f6a9682b037ebb6c7fbba048f36259..upstream/dev

RAW_COUNT=9 ENTRY_COUNT=6 GAP=3
no warning — gap within tolerance, guard passes correctly
```

**2. Fail-closed path — empty `$LOG_RANGE`, fixed guard:**

```
LOG_RANGE=""
if [ -z "$LOG_RANGE" ]; then
  echo "ERROR: could not read RELEASE_CHANGELOG_RANGE ... Do NOT proceed." >&2
  exit 1
fi
→ ERROR: could not read RELEASE_CHANGELOG_RANGE — guard has nothing to check against. Do NOT proceed.
→ exit 1 (fail-closed confirmed)
```

**3. Old (pre-fix) behaviour on the same empty range, for contrast:**

```
LOG_RANGE=""
RAW_COUNT=$(git rev-list --count "$LOG_RANGE")   # fatal: ambiguous argument '' ... (stderr only)
GAP=$(( RAW_COUNT - ENTRY_COUNT ))                # RAW_COUNT treated as 0
→ NO WARNING — silent pass-through (the #1017 bug), exit 0
```

**4. Existing test suites — unaffected (no change to `bin/release-changelog.sh`):**

```
$ bash .claude/hooks/tests/test_release_changelog.sh
All 58 test(s) passed.

$ bash .claude/hooks/tests/test_release_sync.sh
Passed: 14
Failed: 0
```

## Glossary

| Term | Definition |
|------|------------|
| `LOG_RANGE` | The commit range `bin/release-changelog.sh` actually generated the changelog from — trailer-anchored (`Released-From` sha) when available, else the `#737` sync-boundary fallback. Printed to stderr as `RELEASE_CHANGELOG_RANGE=...` so the count-mismatch guard can reuse it. |
| Count-mismatch guard | The `/release` sanity check (AgDR-0094 option D) comparing the changelog's entry count against a raw commit count, meant to catch a silently truncated changelog range. |
| Classification drop-out | A commit genuinely inside `$LOG_RANGE` that `bin/release-changelog.sh`'s classify step failed to turn into a changelog bullet — what the guard now actually detects, as opposed to a truncated range. |
| Fail open / fail closed | A guard "fails open" when it silently allows on a precondition it couldn't evaluate (the `#1017` bug); it "fails closed" when it halts loudly instead — the direction AgDR-0104 requires for trust-chain-adjacent gates. |
| `Released-From` trailer | A git trailer recording the exact `dev` SHA a release was cut from (AgDR-0094) — makes `$LOG_RANGE` deterministic instead of inferred, which is why a truncated *range* is no longer the guard's blind spot. |

Refs #1017
