### PR TITLE
fix(#1086): enforce protected branches from git's pre-push ref list

### DIFF
--- a/.claude/hooks/_lib-protected-branches.sh
+++ b/.claude/hooks/_lib-protected-branches.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# _lib-protected-branches.sh — single source of truth for the protected-
+# branch list, shared by every consumer that needs to answer "is branch X
+# one we refuse to push directly to". me2resh/apexyard#1086 step 2.
+#
+# Not a hook itself (the `_lib-` prefix keeps it out of hook wiring, same
+# convention as every other `_lib-*.sh` in this directory). Source it and
+# call protected_branch_regex to get a `|`-joined alternation suitable for
+# `grep -qE "^(<result>)$"`.
+#
+# WHY THIS EXISTS
+# ---------------
+# `.claude/hooks/block-main-push.sh` has resolved this list inline since
+# me2resh/apexyard#109 (config_get '.git.protected_branches[]', falling back
+# to main|master|dev|develop when config is absent or empty). #1086 adds a
+# SECOND consumer — `.githooks/pre-push`, the git-native enforcement layer —
+# that needs the exact same list. Re-deriving it a second time inline would
+# be precisely the failure mode PR #1087's review flagged as this repo's
+# dominant defect generator: two copies of the same resolution that have to
+# be trusted to agree, with the agreement asserted in a comment rather than
+# enforced in code (see AgDR-0113's whole "additive vs subtractive" /
+# "duplicated function" history for how expensive that pattern has been in
+# this exact file family).
+#
+# block-main-push.sh itself is intentionally NOT touched by #1086 step 2 —
+# demoting it to advisory is step 3, and must land only after this git-
+# native enforcement is proven installed-by-default (step 1) and blocking
+# (this file + .githooks/pre-push, step 2). Until step 3 migrates
+# block-main-push.sh to source this lib too, its own inline copy remains —
+# that overlap is a known, deliberate, temporary consequence of not touching
+# it here, not a second FUTURE source of truth: this file is written to be
+# the thing step 3 migrates block-main-push.sh onto, not a competing
+# implementation.
+#
+# Resolution order (identical to block-main-push.sh's inline version):
+#   1. .claude/project-config.json / .defaults.json -> .git.protected_branches[]
+#      (via _lib-read-config.sh, if available)
+#   2. Fallback: main|master|dev|develop
+#
+# Usage:
+#   . "$(dirname "$0")/_lib-protected-branches.sh"
+#   REGEX=$(protected_branch_regex)
+#   echo "$branch" | grep -qE "^(${REGEX})$" && echo "protected"
+
+# ------------------------------------------------------------------------
+# protected_branch_regex
+#
+# Prints a `|`-joined alternation of protected branch names to stdout (no
+# trailing newline guaranteed either way — callers should use it inside
+# `$(...)`, which strips trailing newlines regardless).
+# ------------------------------------------------------------------------
+protected_branch_regex() {
+  local hook_dir repo_root regex
+
+  hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+
+  regex=""
+  if [ -n "$repo_root" ] && [ -n "$hook_dir" ] && [ -f "$hook_dir/_lib-read-config.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$hook_dir/_lib-read-config.sh"
+    regex=$(config_get '.git.protected_branches[]' 2>/dev/null | paste -sd'|' -)
+  fi
+
+  if [ -z "$regex" ]; then
+    regex="main|master|dev|develop"
+  fi
+
+  echo "$regex"
+}

--- a/.claude/hooks/tests/test_githooks_pre_push_protected_branch.sh
+++ b/.claude/hooks/tests/test_githooks_pre_push_protected_branch.sh
@@ -1,0 +1,446 @@
+#!/bin/bash
+# Tests for .githooks/pre-push's protected-branch enforcement — the git-
+# native layer added in me2resh/apexyard#1086 step 2.
+#
+# WHY REAL GIT, NOT A STUBBED `git` ON PATH
+# ------------------------------------------------------------------------
+# The prior-review standard cited in the #1086 brief ("use a stubbed git on
+# PATH so the push genuinely executes") was written for
+# .claude/hooks/block-main-push.sh — a Claude-Code PreToolUse hook that
+# decides allow/deny from a *simulated* tool_input.command, with the actual
+# command never run by the test harness itself. There, a git stub is the
+# only way to prove the DOWNSTREAM bash -c "$COMMAND" would really have
+# reached (or not reached) git.
+#
+# .githooks/pre-push has no such simulated downstream step — it runs INSIDE
+# the real git-push lifecycle, invoked by git itself with git's own
+# resolved ref lines on stdin. A stub here would have to reimplement git's
+# refspec/tag/HEAD/upstream-tracking resolution to hand the hook correct
+# stdin — exactly the class of "reimplementation that has to be trusted to
+# agree with the real thing" AgDR-0113 spent five review rounds arguing
+# against. Running a REAL git binary against a REAL local bare "remote" and
+# asserting on the remote's actual ref state after each push is a STRICTER
+# proof of "the push genuinely executes or is genuinely rejected" than a
+# stub could give, not a weaker one: there is nothing to reimplement, and
+# nothing left to disagree with the real thing by construction.
+#
+# EACH "must block" CASE IS DISCRIMINATING BY CONSTRUCTION
+# ------------------------------------------------------------------------
+# Before #1086 step 2, .githooks/pre-push contained ZERO protected-branch
+# logic — it only ever delegated to bin/run-pre-push-checks.sh (lint/format
+# checks). Every "must block" case below therefore FAILS against the
+# pre-change file (the push succeeds, the remote ref advances) and PASSES
+# only once the new stdin-reading block exists. The "must NOT block" cases
+# are regression controls, not novelty proofs — they already passed against
+# the pre-change file (which blocked nothing) and exist here to catch
+# OVER-narrowing introduced by this change, the mirror failure mode two
+# prior predicates in block-main-push.sh were redesigned for.
+#
+# Cases:
+#   1.  Feature-branch push                          -> NOT blocked
+#   2.  Genuine tag push                              -> NOT blocked
+#   3.  Two-remote tag push                           -> NOT blocked (both)
+#   4.  Delete a NON-protected branch                 -> NOT blocked
+#   5.  Bare `git push` while checked out on `main`   -> BLOCKED
+#   6.  Explicit `git push origin main`               -> BLOCKED
+#   7.  `--delete main` (deletion of protected branch) -> BLOCKED, remote main intact
+#   8.  #1083 shape: redirect before the push          -> BLOCKED, remote main intact
+#   9.  #1084 shape: decoy ref in unstripped heredoc,
+#       then a bare (ref-less) push                    -> BLOCKED, remote main intact
+#   10. #1085 shape: tag-push prefix + `git push origin HEAD` on main
+#                                                        -> tags succeed, HEAD push BLOCKED
+#   11. #1066 shape: heredoc prose merely discussing
+#       `git push`, then a real push to main            -> BLOCKED, remote main intact
+#
+# Exit 0 if all cases pass; 1 on any failure.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+REAL_PRE_PUSH="$ROOT/.githooks/pre-push"
+REAL_PROTECTED_LIB="$ROOT/.claude/hooks/_lib-protected-branches.sh"
+REAL_READ_CONFIG_LIB="$ROOT/.claude/hooks/_lib-read-config.sh"
+
+PASS=0
+FAIL=0
+FAILED=""
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label] — expected '$expected', got '$actual'" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+  fi
+}
+
+assert_match() {
+  local label="$1" pattern="$2" actual="$3"
+  if printf '%s' "$actual" | grep -qE "$pattern"; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label] — expected to match /$pattern/, got: $actual" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+  fi
+}
+
+assert_ne() {
+  local label="$1" not_expected="$2" actual="$3"
+  if [ "$not_expected" != "$actual" ]; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label] — expected NOT '$not_expected', got exactly that" >&2
+    FAIL=$((FAIL+1)); FAILED="${FAILED}${label} "
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# build_sandbox DIR
+#
+# Builds:
+#   $DIR/remote.git  — a bare "remote" repo
+#   $DIR/work        — a local working repo, `main` checked out, tracking
+#                       origin/main, with the REAL .githooks/pre-push and its
+#                       sourced libs installed via core.hooksPath.
+#
+# The remote's `main` is seeded via `git clone --bare` (not `git push`), so
+# no push — and therefore no hook invocation — happens during setup. Only
+# the pushes performed BY EACH TEST CASE go through the hook under test.
+#
+# bin/run-pre-push-checks.sh is stubbed to an immediate `exit 0` so cases
+# aren't slowed down by (or made to depend on) markdownlint/shellcheck/npx
+# being installed in the test environment — this suite tests the
+# protected-branch block, not the lint check set, which has its own tests.
+# ---------------------------------------------------------------------------
+build_sandbox() {
+  local dir="$1"
+  local work="$dir/work"
+
+  mkdir -p "$work"
+  git -C "$work" init -q -b main
+  git -C "$work" config user.name t
+  git -C "$work" config user.email t@t.com
+
+  mkdir -p "$work/.githooks"
+  cp "$REAL_PRE_PUSH" "$work/.githooks/pre-push"
+  chmod +x "$work/.githooks/pre-push"
+
+  mkdir -p "$work/.claude/hooks"
+  cp "$REAL_PROTECTED_LIB" "$work/.claude/hooks/_lib-protected-branches.sh"
+  cp "$REAL_READ_CONFIG_LIB" "$work/.claude/hooks/_lib-read-config.sh"
+
+  mkdir -p "$work/bin"
+  printf '#!/bin/bash\nexit 0\n' > "$work/bin/run-pre-push-checks.sh"
+  chmod +x "$work/bin/run-pre-push-checks.sh"
+
+  git -C "$work" config core.hooksPath .githooks
+
+  echo "seed" > "$work/README.md"
+  git -C "$work" add README.md
+  git -C "$work" commit -q -m "chore: init"
+
+  git clone -q --bare "$work" "$dir/remote.git"
+  git -C "$work" remote add origin "$dir/remote.git"
+  git -C "$work" fetch -q origin
+  git -C "$work" branch -q --set-upstream-to=origin/main main
+
+  # Neutralise the bare remote's OWN denyDeleteCurrentBranch safety net
+  # (git's server-side default refuses to delete whatever ref the bare
+  # repo's HEAD points at — here, `main`). Without this, case 7's
+  # "delete protected branch" assertions could pass for the WRONG reason —
+  # the remote's own unrelated protection, not our LOCAL pre-push hook —
+  # which would silently mask a broken hook. Disabling it here means the
+  # only thing standing between a delete-main push and the remote is the
+  # hook under test.
+  git -C "$dir/remote.git" config receive.denyDeleteCurrent ignore
+}
+
+# A new, real commit on the currently checked-out branch — used so every
+# "attempt to push main" case carries a genuine ref-update (local sha !=
+# remote sha), not an accidental no-op that git might not even invoke the
+# hook for.
+new_commit() {
+  local work="$1" msg="${2:-chore: advance}"
+  date +%s%N >> "$work/README.md"
+  git -C "$work" add README.md
+  git -C "$work" commit -q -m "$msg" --allow-empty
+}
+
+remote_ref_sha() {
+  local dir="$1" ref="$2"
+  git -C "$dir/remote.git" rev-parse --verify "$ref" 2>/dev/null || echo "MISSING"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 1: feature-branch push -> NOT blocked
+# ---------------------------------------------------------------------------
+case_feature_branch_push_allowed() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_sandbox "$sandbox"
+  local work="$sandbox/work"
+
+  git -C "$work" checkout -q -b feature/GH-1-safe
+  new_commit "$work"
+
+  local out rc
+  out=$(git -C "$work" push -u origin feature/GH-1-safe 2>&1); rc=$?
+  assert_eq "feature branch push: exit code" "0" "$rc"
+  assert_ne "feature branch push: remote ref created" "MISSING" "$(remote_ref_sha "$sandbox" refs/heads/feature/GH-1-safe)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 2: genuine tag push -> NOT blocked
+# ---------------------------------------------------------------------------
+case_genuine_tag_push_allowed() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_sandbox "$sandbox"
+  local work="$sandbox/work"
+
+  git -C "$work" tag v1.0.0-test
+
+  local out rc
+  out=$(git -C "$work" push origin v1.0.0-test 2>&1); rc=$?
+  assert_eq "genuine tag push: exit code" "0" "$rc"
+  assert_ne "genuine tag push: remote tag created" "MISSING" "$(remote_ref_sha "$sandbox" refs/tags/v1.0.0-test)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 3: two-remote tag push -> NOT blocked (both pushes succeed)
+# ---------------------------------------------------------------------------
+case_two_remote_tag_push_allowed() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_sandbox "$sandbox"
+  local work="$sandbox/work"
+
+  git clone -q --bare "$work" "$sandbox/upstream.git"
+  git -C "$work" remote add upstream "$sandbox/upstream.git"
+  git -C "$work" tag v2.0.0-test
+
+  local out rc
+  out=$(git -C "$work" push origin --tags 2>&1 && git -C "$work" push upstream --tags 2>&1); rc=$?
+  assert_eq "two-remote tag push: exit code" "0" "$rc"
+  assert_ne "two-remote tag push: origin has tag" "MISSING" "$(remote_ref_sha "$sandbox" refs/tags/v2.0.0-test)"
+  assert_ne "two-remote tag push: upstream has tag" "MISSING" "$(git -C "$sandbox/upstream.git" rev-parse --verify refs/tags/v2.0.0-test 2>/dev/null || echo MISSING)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 4: delete a NON-protected branch -> NOT blocked
+# ---------------------------------------------------------------------------
+case_delete_nonprotected_allowed() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_sandbox "$sandbox"
+  local work="$sandbox/work"
+
+  git -C "$work" checkout -q -b feature/GH-2-doomed
+  new_commit "$work"
+  git -C "$work" push -q -u origin feature/GH-2-doomed
+  git -C "$work" checkout -q main
+
+  local out rc
+  out=$(git -C "$work" push origin --delete feature/GH-2-doomed 2>&1); rc=$?
+  assert_eq "delete non-protected: exit code" "0" "$rc"
+  assert_eq "delete non-protected: remote ref gone" "MISSING" "$(remote_ref_sha "$sandbox" refs/heads/feature/GH-2-doomed)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 5: bare `git push` while checked out on `main` -> BLOCKED
+# ---------------------------------------------------------------------------
+case_bare_push_on_main_blocked() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_sandbox "$sandbox"
+  local work="$sandbox/work"
+  local before; before=$(remote_ref_sha "$sandbox" refs/heads/main)
+
+  new_commit "$work"
+
+  local out rc
+  out=$(git -C "$work" push 2>&1); rc=$?
+  assert_ne "bare push on main: exit code non-zero" "0" "$rc"
+  assert_match "bare push on main: BLOCKED message" "BLOCKED.*protected branch 'main'" "$out"
+  assert_eq "bare push on main: remote main unchanged" "$before" "$(remote_ref_sha "$sandbox" refs/heads/main)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 6: explicit `git push origin main` -> BLOCKED
+# ---------------------------------------------------------------------------
+case_explicit_push_main_blocked() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_sandbox "$sandbox"
+  local work="$sandbox/work"
+  local before; before=$(remote_ref_sha "$sandbox" refs/heads/main)
+
+  new_commit "$work"
+
+  local out rc
+  out=$(git -C "$work" push origin main 2>&1); rc=$?
+  assert_ne "explicit push origin main: exit code non-zero" "0" "$rc"
+  assert_match "explicit push origin main: BLOCKED message" "BLOCKED.*protected branch 'main'" "$out"
+  assert_eq "explicit push origin main: remote main unchanged" "$before" "$(remote_ref_sha "$sandbox" refs/heads/main)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 7: `git push origin --delete main` -> BLOCKED, remote main intact
+#
+# This is the deletion / all-zeroes-local-sha case. Also the exact shape
+# .claude/hooks/block-main-push.sh does NOT catch when run from a feature-
+# branch checkout (its extract_push_ref bails on --delete and falls back to
+# validating the CURRENT branch instead of the one being deleted) — proving
+# this blocks here demonstrates the git-native layer closes that gap too.
+# ---------------------------------------------------------------------------
+case_delete_protected_blocked() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_sandbox "$sandbox"
+  local work="$sandbox/work"
+  local before; before=$(remote_ref_sha "$sandbox" refs/heads/main)
+
+  # Deliberately checked out on a DIFFERENT branch — the exact shape
+  # block-main-push.sh's text-based fallback gets wrong.
+  git -C "$work" checkout -q -b feature/GH-3-bystander
+
+  local out rc
+  out=$(git -C "$work" push origin --delete main 2>&1); rc=$?
+  assert_ne "delete protected (main): exit code non-zero" "0" "$rc"
+  assert_match "delete protected (main): BLOCKED message says delete" "BLOCKED: Deleting protected branch 'main'" "$out"
+  assert_eq "delete protected (main): remote main intact" "$before" "$(remote_ref_sha "$sandbox" refs/heads/main)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 8 (#1083 shape): a redirect/pipe BEFORE the push -> still BLOCKED
+# ---------------------------------------------------------------------------
+case_1083_redirect_before_push_blocked() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_sandbox "$sandbox"
+  local work="$sandbox/work"
+  local before; before=$(remote_ref_sha "$sandbox" refs/heads/main)
+
+  new_commit "$work"
+
+  local out rc
+  out=$(cd "$work" && echo x > "$sandbox/scratch.txt" && git push origin main 2>&1); rc=$?
+  assert_ne "#1083 redirect-before-push: exit code non-zero" "0" "$rc"
+  assert_match "#1083 redirect-before-push: BLOCKED message" "BLOCKED.*protected branch 'main'" "$out"
+  assert_eq "#1083 redirect-before-push: remote main unchanged" "$before" "$(remote_ref_sha "$sandbox" refs/heads/main)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 9 (#1084 shape): decoy ref inside an unterminated/unconfirmed
+# heredoc, then a genuinely bare (ref-less) push -> still BLOCKED
+# ---------------------------------------------------------------------------
+case_1084_decoy_heredoc_then_bare_push_blocked() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_sandbox "$sandbox"
+  local work="$sandbox/work"
+  local before; before=$(remote_ref_sha "$sandbox" refs/heads/main)
+
+  new_commit "$work"
+
+  local out rc
+  out=$(cd "$work" && cat > "$sandbox/m.txt" <<'END.OF'
+see git push origin feature/GH-1-safe
+END.OF
+git push 2>&1); rc=$?
+  assert_ne "#1084 decoy-heredoc-then-bare-push: exit code non-zero" "0" "$rc"
+  assert_match "#1084 decoy-heredoc-then-bare-push: BLOCKED message" "BLOCKED.*protected branch 'main'" "$out"
+  assert_eq "#1084 decoy-heredoc-then-bare-push: remote main unchanged" "$before" "$(remote_ref_sha "$sandbox" refs/heads/main)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 10 (#1085 shape): a genuine tag-push prefix, followed by
+# `git push origin HEAD` on `main` -> tags succeed, HEAD push BLOCKED
+# ---------------------------------------------------------------------------
+case_1085_tag_prefix_then_head_push_blocked() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_sandbox "$sandbox"
+  local work="$sandbox/work"
+  local before; before=$(remote_ref_sha "$sandbox" refs/heads/main)
+
+  git -C "$work" tag v3.0.0-test
+  new_commit "$work"
+
+  local out rc
+  out=$(cd "$work" && git push origin --tags && git push origin HEAD 2>&1); rc=$?
+  assert_ne "#1085 tag-prefix-then-HEAD-push: exit code non-zero" "0" "$rc"
+  assert_ne "#1085 tag-prefix-then-HEAD-push: tag DID push" "MISSING" "$(remote_ref_sha "$sandbox" refs/tags/v3.0.0-test)"
+  assert_eq "#1085 tag-prefix-then-HEAD-push: remote main unchanged" "$before" "$(remote_ref_sha "$sandbox" refs/heads/main)"
+
+  rm -rf "$sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# CASE 11 (#1066 shape): heredoc prose merely DISCUSSING `git push`, then a
+# real push to `main` -> BLOCKED (the decoy prose changes nothing; the real
+# push is what's evaluated, because nothing here ever parses command text)
+# ---------------------------------------------------------------------------
+case_1066_heredoc_prose_then_real_push_blocked() {
+  local sandbox; sandbox=$(mktemp -d)
+  build_sandbox "$sandbox"
+  local work="$sandbox/work"
+  local before; before=$(remote_ref_sha "$sandbox" refs/heads/main)
+
+  new_commit "$work"
+
+  local out rc
+  out=$(cd "$work" && cat > "$sandbox/m2.txt" <<EOF
+The previous commit claimed terminal git push still runs the checks because
+bin/run-pre-push-checks.sh hardcodes them.
+EOF
+git push origin main 2>&1); rc=$?
+  assert_ne "#1066 heredoc-prose-then-real-push: exit code non-zero" "0" "$rc"
+  assert_match "#1066 heredoc-prose-then-real-push: BLOCKED message" "BLOCKED.*protected branch 'main'" "$out"
+  assert_eq "#1066 heredoc-prose-then-real-push: remote main unchanged" "$before" "$(remote_ref_sha "$sandbox" refs/heads/main)"
+
+  rm -rf "$sandbox"
+}
+
+if [ ! -f "$REAL_PRE_PUSH" ]; then
+  echo "FAIL: .githooks/pre-push not found at $REAL_PRE_PUSH" >&2
+  exit 1
+fi
+if [ ! -f "$REAL_PROTECTED_LIB" ]; then
+  echo "FAIL: .claude/hooks/_lib-protected-branches.sh not found at $REAL_PROTECTED_LIB" >&2
+  exit 1
+fi
+
+case_feature_branch_push_allowed
+case_genuine_tag_push_allowed
+case_two_remote_tag_push_allowed
+case_delete_nonprotected_allowed
+case_bare_push_on_main_blocked
+case_explicit_push_main_blocked
+case_delete_protected_blocked
+case_1083_redirect_before_push_blocked
+case_1084_decoy_heredoc_then_bare_push_blocked
+case_1085_tag_prefix_then_head_push_blocked
+case_1066_heredoc_prose_then_real_push_blocked
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED" >&2
+  exit 1
+fi
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,7 @@
 #!/bin/bash
-# .githooks/pre-push — terminal-push companion to .claude/hooks/pre-push-gate.sh.
+# .githooks/pre-push — terminal-push companion to .claude/hooks/pre-push-gate.sh,
+# AND (as of me2resh/apexyard#1086 step 2) the git-native enforcement layer
+# for "no direct pushes to a protected branch" on terminal `git push`.
 #
 # pre-push-gate.sh fires only on Claude Code-driven pushes (it is a
 # PreToolUse hook). This git hook covers the same check set for terminal
@@ -9,19 +11,147 @@
 # degrade logic, and the same command set. The command set is defined in
 # bin/run-pre-push-checks.sh, which this hook delegates to.
 #
-# Opt-in once per clone:
+# Opt-in once per clone (or run bin/install-git-hooks.sh, which does this
+# for you and is now invoked by /setup and /handover — #1086 step 1):
 #   git config core.hooksPath .githooks
 #
-# Or set it globally for all apexyard clones (the hook is a no-op outside
-# apexyard because bin/run-pre-push-checks.sh checks for the repo root):
-#   git config --global core.hooksPath .githooks
-#
 # See docs/getting-started.md § "Terminal push hook" for details.
+#
+# ---------------------------------------------------------------------------
+# PROTECTED-BRANCH ENFORCEMENT (#1086 step 2)
+# ---------------------------------------------------------------------------
+# Git's pre-push hook receives the refs being pushed on STDIN, one line per
+# ref, already resolved by git itself:
+#
+#   <local ref> SP <local sha1> SP <remote ref> SP <remote sha1> LF
+#
+# That is ground truth — git did the refspec resolution, the upstream-
+# tracking resolution, and the tag-vs-branch classification. There is no
+# command text here to misparse: no heredocs, no decoys, no redirects, no
+# quoting — none of the shapes recorded in #1066, #1081, #1083, #1084,
+# #1085 exist at this layer, because there is no command string being
+# scanned at all. The block below reads ONLY these stdin lines. See
+# docs/agdr/AgDR-0113-heredoc-stripper-additive-only.md for the class of bug
+# this design sidesteps entirely rather than patches further.
+#
+# Deletion (local sha1 = 40 zeroes): the remote ref named on the line is
+# being DELETED, not updated. Deleting a protected branch is at least as
+# destructive as pushing to one — arguably more, since there's no single
+# commit to revert — so a deletion of a protected branch is blocked exactly
+# like an update would be. This also closes a real, pre-existing gap in the
+# text-based `.claude/hooks/block-main-push.sh`: its extract_push_ref
+# deliberately bails out (returns empty) on a `--delete`/`-d` push, which
+# falls back to validating the CURRENT checked-out branch rather than the
+# branch actually being deleted — so `git push origin --delete main` run
+# from a feature-branch checkout was never actually validated there. This
+# hook has no such gap: the branch being deleted is read directly off the
+# remote-ref field regardless of what's currently checked out.
+#
+# New-ref creation (remote sha1 = 40 zeroes): means the branch doesn't
+# exist on the remote YET. It does not change the decision below — the
+# check is purely "does this ref's NAME match the protected list", which
+# holds whether the remote side starts empty or not.
+#
+# Non-branch refs (tags, notes, anything not under refs/heads/) are
+# categorically exempt — not via a heuristic ("does this look like a tag
+# push"), but structurally: the remote ref's own namespace says so, and git
+# is the one who put it there. A two-remote tag push, or an ordinary branch
+# push alongside a separate `--tags` push, both correctly fall out of this
+# with no special-casing, because each ref line is judged independently on
+# its own `remote_ref` value.
+#
+# `--force` / `--force-with-lease` do not change any of the above either:
+# remote_ref and local_sha are the same regardless of the force flag, so a
+# force push to a protected branch is blocked exactly like an ordinary one
+# — a correctness property this design gets for free, not something it had
+# to special-case.
+# ---------------------------------------------------------------------------
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 if [ -z "$REPO_ROOT" ]; then
-  # Not a git repo — nothing to do.
+  # Not a git repo — nothing to do. (No stdin has been read yet; git never
+  # invokes a hook outside a repository in practice, this is defensive for
+  # manual/test invocations only.)
   exit 0
+fi
+
+# Read every ref line git is offering, ONCE, up front. Nothing downstream in
+# this hook — nor bin/run-pre-push-checks.sh, delegated to at the bottom —
+# reads stdin again. See the "STDIN HAND-OFF" note near the bottom of this
+# file for why that delegation is safe.
+STDIN_REFS=$(cat)
+
+ALL_ZERO_SHA='0000000000000000000000000000000000000000'
+
+PROTECTED_LIB="$REPO_ROOT/.claude/hooks/_lib-protected-branches.sh"
+if [ ! -f "$PROTECTED_LIB" ]; then
+  # Old clone that hasn't pulled the lib file yet. Fail open, same shape as
+  # the "RUNNER not found" case below — visible, not silent.
+  echo "WARN: $PROTECTED_LIB not found — protected-branch enforcement skipped at the git layer for this push. Pull latest to enable it." >&2
+else
+  # shellcheck disable=SC1090,SC1091
+  . "$PROTECTED_LIB"
+
+  if [ -n "$STDIN_REFS" ] && command -v protected_branch_regex >/dev/null 2>&1; then
+    PROTECTED_REGEX=$(protected_branch_regex)
+
+    if [ -n "$PROTECTED_REGEX" ]; then
+      # Process substitution (not a pipe) so `exit 1` inside the loop exits
+      # THIS script, not a subshell — a pipe (`cmd | while read; do ...;
+      # done`) runs the loop body in a subshell in bash, and `exit` there
+      # would only terminate the subshell, silently letting the push
+      # through. `printf '%s\n'` guarantees a trailing newline regardless of
+      # whether $STDIN_REFS had one — `$(cat)` above already stripped any
+      # trailing newline from the real input, and `read` does NOT execute
+      # the loop body for a final line that arrives without one (it fills
+      # the read variables but returns non-zero, which is also the while
+      # condition, so the loop exits before running the body). Almost every
+      # real push has exactly ONE ref line — silently skipping it would be
+      # the single worst way this hook could fail.
+      # shellcheck disable=SC2034  # LOCAL_REF/REMOTE_SHA kept named (not
+      # read into `_`) for readability — this is the security-critical
+      # decision loop and a future reader debugging it benefits from every
+      # field of git's own stdin line being visible by name, even the two
+      # this particular check doesn't need.
+      while IFS=' ' read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
+        [ -z "$REMOTE_REF" ] && continue
+
+        case "$REMOTE_REF" in
+          refs/heads/*) BRANCH="${REMOTE_REF#refs/heads/}" ;;
+          *) continue ;;  # tags, notes, anything else: never subject to this check
+        esac
+
+        if echo "$BRANCH" | grep -qE "^(${PROTECTED_REGEX})$"; then
+          if [ "$LOCAL_SHA" = "$ALL_ZERO_SHA" ]; then
+            ACTION_VERB="Deleting"
+            ACTION_NAME="delete"
+          else
+            ACTION_VERB="Pushing to"
+            ACTION_NAME="update"
+          fi
+          cat >&2 <<MSG
+BLOCKED: ${ACTION_VERB} protected branch '${BRANCH}' on the remote is not allowed.
+
+All changes must go through a PR (.claude/rules/git-conventions.md
+§ "No Direct Main"). This was decided from git's own pre-push ref
+resolution (${REMOTE_REF}, action: ${ACTION_NAME}) — no command text was
+parsed to reach this decision.
+
+To unblock:
+  1. Create a feature branch from your current work:
+       git checkout -b feature/GH-<ticket>-<short-description>
+  2. Push the feature branch:
+       git push -u origin feature/GH-<ticket>-<short-description>
+  3. Open a PR via /feature → /start-ticket → gh pr create, OR if the
+     ticket exists, just: gh pr create --base ${BRANCH} --head <feature-branch>
+
+Customise (rare): .claude/project-config.json → .git.protected_branches[]
+MSG
+          exit 1
+        fi
+      done < <(printf '%s\n' "$STDIN_REFS")
+    fi
+  fi
 fi
 
 RUNNER="$REPO_ROOT/bin/run-pre-push-checks.sh"
@@ -32,4 +162,11 @@ if [ ! -f "$RUNNER" ]; then
   exit 0
 fi
 
+# STDIN HAND-OFF NOTE (#1086 step 2): bin/run-pre-push-checks.sh was audited
+# and does not read stdin anywhere — its markdownlint / shellcheck / subpacks
+# checks all run via `bash -c "$cmd"` with no `read` of their own — so
+# consuming stdin above via `cat` is safe; the runner never expected it.
+# `exec` is kept here (rather than `bash "$RUNNER"; exit $?`) to preserve
+# the exact prior behaviour byte-for-byte: this hook's own exit status IS
+# the runner's exit status via process replacement.
 exec bash "$RUNNER"


### PR DESCRIPTION
## Summary

- **`.githooks/pre-push` now decides "block this push?" from git's own stdin ref lines (`<local_ref> <local_sha> <remote_ref> <remote_sha>`), never from the shell command text.** This is step 2 of #1086 and closes the whole bug class AgDR-0113 documents: #1066, #1081, #1083, #1084, #1085 are all instances of one root cause — a hook deciding by pattern-matching the *text* of a shell command, which AgDR-0104 already concluded cannot be made sound. At the git layer there is no command text to misparse: no heredocs, no decoys, no redirects, no quoting shapes, because nothing here scans a command string at all.
- **Deletion pushes (`local_sha` = 40 zeroes) are blocked identically to updates.** Deleting a protected branch is at least as destructive as pushing to one, and this closes a real, pre-existing gap: `.claude/hooks/block-main-push.sh`'s `extract_push_ref` deliberately bails out on `--delete`/`-d` (returns empty), which falls back to validating whatever branch is currently checked out rather than the branch actually being deleted — so `git push origin --delete main` run from a feature-branch checkout was never actually validated there. Verified with a real push (see Testing).
- **New `.claude/hooks/_lib-protected-branches.sh` centralises the protected-branch-list resolution** so the new git-native hook doesn't re-derive it independently. **`block-main-push.sh` is intentionally left untouched** — it still resolves its own copy of the same list inline (identical algorithm and `main|master|dev|develop` fallback). Demoting it to source this lib, and to advisory status generally, is step 3 of #1086 and must land only after this enforcement layer is proven installed-by-default (step 1, merged as #1087) and blocking (this PR). Until step 3, this is a deliberate, temporary duplication of a simple config-resolution algorithm — not the dangerous "two disagreeing text-parsers" pattern AgDR-0113 spent five review rounds on, since both copies use the identical resolution and fallback and `block-main-push.sh`'s role is unchanged.
- **`--force` / `--force-with-lease` don't need special-casing.** `remote_ref` and `local_sha` are the same regardless of the force flag, so a force push to a protected branch is blocked exactly like an ordinary one — a correctness property this design gets for free rather than one it has to parse for.

## What this PR does NOT do

- **`block-main-push.sh` remains the active control** for Claude-Code-driven pushes (it's a `PreToolUse` hook; this git-native layer only fires for pushes that actually reach git — i.e., where `core.hooksPath` is set, per step 1). It is not touched, not demoted, and not disabled here.
- **#1081, #1083, #1084, #1085 are not closed by this PR** — they're bugs in `block-main-push.sh`'s text-parsing, and that file isn't touched. They close in step 3, when `block-main-push.sh` is demoted to advisory (at which point its residual text-matching bugs become cosmetic misses rather than security bypasses, per the issue's own reasoning).

## Testing

**Discriminating pairs — every "must block" case proven to FAIL against the pre-change hook and PASS against this one** (not just green-in-both-directions, which proves nothing):

| Case | Before (pre-#1086-step-2) | After (this PR) |
|---|---|---|
| Bare `git push` on `main` | ALLOWED — exit 0, remote `main` advanced | **BLOCKED** — exit ≠0, remote `main` unchanged |
| Explicit `git push origin main` | ALLOWED | **BLOCKED** |
| `git push origin --delete main` (deletion) | ALLOWED — remote `main` ref actually deleted | **BLOCKED** — remote `main` intact |
| #1083 shape (redirect before the push) | ALLOWED | **BLOCKED** |
| #1084 shape (decoy ref in unstripped heredoc, then a bare push) | ALLOWED | **BLOCKED** |
| #1085 shape (tag-push prefix, then `git push origin HEAD`) | tag push AND the `HEAD` push to `main` both succeeded | tag push succeeds, `HEAD` push to `main` **BLOCKED**, remote `main` unchanged |
| #1066 shape (heredoc prose merely discussing `git push`, then a real push to `main`) | ALLOWED | **BLOCKED** |

For the delete case, I first had to disable the bare test remote's own `receive.denyDeleteCurrent` — without that, the remote's *own*, unrelated safety net masked whether our local hook was doing anything, since it would reject the delete either way. With it neutralised, the "before" run genuinely deletes `main` on the remote (confirmed: ref goes from a real SHA to "MISSING"), and the "after" run blocks locally before any data reaches the remote.

**Over-narrowing controls (regression checks, not novelty proofs — these already passed pre-change since the old hook blocked nothing, and exist to catch this PR accidentally blocking legitimate pushes):**

- Genuine tag push — ALLOWED, both before and after
- Ordinary feature-branch push — ALLOWED, both before and after
- Two-remote tag push (`git push origin --tags && git push upstream --tags`) — ALLOWED, both before and after
- Deleting a non-protected branch — ALLOWED, both before and after

**Why real git + a real local bare remote, not a stubbed `git` on `PATH`.** The "stub git" standard from prior reviews was written for `block-main-push.sh`, a `PreToolUse` hook that decides from a *simulated* command string with no separate execution step — a stub is the only way to prove the downstream command would really have reached git. `.githooks/pre-push` has no such simulated step: it runs *inside* the real git-push lifecycle, invoked by git with git's own resolved ref lines. A stub here would have to reimplement git's own refspec/tag/HEAD/upstream-tracking resolution to hand the hook correct stdin — exactly the "reimplementation that has to be trusted to agree with the real thing" pattern AgDR-0113 argues against. A real git binary against a real local bare remote, asserting on the remote's actual post-push ref state, is a *stricter* proof of "the push genuinely executes or is genuinely rejected," not a weaker one.

**Test suite:** `.claude/hooks/tests/test_githooks_pre_push_protected_branch.sh` (11 cases, 30 assertions) is the automated form of the table above, run as part of `bin/run-hook-tests.sh`. Full suite: 130/130 PASS, 0 FAIL (chunked locally — the suite includes `test_block_main_push.sh` and `test_block_main_push_heredoc.sh`, both still green, confirming `block-main-push.sh` is genuinely untouched).

**Real installer + real push, end to end:** ran `bin/install-git-hooks.sh --repo-dir <scratch-repo>` (the actual installer from step 1, not a manual `git config`), confirmed `core.hooksPath` was set, then performed a real `git push origin main` (BLOCKED, exit 1, remote unchanged) and a real `git push -u origin feature/...` (ALLOWED, exit 0, remote ref created).

**Stdin hand-off (the specific risk called out in the brief):** the old hook ended in `exec bash "$RUNNER"`, which passed stdin through untouched. This PR reads stdin (`STDIN_REFS=$(cat)`) before that point. I audited `bin/run-pre-push-checks.sh` and everything it shells out to (`markdownlint-cli2`, `shellcheck` via `find | xargs`, `test_subpack_extraction.sh`) — none of them read from fd 0; the only `read` calls anywhere in that call chain are against `<(find ...)` process substitutions, never the inherited stdin. Confirmed empirically too: ran `bin/run-pre-push-checks.sh` with `< /dev/null` (no hang, clean exit), and ran a full real push through a sandbox using the **unstubbed** `run-pre-push-checks.sh` — it executed all three checks in order and produced the expected pass/fail output, proving the hand-off is safe in practice, not just by inspection. `exec` is kept at the final delegation specifically so the hook's own exit status still comes from process replacement, unchanged from before.

**No command-text parsing anywhere in the decision:** the only `grep` in `.githooks/pre-push` matches `$BRANCH` (derived solely from `$REMOTE_REF`, itself one of git's own stdin fields) against the static protected-branch regex. There is no `$COMMAND` variable, no `tool_input`, no shell-command scanning of any kind in this file.

**Shellcheck:** `--severity=warning` clean on all three touched/added files.

## Glossary

| Term | Definition |
|------|------------|
| `pre-push` hook | A git-native hook git invokes before a push completes, with the refs being pushed written to its stdin, already resolved — no command text to parse. |
| stdin ref line | `<local ref> SP <local sha1> SP <remote ref> SP <remote sha1> LF` — one line per ref being pushed, printed by git itself. |
| all-zeroes sentinel SHA | `local_sha` = 40 zeroes means the ref named on that line is being **deleted**, not updated. |
| protected branch | A branch (`main`/`master`/`dev`/`develop` by default, configurable via `.claude/project-config.json` → `.git.protected_branches[]`) that this hook refuses to push to or delete directly. |
| `core.hooksPath` | Per-clone git config pointing at this repo's tracked hooks dir (`.githooks/`) — set by `bin/install-git-hooks.sh` (step 1, #1087). Without it, this hook never runs. |

Refs #1086
