### PR TITLE
fix(#1018): normalize Windows drive-letter paths in portfolio_validate

### DIFF
--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -121,9 +121,42 @@ _portfolio_root() {
 # echoes the original input unchanged rather than an empty/broken path —
 # unlike require-active-ticket.sh's fail-CLOSED security check, a
 # portfolio path resolver has no "block on doubt" contract to uphold.
+#
+# Windows/MSYS drive-letter normalization (me2resh/apexyard#1018): on
+# Windows Git Bash, `git rev-parse --show-toplevel` (git.exe is a native
+# Windows binary) returns a drive-letter path like "D:/Projs/fork", but
+# `cd ... && pwd -P` (run directly by bash, an MSYS binary) returns the
+# MSYS mount-point form "/d/Projs/fork" for the SAME location. The two
+# spellings are byte-different for one identical path. Before this fix,
+# the `case "$p" in /*)` guard below didn't recognize a drive-letter path
+# as absolute at all, so it hit the `*)` fallback and was returned RAW,
+# un-normalized — while a caller that instead ran `cd "$root" && pwd -P`
+# directly (portfolio_validate's root_real/wd_real) got the MSYS form.
+# Comparing the two forms via a string prefix match then always failed,
+# even for a perfectly valid, non-split single-fork setup.
+#
+# Fix: normalize a leading `<letter>:/` or `<letter>:\` to `/<letter>/`
+# BEFORE the absolute-path check, as a pure string transform — no
+# dependency on cygpath (absent on macOS/Linux) or on cd/pwd actually
+# resolving a real drive letter (which only MSYS's runtime does). This
+# is a no-op for every POSIX path: a real absolute path always starts
+# with "/", never with "<letter>:", so this branch is simply never
+# entered outside a Windows-drive-letter input.
 # ------------------------------------------------------------------------------
 _portfolio_canonicalize() {
   local p="$1" dir tail=""
+
+  case "$p" in
+    [A-Za-z]:/*|[A-Za-z]:\\*)
+      local drive rest
+      drive="${p%%:*}"
+      rest="${p#*:}"
+      rest="$(printf '%s' "$rest" | tr '\\' '/')"
+      drive="$(printf '%s' "$drive" | tr '[:upper:]' '[:lower:]')"
+      p="/${drive}${rest}"
+      ;;
+  esac
+
   case "$p" in
     /*) : ;;
     *) echo "$p"; return 0 ;;  # not absolute — nothing to canonicalize

--- a/.claude/hooks/tests/test_portfolio_paths_windows_drive_letter.sh
+++ b/.claude/hooks/tests/test_portfolio_paths_windows_drive_letter.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+# Regression test for me2resh/apexyard#1018 — portfolio_validate() false-positives
+# on Windows/Git Bash for a plain single-fork setup, because of a
+# drive-letter (D:/Projs/fork) vs MSYS-mount-point (/d/Projs/fork) path
+# spelling mismatch inside `_portfolio_canonicalize`.
+#
+# Why this test drives the comparison directly instead of a filesystem
+# fixture: the bug is a Windows/MSYS-runtime-specific behavior — git.exe
+# (a native Windows binary) emits drive-letter paths, while `cd ... &&
+# pwd -P` (run by bash, an MSYS binary) emits the MSYS mount-point form
+# FOR THE SAME LOCATION. That translation only exists inside the MSYS
+# runtime. On macOS/Linux, "D:/Projs/fork" and "/d/Projs/fork" are just
+# two unrelated path strings (colon has no special meaning) — there is
+# no way to make `cd` treat them as the same directory here, so a
+# filesystem-based fixture would not exercise the real bug at all; it
+# would only test colon-containing directory names, an unrelated
+# concern. Driving `_portfolio_canonicalize` directly with both
+# spellings as string inputs is the correct, honest reproduction on a
+# non-Windows CI runner — matching the bug report's own repro shape.
+#
+# Exit 0 means all cases passed. Exit 1 on first failure.
+
+set -u
+
+LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-portfolio-paths.sh"
+CONFIG_LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-read-config.sh"
+DEFAULTS_SRC="$(cd "$(dirname "$0")/../.." && pwd)/project-config.defaults.json"
+
+if [ ! -f "$LIB_SRC" ]; then
+  echo "FAIL: helper not found at $LIB_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$CONFIG_LIB_SRC" ]; then
+  echo "FAIL: config lib not found at $CONFIG_LIB_SRC" >&2
+  exit 1
+fi
+if [ ! -f "$DEFAULTS_SRC" ]; then
+  echo "FAIL: defaults file not found at $DEFAULTS_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+run_case() {
+  local name="$1"
+  local snippet="$2"
+  local out rc
+
+  out=$(
+    # shellcheck source=/dev/null
+    . "$LIB_SRC"
+    eval "$snippet"
+  )
+  rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    PASS=$((PASS + 1))
+    echo "PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n  - $name"
+    echo "FAIL: $name"
+    if [ -n "$out" ]; then
+      echo "  output: $out"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: a Windows drive-letter absolute path normalizes to the MSYS
+# mount-point form instead of being returned raw/unchanged.
+# ---------------------------------------------------------------------------
+run_case "#1018: drive-letter path normalizes to MSYS mount-point form" '
+r=$(_portfolio_canonicalize "D:/Projs/fork/apexyard.projects.yaml")
+expected="/d/Projs/fork/apexyard.projects.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 2: lowercase drive letter also normalizes (case-insensitive drive).
+# ---------------------------------------------------------------------------
+run_case "#1018: lowercase drive letter also normalizes" '
+r=$(_portfolio_canonicalize "d:/projs/fork/projects")
+expected="/d/projs/fork/projects"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 3: backslash-separated drive-letter form (native Windows spelling)
+# also normalizes, with backslashes converted to forward slashes.
+# ---------------------------------------------------------------------------
+run_case "#1018: backslash drive-letter form normalizes" '
+r=$(_portfolio_canonicalize "C:\Users\x\apexyard")
+expected="/c/Users/x/apexyard"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 4 (the core acceptance criterion): the drive-letter spelling and the
+# already-MSYS-form spelling of the IDENTICAL location now canonicalize to
+# the same string — this is what makes the string-prefix comparison inside
+# portfolio_validate() succeed instead of false-positiving.
+# ---------------------------------------------------------------------------
+run_case "#1018: drive-letter and MSYS spellings of the same path compare EQUAL" '
+a=$(_portfolio_canonicalize "D:/Projs/fork/apexyard.projects.yaml")
+b=$(_portfolio_canonicalize "/d/Projs/fork/apexyard.projects.yaml")
+if [ "$a" = "$b" ]; then exit 0; else echo "a=$a b=$b (should match)"; exit 1; fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 5: reproduces the exact false-positive mechanism from
+# portfolio_validate()'s partial-split-portfolio-v2 detector (introduced in
+# #373). root_real/wd_real are what a direct `cd "$root" && pwd -P` call
+# yields on real MSYS (already normalized); registry/projects_dir are what
+# portfolio_registry()/portfolio_projects_dir() return for a plain
+# single-fork setup with NO .portfolio overrides (all defaults, so the
+# raw value is $root/apexyard.projects.yaml with $root in drive-letter
+# form, exactly as git.exe would emit it).
+#
+# BEFORE the fix: registry/projects_dir were returned raw (drive-letter
+# form) by _portfolio_canonicalize, so this exact prefix match failed —
+# the false positive this issue reports.
+# AFTER the fix: both sides normalize to the same MSYS form, so the
+# comparison now correctly judges "inside the fork".
+# ---------------------------------------------------------------------------
+run_case "#1018: portfolio_validate prefix comparison no longer false-positives" '
+root_real="/d/Projs/fork"
+registry=$(_portfolio_canonicalize "D:/Projs/fork/apexyard.projects.yaml")
+projects_dir=$(_portfolio_canonicalize "D:/Projs/fork/projects")
+
+_outside_fork() {
+  case "$1" in
+    "$root_real"|"$root_real"/*) return 1 ;;
+  esac
+  return 0
+}
+
+if _outside_fork "$registry"; then
+  echo "registry judged OUTSIDE fork (false positive!): $registry vs root_real=$root_real"
+  exit 1
+fi
+if _outside_fork "$projects_dir"; then
+  echo "projects_dir judged OUTSIDE fork (false positive!): $projects_dir vs root_real=$root_real"
+  exit 1
+fi
+exit 0
+'
+
+# ---------------------------------------------------------------------------
+# Case 6: proves the bug mechanism (not just the fix) — feeding the RAW,
+# un-normalized drive-letter string (what the code returned before this
+# fix) into the identical comparison DOES false-positive. This is the
+# "would have failed before the fix" pin, expressed without needing a
+# second copy of the pre-fix library.
+# ---------------------------------------------------------------------------
+run_case "#1018: sanity — the raw (un-normalized) drive-letter form DOES mismatch (proves the bug was real)" '
+root_real="/d/Projs/fork"
+registry_raw="D:/Projs/fork/apexyard.projects.yaml"   # what the OLD code returned, unnormalized
+
+_outside_fork() {
+  case "$1" in
+    "$root_real"|"$root_real"/*) return 1 ;;
+  esac
+  return 0
+}
+
+if _outside_fork "$registry_raw"; then
+  exit 0   # correctly demonstrates the old bug: raw form mismatches root_real
+else
+  echo "expected the raw/unnormalized form to mismatch (that IS the bug) but it matched"
+  exit 1
+fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 7: a GENUINE misconfiguration — registry/projects_dir resolving to a
+# real, different sibling directory (not just a spelling difference of the
+# SAME path) — must still be detected as outside the fork. The fix must not
+# make the outside-fork check toothless.
+# ---------------------------------------------------------------------------
+run_case "#1018: genuine misconfig (different sibling dir) is still detected as OUTSIDE the fork" '
+root_real="/d/Projs/fork"
+sibling_registry=$(_portfolio_canonicalize "D:/Projs/portfolio-sibling/apexyard.projects.yaml")
+
+_outside_fork() {
+  case "$1" in
+    "$root_real"|"$root_real"/*) return 1 ;;
+  esac
+  return 0
+}
+
+if _outside_fork "$sibling_registry"; then
+  exit 0   # correctly detected as outside — genuine misconfig still caught
+else
+  echo "sibling path ($sibling_registry) was wrongly judged INSIDE root_real ($root_real) — detection broken"
+  exit 1
+fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 8: POSIX no-op — every ordinary absolute POSIX path canonicalizes
+# exactly the way it did before this fix (the drive-letter branch is never
+# entered because none of these start with "<letter>:"). Pinned against the
+# same `cd ... && pwd -P` logic the function itself uses, so this fails if
+# the new preprocessing step ever mutates a real POSIX path.
+# ---------------------------------------------------------------------------
+run_case "#1018: POSIX absolute path is an exact no-op (real dir, symlinks resolved)" '
+r=$(_portfolio_canonicalize "/tmp")
+expected=$(cd /tmp && pwd -P)
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+run_case "#1018: POSIX absolute path to a nonexistent leaf is an exact no-op (tail preserved verbatim)" '
+r=$(_portfolio_canonicalize "/nonexistent-for-test-1018/foo/bar.yaml")
+expected="/nonexistent-for-test-1018/foo/bar.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+run_case "#1018: relative path is an exact no-op (unchanged, not absolute)" '
+r=$(_portfolio_canonicalize "./relative/path.yaml")
+expected="./relative/path.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 9: end-to-end POSIX regression via the real public resolvers + a
+# real single-fork sandbox (same fixture shape as test_portfolio_paths.sh
+# case 1) — proves portfolio_validate() still passes clean on an ordinary
+# macOS/Linux single-fork setup after this fix, i.e. the fix is genuinely
+# a no-op for the framework's default, most common path.
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d)
+SB=$(cd "$SB" && pwd -P)
+(
+  cd "$SB" || exit 1
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "test"
+  touch onboarding.yaml
+  cat > apexyard.projects.yaml <<'YAML'
+version: 1
+projects:
+  - name: example
+    repo: example/example
+YAML
+  mkdir -p projects
+  cat > projects/ideas-backlog.md <<'MD'
+# Ideas Backlog
+MD
+  mkdir -p .claude/hooks
+  cp "$LIB_SRC" .claude/hooks/_lib-portfolio-paths.sh
+  cp "$CONFIG_LIB_SRC" .claude/hooks/_lib-read-config.sh
+  cp "$DEFAULTS_SRC" .claude/project-config.defaults.json
+  git add -A
+  git commit -q -m "test fixture (#1018 regression)"
+)
+run_case "#1018: real POSIX single-fork sandbox — portfolio_validate still OK" "
+out=\$(
+  cd '$SB' || exit 99
+  . .claude/hooks/_lib-read-config.sh
+  . .claude/hooks/_lib-portfolio-paths.sh
+  portfolio_clear_cache
+  if portfolio_validate; then echo OK; else portfolio_validate; fi
+)
+rc=\$?
+if [ \"\$out\" = \"OK\" ] && [ \"\$rc\" -eq 0 ]; then exit 0; else echo \"got out=[\$out] rc=\$rc\"; exit 1; fi
+"
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "===== test_portfolio_paths_windows_drive_letter.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed cases:$FAILED_CASES"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **Fixed a Windows/Git-Bash false positive in `portfolio_validate()`** — a plain single-fork adopter running Git Bash / MSYS2 got a spurious `broken: partial split-portfolio v2 config` error on every session start, because `git rev-parse --show-toplevel` (a native Windows binary) returns a drive-letter path (`D:/Projs/fork`) while `cd ... && pwd -P` (an MSYS binary) returns the mount-point form (`/d/Projs/fork`) for the identical location — two byte-different spellings of one path.
- **Root cause is one level deeper than the original bug report's own suggested fix** — the divergence isn't in `portfolio_validate()` itself, it's in the shared `_portfolio_canonicalize()` helper that every public resolver (`portfolio_registry`, `portfolio_projects_dir`, `portfolio_workspace_dir`, etc.) goes through: its "is this absolute?" guard (`case "$p" in /*)`) never recognized a Windows drive-letter path as absolute, so such paths were returned raw/un-normalized instead of going through the existing `cd`/`pwd -P` canonicalization every other absolute path already gets. Fixing the shared helper fixes it for every consumer, not just this one call site.
- **Fix is a pure string transform, not a special case** — `<letter>:/` or `<letter>:\` is rewritten to `/<letter>/` (lowercased, backslashes to forward slashes) *before* the existing absolute-path logic runs. No `cygpath` dependency (absent on macOS/Linux) and no reliance on `cd` actually resolving a drive letter. For every real POSIX path — which never starts with `<letter>:` — this branch is dead code, so existing single-fork/split-portfolio behavior on macOS/Linux is unchanged byte-for-byte.
- **Genuine split-portfolio misconfiguration is still caught** — the fix normalizes spelling, it doesn't relax the comparison. A registry/projects_dir that actually resolves to a different directory (not just a different spelling of the same one) still trips the existing `broken: partial split-portfolio v2 config` / fork-containment checks.

## Testing

- New test file: `.claude/hooks/tests/test_portfolio_paths_windows_drive_letter.sh` (11 cases). Since real Git Bash/MSYS2 can't run on macOS, the bug is reproduced by driving `_portfolio_canonicalize()` and the exact `_outside_fork()` prefix-match logic directly with both path spellings as string inputs — matching the bug report's own repro shape, not a simulated filesystem fixture (MSYS's drive-letter↔mount-point translation is a Windows-runtime behavior that cannot be faithfully reproduced on macOS's filesystem semantics).
  - Confirmed **BEFORE the fix** (running this new test file against the unmodified `upstream/dev` copy of the library): 5 of 11 cases fail — the drive-letter normalization cases and the `portfolio_validate` prefix-comparison case, exactly matching the reported bug.
  - Confirmed **AFTER the fix**: all 11 cases pass, including:
    - the two spellings of the same path now canonicalize to the identical string,
    - the `portfolio_validate`-style prefix comparison no longer false-positives,
    - a **genuinely misconfigured** portfolio (registry pointing at a real, different sibling directory) is still correctly flagged as outside the fork — the fix doesn't make the check toothless,
    - ordinary POSIX absolute/relative/nonexistent paths canonicalize byte-for-byte identically to before (no behavior change for existing macOS/Linux adopters),
    - a real single-fork sandbox (git-inited, registry + projects dir + ideas backlog) still passes `portfolio_validate()` cleanly end-to-end.
- Full hook test suite (`.claude/hooks/tests/test_*.sh`, run in per-file-timeout chunks to stay within command limits): **BEFORE** (unmodified `upstream/dev`) 93/98 passed → **AFTER** (this branch, 99 files including the new one) 94/99 passed. The 5 failing files are byte-identical before and after (`test_ops_root.sh`, `test_require_agdr_for_arch_pr.sh`, `test_split_portfolio_v2_migration.sh`, `test_sync_codex_adapter.sh`, `test_workspace_tracker_resolution.sh`) — pre-existing, unrelated to this change, confirmed via a line-for-line diff of the two run logs (excluding the new test file) showing **zero** differences. This change causes no regressions and incidentally fixes nothing else.

## Glossary

| Term | Definition |
|------|------------|
| MSYS / Git Bash | The POSIX-emulation shell environment bundled with Git for Windows; paths inside it use `/c/...`-style mount points rather than Windows drive letters |
| `pwd -P` | Prints the current directory with all symlinks resolved — the canonical physical path |
| Drive-letter path | A Windows-native absolute path spelling like `D:/Projs/fork` or `C:\Users\x`, as emitted by native Windows binaries (including `git.exe`) even inside Git Bash |
| Split-portfolio v2 | An ApexYard deployment mode where the public framework fork and the private portfolio (registry, project docs, workspace) live in two separate sibling repos instead of one |
| `portfolio_validate` | The health-check function in `_lib-portfolio-paths.sh` that runs on SessionStart and flags portfolio-path misconfigurations |
| `_portfolio_canonicalize` | The internal helper that normalizes an absolute path to its logical, `/../`-free, symlink-resolved form, used by every public path resolver in the library so downstream prefix-match comparisons are reliable |

Refs #1018
