### PR TITLE
fix(#1025): tracker_review_submit returns 0 without posting under zsh

### DIFF
--- a/.claude/hooks/_lib-audit-history.sh
+++ b/.claude/hooks/_lib-audit-history.sh
@@ -49,9 +49,20 @@
 _LIB_AUDIT_HISTORY_SOURCED=1
 
 # Locate the lib's own dir so we can source siblings (read-config, portfolio-paths).
-_AUDIT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# ${BASH_SOURCE[0]} is bash-only and unset under zsh (#1025) — the `:-` default
+# avoids a hard "parameter not set" error, and the git-rev-parse fallback below
+# is the actual portability fix (works under any shell, since it only depends
+# on `git`, not on a bash-only parameter).
+_AUDIT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+if [ -z "$_AUDIT_LIB_DIR" ] || [ ! -f "$_AUDIT_LIB_DIR/_lib-read-config.sh" ]; then
+  _audit_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+  if [ -n "$_audit_root" ] && [ -f "$_audit_root/.claude/hooks/_lib-read-config.sh" ]; then
+    _AUDIT_LIB_DIR="$_audit_root/.claude/hooks"
+  fi
+  unset _audit_root
+fi
 
-if [ -f "$_AUDIT_LIB_DIR/_lib-read-config.sh" ]; then
+if [ -n "$_AUDIT_LIB_DIR" ] && [ -f "$_AUDIT_LIB_DIR/_lib-read-config.sh" ]; then
   # shellcheck source=/dev/null
   . "$_AUDIT_LIB_DIR/_lib-read-config.sh"
 fi

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -134,7 +134,19 @@
 # resolution. Guarded: only source if not already defined and the lib is
 # present. tracker_kind defaults to "gh" with no config, preserving gh behaviour.
 if ! command -v tracker_kind >/dev/null 2>&1; then
-  _lib_extract_pr_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)"
+  # ${BASH_SOURCE[0]} is bash-only and unset under zsh (#1025) — the `:-`
+  # default avoids a hard "parameter not set" error, but an empty value
+  # still makes `dirname` resolve to ".", i.e. the CALLER's cwd rather than
+  # this lib's real directory, which usually (harmlessly) misses the `-f`
+  # check below. The git-rev-parse fallback is the actual portability fix.
+  _lib_extract_pr_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd 2>/dev/null)"
+  if [ -z "$_lib_extract_pr_dir" ] || [ ! -f "$_lib_extract_pr_dir/_lib-tracker.sh" ]; then
+    _lib_extract_pr_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+    if [ -n "$_lib_extract_pr_root" ] && [ -f "$_lib_extract_pr_root/.claude/hooks/_lib-tracker.sh" ]; then
+      _lib_extract_pr_dir="$_lib_extract_pr_root/.claude/hooks"
+    fi
+    unset _lib_extract_pr_root
+  fi
   if [ -n "$_lib_extract_pr_dir" ] && [ -f "$_lib_extract_pr_dir/_lib-tracker.sh" ]; then
     # shellcheck source=/dev/null
     . "$_lib_extract_pr_dir/_lib-tracker.sh"

--- a/.claude/hooks/_lib-fresh-fork.sh
+++ b/.claude/hooks/_lib-fresh-fork.sh
@@ -47,9 +47,19 @@
 _LIB_FRESH_FORK_SOURCED=1
 
 # Locate the lib's own dir so we can source siblings (read-config, portfolio-paths).
-_FRESH_FORK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# ${BASH_SOURCE[0]} is bash-only and unset under zsh (#1025) — the `:-`
+# default avoids a hard "parameter not set" error; the git-rev-parse
+# fallback is the actual portability fix (works under any shell).
+_FRESH_FORK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+if [ -z "$_FRESH_FORK_LIB_DIR" ] || [ ! -f "$_FRESH_FORK_LIB_DIR/_lib-read-config.sh" ]; then
+  _fresh_fork_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+  if [ -n "$_fresh_fork_root" ] && [ -f "$_fresh_fork_root/.claude/hooks/_lib-read-config.sh" ]; then
+    _FRESH_FORK_LIB_DIR="$_fresh_fork_root/.claude/hooks"
+  fi
+  unset _fresh_fork_root
+fi
 
