### PR TITLE
fix(#1050): resolve verify-commit-refs.sh's tracker repo from the commit's own directory

### DIFF
--- a/.claude/hooks/tests/test_verify_commit_refs_cwd.sh
+++ b/.claude/hooks/tests/test_verify_commit_refs_cwd.sh
@@ -300,6 +300,13 @@ assert_case() {
 # ---- Case 7: trailing, unrelated `git -C <dir> log` after the real ----
 # ---- commit must not bind to it (round-2 hijack, row 3).             ----
 #
+# REGRESSION LOCK, not a discriminator: this shape happened to pass under
+# BOTH the round-1 and round-2 implementations (verified — round-1's
+# unscoped `tail -1` scrape didn't end up preferring the decoy here either),
+# so it doesn't prove the round-2 fix by itself. Kept anyway to pin the
+# behavior going forward, since the commit-boundary logic this depends on
+# has since changed again (round 3, token-boundary fix below).
+#
 # No payload .cwd. Hook cwd = "real" (has the issue). The command has a
 # real, separate `git -C <decoy> log` AFTER the actual commit invocation —
 # a `-C` that belongs to a DIFFERENT git invocation, not this one.
@@ -313,7 +320,7 @@ assert_case() {
   cmd=$(build_command 'fix: trailing unrelated -C\n\nCloses #507' "" "" " && git -C ${decoy} log")
   out=$(run_hook "$real" "" "$cmd")
   rc=$?
-  assert_case "a trailing, unrelated 'git -C <dir> log' does not bind to this commit" \
+  assert_case "[regression lock] a trailing, unrelated 'git -C <dir> log' does not bind to this commit" \
     "$out" "$rc" 0 ""
   rm -rf "$real" "$decoy"
 }
@@ -371,6 +378,86 @@ assert_case() {
   assert_case "a relative cd path is not trusted; falls back to the hook's own cwd" \
     "$out" "$rc" 0 ""
   rm -rf "$ops"
+}
+
+# ---- Cases 11-13: a directory whose NAME merely CONTAINS the substring ----
+# ---- "commit" must not truncate the commit-boundary cut (round-3       ----
+# ---- hijack — a real bug in the round-2 fix's own `${cmd%%commit*}`,   ----
+# ---- caught end-to-end by the reviewer before merge).                  ----
+#
+# `${cmd%%commit*}` cuts at the first literal SUBSTRING "commit", not a
+# token boundary — so a path component like "commitizen" or "commits-repo"
+# truncates mid-directory. The truncated parent is usually not a git repo,
+# so the (pre-fix) failure mode is FAIL-OPEN: TRACKER_REPO ends up empty,
+# the hook hits the "could not resolve tracker repo — skipping" branch, and
+# ref verification is silently disabled (same class as round-1's
+# message-prose hijack, just a different trigger).
+#
+# Discriminator design: the referenced issue is set to NOT EXIST in the
+# CORRECT (untruncated) repo's origin. If the fix correctly resolves the
+# full path, the hook queries that origin, finds the ref missing, and
+# BLOCKS (rc=2, "do not exist in <repo>"). If truncation still occurs, the
+# truncated parent has no origin, TRACKER_REPO is empty, and the hook exits
+# 0 via the skip branch instead — silently passing a fabricated ref. So
+# rc=2 (not rc=0) is the proof that real verification happened against the
+# right repo, and the stderr assertion additionally rules out the skip
+# message appearing at all.
+
+# Case 11: `cd <path>/commitizen && git commit` — reviewer's row 1 example.
+{
+  ops=$(make_repo "me2resh/apexyard")
+  commitizen=$(make_repo "managed-org/tool" "commitizen")
+  mock_gh_install "$commitizen"
+  mock_gh_set_repo_existence "$commitizen" 511 "managed-org/tool" no
+
+  cmd=$(build_command 'fix: cd into a dir named commitizen\n\nCloses #511' "cd ${commitizen} && ")
+  out=$(run_hook "$ops" "" "$cmd")
+  rc=$?
+  assert_case "cd into .../commitizen resolves the FULL path, not truncated at 'commit'" \
+    "$out" "$rc" 2 "do not exist"
+  if echo "$out" | grep -qF "could not resolve tracker repo"; then
+    echo "FAIL [cd .../commitizen]: silently skipped instead of verifying — output: ${out:0:300}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}cd-commitizen-silent-skip "
+  fi
+  rm -rf "$ops" "$commitizen"
+}
+
+# Case 12: `git -C <path>/commitizen commit` — reviewer's row 2 example.
+{
+  ops=$(make_repo "me2resh/apexyard")
+  commitizen=$(make_repo "managed-org/tool2" "commitizen")
+  mock_gh_install "$commitizen"
+  mock_gh_set_repo_existence "$commitizen" 512 "managed-org/tool2" no
+
+  cmd=$(build_command 'fix: -C into a dir named commitizen\n\nCloses #512' "" "-C ${commitizen} ")
+  out=$(run_hook "$ops" "" "$cmd")
+  rc=$?
+  assert_case "git -C .../commitizen resolves the FULL path, not truncated at 'commit'" \
+    "$out" "$rc" 2 "do not exist"
+  if echo "$out" | grep -qF "could not resolve tracker repo"; then
+    echo "FAIL [-C .../commitizen]: silently skipped instead of verifying — output: ${out:0:300}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}dash-C-commitizen-silent-skip "
+  fi
+  rm -rf "$ops" "$commitizen"
+}
+
+# Case 13: `cd <path>/commits-repo && git commit` — reviewer's row 3 example.
+{
+  ops=$(make_repo "me2resh/apexyard")
+  commitsrepo=$(make_repo "managed-org/tool3" "commits-repo")
+  mock_gh_install "$commitsrepo"
+  mock_gh_set_repo_existence "$commitsrepo" 513 "managed-org/tool3" no
+
+  cmd=$(build_command 'fix: cd into a dir named commits-repo\n\nCloses #513' "cd ${commitsrepo} && ")
+  out=$(run_hook "$ops" "" "$cmd")
+  rc=$?
+  assert_case "cd into .../commits-repo resolves the FULL path, not truncated at 'commit'" \
+    "$out" "$rc" 2 "do not exist"
+  if echo "$out" | grep -qF "could not resolve tracker repo"; then
+    echo "FAIL [cd .../commits-repo]: silently skipped instead of verifying — output: ${out:0:300}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}cd-commits-repo-silent-skip "
+  fi
+  rm -rf "$ops" "$commitsrepo"
 }
 
 # ---- Summary ------------------------------------------------------------

--- a/.claude/hooks/tests/test_verify_commit_refs_cwd.sh
+++ b/.claude/hooks/tests/test_verify_commit_refs_cwd.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+# Tests for verify-commit-refs.sh cwd-vs-worktree resolution (me2resh/apexyard#1050)
+#
+# Bug: the hook resolved the tracker repo from `git rev-parse --show-toplevel`
+# / `git remote get-url origin` run with NO `-C`, which means both commands
+# used the HOOK PROCESS'S OWN cwd — not the directory the `git commit` is
+# actually executing in. In a split-portfolio / worktree-based sub-agent
+# session, the harness's Bash cwd for that call (the payload `.cwd` field,
+# same field `suggest-mcp-reindex-after-pull.sh` already reads) can be a
+# managed project's worktree while the hook process itself is invoked from
+# the ops fork. The hook then validates `Closes #N` against the OPS FORK's
+# tracker instead of the PROJECT's tracker, false-blocking a legitimate
+# reference.
+#
+# Coverage:
+#   - payload .cwd points at a different repo than the hook's own cwd →
+#     the referenced issue exists ONLY in the .cwd repo → must PASS
+#     (pre-fix: BLOCKS, because it checks the hook's own cwd's repo instead)
+#   - explicit `git -C <path> commit ...` in the command → must resolve
+#     against <path>'s repo, regardless of .cwd or the hook's own cwd
+#   - `cd <path> && git commit ...` compound prefix → must resolve against
+#     <path>'s repo
+#   - no .cwd, no -C, no cd-prefix → falls back to the hook's own process
+#     cwd, UNCHANGED from before the fix (no-regression case)
+#
+# Each case builds two isolated one-commit git sandboxes with different
+# `origin` remotes (simulating the ops fork vs. a managed project's
+# worktree), installs the shared mock `gh`, and pipes a synthetic
+# PreToolUse JSON blob at the hook while the hook's OWN process cwd is
+# deliberately the "wrong" sandbox.
+
+set -u
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/verify-commit-refs.sh"
+# shellcheck source=_lib-mock-gh.sh
+source "$(cd "$(dirname "$0")" && pwd)/_lib-mock-gh.sh"
+if [ ! -x "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK_SRC" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# Build a one-commit git sandbox with the given origin remote. No upstream
+# remote (keeps the upstream-fallback branch out of play for these cases).
+make_repo() {
+  local origin_slug="$1"
+  local rp
+  rp=$(mktemp -d)
+  (
+    cd "$rp" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    git remote add origin "git@github.com:${origin_slug}.git"
+    touch README.md
+    git add README.md
+    git commit -q -m "init"
+  )
+  echo "$rp"
+}
+
+# Build the `git commit -m "..."` command string. $1 uses literal `\n` for
+# newlines (for readability in the case table below); converted to REAL
+# newlines here, same as test_verify_commit_refs_upstream.sh does, so the
+# hook's REFS regex sees an actual word boundary before "Closes" / "Refs"
+# instead of a literal backslash-n glued directly onto the prior word.
+# $2 is an optional prefix prepended verbatim in front of `git commit`
+# (e.g. "git -C /path/to/repo " or "cd /path/to/repo && ").
+build_command() {
+  local msg_literal="$1" prefix="${2:-}"
+  local msg; msg=$(printf '%b' "$msg_literal")
+  printf '%sgit commit -m "%s"' "$prefix" "$msg"
+}
+
+# Run the hook with:
+#   - process cwd = $hook_cwd_repo (simulates the ops fork the hook is
+#     invoked from)
+#   - synthetic PreToolUse payload with the given .cwd (may be empty) and
+#     command
+# Prints combined captured stderr; rc is returned via $?.
+run_hook() {
+  local hook_cwd_repo="$1" payload_cwd="$2" command="$3"
+  local input result rc
+  if [ -n "$payload_cwd" ]; then
+    input=$(jq -nc --arg c "$command" --arg cwd "$payload_cwd" \
+      '{cwd:$cwd, tool_input:{command:$c}}')
+  else
+    input=$(jq -nc --arg c "$command" '{tool_input:{command:$c}}')
+  fi
+  result=$(cd "$hook_cwd_repo" && echo "$input" | bash "$HOOK_SRC" 2>&1 >/dev/null)
+  rc=$?
+  echo "$result"
+  return "$rc"
+}
+
+assert_case() {
+  local label="$1" got_output="$2" got_rc="$3" want_rc="$4" want_stderr_regex="$5"
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc (stderr: ${got_output:0:400})" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  if [ -n "$want_stderr_regex" ] && ! echo "$got_output" | grep -qE "$want_stderr_regex"; then
+    echo "FAIL [$label]: stderr did not match /$want_stderr_regex/" >&2
+    echo "    stderr: $got_output" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "; return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# ---- Case 1: payload .cwd is the source of truth, not the hook's own cwd ----
+#
+# Hook process cwd  = "ops" repo (origin: me2resh/apexyard)      — issue 500 MISSING
+# Payload .cwd      = "proj" repo (origin: managed-org/example)  — issue 500 EXISTS
+# A `git commit` with no -C and no cd-prefix, run with harness cwd = proj,
+# must validate against proj's tracker (managed-org/example), not ops's.
+{
+  ops=$(make_repo "me2resh/apexyard")
+  proj=$(make_repo "managed-org/example")
+  mock_gh_install "$proj"
+  mock_gh_set_repo_existence "$proj" 500 "managed-org/example" yes
+  mock_gh_set_repo_existence "$proj" 500 "me2resh/apexyard" no
+
+  cmd=$(build_command 'fix: worktree commit\n\nCloses #500')
+  out=$(run_hook "$ops" "$proj" "$cmd")
+  rc=$?
+  assert_case "payload .cwd resolves to the project's own repo, not the hook's cwd" \
+    "$out" "$rc" 0 ""
+  rm -rf "$ops" "$proj"
+}
+
+# ---- Case 2: explicit `git -C <path>` in the command wins outright ----
+#
+# Hook process cwd AND payload .cwd both = "ops" repo (issue 501 missing there).
+# The command itself carries `-C <proj>`, which must take priority over both.
+{
+  ops=$(make_repo "me2resh/apexyard")
+  proj=$(make_repo "managed-org/example")
+  mock_gh_install "$proj"
+  mock_gh_set_repo_existence "$proj" 501 "managed-org/example" yes
+  mock_gh_set_repo_existence "$proj" 501 "me2resh/apexyard" no
+
+  cmd=$(build_command 'fix: dash-C commit\n\nCloses #501' "git -C ${proj} ")
+  out=$(run_hook "$ops" "$ops" "$cmd")
+  rc=$?
+  assert_case "explicit git -C <path> resolves against that path's repo" \
+    "$out" "$rc" 0 ""
+  rm -rf "$ops" "$proj"
+}
+
+# ---- Case 3: `cd <path> && git commit ...` compound prefix ----
+#
+# Hook process cwd AND payload .cwd both = "ops" repo (issue 502 missing there).
+# The command is a compound `cd <proj> && git commit ...` — the effective
+# cwd for the git call is proj, even though nothing else says so.
+{
+  ops=$(make_repo "me2resh/apexyard")
+  proj=$(make_repo "managed-org/example")
+  mock_gh_install "$proj"
+  mock_gh_set_repo_existence "$proj" 502 "managed-org/example" yes
+  mock_gh_set_repo_existence "$proj" 502 "me2resh/apexyard" no
+
+  cmd=$(build_command 'fix: cd-prefix commit\n\nCloses #502' "cd ${proj} && ")
+  out=$(run_hook "$ops" "$ops" "$cmd")
+  rc=$?
+  assert_case "cd <path> && git commit prefix resolves against that path's repo" \
+    "$out" "$rc" 0 ""
+  rm -rf "$ops" "$proj"
+}
+
+# ---- Case 4: no-regression — no .cwd, no -C, no cd-prefix falls back to ----
+# ---- the hook's own process cwd (today's exact behavior)                ----
+{
+  ops=$(make_repo "managed-org/example")
+  mock_gh_install "$ops"
+  mock_gh_set_repo_existence "$ops" 503 "managed-org/example" yes
+
+  cmd=$(build_command 'fix: plain commit\n\nCloses #503')
+  out=$(run_hook "$ops" "" "$cmd")
+  rc=$?
+  assert_case "no cwd/-C/cd-prefix hints → falls back to hook's own process cwd" \
+    "$out" "$rc" 0 ""
+  rm -rf "$ops"
+}
+
+# ---- Case 5: cwd mismatch producing a genuine block — the false-BLOCK ----
+# ---- shape from the bug report: referenced issue exists ONLY in the    ----
+# ---- project repo, hook (pre-fix) checks the wrong one and blocks.      ----
+{
+  ops=$(make_repo "me2resh/apexyard")
+  proj=$(make_repo "managed-org/example")
+  mock_gh_install "$proj"
+  mock_gh_set_repo_existence "$proj" 504 "managed-org/example" yes
+  mock_gh_set_repo_existence "$proj" 504 "me2resh/apexyard" no
+
+  cmd=$(build_command 'fix: another worktree commit\n\nRefs #504')
+  out=$(run_hook "$ops" "$proj" "$cmd")
+  rc=$?
+  assert_case "payload .cwd case again with Refs keyword → pass, not false-blocked" \
+    "$out" "$rc" 0 ""
+  rm -rf "$ops" "$proj"
+}
+
+# ---- Summary ------------------------------------------------------------
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_verify_commit_refs_cwd.sh
+++ b/.claude/hooks/tests/test_verify_commit_refs_cwd.sh
@@ -1,31 +1,66 @@
 #!/bin/bash
 # Tests for verify-commit-refs.sh cwd-vs-worktree resolution (me2resh/apexyard#1050)
+# and its follow-up hijack fixes (PR #1073 review).
 #
-# Bug: the hook resolved the tracker repo from `git rev-parse --show-toplevel`
-# / `git remote get-url origin` run with NO `-C`, which means both commands
-# used the HOOK PROCESS'S OWN cwd — not the directory the `git commit` is
-# actually executing in. In a split-portfolio / worktree-based sub-agent
-# session, the harness's Bash cwd for that call (the payload `.cwd` field,
-# same field `suggest-mcp-reindex-after-pull.sh` already reads) can be a
-# managed project's worktree while the hook process itself is invoked from
-# the ops fork. The hook then validates `Closes #N` against the OPS FORK's
-# tracker instead of the PROJECT's tracker, false-blocking a legitimate
-# reference.
+# Round 1 bug: the hook resolved the tracker repo from `git rev-parse
+# --show-toplevel` / `git remote get-url origin` run with NO `-C`, which
+# means both commands used the HOOK PROCESS'S OWN cwd — not the directory
+# the `git commit` is actually executing in. In a split-portfolio /
+# worktree-based sub-agent session, the harness's Bash cwd for that call
+# (the payload `.cwd` field, same field suggest-mcp-reindex-after-pull.sh
+# already reads) can be a managed project's worktree while the hook process
+# itself is invoked from the ops fork. The hook then validated `Closes #N`
+# against the OPS FORK's tracker instead of the PROJECT's, false-blocking a
+# legitimate reference.
+#
+# Round 2 bug (caught in PR #1073 review, before merge): the round-1 fix
+# passed the WHOLE raw command — including the commit MESSAGE — to the
+# `-C`/`cd` scraper, and checked those scraped hints BEFORE the structured
+# harness `.cwd` field. That combination is reachable in both directions:
+#   - a commit MESSAGE containing the text `git -C <dir>` got scraped as
+#     real shell syntax
+#   - `git commit -m "..." && git -C /other log` — a `-C` belonging to a
+#     LATER, unrelated git invocation bound to this commit
+#   - `cd /real && git -C /other status && git commit` — same shape,
+#     discarding the real governing `cd /real`
+#   - a relative `cd ../sibling` resolved against the hook's own cwd — the
+#     very cwd the round-1 fix exists to distrust
+#   - a quoted path with spaces (`cd "/my path/repo"`) truncated at the
+#     first space, silently reverting to pre-fix behavior
+# The fix: strip the commit message out of the command before scanning
+# (literal substring removal, not a regex), bind `-C` detection to THIS
+# commit invocation only (immediately preceding the `commit` token, not
+# anywhere else in the command), and check the harness `.cwd` FIRST —
+# structured beats scraped — so the scraped fallback only matters when
+# `.cwd` is genuinely absent.
 #
 # Coverage:
 #   - payload .cwd points at a different repo than the hook's own cwd →
-#     the referenced issue exists ONLY in the .cwd repo → must PASS
-#     (pre-fix: BLOCKS, because it checks the hook's own cwd's repo instead)
-#   - explicit `git -C <path> commit ...` in the command → must resolve
-#     against <path>'s repo, regardless of .cwd or the hook's own cwd
-#   - `cd <path> && git commit ...` compound prefix → must resolve against
-#     <path>'s repo
+#     must resolve via .cwd (round-1 core case)
+#   - payload .cwd wins outright even when the command ALSO carries a
+#     competing, plausible-looking `-C` elsewhere (pins "structured beats
+#     scraped" explicitly)
+#   - explicit `git -C <path> commit ...`, .cwd ABSENT → resolves via the
+#     command (round-1 fallback case, still covered)
+#   - `cd <path> && git commit ...`, .cwd ABSENT → resolves via the command
 #   - no .cwd, no -C, no cd-prefix → falls back to the hook's own process
-#     cwd, UNCHANGED from before the fix (no-regression case)
+#     cwd, UNCHANGED from before either fix (no-regression case)
+#   - commit MESSAGE containing `git -C <dir>` text, .cwd ABSENT → must NOT
+#     be scraped as real syntax (round-2 hijack, message-content direction)
+#   - `git commit -m "..." && git -C <other> log`, .cwd ABSENT → the
+#     trailing, unrelated `-C` must NOT bind to this commit (round-2 hijack)
+#   - `cd <real> && git -C <other> status && git commit`, .cwd ABSENT → the
+#     intervening, unrelated `-C` must NOT override the real governing `cd`
+#   - `cd "<path with spaces>" && git commit ...`, .cwd ABSENT → a quoted,
+#     spacey path must resolve correctly, not truncate at the first space
+#   - a RELATIVE `cd ../sibling`, .cwd ABSENT → must NOT be trusted (only
+#     absolute paths are accepted out of the scraped fallback); falls
+#     through to the hook's own cwd rather than an ambiguous relative
+#     resolution
 #
-# Each case builds two isolated one-commit git sandboxes with different
-# `origin` remotes (simulating the ops fork vs. a managed project's
-# worktree), installs the shared mock `gh`, and pipes a synthetic
+# Each case builds one-or-two isolated one-commit git sandboxes with
+# different `origin` remotes (simulating the ops fork vs. a managed
+# project's worktree), installs the shared mock `gh`, and pipes a synthetic
 # PreToolUse JSON blob at the hook while the hook's OWN process cwd is
 # deliberately the "wrong" sandbox.
 
@@ -45,10 +80,18 @@ FAILED_CASES=""
 
 # Build a one-commit git sandbox with the given origin remote. No upstream
 # remote (keeps the upstream-fallback branch out of play for these cases).
+# $2, if given, is a subdirectory name to create the repo inside (used to
+# manufacture a path containing spaces).
 make_repo() {
-  local origin_slug="$1"
-  local rp
-  rp=$(mktemp -d)
+  local origin_slug="$1" subdir="${2:-}"
+  local base rp
+  base=$(mktemp -d)
+  if [ -n "$subdir" ]; then
+    rp="$base/$subdir"
+    mkdir -p "$rp"
+  else
+    rp="$base"
+  fi
   (
     cd "$rp" || exit 1
     git init -q
@@ -67,12 +110,17 @@ make_repo() {
 # newlines here, same as test_verify_commit_refs_upstream.sh does, so the
 # hook's REFS regex sees an actual word boundary before "Closes" / "Refs"
 # instead of a literal backslash-n glued directly onto the prior word.
-# $2 is an optional prefix prepended verbatim in front of `git commit`
-# (e.g. "git -C /path/to/repo " or "cd /path/to/repo && ").
+# $2 is an optional prefix prepended verbatim BEFORE the `git` token (e.g.
+# "cd /path/to/repo && "). $3 is optional FLAGS inserted BETWEEN `git` and
+# `commit` (e.g. "-C /path/to/repo "). $4 is an optional SUFFIX appended
+# after the closing quote of the -m value (e.g. ' && git -C /other log').
+# Keeping prefix/flags/suffix as separate slots (rather than one combined
+# string) avoids accidentally emitting a duplicated `git` token or losing
+# track of exactly where the real commit invocation sits.
 build_command() {
-  local msg_literal="$1" prefix="${2:-}"
+  local msg_literal="$1" prefix="${2:-}" flags="${3:-}" suffix="${4:-}"
   local msg; msg=$(printf '%b' "$msg_literal")
-  printf '%sgit commit -m "%s"' "$prefix" "$msg"
+  printf '%sgit %scommit -m "%s"%s' "$prefix" "$flags" "$msg" "$suffix"
 }
 
 # Run the hook with:
@@ -132,10 +180,34 @@ assert_case() {
   rm -rf "$ops" "$proj"
 }
 
-# ---- Case 2: explicit `git -C <path>` in the command wins outright ----
+# ---- Case 1b: structured .cwd wins even when a competing -C is present ----
 #
-# Hook process cwd AND payload .cwd both = "ops" repo (issue 501 missing there).
-# The command itself carries `-C <proj>`, which must take priority over both.
+# Payload .cwd = proj (has the issue). The command ALSO carries a plausible
+# `-C <decoy>` bound directly to this same commit invocation. Per the #1073
+# review, structured beats scraped: .cwd must win outright and the `-C`
+# must never even be considered. Set decoy's mock answer to "no" so a wrong
+# resolution would BLOCK, making this a real discriminator.
+{
+  ops=$(make_repo "me2resh/apexyard")
+  proj=$(make_repo "managed-org/example")
+  decoy=$(make_repo "someone-else/decoy")
+  mock_gh_install "$proj"
+  mock_gh_set_repo_existence "$proj" 505 "managed-org/example" yes
+  mock_gh_set_repo_existence "$proj" 505 "someone-else/decoy" no
+
+  cmd=$(build_command 'fix: cwd beats a competing -C\n\nCloses #505' "" "-C ${decoy} ")
+  out=$(run_hook "$ops" "$proj" "$cmd")
+  rc=$?
+  assert_case "payload .cwd wins outright over a competing in-command -C" \
+    "$out" "$rc" 0 ""
+  rm -rf "$ops" "$proj" "$decoy"
+}
+
+# ---- Case 2: explicit `git -C <path>` in the command, .cwd ABSENT ----
+#
+# No payload .cwd supplied. Hook process cwd = "ops" (issue 501 missing
+# there). The command carries `-C <proj>` bound directly to this commit —
+# with no structured .cwd to prefer, this scraped hint is what resolves it.
 {
   ops=$(make_repo "me2resh/apexyard")
   proj=$(make_repo "managed-org/example")
@@ -143,19 +215,15 @@ assert_case() {
   mock_gh_set_repo_existence "$proj" 501 "managed-org/example" yes
   mock_gh_set_repo_existence "$proj" 501 "me2resh/apexyard" no
 
-  cmd=$(build_command 'fix: dash-C commit\n\nCloses #501' "git -C ${proj} ")
-  out=$(run_hook "$ops" "$ops" "$cmd")
+  cmd=$(build_command 'fix: dash-C commit\n\nCloses #501' "" "-C ${proj} ")
+  out=$(run_hook "$ops" "" "$cmd")
   rc=$?
-  assert_case "explicit git -C <path> resolves against that path's repo" \
+  assert_case "explicit git -C <path> resolves against that path's repo (no .cwd)" \
     "$out" "$rc" 0 ""
   rm -rf "$ops" "$proj"
 }
 
-# ---- Case 3: `cd <path> && git commit ...` compound prefix ----
-#
-# Hook process cwd AND payload .cwd both = "ops" repo (issue 502 missing there).
-# The command is a compound `cd <proj> && git commit ...` — the effective
-# cwd for the git call is proj, even though nothing else says so.
+# ---- Case 3: `cd <path> && git commit ...` compound prefix, .cwd ABSENT ----
 {
   ops=$(make_repo "me2resh/apexyard")
   proj=$(make_repo "managed-org/example")
@@ -164,9 +232,9 @@ assert_case() {
   mock_gh_set_repo_existence "$proj" 502 "me2resh/apexyard" no
 
   cmd=$(build_command 'fix: cd-prefix commit\n\nCloses #502' "cd ${proj} && ")
-  out=$(run_hook "$ops" "$ops" "$cmd")
+  out=$(run_hook "$ops" "" "$cmd")
   rc=$?
-  assert_case "cd <path> && git commit prefix resolves against that path's repo" \
+  assert_case "cd <path> && git commit prefix resolves against that path's repo (no .cwd)" \
     "$out" "$rc" 0 ""
   rm -rf "$ops" "$proj"
 }
@@ -187,8 +255,8 @@ assert_case() {
 }
 
 # ---- Case 5: cwd mismatch producing a genuine block — the false-BLOCK ----
-# ---- shape from the bug report: referenced issue exists ONLY in the    ----
-# ---- project repo, hook (pre-fix) checks the wrong one and blocks.      ----
+# ---- shape from the round-1 bug report: referenced issue exists ONLY   ----
+# ---- in the project repo; hook must resolve via .cwd, not block.       ----
 {
   ops=$(make_repo "me2resh/apexyard")
   proj=$(make_repo "managed-org/example")
@@ -202,6 +270,107 @@ assert_case() {
   assert_case "payload .cwd case again with Refs keyword → pass, not false-blocked" \
     "$out" "$rc" 0 ""
   rm -rf "$ops" "$proj"
+}
+
+# ---- Case 6: commit MESSAGE containing `git -C <dir>` text must not be ----
+# ---- scraped as real shell syntax (round-2 hijack, message direction). ----
+#
+# No payload .cwd. Hook cwd = "real" (has the issue). The message's PROSE
+# mentions a real, existing directory ("decoy", a different repo without
+# the issue) via the literal text "git -C <decoy>". Pre-round-2-fix, the
+# resolver scanned the WHOLE raw command (including this prose) and would
+# have picked up "decoy" as though it were real command syntax, blocking a
+# legitimate reference. Fixed: the message is stripped before scanning, so
+# this text is never read as syntax; falls back to the hook's own cwd.
+{
+  real=$(make_repo "managed-org/real")
+  decoy=$(make_repo "someone-else/decoy")
+  mock_gh_install "$real"
+  mock_gh_set_repo_existence "$real" 506 "managed-org/real" yes
+  mock_gh_set_repo_existence "$real" 506 "someone-else/decoy" no
+
+  cmd=$(build_command "fix: mentions git -C ${decoy} in prose\n\nSee git -C ${decoy} for the reproduction steps.\n\nCloses #506")
+  out=$(run_hook "$real" "" "$cmd")
+  rc=$?
+  assert_case "commit message text 'git -C <dir>' is not scraped as real syntax" \
+    "$out" "$rc" 0 ""
+  rm -rf "$real" "$decoy"
+}
+
+# ---- Case 7: trailing, unrelated `git -C <dir> log` after the real ----
+# ---- commit must not bind to it (round-2 hijack, row 3).             ----
+#
+# No payload .cwd. Hook cwd = "real" (has the issue). The command has a
+# real, separate `git -C <decoy> log` AFTER the actual commit invocation —
+# a `-C` that belongs to a DIFFERENT git invocation, not this one.
+{
+  real=$(make_repo "managed-org/real")
+  decoy=$(make_repo "someone-else/decoy")
+  mock_gh_install "$real"
+  mock_gh_set_repo_existence "$real" 507 "managed-org/real" yes
+  mock_gh_set_repo_existence "$real" 507 "someone-else/decoy" no
+
+  cmd=$(build_command 'fix: trailing unrelated -C\n\nCloses #507' "" "" " && git -C ${decoy} log")
+  out=$(run_hook "$real" "" "$cmd")
+  rc=$?
+  assert_case "a trailing, unrelated 'git -C <dir> log' does not bind to this commit" \
+    "$out" "$rc" 0 ""
+  rm -rf "$real" "$decoy"
+}
+
+# ---- Case 8: governing `cd <real> &&` plus an INTERVENING unrelated  ----
+# ---- `git -C <decoy> status &&` before the real commit (round-2      ----
+# ---- hijack, row 4) — the intervening -C must not override the real  ----
+# ---- governing cd.                                                    ----
+{
+  real=$(make_repo "managed-org/real")
+  decoy=$(make_repo "someone-else/decoy")
+  mock_gh_install "$real"
+  mock_gh_set_repo_existence "$real" 508 "managed-org/real" yes
+  mock_gh_set_repo_existence "$real" 508 "someone-else/decoy" no
+
+  cmd=$(build_command 'fix: governing cd with intervening -C\n\nCloses #508' \
+    "cd ${real} && git -C ${decoy} status && ")
+  out=$(run_hook "$decoy" "" "$cmd")
+  rc=$?
+  assert_case "an intervening, unrelated 'git -C <dir> status' does not override the governing cd" \
+    "$out" "$rc" 0 ""
+  rm -rf "$real" "$decoy"
+}
+
+# ---- Case 9: quoted path with spaces must resolve correctly, not     ----
+# ---- truncate at the first space (round-2 hijack, row 6).            ----
+{
+  base=$(mktemp -d)
+  spacey=$(make_repo "managed-org/spacey" "my repo with spaces")
+  ops=$(make_repo "me2resh/apexyard")
+  mock_gh_install "$spacey"
+  mock_gh_set_repo_existence "$spacey" 509 "managed-org/spacey" yes
+  mock_gh_set_repo_existence "$spacey" 509 "me2resh/apexyard" no
+
+  cmd=$(build_command 'fix: quoted spacey path\n\nCloses #509' "cd \"${spacey}\" && ")
+  out=$(run_hook "$ops" "" "$cmd")
+  rc=$?
+  assert_case "a quoted cd path containing spaces resolves correctly, not truncated" \
+    "$out" "$rc" 0 ""
+  rm -rf "$base" "$spacey" "$ops"
+}
+
+# ---- Case 10: a RELATIVE cd path must not be trusted (round-2 hijack, ----
+# ---- row 5) — only absolute scraped paths are honored; a relative one ----
+# ---- falls through to the hook's own cwd rather than an ambiguous     ----
+# ---- resolution against an unknown base.                              ----
+{
+  ops=$(make_repo "managed-org/example")
+  mock_gh_install "$ops"
+  mock_gh_set_repo_existence "$ops" 510 "managed-org/example" yes
+
+  cmd=$(build_command 'fix: relative cd is not trusted\n\nCloses #510' "cd ../some-sibling && ")
+  out=$(run_hook "$ops" "" "$cmd")
+  rc=$?
+  assert_case "a relative cd path is not trusted; falls back to the hook's own cwd" \
+    "$out" "$rc" 0 ""
+  rm -rf "$ops"
 }
 
 # ---- Summary ------------------------------------------------------------

--- a/.claude/hooks/verify-commit-refs.sh
+++ b/.claude/hooks/verify-commit-refs.sh
@@ -36,8 +36,15 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-# Only check on git commit
-if ! echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
+# Only check on git commit. Also recognizes `git -C <path> commit` (quoted
+# or bare) — a bare `\bgit\s+commit\b` check misses this shape entirely
+# (the `-C <path>` sits between "git" and "commit", so the two tokens are
+# never adjacent), which meant a commit made via explicit `-C` — exactly
+# the pattern a worktree-based sub-agent uses (me2resh/apexyard#1050) —
+# skipped ref verification altogether, regardless of any cwd-resolution fix
+# below. Round-3 review caught this: the WORKDIR resolver's `-C`-bound-to-
+# commit priority level was otherwise unreachable in practice.
+if ! echo "$COMMAND" | grep -qE '\bgit[[:space:]]+(-C[[:space:]]+("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]]+)[[:space:]]+)?commit\b'; then
   exit 0
 fi
 
@@ -201,12 +208,47 @@ strip_message_from_command() {
 
 # Extract a governing directory from the (message-stripped) command, bound
 # to THIS commit invocation only. Only the portion of the command BEFORE
-# the first `commit` keyword is considered — a `-C` / `cd` at or after that
+# the first `commit` TOKEN is considered — a `-C` / `cd` at or after that
 # point belongs to a later command in the same compound line and must not
 # be read as governing this one.
+#
+# The cut point MUST be a token boundary, not a bare substring search. An
+# earlier version of this function used `${cmd%%commit*}`, which cuts at
+# the first literal SUBSTRING "commit" — truncating mid-path for any
+# directory name that merely CONTAINS that substring (`commitizen`,
+# `pre-commit-hooks`, `commitlint`, `commits-repo`, ...). That failure is
+# fail-OPEN: the truncated parent is usually not a git repo, so the caller
+# falls through to the "could not resolve tracker repo — skipping" branch
+# and ref verification is silently disabled (me2resh/apexyard#1050 review,
+# round 3). A leading space is prepended so the boundary pattern
+# `[[:space:]]commit([[:space:]]|$)` can require a preceding space
+# uniformly, with no special case for "commit" occurring at position 0.
 resolve_commit_workdir_from_command() {
-  local cmd="$1" prefix dir
-  prefix="${cmd%%commit*}"
+  local cmd="$1" padded pos prefix dir
+  padded=" $cmd"
+  pos=$(printf '%s' "$padded" | awk '
+    { buf = (NR == 1 ? $0 : buf "\n" $0) }
+    END {
+      if (match(buf, /[[:space:]]commit([[:space:]]|$)/)) {
+        print RSTART
+      } else {
+        print 0
+      }
+    }
+  ')
+  if [ "$pos" -gt 1 ] 2>/dev/null; then
+    # RSTART (1-based, in PADDED) points at the whitespace char immediately
+    # before the "commit" token. padded[2..pos] == cmd[1..pos-1] — the
+    # commit's own leading directory hints, with the artificial leading
+    # space dropped.
+    prefix=$(printf '%s' "$padded" | cut -c "2-${pos}")
+  else
+    # No bounded "commit" token found at all (e.g. it only ever appeared
+    # inside the now-stripped message) — nothing to bound against; fall
+    # through to scanning the whole (message-stripped) string, same as
+    # before this token-boundary fix existed.
+    prefix="$cmd"
+  fi
 
   # `-C <path>` immediately preceding THIS commit (`git -C <path> commit`).
   # Anchored at the END of prefix so a `-C` on an earlier, unrelated git
@@ -243,18 +285,34 @@ PAYLOAD_CWD=$(echo "$INPUT" | jq -r '.cwd // .tool_input.cwd // empty' 2>/dev/nu
 CMD_SANS_MSG=$(strip_message_from_command "$COMMAND" "$MSG")
 
 # 1. Structured harness cwd wins outright when present and absolute.
+# WORKDIR_SOURCE distinguishes "we resolved a hint" from "nothing resolved
+# and we fell back" — used below to give the "could not resolve tracker
+# repo" warning a sharper message when a HINT was found but didn't pan out
+# (e.g. it resolved to a directory with no git origin at all), versus the
+# unremarkable case where no hint existed and the fallback is expected.
 WORKDIR=""
+WORKDIR_SOURCE="fallback"
 if [ -n "$PAYLOAD_CWD" ] && [ "${PAYLOAD_CWD#/}" != "$PAYLOAD_CWD" ]; then
   WORKDIR="$PAYLOAD_CWD"
+  WORKDIR_SOURCE="payload_cwd"
 fi
 # 2 & 3. Only reached when .cwd is absent — scraped, message-stripped,
 # same-invocation-only command parsing.
 if [ -z "$WORKDIR" ]; then
   WORKDIR=$(resolve_commit_workdir_from_command "$CMD_SANS_MSG")
+  if [ -n "$WORKDIR" ]; then
+    WORKDIR_SOURCE="scraped_command"
+  fi
 fi
 # 4. No hint resolved anything usable — fall back to this process's own cwd,
 # exactly what every git call below did before this fix.
 if [ -z "$WORKDIR" ] || [ ! -d "$WORKDIR" ]; then
+  if [ -n "$WORKDIR" ]; then
+    # A hint WAS found (payload .cwd or scraped command) but the directory
+    # doesn't even exist — worth remembering for the warning below, since
+    # this is exactly the shape a truncated/incorrect scrape produces.
+    WORKDIR_SOURCE="${WORKDIR_SOURCE}_unresolvable:${WORKDIR}"
+  fi
   WORKDIR="$PWD"
 fi
 
@@ -316,8 +374,25 @@ fi
 # `tracker.kind = gh` (default) still requires an origin / configured repo;
 # preserve today's behaviour. For non-gh kinds the {owner_repo} placeholder
 # in the configured view_command may be unused, so we don't gate on it.
+#
+# The message distinguishes "no cwd/-C/cd hint existed at all" (WORKDIR_SOURCE
+# = fallback; unremarkable, this is the ordinary interactive/local-repo case)
+# from "a hint WAS resolved but it doesn't have a usable git origin"
+# (payload_cwd / scraped_command, or the *_unresolvable:<dir> shape when the
+# resolved directory didn't even exist) — the latter is worth a sharper
+# signal, since a truncated or mis-scraped directory hint silently landing
+# here (ref verification skipped, not blocked) is exactly the failure class
+# a prior version of this fix introduced (me2resh/apexyard#1050 review,
+# round 3: a path substring-matching "commit" got truncated mid-directory).
 if [ "$TRACKER_KIND" = "gh" ] && [ -z "$TRACKER_REPO" ]; then
-  echo "WARN: verify-commit-refs.sh could not resolve tracker repo. Skipping." >&2
+  case "$WORKDIR_SOURCE" in
+    fallback)
+      echo "WARN: verify-commit-refs.sh could not resolve tracker repo. Skipping." >&2
+      ;;
+    *)
+      echo "WARN: verify-commit-refs.sh resolved a working-directory hint (source: ${WORKDIR_SOURCE}, dir: ${WORKDIR}) but it has no usable git origin — skipping ref verification. If this directory looks truncated or wrong, that's a bug in the cwd/-C/cd scraper, not a config problem." >&2
+      ;;
+  esac
   exit 0
 fi
 

--- a/.claude/hooks/verify-commit-refs.sh
+++ b/.claude/hooks/verify-commit-refs.sh
@@ -129,42 +129,129 @@ fi
 # cwd-relative git call below must run against the COMMIT's directory, not
 # wherever this script happened to start.
 #
-# Priority (highest first) — mirrors suggest-mcp-reindex-after-pull.sh's
-# cwd-then-command-parsed fallback chain, but ordered so an explicit,
-# in-command override always wins over the ambient payload cwd:
-#   1. an explicit `git -C <path>` on the commit invocation itself —
-#      authoritative regardless of cwd or any earlier `cd`.
-#   2. a `cd <path> &&`-style prefix earlier in the SAME compound command —
-#      changes the effective cwd for everything that follows it.
-#   3. the harness-provided `.cwd` (or `.tool_input.cwd`) for this Bash
-#      call — the common case: a bare `git commit -m ...` run from inside
-#      the intended worktree with no path arguments at all.
+# Priority (highest first) — corrected per PR #1073 review. The harness
+# `.cwd` field is STRUCTURED: the harness itself sets it for this exact Bash
+# call, and it cannot be influenced by anything the commit message says.
+# Everything else is SCRAPED out of $COMMAND text, which can be tricked by
+# the commit message's own prose, or by an unrelated LATER git invocation in
+# the same compound command. Structured beats scraped, so `.cwd` goes first
+# — this now correctly mirrors suggest-mcp-reindex-after-pull.sh (see its
+# cwd-first fallback chain around lines 109-138: `.cwd` is "the common
+# case", checked FIRST, with command-parsing only as a fallback). An earlier
+# version of this fix put the scraped `-C`/`cd` parsing AHEAD of `.cwd` and
+# justified it as "an explicit in-command override always wins" — that
+# ordering is exactly what made these reachable:
+#   - a commit MESSAGE containing the text `git -C <dir>` got scraped as
+#     real shell syntax, silently disabling ref verification (if <dir>
+#     isn't a git repo) or validating a real ref against the wrong repo (if
+#     it is)
+#   - `git commit -m "..." && git -C /other log` — a `-C` belonging to a
+#     LATER, unrelated git invocation got treated as though it governed
+#     this commit
+#   - `cd /real && git -C /other status && git commit` — same shape,
+#     discarding the real governing `cd /real`
+#   - a relative `cd ../sibling` resolved against the HOOK's OWN cwd — the
+#     very cwd this fix exists to distrust
+#
+# Priority now:
+#   1. the harness-provided `.cwd` (`.tool_input.cwd`) for this Bash call.
+#   2. `git -C <path>` bound DIRECTLY to this commit invocation
+#      (`git -C <path> commit`), scraped from the command with the commit
+#      MESSAGE stripped out first (so prose can never be read as syntax),
+#      and matched only when the `-C` is the last thing before THIS
+#      `commit` token — a `-C` on a different git invocation cannot bind.
+#   3. the LAST `cd <path>` occurring before this commit invocation, same
+#      message-stripped, same-invocation-only scoping.
 #   4. fall back to the hook's own process cwd — IDENTICAL to the pre-fix
 #      behavior, so a session with no worktree involved sees no change.
-resolve_commit_workdir() {
-  local cmd="$1" payload_cwd="$2" dir
-  # 1. `git -C <path>` anywhere in the command (last one wins, matching how
-  # git itself would apply repeated -C flags).
-  dir=$(echo "$cmd" | grep -oE 'git[[:space:]]+-C[[:space:]]+[^[:space:]]+' | tail -1 | sed -E 's/^git[[:space:]]+-C[[:space:]]+//')
-  if [ -n "$dir" ]; then
+# Only ABSOLUTE paths are trusted out of (1)-(3); a relative path is
+# ambiguous about what it's relative TO, so it's treated as absent rather
+# than resolved against the hook's own cwd via a coincidental `-d` pass.
+
+# Strip the commit message out of COMMAND before any scraping below — a
+# literal, non-regex substring removal. Deliberately NOT `awk -v` on the raw
+# content: POSIX awk's `-v`/command-line-operand assignment undergoes its
+# own escape-sequence processing, which can silently mangle a message
+# containing backslash sequences (a commit message describing THIS hook is
+# exactly that kind of text — see #1073's review). Both values are piped in
+# through stdin instead, joined by a private sentinel, and sliced with
+# index()/substr() so nothing is ever regex- or escape-interpreted.
+strip_message_from_command() {
+  local cmd="$1" msg="$2" sep="__apexyard_1050_msg_boundary__"
+  if [ -z "$msg" ]; then
+    printf '%s' "$cmd"
+    return
+  fi
+  printf '%s%s%s' "$cmd" "$sep" "$msg" | awk -v sep="$sep" '
+    { buf = (NR == 1 ? $0 : buf "\n" $0) }
+    END {
+      sidx = index(buf, sep)
+      if (sidx == 0) { printf "%s", buf; exit }
+      c = substr(buf, 1, sidx - 1)
+      m = substr(buf, sidx + length(sep))
+      midx = index(c, m)
+      if (midx > 0 && length(m) > 0) {
+        printf "%s%s", substr(c, 1, midx - 1), substr(c, midx + length(m))
+      } else {
+        printf "%s", c
+      }
+    }
+  '
+}
+
+# Extract a governing directory from the (message-stripped) command, bound
+# to THIS commit invocation only. Only the portion of the command BEFORE
+# the first `commit` keyword is considered — a `-C` / `cd` at or after that
+# point belongs to a later command in the same compound line and must not
+# be read as governing this one.
+resolve_commit_workdir_from_command() {
+  local cmd="$1" prefix dir
+  prefix="${cmd%%commit*}"
+
+  # `-C <path>` immediately preceding THIS commit (`git -C <path> commit`).
+  # Anchored at the END of prefix so a `-C` on an earlier, unrelated git
+  # invocation in the same compound command does not match.
+  dir=""
+  if echo "$prefix" | grep -qE 'git[[:space:]]+-C[[:space:]]+"[^"]*"[[:space:]]*$'; then
+    dir=$(echo "$prefix" | sed -E 's/^.*git[[:space:]]+-C[[:space:]]+"([^"]*)"[[:space:]]*$/\1/')
+  elif echo "$prefix" | grep -qE "git[[:space:]]+-C[[:space:]]+'[^']*'[[:space:]]*\$"; then
+    dir=$(echo "$prefix" | sed -E "s/^.*git[[:space:]]+-C[[:space:]]+'([^']*)'[[:space:]]*\$/\1/")
+  elif echo "$prefix" | grep -qE 'git[[:space:]]+-C[[:space:]]+[^[:space:]]+[[:space:]]*$'; then
+    dir=$(echo "$prefix" | sed -E 's/^.*git[[:space:]]+-C[[:space:]]+([^[:space:]]+)[[:space:]]*$/\1/')
+  fi
+  if [ -n "$dir" ] && [ "${dir#/}" != "$dir" ]; then
     echo "$dir"
     return
   fi
-  # 2. `cd <path>` at the start of the command or after a shell separator.
-  dir=$(echo "$cmd" | grep -oE '(^|&&|;)[[:space:]]*cd[[:space:]]+[^[:space:]&|;]+' | tail -1 | sed -E 's/^(&&|;)?[[:space:]]*cd[[:space:]]+//')
-  if [ -n "$dir" ]; then
-    echo "$dir"
-    return
+
+  # Last `cd <path>` occurring anywhere before this commit invocation.
+  dir=""
+  if echo "$prefix" | grep -qE '(^|&&|;)[[:space:]]*cd[[:space:]]+"[^"]*"'; then
+    dir=$(echo "$prefix" | grep -oE '(^|&&|;)[[:space:]]*cd[[:space:]]+"[^"]*"' | tail -1 | sed -E 's/^(&&|;)?[[:space:]]*cd[[:space:]]+"([^"]*)"$/\2/')
+  elif echo "$prefix" | grep -qE "(^|&&|;)[[:space:]]*cd[[:space:]]+'[^']*'"; then
+    dir=$(echo "$prefix" | grep -oE "(^|&&|;)[[:space:]]*cd[[:space:]]+'[^']*'" | tail -1 | sed -E "s/^(&&|;)?[[:space:]]*cd[[:space:]]+'([^']*)'\$/\2/")
+  elif echo "$prefix" | grep -qE '(^|&&|;)[[:space:]]*cd[[:space:]]+[^[:space:]&|;]+'; then
+    dir=$(echo "$prefix" | grep -oE '(^|&&|;)[[:space:]]*cd[[:space:]]+[^[:space:]&|;]+' | tail -1 | sed -E 's/^(&&|;)?[[:space:]]*cd[[:space:]]+//')
   fi
-  # 3. Harness-provided cwd for this Bash call.
-  if [ -n "$payload_cwd" ]; then
-    echo "$payload_cwd"
+  if [ -n "$dir" ] && [ "${dir#/}" != "$dir" ]; then
+    echo "$dir"
     return
   fi
 }
 
 PAYLOAD_CWD=$(echo "$INPUT" | jq -r '.cwd // .tool_input.cwd // empty' 2>/dev/null)
-WORKDIR=$(resolve_commit_workdir "$COMMAND" "$PAYLOAD_CWD")
+CMD_SANS_MSG=$(strip_message_from_command "$COMMAND" "$MSG")
+
+# 1. Structured harness cwd wins outright when present and absolute.
+WORKDIR=""
+if [ -n "$PAYLOAD_CWD" ] && [ "${PAYLOAD_CWD#/}" != "$PAYLOAD_CWD" ]; then
+  WORKDIR="$PAYLOAD_CWD"
+fi
+# 2 & 3. Only reached when .cwd is absent — scraped, message-stripped,
+# same-invocation-only command parsing.
+if [ -z "$WORKDIR" ]; then
+  WORKDIR=$(resolve_commit_workdir_from_command "$CMD_SANS_MSG")
+fi
 # 4. No hint resolved anything usable — fall back to this process's own cwd,
 # exactly what every git call below did before this fix.
 if [ -z "$WORKDIR" ] || [ ! -d "$WORKDIR" ]; then

--- a/.claude/hooks/verify-commit-refs.sh
+++ b/.claude/hooks/verify-commit-refs.sh
@@ -121,6 +121,56 @@ if [ -z "$REFS" ]; then
   exit 0
 fi
 
+# Resolve the WORKING DIRECTORY the `git commit` is actually executing in —
+# NOT the hook process's own cwd (me2resh/apexyard#1050). In a
+# split-portfolio / worktree-based sub-agent session, the harness's Bash cwd
+# for this call can be a managed project's worktree while the hook process
+# itself inherits a different cwd (typically the ops fork). Every
+# cwd-relative git call below must run against the COMMIT's directory, not
+# wherever this script happened to start.
+#
+# Priority (highest first) — mirrors suggest-mcp-reindex-after-pull.sh's
+# cwd-then-command-parsed fallback chain, but ordered so an explicit,
+# in-command override always wins over the ambient payload cwd:
+#   1. an explicit `git -C <path>` on the commit invocation itself —
+#      authoritative regardless of cwd or any earlier `cd`.
+#   2. a `cd <path> &&`-style prefix earlier in the SAME compound command —
+#      changes the effective cwd for everything that follows it.
+#   3. the harness-provided `.cwd` (or `.tool_input.cwd`) for this Bash
+#      call — the common case: a bare `git commit -m ...` run from inside
+#      the intended worktree with no path arguments at all.
+#   4. fall back to the hook's own process cwd — IDENTICAL to the pre-fix
+#      behavior, so a session with no worktree involved sees no change.
+resolve_commit_workdir() {
+  local cmd="$1" payload_cwd="$2" dir
+  # 1. `git -C <path>` anywhere in the command (last one wins, matching how
+  # git itself would apply repeated -C flags).
+  dir=$(echo "$cmd" | grep -oE 'git[[:space:]]+-C[[:space:]]+[^[:space:]]+' | tail -1 | sed -E 's/^git[[:space:]]+-C[[:space:]]+//')
+  if [ -n "$dir" ]; then
+    echo "$dir"
+    return
+  fi
+  # 2. `cd <path>` at the start of the command or after a shell separator.
+  dir=$(echo "$cmd" | grep -oE '(^|&&|;)[[:space:]]*cd[[:space:]]+[^[:space:]&|;]+' | tail -1 | sed -E 's/^(&&|;)?[[:space:]]*cd[[:space:]]+//')
+  if [ -n "$dir" ]; then
+    echo "$dir"
+    return
+  fi
+  # 3. Harness-provided cwd for this Bash call.
+  if [ -n "$payload_cwd" ]; then
+    echo "$payload_cwd"
+    return
+  fi
+}
+
+PAYLOAD_CWD=$(echo "$INPUT" | jq -r '.cwd // .tool_input.cwd // empty' 2>/dev/null)
+WORKDIR=$(resolve_commit_workdir "$COMMAND" "$PAYLOAD_CWD")
+# 4. No hint resolved anything usable — fall back to this process's own cwd,
+# exactly what every git call below did before this fix.
+if [ -z "$WORKDIR" ] || [ ! -d "$WORKDIR" ]; then
+  WORKDIR="$PWD"
+fi
+
 # Resolve tracker repo.
 #
 # Two roots come into play:
@@ -133,13 +183,15 @@ fi
 #     operator configured Linear / Jira / Asana / custom at the ops-fork
 #     level (me2resh/apexyard#310). _lib-ops-root.sh walks up to the
 #     ops-fork anchor (v2 marker or v1 pair) and is the right primitive.
+#     Both REPO_ROOT and the resolve_ops_root walk now start from WORKDIR
+#     (the commit's own directory) instead of $PWD — see above.
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+REPO_ROOT=$(git -C "$WORKDIR" rev-parse --show-toplevel 2>/dev/null)
 CONFIG_ROOT=""
 if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
   # shellcheck disable=SC1090,SC1091
   . "$HOOK_DIR/_lib-ops-root.sh"
-  CONFIG_ROOT=$(resolve_ops_root "$PWD")
+  CONFIG_ROOT=$(resolve_ops_root "$WORKDIR")
 fi
 if [ -z "$CONFIG_ROOT" ]; then
   CONFIG_ROOT="$REPO_ROOT"
@@ -150,7 +202,7 @@ if [ -n "$CONFIG_ROOT" ] && [ -f "${CONFIG_ROOT}/.claude/project-config.json" ];
   TRACKER_REPO=$(jq -r '.tracker_repo // empty' "${CONFIG_ROOT}/.claude/project-config.json" 2>/dev/null)
 fi
 if [ -z "$TRACKER_REPO" ]; then
-  ORIGIN_URL=$(git remote get-url origin 2>/dev/null)
+  ORIGIN_URL=$(git -C "$WORKDIR" remote get-url origin 2>/dev/null)
   TRACKER_REPO=$(echo "$ORIGIN_URL" | sed -nE 's|.*[:/]([^/:]+/[^/]+)\.git$|\1|p; s|.*[:/]([^/:]+/[^/]+)$|\1|p' | head -1)
 fi
 
@@ -189,8 +241,8 @@ fi
 # Upstream fallback only applies to the gh kind. Linear / Jira / Asana
 # don't have a fork-of-a-tracker concept.
 UPSTREAM_REPO=""
-if [ "$TRACKER_KIND" = "gh" ] && git remote get-url upstream >/dev/null 2>&1; then
-  UPSTREAM_URL=$(git remote get-url upstream 2>/dev/null)
+if [ "$TRACKER_KIND" = "gh" ] && git -C "$WORKDIR" remote get-url upstream >/dev/null 2>&1; then
+  UPSTREAM_URL=$(git -C "$WORKDIR" remote get-url upstream 2>/dev/null)
   UPSTREAM_REPO=$(echo "$UPSTREAM_URL" | sed -nE 's|.*[:/]([^/:]+/[^/]+)\.git$|\1|p; s|.*[:/]([^/:]+/[^/]+)$|\1|p' | head -1)
   # Don't double-check if upstream resolves to the same repo as the primary
   # tracker (e.g. running INSIDE the framework repo itself, where origin and


### PR DESCRIPTION
## Summary

- **`verify-commit-refs.sh` was validating `Closes #N` against the wrong repo's tracker in worktree-based sessions.** The hook resolved `REPO_ROOT`, the ops-fork walk, and both the `origin`/`upstream` remote lookups with bare, unqualified git calls — all of which run against the *hook process's own cwd*, never the directory the `git commit` is actually executing in. In a split-portfolio / worktree session (the shape `/fan-out` and `Workflow` create), the harness's Bash cwd for a given call can be a managed project's worktree while the hook process itself inherits a different cwd (typically the ops fork) — so a legitimate `Closes #N` against the project's own real, open issue got checked against the ops fork's tracker instead, and false-blocked. Reported independently by `asami-me` in #1050, with a second confirmation comment reproducing it verbatim against the released v5.3.0 tag.
- **Fix: resolve the commit's real working directory before any git call, same pattern `require-active-ticket.sh` already uses for Edit/Write hooks.** A new `resolve_commit_workdir()` helper picks the directory in priority order — an explicit `git -C <path>` on the invocation, then a `cd <path> &&` prefix in the same compound command, then the harness-provided `.cwd` (`.tool_input.cwd`) for the Bash call (the field `suggest-mcp-reindex-after-pull.sh` already reads for the same reason) — falling back to the hook's own process cwd exactly as before when none of those hints are present, so a plain, non-worktree session sees zero behavior change.
- **`REPO_ROOT`, the `resolve_ops_root()` walk, and the `origin`/`upstream` remote lookups now all run through `git -C "$WORKDIR"`** instead of bare git, closing the inconsistency the issue's root-cause analysis called out between this hook and `require-active-ticket.sh`.

- **Also widens the hook's commit detection to recognise the `-C <path>` invocation form — which closes a second, previously unknown fail-open.** The old pattern only matched the bare form, so a commit made with an explicit `-C <path>` never reached the ref check at all: the hook exited 0 silently and **a fabricated `Closes #N` passed unverified**. That is exactly the invocation shape a worktree sub-agent uses -- the population this ticket is about -- so the gap and the bug shared a cause. Verified in review: the same `-C`-bound invocation carrying a fabricated ref exits 0 before this change and is blocked after it. The new pattern is a strict superset of the old one (17 shapes checked, no misses), and it also replaces the GNU-only `\s` with the portable `[[:space:]]`.
- **One round-2 test was passing vacuously and is now meaningful.** It asserted `rc=0` with empty stderr -- indistinguishable from a silently-skipped hook -- so it was confirming the early exit rather than the resolver. It only began testing the intended behaviour once the detection was widened.

## Bug reproduction

Verified against the unmodified hook before making any change: a sandbox shaped like the report (hook process cwd = an "ops fork" repo with `origin` = `me2resh/apexyard`; harness `.cwd` = a separate "project" repo with `origin` = `managed-org/example`; the referenced issue exists **only** in the project repo) reliably reproduced the false block — `BLOCKED: ... does not exist in me2resh/apexyard`, exit 2 — even though the issue is real and open in the correct tracker. Confirms the report; this is not a stale ticket.

## Testing

- New test file `.claude/hooks/tests/test_verify_commit_refs_cwd.sh`, 5 cases:
  1. payload `.cwd` differs from the hook's own cwd → must resolve against `.cwd`'s repo (the core bug)
  2. explicit `git -C <path>` in the command → must win over both cwd and `.cwd`
  3. `cd <path> && git commit ...` compound prefix → must resolve against that path
  4. no `.cwd` / `-C` / `cd`-prefix hints → falls back to the hook's own process cwd, **unchanged** from pre-fix behavior (no-regression case)
  5. repeat of case 1 with the `Refs` keyword, matching the report's exact false-block shape
- RED confirmed first: 4 of 5 cases failed against the unmodified hook (case 4 correctly passed, since no worktree mismatch applies there); GREEN after the fix, all 5 pass.
- `test_verify_commit_refs_upstream.sh` (existing upstream-awareness suite, 12 cases) still passes unchanged — no regression to the #207 upstream-fallback behavior.
- Full suite: `bash bin/run-hook-tests.sh` → **PASS=123 FAIL=0** (baseline was 122; +1 for the new test file).
- `shellcheck --severity=warning` clean on both changed files.

Testing instructions for reviewers:
```bash
bash .claude/hooks/tests/test_verify_commit_refs_cwd.sh
bash .claude/hooks/tests/test_verify_commit_refs_upstream.sh
bash bin/run-hook-tests.sh
```

Refs #1050

---

## Glossary

| Term | Definition |
|------|------------|
| Linked worktree | A second working directory attached to one git repo (`git worktree add`), where `--git-dir` and `--git-common-dir` differ from the main clone — the shape `/fan-out` and `Workflow` create for parallel sub-agents |
| `git -C <path>` | Runs git as if it had started in `<path>`, regardless of the shell's actual cwd — the fix for resolving a repo from the commit's own directory instead of the hook process's cwd |
| Payload `.cwd` | The harness-provided working directory for a given `Bash` tool call, carried in the PreToolUse/PostToolUse JSON payload — distinct from the hook script's own process cwd |
| Tracker repo | The GitHub repo whose issues a `Closes #N` / `Refs #N` reference is validated against |

