### PR TITLE
fix(#1038): PR-create hooks mis-parse a quoted --body-file path

### DIFF
--- a/.claude/hooks/require-agdr-for-arch-pr.sh
+++ b/.claude/hooks/require-agdr-for-arch-pr.sh
@@ -62,74 +62,98 @@ extract_flag_value() {
   # recognised flag boundary (whitespace + `--<letter>`) or end-of-string. This
   # captures the full quoted span, including any embedded quotes, without
   # bleeding past the start of the next flag.
-  #
-  # #1038 — WIDEN THE ANCHOR, AND STRIP QUOTES IN THE FALLBACK.
-  # The anchor accepted only `--<letter>` or end-of-string, so a quoted
-  # value followed by a shell operator or a single-dash flag missed the
-  # quoted branches entirely:
-  #
-  #   gh pr create ... --body-file "/p/b.md" 2>&1 | tail -5    (shell operator)
-  #   gh pr create ... --body-file "/p/b.md" -t "x"            (single-dash flag)
-  #
-  # Execution then fell through to the unquoted branch, which has no anchor
-  # and returned the token WITH its quotes attached. The caller's
-  # `[ -f "\"/p/b.md\"" ]` was false, BODY_FILE_CONTENT stayed empty, and the
-  # `<!-- agdr: not-applicable -->` marker inside that file was never seen —
-  # so the PR was blocked for a missing AgDR that was actually declared.
-  # Note an UNQUOTED path with a trailing pipe always extracted fine; the
-  # failing combination is specifically quoted-value + non-`--flag` follower.
-  #
-  # The same defect in block-private-refs-in-public-repos.sh fails OPEN
-  # instead of closed (it exits 0 when it recovers no body), which is why
-  # that one is tracked and fixed separately as #1039.
-  #
-  # Both changes only ever cause MORE text to be scanned, and the anchor now
-  # matches what validate-issue-structure.sh already adopted for #695.
   local flag_re="$1"
   local cmd="$2"
   printf '%s' "$cmd" | awk -v FLAG_RE="$flag_re" -v SQ="'" '
     { buf = (NR == 1 ? $0 : buf "\n" $0) }
     END {
       s = buf
-      # Next-token boundary: a flag (one or two dashes), a shell operator,
-      # or end-of-string. `--?[a-zA-Z]` rather than an interval expression
-      # so this stays portable across BSD/GNU awk.
-      ANCH = "([[:space:]]+--?[a-zA-Z]|[[:space:]]*[|;&<>()]|[[:space:]]*$)"
-      # Double-quoted value: greedy `(.*)` anchored on the boundary above.
-      re = "(" FLAG_RE ")[[:space:]]+\"(.*)\"" ANCH
+      # Double-quoted value: greedy `(.*)` anchored on next flag or EOS.
+      re = "(" FLAG_RE ")[[:space:]]+\"(.*)\"([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
       if (match(s, re)) {
         chunk = substr(s, RSTART, RLENGTH)
         sub("^(" FLAG_RE ")[[:space:]]+\"", "", chunk)
-        sub("\"([[:space:]]+--?[a-zA-Z].*|[[:space:]]*[|;&<>()].*)?$", "", chunk)
+        sub("\"([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
         sub("\"[[:space:]]*$", "", chunk)
         print chunk
         exit
       }
       # Single-quoted value: same greedy + anchor treatment.
-      re = "(" FLAG_RE ")[[:space:]]+" SQ "(.*)" SQ ANCH
+      re = "(" FLAG_RE ")[[:space:]]+" SQ "(.*)" SQ "([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
       if (match(s, re)) {
         chunk = substr(s, RSTART, RLENGTH)
         sub("^(" FLAG_RE ")[[:space:]]+" SQ, "", chunk)
-        sub(SQ "([[:space:]]+--?[a-zA-Z].*|[[:space:]]*[|;&<>()].*)?$", "", chunk)
+        sub(SQ "([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
         sub(SQ "[[:space:]]*$", "", chunk)
         print chunk
         exit
       }
-      # Unquoted value: single token. Strip ONE matched surrounding quote
-      # pair (#1038) so a quoted value reaching this branch is still usable.
-      # Only a MATCHED pair, so a file literally named `"x.md"` is not
-      # silently rewritten to a different path than the one gh will read.
+      # Unquoted value: single token, embedded quotes irrelevant.
       re = "(" FLAG_RE ")[[:space:]]+[^[:space:]]+"
       if (match(s, re)) {
         chunk = substr(s, RSTART, RLENGTH)
         sub("^(" FLAG_RE ")[[:space:]]+", "", chunk)
-        if (length(chunk) >= 2) {
-          first = substr(chunk, 1, 1)
-          last  = substr(chunk, length(chunk), 1)
-          if ((first == "\"" && last == "\"") || (first == SQ && last == SQ)) {
-            chunk = substr(chunk, 2, length(chunk) - 2)
-          }
-        }
+        print chunk
+        exit
+      }
+    }
+  '
+}
+
+# extract_path_flag FLAG_RE COMMAND  (me2resh/apexyard#1038)
+#
+# A PATH-valued flag needs the OPPOSITE parsing strategy to a CONTENT-valued
+# one, and conflating them is the actual defect behind #1038:
+#
+#   CONTENT (--title / --body): may contain anything — quotes, pipes,
+#     semicolons, markdown tables. Extraction must be GREEDY and terminate
+#     only on a real flag boundary, or an embedded quote truncates the value.
+#     extract_flag_value above is therefore left exactly as #227 wrote it.
+#
+#   PATH (--body-file / -F): a filesystem path, which never contains a quote.
+#     Extraction must be NON-GREEDY — stop at the FIRST closing quote. The
+#     greedy content matcher cannot terminate `--body-file "/p/b.md" 2>&1 |
+#     tail`, so it fell through to the unquoted branch and returned the token
+#     WITH quotes attached. `[ -f ]` was then false, the body file was never
+#     read, and the `<!-- agdr: not-applicable -->` marker inside it was
+#     never seen — blocking the PR for a missing AgDR that WAS declared.
+#
+# An earlier attempt widened extract_flag_value's anchor to accept shell
+# operators. That fixed the path case and broke the content case: `sub()` is
+# leftmost-first and each alternative ended in `.*`, so a body containing a
+# quote followed by ` |` truncated there. In the sibling leak hook that same
+# change was measurably WORSE than no fix at all (see #1039). Splitting the
+# extractors is the correct fix; widening the shared one is not.
+extract_path_flag() {
+  local flag_re="$1"
+  local cmd="$2"
+  printf '%s' "$cmd" | awk -v FLAG_RE="$flag_re" -v SQ="'" '
+    { buf = (NR == 1 ? $0 : buf "\n" $0) }
+    END {
+      s = buf
+      # Double-quoted path: stop at the first closing quote.
+      re = "(" FLAG_RE ")[[:space:]]+\"[^\"]*\""
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^(" FLAG_RE ")[[:space:]]+\"", "", chunk)
+        sub("\"$", "", chunk)
+        print chunk
+        exit
+      }
+      # Single-quoted path: same treatment.
+      re = "(" FLAG_RE ")[[:space:]]+" SQ "[^" SQ "]*" SQ
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^(" FLAG_RE ")[[:space:]]+" SQ, "", chunk)
+        sub(SQ "$", "", chunk)
+        print chunk
+        exit
+      }
+      # Unquoted path: a single whitespace-delimited token.
+      re = "(" FLAG_RE ")[[:space:]]+[^[:space:]]+"
+      if (match(s, re)) {
+        chunk = substr(s, RSTART, RLENGTH)
+        sub("^(" FLAG_RE ")[[:space:]]+", "", chunk)
         print chunk
         exit
       }
@@ -142,7 +166,8 @@ BODY=$(extract_flag_value '--body|-b' "$COMMAND")
 
 # --body-file <path> / -F <path> (only when -F's value is NOT a key=val pair,
 # because `gh api -F body=@file` uses the same flag letter).
-BODY_FILE=$(extract_flag_value '--body-file' "$COMMAND")
+# #1038: a PATH, so use the non-greedy path extractor.
+BODY_FILE=$(extract_path_flag '--body-file' "$COMMAND")
 if [ -z "$BODY_FILE" ]; then
   F_VAL=$(echo "$COMMAND" | sed -nE "s/.*(^|[[:space:]])-F[[:space:]]+\"([^\"]*)\".*/\2/p" | head -1)
   if [ -z "$F_VAL" ]; then

--- a/.claude/hooks/require-agdr-for-arch-pr.sh
+++ b/.claude/hooks/require-agdr-for-arch-pr.sh
@@ -62,37 +62,74 @@ extract_flag_value() {
   # recognised flag boundary (whitespace + `--<letter>`) or end-of-string. This
   # captures the full quoted span, including any embedded quotes, without
   # bleeding past the start of the next flag.
+  #
+  # #1038 — WIDEN THE ANCHOR, AND STRIP QUOTES IN THE FALLBACK.
+  # The anchor accepted only `--<letter>` or end-of-string, so a quoted
+  # value followed by a shell operator or a single-dash flag missed the
+  # quoted branches entirely:
+  #
+  #   gh pr create ... --body-file "/p/b.md" 2>&1 | tail -5    (shell operator)
+  #   gh pr create ... --body-file "/p/b.md" -t "x"            (single-dash flag)
+  #
+  # Execution then fell through to the unquoted branch, which has no anchor
+  # and returned the token WITH its quotes attached. The caller's
+  # `[ -f "\"/p/b.md\"" ]` was false, BODY_FILE_CONTENT stayed empty, and the
+  # `<!-- agdr: not-applicable -->` marker inside that file was never seen —
+  # so the PR was blocked for a missing AgDR that was actually declared.
+  # Note an UNQUOTED path with a trailing pipe always extracted fine; the
+  # failing combination is specifically quoted-value + non-`--flag` follower.
+  #
+  # The same defect in block-private-refs-in-public-repos.sh fails OPEN
+  # instead of closed (it exits 0 when it recovers no body), which is why
+  # that one is tracked and fixed separately as #1039.
+  #
+  # Both changes only ever cause MORE text to be scanned, and the anchor now
+  # matches what validate-issue-structure.sh already adopted for #695.
   local flag_re="$1"
   local cmd="$2"
   printf '%s' "$cmd" | awk -v FLAG_RE="$flag_re" -v SQ="'" '
     { buf = (NR == 1 ? $0 : buf "\n" $0) }
     END {
       s = buf
-      # Double-quoted value: greedy `(.*)` anchored on next flag or EOS.
-      re = "(" FLAG_RE ")[[:space:]]+\"(.*)\"([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
+      # Next-token boundary: a flag (one or two dashes), a shell operator,
+      # or end-of-string. `--?[a-zA-Z]` rather than an interval expression
+      # so this stays portable across BSD/GNU awk.
+      ANCH = "([[:space:]]+--?[a-zA-Z]|[[:space:]]*[|;&<>()]|[[:space:]]*$)"
+      # Double-quoted value: greedy `(.*)` anchored on the boundary above.
+      re = "(" FLAG_RE ")[[:space:]]+\"(.*)\"" ANCH
       if (match(s, re)) {
         chunk = substr(s, RSTART, RLENGTH)
         sub("^(" FLAG_RE ")[[:space:]]+\"", "", chunk)
-        sub("\"([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
+        sub("\"([[:space:]]+--?[a-zA-Z].*|[[:space:]]*[|;&<>()].*)?$", "", chunk)
         sub("\"[[:space:]]*$", "", chunk)
         print chunk
         exit
       }
       # Single-quoted value: same greedy + anchor treatment.
-      re = "(" FLAG_RE ")[[:space:]]+" SQ "(.*)" SQ "([[:space:]]+--[a-zA-Z]|[[:space:]]*$)"
+      re = "(" FLAG_RE ")[[:space:]]+" SQ "(.*)" SQ ANCH
       if (match(s, re)) {
         chunk = substr(s, RSTART, RLENGTH)
         sub("^(" FLAG_RE ")[[:space:]]+" SQ, "", chunk)
-        sub(SQ "([[:space:]]+--[a-zA-Z].*)?$", "", chunk)
+        sub(SQ "([[:space:]]+--?[a-zA-Z].*|[[:space:]]*[|;&<>()].*)?$", "", chunk)
         sub(SQ "[[:space:]]*$", "", chunk)
         print chunk
         exit
       }
-      # Unquoted value: single token, embedded quotes irrelevant.
+      # Unquoted value: single token. Strip ONE matched surrounding quote
+      # pair (#1038) so a quoted value reaching this branch is still usable.
+      # Only a MATCHED pair, so a file literally named `"x.md"` is not
+      # silently rewritten to a different path than the one gh will read.
       re = "(" FLAG_RE ")[[:space:]]+[^[:space:]]+"
       if (match(s, re)) {
         chunk = substr(s, RSTART, RLENGTH)
         sub("^(" FLAG_RE ")[[:space:]]+", "", chunk)
+        if (length(chunk) >= 2) {
+          first = substr(chunk, 1, 1)
+          last  = substr(chunk, length(chunk), 1)
+          if ((first == "\"" && last == "\"") || (first == SQ && last == SQ)) {
+            chunk = substr(chunk, 2, length(chunk) - 2)
+          }
+        }
         print chunk
         exit
       }

--- a/.claude/hooks/tests/test_flag_extractor_body_file.sh
+++ b/.claude/hooks/tests/test_flag_extractor_body_file.sh
@@ -176,32 +176,72 @@ printf '## Summary\n\n- only a summary\n' > "$TMPDIR/thin-body.md"
 
 PR_CREATE="gh pr create --repo me2resh/apexyard --title \"fix(#1038): x\""
 
-check_hook() {
-  local name="$1" expected_exit="$2" cmd="$3" actual
-  ( cd "$TMPDIR" && jq -n --arg c "$cmd" '{tool_input:{command:$c}}' | "$PRC_HOOK" ) >/dev/null 2>&1
-  actual=$?
-  if [ "$actual" = "$expected_exit" ]; then
-    echo "PASS: $name"
-    PASS=$((PASS + 1))
-  else
-    echo "FAIL: $name — expected exit $expected_exit, got $actual"
-    FAIL=$((FAIL + 1))
-  fi
+# Assert on STDERR CONTENT, not on the exit code.
+#
+# validate-pr-create.sh derives its exit code from several independent
+# checks — branch name, ticket existence in the tracker (a network call),
+# PR-title format — all of which read AMBIENT state. An earlier version of
+# these cases asserted `exit 0`, which passed locally (conforming branch,
+# resolvable ticket) and failed 3/22 in CI, where neither holds. A PR fixing
+# false-positive hook failures cannot ship a test that itself false-fails.
+#
+# What is actually under test here is narrow: can the hook READ a quoted
+# --body-file path? That is observable precisely, and independently of every
+# ambient check, through two stderr signals:
+#
+#   "not readable"                  -> the path was mis-parsed (the #1038 bug)
+#   "missing required '## Testing'" -> it read the file but not the content
+#
+# Neither appears when extraction works, whatever the exit code ends up
+# being for unrelated reasons.
+check_stderr_absent() {
+  local name="$1" needle="$2" cmd="$3" err
+  err=$( cd "$TMPDIR" && jq -n --arg c "$cmd" '{tool_input:{command:$c}}' | "$PRC_HOOK" 2>&1 >/dev/null )
+  case "$err" in
+    *"$needle"*)
+      echo "FAIL: $name — stderr still reports [$needle]"
+      echo "   stderr: $(printf '%s' "$err" | head -2)"
+      FAIL=$((FAIL + 1)) ;;
+    *)
+      echo "PASS: $name"
+      PASS=$((PASS + 1)) ;;
+  esac
 }
 
-check_hook "validate-pr-create: unquoted path, complete body → pass" \
-  0 "$PR_CREATE --body-file $TMPDIR/full-body.md"
-check_hook "validate-pr-create: QUOTED path, complete body → pass (#1038)" \
-  0 "$PR_CREATE --body-file \"$TMPDIR/full-body.md\""
-check_hook "validate-pr-create: single-quoted path, complete body → pass (#1038)" \
-  0 "$PR_CREATE --body-file '$TMPDIR/full-body.md'"
+check_stderr_present() {
+  local name="$1" needle="$2" cmd="$3" err
+  err=$( cd "$TMPDIR" && jq -n --arg c "$cmd" '{tool_input:{command:$c}}' | "$PRC_HOOK" 2>&1 >/dev/null )
+  case "$err" in
+    *"$needle"*)
+      echo "PASS: $name"
+      PASS=$((PASS + 1)) ;;
+    *)
+      echo "FAIL: $name — expected stderr to report [$needle]"
+      echo "   stderr: $(printf '%s' "$err" | head -2)"
+      FAIL=$((FAIL + 1)) ;;
+  esac
+}
+
+# The path must be READ — no "not readable" warning — however it is quoted.
+check_stderr_absent "validate-pr-create: unquoted path is read" \
+  "not readable" "$PR_CREATE --body-file $TMPDIR/full-body.md"
+check_stderr_absent "validate-pr-create: QUOTED path is read (#1038)" \
+  "not readable" "$PR_CREATE --body-file \"$TMPDIR/full-body.md\""
+check_stderr_absent "validate-pr-create: single-quoted path is read (#1038)" \
+  "not readable" "$PR_CREATE --body-file '$TMPDIR/full-body.md'"
+
+# Having read it, the hook must SEE the sections — the pre-fix symptom was
+# reporting them missing because the file was never opened.
+check_stderr_absent "validate-pr-create: quoted path — sections found (#1038)" \
+  "## Testing" "$PR_CREATE --body-file \"$TMPDIR/full-body.md\""
 
 # Regression: the fix must not make the hook permissive. A body genuinely
-# missing required sections still blocks, whether the path is quoted or not.
-check_hook "validate-pr-create: thin body still blocked (unquoted)" \
-  2 "$PR_CREATE --body-file $TMPDIR/thin-body.md"
-check_hook "validate-pr-create: thin body still blocked (quoted)" \
-  2 "$PR_CREATE --body-file \"$TMPDIR/thin-body.md\""
+# missing its sections is still reported, quoted or not — proving the
+# absence assertions above are meaningful rather than vacuous.
+check_stderr_present "validate-pr-create: thin body still reported (unquoted)" \
+  "## Testing" "$PR_CREATE --body-file $TMPDIR/thin-body.md"
+check_stderr_present "validate-pr-create: thin body still reported (quoted)" \
+  "## Testing" "$PR_CREATE --body-file \"$TMPDIR/thin-body.md\""
 
 # ---------------------------------------------------------------------------
 # Result

--- a/.claude/hooks/tests/test_flag_extractor_body_file.sh
+++ b/.claude/hooks/tests/test_flag_extractor_body_file.sh
@@ -149,12 +149,85 @@ TAIL_MARKER\""
 check_extract "extract: single-quoted path + pipe (#1038)" \
   "$BODY_PATH" "gh pr create --body-file '$BODY_PATH' 2>&1 | tail -5"
 
+
 # ---------------------------------------------------------------------------
 # Part 2 — validate-pr-create.sh end-to-end, quoted vs unquoted path.
+#
+# Runs the hook inside an isolated SANDBOX, not against the ambient checkout.
+#
+# Two earlier attempts failed, and the second failed in an instructive way.
+# The first ran in the repo's own working directory and asserted on the exit
+# code: passed locally, failed 3/22 in CI. The second asserted on stderr
+# instead — and failed VACUOUSLY. validate-pr-create.sh exits on the
+# ticket-existence check (~line 447) well before the --body-file logic
+# (~line 502), so in CI the hook never reached the code under test, and every
+# "this message is absent" assertion passed because nothing ran at all.
+#
+# The fix is the pattern test_validate_pr_required_sections.sh already uses
+# and which passes in CI: a `git init` sandbox on a CONFORMING branch, plus
+# the shared gh mock (_lib-mock-gh.sh) so the ticket check resolves against
+# synthetic OPEN data rather than the network. Only then does execution reach
+# the body-file parsing this PR changes.
+#
+# Asserting rc == 0 for a complete body is what makes these non-vacuous:
+# rc 0 is reachable ONLY if the hook opened the file and found its sections.
 # ---------------------------------------------------------------------------
 
-cat > "$TMPDIR/full-body.md" <<'MD'
-## Summary
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_lib-mock-gh.sh"
+
+SRC_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    git checkout -q -b chore/GH-113-test 2>/dev/null || git checkout -q -B chore/GH-113-test
+    touch onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "chore: seed the sandbox"
+  )
+  mkdir -p "$sb/.claude/hooks"
+  cp "$PRC_HOOK" "$sb/.claude/hooks/validate-pr-create.sh"
+  chmod +x "$sb/.claude/hooks/validate-pr-create.sh"
+  cp "$SRC_ROOT/.claude/hooks/_lib-read-config.sh" "$sb/.claude/hooks/_lib-read-config.sh"
+  [ -f "$SRC_ROOT/.claude/hooks/_lib-tracker.sh" ] && \
+    cp "$SRC_ROOT/.claude/hooks/_lib-tracker.sh" "$sb/.claude/hooks/_lib-tracker.sh"
+  [ -f "$SRC_ROOT/.claude/hooks/_lib-pr-repo.sh" ] && \
+    cp "$SRC_ROOT/.claude/hooks/_lib-pr-repo.sh" "$sb/.claude/hooks/_lib-pr-repo.sh"
+  cp "$SRC_ROOT/.claude/project-config.defaults.json" "$sb/.claude/project-config.defaults.json"
+  mock_gh_install "$sb"
+  echo "$sb"
+}
+
+# run_prc BODY QUOTING -> "<rc>|<stderr>"   QUOTING: bare | double | single
+run_prc() {
+  local body_content="$1" quoting="$2" sb body_file cmd rc err
+  sb=$(make_sandbox)
+  body_file="$sb/body.md"
+  printf '%s' "$body_content" > "$body_file"
+  case "$quoting" in
+    double) cmd="gh pr create --repo me2resh/apexyard --title 'chore(#113): test' --body-file \"$body_file\"" ;;
+    single) cmd="gh pr create --repo me2resh/apexyard --title 'chore(#113): test' --body-file '$body_file'" ;;
+    *)      cmd="gh pr create --repo me2resh/apexyard --title 'chore(#113): test' --body-file $body_file" ;;
+  esac
+  # EXPORT the mock onto PATH for the whole subshell. `PATH=... jq ...` would
+  # scope it to jq alone, leaving the hook to find the real gh — which then
+  # answers from the live tracker and reports #113 as CLOSED, exactly the
+  # network dependency the mock exists to remove.
+  err=$(cd "$sb" && export PATH="$sb/bin:$PATH" && \
+        jq -nc --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash .claude/hooks/validate-pr-create.sh 2>&1 >/dev/null)
+  rc=$?
+  rm -rf "$sb"
+  printf '%s|%s' "$rc" "$err"
+}
+
+FULL_BODY='## Summary
 
 - Does a thing, and here is why it matters.
 
