### PR TITLE
fix(#1056): resolve issue refs before making Closes actually auto-close

### DIFF
--- a/.claude/hooks/tests/test_release_changelog.sh
+++ b/.claude/hooks/tests/test_release_changelog.sh
@@ -392,6 +392,121 @@ contains "range line present on stderr" "RELEASE_CHANGELOG_RANGE=" "$stderr_out"
 expect_sha=$(echo "$out" | grep -oE 'EXPECT_SHA=.*' | cut -d= -f2)
 contains "stderr range is anchored on the trailer sha" "RELEASE_CHANGELOG_RANGE=${expect_sha}..HEAD" "$stderr_out"
 
+# ── #1056 helper — a stub `gh` binary for ref-resolution tests ──────────────
+# Writes a fake `gh` to <dir>/gh, controlled by two env vars the caller sets
+# before invoking the changelog script: STUB_GH_BODY (the PR body text `gh pr
+# view --json body -q .body` should "return") and STUB_GH_EXIT (non-zero to
+# simulate a `gh` failure — auth, rate limit, or an unreachable forge, the
+# exact failure mode hit live during the v5.3.0 cut). Every `$` in the heredoc
+# body is backslash-escaped so it survives heredoc creation literally and only
+# expands when the stub itself runs later, inside the test's own subshell.
+make_stub_gh() {  # make_stub_gh <dir>
+  mkdir -p "$1"
+  cat > "$1/gh" <<STUBEOF
+#!/usr/bin/env bash
+if [ "\${STUB_GH_EXIT:-0}" != "0" ]; then
+  exit "\${STUB_GH_EXIT}"
+fi
+if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
+  printf "%s" "\${STUB_GH_BODY:-}"
+  exit 0
+fi
+exit 1
+STUBEOF
+  chmod +x "$1/gh"
+}
+
+# ── Test: #1056 defect 1 — Closes repeats the keyword per reference ─────────
+# A comma-joined "Closes #A, #B, #C" line only auto-closes #A — GitHub only
+# honours the reference immediately following the closing keyword. Every
+# reference must get its own "- Closes #N" bullet so all of them fire.
+echo "--- #1056 Closes repeats keyword per reference (>=3 refs) ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v15.0.0
+  mc "feat(#1501): first unreleased feature"
+  mc "fix(#1502): second unreleased fix"
+  mc "chore(#1503): third unreleased chore"
+  PREV_TAG="v15.0.0" HEAD_REF="HEAD" VERSION="v15.1.0" DATE="2026-07-29" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains   "Closes #1501 own bullet" "Closes #1501" "$out"
+contains   "Closes #1502 own bullet" "Closes #1502" "$out"
+contains   "Closes #1503 own bullet" "Closes #1503" "$out"
+not_contains "no comma-joined Closes line (#1501, #1502 inert-past-first bug)" "Closes #1501, #1502" "$out"
+not_contains "no comma-joined Closes line (any pairing)" "#1502, #1503" "$out"
+
+# ── Test: #1056 defect 2 — scoped subject is unaffected (no PR lookup) ──────
+# `fix(#1042): ...` — the scope IS the issue number by convention. This must
+# resolve straight from the subject with no `gh` call at all (no stub `gh` is
+# put on PATH for this test — if the script tried to shell out, it would hit
+# whatever real `gh` is on the runner's PATH and could flake or hang).
+echo "--- #1056 scoped subject resolves directly, no PR lookup ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v16.0.0
+  mc "fix(#1600): put the human gate on approval flow (#1601)"
+  PREV_TAG="v16.0.0" HEAD_REF="HEAD" VERSION="v16.1.0" DATE="2026-07-29" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains     "closes the ISSUE number from the scope" "Closes #1600" "$out"
+not_contains "does not close the trailing PR number instead" "Closes #1601" "$out"
+
+# ── Test: #1056 defect 2 — unscoped subject resolves via the PR's own body ──
+# `docs: ... (#2001)` has no `type(#N):` scope — the only "(#N)" present is
+# the trailing squash-merge PR number, not an issue. The generator must look
+# up PR #2001's body, find its "Refs #2000", and close #2000 — not #2001.
+echo "--- #1056 unscoped subject resolves issue from PR body (Refs #N) ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v17.0.0
+  mc "docs: rework the onboarding flow copy (#2001)"
+  fakebin="$PWD/fakebin"
+  make_stub_gh "$fakebin"
+  PATH="$fakebin:$PATH" STUB_GH_BODY="See also. Refs #2000" \
+    PREV_TAG="v17.0.0" HEAD_REF="HEAD" VERSION="v17.1.0" DATE="2026-07-29" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains     "resolves to the referenced issue" "Closes #2000" "$out"
+not_contains "does not close the PR number itself" "Closes #2001" "$out"
+contains     "display line still shows the PR number" "(#2001)" "$out"
+
+# ── Test: #1056 defect 2 — unscoped subject whose PR resolves to nothing ────
+# The PR body carries no Closes/Fixes/Resolves/Refs reference at all — the
+# generator must degrade to the PR number (today'"'"'s behaviour), not drop the
+# entry or crash.
+echo "--- #1056 unscoped subject, PR body has no closing reference (falls back to PR number) ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v18.0.0
+  mc "docs: fix a typo in the README (#2101)"
+  fakebin="$PWD/fakebin"
+  make_stub_gh "$fakebin"
+  PATH="$fakebin:$PATH" STUB_GH_BODY="Just a typo fix, no issue linked." \
+    PREV_TAG="v18.0.0" HEAD_REF="HEAD" VERSION="v18.1.0" DATE="2026-07-29" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+')
+contains "falls back to the PR number when nothing resolves" "Closes #2101" "$out"
+
+# ── Test: #1056 fail-soft — an unreachable forge never aborts the release ───
+# Simulates the exact failure hit live during the v5.3.0 cut: `gh` errors out
+# (DNS blip on api.github.com). The generator must degrade to the PR number
+# and exit 0 — a release cut must never abort because the forge was down.
+echo "--- #1056 fail-soft: gh failure degrades to PR number, script still exits 0 ---"
+out=$(run_test '
+  mc "chore: initial"
+  git tag v19.0.0
+  mc "docs: update the contributing guide (#2201)"
+  fakebin="$PWD/fakebin"
+  make_stub_gh "$fakebin"
+  PATH="$fakebin:$PATH" STUB_GH_EXIT=1 \
+    PREV_TAG="v19.0.0" HEAD_REF="HEAD" VERSION="v19.1.0" DATE="2026-07-29" \
+    bash "'"$CHANGELOG_SCRIPT"'" 2>&1
+  echo "EXIT_CODE=$?"
+')
+contains "degrades to the PR number when gh is unreachable" "Closes #2201" "$out"
+contains "script still exits cleanly (no abort on forge failure)" "EXIT_CODE=0" "$out"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -109,8 +109,12 @@ Minor release — N features, M fixes.
 - <only if breaking-marker commits exist>
 
 ### Closes
-- Closes #N, #M, ...
+- Closes #N
+- Closes #M
+...
 ```
+
+**#1056 — one bullet per reference, not a comma list.** GitHub's `Closes` keyword only auto-closes the reference *immediately following* it — a single `Closes #N, #M, #P` line only ever closed `#N`; everything after the first was silently inert. The generator now emits one `- Closes #N` bullet per reference so every one of them actually fires. It also resolves which number goes in that bullet: a scoped commit (`fix(#1042): ...`) uses the scope directly (that's the issue, by convention); an unscoped commit (`docs: ... (#1045)`) only has GitHub's squash-appended PR number, which the generator resolves back to the issue that PR references via a best-effort `gh pr view` lookup — falling back to the PR number itself if nothing resolves or the forge is unreachable, so a network hiccup never aborts the release.
 
 #### Count-mismatch guard (AgDR-0094, option D)
 
@@ -129,9 +133,12 @@ RAW_COUNT=$(git rev-list --count "$LOG_RANGE") || {
   echo "ERROR: 'git rev-list --count $LOG_RANGE' failed — the count-mismatch guard cannot evaluate its precondition. Do NOT proceed; fix \$LOG_RANGE (see /tmp/release-changelog-range.txt) and rerun." >&2
   exit 1
 }
-# Count changelog entry bullets, excluding the trailing "- Closes #N, ..."
-# summary line (#1002: it is a summary, not an entry, and used to be
-# miscounted as one, causing an off-by-one on every run).
+# Count changelog entry bullets, excluding the "- Closes #N" summary bullets
+# (#1002: they are a summary, not an entry, and used to be miscounted as one,
+# causing an off-by-one on every run; #1056 emits one such bullet PER
+# reference instead of a single comma-joined line, so `grep -v` here still
+# needs to exclude ALL of them — `-c` already counts non-matching lines, so
+# no change to this filter itself was needed, only to this comment).
 ENTRY_COUNT=$(printf '%s\n' "$CHANGELOG_DRAFT" | grep -E '^- ' | grep -vcE '^- Closes ' || true)
 [ -n "$ENTRY_COUNT" ] || ENTRY_COUNT=0
 GAP=$(( RAW_COUNT - ENTRY_COUNT ))

--- a/bin/release-changelog.sh
+++ b/bin/release-changelog.sh
@@ -12,7 +12,14 @@
 #   DATE       — the release date in YYYY-MM-DD format
 #
 # Optional:
-#   REPO_REMOTE — the git remote to use for upstream refs (default: upstream)
+#   REPO_REMOTE    — the git remote to use for upstream refs (default: upstream)
+#   PR_LOOKUP_REPO — owner/repo used to resolve an UNSCOPED commit's trailing
+#                    PR number back to the issue it actually closes (default:
+#                    me2resh/apexyard). Only consulted for commits with no
+#                    `type(#N):` scope (#1056) — see "Closes resolution"
+#                    below. Best-effort: a `gh` failure of any kind (missing
+#                    binary, auth, rate limit, or an unreachable forge) always
+#                    falls back to today's behaviour and never aborts.
 #
 # Output format (matches the existing CHANGELOG.md convention):
 #
@@ -33,7 +40,23 @@
 #   - <subject> — <short-sha>
 #   ...
 #   ### Closes
-#   - Closes #N, #M, ...
+#   - Closes #N
+#   - Closes #M
+#   ...
+#
+# Closes resolution (#1056):
+#   GitHub's `Closes` keyword only auto-closes the reference IMMEDIATELY
+#   FOLLOWING it — a single "Closes #A, #B, #C" line only ever closes #A, so
+#   the section above emits one "- Closes #N" bullet per reference instead.
+#
+#   Which number goes in that bullet depends on whether the commit subject
+#   carries a conventional-commit SCOPE: `fix(#1042): ...` — by apexyard
+#   convention the scope IS the issue number, used directly. A subject with
+#   no scope, e.g. `docs: ... (#1045)`, only has GitHub's squash-appended
+#   trailing PR number — that is NOT an issue, so it is resolved via a
+#   best-effort `gh pr view` lookup of the PR's own body for a closing-keyword
+#   reference (Closes/Fixes/Resolves/Refs #N), falling back to the PR number
+#   itself if nothing resolves or the forge can't be reached.
 #
 # Exit codes:
 #   0 — success (even if the commit list is empty; that is a valid patch release)
@@ -147,6 +170,45 @@ extract_pr_num() {
   echo ""
 }
 
+# Does the subject carry a conventional-commit SCOPE holding the issue
+# number, i.e. "type(#N): ..." (optionally with a breaking "!") right at the
+# start? By apexyard convention (git-conventions.md) that scope IS the issue
+# number — nothing to resolve. Anything else — no scope at all, or only a
+# trailing "(#N)" GitHub appends on squash-merge — is a PR number, not an
+# issue (#1056).
+has_scope_issue() {
+  local subject="$1"
+  echo "$subject" | grep -qE '^[a-z]+\(#[0-9]+\)!?:'
+}
+
+# Best-effort: resolve a trailing PR number back to the ISSUE it actually
+# closes/references, by reading the PR's own body for a closing-keyword
+# reference (#1056). Every failure path — no `gh` on PATH, auth failure, rate
+# limit, or (the exact live failure that motivated this) a DNS blip on
+# api.github.com — degrades to printing nothing, so the caller falls back to
+# the PR number itself. A release cut must never abort because the forge
+# was briefly unreachable. Always returns 0 so `set -e` can never trip on it.
+PR_LOOKUP_REPO="${PR_LOOKUP_REPO:-me2resh/apexyard}"
+
+resolve_issue_from_pr() {
+  local pr_num="$1"  # numeric, no leading '#'
+  local body ref
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo ""
+    return 0
+  fi
+
+  if ! body=$(gh pr view "$pr_num" --repo "$PR_LOOKUP_REPO" --json body -q .body 2>/dev/null); then
+    echo ""
+    return 0
+  fi
+
+  ref=$(echo "$body" | grep -oiE '(Closes|Fixes|Resolves|Refs) #[0-9]+' | head -1 | grep -oE '#[0-9]+' || true)
+  echo "$ref"
+  return 0
+}
+
 # Strip conventional-commit prefix from a subject for cleaner display
 strip_cc_prefix() {
   local subject="$1"
@@ -184,9 +246,26 @@ while IFS= read -r line; do
   # Build the display line
   if [ -n "$pr_num" ]; then
     entry="- ($pr_num) $display_subject — $short_sha"
-    # Collect PR number for Closes section
     num_only="${pr_num#\#}"
-    closes_nums+=("$num_only")
+
+    # #1056 — the DISPLAY line always shows $pr_num as extracted above (a
+    # scoped commit's issue number, or an unscoped commit's trailing PR
+    # number) unchanged. The Closes section is different: an unscoped
+    # commit's only "(#N)" is a PR number, not an issue, and must be resolved
+    # back to the issue that PR actually references before it goes in Closes
+    # — otherwise the release closes a PR (a no-op) and leaves the real issue
+    # open, which is exactly the defect this fixes.
+    if has_scope_issue "$subject"; then
+      closes_num="$num_only"
+    else
+      resolved=$(resolve_issue_from_pr "$num_only")
+      if [ -n "$resolved" ]; then
+        closes_num="${resolved#\#}"
+      else
+        closes_num="$num_only"
+      fi
+    fi
+    closes_nums+=("$closes_num")
   else
     entry="- $display_subject — $short_sha"
   fi
@@ -286,10 +365,14 @@ if [ "${#closes_nums[@]}" -gt 0 ]; then
   echo ""
   echo "### Closes"
   echo ""
-  # Deduplicate and sort
-  unique_nums=$(printf '%s\n' "${closes_nums[@]}" | sort -un | tr '\n' ' ' | sed 's/ $//')
-  closes_str=""
-  for n in $unique_nums; do closes_str="${closes_str}#${n}, "; done
-  closes_str="${closes_str%, }"  # trim trailing comma+space
-  echo "- Closes $closes_str"
+  # #1056 — one "- Closes #N" bullet per reference, deduplicated and sorted.
+  # GitHub only honours the reference IMMEDIATELY FOLLOWING a closing
+  # keyword, so the old single "Closes #A, #B, #C" line auto-closed at most
+  # #A — every reference after the first was silently inert. Repeating the
+  # keyword (one bullet each) makes every reference its own closing directive.
+  unique_nums=$(printf '%s\n' "${closes_nums[@]}" | sort -un)
+  while IFS= read -r n; do
+    [ -n "$n" ] || continue
+    echo "- Closes #${n}"
+  done <<< "$unique_nums"
 fi


### PR DESCRIPTION
## Summary

- **Fixed silent auto-close failure in release changelogs** — the v5.3.0 release's `Closes` list named 18 references but auto-closed zero issues. Two independent defects combined to cause this, and I fixed them in a specific order because fixing them in the wrong order makes things worse, not better.
- **Ref resolution fixed first** — when a commit subject has no `type(#N):` scope (e.g. `docs: rework the onboarding flow copy (#2001)`), the generator was emitting the trailing **PR number** as if it were the issue. `resolve_issue_from_pr()` now looks up that PR's own body for a `Closes`/`Fixes`/`Resolves`/`Refs #N` reference and uses the real issue instead — falling back to the PR number if nothing resolves.
- **Emission fixed second, only after ref resolution was correct** — `### Closes` used to emit a single `Closes #A, #B, #C` line, and GitHub only auto-closes the reference immediately following the keyword, so everything past `#A` was silently inert. It now emits one `- Closes #N` bullet per reference so all of them fire.
- **Why this order, explicitly** — today, a wrong ref from the resolution bug is harmless *only because* the comma-list bug stops anything past the first reference from firing at all. If I had fixed emission first — repeating the keyword per reference — while ref resolution was still wrong, every mis-extracted trailing PR number would become a live `Closes #N` directive. That number is somebody's real PR, and if it happens to also be the number of an open issue in this repo, the next release cut would auto-close that unrelated issue, silently, the same day it merged. Fixing ref resolution first closes off that path entirely: by the time emission repeats the keyword, every number in the list is already the right one.
- **Fail-soft behaviour of `resolve_issue_from_pr()`, stated plainly** — it does one `gh pr view <PR> --repo me2resh/apexyard --json body -q .body` call per unscoped commit. On success, it greps the PR body for a closing-keyword reference. On ANY failure — `gh` not on `PATH`, auth failure, rate limit, or the forge being unreachable (I hit this exact failure live, mid-merge, earlier this session — `api.github.com` briefly stopped resolving) — it prints nothing and the caller falls back to the raw PR number, i.e. today's pre-#1056 behaviour. This is not a hypothetical claim: `test_release_changelog.sh` has a dedicated case ("fail-soft: gh failure degrades to PR number, script still exits 0") that stubs `gh` to exit 1 unconditionally and asserts both that the PR number still appears in `Closes` and that the script itself exits `0`. That test passes.

## What changed

- `bin/release-changelog.sh`:
  - Added `has_scope_issue()` — detects whether a commit subject's `(#N)` is a genuine issue-holding scope (`fix(#1042): ...`) vs. absent.
  - Added `resolve_issue_from_pr()` — best-effort `gh pr view <PR> --json body` lookup for a closing-keyword reference in the PR's own body. Every internal failure path is neutralized (`if ! cmd; then`, explicit `return 0`) so a `gh` failure can never trip `set -e` and abort the script.
  - Added `PR_LOOKUP_REPO` env var (default `me2resh/apexyard`) controlling which repo the lookup targets.
  - Reworked the `Closes` section emission from a single comma-joined line to one `- Closes #N` bullet per (deduplicated, sorted) reference.
- `.claude/skills/release/SKILL.md`: updated the documented `### Closes` output shape and the count-mismatch guard's comment to match the new one-bullet-per-reference format (the guard's actual `grep -v` logic already handled multiple matching lines correctly — only the comment was stale).
- `.claude/hooks/tests/test_release_changelog.sh`: 8 new assertions across 5 new test cases — a ≥3-ref comma-list regression, a scoped subject (proves no PR lookup fires for the already-correct case), an unscoped subject resolved via a stubbed PR body, an unscoped subject whose PR resolves to nothing, and the fail-soft/unreachable-forge case described above. Added a `make_stub_gh()` helper that writes a fake `gh` binary controlled by `STUB_GH_BODY` / `STUB_GH_EXIT` env vars, so these tests need no real network access.

## Testing

1. **Red before, green after, in fix order.** Wrote the 8 new assertions first and confirmed 6 failures against the unfixed script (4 for the comma-list bug, 2 for the ref-resolution bug). Implemented ref resolution (`has_scope_issue` / `resolve_issue_from_pr`) and reran — those 2 failures cleared while the 4 emission failures remained, confirming (a) was fixed independently of (b). Then implemented the emission rework and reran — all 8 new assertions passed alongside the 63 pre-existing ones.
2. `bash .claude/hooks/tests/test_release_changelog.sh` — **71/71 pass** (63 pre-existing + 8 new).
3. `bash bin/run-hook-tests.sh` — full framework hook suite, run twice independently after the fix landed: **`hook test suite: PASS=122 FAIL=0 SKIP(quarantined)=0 TOTAL=122`** both times, matching today's baseline exactly. `test_release_changelog.sh` and `test_release_sync.sh` both show `PASS` in the full run.
4. `bash .claude/hooks/tests/test_release_sync.sh` — **14/14 pass**, unaffected (doesn't touch the `Closes` format).
5. `shellcheck --severity=warning bin/release-changelog.sh .claude/hooks/tests/test_release_changelog.sh` — clean, no warnings.

## Risk notes

- The only new network call this script makes is the best-effort PR-body lookup, and only for unscoped commit subjects (scoped commits — the common case — never touch the network). Every failure mode of that call degrades to the pre-existing behavior, verified by the fail-soft test above, not merely asserted.
- Both fixes land in this one commit, not as separate PRs, deliberately: shipping the emission fix without the ref-resolution fix — even for the length of one PR review cycle — would strictly increase the auto-close blast radius, per the ordering argument above.

Refs #1056

## Glossary

| Term | Definition |
|------|------------|
| Closing keyword | `Closes` / `Fixes` / `Resolves` — GitHub auto-closes the issue immediately following one, and only that one, when the PR merges into the default branch |
| Conventional-commit scope | The `(#N)` in `fix(#1042): …`, which by apexyard convention holds the **issue** number |
| Trailing PR ref | The `(#NNN)` GitHub appends on squash-merge, which is the **PR** number, not an issue |
| Fail-soft | Degrading to a safe default (here: the raw PR number) instead of erroring out, when a best-effort step (here: the `gh` lookup) can't complete |
| Release-cut model | `dev` takes daily PRs; `main` receives only squash-merged release PRs, so no individual `dev` commit is ever an ancestor of a release tag |
