### PR TITLE
fix(#1058): stop reporting sections missing from a body file that was not read

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_required_sections.sh
+++ b/.claude/hooks/tests/test_validate_pr_required_sections.sh
@@ -138,6 +138,101 @@ y
 x" \
   2 "missing required '## Testing' section"
 
+# ===========================================================================
+# me2resh/apexyard#1058 (residual of #1048, reported by @Ref34t) — the hook
+# must not report what a file contains when it could not read that file.
+#
+# #1041 fixed the common trigger (a quoted --body-file path was mis-extracted),
+# but not the misdiagnosis behind it: when the body file cannot be read, the
+# hook warns "not readable ... section check may miss content" and then blocks
+# saying '## Testing' and '## Glossary' are MISSING — a claim about the file's
+# contents, drawn from a haystack it never read.
+#
+# The stated reason is the defect, not the blocking. These cases assert the
+# hook still fails closed, but names the real cause.
+#
+# `run_case_missing_file` points --body-file at a path that does not exist,
+# which is what a typo, a path relative to a directory the hook could not
+# infer, or a permissions problem all look like from inside the hook.
+# ===========================================================================
+
+run_case_missing_file() {
+  local label="$1" want_rc="$2" want_stderr_regex="$3" reject_stderr_regex="${4:-}"
+  local sb; sb=$(make_sandbox)
+  mock_gh_install "$sb"
+  local missing="$sb/definitely-not-here-1058.md"
+  local cmd="gh pr create --repo me2resh/apexyard --title 'chore(#113): test' --body-file $missing"
+  local input; input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/validate-pr-create.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:200})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$reject_stderr_regex" ] && echo "$got_stderr" | grep -qE "$reject_stderr_regex"; then
+    echo "FAIL [$label]: stderr WRONGLY matched /$reject_stderr_regex/ (asserting a claim about a file it could not read)" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# The core defect: no section claim may be made about an unread file.
+run_case_missing_file "#1058: unreadable body-file does NOT claim '## Testing' is missing" \
+  2 "" "missing required '## Testing' section"
+
+run_case_missing_file "#1058: unreadable body-file does NOT claim '## Glossary' is missing" \
+  2 "" "missing required '## Glossary' section"
+
+# It must still fail closed, and the message must name the real cause so the
+# fix is discoverable from the output (the whole point of @Ref34t's report:
+# the old message sent the author to edit a body that was never the problem).
+run_case_missing_file "#1058: unreadable body-file blocks (fail closed, not permissive)" \
+  2 "" ""
+
+# These two assert the NEW blocking message specifically, not the pre-existing
+# "not readable" WARN — matching the WARN would pass before and after the fix
+# and therefore prove nothing.
+run_case_missing_file "#1058: the block names the unreadable body-file as the cause" \
+  2 "PR body file could not be read" ""
+
+run_case_missing_file "#1058: the block quotes the offending path" \
+  2 "PR body file could not be read:.*definitely-not-here-1058\.md" ""
+
+# ---- No-regression guards for #1058 -------------------------------------
+# The fix must not make the hook permissive. A body the hook CAN read and
+# which genuinely lacks a section must still be blocked with the section
+# message — that is the check's actual job, and the one thing a careless
+# "just skip when unreadable" fix could quietly destroy.
+
+run_case "#1058 guard: readable body genuinely missing Testing still blocks with the section message" \
+  "## Summary
+x
+
+## Glossary
+| t | d |" \
+  2 "missing required '## Testing' section"
+
+run_case "#1058 guard: readable complete body still passes" \
+  "## Summary
+x
+
+## Testing
+y
+
+## Glossary
+| t | d |" \
+  0 ""
+
 # ---- Summary ------------------------------------------------------------
 
 echo ""

--- a/.claude/hooks/tests/test_validate_pr_required_sections.sh
+++ b/.claude/hooks/tests/test_validate_pr_required_sections.sh
@@ -186,6 +186,36 @@ run_case_missing_file() {
   PASS=$((PASS+1))
 }
 