@@ -162,86 +235,56 @@ cat > "$TMPDIR/full-body.md" <<'MD'
 
 - Ran the suite.
 
-Refs #1038
-
 ## Glossary
 
 | Term | Definition |
 |------|------------|
 | thing | a thing |
-MD
+'
 
-# Deliberately missing ## Testing and ## Glossary.
-printf '## Summary\n\n- only a summary\n' > "$TMPDIR/thin-body.md"
+THIN_BODY='## Summary
 
-PR_CREATE="gh pr create --repo me2resh/apexyard --title \"fix(#1038): x\""
+- only a summary
+'
 
-# Assert on STDERR CONTENT, not on the exit code.
-#
-# validate-pr-create.sh derives its exit code from several independent
-# checks — branch name, ticket existence in the tracker (a network call),
-# PR-title format — all of which read AMBIENT state. An earlier version of
-# these cases asserted `exit 0`, which passed locally (conforming branch,
-# resolvable ticket) and failed 3/22 in CI, where neither holds. A PR fixing
-# false-positive hook failures cannot ship a test that itself false-fails.
-#
-# What is actually under test here is narrow: can the hook READ a quoted
-# --body-file path? That is observable precisely, and independently of every
-# ambient check, through two stderr signals:
-#
-#   "not readable"                  -> the path was mis-parsed (the #1038 bug)
-#   "missing required '## Testing'" -> it read the file but not the content
-#
-# Neither appears when extraction works, whatever the exit code ends up
-# being for unrelated reasons.
-check_stderr_absent() {
-  local name="$1" needle="$2" cmd="$3" err
-  err=$( cd "$TMPDIR" && jq -n --arg c "$cmd" '{tool_input:{command:$c}}' | "$PRC_HOOK" 2>&1 >/dev/null )
-  case "$err" in
-    *"$needle"*)
-      echo "FAIL: $name — stderr still reports [$needle]"
-      echo "   stderr: $(printf '%s' "$err" | head -2)"
-      FAIL=$((FAIL + 1)) ;;
-    *)
-      echo "PASS: $name"
-      PASS=$((PASS + 1)) ;;
-  esac
+check_prc() {
+  local name="$1" want_rc="$2" absent="$3" body="$4" quoting="$5" out rc err
+  out=$(run_prc "$body" "$quoting")
+  rc=${out%%|*}
+  err=${out#*|}
+  if [ "$rc" != "$want_rc" ]; then
+    echo "FAIL: $name — expected rc=$want_rc, got $rc"
+    echo "   stderr: $(printf '%s' "$err" | head -2)"
+    FAIL=$((FAIL + 1)); return
+  fi
+  if [ -n "$absent" ]; then
+    case "$err" in
+      *"$absent"*)
+        echo "FAIL: $name — stderr still reports [$absent]"
+        echo "   stderr: $(printf '%s' "$err" | head -2)"
+        FAIL=$((FAIL + 1)); return ;;
+    esac
+  fi
+  echo "PASS: $name"
+  PASS=$((PASS + 1))
 }
 
