### PR TITLE
fix(#1033): anchor the git-derived self-location fallback to an apexyard fork

### DIFF
--- a/.claude/hooks/_lib-audit-history.sh
+++ b/.claude/hooks/_lib-audit-history.sh
@@ -60,6 +60,9 @@ if [ -z "$_AUDIT_LIB_DIR" ] || [ ! -f "$_AUDIT_LIB_DIR/_lib-read-config.sh" ]; t
   # actually an apexyard fork. Without this the fallback would source a
   # trust-chain library out of ANY repo the cwd happens to be inside --
   # a workspace/<project> clone, or an unrelated checkout.
+# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
+# (marker file over three alternatives; v2 marker with legacy-pair
+# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
   if [ -n "$_audit_root" ] && { [ -f "$_audit_root/.apexyard-fork" ] || { [ -f "$_audit_root/onboarding.yaml" ] && [ -f "$_audit_root/apexyard.projects.yaml" ]; }; } && [ -f "$_audit_root/.claude/hooks/_lib-read-config.sh" ]; then
     _AUDIT_LIB_DIR="$_audit_root/.claude/hooks"
   fi

--- a/.claude/hooks/_lib-audit-history.sh
+++ b/.claude/hooks/_lib-audit-history.sh
@@ -56,7 +56,11 @@ _LIB_AUDIT_HISTORY_SOURCED=1
 _AUDIT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
 if [ -z "$_AUDIT_LIB_DIR" ] || [ ! -f "$_AUDIT_LIB_DIR/_lib-read-config.sh" ]; then
   _audit_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-  if [ -n "$_audit_root" ] && [ -f "$_audit_root/.claude/hooks/_lib-read-config.sh" ]; then
+  # me2resh/apexyard#1033: only accept a git-derived root that is
+  # actually an apexyard fork. Without this the fallback would source a
+  # trust-chain library out of ANY repo the cwd happens to be inside --
+  # a workspace/<project> clone, or an unrelated checkout.
+  if [ -n "$_audit_root" ] && { [ -f "$_audit_root/.apexyard-fork" ] || { [ -f "$_audit_root/onboarding.yaml" ] && [ -f "$_audit_root/apexyard.projects.yaml" ]; }; } && [ -f "$_audit_root/.claude/hooks/_lib-read-config.sh" ]; then
     _AUDIT_LIB_DIR="$_audit_root/.claude/hooks"
   fi
   unset _audit_root

--- a/.claude/hooks/_lib-audit-history.sh
+++ b/.claude/hooks/_lib-audit-history.sh
@@ -56,13 +56,19 @@ _LIB_AUDIT_HISTORY_SOURCED=1
 _AUDIT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
 if [ -z "$_AUDIT_LIB_DIR" ] || [ ! -f "$_AUDIT_LIB_DIR/_lib-read-config.sh" ]; then
   _audit_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-  # me2resh/apexyard#1033: only accept a git-derived root that is
-  # actually an apexyard fork. Without this the fallback would source a
-  # trust-chain library out of ANY repo the cwd happens to be inside --
-  # a workspace/<project> clone, or an unrelated checkout.
-# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
-# (marker file over three alternatives; v2 marker with legacy-pair
-# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
+  # me2resh/apexyard#1033: only accept a git-derived root that is actually
+  # an apexyard fork. Without this the fallback sources a trust-chain
+  # library out of ANY repo the cwd happens to be inside -- a
+  # workspace/<project> clone, or an unrelated checkout.
+  #
+  # This narrows an ACCIDENT surface. It is NOT an access-control boundary:
+  # the anchors are unauthenticated presence-only files, and -f follows
+  # symlinks, so anyone able to write to the candidate root can satisfy it.
+  # What it prevents is a cwd-driven misresolution, not a hostile library.
+  # Anchor pair per AgDR-0021 §A/§E -- the same test
+  # resolve_ops_root_walk applies, evaluated against one candidate rather
+  # than a walk. (resolve_ops_root itself is unusable here: three of these
+  # sites are locating _lib-ops-root.sh, and its pin is session-scoped.)
   if [ -n "$_audit_root" ] && { [ -f "$_audit_root/.apexyard-fork" ] || { [ -f "$_audit_root/onboarding.yaml" ] && [ -f "$_audit_root/apexyard.projects.yaml" ]; }; } && [ -f "$_audit_root/.claude/hooks/_lib-read-config.sh" ]; then
     _AUDIT_LIB_DIR="$_audit_root/.claude/hooks"
   fi

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -142,7 +142,11 @@ if ! command -v tracker_kind >/dev/null 2>&1; then
   _lib_extract_pr_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd 2>/dev/null)"
   if [ -z "$_lib_extract_pr_dir" ] || [ ! -f "$_lib_extract_pr_dir/_lib-tracker.sh" ]; then
     _lib_extract_pr_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-    if [ -n "$_lib_extract_pr_root" ] && [ -f "$_lib_extract_pr_root/.claude/hooks/_lib-tracker.sh" ]; then
+    # me2resh/apexyard#1033: only accept a git-derived root that is
+    # actually an apexyard fork. Without this the fallback would source a
+    # trust-chain library out of ANY repo the cwd happens to be inside --
+    # a workspace/<project> clone, or an unrelated checkout.
+    if [ -n "$_lib_extract_pr_root" ] && { [ -f "$_lib_extract_pr_root/.apexyard-fork" ] || { [ -f "$_lib_extract_pr_root/onboarding.yaml" ] && [ -f "$_lib_extract_pr_root/apexyard.projects.yaml" ]; }; } && [ -f "$_lib_extract_pr_root/.claude/hooks/_lib-tracker.sh" ]; then
       _lib_extract_pr_dir="$_lib_extract_pr_root/.claude/hooks"
     fi
     unset _lib_extract_pr_root

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -146,6 +146,9 @@ if ! command -v tracker_kind >/dev/null 2>&1; then
     # actually an apexyard fork. Without this the fallback would source a
     # trust-chain library out of ANY repo the cwd happens to be inside --
     # a workspace/<project> clone, or an unrelated checkout.
+# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
+# (marker file over three alternatives; v2 marker with legacy-pair
+# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
     if [ -n "$_lib_extract_pr_root" ] && { [ -f "$_lib_extract_pr_root/.apexyard-fork" ] || { [ -f "$_lib_extract_pr_root/onboarding.yaml" ] && [ -f "$_lib_extract_pr_root/apexyard.projects.yaml" ]; }; } && [ -f "$_lib_extract_pr_root/.claude/hooks/_lib-tracker.sh" ]; then
       _lib_extract_pr_dir="$_lib_extract_pr_root/.claude/hooks"
     fi

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -142,13 +142,19 @@ if ! command -v tracker_kind >/dev/null 2>&1; then
   _lib_extract_pr_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd 2>/dev/null)"
   if [ -z "$_lib_extract_pr_dir" ] || [ ! -f "$_lib_extract_pr_dir/_lib-tracker.sh" ]; then
     _lib_extract_pr_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-    # me2resh/apexyard#1033: only accept a git-derived root that is
-    # actually an apexyard fork. Without this the fallback would source a
-    # trust-chain library out of ANY repo the cwd happens to be inside --
-    # a workspace/<project> clone, or an unrelated checkout.
-# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
-# (marker file over three alternatives; v2 marker with legacy-pair
-# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
+    # me2resh/apexyard#1033: only accept a git-derived root that is actually
+    # an apexyard fork. Without this the fallback sources a trust-chain
+    # library out of ANY repo the cwd happens to be inside -- a
+    # workspace/<project> clone, or an unrelated checkout.
+    #
+    # This narrows an ACCIDENT surface. It is NOT an access-control boundary:
+    # the anchors are unauthenticated presence-only files, and -f follows
+    # symlinks, so anyone able to write to the candidate root can satisfy it.
+    # What it prevents is a cwd-driven misresolution, not a hostile library.
+    # Anchor pair per AgDR-0021 §A/§E -- the same test
+    # resolve_ops_root_walk applies, evaluated against one candidate rather
+    # than a walk. (resolve_ops_root itself is unusable here: three of these
+    # sites are locating _lib-ops-root.sh, and its pin is session-scoped.)
     if [ -n "$_lib_extract_pr_root" ] && { [ -f "$_lib_extract_pr_root/.apexyard-fork" ] || { [ -f "$_lib_extract_pr_root/onboarding.yaml" ] && [ -f "$_lib_extract_pr_root/apexyard.projects.yaml" ]; }; } && [ -f "$_lib_extract_pr_root/.claude/hooks/_lib-tracker.sh" ]; then
       _lib_extract_pr_dir="$_lib_extract_pr_root/.claude/hooks"
     fi