-if [ -f "$_FRESH_FORK_LIB_DIR/_lib-read-config.sh" ]; then
+if [ -n "$_FRESH_FORK_LIB_DIR" ] && [ -f "$_FRESH_FORK_LIB_DIR/_lib-read-config.sh" ]; then
   # shellcheck source=/dev/null
   . "$_FRESH_FORK_LIB_DIR/_lib-read-config.sh"
 fi

--- a/.claude/hooks/_lib-onboarding-depth-mode.sh
+++ b/.claude/hooks/_lib-onboarding-depth-mode.sh
@@ -53,9 +53,19 @@
 [ -n "${_LIB_ONBOARDING_DEPTH_MODE_SOURCED:-}" ] && return 0
 _LIB_ONBOARDING_DEPTH_MODE_SOURCED=1
 
-_DEPTH_MODE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# ${BASH_SOURCE[0]} is bash-only and unset under zsh (#1025) — the `:-`
+# default avoids a hard "parameter not set" error; the git-rev-parse
+# fallback is the actual portability fix (works under any shell).
+_DEPTH_MODE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+if [ -z "$_DEPTH_MODE_LIB_DIR" ] || [ ! -f "$_DEPTH_MODE_LIB_DIR/_lib-ops-root.sh" ]; then
+  _depth_mode_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+  if [ -n "$_depth_mode_root" ] && [ -f "$_depth_mode_root/.claude/hooks/_lib-ops-root.sh" ]; then
+    _DEPTH_MODE_LIB_DIR="$_depth_mode_root/.claude/hooks"
+  fi
+  unset _depth_mode_root
+fi
 
-if [ -f "$_DEPTH_MODE_LIB_DIR/_lib-ops-root.sh" ]; then
+if [ -n "$_DEPTH_MODE_LIB_DIR" ] && [ -f "$_DEPTH_MODE_LIB_DIR/_lib-ops-root.sh" ]; then
   # shellcheck source=/dev/null
   . "$_DEPTH_MODE_LIB_DIR/_lib-ops-root.sh"
 fi

--- a/.claude/hooks/_lib-onboarding-glossary-seen.sh
+++ b/.claude/hooks/_lib-onboarding-glossary-seen.sh
@@ -73,9 +73,19 @@
 [ -n "${_LIB_ONBOARDING_GLOSSARY_SEEN_SOURCED:-}" ] && return 0
 _LIB_ONBOARDING_GLOSSARY_SEEN_SOURCED=1
 
-_GLOSSARY_SEEN_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# ${BASH_SOURCE[0]} is bash-only and unset under zsh (#1025) — the `:-`
+# default avoids a hard "parameter not set" error; the git-rev-parse
+# fallback is the actual portability fix (works under any shell).
+_GLOSSARY_SEEN_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+if [ -z "$_GLOSSARY_SEEN_LIB_DIR" ] || [ ! -f "$_GLOSSARY_SEEN_LIB_DIR/_lib-ops-root.sh" ]; then
+  _glossary_seen_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+  if [ -n "$_glossary_seen_root" ] && [ -f "$_glossary_seen_root/.claude/hooks/_lib-ops-root.sh" ]; then
+    _GLOSSARY_SEEN_LIB_DIR="$_glossary_seen_root/.claude/hooks"
+  fi
+  unset _glossary_seen_root
+fi
 
-if [ -f "$_GLOSSARY_SEEN_LIB_DIR/_lib-ops-root.sh" ]; then
+if [ -n "$_GLOSSARY_SEEN_LIB_DIR" ] && [ -f "$_GLOSSARY_SEEN_LIB_DIR/_lib-ops-root.sh" ]; then
   # shellcheck source=/dev/null
   . "$_GLOSSARY_SEEN_LIB_DIR/_lib-ops-root.sh"
 fi