-check_stderr_present() {
-  local name="$1" needle="$2" cmd="$3" err
-  err=$( cd "$TMPDIR" && jq -n --arg c "$cmd" '{tool_input:{command:$c}}' | "$PRC_HOOK" 2>&1 >/dev/null )
-  case "$err" in
-    *"$needle"*)
-      echo "PASS: $name"
-      PASS=$((PASS + 1)) ;;
-    *)
-      echo "FAIL: $name — expected stderr to report [$needle]"
-      echo "   stderr: $(printf '%s' "$err" | head -2)"
-      FAIL=$((FAIL + 1)) ;;
-  esac
-}
+# A complete body must PASS whatever the quoting. rc 0 is reachable only if
+# the hook opened the file and found its sections, so these cannot pass
+# vacuously the way the earlier stderr-only assertions could.
+check_prc "validate-pr-create: unquoted path, complete body -> rc 0" \
+  0 "not readable" "$FULL_BODY" bare
+check_prc "validate-pr-create: QUOTED path, complete body -> rc 0 (#1038)" \
+  0 "not readable" "$FULL_BODY" double
+check_prc "validate-pr-create: single-quoted path, complete body -> rc 0 (#1038)" \
+  0 "not readable" "$FULL_BODY" single
 
-# The path must be READ — no "not readable" warning — however it is quoted.
-check_stderr_absent "validate-pr-create: unquoted path is read" \
-  "not readable" "$PR_CREATE --body-file $TMPDIR/full-body.md"
-check_stderr_absent "validate-pr-create: QUOTED path is read (#1038)" \
-  "not readable" "$PR_CREATE --body-file \"$TMPDIR/full-body.md\""
-check_stderr_absent "validate-pr-create: single-quoted path is read (#1038)" \
-  "not readable" "$PR_CREATE --body-file '$TMPDIR/full-body.md'"
-
-# Having read it, the hook must SEE the sections — the pre-fix symptom was
-# reporting them missing because the file was never opened.
-check_stderr_absent "validate-pr-create: quoted path — sections found (#1038)" \
-  "## Testing" "$PR_CREATE --body-file \"$TMPDIR/full-body.md\""
-
-# Regression: the fix must not make the hook permissive. A body genuinely
-# missing its sections is still reported, quoted or not — proving the
-# absence assertions above are meaningful rather than vacuous.
-check_stderr_present "validate-pr-create: thin body still reported (unquoted)" \
-  "## Testing" "$PR_CREATE --body-file $TMPDIR/thin-body.md"
-check_stderr_present "validate-pr-create: thin body still reported (quoted)" \
-  "## Testing" "$PR_CREATE --body-file \"$TMPDIR/thin-body.md\""
+# Regression: a body genuinely missing its sections still blocks, quoted or
+# not — so the passes above reflect real extraction, not permissiveness.
+check_prc "validate-pr-create: thin body still blocked (unquoted)" \
+  2 "" "$THIN_BODY" bare
+check_prc "validate-pr-create: thin body still blocked (quoted)" \
+  2 "" "$THIN_BODY" double
 
 # ---------------------------------------------------------------------------
 # Result