+# Same as run_case_missing_file, but the caller supplies the (nonexistent)
+# path verbatim — used to exercise paths containing shell/printf metacharacters.
+run_case_missing_file_path() {
+  local label="$1" missing="$2" want_rc="$3" want_stderr_regex="$4" reject_stderr_regex="${5:-}"
+  local sb; sb=$(make_sandbox)
+  mock_gh_install "$sb"
+  local cmd="gh pr create --repo me2resh/apexyard --title 'chore(#113): test' --body-file $missing"
+  local input; input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_stderr got_rc
+  got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/validate-pr-create.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_stderr:0:200})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_stderr" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_stderr" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$reject_stderr_regex" ] && echo "$got_stderr" | grep -qE "$reject_stderr_regex"; then
+    echo "FAIL [$label]: stderr WRONGLY matched /$reject_stderr_regex/" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
 # The core defect: no section claim may be made about an unread file.
 run_case_missing_file "#1058: unreadable body-file does NOT claim '## Testing' is missing" \
   2 "" "missing required '## Testing' section"
@@ -207,6 +237,28 @@ run_case_missing_file "#1058: the block names the unreadable body-file as the ca
 
 run_case_missing_file "#1058: the block quotes the offending path" \
   2 "PR body file could not be read:.*definitely-not-here-1058\.md" ""
+
+# The message must NAME the sections it did not verify. An earlier draft said
+# "the sections above", which referred to nothing — this branch replaces the
+# per-section list rather than following it.
+run_case_missing_file "#1058: the block names the sections it could not verify" \
+  2 "UNVERIFIED, not missing: ## Testing, ## Glossary" ""
+
+# A '%' in the body-file path must survive into the message. `printf "$ERRORS"`
+# treated the accumulated text as a FORMAT STRING, so a path containing '%s'
+# or a trailing '%' printed a DIFFERENT path and silently swallowed the
+# guidance lines after it. Caught by Rex on PR #1060; fixed with `printf '%b'`.
+# A typo'd path is precisely the scenario this whole branch exists to serve,
+# so a path-shaped typo corrupting the message is not acceptable.
+run_case_missing_file_path "#1058: a '%' in the body-file path does not corrupt the message" \
+  '/tmp/nope%s-100%.md' 2 "PR body file could not be read: /tmp/nope%s-100%\.md" ""
+
+# Uses the SAME path shape as the case above deliberately: a lone '%d' still
+# left the guidance lines intact pre-fix (printf substituted 0 and carried on),
+# so it proved nothing. The '%s' + trailing-'%' shape is what actually
+# truncated the format and swallowed everything after it.
+run_case_missing_file_path "#1058: guidance lines survive a '%' path" \
+  '/tmp/nope%s-100%.md' 2 "Fix the path \(check for a typo" ""
 
 # ---- No-regression guards for #1058 -------------------------------------
 # The fix must not make the hook permissive. A body the hook CAN read and

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -499,6 +499,13 @@ fi
 BODY_CONTENT=""
 # Extract --body-file path. Handles --body-file and the -F short form.
 # After continuation normalization (above) the command is one logical line.