--- a/.claude/hooks/_lib-premium-hook.sh
+++ b/.claude/hooks/_lib-premium-hook.sh
@@ -146,7 +146,21 @@ set -u
 _PREMIUM_HOOK_DIR_CACHE=""
 _premium_hook_dir() {
   if [ -z "$_PREMIUM_HOOK_DIR_CACHE" ]; then
-    _PREMIUM_HOOK_DIR_CACHE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # ${BASH_SOURCE[0]} is bash-only and unset under zsh (#1025). This file
+    # sets `set -u` above, so a bare reference would hard-error immediately
+    # if ever sourced under zsh (e.g. manual debugging) — worse than the
+    # usual silent-wrong-dir failure mode, because `set -u` also persists
+    # into the CALLING shell (this file is sourced, not subshelled). The
+    # `:-` default neutralises that; the git-rev-parse fallback is the
+    # actual portability fix (works under any shell).
+    _PREMIUM_HOOK_DIR_CACHE="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+    if [ -z "$_PREMIUM_HOOK_DIR_CACHE" ] || [ ! -f "$_PREMIUM_HOOK_DIR_CACHE/_lib-premium-hook.sh" ]; then
+      local _premium_root
+      _premium_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+      if [ -n "$_premium_root" ] && [ -f "$_premium_root/.claude/hooks/_lib-premium-hook.sh" ]; then
+        _PREMIUM_HOOK_DIR_CACHE="$_premium_root/.claude/hooks"
+      fi
+    fi
   fi
   printf '%s' "$_PREMIUM_HOOK_DIR_CACHE"
 }

--- a/.claude/hooks/_lib-project-board.sh
+++ b/.claude/hooks/_lib-project-board.sh
@@ -57,8 +57,19 @@ _LIB_PROJECT_BOARD_SOURCED=1
 # Source sibling libs — located in the same .claude/hooks/ directory.
 # Use BASH_SOURCE so the path is correct even when the lib is sourced from a
 # different cwd (e.g. from a skill that cd'd into a project clone).
+# ${BASH_SOURCE[0]} is bash-only and unset under zsh (#1025) — the `:-`
+# default avoids a hard "parameter not set" error, and the git-rev-parse
+# fallback below is the actual portability fix: it resolves correctly
+# under any shell because it depends on `git`, not on a bash-only parameter.
 # ---------------------------------------------------------------------------
-_lib_board_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_lib_board_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+if [ -z "$_lib_board_dir" ] || [ ! -f "$_lib_board_dir/_lib-ops-root.sh" ]; then
+  _lib_board_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+  if [ -n "$_lib_board_root" ] && [ -f "$_lib_board_root/.claude/hooks/_lib-ops-root.sh" ]; then
+    _lib_board_dir="$_lib_board_root/.claude/hooks"
+  fi
+  unset _lib_board_root
+fi
 
 # Pin-first ops-root resolver (provides resolve_ops_root).
 if [ -f "$_lib_board_dir/_lib-ops-root.sh" ]; then