--- a/.claude/hooks/tests/test_flag_extractor_body_file.sh
+++ b/.claude/hooks/tests/test_flag_extractor_body_file.sh
@@ -54,25 +54,32 @@ TMPDIR=$(mktemp -d -t flag-extractor.XXXXXX)
 trap 'rm -rf "$TMPDIR"' EXIT
 
 # ---------------------------------------------------------------------------
-# Part 1 — extract_flag_value, driven directly out of the hook source.
+# Part 1 — the two extractors, driven directly out of the hook source.
 #
-# Pulling the function out rather than invoking the whole hook keeps these
+# Pulling the functions out rather than invoking the whole hook keeps these
 # cases pinned to the parsing contract itself, independent of the diff
 # inspection and git state the hook otherwise needs.
+#
+# There are TWO extractors on purpose, and the split is the fix:
+#   extract_path_flag  — non-greedy, for --body-file (a path; no quotes in it)
+#   extract_flag_value — greedy, for --title / --body (content; anything in it)
 # ---------------------------------------------------------------------------
 
 eval "$(awk '/^extract_flag_value\(\) \{/,/^\}/' "$AGDR_HOOK")"
+eval "$(awk '/^extract_path_flag\(\) \{/,/^\}/' "$AGDR_HOOK")"
 
-if ! command -v extract_flag_value >/dev/null 2>&1; then
-  echo "FAIL: could not load extract_flag_value from $AGDR_HOOK" >&2
-  exit 1
-fi
+for fn in extract_flag_value extract_path_flag; do
+  if ! command -v "$fn" >/dev/null 2>&1; then
+    echo "FAIL: could not load $fn from $AGDR_HOOK" >&2
+    exit 1
+  fi
+done
 
 BODY_PATH="$TMPDIR/body.md"
 
 check_extract() {
   local name="$1" expected="$2" cmd="$3" got
-  got=$(extract_flag_value '--body-file' "$cmd")
+  got=$(extract_path_flag '--body-file' "$cmd")
   if [ "$got" = "$expected" ]; then
     echo "PASS: $name"
     PASS=$((PASS + 1))
@@ -82,6 +89,26 @@ check_extract() {
     echo "   got      [$got]"
     FAIL=$((FAIL + 1))
   fi
+}
+
+# Content extraction must NOT be truncated by a boundary character. This is
+# the guard against "fix the path case by widening the shared anchor" — that
+# approach reopens the #227 leak, and in the sibling hook it measured WORSE
+# than no fix at all (#1039). A --body carrying a quote followed by a shell
+# operator must survive intact, tail included.
+check_content() {
+  local name="$1" needle="$2" cmd="$3" got
+  got=$(extract_flag_value '--body|-b' "$cmd")
+  case "$got" in
+    *"$needle"*)
+      echo "PASS: $name"
+      PASS=$((PASS + 1)) ;;
+    *)
+      echo "FAIL: $name — content truncated before the tail"
+      echo "   expected the value to contain [$needle]"
+      echo "   got      [$got]"
+      FAIL=$((FAIL + 1)) ;;
+  esac
 }
 
 # Shapes that already worked — regression guards.