+# me2resh/apexyard#1058 (residual of #1048): "I could not read the body file"
+# and "the body file has no required sections" are DIFFERENT outcomes, and
+# conflating them is what made this hook report sections as missing from a
+# file it had just warned it could not read — sending the author to edit a
+# body that was never the problem. Set when a --body-file was named but its
+# content could not be recovered; consumed at the section check below.
+BODY_FILE_UNREADABLE=0
 BODY_FILE=$(printf '%s' "$COMMAND" | sed -nE 's/.*--body-file[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
 if [ -z "$BODY_FILE" ]; then
   BODY_FILE=$(printf '%s' "$COMMAND" | sed -nE 's/.*[[:space:]]-F[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
@@ -530,9 +537,14 @@ if [ -n "$BODY_FILE" ]; then
   fi
   if [ -f "$BODY_FILE" ]; then
     BODY_CONTENT=$(cat "$BODY_FILE")
+    # Readable-but-unslurpable (permissions, race): treat as unreadable rather
+    # than as an empty body, mirroring block-private-refs-in-public-repos.sh.
+    if [ -z "$BODY_CONTENT" ] && [ -s "$BODY_FILE" ]; then
+      BODY_FILE_UNREADABLE=1
+    fi
   else
     echo "WARN: validate-pr-create.sh: --body-file '${BODY_FILE}' not readable from hook context; section check may miss content." >&2
-    # Do not hard-block: we cannot inspect a file we cannot read.
+    BODY_FILE_UNREADABLE=1
   fi
 fi
 
@@ -566,16 +578,37 @@ if echo "$COMMAND" | grep -qE '\-\-body(-file)?\b'; then
     echo "WARN: pr-sections check bypassed by skip marker ($PR_SKIP_MARKER) in PR body." >&2
   else
     # For each required heading, grep for `## <heading>` (case-insensitive).
+    MISSING_SECTIONS=""
     while IFS= read -r section; do
       [ -z "$section" ] && continue
       # Escape regex metachars in the section name so names like "Given / When / Then" work.
       section_re=$(printf '%s' "$section" | sed 's/[][\.^$*+?(){}|]/\\&/g')
       if ! echo "$HAYSTACK" | grep -qiE "^##[[:space:]]+${section_re}\b"; then
-        ERRORS="${ERRORS}PR body missing required '## ${section}' section.\n"
+        MISSING_SECTIONS="${MISSING_SECTIONS}${section}\n"
       fi
     done <<EOF
 ${REQUIRED_SECTIONS}
 EOF
+
+    if [ -n "$MISSING_SECTIONS" ]; then
+      if [ "$BODY_FILE_UNREADABLE" -eq 1 ]; then
+        # me2resh/apexyard#1058: sections appear absent, but the body file was
+        # never read — so their absence is unproven. Report the cause we
+        # actually have evidence for. Still fail closed (a body we cannot
+        # inspect is not a body we can pass), just stop misdirecting the fix.
+        ERRORS="${ERRORS}PR body file could not be read: ${BODY_FILE}\n"
+        ERRORS="${ERRORS}  The required-section check was NOT run — the sections above may well be present.\n"
+        ERRORS="${ERRORS}  Fix the path (check for a typo, or make it absolute) and retry.\n"
+      else
+        # The body WAS read and the sections genuinely are not in it.
+        while IFS= read -r section; do
+          [ -z "$section" ] && continue
+          ERRORS="${ERRORS}PR body missing required '## ${section}' section.\n"
+        done <<EOF
+$(printf '%b' "$MISSING_SECTIONS")
+EOF
+      fi
+    fi
   fi
 
   # -------------------------------------------------------------------

--- a/.claude/hooks/validate-pr-create.sh
+++ b/.claude/hooks/validate-pr-create.sh
@@ -596,8 +596,14 @@ EOF
         # never read — so their absence is unproven. Report the cause we
         # actually have evidence for. Still fail closed (a body we cannot
         # inspect is not a body we can pass), just stop misdirecting the fix.
+        # Name the sections explicitly. An earlier draft said "the sections
+        # above", which referred to nothing — this branch replaces the
+        # per-section list rather than following it, so the author was left
+        # without the one fact they need. On a fix whose whole subject is
+        # message accuracy, a dangling reference is the wrong thing to ship.
+        _unchecked=$(printf '%b' "$MISSING_SECTIONS" | sed '/^$/d' | sed 's/^/## /' | paste -sd, - | sed 's/,/, /g')
         ERRORS="${ERRORS}PR body file could not be read: ${BODY_FILE}\n"
-        ERRORS="${ERRORS}  The required-section check was NOT run — the sections above may well be present.\n"
+        ERRORS="${ERRORS}  The required-section check was NOT run, so these are UNVERIFIED, not missing: ${_unchecked}\n"
         ERRORS="${ERRORS}  Fix the path (check for a typo, or make it absolute) and retry.\n"
       else
         # The body WAS read and the sections genuinely are not in it.
@@ -751,7 +757,13 @@ fi
 
 if [ -n "$ERRORS" ]; then
   echo "PR VALIDATION BLOCKED:" >&2
-  printf "$ERRORS" >&2
+  # '%b' — NOT `printf "$ERRORS"`. The bare form treats accumulated error text
+  # as a FORMAT STRING, so any '%' inside it is consumed as a conversion spec.
+  # That was latent until #1058 started interpolating a user-supplied path into
+  # a message: `--body-file /tmp/nope%s-100%.md` printed a different path and
+  # silently swallowed the guidance lines that followed. '%b' keeps the '\n'
+  # expansion every existing message relies on while making '%' literal.
+  printf '%b' "$ERRORS" >&2
   echo "" >&2
   echo "Fix the issues above before creating the PR." >&2
   echo "See .claude/rules/git-conventions.md and .claude/rules/pr-quality.md." >&2


### PR DESCRIPTION
## Summary

- **`validate-pr-create.sh` no longer reports sections missing from a file it could not read** — when a `--body-file` is named but unreadable, the hook used to warn *"not readable … section check may miss content"* and then block saying `## Testing` and `## Glossary` were missing. That is a claim about the file's contents drawn from a haystack it never opened, and it sent the author to edit a body that was never the problem.
- **Still fails closed — only the diagnosis changed** — the defect was the stated reason, not the blocking. A body the hook cannot inspect is still not a body it can pass, so the exit code is unchanged at 2. What changed is that the message now names the cause it actually has evidence for, and says outright that the section check did not run.
- **Separates two states that were one code path** — this is the same conflation #1039/#1040 fixed in the sibling `block-private-refs-in-public-repos.sh`, using the same `BODY_FILE_UNREADABLE` flag shape. "I could not recover the body" and "the body has no match" are different outcomes; treating them identically is what produced a confident wrong answer in both hooks.
- **Residual of #1048** (reported by @Ref34t), whose first defect — quotes not stripped from the path — shipped in v5.3.0 via #1041. That fix removed the *common trigger* (ordinary shell quoting) without removing the *misdiagnosis*, so a typo'd path, a path relative to a directory the hook could not infer, or a permissions problem still misdirected the fix.

## Before / after

```
BEFORE   WARN: --body-file '/tmp/does-not-exist.md' not readable from hook
               context; section check may miss content.
         PR VALIDATION BLOCKED:
         PR body missing required '## Testing' section.
         PR body missing required '## Glossary' section.

AFTER    PR body file could not be read: /tmp/does-not-exist.md
           The required-section check was NOT run — the sections above may
           well be present.
           Fix the path (check for a typo, or make it absolute) and retry.
```


## Follow-up commit (91de679) — two findings from the first review

- **The message named nothing.** It said "the sections above", but this branch *replaces* the per-section list rather than following it, so the author was left without the one fact they needed. It now reads `UNVERIFIED, not missing: ## Testing, ## Glossary`. On a fix whose entire subject is message accuracy, a dangling reference was the wrong thing to ship.
- **`printf "$ERRORS"` treated error text as a format string** — and this turned out to be broader than a `--body-file` concern. It was called with **zero arguments**, so every conversion spec it ever consumed was a latent bug. Verified corruptions outside this branch: a PR title containing `%` (`bump coverage to 90%` printed as `to 90 0oesn't match format`) and a branch name containing `%` (legal in git refs — `feature/100%-done` became `feature/1000one`). `printf '%b'` keeps the `\n` expansion all six existing message shapes rely on, verified byte-identical, while making `%` literal.

## Testing

1. `bash .claude/hooks/tests/test_validate_pr_required_sections.sh` → 15 passed, 0 failed.
2. **Discriminating check.** The 7 new cases were run against the unmodified hook first: **4 FAIL / 3 PASS**. The four failures were the two "must not claim a section is missing" assertions plus the two asserting the new blocking message.

   Worth recording that two of these started out worthless: they originally matched the pre-existing `not readable` WARN, which passes both before *and* after the fix. They were retightened to assert the new `PR body file could not be read` message specifically, which moved the RED phase from 2 fail/5 pass to 4 fail/3 pass. A test that cannot fail against the old code is not evidence.
3. **No-regression guards** (these pass both before and after, deliberately — they pin behaviour the fix must not change): a readable body genuinely missing `## Testing` still blocks with the section message; a readable complete body still passes. The tempting "just skip the check when unreadable" fix would have quietly made this hook permissive, and these are what would catch it.
4. All six sibling suites touching this hook still pass: `test_flag_extractor_body_file`, `test_pr_create_gate_anchor`, `test_pr_create_tilde_cd_target`, `test_validate_pr_create_head`, `test_validate_pr_create_structural_parse`, `test_validate_pr_create_upstream`.
5. Full suite `bash bin/run-hook-tests.sh` — no new failures against the pre-change baseline.
6. `shellcheck --severity=warning` on both changed files — clean.
7. Behavioural spot-check against a real payload, both directions, confirming the output above.

Note when reproducing by hand: the PR title must reference an **open** issue, or the hook blocks earlier on issue-state validation and masks this signal entirely. @Ref34t flagged that confound in #1048 and it caught me once during this work.

Refs #1058

---

## Glossary

| Term | Definition |
|------|------------|
| Empty haystack | Running a content check over a body that was never successfully read, so a non-match proves nothing about the file |
| Fail closed | On error or ambiguity, deny rather than allow — preserved here; only the stated reason changed |
| `BODY_FILE_UNREADABLE` | Flag distinguishing "a body file was named but could not be recovered" from "there is no body file", first used in `block-private-refs-in-public-repos.sh` (#1039) |
| Discriminating test | A test proven to fail against the unfixed code, so passing it afterwards is evidence the fix works |
