### PR TITLE
chore(#1086): install git pre-push hooks by default

### DIFF
--- a/.claude/hooks/_lib-git-hooks-path.sh
+++ b/.claude/hooks/_lib-git-hooks-path.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# _lib-git-hooks-path.sh — shared core.hooksPath detection logic.
+#
+# Sourced by:
+#   - bin/install-git-hooks.sh              (mutates core.hooksPath)
+#   - .claude/hooks/check-git-hooks-installed.sh  (advisory, read-only)
+#
+# Kept as a single shared lib so the installer and the advisory banner can
+# never drift on what counts as "unset" / "correct" / "stale" / "deliberate
+# third-party" — see me2resh/apexyard#1086.
+
+# ------------------------------------------------------------------------
+# _resolve_real_path PATH
+#
+# Resolves PATH to its canonical, symlink-free absolute form. Walks up to
+# the nearest EXISTING ancestor, physically resolves it (`pwd -P`, which
+# follows symlinks), then re-appends any not-yet-created tail literally —
+# a tail that doesn't exist yet cannot itself be a symlink. This mirrors
+# `realpath -m` without depending on GNU coreutils (not guaranteed present
+# on macOS/BSD). Echoes the resolved path, or nothing if even "/" can't be
+# stat'd (should not happen for a well-formed absolute path).
+#
+# Copied verbatim from require-active-ticket.sh's _resolve_real_path (see
+# that file for the fuller symlink-bypass rationale) rather than sourcing
+# it directly — that hook's copy carries ticket-gate-specific comments and
+# the two call sites shouldn't share a lifecycle.
+# ------------------------------------------------------------------------
+_resolve_real_path() {
+  local p="$1" dir tail=""
+  [ -n "$p" ] || return 0
+  dir="$p"
+  while [ -n "$dir" ] && [ "$dir" != "/" ] && [ ! -e "$dir" ]; do
+    if [ -z "$tail" ]; then
+      tail="$(basename "$dir")"
+    else
+      tail="$(basename "$dir")/$tail"
+    fi
+    dir="$(dirname "$dir")"
+  done
+  if [ ! -e "$dir" ]; then
+    return 0
+  fi
+  if [ -d "$dir" ]; then
+    dir="$(cd "$dir" 2>/dev/null && pwd -P)"
+  else
+    local parent
+    parent="$(cd "$(dirname "$dir")" 2>/dev/null && pwd -P)"
+    if [ -n "$parent" ]; then
+      dir="$parent/$(basename "$dir")"
+    else
+      dir=""
+    fi
+  fi
+  [ -n "$dir" ] || return 0
+  if [ -n "$tail" ]; then
+    printf '%s/%s' "$dir" "$tail"
+  else
+    printf '%s' "$dir"
+  fi
+}
+
+# ------------------------------------------------------------------------
+# ghp_classify REPO_ROOT HOOKS_DIR_NAME
+#
+# REPO_ROOT must already be an absolute, resolved git toplevel path.
+# HOOKS_DIR_NAME is the tracked hooks dir name relative to REPO_ROOT
+# (default convention: ".githooks").
+#
+# Prints exactly one of, to stdout (no trailing newline):
+#
+#   unset
+#     core.hooksPath has no value in this clone's git config.
+#
+#   correct
+#     core.hooksPath resolves exactly to REPO_ROOT/HOOKS_DIR_NAME.
+#
+#   missing:<raw>
+#     core.hooksPath is set to <raw>, which resolves to a path that does
+#     not exist on disk (a deleted directory, a typo, or a config value
+#     copied from a machine/clone that no longer has that path).
+#
+#   foreign-git-dir:<raw>:<resolved>
+#     core.hooksPath resolves to an existing directory, but that
+#     directory sits inside SOME repo's .git directory (path contains a
+#     `.git` component) and is outside REPO_ROOT. A tracked hooks dir can
+#     never legitimately live inside `.git/` (that directory is never
+#     committed), so this can only be a stale absolute path left over
+#     from a different clone's default hooks location — the concrete
+#     failure mode #1086 was filed against.
+#
+#   third-party:<raw>:<resolved>
+#     core.hooksPath resolves to an existing, real directory that is
+#     neither of the above — could be inside REPO_ROOT under a different
+#     name, or a genuinely external directory an adopter configured on
+#     purpose (e.g. a company-wide shared hooks dir). Ambiguous by
+#     design: treated as a deliberate adopter choice, never auto-repaired.
+# ------------------------------------------------------------------------
+ghp_classify() {
+  local repo_root="$1" hooks_dir_name="$2"
+  local current current_resolved target_resolved
+
+  current=$(git -C "$repo_root" config --get core.hooksPath 2>/dev/null || true)
+  target_resolved=$(_resolve_real_path "$repo_root/$hooks_dir_name")
+
+  if [ -z "$current" ]; then
+    printf 'unset'
+    return 0
+  fi
+
+  case "$current" in
+    /*) current_resolved=$(_resolve_real_path "$current") ;;
+    *)  current_resolved=$(_resolve_real_path "$repo_root/$current") ;;
+  esac
+
+  if [ -n "$current_resolved" ] && [ "$current_resolved" = "$target_resolved" ]; then
+    printf 'correct'
+    return 0
+  fi
+
+  if [ -z "$current_resolved" ] || [ ! -d "$current_resolved" ]; then
+    printf 'missing:%s' "$current"
+    return 0
+  fi
+
+  # Inside REPO_ROOT but under a different name than HOOKS_DIR_NAME — a
+  # real directory the adopter (or a script) deliberately created in this
+  # very repo. Ambiguous-by-design: third-party, not stale.
+  case "$current_resolved" in
+    "$repo_root"/*)
+      printf 'third-party:%s:%s' "$current" "$current_resolved"
+      return 0
+      ;;
+  esac
+
+  # Outside REPO_ROOT. If it sits inside a `.git` directory anywhere on
+  # its path, it cannot be a tracked hooks dir (never committed) — almost
+  # certainly a stale pointer into a different clone's default hooks
+  # location. Otherwise it's an external directory that could be a
+  # deliberate shared setup — leave it alone.
+  case "$current_resolved" in
+    */.git/*|*/.git)
+      printf 'foreign-git-dir:%s:%s' "$current" "$current_resolved"
+      return 0
+      ;;
+  esac
+
+  printf 'third-party:%s:%s' "$current" "$current_resolved"
+}

--- a/.claude/hooks/_lib-git-hooks-path.sh
+++ b/.claude/hooks/_lib-git-hooks-path.sh
@@ -9,55 +9,20 @@
 # never drift on what counts as "unset" / "correct" / "stale" / "deliberate
 # third-party" — see me2resh/apexyard#1086.
 