@@ -101,6 +128,24 @@ check_extract "extract: quoted path + redirect (#1038)" \
   "$BODY_PATH" "gh pr create --body-file \"$BODY_PATH\" > /dev/null"
 check_extract "extract: quoted path + semicolon (#1038)" \
   "$BODY_PATH" "gh pr create --body-file \"$BODY_PATH\"; echo done"
+
+# Content must survive a quote followed by each boundary character. These
+# fail against the rejected "widen the shared anchor" approach, which is the
+# whole point of keeping the two extractors separate.
+for boundary in '|' ';' '&' '<' '>' '(' ')'; do
+  check_content "content: quote then '$boundary' keeps the tail" \
+    "TAIL_MARKER" \
+    "gh pr create --title t --body \"The \\\"admin notice\\\" $boundary more text. TAIL_MARKER\""
+done
+check_content "content: quote then ' -t' keeps the tail" \
+  "TAIL_MARKER" \
+  "gh pr create --title t --body \"The \\\"admin notice\\\" -t more. TAIL_MARKER\""
+check_content "content: markdown table row keeps the tail" \
+  "TAIL_MARKER" \
+  "gh pr create --title t --body \"| Term | Definition |
+| \\\"thing\\\" | a thing |
+
+TAIL_MARKER\""
 check_extract "extract: single-quoted path + pipe (#1038)" \
   "$BODY_PATH" "gh pr create --body-file '$BODY_PATH' 2>&1 | tail -5"
 