--- a/.claude/hooks/_lib-fresh-fork.sh
+++ b/.claude/hooks/_lib-fresh-fork.sh
@@ -57,6 +57,9 @@ if [ -z "$_FRESH_FORK_LIB_DIR" ] || [ ! -f "$_FRESH_FORK_LIB_DIR/_lib-read-confi
   # actually an apexyard fork. Without this the fallback would source a
   # trust-chain library out of ANY repo the cwd happens to be inside --
   # a workspace/<project> clone, or an unrelated checkout.
+# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
+# (marker file over three alternatives; v2 marker with legacy-pair
+# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
   if [ -n "$_fresh_fork_root" ] && { [ -f "$_fresh_fork_root/.apexyard-fork" ] || { [ -f "$_fresh_fork_root/onboarding.yaml" ] && [ -f "$_fresh_fork_root/apexyard.projects.yaml" ]; }; } && [ -f "$_fresh_fork_root/.claude/hooks/_lib-read-config.sh" ]; then
     _FRESH_FORK_LIB_DIR="$_fresh_fork_root/.claude/hooks"
   fi

--- a/.claude/hooks/_lib-fresh-fork.sh
+++ b/.claude/hooks/_lib-fresh-fork.sh
@@ -53,13 +53,19 @@ _LIB_FRESH_FORK_SOURCED=1
 _FRESH_FORK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
 if [ -z "$_FRESH_FORK_LIB_DIR" ] || [ ! -f "$_FRESH_FORK_LIB_DIR/_lib-read-config.sh" ]; then
   _fresh_fork_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-  # me2resh/apexyard#1033: only accept a git-derived root that is
-  # actually an apexyard fork. Without this the fallback would source a
-  # trust-chain library out of ANY repo the cwd happens to be inside --
-  # a workspace/<project> clone, or an unrelated checkout.
-# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
-# (marker file over three alternatives; v2 marker with legacy-pair
-# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
+  # me2resh/apexyard#1033: only accept a git-derived root that is actually
+  # an apexyard fork. Without this the fallback sources a trust-chain
+  # library out of ANY repo the cwd happens to be inside -- a
+  # workspace/<project> clone, or an unrelated checkout.
+  #
+  # This narrows an ACCIDENT surface. It is NOT an access-control boundary:
+  # the anchors are unauthenticated presence-only files, and -f follows
+  # symlinks, so anyone able to write to the candidate root can satisfy it.
+  # What it prevents is a cwd-driven misresolution, not a hostile library.
+  # Anchor pair per AgDR-0021 §A/§E -- the same test
+  # resolve_ops_root_walk applies, evaluated against one candidate rather
+  # than a walk. (resolve_ops_root itself is unusable here: three of these
+  # sites are locating _lib-ops-root.sh, and its pin is session-scoped.)
   if [ -n "$_fresh_fork_root" ] && { [ -f "$_fresh_fork_root/.apexyard-fork" ] || { [ -f "$_fresh_fork_root/onboarding.yaml" ] && [ -f "$_fresh_fork_root/apexyard.projects.yaml" ]; }; } && [ -f "$_fresh_fork_root/.claude/hooks/_lib-read-config.sh" ]; then
     _FRESH_FORK_LIB_DIR="$_fresh_fork_root/.claude/hooks"
   fi

--- a/.claude/hooks/_lib-fresh-fork.sh
+++ b/.claude/hooks/_lib-fresh-fork.sh
@@ -53,7 +53,11 @@ _LIB_FRESH_FORK_SOURCED=1
 _FRESH_FORK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
 if [ -z "$_FRESH_FORK_LIB_DIR" ] || [ ! -f "$_FRESH_FORK_LIB_DIR/_lib-read-config.sh" ]; then
   _fresh_fork_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-  if [ -n "$_fresh_fork_root" ] && [ -f "$_fresh_fork_root/.claude/hooks/_lib-read-config.sh" ]; then
+  # me2resh/apexyard#1033: only accept a git-derived root that is
+  # actually an apexyard fork. Without this the fallback would source a
+  # trust-chain library out of ANY repo the cwd happens to be inside --
+  # a workspace/<project> clone, or an unrelated checkout.
+  if [ -n "$_fresh_fork_root" ] && { [ -f "$_fresh_fork_root/.apexyard-fork" ] || { [ -f "$_fresh_fork_root/onboarding.yaml" ] && [ -f "$_fresh_fork_root/apexyard.projects.yaml" ]; }; } && [ -f "$_fresh_fork_root/.claude/hooks/_lib-read-config.sh" ]; then
     _FRESH_FORK_LIB_DIR="$_fresh_fork_root/.claude/hooks"
   fi
   unset _fresh_fork_root

--- a/.claude/hooks/_lib-onboarding-depth-mode.sh
+++ b/.claude/hooks/_lib-onboarding-depth-mode.sh
@@ -59,13 +59,19 @@ _LIB_ONBOARDING_DEPTH_MODE_SOURCED=1
 _DEPTH_MODE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
 if [ -z "$_DEPTH_MODE_LIB_DIR" ] || [ ! -f "$_DEPTH_MODE_LIB_DIR/_lib-ops-root.sh" ]; then
   _depth_mode_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-  # me2resh/apexyard#1033: only accept a git-derived root that is
-  # actually an apexyard fork. Without this the fallback would source a
-  # trust-chain library out of ANY repo the cwd happens to be inside --
-  # a workspace/<project> clone, or an unrelated checkout.
-# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
-# (marker file over three alternatives; v2 marker with legacy-pair
-# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
+  # me2resh/apexyard#1033: only accept a git-derived root that is actually
+  # an apexyard fork. Without this the fallback sources a trust-chain
+  # library out of ANY repo the cwd happens to be inside -- a
+  # workspace/<project> clone, or an unrelated checkout.
+  #
+  # This narrows an ACCIDENT surface. It is NOT an access-control boundary:
+  # the anchors are unauthenticated presence-only files, and -f follows
+  # symlinks, so anyone able to write to the candidate root can satisfy it.
+  # What it prevents is a cwd-driven misresolution, not a hostile library.
+  # Anchor pair per AgDR-0021 §A/§E -- the same test
+  # resolve_ops_root_walk applies, evaluated against one candidate rather
+  # than a walk. (resolve_ops_root itself is unusable here: three of these
+  # sites are locating _lib-ops-root.sh, and its pin is session-scoped.)
   if [ -n "$_depth_mode_root" ] && { [ -f "$_depth_mode_root/.apexyard-fork" ] || { [ -f "$_depth_mode_root/onboarding.yaml" ] && [ -f "$_depth_mode_root/apexyard.projects.yaml" ]; }; } && [ -f "$_depth_mode_root/.claude/hooks/_lib-ops-root.sh" ]; then
     _DEPTH_MODE_LIB_DIR="$_depth_mode_root/.claude/hooks"
   fi

--- a/.claude/hooks/_lib-onboarding-depth-mode.sh
+++ b/.claude/hooks/_lib-onboarding-depth-mode.sh
@@ -59,7 +59,11 @@ _LIB_ONBOARDING_DEPTH_MODE_SOURCED=1
 _DEPTH_MODE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
 if [ -z "$_DEPTH_MODE_LIB_DIR" ] || [ ! -f "$_DEPTH_MODE_LIB_DIR/_lib-ops-root.sh" ]; then
   _depth_mode_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-  if [ -n "$_depth_mode_root" ] && [ -f "$_depth_mode_root/.claude/hooks/_lib-ops-root.sh" ]; then
+  # me2resh/apexyard#1033: only accept a git-derived root that is
+  # actually an apexyard fork. Without this the fallback would source a
+  # trust-chain library out of ANY repo the cwd happens to be inside --
+  # a workspace/<project> clone, or an unrelated checkout.
+  if [ -n "$_depth_mode_root" ] && { [ -f "$_depth_mode_root/.apexyard-fork" ] || { [ -f "$_depth_mode_root/onboarding.yaml" ] && [ -f "$_depth_mode_root/apexyard.projects.yaml" ]; }; } && [ -f "$_depth_mode_root/.claude/hooks/_lib-ops-root.sh" ]; then
     _DEPTH_MODE_LIB_DIR="$_depth_mode_root/.claude/hooks"
   fi
   unset _depth_mode_root

--- a/.claude/hooks/_lib-onboarding-depth-mode.sh
+++ b/.claude/hooks/_lib-onboarding-depth-mode.sh
@@ -63,6 +63,9 @@ if [ -z "$_DEPTH_MODE_LIB_DIR" ] || [ ! -f "$_DEPTH_MODE_LIB_DIR/_lib-ops-root.s
   # actually an apexyard fork. Without this the fallback would source a
   # trust-chain library out of ANY repo the cwd happens to be inside --
   # a workspace/<project> clone, or an unrelated checkout.
+# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
+# (marker file over three alternatives; v2 marker with legacy-pair
+# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
   if [ -n "$_depth_mode_root" ] && { [ -f "$_depth_mode_root/.apexyard-fork" ] || { [ -f "$_depth_mode_root/onboarding.yaml" ] && [ -f "$_depth_mode_root/apexyard.projects.yaml" ]; }; } && [ -f "$_depth_mode_root/.claude/hooks/_lib-ops-root.sh" ]; then
     _DEPTH_MODE_LIB_DIR="$_depth_mode_root/.claude/hooks"
   fi

--- a/.claude/hooks/_lib-onboarding-glossary-seen.sh
+++ b/.claude/hooks/_lib-onboarding-glossary-seen.sh
@@ -83,6 +83,9 @@ if [ -z "$_GLOSSARY_SEEN_LIB_DIR" ] || [ ! -f "$_GLOSSARY_SEEN_LIB_DIR/_lib-ops-
   # actually an apexyard fork. Without this the fallback would source a
   # trust-chain library out of ANY repo the cwd happens to be inside --
   # a workspace/<project> clone, or an unrelated checkout.
+# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
+# (marker file over three alternatives; v2 marker with legacy-pair
+# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
   if [ -n "$_glossary_seen_root" ] && { [ -f "$_glossary_seen_root/.apexyard-fork" ] || { [ -f "$_glossary_seen_root/onboarding.yaml" ] && [ -f "$_glossary_seen_root/apexyard.projects.yaml" ]; }; } && [ -f "$_glossary_seen_root/.claude/hooks/_lib-ops-root.sh" ]; then
     _GLOSSARY_SEEN_LIB_DIR="$_glossary_seen_root/.claude/hooks"
   fi

--- a/.claude/hooks/_lib-onboarding-glossary-seen.sh
+++ b/.claude/hooks/_lib-onboarding-glossary-seen.sh
@@ -79,13 +79,19 @@ _LIB_ONBOARDING_GLOSSARY_SEEN_SOURCED=1
 _GLOSSARY_SEEN_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
 if [ -z "$_GLOSSARY_SEEN_LIB_DIR" ] || [ ! -f "$_GLOSSARY_SEEN_LIB_DIR/_lib-ops-root.sh" ]; then
   _glossary_seen_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-  # me2resh/apexyard#1033: only accept a git-derived root that is
-  # actually an apexyard fork. Without this the fallback would source a
-  # trust-chain library out of ANY repo the cwd happens to be inside --
-  # a workspace/<project> clone, or an unrelated checkout.
-# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
-# (marker file over three alternatives; v2 marker with legacy-pair
-# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
+  # me2resh/apexyard#1033: only accept a git-derived root that is actually
+  # an apexyard fork. Without this the fallback sources a trust-chain
+  # library out of ANY repo the cwd happens to be inside -- a
+  # workspace/<project> clone, or an unrelated checkout.
+  #
+  # This narrows an ACCIDENT surface. It is NOT an access-control boundary:
+  # the anchors are unauthenticated presence-only files, and -f follows
+  # symlinks, so anyone able to write to the candidate root can satisfy it.
+  # What it prevents is a cwd-driven misresolution, not a hostile library.
+  # Anchor pair per AgDR-0021 §A/§E -- the same test
+  # resolve_ops_root_walk applies, evaluated against one candidate rather
+  # than a walk. (resolve_ops_root itself is unusable here: three of these
+  # sites are locating _lib-ops-root.sh, and its pin is session-scoped.)
   if [ -n "$_glossary_seen_root" ] && { [ -f "$_glossary_seen_root/.apexyard-fork" ] || { [ -f "$_glossary_seen_root/onboarding.yaml" ] && [ -f "$_glossary_seen_root/apexyard.projects.yaml" ]; }; } && [ -f "$_glossary_seen_root/.claude/hooks/_lib-ops-root.sh" ]; then
     _GLOSSARY_SEEN_LIB_DIR="$_glossary_seen_root/.claude/hooks"
   fi

--- a/.claude/hooks/_lib-onboarding-glossary-seen.sh
+++ b/.claude/hooks/_lib-onboarding-glossary-seen.sh
@@ -79,7 +79,11 @@ _LIB_ONBOARDING_GLOSSARY_SEEN_SOURCED=1
 _GLOSSARY_SEEN_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
 if [ -z "$_GLOSSARY_SEEN_LIB_DIR" ] || [ ! -f "$_GLOSSARY_SEEN_LIB_DIR/_lib-ops-root.sh" ]; then
   _glossary_seen_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-  if [ -n "$_glossary_seen_root" ] && [ -f "$_glossary_seen_root/.claude/hooks/_lib-ops-root.sh" ]; then
+  # me2resh/apexyard#1033: only accept a git-derived root that is
+  # actually an apexyard fork. Without this the fallback would source a
+  # trust-chain library out of ANY repo the cwd happens to be inside --
+  # a workspace/<project> clone, or an unrelated checkout.
+  if [ -n "$_glossary_seen_root" ] && { [ -f "$_glossary_seen_root/.apexyard-fork" ] || { [ -f "$_glossary_seen_root/onboarding.yaml" ] && [ -f "$_glossary_seen_root/apexyard.projects.yaml" ]; }; } && [ -f "$_glossary_seen_root/.claude/hooks/_lib-ops-root.sh" ]; then
     _GLOSSARY_SEEN_LIB_DIR="$_glossary_seen_root/.claude/hooks"
   fi
   unset _glossary_seen_root

--- a/.claude/hooks/_lib-premium-hook.sh
+++ b/.claude/hooks/_lib-premium-hook.sh
@@ -157,13 +157,19 @@ _premium_hook_dir() {
     if [ -z "$_PREMIUM_HOOK_DIR_CACHE" ] || [ ! -f "$_PREMIUM_HOOK_DIR_CACHE/_lib-premium-hook.sh" ]; then
       local _premium_root
       _premium_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-      # me2resh/apexyard#1033: only accept a git-derived root that is
-      # actually an apexyard fork. Without this the fallback would source a
-      # trust-chain library out of ANY repo the cwd happens to be inside --
-      # a workspace/<project> clone, or an unrelated checkout.
-# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
-# (marker file over three alternatives; v2 marker with legacy-pair
-# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
+      # me2resh/apexyard#1033: only accept a git-derived root that is actually
+      # an apexyard fork. Without this the fallback sources a trust-chain
+      # library out of ANY repo the cwd happens to be inside -- a
+      # workspace/<project> clone, or an unrelated checkout.
+      #
+      # This narrows an ACCIDENT surface. It is NOT an access-control boundary:
+      # the anchors are unauthenticated presence-only files, and -f follows
+      # symlinks, so anyone able to write to the candidate root can satisfy it.
+      # What it prevents is a cwd-driven misresolution, not a hostile library.
+      # Anchor pair per AgDR-0021 §A/§E -- the same test
+      # resolve_ops_root_walk applies, evaluated against one candidate rather
+      # than a walk. (resolve_ops_root itself is unusable here: three of these
+      # sites are locating _lib-ops-root.sh, and its pin is session-scoped.)
       if [ -n "$_premium_root" ] && { [ -f "$_premium_root/.apexyard-fork" ] || { [ -f "$_premium_root/onboarding.yaml" ] && [ -f "$_premium_root/apexyard.projects.yaml" ]; }; } && [ -f "$_premium_root/.claude/hooks/_lib-premium-hook.sh" ]; then
         _PREMIUM_HOOK_DIR_CACHE="$_premium_root/.claude/hooks"
       fi

--- a/.claude/hooks/_lib-premium-hook.sh
+++ b/.claude/hooks/_lib-premium-hook.sh
@@ -157,7 +157,11 @@ _premium_hook_dir() {
     if [ -z "$_PREMIUM_HOOK_DIR_CACHE" ] || [ ! -f "$_PREMIUM_HOOK_DIR_CACHE/_lib-premium-hook.sh" ]; then
       local _premium_root
       _premium_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-      if [ -n "$_premium_root" ] && [ -f "$_premium_root/.claude/hooks/_lib-premium-hook.sh" ]; then
+      # me2resh/apexyard#1033: only accept a git-derived root that is
+      # actually an apexyard fork. Without this the fallback would source a
+      # trust-chain library out of ANY repo the cwd happens to be inside --
+      # a workspace/<project> clone, or an unrelated checkout.
+      if [ -n "$_premium_root" ] && { [ -f "$_premium_root/.apexyard-fork" ] || { [ -f "$_premium_root/onboarding.yaml" ] && [ -f "$_premium_root/apexyard.projects.yaml" ]; }; } && [ -f "$_premium_root/.claude/hooks/_lib-premium-hook.sh" ]; then
         _PREMIUM_HOOK_DIR_CACHE="$_premium_root/.claude/hooks"
       fi
     fi

--- a/.claude/hooks/_lib-premium-hook.sh
+++ b/.claude/hooks/_lib-premium-hook.sh
@@ -161,6 +161,9 @@ _premium_hook_dir() {
       # actually an apexyard fork. Without this the fallback would source a
       # trust-chain library out of ANY repo the cwd happens to be inside --
       # a workspace/<project> clone, or an unrelated checkout.
+# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
+# (marker file over three alternatives; v2 marker with legacy-pair
+# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
       if [ -n "$_premium_root" ] && { [ -f "$_premium_root/.apexyard-fork" ] || { [ -f "$_premium_root/onboarding.yaml" ] && [ -f "$_premium_root/apexyard.projects.yaml" ]; }; } && [ -f "$_premium_root/.claude/hooks/_lib-premium-hook.sh" ]; then
         _PREMIUM_HOOK_DIR_CACHE="$_premium_root/.claude/hooks"
       fi

--- a/.claude/hooks/_lib-project-board.sh
+++ b/.claude/hooks/_lib-project-board.sh
@@ -69,6 +69,9 @@ if [ -z "$_lib_board_dir" ] || [ ! -f "$_lib_board_dir/_lib-ops-root.sh" ]; then
   # actually an apexyard fork. Without this the fallback would source a
   # trust-chain library out of ANY repo the cwd happens to be inside --
   # a workspace/<project> clone, or an unrelated checkout.
+# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
+# (marker file over three alternatives; v2 marker with legacy-pair
+# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
   if [ -n "$_lib_board_root" ] && { [ -f "$_lib_board_root/.apexyard-fork" ] || { [ -f "$_lib_board_root/onboarding.yaml" ] && [ -f "$_lib_board_root/apexyard.projects.yaml" ]; }; } && [ -f "$_lib_board_root/.claude/hooks/_lib-ops-root.sh" ]; then
     _lib_board_dir="$_lib_board_root/.claude/hooks"
   fi

--- a/.claude/hooks/_lib-project-board.sh
+++ b/.claude/hooks/_lib-project-board.sh
@@ -65,7 +65,11 @@ _LIB_PROJECT_BOARD_SOURCED=1
 _lib_board_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
 if [ -z "$_lib_board_dir" ] || [ ! -f "$_lib_board_dir/_lib-ops-root.sh" ]; then
   _lib_board_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-  if [ -n "$_lib_board_root" ] && [ -f "$_lib_board_root/.claude/hooks/_lib-ops-root.sh" ]; then
+  # me2resh/apexyard#1033: only accept a git-derived root that is
+  # actually an apexyard fork. Without this the fallback would source a
+  # trust-chain library out of ANY repo the cwd happens to be inside --
+  # a workspace/<project> clone, or an unrelated checkout.
+  if [ -n "$_lib_board_root" ] && { [ -f "$_lib_board_root/.apexyard-fork" ] || { [ -f "$_lib_board_root/onboarding.yaml" ] && [ -f "$_lib_board_root/apexyard.projects.yaml" ]; }; } && [ -f "$_lib_board_root/.claude/hooks/_lib-ops-root.sh" ]; then
     _lib_board_dir="$_lib_board_root/.claude/hooks"
   fi
   unset _lib_board_root

--- a/.claude/hooks/_lib-project-board.sh
+++ b/.claude/hooks/_lib-project-board.sh
@@ -65,13 +65,19 @@ _LIB_PROJECT_BOARD_SOURCED=1
 _lib_board_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
 if [ -z "$_lib_board_dir" ] || [ ! -f "$_lib_board_dir/_lib-ops-root.sh" ]; then
   _lib_board_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-  # me2resh/apexyard#1033: only accept a git-derived root that is
-  # actually an apexyard fork. Without this the fallback would source a
-  # trust-chain library out of ANY repo the cwd happens to be inside --
-  # a workspace/<project> clone, or an unrelated checkout.
-# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
-# (marker file over three alternatives; v2 marker with legacy-pair
-# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
+  # me2resh/apexyard#1033: only accept a git-derived root that is actually
+  # an apexyard fork. Without this the fallback sources a trust-chain
+  # library out of ANY repo the cwd happens to be inside -- a
+  # workspace/<project> clone, or an unrelated checkout.
+  #
+  # This narrows an ACCIDENT surface. It is NOT an access-control boundary:
+  # the anchors are unauthenticated presence-only files, and -f follows
+  # symlinks, so anyone able to write to the candidate root can satisfy it.
+  # What it prevents is a cwd-driven misresolution, not a hostile library.
+  # Anchor pair per AgDR-0021 §A/§E -- the same test
+  # resolve_ops_root_walk applies, evaluated against one candidate rather
+  # than a walk. (resolve_ops_root itself is unusable here: three of these
+  # sites are locating _lib-ops-root.sh, and its pin is session-scoped.)
   if [ -n "$_lib_board_root" ] && { [ -f "$_lib_board_root/.apexyard-fork" ] || { [ -f "$_lib_board_root/onboarding.yaml" ] && [ -f "$_lib_board_root/apexyard.projects.yaml" ]; }; } && [ -f "$_lib_board_root/.claude/hooks/_lib-ops-root.sh" ]; then
     _lib_board_dir="$_lib_board_root/.claude/hooks"
   fi

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -90,7 +90,11 @@ _tracker_load_config_lib() {
   hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
   if [ -z "$hook_dir" ] || [ ! -f "$hook_dir/_lib-read-config.sh" ]; then
     root=$(git rev-parse --show-toplevel 2>/dev/null)
-    if [ -n "$root" ] && [ -f "$root/.claude/hooks/_lib-read-config.sh" ]; then
+    # me2resh/apexyard#1033: only accept a git-derived root that is
+    # actually an apexyard fork. Without this the fallback would source a
+    # trust-chain library out of ANY repo the cwd happens to be inside --
+    # a workspace/<project> clone, or an unrelated checkout.
+    if [ -n "$root" ] && { [ -f "$root/.apexyard-fork" ] || { [ -f "$root/onboarding.yaml" ] && [ -f "$root/apexyard.projects.yaml" ]; }; } && [ -f "$root/.claude/hooks/_lib-read-config.sh" ]; then
       hook_dir="$root/.claude/hooks"
     fi
   fi
@@ -123,7 +127,11 @@ _tracker_load_portfolio_lib() {
   hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
   if [ -z "$hook_dir" ] || [ ! -f "$hook_dir/_lib-portfolio-paths.sh" ]; then
     root=$(git rev-parse --show-toplevel 2>/dev/null)
-    if [ -n "$root" ] && [ -f "$root/.claude/hooks/_lib-portfolio-paths.sh" ]; then
+    # me2resh/apexyard#1033: only accept a git-derived root that is
+    # actually an apexyard fork. Without this the fallback would source a
+    # trust-chain library out of ANY repo the cwd happens to be inside --
+    # a workspace/<project> clone, or an unrelated checkout.
+    if [ -n "$root" ] && { [ -f "$root/.apexyard-fork" ] || { [ -f "$root/onboarding.yaml" ] && [ -f "$root/apexyard.projects.yaml" ]; }; } && [ -f "$root/.claude/hooks/_lib-portfolio-paths.sh" ]; then
       hook_dir="$root/.claude/hooks"
     fi
   fi

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -90,13 +90,19 @@ _tracker_load_config_lib() {
   hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
   if [ -z "$hook_dir" ] || [ ! -f "$hook_dir/_lib-read-config.sh" ]; then
     root=$(git rev-parse --show-toplevel 2>/dev/null)
-    # me2resh/apexyard#1033: only accept a git-derived root that is
-    # actually an apexyard fork. Without this the fallback would source a
-    # trust-chain library out of ANY repo the cwd happens to be inside --
-    # a workspace/<project> clone, or an unrelated checkout.
-# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
-# (marker file over three alternatives; v2 marker with legacy-pair
-# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
+    # me2resh/apexyard#1033: only accept a git-derived root that is actually
+    # an apexyard fork. Without this the fallback sources a trust-chain
+    # library out of ANY repo the cwd happens to be inside -- a
+    # workspace/<project> clone, or an unrelated checkout.
+    #
+    # This narrows an ACCIDENT surface. It is NOT an access-control boundary:
+    # the anchors are unauthenticated presence-only files, and -f follows
+    # symlinks, so anyone able to write to the candidate root can satisfy it.
+    # What it prevents is a cwd-driven misresolution, not a hostile library.
+    # Anchor pair per AgDR-0021 §A/§E -- the same test
+    # resolve_ops_root_walk applies, evaluated against one candidate rather
+    # than a walk. (resolve_ops_root itself is unusable here: three of these
+    # sites are locating _lib-ops-root.sh, and its pin is session-scoped.)
     if [ -n "$root" ] && { [ -f "$root/.apexyard-fork" ] || { [ -f "$root/onboarding.yaml" ] && [ -f "$root/apexyard.projects.yaml" ]; }; } && [ -f "$root/.claude/hooks/_lib-read-config.sh" ]; then
       hook_dir="$root/.claude/hooks"
     fi
@@ -130,13 +136,19 @@ _tracker_load_portfolio_lib() {
   hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
   if [ -z "$hook_dir" ] || [ ! -f "$hook_dir/_lib-portfolio-paths.sh" ]; then
     root=$(git rev-parse --show-toplevel 2>/dev/null)
-    # me2resh/apexyard#1033: only accept a git-derived root that is
-    # actually an apexyard fork. Without this the fallback would source a
-    # trust-chain library out of ANY repo the cwd happens to be inside --
-    # a workspace/<project> clone, or an unrelated checkout.
-# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
-# (marker file over three alternatives; v2 marker with legacy-pair
-# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
+    # me2resh/apexyard#1033: only accept a git-derived root that is actually
+    # an apexyard fork. Without this the fallback sources a trust-chain
+    # library out of ANY repo the cwd happens to be inside -- a
+    # workspace/<project> clone, or an unrelated checkout.
+    #
+    # This narrows an ACCIDENT surface. It is NOT an access-control boundary:
+    # the anchors are unauthenticated presence-only files, and -f follows
+    # symlinks, so anyone able to write to the candidate root can satisfy it.
+    # What it prevents is a cwd-driven misresolution, not a hostile library.
+    # Anchor pair per AgDR-0021 §A/§E -- the same test
+    # resolve_ops_root_walk applies, evaluated against one candidate rather
+    # than a walk. (resolve_ops_root itself is unusable here: three of these
+    # sites are locating _lib-ops-root.sh, and its pin is session-scoped.)
     if [ -n "$root" ] && { [ -f "$root/.apexyard-fork" ] || { [ -f "$root/onboarding.yaml" ] && [ -f "$root/apexyard.projects.yaml" ]; }; } && [ -f "$root/.claude/hooks/_lib-portfolio-paths.sh" ]; then
       hook_dir="$root/.claude/hooks"
     fi

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -94,6 +94,9 @@ _tracker_load_config_lib() {
     # actually an apexyard fork. Without this the fallback would source a
     # trust-chain library out of ANY repo the cwd happens to be inside --
     # a workspace/<project> clone, or an unrelated checkout.
+# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
+# (marker file over three alternatives; v2 marker with legacy-pair
+# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
     if [ -n "$root" ] && { [ -f "$root/.apexyard-fork" ] || { [ -f "$root/onboarding.yaml" ] && [ -f "$root/apexyard.projects.yaml" ]; }; } && [ -f "$root/.claude/hooks/_lib-read-config.sh" ]; then
       hook_dir="$root/.claude/hooks"
     fi
@@ -131,6 +134,9 @@ _tracker_load_portfolio_lib() {
     # actually an apexyard fork. Without this the fallback would source a
     # trust-chain library out of ANY repo the cwd happens to be inside --
     # a workspace/<project> clone, or an unrelated checkout.
+# The anchor pair is not a new choice -- it is AgDR-0021 SS A/E
+# (marker file over three alternatives; v2 marker with legacy-pair
+# fallback), already used by _lib-ops-root.sh. Cite it, do not re-derive.
     if [ -n "$root" ] && { [ -f "$root/.apexyard-fork" ] || { [ -f "$root/onboarding.yaml" ] && [ -f "$root/apexyard.projects.yaml" ]; }; } && [ -f "$root/.claude/hooks/_lib-portfolio-paths.sh" ]; then
       hook_dir="$root/.claude/hooks"
     fi

--- a/.claude/hooks/tests/test_lib_self_location_anchor.sh
+++ b/.claude/hooks/tests/test_lib_self_location_anchor.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# Regression test for me2resh/apexyard#1033 — trust-chain libraries must not
+# load a sibling lib out of whatever repository the caller happens to be
+# sitting in.
+#
+# #1028 made nine self-location sites zsh-safe by adding a
+# `git rev-parse --show-toplevel` fallback for when BASH_SOURCE is
+# unavailable. The fallback had no anchor check, so it accepted ANY git
+# repository's `.claude/hooks/` — including a managed project's clone under
+# workspace/, or any unrelated repo the operator's cwd is inside. The
+# framework argues against exactly this primitive in its own source:
+# `_lib-read-config.sh` says to locate via BASH_SOURCE "not via `git
+# rev-parse` (which would defeat the whole point of this fix)", and
+# `_lib-ops-root.sh` documents the #381 hijack incident that motivated
+# pin-first, anchor-validated resolution.
+#
+# HOW THE FALLBACK IS TRIGGERED HERE, PORTABLY
+# --------------------------------------------
+# The real trigger is a non-bash sourcing shell (zsh leaves BASH_SOURCE
+# unset). Depending on zsh being installed would make this test skip on some
+# CI runners, so instead it sources the lib from a stream:
+#
+#     bash -c '. /dev/stdin' < lib.sh
+#
+# BASH_SOURCE[0] is then `/dev/stdin`, whose dirname is `/dev` — no sibling
+# lib there, so the `[ ! -f "$hook_dir/<sibling>" ]` guard fails and the
+# rev-parse fallback fires. That is the identical code path zsh reaches,
+# exercised without a zsh dependency.
+#
+# Exit 0 if all cases pass; exit 1 on first failure.
+
+set -u
+
+HOOKS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+ok()   { PASS=$((PASS+1)); echo "PASS [$1]"; }
+bad()  { FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}$1 "; echo "FAIL [$1]: $2" >&2; }
+
+# Builds a git repo that is NOT an apexyard fork (no .apexyard-fork, no
+# onboarding.yaml + apexyard.projects.yaml pair) but which DOES ship its own
+# .claude/hooks/ with a same-named lib — the shape of a managed project clone
+# under workspace/, and the thing the fallback must refuse.
+make_impostor_repo() {
+  local sb; sb=$(mktemp -d)
+  ( cd "$sb" || exit 1
+    git init -q
+    git config user.email t@e.com
+    git config user.name t
+    mkdir -p .claude/hooks
+    # Each impostor lib defines the SAME function name the real one does, but
+    # sets a tripwire variable. If a tripwire is set after loading, the wrong
+    # copy was sourced.
+    cat > .claude/hooks/_lib-read-config.sh <<'IMP'
+IMPOSTOR_CONFIG_LOADED=1
+config_get_or() { echo "IMPOSTOR"; }
+config_get() { echo "IMPOSTOR"; }
+IMP
+    cat > .claude/hooks/_lib-portfolio-paths.sh <<'IMP'
+IMPOSTOR_PORTFOLIO_LOADED=1
+portfolio_registry() { echo "/impostor/apexyard.projects.yaml"; }
+IMP
+    cat > .claude/hooks/_lib-ops-root.sh <<'IMP'
+IMPOSTOR_OPS_ROOT_LOADED=1
+resolve_ops_root() { echo "/impostor"; }
+IMP
+    cat > .claude/hooks/_lib-tracker.sh <<'IMP'
+IMPOSTOR_TRACKER_LOADED=1
+IMP
+    # Required for the _lib-premium-hook.sh case: that site's fallback only
+    # fires when a same-named file EXISTS at the git-derived root. Omitting it
+    # made the guard's existence check fail, the fallback never ran, and the
+    # case reported PASS against an unfixed lib — a fixture gap masquerading
+    # as a fixed site.
+    cat > .claude/hooks/_lib-premium-hook.sh <<'IMP'
+IMPOSTOR_PREMIUM_LOADED=1
+IMP
+    touch README.md
+    git add README.md .claude >/dev/null 2>&1
+    git commit -q -m init >/dev/null 2>&1
+  )
+  echo "$sb"
+}
+
+# Source $lib from a stream (so BASH_SOURCE cannot locate its directory),
+# with cwd inside the impostor repo, then run $probe. Echoes the probe output.
+run_from_impostor() {
+  local lib="$1" probe="$2" repo="$3"
+  ( cd "$repo" || exit 1
+    bash -c ". /dev/stdin; $probe" < "$HOOKS_DIR/$lib" 2>/dev/null
+  )
+}
+
+# ---------------------------------------------------------------------------
+# The nine #1033 sites, grouped by the lib that owns them. Each case asserts
+# that NO impostor tripwire is set after the loader runs from inside a
+# non-fork repo.
+#
+# Note these assert on the TRIPWIRE, not on whether loading succeeded.
+# Refusing to load at all is a correct outcome here (the caller then degrades
+# per its own contract); loading the IMPOSTOR is the bug.
+# ---------------------------------------------------------------------------
+
+assert_no_impostor() {
+  local label="$1" lib="$2" probe="$3"
+  local repo out
+  repo=$(make_impostor_repo)
+  out=$(run_from_impostor "$lib" "$probe" "$repo")
+  rm -rf "$repo"
+  case "$out" in
+    *IMPOSTOR*) bad "$label" "loaded the impostor lib from the cwd's repo (got: $out)" ;;
+    *)          ok  "$label" ;;
+  esac
+}
+
+assert_no_impostor "#1033: _lib-tracker.sh config-lib loader refuses a non-fork repo" \
+  "_lib-tracker.sh" \
+  '_tracker_load_config_lib >/dev/null 2>&1; [ -n "${IMPOSTOR_CONFIG_LOADED:-}" ] && echo IMPOSTOR'
+
+assert_no_impostor "#1033: _lib-tracker.sh portfolio-lib loader refuses a non-fork repo" \
+  "_lib-tracker.sh" \
+  '_tracker_load_portfolio_lib >/dev/null 2>&1; [ -n "${IMPOSTOR_PORTFOLIO_LOADED:-}" ] && echo IMPOSTOR'
+
+assert_no_impostor "#1033: _lib-audit-history.sh refuses a non-fork repo" \
+  "_lib-audit-history.sh" \
+  '[ -n "${IMPOSTOR_CONFIG_LOADED:-}" ] && echo IMPOSTOR'
+
+assert_no_impostor "#1033: _lib-extract-pr.sh refuses a non-fork repo" \
+  "_lib-extract-pr.sh" \
+  '[ -n "${IMPOSTOR_TRACKER_LOADED:-}" ] && echo IMPOSTOR'
+
+assert_no_impostor "#1033: _lib-fresh-fork.sh refuses a non-fork repo" \
+  "_lib-fresh-fork.sh" \
+  '[ -n "${IMPOSTOR_CONFIG_LOADED:-}" ] && echo IMPOSTOR'
+
+assert_no_impostor "#1033: _lib-onboarding-depth-mode.sh refuses a non-fork repo" \
+  "_lib-onboarding-depth-mode.sh" \
+  '[ -n "${IMPOSTOR_OPS_ROOT_LOADED:-}" ] && echo IMPOSTOR'
+
+assert_no_impostor "#1033: _lib-onboarding-glossary-seen.sh refuses a non-fork repo" \
+  "_lib-onboarding-glossary-seen.sh" \
+  '[ -n "${IMPOSTOR_OPS_ROOT_LOADED:-}" ] && echo IMPOSTOR'
+
+assert_no_impostor "#1033: _lib-project-board.sh refuses a non-fork repo" \
+  "_lib-project-board.sh" \
+  '[ -n "${IMPOSTOR_OPS_ROOT_LOADED:-}" ] && echo IMPOSTOR'
+
+# _lib-premium-hook.sh is the odd one out: its fallback resolves the lib's OWN
+# directory rather than sourcing a sibling, so there is no tripwire variable to
+# catch. The equivalent assertion is that the resolved directory must not point
+# into the cwd's repo. Probed via the returned path instead of a load side
+# effect — same defect, different observable.
+#
+# This case was MISSING from the first draft of this file, which covered 8 of
+# the 9 sites while the commit message claimed all of them. Left here as the
+# ninth precisely because an uncovered site is indistinguishable from a fixed
+# one in a green test run.
+# Compare against `git rev-parse --show-toplevel`, NOT against $PWD. On macOS
+# mktemp -d hands back /var/folders/... while git resolves the same location to
+# /private/var/folders/... — a $PWD comparison silently never matches, and the
+# case reports PASS while the lib is in fact loading from the impostor. That is
+# how the first version of this case was written, and it produced a green result
+# for a genuinely vulnerable site. A lone PASS among failing siblings in a RED
+# phase is a signal to check the probe, not to celebrate.
+assert_no_impostor "#1033: _lib-premium-hook.sh refuses a non-fork repo" \
+  "_lib-premium-hook.sh" \
+  '_top=$(git rev-parse --show-toplevel 2>/dev/null); _d=$(_premium_hook_dir 2>/dev/null);
+   [ -n "$_top" ] && case "$_d" in "$_top"/*|"$_top") echo IMPOSTOR ;; esac'
+
+# ---------------------------------------------------------------------------
+# MUST-NOT-REGRESS: the anchor check must not break the legitimate fallback.
+# A genuine apexyard fork (anchored by .apexyard-fork) must still resolve, or
+# the #1028 zsh fix is undone and tracker_review_submit silently stops
+# posting again — the exact failure #1028 existed to repair.
+# ---------------------------------------------------------------------------
+
+make_real_fork() {
+  local sb; sb=$(mktemp -d)
+  ( cd "$sb" || exit 1
+    git init -q; git config user.email t@e.com; git config user.name t
+    touch .apexyard-fork
+    mkdir -p .claude/hooks
+    cp "$HOOKS_DIR/_lib-read-config.sh"      .claude/hooks/
+    cp "$HOOKS_DIR/_lib-portfolio-paths.sh"  .claude/hooks/
+    cp "$HOOKS_DIR/_lib-ops-root.sh"         .claude/hooks/
+    cp "$HOOKS_DIR/../project-config.defaults.json" .claude/ 2>/dev/null || true
+    git add README.md .claude >/dev/null 2>&1; git commit -q -m init >/dev/null 2>&1
+  )
+  echo "$sb"
+}
+
+assert_loads_in_real_fork() {
+  local label="$1" lib="$2" probe="$3"
+  local repo out
+  repo=$(make_real_fork)
+  cp "$HOOKS_DIR/$lib" "$repo/.claude/hooks/" 2>/dev/null || true
+  out=$( cd "$repo" || exit 1
+         bash -c ". /dev/stdin; $probe" < "$HOOKS_DIR/$lib" 2>/dev/null )
+  rm -rf "$repo"
+  if [ "$out" = "OK" ]; then ok "$label"; else bad "$label" "legitimate fork fallback broke (got: '$out')"; fi
+}
+
+assert_loads_in_real_fork "#1033 guard: real fork (.apexyard-fork) still resolves the config lib" \
+  "_lib-tracker.sh" \
+  '_tracker_load_config_lib >/dev/null 2>&1 && command -v config_get_or >/dev/null 2>&1 && echo OK'
+
+assert_loads_in_real_fork "#1033 guard: real fork still resolves the portfolio lib" \
+  "_lib-tracker.sh" \
+  '_tracker_load_portfolio_lib >/dev/null 2>&1 && command -v portfolio_registry >/dev/null 2>&1 && echo OK'
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "===== test_lib_self_location_anchor.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_lib_self_location_anchor.sh
+++ b/.claude/hooks/tests/test_lib_self_location_anchor.sh
@@ -177,19 +177,59 @@ assert_no_impostor "#1033: _lib-premium-hook.sh refuses a non-fork repo" \
 # posting again — the exact failure #1028 existed to repair.
 # ---------------------------------------------------------------------------
 
+# $1 = layout: "v2" (.apexyard-fork marker) or "v1" (onboarding.yaml +
+# apexyard.projects.yaml pair). Both anchors must work — a v1-only or v2-only
+# guard silently breaks every fallback on the other layout.
 make_real_fork() {
+  local layout="${1:-v2}"
   local sb; sb=$(mktemp -d)
   ( cd "$sb" || exit 1
     git init -q; git config user.email t@e.com; git config user.name t
-    touch .apexyard-fork
+    if [ "$layout" = "v1" ]; then
+      touch onboarding.yaml
+      printf 'version: 1\nprojects: []\n' > apexyard.projects.yaml
+    else
+      touch .apexyard-fork
+    fi
     mkdir -p .claude/hooks
-    cp "$HOOKS_DIR/_lib-read-config.sh"      .claude/hooks/
-    cp "$HOOKS_DIR/_lib-portfolio-paths.sh"  .claude/hooks/
-    cp "$HOOKS_DIR/_lib-ops-root.sh"         .claude/hooks/
+    # Every lib a guarded site might source, plus the sites themselves.
+    for l in _lib-read-config.sh _lib-portfolio-paths.sh _lib-ops-root.sh \
+             _lib-tracker.sh _lib-audit-history.sh _lib-extract-pr.sh \
+             _lib-fresh-fork.sh _lib-onboarding-depth-mode.sh \
+             _lib-onboarding-glossary-seen.sh _lib-premium-hook.sh \
+             _lib-project-board.sh; do
+      [ -f "$HOOKS_DIR/$l" ] && cp "$HOOKS_DIR/$l" .claude/hooks/
+    done
     cp "$HOOKS_DIR/../project-config.defaults.json" .claude/ 2>/dev/null || true
-    git add README.md .claude >/dev/null 2>&1; git commit -q -m init >/dev/null 2>&1
+    # README must EXIST before it is staged. The first version of this fixture
+    # staged a file it never created, so `git add` and `git commit` both failed
+    # silently — the repo was uncommitted and the fixture only worked by
+    # accident. Same latent-fixture class as the impostor gap fixed earlier.
+    printf 'fixture\n' > README.md
+    git add README.md .claude >/dev/null 2>&1
+    [ "$layout" = "v1" ] && git add onboarding.yaml apexyard.projects.yaml >/dev/null 2>&1
+    [ "$layout" = "v2" ] && git add .apexyard-fork >/dev/null 2>&1
+    git commit -q -m init >/dev/null 2>&1
   )
   echo "$sb"
+}
+
+# POSITIVE coverage — the half the first version of this file was missing.
+#
+# The impostor cases above pass whenever a site refuses to load AT ALL, so an
+# over-strict anchor ships green through every one of them. Rex demonstrated
+# this on PR #1061 by mutation: breaking _lib-project-board.sh's anchor so it
+# could never resolve left the suite 11/11. These cases close that, for all
+# nine sites and on BOTH fork layouts, so an anchor that is too strict fails
+# just as loudly as one that is too loose.
+assert_resolves_in_fork() {
+  local label="$1" lib="$2" probe="$3" layout="$4"
+  local repo out
+  repo=$(make_real_fork "$layout")
+  out=$( cd "$repo" || exit 1
+         bash -c ". /dev/stdin; $probe" < "$HOOKS_DIR/$lib" 2>/dev/null )
+  rm -rf "$repo"
+  if [ "$out" = "OK" ]; then ok "$label"; else bad "$label" "legitimate fork ($layout) failed to resolve (got: '$out')"; fi
 }
 
 assert_loads_in_real_fork() {
@@ -203,13 +243,46 @@ assert_loads_in_real_fork() {
   if [ "$out" = "OK" ]; then ok "$label"; else bad "$label" "legitimate fork fallback broke (got: '$out')"; fi
 }
 
-assert_loads_in_real_fork "#1033 guard: real fork (.apexyard-fork) still resolves the config lib" \
-  "_lib-tracker.sh" \
-  '_tracker_load_config_lib >/dev/null 2>&1 && command -v config_get_or >/dev/null 2>&1 && echo OK'
+for LAYOUT in v2 v1; do
+  assert_resolves_in_fork "#1033 guard [$LAYOUT]: _lib-tracker.sh resolves the config lib" \
+    "_lib-tracker.sh" \
+    '_tracker_load_config_lib >/dev/null 2>&1 && command -v config_get_or >/dev/null 2>&1 && echo OK' "$LAYOUT"
 
-assert_loads_in_real_fork "#1033 guard: real fork still resolves the portfolio lib" \
-  "_lib-tracker.sh" \
-  '_tracker_load_portfolio_lib >/dev/null 2>&1 && command -v portfolio_registry >/dev/null 2>&1 && echo OK'
+  assert_resolves_in_fork "#1033 guard [$LAYOUT]: _lib-tracker.sh resolves the portfolio lib" \
+    "_lib-tracker.sh" \
+    '_tracker_load_portfolio_lib >/dev/null 2>&1 && command -v portfolio_registry >/dev/null 2>&1 && echo OK' "$LAYOUT"
+
+  assert_resolves_in_fork "#1033 guard [$LAYOUT]: _lib-audit-history.sh resolves the config lib" \
+    "_lib-audit-history.sh" \
+    'command -v config_get_or >/dev/null 2>&1 && echo OK' "$LAYOUT"
+
+  assert_resolves_in_fork "#1033 guard [$LAYOUT]: _lib-fresh-fork.sh resolves the config lib" \
+    "_lib-fresh-fork.sh" \
+    'command -v config_get_or >/dev/null 2>&1 && echo OK' "$LAYOUT"
+
+  assert_resolves_in_fork "#1033 guard [$LAYOUT]: _lib-extract-pr.sh resolves the tracker lib" \
+    "_lib-extract-pr.sh" \
+    'command -v tracker_view >/dev/null 2>&1 && echo OK' "$LAYOUT"
+
+  assert_resolves_in_fork "#1033 guard [$LAYOUT]: _lib-onboarding-depth-mode.sh resolves the ops-root lib" \
+    "_lib-onboarding-depth-mode.sh" \
+    'command -v resolve_ops_root >/dev/null 2>&1 && echo OK' "$LAYOUT"
+
+  assert_resolves_in_fork "#1033 guard [$LAYOUT]: _lib-onboarding-glossary-seen.sh resolves the ops-root lib" \
+    "_lib-onboarding-glossary-seen.sh" \
+    'command -v resolve_ops_root >/dev/null 2>&1 && echo OK' "$LAYOUT"
+
+  assert_resolves_in_fork "#1033 guard [$LAYOUT]: _lib-project-board.sh resolves the ops-root lib" \
+    "_lib-project-board.sh" \
+    'command -v resolve_ops_root >/dev/null 2>&1 && echo OK' "$LAYOUT"
+
+  # premium-hook resolves its OWN dir, so assert the resolved path lands inside
+  # the fork rather than checking for a loaded function.
+  assert_resolves_in_fork "#1033 guard [$LAYOUT]: _lib-premium-hook.sh resolves its own dir inside the fork" \
+    "_lib-premium-hook.sh" \
+    '_top=$(git rev-parse --show-toplevel 2>/dev/null); _d=$(_premium_hook_dir 2>/dev/null);
+     [ -n "$_d" ] && case "$_d" in "$_top"/*) echo OK ;; esac' "$LAYOUT"
+done
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

- **Nine trust-chain self-location sites now refuse a git-derived root that isn't an apexyard fork.** `#1028` made those sites zsh-safe by falling back to `git rev-parse --show-toplevel` when `BASH_SOURCE` is unavailable. The fallback had no anchor check, so it accepted any git repository that also happened to ship a same-named trust-chain library at that path — a `workspace/<project>` clone, or any unrelated checkout the operator's cwd happened to be inside. Each site now additionally requires `.apexyard-fork`, or the `onboarding.yaml` + `apexyard.projects.yaml` pair.
- **The framework already argued against this primitive in its own source.** `_lib-read-config.sh` says to locate via `BASH_SOURCE` *"not via `git rev-parse` (which would defeat the whole point of this fix)"*, and `_lib-ops-root.sh` documents the #381 hijack incident that motivated pin-first, anchor-validated resolution. The zsh fix reached for the weaker primitive; this restores the intent.
- **The guard is inlined at each site, deliberately, not extracted into a helper.** These libraries *are* the bootstrap layer — a shared helper would itself need locating, which is the problem being solved. Nine copies of a two-condition check is the honest shape.
- **The #1028 zsh fix is preserved, and that is the load-bearing constraint.** Written too strictly, this change would undo it and `tracker_review_submit` would silently stop posting reviews again — the exact failure #1028 existed to repair. Eighteen positive cases (9 sites x 2 fork layouts) pin that a real fork still resolves.

## Scope of the change

| File | Sites |
|---|---|
| `_lib-tracker.sh` | 2 (config lib, portfolio lib) |
| `_lib-audit-history.sh` | 1 |
| `_lib-extract-pr.sh` | 1 |
| `_lib-fresh-fork.sh` | 1 |
| `_lib-onboarding-depth-mode.sh` | 1 |
| `_lib-onboarding-glossary-seen.sh` | 1 |
| `_lib-premium-hook.sh` | 1 |
| `_lib-project-board.sh` | 1 |

Nine sites, eight files. `_lib-premium-hook.sh` is the odd one out — its fallback resolves the lib's **own** directory rather than sourcing a sibling, so it has no load side effect to observe and is asserted on the returned path instead.

## Testing

New file: `.claude/hooks/tests/test_lib_self_location_anchor.sh` — **27 cases** (9 negative + 9 positive × 2 fork layouts).

**Discriminating check.** Against the unmodified libraries: **9 FAIL / 18 PASS.** All nine sites loaded an impostor library out of an unrelated repo; both no-regression guards already passed. After the change: **27/27**.

How the fallback is triggered portably: the real trigger is a non-bash sourcing shell (zsh leaves `BASH_SOURCE` unset). Rather than depend on zsh being installed on a CI runner, each lib is sourced from a stream — `bash -c '. /dev/stdin' < lib.sh` — so `BASH_SOURCE[0]` is `/dev/stdin`, its dirname is `/dev`, the sibling-exists guard fails, and the rev-parse fallback fires. Identical code path, no zsh dependency.

The fixture builds a git repo that is **not** a fork but ships its own `.claude/hooks/` with same-named libs, each setting a tripwire variable. A tripwire set after loading means the wrong copy was sourced.

**Four defects in this test were found and fixed before it was trustworthy**, recorded because each produced a *green* result against vulnerable code:

1. The first draft covered 8 of the 9 sites while claiming all of them — `_lib-premium-hook.sh` had zero cases.
2. Its probe compared `$PWD` against a git-resolved path. On macOS `mktemp -d` returns `/var/folders/…` while git resolves `/private/var/folders/…`, so the comparison never matched and reported PASS on a vulnerable site.
3. The fixture never created `_lib-premium-hook.sh` in the impostor repo, so that site's existence check failed and the fallback never fired — a fixture gap indistinguishable from a fix.
4. The sandbox used `git add -A`, which this framework's own `block-git-add-all.sh` correctly refuses.

The structural tell for (2) and (3) was a lone PASS sitting among eight FAILs in a RED phase. In a security test, an unexplained pass is a reason to check the probe.

**Verified against this fork specifically** (split-portfolio v2 — `.apexyard-fork` present, v1 pair absent): both `_tracker_load_config_lib` and `_tracker_load_portfolio_lib` still resolve. A v1-only anchor would have broken every hook on a v2 fork.

Full suite: no new failures against the pre-change baseline. `shellcheck --severity=warning` clean on all nine changed files.

## What this is, stated accurately

**This narrows an accident surface. It is not an access-control boundary**, and should not be described as one. The anchors are unauthenticated, presence-only files, and `-f` follows symlinks — Hakim demonstrated `ln -s /etc/hosts .apexyard-fork` satisfying the guard, and I reproduced it. Against an adversary who can already write into the candidate root, this raises the bar by one `touch`.

What it genuinely does is convert a **broad, silent, accidental** misresolution into a **narrow, deliberate** one. The realistic failure was never a targeted attacker; it was a cwd sitting inside a `workspace/<project>` clone while an agent sourced a trust-chain lib and silently got the wrong code. That surface was *any repo shipping a same-named lib under `.claude/hooks/`*; it is now *only such a repo that is also deliberately marked as a fork*. (Hakim caught me overstating this as "every git repo on the machine" — the sibling-exists co-condition was always present. Correcting it here; the nine code comments carry the same overstatement and are folded into #1062, which edits those sites anyway.) The code comments say this plainly at all nine sites.

**Reachability is unchanged and low.** Hooks launch via `bash -c` with absolute paths and a bash shebang, so `BASH_SOURCE` resolves and the fallback never fires there. Verified independently by both reviewers: no merge, ticket, migration, marker, or CI gate can reach these nine fallbacks. MEDIUM is the right rating.

**Known limit, pre-existing, not fixed here:** the anchor guards only the *fallback* branch. Under a non-bash shell `dirname ""` → `.`, so if the cwd *directly contains* the sibling filename the `if` body never runs and the anchor is never consulted. Filed as a follow-up rather than widened into this PR.

## Review

Trust-chain change — Heavy tier per `.claude/rules/right-size-ceremony.md` rail 1. Reviewed by both Rex (correctness) and Hakim (security, 85/100).

Refs #1033

---

## Glossary

| Term | Definition |
|------|------------|
| Trust chain | The hooks and libraries that mechanically enforce the merge, ticket, and marker gates |
| Self-location | A library resolving the directory it lives in, so it can source its siblings |
| Anchor | A marker file proving a directory is an apexyard fork — `.apexyard-fork` (v2) or the `onboarding.yaml` + `apexyard.projects.yaml` pair (v1) |
| Impostor repo | Test fixture: a non-fork git repo shipping same-named libraries, used to prove the fallback refuses it |
| Discriminating test | A test proven to fail against the unfixed code, so passing it afterwards is evidence |