-# ------------------------------------------------------------------------
-# _resolve_real_path PATH
-#
-# Resolves PATH to its canonical, symlink-free absolute form. Walks up to
-# the nearest EXISTING ancestor, physically resolves it (`pwd -P`, which
-# follows symlinks), then re-appends any not-yet-created tail literally —
-# a tail that doesn't exist yet cannot itself be a symlink. This mirrors
-# `realpath -m` without depending on GNU coreutils (not guaranteed present
-# on macOS/BSD). Echoes the resolved path, or nothing if even "/" can't be
-# stat'd (should not happen for a well-formed absolute path).
-#
-# Copied verbatim from require-active-ticket.sh's _resolve_real_path (see
-# that file for the fuller symlink-bypass rationale) rather than sourcing
-# it directly — that hook's copy carries ticket-gate-specific comments and
-# the two call sites shouldn't share a lifecycle.
-# ------------------------------------------------------------------------
-_resolve_real_path() {
-  local p="$1" dir tail=""
-  [ -n "$p" ] || return 0
-  dir="$p"
-  while [ -n "$dir" ] && [ "$dir" != "/" ] && [ ! -e "$dir" ]; do
-    if [ -z "$tail" ]; then
-      tail="$(basename "$dir")"
-    else
-      tail="$(basename "$dir")/$tail"
-    fi
-    dir="$(dirname "$dir")"
-  done
-  if [ ! -e "$dir" ]; then
-    return 0
-  fi
-  if [ -d "$dir" ]; then
-    dir="$(cd "$dir" 2>/dev/null && pwd -P)"
-  else
-    local parent
-    parent="$(cd "$(dirname "$dir")" 2>/dev/null && pwd -P)"
-    if [ -n "$parent" ]; then
-      dir="$parent/$(basename "$dir")"
-    else
-      dir=""
-    fi
-  fi
-  [ -n "$dir" ] || return 0
-  if [ -n "$tail" ]; then
-    printf '%s/%s' "$dir" "$tail"
-  else
-    printf '%s' "$dir"
-  fi
-}
+# _resolve_real_path is sourced from _lib-path-resolve.sh — the single
+# shared definition (PR #1087 review, Rex finding #4). This file used to
+# carry its own inline copy with a comment claiming it was deliberately
+# separate from require-active-ticket.sh's; that "copied verbatim, not
+# sourced" shape is exactly the AgDR-0113 pattern #1086 exists to retire,
+# and the two copies had already started drifting. See
+# _lib-path-resolve.sh's header comment for the full rationale, including
+# why it is NOT the same thing as _lib-portfolio-paths.sh's
+# `_portfolio_canonicalize` (a deliberately different, fail-soft sibling).
+_LGHP_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+if [ -f "$_LGHP_LIB_DIR/_lib-path-resolve.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$_LGHP_LIB_DIR/_lib-path-resolve.sh"
+fi
 
 # ------------------------------------------------------------------------
 # ghp_classify REPO_ROOT HOOKS_DIR_NAME

--- a/.claude/hooks/_lib-path-resolve.sh
+++ b/.claude/hooks/_lib-path-resolve.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# _lib-path-resolve.sh — single shared implementation of the portable
+# "realpath -m without GNU coreutils" helper used across the trust chain.
+#
+# Sourced by:
+#   - require-active-ticket.sh (the ticket gate's symlink-safe path check)
+#   - _lib-git-hooks-path.sh (used by bin/install-git-hooks.sh and
+#     .claude/hooks/check-git-hooks-installed.sh)
+#
+# Why this file exists (PR #1087 review, Rex finding #4): the installer
+# PR originally shipped its OWN copy of this function with a comment
+# claiming it was "copied verbatim ... rather than sourcing it directly."
+# That is exactly the AgDR-0113 pattern the #1086 arc exists to retire —
+# an agreement asserted in a comment instead of enforced by one shared
+# definition, in the very PR whose stated purpose is replacing
+# command-text-matching duplication with structured ground truth. There
+# is now exactly ONE _resolve_real_path in the codebase; every caller
+# sources this file rather than embedding its own copy.
+#
+# NOT the same thing as _lib-portfolio-paths.sh's `_portfolio_canonicalize`.
+# That function solves a related but distinct problem (portfolio-path
+# resolution across split-portfolio mode) and has deliberately different
+# semantics — it carries Windows drive-letter normalisation (#1018) and
+# fails SOFT (echoes the input unchanged when unresolvable), where this
+# function fails EMPTY (echoes nothing). Do not fold the two together;
+# `_portfolio_canonicalize`'s callers rely on its fail-soft behaviour.
+
+# Resolve PATH to its canonical, symlink-free absolute form. Walks up to
+# the nearest EXISTING ancestor, physically resolves it (`pwd -P`, which
+# follows symlinks), then re-appends any not-yet-created tail literally —
+# a tail that doesn't exist yet cannot itself be a symlink. This mirrors
+# `realpath -m` without depending on GNU coreutils (not guaranteed present
+# on macOS/BSD). Echoes the resolved path, or nothing if even "/" can't be
+# stat'd (should not happen for a well-formed absolute path).
+#
+# Why this matters (#883): without resolving symlinks first, a symlink
+# living under $HOME that POINTS INTO a governed tree (e.g.
+# ~/link-into-repo → the ops fork) would compare as "outside" the repo
+# under a naive string-prefix check, silently bypassing the gate.
+_resolve_real_path() {
+  local p="$1" dir tail=""
+  [ -n "$p" ] || return 0
+  dir="$p"
+  while [ -n "$dir" ] && [ "$dir" != "/" ] && [ ! -e "$dir" ]; do
+    if [ -z "$tail" ]; then
+      tail="$(basename "$dir")"
+    else
+      tail="$(basename "$dir")/$tail"
+    fi
+    dir="$(dirname "$dir")"
+  done
+  if [ ! -e "$dir" ]; then
+    return 0
+  fi
+  if [ -d "$dir" ]; then
+    dir="$(cd "$dir" 2>/dev/null && pwd -P)"
+  else
+    local parent
+    parent="$(cd "$(dirname "$dir")" 2>/dev/null && pwd -P)"
+    if [ -n "$parent" ]; then
+      dir="$parent/$(basename "$dir")"
+    else
+      dir=""
+    fi
+  fi
+  [ -n "$dir" ] || return 0
+  if [ -n "$tail" ]; then
+    printf '%s/%s' "$dir" "$tail"
+  else
+    printf '%s' "$dir"
+  fi
+}

--- a/.claude/hooks/check-git-hooks-installed.sh
+++ b/.claude/hooks/check-git-hooks-installed.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# check-git-hooks-installed.sh — SessionStart advisory: warns when this
+# clone's core.hooksPath is unset, points at a non-existent directory, or
+# points at a stale leftover from a different clone, so the tracked
+# .githooks/pre-push hook silently never runs on a terminal `git push`.
+#
+# Part of me2resh/apexyard#1086 step 1. Same advisory shape as
+# check-upstream-drift.sh and check-jq-installed.sh: non-blocking, exit 0
+# always. The banner cannot force the fix — it removes the "nobody knew
+# this clone's terminal pushes were unprotected" failure mode.
+#
+# Silent exit paths (no output, no error):
+#   - Not a git repo
+#   - No tracked hooks dir (default: .githooks) in this repo at all — a
+#     managed-project clone that hasn't adopted ApexYard's git hooks yet
+#     is not a misconfiguration, just nothing to advise on
+#   - core.hooksPath already resolves correctly ("correct" classification)
+#   - The shared detection lib is missing (older fork pre-#1086; nothing
+#     to check against)
+#
+# Banner fires only for the three states install-git-hooks.sh's own README
+# documents as fixable: unset, missing (non-existent target dir), and
+# foreign-git-dir (stale pointer into a different clone) or a third-party
+# directory the classify lib can't confirm is deliberate.
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+cd "$REPO_ROOT" || exit 0
+
+HOOKS_DIR_NAME=".githooks"
+
+# Nothing tracked to install in this repo — silent. (Most managed-project
+# workspace clones today; the ops fork always carries .githooks/.)
+if [ ! -d "$REPO_ROOT/$HOOKS_DIR_NAME" ]; then
+  exit 0
+fi
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$HOOK_DIR/_lib-git-hooks-path.sh"
+if [ ! -f "$LIB" ]; then
+  exit 0
+fi
+# shellcheck source=/dev/null
+. "$LIB"
+
+STATE=$(ghp_classify "$REPO_ROOT" "$HOOKS_DIR_NAME")
+
+case "$STATE" in
+  correct)
+    exit 0
+    ;;
+
+  unset)
+    cat >&2 <<MSG
+ApexYard: core.hooksPath is unset in this clone — the tracked git pre-push
+hook isn't installed. A terminal \`git push\` won't run the tracked check
+set, only Claude-Code-driven pushes will. Run:
+  bash bin/install-git-hooks.sh
+MSG
+    ;;
+
+  missing:*)
+    RAW="${STATE#missing:}"
+    cat >&2 <<MSG
+ApexYard: core.hooksPath is set to '$RAW', which doesn't exist — the
+tracked git hook here is silently inert. Run:
+  bash bin/install-git-hooks.sh
+MSG
+    ;;
+
+  foreign-git-dir:*)
+    REST="${STATE#foreign-git-dir:}"
+    RAW="${REST%%:*}"
+    cat >&2 <<MSG
+ApexYard: core.hooksPath is set to '$RAW' — looks like a stale pointer into
+a different clone's .git directory. The tracked git hook here is silently
+inert. Run:
+  bash bin/install-git-hooks.sh
+MSG
+    ;;
+
+  third-party:*)
+    REST="${STATE#third-party:}"
+    RAW="${REST%%:*}"
+    cat >&2 <<MSG
+ApexYard: core.hooksPath is set to '$RAW', a directory that isn't this
+repo's tracked $HOOKS_DIR_NAME. If that's deliberate, ignore this. To
+install ApexYard's tracked hooks instead:
+  bash bin/install-git-hooks.sh --force
+MSG
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/check-git-hooks-installed.sh
+++ b/.claude/hooks/check-git-hooks-installed.sh
@@ -87,9 +87,8 @@ MSG
     RAW="${REST%%:*}"
     cat >&2 <<MSG
 ApexYard: core.hooksPath is set to '$RAW', a directory that isn't this
-repo's tracked $HOOKS_DIR_NAME. If that's deliberate, ignore this. To
-install ApexYard's tracked hooks instead:
-  bash bin/install-git-hooks.sh --force
+repo's tracked $HOOKS_DIR_NAME. If that's deliberate, ignore this — see
+bash bin/install-git-hooks.sh --help if you want to review or change it.
 MSG
     ;;
 esac

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -52,55 +52,24 @@
 # let a command that also names an out-of-governance target FIRST slip an
 # in-repo target past a gate that stopped looking after target #1.
 
-# Resolve PATH to its canonical, symlink-free absolute form. Walks up to
-# the nearest EXISTING ancestor, physically resolves it (`pwd -P`, which
-# follows symlinks), then re-appends any not-yet-created tail literally —
-# a tail that doesn't exist yet cannot itself be a symlink. This mirrors
-# `realpath -m` without depending on GNU coreutils (not guaranteed present
-# on macOS/BSD). Echoes the resolved path, or nothing if even "/" can't be
-# stat'd (should not happen for a well-formed absolute path).
+# _resolve_real_path — portable, symlink-safe path canonicalisation.
 #
 # Why this matters (#883): without resolving symlinks first, a symlink
 # living under $HOME that POINTS INTO a governed tree (e.g.
 # ~/link-into-repo → the ops fork) would compare as "outside" the repo
 # under a naive string-prefix check, silently bypassing the gate.
-_resolve_real_path() {
-  local p="$1" dir tail=""
-  [ -n "$p" ] || return 0
-  dir="$p"
-  while [ -n "$dir" ] && [ "$dir" != "/" ] && [ ! -e "$dir" ]; do
-    if [ -z "$tail" ]; then
-      tail="$(basename "$dir")"
-    else
-      tail="$(basename "$dir")/$tail"
-    fi
-    dir="$(dirname "$dir")"
-  done
-  if [ ! -e "$dir" ]; then
-    # Nothing on the path exists at all — cannot resolve. Should not
-    # happen for an absolute path since "/" always exists.
-    return 0
-  fi
-  if [ -d "$dir" ]; then
-    dir="$(cd "$dir" 2>/dev/null && pwd -P)"
-  else
-    # $dir resolved to an existing FILE (not a directory) partway through
-    # the walk — canonicalize its parent and re-append its own basename.
-    local parent
-    parent="$(cd "$(dirname "$dir")" 2>/dev/null && pwd -P)"
-    if [ -n "$parent" ]; then
-      dir="$parent/$(basename "$dir")"
-    else
-      dir=""
-    fi
-  fi
-  [ -n "$dir" ] || return 0
-  if [ -n "$tail" ]; then
-    printf '%s/%s' "$dir" "$tail"
-  else
-    printf '%s' "$dir"
-  fi
-}
+#
+# Sourced from the single shared definition at _lib-path-resolve.sh (PR
+# #1087 review, Rex finding #4) rather than defined inline — this used to
+# be a self-contained copy, which put THREE near-identical
+# implementations of the same algorithm in .claude/hooks/ across two
+# files, one of which had already silently diverged. See
+# _lib-path-resolve.sh's own header comment for the full rationale.
+_RATC_HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "$_RATC_HOOK_DIR/_lib-path-resolve.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$_RATC_HOOK_DIR/_lib-path-resolve.sh"
+fi
 
 # ------------------------------------------------------------------------------
 # _ratc_evaluate_target FILE_PATH TOOL_NAME

