### PR TITLE
fix(#1034): treat absolute drive-letter paths as absolute in _portfolio_resolve

### DIFF
--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -213,11 +213,32 @@ _portfolio_canonicalize() {
 # input is already absolute, it is still canonicalized — an absolute
 # override in project-config.json could itself carry a relative segment
 # (e.g. "$SIBLING/../other").
+#
+# Absoluteness has TWO spellings, not one (me2resh/apexyard#1034). #1029
+# taught `_portfolio_canonicalize` (below) to normalize a Windows
+# drive-letter prefix, but left this function's own test as a bare `/*)`.
+# A drive-letter path IS absolute and does NOT start with "/", so it fell
+# into the relative arm and got concatenated onto the ops-fork root:
+#
+#   .portfolio.registry: "D:/Portfolio/apexyard.projects.yaml"
+#     -> /Users/fork/D:/Portfolio/apexyard.projects.yaml
+#
+# The drive-letter arm below mirrors the pattern `_portfolio_canonicalize`
+# already uses, so the two functions now agree on what "absolute" means.
+#
+# Deliberately NOT matched: drive-RELATIVE spellings (`C:foo`, bare `C:`).
+# `C:foo` means "foo, relative to the current directory ON drive C" — it is
+# genuinely not absolute, and treating it as such would resolve it somewhere
+# the caller never asked for. The `[/\\]` after the colon is what draws that
+# line, and it is load-bearing: do not relax it to a bare `[A-Za-z]:*)`.
+# Pinned by the drive-relative case in
+# tests/test_portfolio_paths_windows_drive_letter.sh.
 # ------------------------------------------------------------------------------
 _portfolio_resolve() {
   local p="$1" abs
   case "$p" in
     /*) abs="$p" ;;
+    [A-Za-z]:/*|[A-Za-z]:\\*) abs="$p" ;;
     *)
       local root
       root=$(_portfolio_root)

--- a/.claude/hooks/tests/test_portfolio_paths_windows_drive_letter.sh
+++ b/.claude/hooks/tests/test_portfolio_paths_windows_drive_letter.sh
@@ -269,6 +269,117 @@ if [ \"\$out\" = \"OK\" ] && [ \"\$rc\" -eq 0 ]; then exit 0; else echo \"got ou
 "
 rm -rf "$SB"
 
+# ===========================================================================
+# me2resh/apexyard#1034 — the follow-up gap #1029 left open.
+#
+# #1029 taught `_portfolio_canonicalize` about drive-letter prefixes, but
+# `_portfolio_resolve` kept its own absoluteness test as a bare `case "$p" in
+# /*)`. A drive-letter path is absolute and does NOT start with "/", so it
+# fell into the relative arm and was concatenated onto the ops-fork root:
+#
+#   _portfolio_resolve "D:/Portfolio/apexyard.projects.yaml"
+#     -> /Users/fork/D:/Portfolio/apexyard.projects.yaml     (wrong)
+#
+# The cases below drive `_portfolio_resolve` directly with a stubbed
+# `_portfolio_root`, for the same reason the #1018 cases above drive
+# `_portfolio_canonicalize` directly: the drive-letter/MSYS equivalence only
+# exists inside the MSYS runtime, so a filesystem fixture cannot reproduce it
+# on a POSIX CI runner. Stubbing the root keeps the assertion about the
+# absoluteness DECISION, which is the actual defect.
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Case 10 (the core acceptance criterion): an absolute drive-letter path is
+# treated as ABSOLUTE — not concatenated onto the fork root.
+# ---------------------------------------------------------------------------
+run_case "#1034: absolute drive-letter path is NOT concatenated onto the fork root" '
+_portfolio_root() { echo "/Users/fork"; }
+r=$(_portfolio_resolve "D:/Portfolio/apexyard.projects.yaml")
+case "$r" in
+  /Users/fork/*) echo "got=$r — still concatenated onto the fork root (the #1034 bug)"; exit 1 ;;
+esac
+expected="/d/Portfolio/apexyard.projects.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 11: lowercase drive letter, same treatment.
+# ---------------------------------------------------------------------------
+run_case "#1034: lowercase absolute drive-letter path resolves absolute" '
+_portfolio_root() { echo "/Users/fork"; }
+r=$(_portfolio_resolve "d:/portfolio/projects")
+expected="/d/portfolio/projects"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 12: native backslash spelling, same treatment.
+# ---------------------------------------------------------------------------
+run_case "#1034: backslash drive-letter path resolves absolute" '
+_portfolio_root() { echo "/Users/fork"; }
+r=$(_portfolio_resolve "C:\Portfolio\apexyard.projects.yaml")
+expected="/c/Portfolio/apexyard.projects.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 13 (must-NOT-change): a POSIX absolute path still resolves absolute.
+# ---------------------------------------------------------------------------
+run_case "#1034: POSIX absolute path still resolves absolute (no regression)" '
+_portfolio_root() { echo "/Users/fork"; }
+r=$(_portfolio_resolve "/nonexistent-1034/registry.yaml")
+expected="/nonexistent-1034/registry.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 14 (must-NOT-change): a genuinely relative path is STILL joined to the
+# fork root. This is the guard that stops the fix from making everything
+# absolute — the failure mode that would silently break every default setup.
+# ---------------------------------------------------------------------------
+run_case "#1034: relative path is still joined to the fork root (no regression)" '
+_portfolio_root() { echo "/Users/fork"; }
+r=$(_portfolio_resolve "sub/registry.yaml")
+expected="/Users/fork/sub/registry.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+run_case "#1034: ./-prefixed relative path is still joined to the fork root (no regression)" '
+_portfolio_root() { echo "/Users/fork"; }
+r=$(_portfolio_resolve "./registry.yaml")
+expected="/Users/fork/registry.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 15: DRIVE-RELATIVE spellings (`C:foo`, bare `C:`) deliberately do NOT
+# match the absolute arm and keep falling through as relative.
+#
+# `C:foo` means "foo, relative to the current directory ON drive C" — it is
+# genuinely not absolute, so treating it as such would resolve it to the wrong
+# place. #1034 called out that the comment block never said this, leaving a
+# future reader liable to "fix" it. This case pins the behaviour so that
+# reader gets a failing test instead of a silent semantic change.
+# ---------------------------------------------------------------------------
+run_case "#1034: drive-RELATIVE C:foo stays relative (documented, deliberate)" '
+_portfolio_root() { echo "/Users/fork"; }
+r=$(_portfolio_resolve "C:foo/registry.yaml")
+expected="/Users/fork/C:foo/registry.yaml"
+if [ "$r" = "$expected" ]; then exit 0; else echo "got=$r expected=$expected"; exit 1; fi
+'
+
+# ---------------------------------------------------------------------------
+# Case 16: the two spellings of the SAME absolute location resolve equal —
+# the property that makes downstream prefix comparisons work, mirroring
+# case 4 above but at the `_portfolio_resolve` level.
+# ---------------------------------------------------------------------------
+run_case "#1034: drive-letter and MSYS spellings resolve EQUAL through _portfolio_resolve" '
+_portfolio_root() { echo "/Users/fork"; }
+a=$(_portfolio_resolve "D:/Portfolio/apexyard.projects.yaml")
+b=$(_portfolio_resolve "/d/Portfolio/apexyard.projects.yaml")
+if [ "$a" = "$b" ]; then exit 0; else echo "a=$a b=$b (should match)"; exit 1; fi
+'
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **`_portfolio_resolve` now recognises a drive-letter path as absolute** — a Windows adopter setting `.portfolio.registry: "D:/Portfolio/apexyard.projects.yaml"` had that value classified as *relative* and concatenated onto the ops-fork root, producing `/Users/fork/D:/Portfolio/apexyard.projects.yaml`. The one-line `case` arm added here mirrors the pattern `_portfolio_canonicalize` already used, so the two functions finally agree on what "absolute" means.
- **Closes the gap #1029 left open** — that fix taught the shared canonicalizer about drive letters and stated the rationale as "fixing the shared helper fixes it for every consumer." That was not quite true: this consumer made its own absoluteness decision first, so the value never reached the helper in a form it could repair. Both code reviews on #1029 flagged this independently as MEDIUM.
- **Drive-*relative* spellings stay relative, on purpose, and are now pinned by a test** — `C:foo` means "foo, relative to the current directory on drive C" and is genuinely not absolute. #1034 noted the comment block never said so, leaving a future reader liable to "fix" it into an absolute match. The `[/\\]` after the colon is the line between the two, and there is now a failing test waiting for anyone who relaxes it.
- **Zero POSIX impact** — the new arm can only match a string beginning `<letter>:` followed by a slash, which no POSIX absolute path ever does. Two explicit no-regression cases assert that ordinary absolute and relative paths resolve exactly as before.

## Testing

1. `bash .claude/hooks/tests/test_portfolio_paths_windows_drive_letter.sh` → 19 passed, 0 failed.
2. **Discriminating check (the part that matters).** The 8 new cases were written and run *before* the fix. Result against the unmodified library: **4 FAIL, 4 PASS** — the four bug cases failed, and the no-regression guards passed. After the fix: **all 8 pass**. A test that passes both before and after proves nothing; these do not.
3. Full suite: `bash bin/run-hook-tests.sh` — no new failures against the pre-change baseline.
4. `shellcheck --severity=warning` on both changed files — clean.

Why the tests drive the function directly rather than using a filesystem fixture: the drive-letter/MSYS-mount equivalence only exists inside the MSYS runtime. On macOS/Linux `D:/x` and `/d/x` are two unrelated strings, so a fixture would only exercise colon-containing directory names — an unrelated concern. This matches the reasoning already recorded in this test file for the #1018 cases.

Refs #1034

---

## Glossary

| Term | Definition |
|------|------------|
| MSYS mount point | Git-Bash's POSIX spelling of a Windows drive — `/d/` for `D:` |
| Drive-relative path | `C:foo` — relative to the current directory *on that drive*, distinct from absolute `C:/foo` |
| Discriminating test | A test proven to fail against the unfixed code, so passing it afterwards is evidence the fix works |
| Canonicalize | Resolve a path to an absolute, symlink-free, `/../`-free form |
