### PR TITLE
fix(#1014): isolate test_sync_codex_adapter.sh from the ambient session-pin

### DIFF
--- a/.claude/hooks/tests/test_sync_codex_adapter.sh
+++ b/.claude/hooks/tests/test_sync_codex_adapter.sh
@@ -160,8 +160,25 @@ else
   mark_pass "hooks.json omits unsupported if fields"
 fi
 
+# Test isolation (mirrors bin/run-hook-tests.sh's APEXYARD_OPS_DISABLE_PIN
+# rationale, see #528): the generated command below is copied verbatim from
+# a real .claude/settings.json hook entry, and that literal resolves the
+# ops root via a session-pin-first, PWD-walk-up-second precedence — it
+# checks CLAUDE_CODE_SESSION_ID + $APEXYARD_OPS_PIN_DIR directly rather than
+# sourcing _lib-ops-root.sh, so it does NOT honour APEXYARD_OPS_DISABLE_PIN.
+# Running this test from inside a live Claude Code session (exactly how it
+# is normally invoked, by an agent working in this repo) leaves
+# CLAUDE_CODE_SESSION_ID set with a real ops-root pin file already on disk
+# for that session — so the session-pin branch wins and execs
+# "<real-ops-root>/.claude/hooks/block-test.sh", which only exists under
+# $TMPROOT, never under the real ops root. That is a test-isolation gap in
+# THIS test, not a defect in the generated adapter output (preserving the
+# session-pin precedence is the whole point of the "hooks.json preserves
+# Claude session pin path" assertion above) — see me2resh/apexyard#1014.
+# Unsetting the session-id var for just this invocation forces the
+# fallback PWD-walk-up path the fixture below was actually built for.
 hook_command=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$TMPROOT/.codex/hooks.json")
-printf '{"tool_name":"Bash","tool_input":{"command":"policy deny"}}\n' | (cd "$TMPROOT" && bash -c "$hook_command") >/tmp/_codex_adapter_block.out 2>&1
+printf '{"tool_name":"Bash","tool_input":{"command":"policy deny"}}\n' | (cd "$TMPROOT" && unset CLAUDE_CODE_SESSION_ID && bash -c "$hook_command") >/tmp/_codex_adapter_block.out 2>&1
 block_rc=$?
 if [ "$block_rc" -eq 2 ]; then
   mark_pass "generated hook command preserves blocking exit"
@@ -169,7 +186,7 @@ else
   mark_fail "generated hook command preserves blocking exit" "expected exit 2, got $block_rc: $(cat /tmp/_codex_adapter_block.out)"
 fi
 
-printf '{"tool_name":"Bash","tool_input":{"command":"policy allow"}}\n' | (cd "$TMPROOT" && bash -c "$hook_command") >/tmp/_codex_adapter_allow.out 2>&1
+printf '{"tool_name":"Bash","tool_input":{"command":"policy allow"}}\n' | (cd "$TMPROOT" && unset CLAUDE_CODE_SESSION_ID && bash -c "$hook_command") >/tmp/_codex_adapter_allow.out 2>&1
 allow_rc=$?
 if [ "$allow_rc" -eq 0 ]; then
   mark_pass "generated hook command preserves allowing exit"
@@ -177,7 +194,7 @@ else
   mark_fail "generated hook command preserves allowing exit" "expected exit 0, got $allow_rc: $(cat /tmp/_codex_adapter_allow.out)"
 fi
 
-printf '{"tool_name":"Bash","tool_input":{"command":"other deny"}}\n' | (cd "$TMPROOT" && bash -c "$hook_command") >/tmp/_codex_adapter_skip.out 2>&1
+printf '{"tool_name":"Bash","tool_input":{"command":"other deny"}}\n' | (cd "$TMPROOT" && unset CLAUDE_CODE_SESSION_ID && bash -c "$hook_command") >/tmp/_codex_adapter_skip.out 2>&1
 skip_rc=$?
 if [ "$skip_rc" -eq 0 ]; then
   mark_pass "generated hook command skips nonmatching predicates"


### PR DESCRIPTION
## Summary

- **Fixed a test-isolation gap in `test_sync_codex_adapter.sh`, not a bug in the Codex adapter** — the two failing assertions ("preserves blocking exit" / "preserves allowing exit") exec a generated hook command copied verbatim from a real `.claude/settings.json` entry. That command resolves the ops root via a session-pin-first, PWD-walk-up-second precedence, checking `CLAUDE_CODE_SESSION_ID` + `$APEXYARD_OPS_PIN_DIR` directly rather than sourcing `_lib-ops-root.sh` — so it does not honour `APEXYARD_OPS_DISABLE_PIN`, the isolation var `bin/run-hook-tests.sh` already exports for the rest of the suite (#528).
- **Why it surfaced on a clean checkout** — running the test from inside a live Claude Code session (exactly how #1009's and #999's agents ran it, and how I reproduced it) leaves `CLAUDE_CODE_SESSION_ID` set with a real ops-root pin file already on disk for that session (`~/.claude/apexyard/ops-root-<session-id>`). The session-pin branch then wins and execs `<real-ops-root>/.claude/hooks/block-test.sh`, which only exists under the test's ephemeral `$TMPROOT`, never under the real ops root — hence exit 126 ("No such file or directory") instead of the expected 2/0.
- **The fix scopes the isolation to just the three hook-command invocations** — unsetting `CLAUDE_CODE_SESSION_ID` in the subshell that execs the generated command forces the PWD-walk-up path the fixture (`$TMPROOT/.apexyard-fork` + `$TMPROOT/.claude/hooks/block-test.sh`) was actually built for, without touching the generator's own `--root`-scoped invocation or any other assertion in the file.

## Root cause determination (issue's own decision tree)

Per #1014's three options, this is **option 3 — the test is environment-dependent** (not option 1, adapter genuinely broken; not option 2, stale assertion). The generated hook command's session-pin-first precedence is *intentional, correct, production behaviour* — it's the exact thing the neighbouring "hooks.json preserves Claude session pin path" assertion in this same file verifies on purpose. Making the adapter *not* prefer the session pin would break that assertion and real Codex-CLI hook resolution. The defect is entirely in the test's own isolation: it fails to neutralize ambient session state before exercising a fixture built to be found only via PWD walk-up.

## Testing

Reproduced the failure first, then verified the fix, both from inside a live Claude Code session (the exact condition that was hiding the bug) and headless (no `CLAUDE_CODE_SESSION_ID`, simulating CI):

| Scope | Before | After |
|---|---|---|
| `test_sync_codex_adapter.sh` alone, live session | 57 pass / 2 fail | 59 pass / 0 fail |
| `test_sync_codex_adapter.sh` alone, headless (`env -u CLAUDE_CODE_SESSION_ID`) | n/a (already passed headless) | 59 pass / 0 fail |
| Full hook suite (`bin/run-hook-tests.sh`, 114 files, `APEXYARD_OPS_DISABLE_PIN=1` applied consistently both runs) | **113 pass / 1 fail** (only `test_sync_codex_adapter.sh`) — matches the issue's "113/114" exactly | **114 pass / 0 fail** |

The full-suite comparison ran in bounded ~10-file chunks (`timeout 100` per file) rather than one long foreground call, to stay under tool limits; both runs used the same `APEXYARD_OPS_DISABLE_PIN=1` isolation `bin/run-hook-tests.sh` exports, so it's an apples-to-apples comparison. No other test changed state in either direction.

Reconciliation done first per the SDLC rule: `gh issue view 1014` (no comments), and `gh pr list --search "1014 in:title,body" --state merged` returned nothing — no prior fix existed.

## Glossary

| Term | Definition |
|------|------------|
| Ops-root session pin | A per-session marker file (`~/.claude/apexyard/ops-root-<session-id>`) that lets a hook resolve the real ApexYard fork root reliably even if the shell's cwd has wandered, instead of walking up parent directories |
| `APEXYARD_OPS_DISABLE_PIN` | Env var honoured by `_lib-ops-root.sh` (and the suite runner `bin/run-hook-tests.sh`) to force the PWD-walk-up path and ignore the session pin, so sandboxed tests can't accidentally resolve onto the real ops fork |
| Codex adapter | The generated Codex-CLI-compatible hook/skill/agent configuration produced by `bin/sync-codex-adapter.sh` from this repo's native `.claude/` sources |
| Test-isolation gap | A test failure caused by ambient environment/session state leaking into a fixture the test intended to run in isolation — distinct from a defect in the code under test |

Refs #1014
