### PR TITLE
fix(#1063): stage-then-promote audit_run_persist so a jq failure leaves no file

### DIFF
--- a/.claude/hooks/_lib-audit-history.sh
+++ b/.claude/hooks/_lib-audit-history.sh
@@ -185,7 +185,22 @@ audit_run_persist() {
 
   # Read stdin JSON. Augment with top-level metadata, derive stats from
   # findings[] if absent.
+  #
+  # Written to a scratch file in the SAME directory as the destination
+  # first, then promoted with `mv` (atomic rename on one filesystem) only
+  # if jq produced usable output. This is deliberately NOT just an
+  # exit-status check: jq exits 0 on empty/absent stdin -- it reads no
+  # input, emits no output, and reports success -- so a caller that
+  # forgot to pipe a payload previously got a zero-byte run file promoted
+  # AND a rc=0 "it worked" from this function (apexyard#1063). A reader
+  # (`audit_run_list` / `audit_render_trend`) must never be able to
+  # observe a partially-written or empty run file at json_path.
   local json_path="$dim_dir/runs/$ts_safe.json"
+  local json_tmp
+  json_tmp=$(mktemp "$dim_dir/runs/.audit-run-tmp.XXXXXX" 2>/dev/null) || {
+    echo "audit_run_persist: mktemp failed while staging $json_path" >&2
+    return 1
+  }
   jq --arg ts "$ts" --arg dim "$dimension" --arg v "$verdict" --argjson s "$score" '
     . as $in
     | (.findings // []) as $f
@@ -201,13 +216,35 @@ audit_run_persist() {
       + { ts: $ts, dimension: $dim, verdict: $v, score: $s,
           schema_version: ($in.schema_version // 1),
           stats: ($existing_stats // $derived_stats) }
-  ' > "$json_path" || {
-    echo "audit_run_persist: jq failed writing JSON" >&2
+  ' > "$json_tmp"
+  local jq_rc=$?
+
+  # Promotion gate: exit status alone is not enough (empty stdin exits 0
+  # with zero bytes written) -- also require non-empty AND independently
+  # re-parseable output before this run is allowed to exist on disk.
+  if [ "$jq_rc" -ne 0 ] || [ ! -s "$json_tmp" ] || ! jq -e . "$json_tmp" >/dev/null 2>&1; then
+    rm -f "$json_tmp"
+    echo "audit_run_persist: jq produced no usable JSON for $json_path (rc=$jq_rc; empty or malformed stdin?)" >&2
+    return 1
+  fi
+
+  mv "$json_tmp" "$json_path" || {
+    rm -f "$json_tmp"
+    echo "audit_run_persist: failed to move staged JSON into place at $json_path" >&2
     return 1
   }
 
-  # Build frontmatter from the just-written JSON, then concatenate with body.
+  # Build frontmatter from the just-written JSON, then concatenate with
+  # body -- staged the same way. Reaching this point means json_path
+  # already holds a valid run, so an .md file can never be written
+  # without a matching JSON run behind it (the orphan-.md defect also
+  # reported in apexyard#1063).
   local md_path="$dim_dir/$ts_safe.md"
+  local md_tmp
+  md_tmp=$(mktemp "$dim_dir/.audit-run-tmp.XXXXXX" 2>/dev/null) || {
+    echo "audit_run_persist: mktemp failed while staging $md_path" >&2
+    return 1
+  }
   local fm
   fm=$(jq -r '
     "---",
@@ -226,14 +263,25 @@ audit_run_persist() {
     "---",
     ""
   ' "$json_path") || {
-    echo "audit_run_persist: jq failed building frontmatter" >&2
+    rm -f "$md_tmp"
+    echo "audit_run_persist: jq failed building frontmatter for $md_path" >&2
     return 1
   }
 
   {
     printf '%s\n' "$fm"
     cat "$body_file"
-  } > "$md_path" || return 1
+  } > "$md_tmp" || {
+    rm -f "$md_tmp"
+    echo "audit_run_persist: failed writing staged MD for $md_path" >&2
+    return 1
+  }
+
+  mv "$md_tmp" "$md_path" || {
+    rm -f "$md_tmp"
+    echo "audit_run_persist: failed to move staged MD into place at $md_path" >&2
+    return 1
+  }
 
   _audit_apply_marker "$dim_dir"
   return 0
@@ -283,6 +331,13 @@ audit_run_list() {
       [ -d "$d" ] || continue
       for f in "$d"/*.json; do
         [ -f "$f" ] || continue
+        # Defensive: skip zero-byte / orphaned run files that may already
+        # be sitting on disk from before apexyard#1063's fix (or any other
+        # source of a truncated write). The ts-empty check below already
+        # incidentally catches this (jq on an empty/unparseable file emits
+        # nothing), but make the intent explicit rather than relying on
+        # that side effect.
+        [ -s "$f" ] || continue
         local ts
         ts=$(jq -r '.ts // ""' "$f" 2>/dev/null) || ts=""
         [ -n "$ts" ] || continue

--- a/.claude/hooks/tests/test_audit_history.sh
+++ b/.claude/hooks/tests/test_audit_history.sh
@@ -357,7 +357,112 @@ EOF
   )
 }
 
-for fn in case_1 case_2 case_3 case_4 case_5 case_6 case_7 case_8 case_9 case_10 case_11; do
+# ---------------------------------------------------------------------------
+# Case 12: audit_run_persist leaves NO file (and returns non-zero) on empty
+# stdin -- apexyard#1063. jq exits 0 on empty stdin (no findings emitted at
+# all), so the pre-fix code took the success path and moved a zero-byte JSON
+# into place while returning rc=0 -- reporting success for a run that never
+# happened. This is the discriminating case: the pre-existing `|| return 1`
+# guard already caught malformed input (jq exits non-zero there), but NOT
+# empty/absent stdin (jq exits 0 with no output).
+# ---------------------------------------------------------------------------
+case_12() {
+  local case_name="audit_run_persist: empty stdin leaves no file, returns non-zero"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    body=$(mktemp); echo "## Body" > "$body"
+    printf '' | audit_run_persist "demo" "threat-model" "2026-06-01T00:00:00Z" "fail" 0 "$body"
+    rc=$?
+    json="$sb/projects/demo/audits/threat-model/runs/2026-06-01T00-00-00Z.json"
+    md="$sb/projects/demo/audits/threat-model/2026-06-01T00-00-00Z.md"
+    [ "$rc" -ne 0 ] || { mark_fail "$case_name" "expected non-zero rc, got $rc"; return; }
+    [ -f "$json" ] && { mark_fail "$case_name" "zero-byte JSON left at $json"; return; }
+    [ -f "$md" ] && { mark_fail "$case_name" "orphan MD left at $md (json step never succeeded)"; return; }
+    rm -f "$body"
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 13: audit_run_persist leaves NO file on malformed (non-JSON) stdin.
+# jq exits non-zero here, so the pre-fix `|| return 1` guard already
+# reported failure -- but the `>` redirect had already truncated/created
+# json_path before jq ran, so a zero-byte file survived the return 1. This
+# case pins that the file itself must not survive either.
+# ---------------------------------------------------------------------------
+case_13() {
+  local case_name="audit_run_persist: malformed stdin leaves no file, returns non-zero"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    body=$(mktemp); echo "## Body" > "$body"
+    printf 'not json' | audit_run_persist "demo" "threat-model" "2026-06-02T00:00:00Z" "fail" 0 "$body"
+    rc=$?
+    json="$sb/projects/demo/audits/threat-model/runs/2026-06-02T00-00-00Z.json"
+    [ "$rc" -ne 0 ] || { mark_fail "$case_name" "expected non-zero rc, got $rc"; return; }
+    [ -f "$json" ] && { mark_fail "$case_name" "zero-byte JSON left at $json"; return; }
+    rm -f "$body"
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 14: audit_run_list defensively skips a pre-existing zero-byte run
+# file on disk (belt-and-braces for forks that already carry one from
+# before this fix -- apexyard#1063).
+# ---------------------------------------------------------------------------
+case_14() {
+  local case_name="audit_run_list skips a pre-existing zero-byte run file"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    body=$(mktemp); echo "x" > "$body"
+    printf '{"findings":[]}' \
+      | audit_run_persist "demo" "threat-model" "2026-05-11T20:30:00Z" "pass" 90 "$body"
+    # Simulate a pre-existing zero-byte orphan left by the old bug.
+    dim_dir="$sb/projects/demo/audits/threat-model"
+    : > "$dim_dir/runs/2026-05-12T00-00-00Z.json"
+    out=$(audit_run_list "demo" "threat-model" 10)
+    echo "$out" | grep -q "2026-05-12T00-00-00Z.json" \
+      && { mark_fail "$case_name" "zero-byte run was not skipped: $out"; return; }
+    echo "$out" | grep -q "2026-05-11T20-30-00Z.json" \
+      || { mark_fail "$case_name" "valid run missing from list: $out"; return; }
+    rm -f "$body"
+    mark_pass "$case_name"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 15: audit_render_trend still renders correctly when an orphan
+# zero-byte JSON and an orphan .md (no matching JSON) sit alongside valid
+# runs -- apexyard#1063 AC.
+# ---------------------------------------------------------------------------
+case_15() {
+  local case_name="audit_render_trend renders correctly with orphan zero-byte/md present"
+  local sb
+  sb=$(fresh_sandbox)
+  ( source_lib_with_projects_dir "$sb"
+    body=$(mktemp); echo "x" > "$body"
+    for ts in "2026-04-15T14:22:00Z" "2026-05-11T20:30:00Z"; do
+      printf '{"findings":[]}' \
+        | audit_run_persist "demo" "threat-model" "$ts" "pass" 90 "$body"
+    done
+    dim_dir="$sb/projects/demo/audits/threat-model"
+    : > "$dim_dir/runs/2026-05-12T00-00-00Z.json"           # orphan zero-byte JSON
+    echo "orphan body, no matching run" > "$dim_dir/2026-05-13T00-00-00Z.md"  # orphan MD
+    out=$(audit_render_trend "demo" "threat-model" 5)
+    echo "$out" | grep -q "## Trend (last 2 runs)" \
+      || { mark_fail "$case_name" "orphan files broke the trend render. out=$out"; return; }
+    echo "$out" | grep -q "2026-05-12" \
+      && { mark_fail "$case_name" "orphan zero-byte run leaked into trend: $out"; return; }
+    rm -f "$body"
+    mark_pass "$case_name"
+  )
+}
+
+for fn in case_1 case_2 case_3 case_4 case_5 case_6 case_7 case_8 case_9 case_10 case_11 \
+          case_12 case_13 case_14 case_15; do
   run_case "$fn"
 done
 


### PR DESCRIPTION
## Summary

- **`audit_run_persist` now stages both the JSON and the MD artefact to a scratch file and promotes with `mv` only after the content is confirmed non-empty and re-parseable** — the old code wrote straight to the destination via `>`, which truncates/creates the file *before* `jq` runs at all. Combined with `jq` exiting 0 on empty/absent stdin (it reads no input and emits nothing), the old status-only guard reported success while leaving a zero-byte run file behind — exactly the case Hakim hit twice reviewing #1061.
- **The `.md` write is now gated on the JSON promotion having actually succeeded**, closing the second defect from the issue's follow-up comment: an orphan `.md` can no longer be written behind a JSON run that never landed.

  **Corrected in review — this closes one direction, not both.** Once the JSON `mv` succeeds, four later paths (the md `mktemp`, the frontmatter `jq`, the staged write, the md `mv`) each `return 1` while leaving a *valid* JSON run on disk. The caller is told the persist failed, yet the run has a parseable `ts` and will appear as a trend point. That is not a regression — `dev` behaves identically, and the surviving point is well-formed rather than corrupt — but the original wording claimed more than the change delivers. Narrowed rather than papered over; adding a rollback would be a larger change than the defect warrants.
- **`audit_run_list` now explicitly skips zero-byte run files** rather than relying on the incidental side effect that an empty file happens to yield an empty `.ts` — belt-and-braces for forks that already carry a pre-#1063 orphan on disk.

## The judgement call — atomic write vs. detect-and-cleanup

I went with **atomic** (stage to a temp file in the same directory, promote with `mv` only on success), not detect-then-delete. Two reasons, not just "atomic sounds safer":

1. **The two approaches need the identical validity check anyway.** `jq`'s exit status alone doesn't distinguish "wrote a good run" from "read empty stdin and reported success" — both need the `[ -s tmp ] && jq -e . tmp` check I added. The only real difference between the two designs is *where* the destination file sits while that check runs: atomic never creates it at the real path until the check has already passed; detect-and-cleanup necessarily creates it there first (that's what makes it detectable), then removes it. Given the check is the same either way, atomic buys the "no reader can ever observe the bad state" property for free.
2. **Nothing in this lib's contract promises single-threaded access.** Today, `audit_run_persist` and `audit_run_list`/`audit_render_trend` run from a single Claude Code session per invocation, so a concurrent read during the ~unlucky window is unlikely in practice. But this is a shared lib sourced by nine different audit skills, and the failure mode if that assumption ever breaks — a security-trend chart silently reading a truncated file mid-write — is exactly the "worse than no artefact" case the issue opened on. `mktemp` + `mv` costs one extra syscall pair per artefact; paying it removes the assumption from the picture entirely rather than relying on it staying true.

I staged both temp files **inside `dim_dir`** (`runs/.audit-run-tmp.XXXXXX` and `dim_dir/.audit-run-tmp.XXXXXX`), not in `$TMPDIR` as the issue's illustrative snippet showed — `mv` is only atomic within a single filesystem, and `dim_dir` can be a `workspace/<project>` mount that isn't guaranteed to share a filesystem with `$TMPDIR`.

## What `audit_render_trend` does with a zero-byte file today

Checked before writing any fix code: `audit_render_trend` never opens run files itself — it delegates discovery entirely to `audit_run_list`, and `audit_run_list`'s existing sort loop reads each file's `.ts` via `jq -r '.ts // ""' ... || ts=""` and skips anything that yields an empty `ts`. A zero-byte file makes `jq` emit nothing (rc 0, empty stdout), so `ts` comes back empty and the file is silently dropped from the sorted list *before* `audit_render_trend` ever sees it.

So the zero-byte file does **not** break the render or inject a bogus point into the security-trend chart today — it's silently excluded, by an incidental side effect of the `ts`-empty check rather than an explicit one. That's still worth hardening (case 14/15 below, and the explicit `[ -s "$f" ]` guard in `audit_run_list`), both to make the intent visible in the code rather than load-bearing-by-accident, and because a future change to the `ts`-check shape could silently remove the protection.

## Testing

Wrote the discriminating tests **first** and confirmed RED against the unmodified lib:

```
✗ audit_run_persist: empty stdin leaves no file, returns non-zero: expected non-zero rc, got 0
✗ audit_run_persist: malformed stdin leaves no file, returns non-zero: zero-byte JSON left at .../runs/2026-06-02T00-00-00Z.json
Results: 13 passed, 2 failed
```

(Case 13 confirms the pre-existing `jq ... || return 1` guard already reported failure correctly for malformed input — the survivor was purely the zero-byte file left by the `>` redirect having already fired before `jq` errored. Case 12, empty stdin, is the case the issue's follow-up comment specifically called out: `jq` exits 0 there, so the old status-only check never even considered it a failure.)

After the fix, `test_audit_history.sh` is green in full — 15 cases (11 pre-existing + 4 new: empty-stdin no-file/nonzero-rc, malformed-stdin no-file/nonzero-rc, `audit_run_list` skips a pre-existing zero-byte orphan, `audit_render_trend` renders correctly with an orphan zero-byte JSON *and* an orphan `.md` both present):

```
Results: 15 passed, 0 failed
```

Full hook suite: `bash bin/run-hook-tests.sh` — PASS=122 FAIL=0 (unchanged baseline; `test_audit_history.sh` counts as one file in this runner regardless of its internal case count, so the total didn't move).

`shellcheck --severity=warning` clean on both changed files.

No behaviour change on the success path — cases 1-11 (pre-existing) pass unmodified.

Refs #1063

---

## Glossary

| Term | Definition |
|------|------------|
| Run file | Per-audit-run JSON under `projects/<name>/audits/<dimension>/runs/` — the persisted record one audit invocation writes, consumed by `audit_run_list` / `audit_render_trend` to build the trend chart |
| Stage-then-promote | Write output to a temp file first, then `mv` it into the real destination only once the content is verified good — the destination path never exists in a partial state |
| Atomic rename | `mv` within a single filesystem is atomic at the OS level — a reader either sees the old file or the new one, never a half-written one |
| Orphan `.md` | The markdown artefact existing on disk with no matching JSON run behind it — the pair has desynchronised |

