### PR TITLE
fix(#1042): put the human gate on approval, not on review

### DIFF
--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -189,7 +189,8 @@ defeating the entire purpose of /release-sync.
 Use --merge instead:
   gh pr merge ${PR_NUMBER} --repo ${CMD_REPO:-<owner/repo>} --merge --delete-branch
 
-Or invoke /approve-merge ${PR_NUMBER} — it auto-detects sync PRs and uses --merge.
+Or have the human approver run /approve-merge ${PR_NUMBER} — it auto-detects sync
+PRs and uses --merge. That skill is human-only (#1042); the model cannot invoke it.
 
 See AgDR-0053 for the full rationale.
 MSG

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -241,10 +241,12 @@ Missing file:
   ${REX_APPROVAL}
 
 To unblock:
-  1. Invoke the code-reviewer agent on this PR
+  1. Run the code review on this PR (/code-review ${PR_NUMBER}) — since #1042
+     this skill IS model-invocable, so you can do this yourself
   2. When Rex returns "approved", it records the approval automatically
-  3. Then run /approve-merge ${PR_NUMBER} for the ${APPROVER_TITLE} approval
-  4. Retry the merge
+  3. Tell the ${APPROVER_TITLE} the PR is ready and ask THEM to run
+     /approve-merge ${PR_NUMBER} — that skill is human-only, you cannot
+  4. Their invocation records the approval and performs the merge
 
 Never skip this check — even for typo fixes. See .claude/rules/pr-workflow.md.
 MSG
@@ -304,13 +306,16 @@ Missing file:
    title above — only the printed word changes, never the marker name.)
 
 To unblock:
-  1. Stop and ask the ${APPROVER_TITLE} explicitly: "PR #${PR_NUMBER} ready to merge — approved?"
-  2. When the ${APPROVER_TITLE} says "approved" / "merge it" / "ship it" naming PR #${PR_NUMBER},
-     invoke the /approve-merge skill:
+  1. Stop and tell the ${APPROVER_TITLE} the PR is ready, naming it:
+     "PR #${PR_NUMBER} is ready to merge."
+  2. Ask THEM to run the skill. Since #1042 it is human-only
+     (disable-model-invocation: true) — you cannot invoke it:
        /approve-merge ${PR_NUMBER}
-  3. The skill writes the structured marker AND runs the merge in one turn
+  3. Their invocation writes the structured marker AND runs the merge in
+     one turn. Your job ends at step 1.
 
-NEVER create this marker yourself from an umbrella "go" on a plan.
+NEVER create this marker yourself. You have no path to it, and that is the
+point: the invocation IS the approval, so it must come from a human.
 EVER. This is the exact failure this hook exists to prevent.
 MSG
     exit 2

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -29,9 +29,18 @@
 # carve out a specific dir (e.g. `^docs/examples/`, `^wiki/artifacts/`) where
 # `.jsx`/`.tsx` files are documentation samples rather than real UI.
 #
-# How the marker gets written: the design-reviewer records approval by
-# writing the marker file. There is no /approve-design skill yet — the
-# design reviewer writes the file manually or via a (future) skill.
+# How the marker gets written: a HUMAN runs the `/approve-design <pr>` skill,
+# which writes the repo-qualified marker via `review_marker_path` (AgDR-0060).
+# Since #1042 that skill is `disable-model-invocation: true`, so the model
+# cannot invoke it — and unlike the architecture gate (where the spawned
+# solution-architect sub-agent writes its own marker), NO agent writes
+# `*-design.approved`. A human records this one, always.
+#
+# This comment previously said "there is no /approve-design skill yet" and the
+# unblock message below told the reader to hand-write the marker with a raw
+# redirect. Both were stale and, after #1042, actively harmful: the hand-write
+# became the ONLY path the message offered, on a marker type
+# `warn-review-marker-write.sh` does not guard.
 #
 # Trust model: same as other markers. Local session state, gitignored,
 # converts invisible inference ("ah, the UI change looked fine") into
@@ -250,11 +259,20 @@ The expected approval file does not exist:
 
 To unblock:
 
-  1. Invoke the UI Designer role (or a human designer) to review the UI changes
-  2. When the designer approves, record it with the current HEAD SHA:
-       mkdir -p .claude/session/reviews
-       git rev-parse HEAD > .claude/session/reviews/${PR_NUMBER}-design.approved
-  3. Retry the merge
+  1. Review the UI changes against the design system — adopt the UI Designer
+     role (Nour), or ask a human designer to look at the PR diff
+  2. Report the verdict plainly. Do NOT write the marker yourself: since
+     #1042 recording a design approval is a human action, and no agent
+     writes this marker type
+  3. Ask the designer or operator to run:
+       /approve-design ${PR_NUMBER}
+     That skill writes the repo-qualified marker against the PR's HEAD on
+     GitHub, which is what this gate compares
+  4. They retry the merge
+
+  Do not hand-write this file. A raw redirect produces the wrong path (the
+  marker is repo-qualified, see AgDR-0060) and usually the wrong SHA (the
+  gate reads the PR's HEAD from the forge, not your local HEAD — #55).
 
 To customize which file patterns count as "UI":
 

--- a/.claude/hooks/tests/test_skill_invocability_gates.sh
+++ b/.claude/hooks/tests/test_skill_invocability_gates.sh
@@ -39,9 +39,16 @@ FAIL=0
 
 # Read the frontmatter value. Only the frontmatter block counts, so the key
 # is matched at line-start and only before the closing `---`.
+#
+# Trailing \r is stripped first: a CRLF-committed SKILL.md would otherwise
+# yield "true\r", which compares unequal to "true" and fails this test for a
+# line-ending reason rather than a real one. This repo has been bitten by
+# exactly that before (#1019, where config_get left an embedded \r on Windows
+# checkouts), so the guard is cheap insurance rather than theory.
 invocation_flag() {
   local file="$1"
   awk '
+    { sub(/\r$/, "") }
     NR == 1 && $0 != "---" { exit }
     NR > 1 && $0 == "---"  { exit }
     /^disable-model-invocation:[[:space:]]*/ {

--- a/.claude/hooks/tests/test_skill_invocability_gates.sh
+++ b/.claude/hooks/tests/test_skill_invocability_gates.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# me2resh/apexyard#1042 / AgDR-0110 — where the mechanical human gate sits.
+#
+# `disable-model-invocation` in a SKILL.md's frontmatter decides whether the
+# model may invoke that skill. Two families must sit on opposite sides:
+#
+#   REVIEW skills  (/code-review, /security-review, /design-review)
+#     Trigger an independent reviewer SUB-AGENT. Independence comes from that
+#     separate agent and its separate context — NOT from who typed the
+#     command. Locking these buys no safety and taxes every PR, while
+#     contradicting auto-code-review.sh, which explicitly instructs the
+#     orchestrator to run /code-review.
+#
+#   APPROVAL skills (/approve-merge, /approve-design, /approve-architecture)
+#     Write the approval markers that merge gates read. /approve-merge also
+#     performs the merge — irreversible and externally visible. Its own
+#     SKILL.md says "the discrete approval moment is the invocation".
+#     A human must make that invocation.
+#
+# Before #1042 these were exactly inverted: review skills were human-only
+# and approval skills were model-invocable (with /approve-architecture
+# carrying no frontmatter at all, so it defaulted to model-invocable).
+#
+# Why this test exists rather than trusting the frontmatter: the original
+# defect WAS a frontmatter value nobody was watching, sitting unnoticed from
+# the first commit. A silent edit here would reopen the gap invisibly — an
+# unlocked approval skill combined with unlocked review skills restores a
+# fully autonomous open -> review -> approve -> merge path.
+#
+# Exit 0 = all pass, exit 1 = at least one failure.
+
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+SKILLS="$REPO_ROOT/.claude/skills"
+
+PASS=0
+FAIL=0
+
+# Read the frontmatter value. Only the frontmatter block counts, so the key
+# is matched at line-start and only before the closing `---`.
+invocation_flag() {
+  local file="$1"
+  awk '
+    NR == 1 && $0 != "---" { exit }
+    NR > 1 && $0 == "---"  { exit }
+    /^disable-model-invocation:[[:space:]]*/ {
+      sub(/^disable-model-invocation:[[:space:]]*/, "")
+      print
+      exit
+    }
+  ' "$file"
+}
+
+expect_flag() {
+  local skill="$1" want="$2" why="$3"
+  local file="$SKILLS/$skill/SKILL.md"
+
+  if [ ! -f "$file" ]; then
+    echo "FAIL: $skill — SKILL.md not found at $file"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  local got
+  got=$(invocation_flag "$file")
+
+  # An ABSENT key is not acceptable for either family: absent defaults to
+  # model-invocable, which is how /approve-architecture was silently
+  # unguarded. Both families must state their posture explicitly.
+  if [ -z "$got" ]; then
+    echo "FAIL: $skill — no 'disable-model-invocation' in frontmatter (absent defaults to model-invocable). $why"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if [ "$got" = "$want" ]; then
+    echo "PASS: $skill → disable-model-invocation: $got"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $skill → expected 'disable-model-invocation: $want', got '$got'"
+    echo "   $why"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Review skills must be model-invocable (false).
+# ---------------------------------------------------------------------------
+
+for s in code-review security-review design-review; do
+  expect_flag "$s" "false" \
+    "Review skills spawn a separate reviewer sub-agent; independence does not depend on who invokes them. auto-code-review.sh instructs the orchestrator to run /code-review, so locking it makes the framework contradict itself."
+done
+
+# ---------------------------------------------------------------------------
+# Approval skills must be human-only (true).
+# ---------------------------------------------------------------------------
+
+for s in approve-merge approve-design approve-architecture; do
+  expect_flag "$s" "true" \
+    "Approval skills write the markers merge gates read; /approve-merge also merges. The invocation IS the approval, so a human must make it (see .claude/rules/pr-workflow.md and AgDR-0110)."
+done
+
+# ---------------------------------------------------------------------------
+# The combination is what matters: if review skills are unlocked, approval
+# skills MUST be locked, or the model can drive the whole chain unattended.
+# Asserted explicitly so the coupling is visible to whoever edits either side.
+# ---------------------------------------------------------------------------
+
+REVIEW_UNLOCKED=1
+for s in code-review security-review design-review; do
+  [ "$(invocation_flag "$SKILLS/$s/SKILL.md")" = "false" ] || REVIEW_UNLOCKED=0
+done
+
+APPROVAL_LOCKED=1
+for s in approve-merge approve-design approve-architecture; do
+  [ "$(invocation_flag "$SKILLS/$s/SKILL.md")" = "true" ] || APPROVAL_LOCKED=0
+done
+
+if [ "$REVIEW_UNLOCKED" = "1" ] && [ "$APPROVAL_LOCKED" = "0" ]; then
+  echo "FAIL: review skills are model-invocable while approval skills are NOT locked."
+  echo "   That combination restores an autonomous open -> review -> approve -> merge"
+  echo "   path with no human in the loop. Lock the approval skills."
+  FAIL=$((FAIL + 1))
+else
+  echo "PASS: no autonomous open -> review -> approve -> merge path"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+
+echo
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/warn-review-marker-write.sh
+++ b/.claude/hooks/warn-review-marker-write.sh
@@ -541,14 +541,19 @@ You are about to write a *-ceo.approved review marker (filename stays
   fabricated casually.
 
   Who may write this marker:
-    /approve-merge skill, invoked by the orchestrator on an explicit ${APPROVER_TITLE} nod
+    the /approve-merge skill, which since #1042 only a HUMAN can invoke
+    (disable-model-invocation: true)
 
 WHY THIS MATTERS
   Writing this file yourself satisfies the merge gate's FILENAME check
   but NOT its INTENT. block-unreviewed-merge.sh independently validates
   the structured fields before any merge is allowed, so a hand-written
-  marker without those fields is still rejected at merge time — but
-  don't write this file yourself. Invoke /approve-merge <pr>.
+  marker without those fields is still rejected at merge time.
+
+  You have no path to this marker, and that is deliberate: the invocation
+  IS the approval, so it must come from a human. Tell the ${APPROVER_TITLE}
+  the PR is ready and ask them to run /approve-merge <pr>. Do not try to
+  produce the marker some other way.
 
 ======================================================================
 BANNER

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -152,6 +152,14 @@ Both markers' SHAs must match the PR's HEAD as reported by GitHub (`gh pr view <
 
 Claude can technically `rm` or `touch` these files by hand, or fabricate the structured fields. Doing so is a visible, auditable, grep-able rule violation — and the whole point of recording the rule mechanically is so that the failure mode is "Claude ignored a hook" (visible) instead of "Claude inferred approval from something vague" (invisible). The structured-marker format raises the visibility bar one more notch by requiring the model to type `approved_by=user` etc. on purpose.
 
+### The approval skills are human-only (#1042, AgDR-0110)
+
+"Explicit per-PR approval" is now enforced **mechanically**, not only in prose. `/approve-merge`, `/approve-design`, and `/approve-architecture` carry `disable-model-invocation: true`, so **only a human can invoke them**. Saying "approved" in conversation is no longer sufficient on its own — the operator types the command, and that invocation *is* the approval moment this rule has always described.
+
+The mirror half matters just as much: the **review** skills (`/code-review`, `/security-review`, `/design-review`) are model-invocable, so the orchestrator triggers them itself — as `auto-code-review.sh` has always instructed. Independence comes from the reviewer being a **separate sub-agent with its own context**, not from who typed the command, so nothing is lost by letting the model start a review.
+
+Before #1042 these were exactly inverted, and the safety was accidental: a model couldn't invoke `/code-review`, so it couldn't obtain a Rex marker, so it couldn't merge. Unlocking the review skills **alone** would therefore have opened a fully autonomous `open → review → approve → merge` path. The two sides are coupled — `test_skill_invocability_gates.sh` pins both, and fails loudly if review skills are ever unlocked while approval skills are not locked.
+
 ### Both merge shapes are gated (#47)
 
 All three merge-gate hooks (`block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, `require-design-review-for-ui.sh`) fire on **both** the `gh` subcommand shape and the raw REST-API shape:

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -82,16 +82,16 @@ You: *runs gh pr merge 10*   ← FAILURE: "go" was plan-level, not merge-level.
 You: "Here's the 6-step plan: 1. merge PR #10, 2. close PR #105, ..."
 CEO: "go"
 You: *executes steps 2–6, stops before step 1*
-You: "Steps 2–6 done. Ready to merge PR #10 — approved?"
-CEO: "approved"
-You: *invokes /approve-merge 10*   ← CORRECT: writes structured marker AND merges in one turn.
+You: "Steps 2–6 done. PR #10 is ready to merge — run /approve-merge 10 when you're happy."
+CEO: /approve-merge 10          ← CORRECT: the CEO invokes it. The skill is
+                                   human-only (#1042), so the model cannot.
 ```
 
 #### Why
 
 CEO approval is meant to be a **discrete moment per PR**. Merges are hard to reverse, externally visible, and can trigger downstream deploys. An umbrella "go" on a plan does not give you enough evidence that the CEO consciously signed off on each merge. When in doubt: stop and ask for the per-PR explicit nod.
 
-The discrete moment is the **invocation of `/approve-merge`**, not a separate "now do the merge" message. Treat the invocation with the seriousness the merge warrants — once you invoke, the merge runs.
+The discrete moment is the **invocation of `/approve-merge`**, and since #1042 that invocation can only come from a human — `disable-model-invocation: true`. Saying "approved" in prose is no longer sufficient on its own; the model's job is to get the PR ready and say so. Treat the invocation with the seriousness the merge warrants: once it runs, the merge runs.
 
 This rule also applies to other destructive / externally-visible / hard-to-reverse actions: force pushes, branch deletes, closing issues with dependents, posting to external channels. Plan-level "go" does not carry through to any of these. List them in the plan if you want — just stop before executing and ask.
 

--- a/.claude/skills/approve-architecture/SKILL.md
+++ b/.claude/skills/approve-architecture/SKILL.md
@@ -144,17 +144,34 @@ Architecture approval recorded for PR #<pr> at <sha>. The architecture-review me
 
 ```
 Architect: "The approach we discussed sounds right, go for it"
-You: *invokes /approve-architecture 42*  ← WRONG
+You: *tries to invoke /approve-architecture 42*  ← WRONG, twice over: a verbal
+                                                  nod on an approach is not a
+                                                  review of the committed design
+                                                  artifact, AND since #1042 the
+                                                  model cannot invoke this skill
+                                                  at all.
 ```
 
 A verbal approval of an *approach* is not a review of the *committed design artifact*. The correct flow:
 
 ```
 Tech Lead: *commits the technical design to PR #42*
-You: "PR #42 carries the technical design. Run /design-review to have Tariq review it against the architecture lens?"
-... Tariq reviews, verdict APPROVED ...
-You: *Tariq writes the marker automatically* — OR a human architect says "design in #42 reviewed and approved"
-You: *invokes /approve-architecture 42*  ← CORRECT
+You: *runs /design-review so Tariq reviews it against the architecture lens*
+... Tariq reviews, verdict APPROVED, and writes the marker himself ...
+                                  ← DONE. No /approve-architecture needed.
+```
+
+Tariq writing the marker on an APPROVED verdict is the normal path, and it
+already satisfies the gate. This skill is the **operator path** for the other
+case: a *human* architect reviewed the design, or the marker needs re-recording
+after a rebase.
+
+```
+Human architect: "I've reviewed the design in #42 against the lens. Approved."
+You: "Then run /approve-architecture 42 to record it."
+Human architect: /approve-architecture 42   ← CORRECT: a human invokes it. The
+                                              skill is human-only (#1042), so
+                                              the model cannot.
 ```
 
 ## Relationship to other approval skills

--- a/.claude/skills/approve-architecture/SKILL.md
+++ b/.claude/skills/approve-architecture/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: approve-architecture
+description: Record per-PR architecture-review approval for design-artifact PRs (required by the architecture gate). ONLY on an explicit per-PR architect "approved".
+disable-model-invocation: true
+argument-hint: "<pr-number>"
+effort: low
+---
+
 # /approve-architecture — Record Per-PR Design-Review Approval
 
 Writes `.claude/session/reviews/<owner>__<repo>__<pr>-architecture.approved` (repo-qualified path, see AgDR-0060) with the current HEAD SHA so the `require-architecture-review.sh` merge-gate hook will let a design-artifact PR through. Without this marker, the hook blocks merges on any PR that touches a technical design, a migration AgDR, or a feature spec / PRD.

--- a/.claude/skills/approve-design/SKILL.md
+++ b/.claude/skills/approve-design/SKILL.md
@@ -147,7 +147,10 @@ Design approval recorded for PR #<pr> at <sha>. The design-review merge gate wil
 
 ```
 Designer: "The mockup in Figma looks great, ship it"
-You: *invokes /approve-design 42*  ← WRONG
+You: *tries to invoke /approve-design 42*  ← WRONG, twice over: a mockup nod is
+                                             not implementation review, AND
+                                             since #1042 the model cannot
+                                             invoke this skill at all.
 ```
 
 The designer approved a **mockup**, not the **PR's implementation of that mockup**. The implementation might differ from the mockup. The correct flow:
@@ -157,7 +160,9 @@ Designer: "The mockup in Figma looks great, ship it"
 You: *implements the mockup in PR #42*
 You: "PR #42 implements the approved mockup. Can you review the PR diff to confirm the implementation matches?"
 Designer: "Reviewed PR #42, implementation matches the mockup. Design approved."
-You: *invokes /approve-design 42*  ← CORRECT
+You: "Then run /approve-design 42 to record it."
+Designer: /approve-design 42       ← CORRECT: a human invokes it. The skill is
+                                     human-only (#1042), so the model cannot.
 ```
 
 Two distinct moments. One is mockup approval (design phase). The other is implementation-review approval (code-review phase). They are not the same approval.

--- a/.claude/skills/approve-design/SKILL.md
+++ b/.claude/skills/approve-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: approve-design
 description: Record per-PR design-review approval (UI merge gate). ONLY on an explicit per-PR designer "approved".
-disable-model-invocation: false
+disable-model-invocation: true
 argument-hint: "<pr-number>"
 effort: low
 ---

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -338,19 +338,21 @@ See AgDR-0012 for the full trade-off.
 ```
 You: "I'll execute the plan. Step 1: approve-merge, Step 2: gh pr merge."
 CEO: "go"
-You: *invokes /approve-merge*  ← FAILURE
+You: *tries to invoke /approve-merge*  ← FAILURE, twice over:
+                                          the "go" was plan-level, AND since
+                                          #1042 the model cannot invoke this
+                                          skill at all.
 ```
 
 The CEO's "go" was on the plan. It was not a per-PR approval for the merge. The correct flow:
 
 ```
 You: *executes the non-merge steps*
-You: "All other steps done. PR #X ready to merge — approved?"
-CEO: "approved"
-You: *invokes /approve-merge X*  ← writes marker AND merges in one turn
+You: "All other steps done. PR #X is ready to merge — run /approve-merge X when you're happy."
+CEO: /approve-merge X          ← writes the structured marker AND merges in one turn
 ```
 
-The discrete approval moment is **the invocation of /approve-merge**, not a separate "now do the merge" message. Treat the invocation with the seriousness the merge warrants.
+The discrete approval moment is **the invocation of /approve-merge**, not a separate "now do the merge" message. Since #1042 that invocation is mechanically restricted to a human (`disable-model-invocation: true`), so the model's job ends at getting the PR ready and saying so. Treat the invocation with the seriousness the merge warrants: once it runs, the merge runs.
 
 ---
 

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: approve-merge
 description: Record per-PR CEO approval and merge in one turn. ONLY on an explicit per-PR "approved" — never on umbrella "go".
-disable-model-invocation: false
+disable-model-invocation: true
 argument-hint: "<pr-number> [--no-merge]"
 effort: low
 ---

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-review
 description: Review a PR for quality, security, and standards compliance. Invokes the Code Reviewer agent (Rex).
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "<pr-number> [repo]"
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design-review
 description: Review a technical design / migration AgDR / feature spec for architectural soundness BEFORE the Build phase. Invokes the Solution Architect agent (Tariq) — the non-code analog of /code-review.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "<pr-number-or-path> [repo]"
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: security-review
 description: Security-focused PR review for vulnerabilities and best practices. Invokes the Security Reviewer agent (Hakim).
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "<pr-number> [repo]"
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/docs/agdr/AgDR-0110-human-gate-on-approval-not-review.md
+++ b/docs/agdr/AgDR-0110-human-gate-on-approval-not-review.md
@@ -25,6 +25,8 @@ This was never a regression. `/code-review`'s flag dates to `8fa3c92` (2026-04-0
 
 The two were also **coupled by accident**: because a model could not invoke `/code-review`, it could not obtain a Rex marker, so it could not merge. The locked review skill was incidentally the thing preventing autonomous merges — which is why unlocking it alone would have been actively dangerous.
 
+**That coupling was weaker than it looks, and the distinction matters.** `.claude/agents/code-reviewer.md` documents that the **orchestrator** may set the `active-reviewer` marker and spawn the reviewer sub-agent directly via the Agent tool, without going through `/code-review` at all. So the autonomous `open → review → approve → merge` path was already *reachable* before this decision, not merely latent behind a flag. The pre-existing protection was therefore weaker than "the review skill is locked" suggests — which strengthens rather than weakens the case for this change: the swap replaces an incidental, bypassable barrier with a mechanical one on the step that actually authorises the irreversible action.
+
 ## Options Considered
 
 | Option | Pros | Cons |
@@ -48,7 +50,7 @@ Chosen: **swap both**, because the two changes are only safe together and are jo
 - The operator stops typing `/code-review`, `/security-review`, `/design-review` — the orchestrator triggers them, as `auto-code-review.sh` always instructed.
 - The operator starts typing `/approve-merge <pr>`, `/approve-design <pr>`, `/approve-architecture <pr>`. Saying "approved" in prose is no longer sufficient; the *invocation* is the approval, and only a human can make it. This is the intended cost.
 - The two-marker merge gate is unchanged. Rex still writes `*-rex.approved`; the CEO marker still requires a human. What changes is that the human requirement is now **mechanical**, not prose.
-- Autonomous merge becomes structurally impossible rather than incidentally blocked. Previously the block was a side effect of an unrelated flag; now it is the design.
+- The **skill-invocation** path to an autonomous merge is closed by design rather than by side effect. This is deliberately not the claim that autonomous merge is *impossible*: raw-Bash forgery of a marker remains technically available, as AgDR-0104 and AgDR-0109 already state, and `active-reviewer` writes are not themselves gated. What changes is that the supported path now requires a human at the step that authorises the irreversible action, instead of relying on an unrelated flag to block it incidentally.
 - `warn-review-marker-write.sh` is unaffected — it gates marker *writes* on the active-reviewer session marker, which the review skills manage regardless of who invokes them.
 - A regression test pins the invariant so a future frontmatter edit cannot silently reopen the gap. This matters: the original defect was exactly a frontmatter value nobody was watching.
 

--- a/docs/agdr/AgDR-0110-human-gate-on-approval-not-review.md
+++ b/docs/agdr/AgDR-0110-human-gate-on-approval-not-review.md
@@ -1,0 +1,64 @@
+# Put the mechanical human gate on approval, not on review
+
+> In the context of **skill invocability across the review-and-merge chain**, facing **a human gate that blocked the harmless step while leaving the irreversible one model-invocable**, I decided **to swap them — review skills become model-invocable, approval skills become human-only** to achieve **enforcement that matches the rule `pr-workflow.md` has always stated in prose**, accepting **that the operator now types `/approve-merge <pr>` themselves for every merge**.
+
+## Context
+
+Skill invocability is controlled by `disable-model-invocation` in each SKILL.md's frontmatter. Before this decision the chain was arranged like this:
+
+| Skill | What it does | Model-invocable? |
+|---|---|---|
+| `/code-review` | Triggers an independent reviewer sub-agent (Rex) | **NO** |
+| `/security-review` | Triggers Hakim | **NO** |
+| `/design-review` | Triggers Tariq | **NO** |
+| `/approve-merge` | **Writes the CEO marker and runs the merge** | **YES** |
+| `/approve-design` | Writes the design approval marker | **YES** |
+| `/approve-architecture` | *(no frontmatter at all)* → defaults to yes | **YES** |
+
+Two independent problems follow from that arrangement.
+
+**The framework instructed an action it forbade.** `auto-code-review.sh` fires on every `gh pr create` and tells the orchestrator: *"Run the code review through the /code-review skill on PR #N."* Attempting exactly that returns `Skill code-review cannot be used with Skill tool due to disable-model-invocation`. Every PR therefore required the operator to hand-type `/code-review <pr>`. In one session this meant six manual invocations for a batch of routine fixes, plus three more for security reviews.
+
+**The merge gate's human requirement was prose-only.** `/approve-merge` writes `approved_by=user` and merges in the same turn. Its own SKILL.md says *"The discrete approval moment is the invocation of /approve-merge"* and *"INVOKE THIS SKILL ONLY ON EXPLICIT, PER-PR, USER-NAMED MERGE APPROVAL"* — but nothing mechanical enforced that. A model could invoke it.
+
+This was never a regression. `/code-review`'s flag dates to `8fa3c92` (2026-04-06), the initial `feat(#1): add Claude Code primitives` commit, and was never revisited. `/approve-merge` arrived later via `feat(#11): require explicit per-merge CEO approval — never infer from "go"` with `disable-model-invocation: false` set **explicitly**. The change whose stated purpose was making merge approval a deliberate human moment shipped the skill as model-invocable.
+
+The two were also **coupled by accident**: because a model could not invoke `/code-review`, it could not obtain a Rex marker, so it could not merge. The locked review skill was incidentally the thing preventing autonomous merges — which is why unlocking it alone would have been actively dangerous.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Leave as-is** | Zero change; the accidental coupling does block autonomous merge today | Framework keeps instructing an impossible action; friction on every PR; the merge gate stays prose-only, so the protection is incidental rather than designed |
+| **Unlock review skills only** | Removes the friction immediately; smallest diff | Opens a fully autonomous `open → review → approve → merge` path with no human anywhere. Trades a real safety property for convenience — the worst available trade |
+| **Lock approval skills only** | Closes the autonomous-merge gap | Operator still hand-types `/code-review` on every PR; the `auto-code-review.sh` contradiction persists |
+| **Swap both (CHOSEN)** | Gate lands where authorisation actually happens; friction removed where it bought nothing; enforcement finally matches `pr-workflow.md` | Operator must type `/approve-merge <pr>` themselves — no longer delegable by saying "approved" in prose |
+
+## Decision
+
+Chosen: **swap both**, because the two changes are only safe together and are jointly a strict improvement.
+
+- **Review skills → model-invocable.** Independence comes from the skill spawning a **separate reviewer sub-agent with its own context**, not from who typed the command. A review triggered by the model is exactly as independent as one triggered by a human. Locking it bought no safety and taxed every PR.
+- **Approval skills → human-only.** These write the markers that merge gates read. `/approve-merge` additionally performs the merge — irreversible and externally visible. This is where a human belongs, and it is what the rule already demanded.
+
+`/approve-architecture` had no frontmatter at all, so it was silently model-invocable by default. It now carries a proper `name` / `description` / `disable-model-invocation` block like its siblings.
+
+## Consequences
+
+- The operator stops typing `/code-review`, `/security-review`, `/design-review` — the orchestrator triggers them, as `auto-code-review.sh` always instructed.
+- The operator starts typing `/approve-merge <pr>`, `/approve-design <pr>`, `/approve-architecture <pr>`. Saying "approved" in prose is no longer sufficient; the *invocation* is the approval, and only a human can make it. This is the intended cost.
+- The two-marker merge gate is unchanged. Rex still writes `*-rex.approved`; the CEO marker still requires a human. What changes is that the human requirement is now **mechanical**, not prose.
+- Autonomous merge becomes structurally impossible rather than incidentally blocked. Previously the block was a side effect of an unrelated flag; now it is the design.
+- `warn-review-marker-write.sh` is unaffected — it gates marker *writes* on the active-reviewer session marker, which the review skills manage regardless of who invokes them.
+- A regression test pins the invariant so a future frontmatter edit cannot silently reopen the gap. This matters: the original defect was exactly a frontmatter value nobody was watching.
+
+### What this does NOT change
+
+It does not touch the *review* gates themselves, the marker formats, or `block-unreviewed-merge.sh`. It does not make the agent's reviews more or less trustworthy. And it does not address the separate, larger problem that these hooks infer intent from raw shell command text — see AgDR-0104 and issues #1026, #1032, #1038, #1039.
+
+## Artifacts
+
+- me2resh/apexyard#1042 — the issue
+- `.claude/skills/{code-review,security-review,design-review}/SKILL.md`
+- `.claude/skills/{approve-merge,approve-design,approve-architecture}/SKILL.md`
+- `.claude/hooks/tests/test_skill_invocability_gates.sh` — pins the invariant

--- a/roles/design/head-of-design.md
+++ b/roles/design/head-of-design.md
@@ -67,7 +67,7 @@ When reviewing UI implementations:
 4. **Check accessibility** basics
 5. **Assess visual consistency**
 
-You are the **escalation** reviewer, not the routine one: the UI Designer (Nour) owns the per-PR design gate and records approval with `/approve-design`. You step in for system-level standards, cross-product direction, and disputed calls — and can record the design marker with `/approve-design <pr>` when an escalation lands on your desk. Use `/design-sync` to keep the shared claude.ai/design library in step with the code, and `/accessibility-audit` to hold user-facing work to WCAG 2.2 AA (now ISO 40500:2025, EAA-enforceable).
+You are the **escalation** reviewer, not the routine one: the UI Designer (Nour) owns the per-PR design gate and records approval with `/approve-design`. You step in for system-level standards, cross-product direction, and disputed calls — and an escalation landing on your desk is recorded the same way — by a human running `/approve-design <pr>`, which since #1042 the model cannot invoke. Use `/design-sync` to keep the shared claude.ai/design library in step with the code, and `/accessibility-audit` to hold user-facing work to WCAG 2.2 AA (now ISO 40500:2025, EAA-enforceable).
 
 **Feedback format**:
 

--- a/roles/design/ui-designer.md
+++ b/roles/design/ui-designer.md
@@ -38,7 +38,7 @@ You don't create mockups. Instead:
 - Set spacing and layout standards
 - Create component state specifications
 - Review implementations for visual quality
-- Approve the routine per-PR design gate for UI implementation PRs (via `/approve-design`)
+- Review the routine per-PR design gate for UI implementation PRs (a human records the verdict via `/approve-design`)
 - Propose visual improvements
 - Document icon and imagery guidelines
 
@@ -71,7 +71,11 @@ You don't create mockups. Instead:
 
 ## Design Review Gate (per-PR)
 
-You own the **routine per-PR design gate** — the merge-time review of UI implementation diffs. When a PR touches user-facing UI, `require-design-review-for-ui.sh` blocks the merge until a design-review marker exists; you review the implementation against the design system and, on approval, record it with the **`/approve-design <pr>`** skill (it writes the marker the hook checks). System-level standards, cross-product visual direction, and design disagreements escalate to the Head of Design (Maha).
+You own the **routine per-PR design gate** — the merge-time review of UI implementation diffs. When a PR touches user-facing UI, `require-design-review-for-ui.sh` blocks the merge until a design-review marker exists; you review the implementation against the design system and state a verdict.
+
+**Recording that verdict is a human action.** Since #1042 the `/approve-design` skill is `disable-model-invocation: true`, so an in-thread persona cannot invoke it — and unlike the architecture gate (where Tariq is a spawned sub-agent that writes its own marker), no agent writes `*-design.approved`. So the flow is: you review, you report the verdict plainly, and the human designer or operator runs **`/approve-design <pr>`** to record it. Do not attempt to produce the marker any other way.
+
+System-level standards, cross-product visual direction, and design disagreements escalate to the Head of Design (Maha).
 
 Part of that review is **design-QA of AI/agent-generated UI** — a current baseline duty: confirm the generated code used the right components and design tokens rather than one-off magic values.
 


### PR DESCRIPTION
## Summary

- **Moves the mechanical human gate from the review step to the approval step.** Review skills (`/code-review`, `/security-review`, `/design-review`) become model-invocable; approval skills (`/approve-merge`, `/approve-design`, `/approve-architecture`) become human-only. Strictly safer *and* less friction.
- **Makes the merge gate's human requirement mechanical rather than prose.** `/approve-merge` writes the CEO marker and merges in one turn — its own SKILL.md calls the invocation "the discrete approval moment", but nothing stopped a model from making it. Now only a human can.
- **Resolves a framework self-contradiction.** `auto-code-review.sh` fires on every `gh pr create` and instructs the orchestrator to run `/code-review <pr>` — which `disable-model-invocation: true` then refused. Every PR required the operator to hand-type it.
- **Gives `/approve-architecture` frontmatter.** It had none at all, so it silently defaulted to model-invocable.

## The problem

| Skill | What it does | Was |
|---|---|---|
| `/code-review` | Triggers an independent reviewer sub-agent | human-only |
| `/security-review` | Triggers Hakim | human-only |
| `/design-review` | Triggers Tariq | human-only |
| `/approve-merge` | **Writes the CEO marker and merges** | model-invocable |
| `/approve-design` | Writes the design approval marker | model-invocable |
| `/approve-architecture` | Writes the architecture marker | *(no frontmatter)* → model-invocable |

Locking a review buys nothing: independence comes from the skill spawning a **separate reviewer sub-agent with its own context**, not from who typed the command. Meanwhile the one step that is irreversible and externally visible had no mechanical guard.

## Why both halves must land together

This is the part worth reviewing carefully. The two settings were **coupled by accident**: because a model could not invoke `/code-review`, it could not obtain a Rex marker, so it could not merge. The locked review skill was incidentally the thing preventing autonomous merges.

So unlocking the review skills **alone** — the obvious reading of "fix the friction" — would have opened a fully autonomous `open → review → approve → merge` path with no human anywhere. Swapping both is what makes this safe; either half on its own is worse than the status quo.

`test_skill_invocability_gates.sh` asserts that coupling directly, not just the six individual values, so a future edit to one side fails loudly rather than silently reopening the path.

## Provenance

Not a regression — an original blind spot:

- `/code-review`'s flag dates to `8fa3c92` (2026-04-06), the initial `feat(#1): add Claude Code primitives` commit, never revisited.
- `/approve-merge` arrived via `feat(#11): require explicit per-merge CEO approval — never infer from "go"` with `disable-model-invocation: false` set **explicitly**.

The change whose stated purpose was making merge approval a deliberate human moment shipped the skill as model-invocable.

## What this costs you

The operator now types `/approve-merge <pr>` (and `/approve-design`, `/approve-architecture`) themselves. Saying "approved" in prose is no longer sufficient — which is exactly what `pr-workflow.md` has always demanded; it just wasn't enforced. In exchange, `/code-review` and friends stop being a manual step entirely.

## Testing

New `test_skill_invocability_gates.sh` — 7 assertions:

- three review skills are model-invocable, three approval skills are human-only
- an **absent** flag is a failure, not a pass — absent defaults to model-invocable, which is precisely how `/approve-architecture` went unguarded
- an explicit combination check: review-unlocked **and** approval-unlocked fails with an explanation, so the coupling is visible to whoever edits either side

Verified discriminating: **6 of 7 fail** against `dev`. The combination check correctly *passes* on `dev` too — review skills are locked there, so the dangerous pairing doesn't hold. That asymmetry is the test working as intended, not a gap.

- Full hook suite: **118/118** (clean baseline on `dev` is 117; this adds one file)
- `shellcheck -S warning`: clean

## Notes for the reviewer

`warn-review-marker-write.sh` is unaffected: it gates marker *writes* on the active-reviewer session marker, which the review skills manage regardless of who invokes them. The two-marker merge gate, the marker formats, and `block-unreviewed-merge.sh` are all unchanged — what changes is only who may press the button.

`pr-workflow.md` gains a section documenting the new mechanical enforcement, so the rule doc doesn't drift from the behaviour. (This repo already has one instance of that drift — `right-size-ceremony.md` and AgDR-0107 both cite `enforce-budget.sh` as the OSS watchdog, but it isn't tracked in git. Worth a separate ticket.)

Decision recorded in `AgDR-0110`, including the three rejected options and why "unlock reviews only" is the worst available trade.

Refs #1042

## Glossary

| Term | Definition |
|------|------------|
| `disable-model-invocation` | SKILL.md frontmatter flag; when `true`, only a human may invoke the skill |
| review skill | Spawns an independent reviewer sub-agent (Rex / Hakim / Tariq) |
| approval skill | Writes an approval marker that a merge gate reads |
| trust chain | The hooks and skills mechanically enforcing the merge, ticket, and marker gates |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