--- a/.claude/hooks/tests/test_flag_extractor_body_file.sh
+++ b/.claude/hooks/tests/test_flag_extractor_body_file.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# me2resh/apexyard#1038 — --body-file flag extraction across the PR-create hooks.
+#
+# Both hooks recover a flag's value from the RAW command text a PreToolUse
+# hook receives. Two defects made them mis-parse ordinary command shapes:
+#
+#   1. require-agdr-for-arch-pr.sh — extract_flag_value's quoted branches
+#      anchored only on `--<letter>` or end-of-string. A quoted value
+#      followed by a shell operator or a single-dash flag missed those
+#      branches, fell through to the unquoted branch (which has no anchor),
+#      and returned the token WITH its quotes attached.
+#
+#   2. validate-pr-create.sh — its `[^[:space:]]+` sed token grab is
+#      quote-blind, so a quoted path came back as `"/p/body.md"`.
+#
+# In both cases `[ -f "\"/p/body.md\"" ]` is false, so the file is never
+# read. The consequences differ by hook:
+#
+#   - require-agdr-for-arch-pr.sh: the `<!-- agdr: not-applicable -->`
+#     marker inside the body file is never seen → PR blocked for a missing
+#     AgDR that was in fact declared.
+#   - validate-pr-create.sh: `## Testing` / `## Glossary` are reported
+#     missing when both are present.
+#
+# Both fail CLOSED, so these are false positives rather than a security
+# hole — but the error messages point at the PR author instead of at the
+# parser, which is what makes them expensive. The SAME extractor defect in
+# block-private-refs-in-public-repos.sh fails OPEN (silent leak) and is
+# covered separately by test_block_private_refs.sh (#1039).
+#
+# Note the failing combination is specifically QUOTED value + non-`--flag`
+# follower. An unquoted path with a trailing pipe always extracted fine —
+# which is why this went unnoticed.
+#
+# Exit 0 = all pass, exit 1 = at least one failure.
+
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+AGDR_HOOK="$REPO_ROOT/.claude/hooks/require-agdr-for-arch-pr.sh"
+PRC_HOOK="$REPO_ROOT/.claude/hooks/validate-pr-create.sh"
+
+for h in "$AGDR_HOOK" "$PRC_HOOK"; do
+  if [ ! -f "$h" ]; then
+    echo "FAIL: hook not found at $h" >&2
+    exit 1
+  fi
+done
+
+PASS=0
+FAIL=0
+
+TMPDIR=$(mktemp -d -t flag-extractor.XXXXXX)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Part 1 — extract_flag_value, driven directly out of the hook source.
+#
+# Pulling the function out rather than invoking the whole hook keeps these
+# cases pinned to the parsing contract itself, independent of the diff
+# inspection and git state the hook otherwise needs.
+# ---------------------------------------------------------------------------
+
+eval "$(awk '/^extract_flag_value\(\) \{/,/^\}/' "$AGDR_HOOK")"
+
+if ! command -v extract_flag_value >/dev/null 2>&1; then
+  echo "FAIL: could not load extract_flag_value from $AGDR_HOOK" >&2
+  exit 1
+fi
+
+BODY_PATH="$TMPDIR/body.md"
+
+check_extract() {
+  local name="$1" expected="$2" cmd="$3" got
+  got=$(extract_flag_value '--body-file' "$cmd")
+  if [ "$got" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name"
+    echo "   expected [$expected]"
+    echo "   got      [$got]"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Shapes that already worked — regression guards.
+check_extract "extract: unquoted path, flag last" \
+  "$BODY_PATH" "gh pr create --body-file $BODY_PATH"
+check_extract "extract: unquoted path + trailing pipe" \
+  "$BODY_PATH" "gh pr create --body-file $BODY_PATH 2>&1 | tail -5"
+check_extract "extract: quoted path + following --flag" \
+  "$BODY_PATH" "gh pr create --body-file \"$BODY_PATH\" --base dev"
+
+# The #1038 shapes — each returned the token WITH quotes before the fix.
+check_extract "extract: quoted path + pipe (#1038)" \
+  "$BODY_PATH" "gh pr create --body-file \"$BODY_PATH\" 2>&1 | tail -5"
+check_extract "extract: quoted path + single-dash flag (#1038)" \
+  "$BODY_PATH" "gh pr create --body-file \"$BODY_PATH\" -t \"x\""
+check_extract "extract: quoted path + redirect (#1038)" \
+  "$BODY_PATH" "gh pr create --body-file \"$BODY_PATH\" > /dev/null"
+check_extract "extract: quoted path + semicolon (#1038)" \
+  "$BODY_PATH" "gh pr create --body-file \"$BODY_PATH\"; echo done"
+check_extract "extract: single-quoted path + pipe (#1038)" \
+  "$BODY_PATH" "gh pr create --body-file '$BODY_PATH' 2>&1 | tail -5"
+
+# ---------------------------------------------------------------------------
+# Part 2 — validate-pr-create.sh end-to-end, quoted vs unquoted path.
+# ---------------------------------------------------------------------------
+
+cat > "$TMPDIR/full-body.md" <<'MD'
+## Summary
+
+- Does a thing, and here is why it matters.
+
+## Testing
+
+- Ran the suite.
+
+Refs #1038
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| thing | a thing |
+MD
+
+# Deliberately missing ## Testing and ## Glossary.
+printf '## Summary\n\n- only a summary\n' > "$TMPDIR/thin-body.md"
+
+PR_CREATE="gh pr create --repo me2resh/apexyard --title \"fix(#1038): x\""
+
+check_hook() {
+  local name="$1" expected_exit="$2" cmd="$3" actual
+  ( cd "$TMPDIR" && jq -n --arg c "$cmd" '{tool_input:{command:$c}}' | "$PRC_HOOK" ) >/dev/null 2>&1
+  actual=$?
+  if [ "$actual" = "$expected_exit" ]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name — expected exit $expected_exit, got $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_hook "validate-pr-create: unquoted path, complete body → pass" \
+  0 "$PR_CREATE --body-file $TMPDIR/full-body.md"
+check_hook "validate-pr-create: QUOTED path, complete body → pass (#1038)" \
+  0 "$PR_CREATE --body-file \"$TMPDIR/full-body.md\""
+check_hook "validate-pr-create: single-quoted path, complete body → pass (#1038)" \
+  0 "$PR_CREATE --body-file '$TMPDIR/full-body.md'"
+
+# Regression: the fix must not make the hook permissive. A body genuinely
+# missing required sections still blocks, whether the path is quoted or not.
+check_hook "validate-pr-create: thin body still blocked (unquoted)" \
+  2 "$PR_CREATE --body-file $TMPDIR/thin-body.md"
+check_hook "validate-pr-create: thin body still blocked (quoted)" \
+  2 "$PR_CREATE --body-file \"$TMPDIR/thin-body.md\""
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+
+echo
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -503,6 +503,23 @@ BODY_FILE=$(printf '%s' "$COMMAND" | sed -nE 's/.*--body-file[[:space:]]+([^[:sp
 if [ -z "$BODY_FILE" ]; then
   BODY_FILE=$(printf '%s' "$COMMAND" | sed -nE 's/.*[[:space:]]-F[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
 fi
+# #1038 — strip ONE matched surrounding quote pair.
+#
+# The `[^[:space:]]+` token grab above is quote-blind, so `--body-file
+# "/p/body.md"` yielded the value WITH its quotes: `"/p/body.md"`. The
+# `-f` test below was then false, BODY_CONTENT stayed empty, and the hook
+# blocked the PR reporting `## Testing` / `## Glossary` as missing when both
+# were present in the file — an error message that points at the PR author
+# rather than at the parser. Quoting a path is correct shell practice, so
+# this fired on ordinary usage.
+#
+# Only a MATCHED pair is stripped: a file literally named `"x.md"` (quotes
+# in the filename) must keep resolving to the same path gh will read, not a
+# different one.
+case "$BODY_FILE" in
+  '"'*'"') BODY_FILE=${BODY_FILE#\"}; BODY_FILE=${BODY_FILE%\"} ;;
+  "'"*"'") BODY_FILE=${BODY_FILE#\'}; BODY_FILE=${BODY_FILE%\'} ;;
+esac
 if [ -n "$BODY_FILE" ]; then
   # Resolve relative paths against the command's cd-target (if any), so
   # 'cd /project && gh pr create --body-file body.md' finds the file at


### PR DESCRIPTION
## Summary

- **Fixes two hooks that could not read a quoted `--body-file` path** and then blamed the PR author for it. `require-agdr-for-arch-pr.sh` blocked PRs for a missing AgDR that *was* declared (the `<!-- agdr: not-applicable -->` marker lives in the file it failed to open), and `validate-pr-create.sh` reported `## Testing` / `## Glossary` missing when both were present.
- **Splits path-valued from content-valued flag extraction.** This is the fix. `extract_flag_value` is left **byte-identical to `dev`**; a new non-greedy `extract_path_flag` handles `--body-file`.
- **Adds a matched-quote strip** to `validate-pr-create.sh`'s own sed-based path extraction.

## The bug

```
--body-file "/p/b.md" 2>&1 | tail -5   ->  "/p/b.md"
--body-file "/p/b.md" -t "x"           ->  /p/b.md" -t "x
```

The greedy content matcher cannot terminate a quoted path followed by a shell operator, so extraction fell through to the unquoted branch and returned the token **with quotes attached**. `[ -f "\"/p/b.md\"" ]` is then false and the file is never read.

Worth stating precisely, because the original issue got it wrong: the failing combination is a **quoted value followed by a non-`--flag` token**. An *unquoted* path with a trailing pipe always worked, and a quoted path followed by `--base dev` also worked. That narrowness is why it survived.

## The wrong turn on the way here

**An earlier revision of this PR widened `extract_flag_value`'s shared anchor to accept shell operators. That was wrong and was reverted.** It fixed the path case and broke the content case: `sub()` is leftmost-first and each alternative ended in `.*`, so a `--body` containing a quote followed by a boundary character truncated there.

Measured on this hook's own content extractor: `dev` preserves **8/8** body tails, the widened version preserves **0/8**. In the sibling leak hook (#1039 / PR #1040) the same change was measurably *worse than no fix at all* — 5 failures became 9.

So the root cause is that one extractor was serving two incompatible jobs:

- **CONTENT** (`--title` / `--body`) may contain quotes, pipes, semicolons, markdown tables. Extraction must be **greedy**, terminating only on a real flag boundary. `extract_flag_value` is therefore unchanged.
- **PATH** (`--body-file` / `-F`) is a filesystem path and never contains a quote. Extraction must be **non-greedy**, stopping at the first closing quote.

`extract_path_flag` is new; the shared extractor is untouched. The non-greedy `[^"]*` is safe here for exactly the reason it was unsafe there.

`validate-pr-create.sh` is unaffected by the truncation class — it extracts the path with its own sed and never runs content through a greedy matcher — so it gets only the matched-quote strip.

## Testing

`test_flag_extractor_body_file.sh` — **22 cases**, all passing.

**Part 1** drives both extractors directly out of the hook source: the four quoted-plus-operator shapes plus the single-quoted variant, three regression guards for shapes that already worked, and **9 content-tail cases** asserting a `--body` survives a quote followed by each boundary character (`| ; & < > ( )`), a single-dash flag, and a markdown Glossary table. Those content guards fail **8/8** against the widened-anchor approach, which is what makes keeping the extractors separate load-bearing rather than stylistic.

**Part 2** runs `validate-pr-create.sh` end-to-end in a `git init` sandbox on a conforming branch, with the shared `_lib-mock-gh.sh` shim so the ticket check resolves against synthetic data rather than the network.

That sandbox matters, and two earlier attempts at it failed:

1. Asserting on exit code from the ambient checkout — passed locally, failed 3/22 in CI where branch name and ticket existence differ.
2. Asserting on stderr instead — still failed, and **vacuously**: the hook exits on the ticket check (~line 447) long before the `--body-file` logic (~line 502), so in CI it never reached the code under test and every "message absent" assertion passed because nothing ran.

The current version asserts `rc == 0` for a complete body, which is reachable **only** if the hook opened the file and found its sections. Verified 22/22 locally and green in CI.

- Full hook suite: **118/118**
- `shellcheck -S warning`: clean

## Notes for the reviewer

Quote-stripping is **matched-pair only**. Stripping unconditionally would rewrite a file literally named `"x.md"`, so the hook would read a different file than `gh` does.

The identical extractor defect in `block-private-refs-in-public-repos.sh` fails **OPEN** — a silent leak rather than an over-block — and was fixed separately in #1040, now merged.

<!-- agdr: not-applicable -->

AgDR not applicable: a parser correctness fix in existing hooks. No new dependency, service, schema, or security control; reversible in one commit. It touches `.claude/hooks/**` but changes no gate semantics, only whether a hook can read the file it was always meant to read.

Refs #1038

## Glossary

| Term | Definition |
|------|------------|
| `extract_flag_value` | Greedy extractor for CONTENT-valued flags; terminates on a real flag boundary |
| `extract_path_flag` | Non-greedy extractor for PATH-valued flags; stops at the first closing quote |
| fail closed | On ambiguity, deny — what these two hooks correctly do, hence "false positive" not "leak" |
| vacuous test | One that passes because the code under test never ran |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