--- a/.claude/hooks/tests/test_check_git_hooks_installed.sh
+++ b/.claude/hooks/tests/test_check_git_hooks_installed.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Smoke tests for .claude/hooks/check-git-hooks-installed.sh — SessionStart
+# advisory that warns when this clone's core.hooksPath is unset, stale, or
+# pointing at a foreign clone (me2resh/apexyard#1086 step 1).
+#
+# Discriminating by construction: this hook (and the _lib-git-hooks-path.sh
+# lib it sources) did not exist before #1086 step 1, so every case here
+# fails against the pre-change tree and passes only once both files exist
+# with the exact behaviour this suite exercises.
+#
+# Each case builds an isolated sandbox git repo, sets core.hooksPath to a
+# specific state, runs the hook from inside that repo, and asserts banner
+# output / silence. Same harness shape as test_check_jq_installed.sh.
+#
+# Cases covered:
+#   1. core.hooksPath unset               -> banner fires
+#   2. core.hooksPath already correct     -> silent
+#   3. core.hooksPath points at a missing dir           -> banner fires
+#   4. core.hooksPath points at a different clone's
+#      .git/hooks (the concrete #1086 failure mode)      -> banner fires
+#   5. No tracked .githooks/ dir in the repo at all      -> silent (nothing
+#      to advise on — a managed-project clone that hasn't adopted the
+#      framework's git hooks yet)
+#   6. Not inside a git repo at all                       -> silent
+#
+# Exit 0 if all cases pass; 1 on first failure tally.
+
+set -u
+
+HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/check-git-hooks-installed.sh"
+LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-git-hooks-path.sh"
+PASS=0
+FAIL=0
+FAILED=""
+
+assert_silent() {
+  local label="$1" output="$2"
+  if [ -z "$output" ]; then
+    echo "PASS [$label] — silent"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label] — expected silent, got: $output" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+  fi
+}
+
+assert_fires() {
+  local label="$1" pattern="$2" output="$3"
+  if [ -n "$output" ] && printf '%s' "$output" | grep -qE "$pattern"; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label] — expected /$pattern/, got: $output" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+  fi
+}
+
+# Build a sandbox with a copy of the hook + lib, so the test doesn't depend
+# on the real ops fork's checked-out state.
+build_repo() {
+  local dir="$1"
+  mkdir -p "$dir/.claude/hooks"
+  cp "$HOOK_SRC" "$dir/.claude/hooks/check-git-hooks-installed.sh"
+  chmod +x "$dir/.claude/hooks/check-git-hooks-installed.sh"
+  if [ -f "$LIB_SRC" ]; then
+    cp "$LIB_SRC" "$dir/.claude/hooks/_lib-git-hooks-path.sh"
+  fi
+  ( cd "$dir" && git init -q )
+}
+
+add_githooks() {
+  local dir="$1"
+  mkdir -p "$dir/.githooks"
+  printf '#!/bin/sh\nexit 0\n' > "$dir/.githooks/pre-push"
+  ( cd "$dir" && git add .githooks .claude && GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t.com \
+      GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t.com \
+      git commit -q -m "chore: init" )
+}
+
+run_hook_from() {
+  local dir="$1"
+  ( cd "$dir" && bash .claude/hooks/check-git-hooks-installed.sh 2>&1 )
+}
+
+if [ ! -f "$HOOK_SRC" ]; then
+  echo "FAIL: hook not found at $HOOK_SRC" >&2
+  exit 1
+fi
+
+# CASE 1: unset -> banner
+case_unset() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_repo "$sandbox"
+  add_githooks "$sandbox"
+  assert_fires "unset -> banner fires" "core\.hooksPath is unset" "$(run_hook_from "$sandbox")"
+  rm -rf "$sandbox"
+}
+
+# CASE 2: already correct -> silent
+case_correct() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_repo "$sandbox"
+  add_githooks "$sandbox"
+  git -C "$sandbox" config core.hooksPath .githooks
+  assert_silent "already correct -> silent" "$(run_hook_from "$sandbox")"
+  rm -rf "$sandbox"
+}
+
+# CASE 3: missing dir -> banner
+case_missing_dir() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_repo "$sandbox"
+  add_githooks "$sandbox"
+  git -C "$sandbox" config core.hooksPath "$sandbox/nope-not-here"
+  assert_fires "missing dir -> banner fires" "doesn't exist" "$(run_hook_from "$sandbox")"
+  rm -rf "$sandbox"
+}
+
+# CASE 4: foreign clone's .git/hooks -> banner
+# repo and other-clone are SIBLINGS (both directly under $parent), not
+# nested — nesting them would make other-clone's path resolve as "inside
+# repo's own tree" and get classified as third-party instead of
+# foreign-git-dir, which is a different code path this case must exercise.
+case_foreign_clone() {
+  local parent; parent=$(mktemp -d)
+  local repo="$parent/repo"
+  local other="$parent/other-clone"
+  build_repo "$repo"
+  add_githooks "$repo"
+  build_repo "$other"
+  add_githooks "$other"
+
+  local other_git_dir
+  other_git_dir=$(cd "$other" && git rev-parse --git-dir)
+  case "$other_git_dir" in
+    /*) : ;;
+    *) other_git_dir="$other/$other_git_dir" ;;
+  esac
+  git -C "$repo" config core.hooksPath "$other_git_dir/hooks"
+
+  assert_fires "foreign clone -> banner fires" "different clone" "$(run_hook_from "$repo")"
+  rm -rf "$parent"
+}
+
+# CASE 5: no tracked .githooks/ at all -> silent
+case_no_githooks_dir() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_repo "$sandbox"
+  # Commit without adding .githooks/ — the repo has .claude/hooks but no
+  # tracked pre-push hooks dir of its own.
+  ( cd "$sandbox" && git add .claude && GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t.com \
+      GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t.com \
+      git commit -q -m "chore: init" )
+  assert_silent "no .githooks/ -> silent" "$(run_hook_from "$sandbox")"
+  rm -rf "$sandbox"
+}
+
+# CASE 6: not inside a git repo -> silent
+case_not_a_repo() {
+  local outside; outside=$(mktemp -d)
+  mkdir -p "$outside/.claude/hooks"
+  cp "$HOOK_SRC" "$outside/.claude/hooks/check-git-hooks-installed.sh"
+  chmod +x "$outside/.claude/hooks/check-git-hooks-installed.sh"
+  [ -f "$LIB_SRC" ] && cp "$LIB_SRC" "$outside/.claude/hooks/_lib-git-hooks-path.sh"
+  assert_silent "not a git repo -> silent" "$(run_hook_from "$outside")"
+  rm -rf "$outside"
+}
+
+case_unset
+case_correct
+case_missing_dir
+case_foreign_clone
+case_no_githooks_dir
+case_not_a_repo
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_check_git_hooks_installed.sh
+++ b/.claude/hooks/tests/test_check_git_hooks_installed.sh
@@ -29,6 +29,7 @@ set -u
 
 HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/check-git-hooks-installed.sh"
 LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-git-hooks-path.sh"
+LIB_PATH_RESOLVE_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-path-resolve.sh"
 PASS=0
 FAIL=0
 FAILED=""
@@ -64,6 +65,9 @@ build_repo() {
   chmod +x "$dir/.claude/hooks/check-git-hooks-installed.sh"
   if [ -f "$LIB_SRC" ]; then
     cp "$LIB_SRC" "$dir/.claude/hooks/_lib-git-hooks-path.sh"
+  fi
+  if [ -f "$LIB_PATH_RESOLVE_SRC" ]; then
+    cp "$LIB_PATH_RESOLVE_SRC" "$dir/.claude/hooks/_lib-path-resolve.sh"
   fi
   ( cd "$dir" && git init -q )
 }
@@ -142,6 +146,35 @@ case_foreign_clone() {
   rm -rf "$parent"
 }
 
+# CASE 4b (PR #1087 review §2b + LOW-6 — the third-party branch had ZERO
+# coverage; deleting it outright still passed the suite 6/6). A real,
+# existing directory OUTSIDE the repo with no `.git` component (the
+# canonical "adopter configured a shared hooks dir" shape) must fire the
+# banner, AND the banner must NOT recommend --force (LOW-6: a banner that
+# suggests overriding a deliberate choice erodes the one guard protecting
+# it — dropped in favour of pointing at --help).
+case_third_party() {
+  local parent; parent=$(mktemp -d)
+  local repo="$parent/repo"
+  local external="$parent/company-wide-hooks"
+  build_repo "$repo"
+  add_githooks "$repo"
+  mkdir -p "$external"
+  git -C "$repo" config core.hooksPath "$external"
+
+  local out
+  out=$(run_hook_from "$repo")
+  assert_fires "third-party -> banner fires" "isn't this" "$out"
+  if printf '%s' "$out" | grep -qE -- '--force'; then
+    echo "FAIL [third-party banner must NOT recommend --force] — got: $out" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}third-party-no-force-mention "
+  else
+    echo "PASS [third-party banner must NOT recommend --force]"
+    PASS=$((PASS+1))
+  fi
+  rm -rf "$parent"
+}
+
 # CASE 5: no tracked .githooks/ at all -> silent
 case_no_githooks_dir() {
   local sandbox; sandbox=$(mktemp -d)
@@ -162,6 +195,7 @@ case_not_a_repo() {
   cp "$HOOK_SRC" "$outside/.claude/hooks/check-git-hooks-installed.sh"
   chmod +x "$outside/.claude/hooks/check-git-hooks-installed.sh"
   [ -f "$LIB_SRC" ] && cp "$LIB_SRC" "$outside/.claude/hooks/_lib-git-hooks-path.sh"
+  [ -f "$LIB_PATH_RESOLVE_SRC" ] && cp "$LIB_PATH_RESOLVE_SRC" "$outside/.claude/hooks/_lib-path-resolve.sh"
   assert_silent "not a git repo -> silent" "$(run_hook_from "$outside")"
   rm -rf "$outside"
 }
@@ -170,6 +204,7 @@ case_unset
 case_correct
 case_missing_dir
 case_foreign_clone
+case_third_party
 case_no_githooks_dir
 case_not_a_repo
 

--- a/.claude/hooks/tests/test_install_git_hooks.sh
+++ b/.claude/hooks/tests/test_install_git_hooks.sh
@@ -1,0 +1,257 @@
+#!/bin/bash
+# Smoke tests for bin/install-git-hooks.sh (me2resh/apexyard#1086 step 1).
+#
+# Each case builds an isolated sandbox git repo under $TMPDIR, puts
+# core.hooksPath into a specific starting state, runs the installer against
+# it via --repo-dir, and asserts both the stdout/stderr message shape AND
+# the exit code AND the resulting `git config --get core.hooksPath` value.
+#
+# Discriminating by construction: bin/install-git-hooks.sh did not exist
+# before me2resh/apexyard#1086 step 1, so every case here fails against the
+# pre-change tree (the script is simply absent — `bash: no such file`) and
+# passes only once the script exists with the exact branching this suite
+# exercises. Cases 3-6 additionally verify the four-way state-classification
+# logic in _lib-git-hooks-path.sh (unset / correct / missing / foreign-git-dir
+# / third-party) is actually reached, not just that *some* path succeeds.
+#
+# Cases covered:
+#   1. Fresh clone (core.hooksPath unset)                  -> sets it, exit 0
+#   2. Already correct (idempotent re-run)                 -> no-op, exit 0
+#   3. Stale: core.hooksPath points at a non-existent dir   -> repaired, exit 0
+#   4. Stale: core.hooksPath points at a DIFFERENT clone's
+#      .git/hooks (the concrete #1086 failure mode)         -> repaired, exit 0
+#   5. Deliberate third-party real directory, no --force    -> refused, exit 1,
+#                                                               config UNCHANGED
+#   6. Deliberate third-party real directory, WITH --force  -> overwritten, exit 0
+#   7. --repo-dir target is not a git repository at all     -> exit 2, loud error
+#   8. Target repo has no tracked hooks dir to install       -> exit 3, config
+#                                                               UNCHANGED
+#
+# Exit 0 if all cases pass; 1 on first failure tally.
+
+set -u
+
+SCRIPT_SRC="$(cd "$(dirname "$0")/../../.." && pwd)/bin/install-git-hooks.sh"
+PASS=0
+FAIL=0
+FAILED=""
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label] — expected '$expected', got '$actual'" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+  fi
+}
+
+assert_match() {
+  local label="$1" pattern="$2" actual="$3"
+  if printf '%s' "$actual" | grep -qE "$pattern"; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label] — expected to match /$pattern/, got: $actual" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+  fi
+}
+
+# Build a tiny standalone git repo at $1 with a tracked .githooks/pre-push.
+build_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  ( cd "$dir" && git init -q )
+  mkdir -p "$dir/.githooks"
+  printf '#!/bin/sh\nexit 0\n' > "$dir/.githooks/pre-push"
+  ( cd "$dir" && git add .githooks && GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t.com \
+      GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t.com \
+      git commit -q -m "chore: init" )
+}
+
+run_installer() {
+  bash "$SCRIPT_SRC" "$@" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# CASE 1: fresh clone (unset) -> sets it, exit 0
+# ---------------------------------------------------------------------------
+case_fresh_unset() {
+  local sandbox; sandbox=$(mktemp -d)
+  local repo="$sandbox/repo"
+  build_repo "$repo"
+
+  local out rc
+  out=$(run_installer --repo-dir "$repo"); rc=$?
+  assert_eq "fresh unset: exit code" "0" "$rc"
+  assert_match "fresh unset: message" "set to \.githooks.*was unset" "$out"
+  assert_eq "fresh unset: config value" ".githooks" "$(git -C "$repo" config --get core.hooksPath)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 2: already correct -> no-op, exit 0, message says idempotent
+# ---------------------------------------------------------------------------
+case_idempotent() {
+  local sandbox; sandbox=$(mktemp -d)
+  local repo="$sandbox/repo"
+  build_repo "$repo"
+  git -C "$repo" config core.hooksPath .githooks
+
+  local out rc
+  out=$(run_installer --repo-dir "$repo"); rc=$?
+  assert_eq "idempotent: exit code" "0" "$rc"
+  assert_match "idempotent: message says no change" "idempotent" "$out"
+  assert_eq "idempotent: config value unchanged" ".githooks" "$(git -C "$repo" config --get core.hooksPath)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 3: core.hooksPath points at a directory that doesn't exist -> repaired
+# ---------------------------------------------------------------------------
+case_stale_missing_dir() {
+  local sandbox; sandbox=$(mktemp -d)
+  local repo="$sandbox/repo"
+  build_repo "$repo"
+  git -C "$repo" config core.hooksPath "$sandbox/this-does-not-exist"
+
+  local out rc
+  out=$(run_installer --repo-dir "$repo"); rc=$?
+  assert_eq "stale missing dir: exit code" "0" "$rc"
+  assert_match "stale missing dir: message says repaired" "repaired.*non-existent directory" "$out"
+  assert_eq "stale missing dir: config now correct" ".githooks" "$(git -C "$repo" config --get core.hooksPath)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 4: core.hooksPath points at a DIFFERENT clone's .git/hooks — the
+# concrete failure mode #1086 was filed against.
+# ---------------------------------------------------------------------------
+case_stale_foreign_clone() {
+  local sandbox; sandbox=$(mktemp -d)
+  local repo="$sandbox/repo"
+  local other="$sandbox/other-clone"
+  build_repo "$repo"
+  build_repo "$other"
+
+  local other_git_dir
+  other_git_dir=$(cd "$other" && git rev-parse --git-dir)
+  case "$other_git_dir" in
+    /*) : ;;
+    *) other_git_dir="$other/$other_git_dir" ;;
+  esac
+  git -C "$repo" config core.hooksPath "$other_git_dir/hooks"
+
+  local out rc
+  out=$(run_installer --repo-dir "$repo"); rc=$?
+  assert_eq "stale foreign clone: exit code" "0" "$rc"
+  assert_match "stale foreign clone: message says repaired + different clone" "repaired.*different clone" "$out"
+  assert_eq "stale foreign clone: config now correct" ".githooks" "$(git -C "$repo" config --get core.hooksPath)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 5: a real, existing, different directory the adopter configured on
+# purpose -> refused without --force, exit 1, config left untouched.
+# ---------------------------------------------------------------------------
+case_third_party_no_force() {
+  local sandbox; sandbox=$(mktemp -d)
+  local repo="$sandbox/repo"
+  build_repo "$repo"
+  mkdir -p "$repo/custom-hooks-dir"
+  git -C "$repo" config core.hooksPath custom-hooks-dir
+
+  local out rc
+  out=$(run_installer --repo-dir "$repo"); rc=$?
+  assert_eq "third-party no --force: exit code" "1" "$rc"
+  assert_match "third-party no --force: message says refusing" "[Rr]efusing to overwrite" "$out"
+  assert_eq "third-party no --force: config UNCHANGED" "custom-hooks-dir" "$(git -C "$repo" config --get core.hooksPath)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 6: same as case 5, but with --force -> overwritten, exit 0
+# ---------------------------------------------------------------------------
+case_third_party_with_force() {
+  local sandbox; sandbox=$(mktemp -d)
+  local repo="$sandbox/repo"
+  build_repo "$repo"
+  mkdir -p "$repo/custom-hooks-dir"
+  git -C "$repo" config core.hooksPath custom-hooks-dir
+
+  local out rc
+  out=$(run_installer --repo-dir "$repo" --force); rc=$?
+  assert_eq "third-party --force: exit code" "0" "$rc"
+  assert_match "third-party --force: message says overwritten" "overwritten" "$out"
+  assert_eq "third-party --force: config now correct" ".githooks" "$(git -C "$repo" config --get core.hooksPath)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 7: --repo-dir target is not a git repository at all -> loud error, exit 2
+# ---------------------------------------------------------------------------
+case_not_a_git_repo() {
+  local sandbox; sandbox=$(mktemp -d)
+  local plain="$sandbox/not-a-repo"
+  mkdir -p "$plain"
+
+  local out rc
+  out=$(run_installer --repo-dir "$plain"); rc=$?
+  assert_eq "not a git repo: exit code" "2" "$rc"
+  assert_match "not a git repo: message" "not inside a git repository" "$out"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 8: target repo has no tracked .githooks/ dir -> exit 3, nothing changed
+# ---------------------------------------------------------------------------
+case_no_hooks_dir() {
+  local sandbox; sandbox=$(mktemp -d)
+  local repo="$sandbox/repo"
+  mkdir -p "$repo"
+  ( cd "$repo" && git init -q )
+  printf 'x' > "$repo/README.md"
+  ( cd "$repo" && git add README.md && GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t.com \
+      GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t.com \
+      git commit -q -m "chore: init" )
+
+  local out rc
+  out=$(run_installer --repo-dir "$repo"); rc=$?
+  assert_eq "no hooks dir: exit code" "3" "$rc"
+  assert_match "no hooks dir: message" "nothing to install" "$out"
+  assert_eq "no hooks dir: config still unset" "" "$(git -C "$repo" config --get core.hooksPath 2>/dev/null || true)"
+
+  rm -rf "$sandbox"
+}
+
+if [ ! -f "$SCRIPT_SRC" ]; then
+  echo "FAIL: bin/install-git-hooks.sh not found at $SCRIPT_SRC" >&2
+  exit 1
+fi
+
+case_fresh_unset
+case_idempotent
+case_stale_missing_dir
+case_stale_foreign_clone
+case_third_party_no_force
+case_third_party_with_force
+case_not_a_git_repo
+case_no_hooks_dir
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/tests/test_install_git_hooks.sh
+++ b/.claude/hooks/tests/test_install_git_hooks.sh
@@ -232,6 +232,162 @@ case_no_hooks_dir() {
   rm -rf "$sandbox"
 }
 
+# ---------------------------------------------------------------------------
+# CASE 9 (PR #1087 review §2a — kills the _resolve_real_path passthrough
+# mutant): core.hooksPath set through a SYMLINK to the repo's own real
+# .githooks dir must classify as "correct" (idempotent no-op), not
+# "third-party". A mutant that replaces _resolve_real_path's body with a
+# bare passthrough (`printf '%s' "$1"`) makes this flip from rc=0
+# "idempotent" to rc=1 "refuses" — proven by direct probe during review;
+# this case pins the shipped (correct) behaviour so a regression is caught.
+# ---------------------------------------------------------------------------
+case_symlinked_repo_idempotent() {
+  local sandbox; sandbox=$(mktemp -d)
+  local repo="$sandbox/repo"
+  build_repo "$repo"
+  local link="$sandbox/githooks-link"
+  ln -s "$repo/.githooks" "$link"
+  git -C "$repo" config core.hooksPath "$link"
+
+  local out rc
+  out=$(run_installer --repo-dir "$repo"); rc=$?
+  assert_eq "symlinked repo idempotent: exit code" "0" "$rc"
+  assert_match "symlinked repo idempotent: message says idempotent" "idempotent" "$out"
+  assert_eq "symlinked repo idempotent: config UNCHANGED (still the symlink path)" "$link" "$(git -C "$repo" config --get core.hooksPath)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 10 (PR #1087 review §2c — kills the classifier's external-third-party
+# fallthrough mutant, the branch guarding this PR's central safety
+# property): core.hooksPath pointing at a real, existing directory OUTSIDE
+# the repo tree, with no `.git` component in its path — the canonical
+# "adopter configured a company-wide shared hooks dir" shape the lib's own
+# comment names. Cases 5/6 above only exercise the third-party branch via a
+# directory INSIDE the repo (the "$repo_root"/* prefix branch); this one
+# exercises the DIFFERENT, final fallthrough branch. A mutant that turns
+# that fallthrough into `unset` makes the installer silently CLOBBER this
+# deliberate value with no --force — proven during review; this case pins
+# the shipped (refuse) behaviour.
+# ---------------------------------------------------------------------------
+case_external_third_party_no_force() {
+  local sandbox; sandbox=$(mktemp -d)
+  local repo="$sandbox/repo"
+  local external="$sandbox/company-wide-hooks"
+  build_repo "$repo"
+  mkdir -p "$external"
+
+  git -C "$repo" config core.hooksPath "$external"
+
+  local out rc
+  out=$(run_installer --repo-dir "$repo"); rc=$?
+  assert_eq "external third-party no --force: exit code" "1" "$rc"
+  assert_match "external third-party no --force: message says refusing" "[Rr]efusing to overwrite" "$out"
+  assert_eq "external third-party no --force: config UNCHANGED" "$external" "$(git -C "$repo" config --get core.hooksPath)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 11 (PR #1087 review MEDIUM-3): --repo-dir naming a directory that
+# exists but is NOT itself a repo root must refuse rather than silently
+# walk up and configure the ENCLOSING repo. Reproduced during review via
+# workspace/<project> on a partial clone; this sandbox reproduces the
+# general shape (a plain subdirectory of a real repo).
+# ---------------------------------------------------------------------------
+case_repo_dir_retarget_refused() {
+  local sandbox; sandbox=$(mktemp -d)
+  local outer="$sandbox/outer"
+  build_repo "$outer"
+  local not_a_repo="$outer/subdir-not-a-repo"
+  mkdir -p "$not_a_repo"
+
+  local out rc
+  out=$(run_installer --repo-dir "$not_a_repo"); rc=$?
+  assert_eq "repo-dir retarget: exit code" "2" "$rc"
+  assert_match "repo-dir retarget: message names the enclosing repo" "ENCLOSING repo" "$out"
+  assert_eq "repo-dir retarget: outer repo's config UNCHANGED" "" "$(git -C "$outer" config --get core.hooksPath 2>/dev/null || true)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 12 (PR #1087 review LOW-4): --hooks-dir resolving outside the repo
+# tree (path traversal) must be refused, not written verbatim.
+# ---------------------------------------------------------------------------
+case_hooks_dir_traversal_refused() {
+  local sandbox; sandbox=$(mktemp -d)
+  local repo="$sandbox/repo"
+  build_repo "$repo"
+  mkdir -p "$sandbox/evil-outside-hooks"
+
+  local out rc
+  out=$(run_installer --repo-dir "$repo" --hooks-dir "../evil-outside-hooks"); rc=$?
+  assert_eq "hooks-dir traversal: exit code" "2" "$rc"
+  assert_match "hooks-dir traversal: message says outside" "outside" "$out"
+  assert_eq "hooks-dir traversal: config UNCHANGED" "" "$(git -C "$repo" config --get core.hooksPath 2>/dev/null || true)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 13 (PR #1087 review LOW-5): a tracked hooks dir committed as a
+# SYMLINK must be refused, not silently followed.
+# ---------------------------------------------------------------------------
+case_symlinked_hooks_dir_refused() {
+  local sandbox; sandbox=$(mktemp -d)
+  local repo="$sandbox/repo"
+  local elsewhere="$sandbox/real-hooks-elsewhere"
+  mkdir -p "$repo" "$elsewhere"
+  ( cd "$repo" && git init -q )
+  printf '#!/bin/sh\nexit 0\n' > "$elsewhere/pre-push"
+  ln -s "$elsewhere" "$repo/.githooks"
+  ( cd "$repo" && git add .githooks && GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t.com \
+      GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t.com \
+      git commit -q -m "chore: init" )
+
+  local out rc
+  out=$(run_installer --repo-dir "$repo"); rc=$?
+  assert_eq "symlinked hooks dir: exit code" "2" "$rc"
+  assert_match "symlinked hooks dir: message says symlink" "symlink" "$out"
+  assert_eq "symlinked hooks dir: config UNCHANGED" "" "$(git -C "$repo" config --get core.hooksPath 2>/dev/null || true)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 14 (PR #1087 review MEDIUM-2): a `git config` write that fails (a
+# stale .git/config.lock — routine when several worktree agents run in
+# parallel) must fail CLOSED: non-zero exit, no false success message, and
+# the config value left exactly as it was. Uses a REAL git lock file, not
+# a mock, so this is a genuine end-to-end reproduction of the review's
+# finding, not a simulation of one.
+# ---------------------------------------------------------------------------
+case_config_lock_fails_closed() {
+  local sandbox; sandbox=$(mktemp -d)
+  local repo="$sandbox/repo"
+  build_repo "$repo"
+
+  : > "$repo/.git/config.lock"
+
+  local out rc
+  out=$(run_installer --repo-dir "$repo"); rc=$?
+  rm -f "$repo/.git/config.lock"
+
+  assert_eq "config.lock fails closed: exit code is 4 (fail-closed), not 0" "4" "$rc"
+  if printf '%s' "$out" | grep -qE "core\.hooksPath set to \.githooks.*was unset"; then
+    echo "FAIL [config.lock fails closed: must NOT print the success message]" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}config.lock-no-false-success "
+  else
+    echo "PASS [config.lock fails closed: no false success message]"
+    PASS=$((PASS+1))
+  fi
+  assert_eq "config.lock fails closed: config still unset (write never took)" "" "$(git -C "$repo" config --get core.hooksPath 2>/dev/null || true)"
+
+  rm -rf "$sandbox"
+}
+
 if [ ! -f "$SCRIPT_SRC" ]; then
   echo "FAIL: bin/install-git-hooks.sh not found at $SCRIPT_SRC" >&2
   exit 1
@@ -245,6 +401,12 @@ case_third_party_no_force
 case_third_party_with_force
 case_not_a_git_repo
 case_no_hooks_dir
+case_symlinked_repo_idempotent
+case_external_third_party_no_force
+case_repo_dir_retarget_refused
+case_hooks_dir_traversal_refused
+case_symlinked_hooks_dir_refused
+case_config_lock_fails_closed
 
 echo ""
 echo "==================================="

--- a/.claude/hooks/tests/test_require_active_ticket_bash.sh
+++ b/.claude/hooks/tests/test_require_active_ticket_bash.sh
@@ -19,9 +19,10 @@ SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 HOOK_SRC="$SRC_ROOT/.claude/hooks/require-active-ticket.sh"
 LIB_BASH="$SRC_ROOT/.claude/hooks/_lib-detect-bash-write.sh"
 LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+LIB_PATH_RESOLVE="$SRC_ROOT/.claude/hooks/_lib-path-resolve.sh"
 DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
 
-for f in "$HOOK_SRC" "$LIB_BASH" "$LIB_CFG" "$DEFAULTS"; do
+for f in "$HOOK_SRC" "$LIB_BASH" "$LIB_CFG" "$LIB_PATH_RESOLVE" "$DEFAULTS"; do
   if [ ! -f "$f" ]; then
     echo "FAIL: required source missing: $f" >&2
     exit 1
@@ -49,6 +50,7 @@ make_sandbox() {
   cp "$HOOK_SRC" "$sb/.claude/hooks/require-active-ticket.sh"
   cp "$LIB_BASH" "$sb/.claude/hooks/_lib-detect-bash-write.sh"
   cp "$LIB_CFG"  "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$LIB_PATH_RESOLVE" "$sb/.claude/hooks/_lib-path-resolve.sh"
   cp "$DEFAULTS" "$sb/.claude/project-config.defaults.json"
   chmod +x "$sb/.claude/hooks/require-active-ticket.sh"
   echo "$sb"
@@ -404,6 +406,7 @@ mkdir -p "$_t30_ops/.claude/hooks"
 cp "$HOOK_SRC"  "$_t30_ops/.claude/hooks/require-active-ticket.sh"
 cp "$LIB_BASH"  "$_t30_ops/.claude/hooks/_lib-detect-bash-write.sh"
 cp "$LIB_CFG"   "$_t30_ops/.claude/hooks/_lib-read-config.sh"
+cp "$LIB_PATH_RESOLVE" "$_t30_ops/.claude/hooks/_lib-path-resolve.sh"
 cp "$DEFAULTS"  "$_t30_ops/.claude/project-config.defaults.json"
 [ -f "$LIB_OPS_SRC" ]  && cp "$LIB_OPS_SRC"  "$_t30_ops/.claude/hooks/_lib-ops-root.sh"
 [ -f "$LIB_PORT_SRC" ] && cp "$LIB_PORT_SRC" "$_t30_ops/.claude/hooks/_lib-portfolio-paths.sh"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,10 @@
           },
           {
             "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/check-git-hooks-installed.sh\"'"
+          },
+          {
+            "type": "command",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/check-portfolio-config.sh\"'"
           },
           {

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -167,6 +167,20 @@ CLONE_STATUS="cloned"   # or "preserved" | "declined" | "failed: <reason>"
 
 All subsequent reads in steps 2–6 use `$WORKSPACE_DIR/<name>/` as the repo root whenever `$CLONE_STATUS` is `cloned` or `preserved`. When `$CLONE_STATUS` is `declined` or `failed`, fall back to GitHub API reads via `gh api` / `gh -R <owner/name> …` (degraded but functional).
 
+### 1.5-git-hooks. Install the tracked git hooks in the new clone (default: always attempt)
+
+After a successful clone (`$CLONE_STATUS=cloned` or `preserved`), attempt to install ApexYard's tracked git hooks into the workspace clone the same way `/setup` does for the ops fork — `core.hooksPath` is per-clone git config, never committed, so this fresh clone starts unset regardless of what any other clone of the same project has configured:
+
+```bash
+bash bin/install-git-hooks.sh --repo-dir "$WORKSPACE_DIR/<name>"
+```
+
+This is a **best-effort, non-fatal** step — most managed-project clones don't carry a `.githooks/` directory of their own yet (adopting that is a separate, out-of-scope piece of work per me2resh/apexyard#1086), so exit 3 ("nothing to install") is the common, expected outcome here, not a failure to report loudly. Branch on the exit code:
+
+- **0** (installed / repaired / already correct): note it in the step 10 summary, one line.
+- **3** (no tracked hooks dir in the clone): silent — this is the expected case for the vast majority of handovers today; don't clutter the summary with an expected no-op.
+- **1** (a real, different `core.hooksPath` the operator configured on purpose in that clone) or **2** (misuse / not a git repo, shouldn't happen right after a successful clone): print a one-line note and continue — this step never blocks the rest of `/handover`.
+
 ### 1.5-reindex. Reindex the cloned repo in MCP (default: always attempt)
 
 After a successful clone (`$CLONE_STATUS=cloned`), trigger an MCP reindex so `search_code` and `search_docs` return results during the deep-dive phases that follow (steps 2–6). Without this step those queries return empty against the just-cloned repo, and the agent silently falls back to `find` + `cat` + `Bash` — defeating the token-cost benefit of cloning early.

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -167,19 +167,9 @@ CLONE_STATUS="cloned"   # or "preserved" | "declined" | "failed: <reason>"
 
 All subsequent reads in steps 2–6 use `$WORKSPACE_DIR/<name>/` as the repo root whenever `$CLONE_STATUS` is `cloned` or `preserved`. When `$CLONE_STATUS` is `declined` or `failed`, fall back to GitHub API reads via `gh api` / `gh -R <owner/name> …` (degraded but functional).
 
-### 1.5-git-hooks. Install the tracked git hooks in the new clone (default: always attempt)
-
-After a successful clone (`$CLONE_STATUS=cloned` or `preserved`), attempt to install ApexYard's tracked git hooks into the workspace clone the same way `/setup` does for the ops fork — `core.hooksPath` is per-clone git config, never committed, so this fresh clone starts unset regardless of what any other clone of the same project has configured:
-
-```bash
-bash bin/install-git-hooks.sh --repo-dir "$WORKSPACE_DIR/<name>"
-```
-
-This is a **best-effort, non-fatal** step — most managed-project clones don't carry a `.githooks/` directory of their own yet (adopting that is a separate, out-of-scope piece of work per me2resh/apexyard#1086), so exit 3 ("nothing to install") is the common, expected outcome here, not a failure to report loudly. Branch on the exit code:
-
-- **0** (installed / repaired / already correct): note it in the step 10 summary, one line.
-- **3** (no tracked hooks dir in the clone): silent — this is the expected case for the vast majority of handovers today; don't clutter the summary with an expected no-op.
-- **1** (a real, different `core.hooksPath` the operator configured on purpose in that clone) or **2** (misuse / not a git repo, shouldn't happen right after a successful clone): print a one-line note and continue — this step never blocks the rest of `/handover`.
+> **`bin/install-git-hooks.sh` is deliberately NOT invoked here.** An earlier version of this step called it against the freshly-cloned workspace, on the reasoning that it mirrors `/setup`'s call for the ops fork. It does not: `/setup` points `core.hooksPath` at the **ops fork's own** `.githooks/`, which ApexYard controls. Calling the same installer against an arbitrary, just-cloned third-party repo instead points git at *that repo's own* `.githooks/` (whatever it ships), and does so with no provenance check — the installer's only gate is "does a directory of that name exist." Git deliberately never clones `$GIT_DIR/hooks`, which is exactly what makes `git clone` of an untrusted repo a safe, read-only act; repointing `core.hooksPath` at a *tracked* directory removes that property, and a hostile `.githooks/post-checkout` or `.githooks/reference-transaction` then runs as the operator on the very next ordinary git operation — no push required. `/handover`'s whole point is to evaluate a repo before deeper commitment, so this is exactly the wrong moment to hand it code execution. Confirmed by security review on PR #1087 (HIGH-1).
+>
+> The gap this leaves — a managed-project clone's *own* `.githooks/` still isn't wired up by anything, so its terminal `git push` stays unprotected — is real and deliberately deferred, not silently dropped. The correct shape is for the framework to install **its own** hook into the clone's untracked `.git/hooks/` (never point at a tracked third-party directory), which needs its own design and its own ticket. Do not attempt it here.
 
 ### 1.5-reindex. Reindex the cloned repo in MCP (default: always attempt)
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -71,6 +71,16 @@ The marker is cleared in Step 8 below (and on the next SessionStart by `clear-bo
 
 See AgDR-0011 + me2resh/apexyard#150 for the design rationale.
 
+### Step 0.5: Install the tracked git hooks (REQUIRED)
+
+`core.hooksPath` is a **per-clone** git config value — it lives in `.git/config`, never committed, so every fresh clone of the ops fork starts unset regardless of how many sibling clones already have it configured. Left unset, `.githooks/pre-push` (tracked, but inert without this) never runs on a terminal `git push` — only Claude-Code-driven pushes go through the equivalent `pre-push-gate.sh` PreToolUse hook. Run the installer once per fork, here, so a fresh `/setup` always leaves the clone protected on both paths:
+
+```bash
+bash bin/install-git-hooks.sh
+```
+
+Idempotent — a re-run on an already-configured clone reports "no change" and exits 0. If it exits 1 (a real, different `core.hooksPath` the operator configured on purpose), report that plainly and move on without `--force` — overriding a deliberate adopter choice isn't this step's call to make silently. See `bin/install-git-hooks.sh --help` and me2resh/apexyard#1086 for the full state machine (fresh / idempotent / stale-repair / deliberate-third-party).
+
 ### Step 1: Check current state
 
 Read `onboarding.yaml`. Four modes:

--- a/bin/install-git-hooks.sh
+++ b/bin/install-git-hooks.sh
@@ -43,10 +43,26 @@
 #       or was already correct)
 #   1 — refused: an existing, real, non-stale core.hooksPath is set to
 #       something else; re-run with --force to override
-#   2 — usage error, or the target isn't a git repository at all
+#   2 — usage error, the target isn't a git repository at all, --repo-dir
+#       resolved to a DIFFERENT (enclosing) repo than requested, the
+#       tracked hooks dir is a symlink, or --hooks-dir resolves outside
+#       the target repo
 #   3 — the target repo has no tracked hooks dir to install (e.g. a
 #       managed-project clone that hasn't adopted .githooks/ yet) — not a
 #       bug, just nothing to do here
+#   4 — the core.hooksPath write did not take effect (a `git config`
+#       error, e.g. a stale .git/config.lock or a multi-valued key) —
+#       fails CLOSED: never reports success on an unverified write
+#
+# Security note (PR #1087 review, HIGH-1): this script gates only on
+# whether $TARGET_ROOT/$HOOKS_DIR_NAME exists. It performs NO provenance
+# check on what that directory contains. That is fine when the caller
+# controls the target repo (the ops fork configuring its own .githooks/,
+# via /setup) — it is NOT fine against an arbitrary, just-cloned
+# third-party repo, because doing so points git at THAT repo's own
+# scripts with no operator confirmation. Callers MUST NOT invoke this
+# against an untrusted clone. See .claude/skills/handover/SKILL.md's
+# explicit note on why /handover deliberately does not call this script.
 #
 # See me2resh/apexyard#1086 for the full driver and the two follow-up
 # steps (enforcement inside .githooks/pre-push; demoting block-main-push.sh
@@ -83,9 +99,52 @@ Options:
 Exit codes:
   0 — core.hooksPath is now correctly set (fresh, repaired, or already correct)
   1 — refused: a deliberate third-party core.hooksPath exists; re-run with --force
-  2 — usage / not-a-git-repo error
+  2 — usage / not-a-git-repo / wrong-repo-resolved / symlinked-hooks-dir error
   3 — target repo has no tracked hooks dir to install (nothing to do)
+  4 — the core.hooksPath write did not take effect (fails closed)
 USAGE
+}
+
+# ---------------------------------------------------------------------------
+# _ghp_set_hookspath TARGET_ROOT HOOKS_DIR_NAME
+#
+# Writes core.hooksPath and FAILS CLOSED (PR #1087 review, MEDIUM-2): the
+# advisory hook is allowed to fail open (warn, never block), but this
+# installer's whole job is telling the operator their clone IS protected —
+# reporting success on a write that silently didn't take is worse than not
+# writing at all, because the operator stops worrying about exactly the
+# thing that's still broken.
+#
+# Two independent checks, neither trusted alone:
+#   1. `git config`'s own exit status — catches a stale .git/config.lock
+#      (a routine race when several worktree agents run in parallel) and
+#      a multi-valued core.hooksPath (`git config <key> <value>` refuses
+#      to collapse multiple values to one and exits non-zero).
+#   2. Re-classify afterward and require "correct" — a defence-in-depth
+#      read-back in case some git version/config-shape combination exits
+#      0 without the value actually landing.
+#
+# Prints nothing on success (caller prints its own message); prints a
+# specific error and returns 1 on failure.
+# ---------------------------------------------------------------------------
+_ghp_set_hookspath() {
+  local target_root="$1" hooks_dir_name="$2"
+  local err rc recheck
+
+  err=$(git -C "$target_root" config core.hooksPath "$hooks_dir_name" 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "ERROR: 'git config core.hooksPath' failed (exit $rc): $err" >&2
+    return 1
+  fi
+
+  recheck=$(ghp_classify "$target_root" "$hooks_dir_name")
+  if [ "$recheck" != "correct" ]; then
+    echo "ERROR: core.hooksPath write did not take effect (post-write state: '$recheck'). Not reporting success." >&2
+    return 1
+  fi
+
+  return 0
 }
 
 REPO_DIR=""
@@ -128,23 +187,78 @@ if [ -z "$TARGET_ROOT" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# MEDIUM-3 (PR #1087 review): when --repo-dir is given but is not itself a
+# repo's own root, `git rev-parse --show-toplevel` walks UP and silently
+# returns whatever repo ENCLOSES it — e.g. --repo-dir <ops>/workspace/proj
+# on a failed or partial clone resolves to the ops fork itself. Without
+# this check the installer would then configure a repo the caller never
+# named, and report success as if it had configured the one it did name.
+# This is exactly the wrong-repo-write class .claude/rules/isolated-builds.md
+# exists to prevent: a wrong-target resolution must stop, not continue.
+# Compare resolved, symlink-free forms so a legitimate symlinked repo path
+# doesn't false-positive here.
+# ---------------------------------------------------------------------------
+if [ -n "$REPO_DIR" ]; then
+  REQUESTED_RESOLVED=$(_resolve_real_path "$REPO_DIR")
+  TARGET_RESOLVED_FOR_CHECK=$(_resolve_real_path "$TARGET_ROOT")
+  if [ -z "$REQUESTED_RESOLVED" ] || [ "$REQUESTED_RESOLVED" != "$TARGET_RESOLVED_FOR_CHECK" ]; then
+    echo "ERROR: --repo-dir '$REPO_DIR' is not itself a git repository root — it resolved to the ENCLOSING repo at '$TARGET_ROOT' instead. Refusing to silently configure a different repo than requested. Pass the actual repo root, or omit --repo-dir to target the current directory's repo." >&2
+    exit 2
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# LOW-5 (PR #1087 review): refuse a tracked hooks dir committed as a
+# SYMLINK, checked BEFORE the existence/directory test below. `[ -L ]`
+# tests the entry itself without following it, so it catches a symlink
+# named .githooks regardless of what it points to (a real dir outside the
+# repo, a missing target, anything) — `[ -d ]` alone would follow a
+# symlink-to-directory and treat it as an ordinary tracked dir, letting it
+# resolve hooks from wherever the link leads instead of what "the repo's
+# tracked hooks directory" is supposed to mean.
+# ---------------------------------------------------------------------------
+if [ -L "$TARGET_ROOT/$HOOKS_DIR_NAME" ]; then
+  echo "ERROR: $TARGET_ROOT/$HOOKS_DIR_NAME is a symlink, not a real directory. Refusing to point core.hooksPath at a symlinked hooks dir (it can resolve outside the repo tree)." >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
 # Nothing to install if this repo carries no tracked hooks dir at all — this
 # is the expected, non-error state for a managed-project clone that hasn't
-# adopted .githooks/ yet (see /handover's invocation of this script). Still
-# loud (non-zero, explicit message) rather than a silent no-op.
+# adopted .githooks/ yet. Still loud (non-zero, explicit message) rather
+# than a silent no-op.
 # ---------------------------------------------------------------------------
 if [ ! -d "$TARGET_ROOT/$HOOKS_DIR_NAME" ]; then
   echo "No $HOOKS_DIR_NAME/ directory in $TARGET_ROOT — nothing to install (this repo hasn't adopted ApexYard's tracked git hooks). Skipping." >&2
   exit 3
 fi
 
+# ---------------------------------------------------------------------------
+# LOW-4 (PR #1087 review): reject a --hooks-dir value that resolves OUTSIDE
+# the target repo (e.g. `--hooks-dir ../evil-hooks`). The classifier lib
+# already reasons carefully about "outside REPO_ROOT" when DETECTING state;
+# this is the matching check on the value we're about to WRITE.
+# ---------------------------------------------------------------------------
+HOOKS_DIR_RESOLVED=$(_resolve_real_path "$TARGET_ROOT/$HOOKS_DIR_NAME")
+case "$HOOKS_DIR_RESOLVED" in
+  "$TARGET_ROOT"/*|"$TARGET_ROOT") : ;;
+  *)
+    echo "ERROR: --hooks-dir '$HOOKS_DIR_NAME' resolves to '$HOOKS_DIR_RESOLVED', which is outside $TARGET_ROOT. Refusing to point core.hooksPath outside the repo tree." >&2
+    exit 2
+    ;;
+esac
+
 STATE=$(ghp_classify "$TARGET_ROOT" "$HOOKS_DIR_NAME")
 
 case "$STATE" in
   unset)
-    git -C "$TARGET_ROOT" config core.hooksPath "$HOOKS_DIR_NAME"
-    echo "core.hooksPath set to $HOOKS_DIR_NAME in $TARGET_ROOT (was unset)."
-    exit 0
+    if _ghp_set_hookspath "$TARGET_ROOT" "$HOOKS_DIR_NAME"; then
+      echo "core.hooksPath set to $HOOKS_DIR_NAME in $TARGET_ROOT (was unset)."
+      exit 0
+    else
+      echo "ERROR: failed to set core.hooksPath in $TARGET_ROOT — clone is NOT protected. Check for a stale .git/config.lock, retry, or investigate the error above." >&2
+      exit 4
+    fi
     ;;
 
   correct)
@@ -154,18 +268,26 @@ case "$STATE" in
 
   missing:*)
     RAW="${STATE#missing:}"
-    git -C "$TARGET_ROOT" config core.hooksPath "$HOOKS_DIR_NAME"
-    echo "core.hooksPath repaired: was '$RAW' (points at a non-existent directory), now $HOOKS_DIR_NAME in $TARGET_ROOT."
-    exit 0
+    if _ghp_set_hookspath "$TARGET_ROOT" "$HOOKS_DIR_NAME"; then
+      echo "core.hooksPath repaired: was '$RAW' (points at a non-existent directory), now $HOOKS_DIR_NAME in $TARGET_ROOT."
+      exit 0
+    else
+      echo "ERROR: failed to repair core.hooksPath in $TARGET_ROOT (was '$RAW') — clone is NOT protected. Check for a stale .git/config.lock, retry, or investigate the error above." >&2
+      exit 4
+    fi
     ;;
 
   foreign-git-dir:*)
     REST="${STATE#foreign-git-dir:}"
     RAW="${REST%%:*}"
     RESOLVED="${REST#*:}"
-    git -C "$TARGET_ROOT" config core.hooksPath "$HOOKS_DIR_NAME"
-    echo "core.hooksPath repaired: was '$RAW' (resolves to $RESOLVED — a different clone's git hooks dir), now $HOOKS_DIR_NAME in $TARGET_ROOT."
-    exit 0
+    if _ghp_set_hookspath "$TARGET_ROOT" "$HOOKS_DIR_NAME"; then
+      echo "core.hooksPath repaired: was '$RAW' (resolves to $RESOLVED — a different clone's git hooks dir), now $HOOKS_DIR_NAME in $TARGET_ROOT."
+      exit 0
+    else
+      echo "ERROR: failed to repair core.hooksPath in $TARGET_ROOT (was '$RAW') — clone is NOT protected. Check for a stale .git/config.lock, retry, or investigate the error above." >&2
+      exit 4
+    fi
     ;;
 
   third-party:*)
@@ -183,9 +305,13 @@ Re-run with --force to install ApexYard's tracked hooks ($HOOKS_DIR_NAME) instea
 MSG
       exit 1
     fi
-    git -C "$TARGET_ROOT" config core.hooksPath "$HOOKS_DIR_NAME"
-    echo "core.hooksPath overwritten (--force): was '$RAW', now $HOOKS_DIR_NAME in $TARGET_ROOT."
-    exit 0
+    if _ghp_set_hookspath "$TARGET_ROOT" "$HOOKS_DIR_NAME"; then
+      echo "core.hooksPath overwritten (--force): was '$RAW', now $HOOKS_DIR_NAME in $TARGET_ROOT."
+      exit 0
+    else
+      echo "ERROR: failed to overwrite core.hooksPath in $TARGET_ROOT (was '$RAW') — clone is NOT protected. Check for a stale .git/config.lock, retry, or investigate the error above." >&2
+      exit 4
+    fi
     ;;
 
   *)

--- a/bin/install-git-hooks.sh
+++ b/bin/install-git-hooks.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# bin/install-git-hooks.sh — install ApexYard's tracked git hooks by setting
+# `core.hooksPath`, per clone. Step 1 of me2resh/apexyard#1086.
+#
+# Background: `.githooks/pre-push` already exists and is tracked, but
+# NOTHING sets `core.hooksPath` to point at it. Adopters were expected to
+# run `git config core.hooksPath .githooks` by hand (docs/getting-started.md
+# § "Optional: Terminal push hook") — and empirically that doesn't happen:
+# one fork inherits `.githooks/` with the config unset, another has it
+# pointing at a stale absolute path left over from a prior clone location,
+# leaving the tracked hook silently inert either way.
+#
+# `core.hooksPath` is a PER-CLONE git config value, not a repo property —
+# it lives in `.git/config`, never committed, so every fresh clone starts
+# unset regardless of how many times a sibling clone has run this script.
+# That's exactly why this needs to be invoked from `/setup` (for the ops
+# fork) and `/handover` (for each newly-cloned managed-project workspace),
+# not run once and forgotten.
+#
+# This script is idempotent and safe to re-run: unset -> set, already
+# correct -> no-op, stale (missing dir, or a leftover pointer into a
+# different clone's .git/hooks) -> auto-repaired, a real third-party
+# directory the adopter set on purpose -> left alone unless --force.
+#
+# Usage:
+#   bin/install-git-hooks.sh [--repo-dir <path>] [--hooks-dir <name>] [--force]
+#
+# Options:
+#   --repo-dir <path>   Target repo (default: the repo containing the
+#                       current working directory). Lets /handover call
+#                       this against a freshly-cloned managed-project
+#                       workspace instead of the ops fork.
+#   --hooks-dir <name>  Tracked hooks dir name, relative to the repo root
+#                       (default: .githooks). Mainly useful for tests.
+#   --force             Overwrite a core.hooksPath an adopter set to a
+#                       real, existing, different directory on purpose.
+#                       Without --force such a "third-party" value is left
+#                       untouched (exit 1) — this script never clobbers a
+#                       deliberate choice silently.
+#
+# Exit codes:
+#   0 — core.hooksPath is now correctly set (freshly set, auto-repaired,
+#       or was already correct)
+#   1 — refused: an existing, real, non-stale core.hooksPath is set to
+#       something else; re-run with --force to override
+#   2 — usage error, or the target isn't a git repository at all
+#   3 — the target repo has no tracked hooks dir to install (e.g. a
+#       managed-project clone that hasn't adopted .githooks/ yet) — not a
+#       bug, just nothing to do here
+#
+# See me2resh/apexyard#1086 for the full driver and the two follow-up
+# steps (enforcement inside .githooks/pre-push; demoting block-main-push.sh
+# to advisory) that build on top of this installer but are explicitly OUT
+# OF SCOPE here — landing them before this script exists and is wired up
+# would move enforcement to a layer that's off by default for every
+# adopter, which AgDR-0104 already flagged as strictly worse than today.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+LIB="$SCRIPT_DIR/../.claude/hooks/_lib-git-hooks-path.sh"
+
+if [ ! -f "$LIB" ]; then
+  echo "ERROR: missing $LIB — cannot resolve core.hooksPath state. Is this running from inside an apexyard clone?" >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
+. "$LIB"
+
+usage() {
+  cat <<'USAGE'
+Usage: bin/install-git-hooks.sh [--repo-dir <path>] [--hooks-dir <name>] [--force]
+
+Sets core.hooksPath so this clone picks up ApexYard's tracked git hooks
+(.githooks/pre-push and friends). Idempotent — safe to re-run.
+
+Options:
+  --repo-dir <path>   Target repo (default: the repo containing the cwd).
+  --hooks-dir <name>  Hooks dir name relative to repo root (default: .githooks).
+  --force             Overwrite a core.hooksPath an adopter set to a real,
+                       different directory on purpose.
+
+Exit codes:
+  0 — core.hooksPath is now correctly set (fresh, repaired, or already correct)
+  1 — refused: a deliberate third-party core.hooksPath exists; re-run with --force
+  2 — usage / not-a-git-repo error
+  3 — target repo has no tracked hooks dir to install (nothing to do)
+USAGE
+}
+
+REPO_DIR=""
+HOOKS_DIR_NAME=".githooks"
+FORCE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-dir)
+      [ $# -ge 2 ] || { echo "ERROR: --repo-dir requires a value." >&2; usage >&2; exit 2; }
+      REPO_DIR="$2"; shift 2 ;;
+    --repo-dir=*) REPO_DIR="${1#*=}"; shift ;;
+    --hooks-dir)
+      [ $# -ge 2 ] || { echo "ERROR: --hooks-dir requires a value." >&2; usage >&2; exit 2; }
+      HOOKS_DIR_NAME="$2"; shift 2 ;;
+    --hooks-dir=*) HOOKS_DIR_NAME="${1#*=}"; shift ;;
+    --force) FORCE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve the target repo's toplevel. Fails loudly (never silently) when the
+# target isn't a git repository at all.
+# ---------------------------------------------------------------------------
+if [ -n "$REPO_DIR" ]; then
+  if [ ! -d "$REPO_DIR" ]; then
+    echo "ERROR: --repo-dir '$REPO_DIR' does not exist." >&2
+    exit 2
+  fi
+  TARGET_ROOT=$(cd "$REPO_DIR" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null || true)
+else
+  TARGET_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+fi
+
+if [ -z "$TARGET_ROOT" ]; then
+  echo "ERROR: ${REPO_DIR:-$PWD} is not inside a git repository. Nothing to install." >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Nothing to install if this repo carries no tracked hooks dir at all — this
+# is the expected, non-error state for a managed-project clone that hasn't
+# adopted .githooks/ yet (see /handover's invocation of this script). Still
+# loud (non-zero, explicit message) rather than a silent no-op.
+# ---------------------------------------------------------------------------
+if [ ! -d "$TARGET_ROOT/$HOOKS_DIR_NAME" ]; then
+  echo "No $HOOKS_DIR_NAME/ directory in $TARGET_ROOT — nothing to install (this repo hasn't adopted ApexYard's tracked git hooks). Skipping." >&2
+  exit 3
+fi
+
+STATE=$(ghp_classify "$TARGET_ROOT" "$HOOKS_DIR_NAME")
+
+case "$STATE" in
+  unset)
+    git -C "$TARGET_ROOT" config core.hooksPath "$HOOKS_DIR_NAME"
+    echo "core.hooksPath set to $HOOKS_DIR_NAME in $TARGET_ROOT (was unset)."
+    exit 0
+    ;;
+
+  correct)
+    echo "core.hooksPath already set to $HOOKS_DIR_NAME in $TARGET_ROOT — no change (idempotent)."
+    exit 0
+    ;;
+
+  missing:*)
+    RAW="${STATE#missing:}"
+    git -C "$TARGET_ROOT" config core.hooksPath "$HOOKS_DIR_NAME"
+    echo "core.hooksPath repaired: was '$RAW' (points at a non-existent directory), now $HOOKS_DIR_NAME in $TARGET_ROOT."
+    exit 0
+    ;;
+
+  foreign-git-dir:*)
+    REST="${STATE#foreign-git-dir:}"
+    RAW="${REST%%:*}"
+    RESOLVED="${REST#*:}"
+    git -C "$TARGET_ROOT" config core.hooksPath "$HOOKS_DIR_NAME"
+    echo "core.hooksPath repaired: was '$RAW' (resolves to $RESOLVED — a different clone's git hooks dir), now $HOOKS_DIR_NAME in $TARGET_ROOT."
+    exit 0
+    ;;
+
+  third-party:*)
+    REST="${STATE#third-party:}"
+    RAW="${REST%%:*}"
+    RESOLVED="${REST#*:}"
+    if [ "$FORCE" != "1" ]; then
+      cat >&2 <<MSG
+core.hooksPath is set to '$RAW' (resolves to $RESOLVED) in $TARGET_ROOT, and
+that directory exists — this looks like a deliberate adopter choice, not a
+stale leftover. Refusing to overwrite without --force.
+
+Re-run with --force to install ApexYard's tracked hooks ($HOOKS_DIR_NAME) instead:
+  bash bin/install-git-hooks.sh --repo-dir "$TARGET_ROOT" --force
+MSG
+      exit 1
+    fi
+    git -C "$TARGET_ROOT" config core.hooksPath "$HOOKS_DIR_NAME"
+    echo "core.hooksPath overwritten (--force): was '$RAW', now $HOOKS_DIR_NAME in $TARGET_ROOT."
+    exit 0
+    ;;
+
+  *)
+    echo "ERROR: internal — unrecognised core.hooksPath state '$STATE'." >&2
+    exit 2
+    ;;
+esac

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -137,27 +137,25 @@ Create an AgDR.
 
 ---
 
-## Optional: Terminal push hook (`core.hooksPath`)
+## Terminal push hook (`core.hooksPath`)
 
 The framework ships a `.githooks/pre-push` hook that runs the same check set as the Claude Code `pre-push-gate.sh` hook — markdownlint, shellcheck, and the subpack extraction smoke test — for terminal `git push` commands.
 
 The Claude Code hook (`pre-push-gate.sh`) only fires on pushes made _through Claude Code_. The git hook covers pushes made directly from the terminal.
 
-### One-time opt-in per clone
+### Installed automatically by `/setup`
+
+As of me2resh/apexyard#1086, `/setup` runs `bin/install-git-hooks.sh` for you, so a fresh ops-fork clone that's been through `/setup` already has `core.hooksPath` pointing at `.githooks`. A `check-git-hooks-installed.sh` SessionStart advisory also warns — same non-blocking shape as `check-upstream-drift.sh` — if a clone's `core.hooksPath` is unset, stale (points at a deleted directory), or a leftover pointer into a different clone's `.git/hooks`.
+
+If you skipped `/setup`, or want to run it by hand:
 
 ```bash
-git config core.hooksPath .githooks
+bash bin/install-git-hooks.sh
 ```
 
-Run this once inside your apexyard clone. Git then picks up `.githooks/pre-push` on every `git push` regardless of how you invoke it.
+Idempotent — safe to re-run. Repairs the stale-pointer cases above automatically; refuses to overwrite a `core.hooksPath` you set to something else on purpose unless you pass `--force`. See `bash bin/install-git-hooks.sh --help`.
 
-To enable it globally for all clones of apexyard (useful if you work across multiple machines or re-clone often):
-
-```bash
-git config --global core.hooksPath .githooks
-```
-
-Note: `--global` affects every git repo on your machine, not just apexyard. If other repos ship their own hooks under `.git/hooks/`, those will be shadowed. The safest approach is per-clone.
+`core.hooksPath` is per-clone git config (never committed), so this needs to run once per clone — that's exactly why `/setup` and `/handover` call it rather than leaving it as a one-time manual step to remember. `--global` also works (`git config --global core.hooksPath .githooks`) if you want every clone on a machine covered at once, but note it affects every git repo on that machine, not just apexyard — if other repos ship their own hooks under `.git/hooks/`, those get shadowed. Per-clone (what the installer does by default) is the safer default.
 
 ### Missing tools degrade gracefully
 


### PR DESCRIPTION
## Summary

- **Ships `bin/install-git-hooks.sh`, an idempotent per-clone installer for `core.hooksPath`** — `.githooks/pre-push` has existed and been tracked for a while, but nothing ever set the git config that makes it run. It's a per-clone value (lives in `.git/config`, never committed), so every fresh clone starts unset regardless of how many sibling clones already have it configured. The installer classifies the current state — unset, already correct, pointing at a deleted directory, or a stale leftover pointing into a *different* clone's `.git/hooks` (a real observed failure this ticket cites) — and auto-repairs the first three. A real, different directory the adopter configured on purpose is left untouched unless `--force` is passed, so this never silently clobbers a deliberate choice.
- **Adds a shared classification lib (`_lib-git-hooks-path.sh`)** so the installer and the advisory hook can't drift on what counts as "stale" vs "deliberate third-party" — both read the exact same state machine.
- **Adds a `SessionStart` advisory (`check-git-hooks-installed.sh`)** — same non-blocking shape as `check-upstream-drift.sh` (exit 0 always) — that warns when a clone's `core.hooksPath` is unset or stale, so a contributor finds out their terminal `git push` is unprotected instead of discovering it after the fact.
- **Wires the installer into `/setup` only** — the ops fork configuring its own `.githooks/`. `/handover` deliberately does **not** call it (see the security-fix bullet below).
- **Updates `docs/getting-started.md`'s "Terminal push hook" section** to describe the new automatic path instead of the old manual-only `git config core.hooksPath .githooks` instruction (kept as the fallback for anyone who skips `/setup`).

This is **step 1 of 3** from #1086. Steps 2 (moving protected-branch enforcement into `.githooks/pre-push` using git's own resolved ref data instead of command-text parsing) and 3 (demoting `block-main-push.sh` to advisory) are **explicitly out of scope here and must not land before this PR**. Nothing in this PR touches `.githooks/pre-push`'s check logic or `block-main-push.sh` at all.

### Review round 2 — every finding fixed in this batch

Both Rex and Hakim returned CHANGES REQUESTED on the first commit. All findings are addressed here in one pass (no incremental re-request, per the #1075 lesson):

- **[HIGH, Hakim] Dropped the `/handover` wiring entirely.** The installer gates only on "does a `.githooks/` directory exist" — it has no provenance check. Calling it against a freshly-cloned *third-party* repo doesn't install anything ApexYard-provided; it points git at *that repo's own* committed scripts, with no operator confirmation. Hakim proved this hands the clone code execution on ordinary git operations (`post-checkout`, `reference-transaction` — no push required), because git deliberately never clones `$GIT_DIR/hooks`, and pointing `core.hooksPath` at a tracked directory removes that safety property. `/handover`'s whole point is evaluating a repo before deeper commitment — exactly the wrong moment to hand it execution. `/setup` (the ops fork configuring its own repo) is unaffected and stays wired up. The gap this leaves — a managed-project clone's own git hooks still aren't installed by anything — is real and **deliberately deferred, not silently dropped**: `.claude/skills/handover/SKILL.md` now carries an explicit note that the correct fix is a *different* mechanism (install ApexYard's own hook into the clone's untracked `.git/hooks/`, never point at a tracked third-party directory), which needs its own design and its own ticket.
- **[MEDIUM, Hakim] The installer now fails CLOSED on a `git config` write that doesn't take.** None of the four writes checked their exit status before — a stale `.git/config.lock` (routine with several parallel worktree agents) or a multi-valued `core.hooksPath` made the script print its success message and exit 0 while the value stayed unchanged. `_ghp_set_hookspath()` now checks the write's exit status AND re-classifies afterward to confirm the state actually landed on `correct`; either check failing exits **4** with a loud error and zero false-success output. Reproduced for real with an actual `.git/config.lock` (not a mock) as part of verification — see Testing.
- **[MEDIUM, Hakim + suggestion from Rex, same root cause] `--repo-dir` no longer silently retargets to an enclosing repo.** `git rev-parse --show-toplevel` walks *up* when the given directory isn't a repo's own root — so `--repo-dir workspace/proj` on a failed or partial clone previously resolved to (and configured) the *ops fork*, while reporting success as if it had configured the named project. The installer now asserts the resolved toplevel equals the resolved `--repo-dir` and exits 2 loudly otherwise — the wrong-target-write class `.claude/rules/isolated-builds.md` exists to prevent.
- **[Rex finding #4] Retired the third copy of `_resolve_real_path`.** The PR's own comment admitted this was "copied verbatim... rather than sourcing it directly" from `require-active-ticket.sh` — precisely the AgDR-0113 pattern (an agreement asserted in a comment, not enforced by sharing) this PR's own arc exists to retire, in the very PR making that argument. There is now exactly **one** `_resolve_real_path`, at `.claude/hooks/_lib-path-resolve.sh`; `require-active-ticket.sh` and `_lib-git-hooks-path.sh` both source it. (This is explicitly *not* the same thing as `_lib-portfolio-paths.sh`'s `_portfolio_canonicalize`, a deliberately different fail-soft sibling with Windows drive-letter handling — the lib's header comment says so directly, so a future reader doesn't try to fold the two together.)
- **[Rex finding #5, three mutation-proven gaps] Added the three missing discriminating tests.** All three were verified by actually re-applying the mutant and confirming the suite goes red — see Testing:
  - A symlinked repo path resolving to the same real `.githooks` dir must classify `correct` (idempotent), not `third-party` — the case that pins `_resolve_real_path`'s actual behaviour rather than its mere presence.
  - The advisory hook's `third-party:*` banner now has coverage (previously zero — deleting the branch outright still passed 6/6).
  - The classifier's *external* third-party fallthrough (a real directory outside the repo, no `.git` component — the canonical "shared company hooks dir" shape) now has coverage on the installer side. This is the branch guarding the PR's central safety guarantee (never clobber a deliberate value without `--force`); it had zero tests before this round.
- **[LOW, Hakim] `--hooks-dir` traversal outside the repo is now rejected** (`--hooks-dir ../evil-hooks` used to write verbatim); **a `.githooks` committed as a symlink is now refused** (`[ -L ]` checked before `[ -d ]`, which previously followed it silently); **the advisory banner no longer suggests `--force`** on the third-party state — a recurring nudge toward overriding a deliberate choice was the wrong shape for a guard whose whole job is protecting that choice. Points at `--help` instead.

Three Rex notes were reviewed and intentionally left as-is (stated here rather than resolved silently): fail-empty vs. fail-soft path resolution is a documented, deliberate difference from `_portfolio_canonicalize` (see the lib header); a `git config` read failure degrading to `unset` is already the fail-safe direction; pointing `core.hooksPath` at *this* repo's own `.git/hooks` classifies as `third-party` (refuse) rather than `foreign-git-dir` by design, per the lib's own doc comment — all three are Low/informational, not requested fixes.

## Testing

- Full suite chunked (3 × ~43 tests, ≤90s/test cap): **PASS=129 FAIL=0** across all three chunks, zero regressions. `require-active-ticket.sh`'s own suite (`test_require_active_ticket_bash.sh`, updated to carry the new shared lib into its sandboxes) independently reruns clean: **PASS=78 FAIL=0**.
- `test_install_git_hooks.sh`: **41 assertions**, up from 23 — added cases for the symlinked-repo idempotent state, the external-third-party refusal, `--repo-dir` retargeting, `--hooks-dir` traversal, a symlinked hooks dir, and the real `.git/config.lock` fail-closed path.
- `test_check_git_hooks_installed.sh`: **8 assertions**, up from 6 — added the third-party banner case (asserts both that it fires and that it does *not* mention `--force`).
- **All three review-cited mutants re-applied and confirmed killed, not just described:**
  - `_resolve_real_path` → bare passthrough: installer suite **16/41 pass, 25 fail**; restored → 41/41.
  - Advisory hook's `third-party:*` branch deleted: advisory suite **7/8 pass, 1 fail**; restored → 8/8.
  - Classifier's external-third-party fallthrough → `unset`: installer suite **38/41 pass, 3 fail** + advisory suite **7/8 pass, 1 fail**; restored → both fully green.
- **MEDIUM-2 exercised for real**, not simulated: created an actual `.git/config.lock` in a scratch repo, ran the installer — `exit=4`, `error: could not lock config file .git/config: File exists` surfaced, no false-success message printed, `core.hooksPath` confirmed still unset afterward.
- **MEDIUM-3 exercised for real**: `--repo-dir <outer>/subdir-not-a-repo` against a real two-level scratch repo — refused with `exit=2`, names the enclosing repo, outer repo's config confirmed untouched.
- `shellcheck --severity=warning` on all eight touched/added shell files (including the two updated test files and the new shared lib) — clean.
- `markdownlint-cli2` across the repo — clean, including the updated `docs/getting-started.md` and `.claude/skills/handover/SKILL.md`.

## Glossary

| Term | Definition |
|------|------------|
| `core.hooksPath` | Per-clone git config naming the directory git reads hooks from. Lets a repo ship tracked hooks (like `.githooks/pre-push`), but the config must be set once per clone — cloning a repo does not inherit it. |
| `pre-push` hook | A git-native hook that runs before a push completes, given the refs being pushed on stdin already resolved by git — no command-text parsing required. |
| fail closed / fail open | Fail closed: on an error, refuse and report failure (the installer's `git config` write). Fail open: on an error, let the action through with a warning (the advisory `SessionStart` hook — it must never block a session). This PR's central fix (MEDIUM-2) was that the installer had accidentally inherited the advisory's fail-open shape. |
| `foreign-git-dir` | This PR's stale-detection signal: a `core.hooksPath` value resolving to a path with a `.git` component outside the target repo. Since a tracked hooks dir can never live inside `.git/` (never committed), this can only be a leftover pointer into a different clone's default hooks location. |
| third-party (in this PR) | `core.hooksPath` resolving to a real, existing directory that isn't the repo's own tracked dir and isn't `foreign-git-dir`-shaped — ambiguous by design, so treated as a deliberate adopter choice and never auto-repaired. |
| mutation testing (as used here) | Deliberately reintroducing a specific plausible bug (a "mutant") into already-passing code, then confirming the test suite goes red. A suite that stays green against a real mutant proves nothing — the standard this round's new tests were held to. |

Refs #1086