--- a/.claude/hooks/_lib-read-config.sh
+++ b/.claude/hooks/_lib-read-config.sh
@@ -71,7 +71,12 @@ _config_repo_root() {
   if [ -n "${ZSH_VERSION:-}" ]; then
     printf 'apexyard: source the .claude/hooks/_lib-*.sh helpers under bash, not zsh — path resolution is unreliable under zsh. Wrap manual checks in `bash -c '"'"'...'"'"'`.\n' >&2
   fi
-  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # `:-` default (#1025): under zsh, a bare ${BASH_SOURCE[0]} reference is
+  # a hard "parameter not set" error whenever the caller's shell has
+  # nounset active, on top of the already-documented empty-value hazard
+  # above. The `git rev-parse` fallback a few lines below is what actually
+  # recovers root in that case.
+  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
   if [ -f "$lib_dir/_lib-ops-root.sh" ]; then
     # shellcheck source=/dev/null
     . "$lib_dir/_lib-ops-root.sh"

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -65,38 +65,73 @@
 
 # ------------------------------------------------------------------------------
 # Internal: ensure _lib-read-config.sh is loaded so config_get_or works.
+#
+# Self-location note (#1025): ${BASH_SOURCE[0]} is bash-only. Under zsh it is
+# UNSET, not merely empty — a bare reference errors ("parameter not set")
+# whenever the caller's shell has nounset active (`set -u`, common in
+# defensive script headers), and even without nounset an empty value makes
+# `dirname` resolve to ".", silently pointing hook_dir at the CALLER's cwd
+# instead of this lib's real directory (same failure class as #950). The
+# `:-` default below neutralises the hard error under either shell; the
+# `git rev-parse --show-toplevel` fallback is the actual portability fix —
+# it works identically under bash and zsh because it depends on `git`, not
+# on a bash-only parameter. Only fall back when the BASH_SOURCE-derived path
+# didn't actually find the sibling file, so the common (bash) path stays a
+# single cheap resolution. Returns non-zero when the lib still isn't
+# loadable after both attempts, so callers can tell "loaded" from "silently
+# gave up" instead of always reading exit 0 (part of the #1025 fix — see
+# _tracker_load_portfolio_lib below for the case this asymmetry actually broke).
 # ------------------------------------------------------------------------------
 _tracker_load_config_lib() {
   if command -v config_get_or >/dev/null 2>&1; then
     return 0
   fi
   local root hook_dir
-  hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  if [ -f "$hook_dir/_lib-read-config.sh" ]; then
+  hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+  if [ -z "$hook_dir" ] || [ ! -f "$hook_dir/_lib-read-config.sh" ]; then
+    root=$(git rev-parse --show-toplevel 2>/dev/null)
+    if [ -n "$root" ] && [ -f "$root/.claude/hooks/_lib-read-config.sh" ]; then
+      hook_dir="$root/.claude/hooks"
+    fi
+  fi
+  if [ -n "$hook_dir" ] && [ -f "$hook_dir/_lib-read-config.sh" ]; then
     # shellcheck source=/dev/null
     . "$hook_dir/_lib-read-config.sh"
-    return 0
   fi
-  root=$(git rev-parse --show-toplevel 2>/dev/null)
-  if [ -n "$root" ] && [ -f "$root/.claude/hooks/_lib-read-config.sh" ]; then
-    # shellcheck source=/dev/null
-    . "$root/.claude/hooks/_lib-read-config.sh"
-  fi
+  command -v config_get_or >/dev/null 2>&1
 }
 
 # ------------------------------------------------------------------------------
 # Internal: ensure _lib-portfolio-paths.sh is loaded so portfolio_registry works.
+#
+# Same zsh self-location hazard and fix shape as _tracker_load_config_lib
+# above (#1025) — but this function previously had NO git-rev-parse fallback
+# at all, unlike its sibling. Under zsh it would resolve hook_dir to the
+# caller's cwd, fail the `-f` test, and silently `return 0` having loaded
+# nothing. That asymmetry is what #1025 actually observed: a per-project
+# tracker.kind override (read via portfolio_registry, in
+# _tracker_project_value) silently stopped resolving under zsh, and callers
+# fell through to the global tracker.kind default with no signal anything
+# had gone wrong. Fixed to match the sibling's fallback + explicit
+# success/failure return.
 # ------------------------------------------------------------------------------
 _tracker_load_portfolio_lib() {
   if command -v portfolio_registry >/dev/null 2>&1; then
     return 0
   fi
-  local hook_dir
-  hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  if [ -f "$hook_dir/_lib-portfolio-paths.sh" ]; then
+  local hook_dir root
+  hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+  if [ -z "$hook_dir" ] || [ ! -f "$hook_dir/_lib-portfolio-paths.sh" ]; then
+    root=$(git rev-parse --show-toplevel 2>/dev/null)
+    if [ -n "$root" ] && [ -f "$root/.claude/hooks/_lib-portfolio-paths.sh" ]; then
+      hook_dir="$root/.claude/hooks"
+    fi
+  fi
+  if [ -n "$hook_dir" ] && [ -f "$hook_dir/_lib-portfolio-paths.sh" ]; then
     # shellcheck source=/dev/null
     . "$hook_dir/_lib-portfolio-paths.sh"
   fi
+  command -v portfolio_registry >/dev/null 2>&1
 }
 
 # ------------------------------------------------------------------------------

--- a/.claude/hooks/tests/test_tracker_zsh_self_location.sh
+++ b/.claude/hooks/tests/test_tracker_zsh_self_location.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# test_tracker_zsh_self_location.sh — regression test for #1025.
+#
+# tracker_review_submit posts the code reviewer's (Rex's) human-visible
+# review to the PR. #1025: under zsh (the macOS default shell), the internal
+# loader functions _tracker_load_portfolio_lib / _tracker_load_config_lib
+# resolve their own directory via ${BASH_SOURCE[0]} — a bash-only parameter
+# that is UNSET under zsh. A bare reference to it:
+#   - hard-errors ("parameter not set") whenever the calling shell has
+#     nounset active (a common defensive `set -u` header) — and
+#     _tracker_load_portfolio_lib had NO git-rev-parse fallback at all (unlike
+#     its sibling _tracker_load_config_lib), so it silently `return 0`'d
+#     having loaded nothing;
+#   - even WITHOUT nounset, an empty BASH_SOURCE[0] makes `dirname` resolve
+#     to ".", i.e. the CALLER's cwd rather than the lib's real directory —
+#     the same failure class as #950.
+#
+# The practical consequence: a per-project tracker.kind override (read via
+# portfolio_registry) silently stopped resolving under zsh, and callers fell
+# through to the global tracker.kind default with no signal anything had
+# gone wrong — the "returns 0 without posting" shape #1025 reports.
+#
+# This test:
+#   1. Skips gracefully if zsh isn't installed.
+#   2. Proves _tracker_load_portfolio_lib actually loads under zsh (with
+#      nounset active — the exact condition from the bug report).
+#   3. Proves the PRACTICAL consequence is fixed: a per-project tracker.kind
+#      override resolves correctly under zsh, not silently defaulting.
+#   4. Proves tracker_review_submit's full call chain still reaches the
+#      host CLI under zsh (a mock gh is actually invoked, not skipped).
+#   5. Proves a CLI failure propagates as a real non-zero exit under zsh +
+#      `set -euo pipefail` — the process must not die silently mid-call, and
+#      must never report success without posting.
+#   6. Regression pin: every self-locating library BASH_SOURCE[0] reference
+#      audited under #1025 uses the `:-` safe-default form — so a future
+#      revert of the fix fails loudly here instead of silently
+#      reintroducing the bug (mirrors the #950 prior-art test's own pin).
+#
+# Run: bash .claude/hooks/tests/test_tracker_zsh_self_location.sh
+
+set -u
+unset APEXYARD_OPS_PIN_DIR CLAUDE_CODE_SESSION_ID 2>/dev/null || true
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TRACKER_LIB="$HOOK_DIR/_lib-tracker.sh"
+CONFIG_LIB="$HOOK_DIR/_lib-read-config.sh"
+PORTFOLIO_LIB="$HOOK_DIR/_lib-portfolio-paths.sh"
+OPSROOT_LIB="$HOOK_DIR/_lib-ops-root.sh"
+
+PASS=0
+FAIL=0
+FAILED=""
+pass() { PASS=$((PASS+1)); echo "PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); FAILED="$FAILED\n  - $1"; echo "FAIL: $1"; echo "    expected: [$2]"; echo "    actual:   [$3]"; }
+assert_eq() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1" "$2" "$3"; fi; }
+
+HAVE_YAML=no
+if command -v yq >/dev/null 2>&1 || python3 -c 'import yaml' >/dev/null 2>&1; then HAVE_YAML=yes; fi
+
+if ! command -v zsh >/dev/null 2>&1; then
+  echo "SKIP: zsh not installed, skipping the #1025 zsh-invocation regression suite"
+  echo "=========================================="
+  echo "PASS: 0  FAIL: 0"
+  exit 0
+fi
+
+make_sandbox() {
+  local sb registry_body="${1:-}"
+  sb=$(mktemp -d); sb=$(cd "$sb" && pwd -P)
+  mkdir -p "$sb/.claude/hooks" "$sb/bin"
+  touch "$sb/onboarding.yaml"
+  # A real (if minimal) git repo — the fix's fallback path resolves the lib
+  # dir via `git rev-parse --show-toplevel`, which needs an actual repo to
+  # answer. Real-world usage always runs this lib inside the ops fork or a
+  # workspace clone (both real repos), so the sandbox must match that shape
+  # or this test would fail on the fallback path for the wrong reason.
+  ( cd "$sb" && git init -q ) 2>/dev/null || true
+  cp "$TRACKER_LIB"   "$sb/.claude/hooks/_lib-tracker.sh"
+  cp "$CONFIG_LIB"    "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$PORTFOLIO_LIB" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  [ -f "$OPSROOT_LIB" ] && cp "$OPSROOT_LIB" "$sb/.claude/hooks/_lib-ops-root.sh"
+  cat > "$sb/.claude/project-config.defaults.json" <<'JSON'
+{ "tracker": { "kind": "gh" } }
+JSON
+  if [ -n "$registry_body" ]; then
+    printf '%s\n' "$registry_body" > "$sb/apexyard.projects.yaml"
+  else
+    printf 'version: 1\nprojects: []\n' > "$sb/apexyard.projects.yaml"
+  fi
+  echo "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1 — _tracker_load_portfolio_lib actually loads under zsh WITH nounset
+# active (the exact condition in the bug report's stderr line). Before the
+# fix this silently returned 0 having loaded nothing; after the fix,
+# portfolio_registry becomes available and the loader itself reports success.
+# ---------------------------------------------------------------------------
+SB1=$(make_sandbox)
+cd "$SB1" || { echo "FAIL: cd sandbox 1"; exit 1; }
+OUT1=$(zsh -c '
+setopt NO_UNSET
+source .claude/hooks/_lib-tracker.sh
+_tracker_load_portfolio_lib
+lib_rc=$?
+have=no
+command -v portfolio_registry >/dev/null 2>&1 && have=yes
+printf "%s|%s\n" "$lib_rc" "$have"
+' 2>"$SB1/stderr1")
+IFS='|' read -r c1_rc c1_have <<< "$OUT1"
+assert_eq "zsh+nounset: _tracker_load_portfolio_lib returns 0 (loaded)" "0" "$c1_rc"
+assert_eq "zsh+nounset: portfolio_registry becomes available" "yes" "$c1_have"
+assert_eq "zsh+nounset: no 'parameter not set' error on stderr" "0" "$(grep -c 'parameter not set' "$SB1/stderr1")"
+cd - >/dev/null || true
+rm -rf "$SB1"
+
+# ---------------------------------------------------------------------------
+# Case 2 — the PRACTICAL consequence: a per-project tracker.kind override
+# (glab, differing from the global default of gh) resolves correctly under
+# zsh. Before the fix, _tracker_load_portfolio_lib's silent no-op meant
+# _tracker_project_value could never see the registry, and tracker_kind fell
+# through to the global "gh" default — silently wrong for a non-GitHub
+# project. Needs a YAML parser (yq or python3+PyYAML) to read the registry.
+# ---------------------------------------------------------------------------
+if [ "$HAVE_YAML" = yes ]; then
+  SB2=$(make_sandbox "version: 1
+projects:
+  - name: gl
+    repo: g/p
+    tracker:
+      kind: glab")
+  cd "$SB2" || { echo "FAIL: cd sandbox 2"; exit 1; }
+  kind_seen=$(zsh -c '
+setopt NO_UNSET
+source .claude/hooks/_lib-tracker.sh
+tracker_kind "g/p"
+' 2>/dev/null)
+  assert_eq "zsh+nounset: per-project tracker.kind override resolves (glab, not global gh default)" "glab" "$kind_seen"
+  cd - >/dev/null || true
+  rm -rf "$SB2"
+else
+  echo "SKIP: per-project override case (no yq / python3+PyYAML)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3 — end-to-end: tracker_review_submit's full call chain still reaches
+# the host CLI under zsh (a mock gh is actually invoked — argv captured).
+# ---------------------------------------------------------------------------
+SB3=$(make_sandbox)
+cat > "$SB3/bin/gh" <<'EOF'
+#!/bin/bash
+[ -n "${GH_CAPTURE:-}" ] && printf '%s\n' "$@" > "$GH_CAPTURE"
+exit 0
+EOF
+chmod +x "$SB3/bin/gh"
+printf 'APPROVED — verdict in body.\n' > "$SB3/rev.md"
+cd "$SB3" || { echo "FAIL: cd sandbox 3"; exit 1; }
+rc3=$(PATH="$SB3/bin:$PATH" GH_CAPTURE="$SB3/cap3" zsh -c '
+setopt NO_UNSET
+source .claude/hooks/_lib-tracker.sh
+tracker_review_submit "o/r" 42 comment "$1"
+echo $?
+' _ "$SB3/rev.md" 2>/dev/null | tail -1)
+assert_eq "zsh: tracker_review_submit reaches gh and returns 0" "0" "$rc3"
+assert_eq "zsh: gh mock was actually invoked (argv captured)" "yes" "$([ -f "$SB3/cap3" ] && echo yes || echo no)"
+cd - >/dev/null || true
+rm -rf "$SB3"
+
+# ---------------------------------------------------------------------------
+# Case 4 — a CLI failure propagates as a REAL non-zero exit under zsh +
+# `set -euo pipefail`, and the process does not die silently mid-call before
+# ever reaching the CLI (the pre-fix failure mode: the whole zsh process
+# aborted at the BASH_SOURCE reference before gh was ever invoked). This is
+# the literal "fails loudly rather than returning 0" acceptance criterion.
+# ---------------------------------------------------------------------------
+SB4=$(make_sandbox)
+cat > "$SB4/bin/gh" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x "$SB4/bin/gh"
+printf 'body\n' > "$SB4/rev.md"
+cd "$SB4" || { echo "FAIL: cd sandbox 4"; exit 1; }
+OUT4=$(PATH="$SB4/bin:$PATH" zsh -c '
+set -euo pipefail
+source .claude/hooks/_lib-tracker.sh
+echo "REACHED_BEFORE"
+set +e
+tracker_review_submit "o/r" 42 comment "$1"
+rc=$?
+set -e
+echo "REACHED_AFTER:$rc"
+' _ "$SB4/rev.md" 2>/dev/null)
+assert_eq "zsh+errexit: reaches the call (lib load did not abort the process)" "yes" "$(printf '%s' "$OUT4" | grep -qc REACHED_BEFORE && echo yes || echo no)"
+assert_eq "zsh+errexit: gh's real non-zero exit propagates, not silent 0" "REACHED_AFTER:1" "$(printf '%s' "$OUT4" | grep REACHED_AFTER)"
+cd - >/dev/null || true
+rm -rf "$SB4"
+
+# ---------------------------------------------------------------------------
+# Case 5 — regression pin: every BASH_SOURCE[0] self-location reference in
+# the tracker lib uses the `:-` safe-default form. A future revert to the
+# bare form fails loudly HERE instead of silently reintroducing #1025.
+# ---------------------------------------------------------------------------
+# Only CODE lines (strip full-line comments) count — the file's own prose
+# explaining the hazard legitimately writes the bare form in a comment.
+bare_refs=$(grep -v '^\s*#' "$TRACKER_LIB" | grep -oE '\$\{BASH_SOURCE\[0\][^}]*\}' | grep -vc ':-' || true)
+assert_eq "no bare (unguarded) \${BASH_SOURCE[0]} references remain in _lib-tracker.sh code" "0" "${bare_refs:-0}"
+
+echo "=========================================="
+echo "PASS: $PASS  FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then printf "Failed:%b\n" "$FAILED"; exit 1; fi
+exit 0


### PR DESCRIPTION
## Summary

- **Fixed the silent no-op** — `_tracker_load_portfolio_lib` (in `_lib-tracker.sh`) resolved its own directory via the bash-only `${BASH_SOURCE[0]}`, which is unset under zsh. Unlike its sibling `_tracker_load_config_lib`, it had **no git-rev-parse fallback at all**, so under zsh it printed `_tracker_load_portfolio_lib:5: BASH_SOURCE[0]: parameter not set` and silently `return 0`'d having loaded nothing. A per-project `tracker.kind` registry override then silently stopped resolving, and callers fell through to the global default with no signal anything had gone wrong — the exact "reports success while posting nothing" defect this ticket describes.
- **Made the fix portable, not just quiet** — `${BASH_SOURCE[0]:-}` neutralises the hard "parameter not set" error under zsh's `nounset` (a common `set -u` defensive header — and under `set -euo pipefail` the old bug killed the *entire calling process* at the first reference, before `gh` was ever invoked). The added `git rev-parse --show-toplevel` fallback is the actual portability fix: it resolves the right directory under any shell because it depends on `git`, not a bash-only parameter. Both loader functions in `_lib-tracker.sh` now return non-zero when the target still isn't loadable, instead of unconditionally returning 0.
- **Audited every sibling** — grepped `.claude/hooks/` and `.claude/skills/` for other `BASH_SOURCE[0]` self-location sites (16 files). Applied the same guard to the ones genuinely at risk: `_lib-audit-history.sh`, `_lib-onboarding-depth-mode.sh`, `_lib-onboarding-glossary-seen.sh`, `_lib-fresh-fork.sh`, `_lib-project-board.sh`, `_lib-extract-pr.sh` (its existing guard didn't catch the "resolves to caller's cwd" case), and `_lib-premium-hook.sh` (the worst of the bunch — it sets `set -u` unconditionally, so a bare reference hard-errors even without an external `nounset`, and being sourced rather than subshelled, that `set -u` would leak into the calling shell too). `_lib-read-config.sh` already had a `#950` warn+fallback guard; added the same `:-` safety net without changing its warning behaviour. Hook scripts invoked only through the harness's `bash -c` wrapper, and test scripts run only via explicit `bash <script>`, were confirmed safe as-is (never sourced under the operator's shell) — no changes needed there.
- **Added a zsh-specific regression test** (`test_tracker_zsh_self_location.sh`) that fails against the pre-fix code and passes against the fix — proving the loader now works under zsh with `nounset` active, a per-project `tracker.kind` override resolves correctly instead of silently defaulting, `tracker_review_submit`'s full call chain still reaches the host CLI under zsh, a CLI failure propagates as a real non-zero exit under `set -euo pipefail` (rather than the process dying silently before ever posting), and a regression pin against any bare `${BASH_SOURCE[0]}` reference creeping back into the lib.

## Why this matters

`tracker_review_submit` is how the sanctioned code-reviewer agent (Rex) posts its review to a PR. A reviewer that believes it posted — because the function returned 0 — will write its approval marker and report success, with nothing downstream to contradict it (the merge gate reads the local marker, not GitHub's review state, by design per AgDR-0075). Losing the human-readable review silently means the audit trail says "reviewed" while the PR shows nothing, and the failure is invisible at exactly the moment it matters.

## Testing

```bash
# The new regression test — fails on pre-fix code, passes on the fix
bash .claude/hooks/tests/test_tracker_zsh_self_location.sh

# No regressions in the existing tracker-review test
bash .claude/hooks/tests/test_tracker_review_submit.sh

# Full hook suite
bash bin/run-hook-tests.sh
```

Full suite: **114 passed, 1 failed** (`test_sync_codex_adapter.sh`) — confirmed pre-existing and unrelated by re-running it against the unmodified baseline (same 2 sub-case failures with none of this PR's changes applied). `shellcheck -S warning` is clean on every modified file plus the new test.

## Security note

This PR touches `.claude/hooks/**` (the trust chain) — flagging for Security Auditor review per the auto-fire trigger in `.claude/rules/role-triggers.md`. The change is narrowly scoped to self-location path resolution (no new external input handling, no change to what gets executed) but the path is security-relevant by policy regardless of diff shape.

## Glossary

| Term | Definition |
|------|------------|
| `BASH_SOURCE` | A bash-only array holding the currently-executing script's path; unset under zsh, so any bare reference to it is a latent cross-shell bug |
| `nounset` / `set -u` | A shell strictness mode where referencing an unset variable is a hard error instead of silently expanding to empty — common in defensive script headers |
| Self-location | A shell library's own pattern for finding the directory it lives in, so it can `source` sibling files next to it regardless of the caller's `cwd` |
| Silent no-op | A function that returns success (`exit 0`) without performing its documented side effect — the failure mode this ticket closes |
| Regression pin | A test assertion that fails if a fixed bug's exact code shape (here: a bare, unguarded `${BASH_SOURCE[0]}`) is ever reintroduced |

Refs #1025