### PR TITLE
fix(#1095): lint tracked markdown in the pre-push gate, not the whole disk

### DIFF
--- a/bin/run-pre-push-checks.sh
+++ b/bin/run-pre-push-checks.sh
@@ -124,7 +124,38 @@ echo "pre-push checks:" >&2
 
 # 1. markdownlint
 # Uses npx so no global install is required. Missing npx → skip with note.
-MARKDOWNLINT_CMD="command -v npx >/dev/null 2>&1 || { echo 'INFO: npx not found — markdownlint check skipped. Install Node.js (https://nodejs.org) to enable it locally.'; exit 0; }; npx --yes markdownlint-cli2 '**/*.md' '#node_modules' '#.git' '#workspace' 2>&1"
+#
+# Lints TRACKED markdown only (`git ls-files`), not everything on disk.
+#
+# The mirror in .claude/project-config.example.json has used this form since
+# 8822d05 (#1065); this script never adopted it, though the header above
+# requires the two to stay in sync. Copied from the mirror verbatim.
+#
+# The previous `'**/*.md'` glob walked the whole working tree minus three
+# excluded dirs, which meant:
+#   - untracked scratch (scratchpad/, .apexyard/briefs/) blocked every push,
+#     on files that will never be committed;
+#   - agent worktrees under .claude/worktrees/ were linted too, re-linting the
+#     same content once per live worktree.
+# On this repo that was ~6900 files against 404 tracked.
+#
+# Coverage is unchanged for anything that matters: pre-push runs AFTER commit,
+# so every file being pushed is tracked and therefore still linted. A file that
+# is not tracked is not being pushed, and CI lints the pushed tree regardless.
+# Known limit: `git ls-files` reads the CURRENT checkout's index, so pushing a
+# branch you are not on lints the wrong branch's markdown. The old glob had the
+# same hole and worse (those files are not on disk either); CI is the backstop.
+#
+# NUL-delimited (`tr '\n' '\0' | xargs -0`) so a path containing a space or an
+# apostrophe cannot be word-split or trip xargs' quote handling. Plain `xargs`
+# fails on both.
+#
+# The empty guard is required because `markdownlint-cli2` with no file
+# arguments prints its usage banner and lints nothing — so without the guard an
+# empty repo produces a confusing non-zero rather than a clean skip. (It does
+# NOT fall back to a default glob: .markdownlint.json is a rules-only format
+# and cannot carry `globs`.)
+MARKDOWNLINT_CMD="command -v npx >/dev/null 2>&1 || { echo 'INFO: npx not found — markdownlint check skipped. Install Node.js (https://nodejs.org) to enable it locally.'; exit 0; }; md_files=\$(git ls-files '*.md' 2>/dev/null); [ -z \"\$md_files\" ] && { echo 'INFO: no tracked markdown files found — markdownlint check skipped.'; exit 0; }; echo \"\$md_files\" | tr '\\n' '\\0' | xargs -0 npx --yes markdownlint-cli2 2>&1"
 run_check "markdownlint" "$MARKDOWNLINT_CMD" || true
 
 # 2. shellcheck — .claude/hooks/*.sh, severity=warning


### PR DESCRIPTION
## Summary

- **The pre-push markdownlint check globbed the working tree, so untracked scratch blocked every push** — agent notes under `scratchpad/` and `.apexyard/briefs/` fail style rules and will never be committed, yet they failed the gate and stopped the push. A real push was blocked by 12+ errors, every one in a file `git ls-files` does not know about.
- **It also re-linted agent worktrees, once each** — every checkout under `.claude/worktrees/` is a full copy of the repo, so the same markdown was linted once per live worktree. The glob resolved to **~6,900 files against 404 tracked**.
- **This closes a divergence, not a regression** — `.claude/project-config.example.json` has used the tracked-files form since `8822d05` (#1065) and this script's header requires the two to stay in sync, but the script never adopted it (`git log -S'git ls-files'` on this file returns only this commit). The command is now copied from the mirror **verbatim** (verified byte-identical after shell unescaping, 395 chars) rather than reimplemented — two implementations of one command is exactly how they diverged.
- **That brings NUL-delimited handling across too** — `tr '\n' '\0' | xargs -0`, so a path containing a space or an apostrophe cannot be word-split or trip `xargs`' quote parsing. Plain `xargs` fails on both.

## Coverage

Unchanged for anything that matters. Pre-push runs *after* commit, so every file being pushed is tracked and still linted; a file that is not tracked is not being pushed; and CI lints the pushed tree regardless.

**Known limit, now documented in the code:** `git ls-files` reads the *current checkout's* index, so publishing a branch you are not on lints the wrong branch's markdown. The old glob had the same hole and worse — those files are not on disk either.

## Corrections from the first review round

**A wrong claim, fixed.** The first version said the empty-set guard existed because a no-argument invocation would fall back to a default glob. That is wrong, and verified wrong: `markdownlint-cli2` with no file arguments prints its usage banner and lints nothing, and `.markdownlint.json` is a rules-only format that cannot carry `globs`. The guard is still needed — without it an empty repo produces a confusing non-zero instead of a clean skip — but the comment now gives that reason instead.

**The gate had disabled itself on this PR.** The first commit body *explained* the escape hatch by quoting its marker verbatim. Detection is an unanchored `grep -qF` over the whole commit body, so merely describing the marker switched all three checks off — and on a squash-merge that string would have landed on `dev`, silently skipping checks for the next contributor to push. The marker is no longer quoted in the commit body or this PR body — the only places the detector reads. (It necessarily still exists as the `SKIP_MARKER` definition at `bin/run-pre-push-checks.sh:77`.) Filed separately as a detector bug; it is not a regression from this diff.

## Testing

1. **Discriminating test** — inject a deliberate `MD018` error into a *tracked* file and run `bash bin/run-pre-push-checks.sh`: **rc=1, blocked**. This is the property the change must not lose, and the first version of this PR never demonstrated it.
2. Clean tree with untracked scratch present: 404 files, 0 issues, **pass** — the exact state that failed before this change.
3. Command parity: the evaluated `MARKDOWNLINT_CMD` is byte-identical to `.claude/project-config.example.json`'s `markdownlint` entry (395 chars).
4. `bash -n` and `shellcheck --severity=warning` both clean.

## Note for review

The sibling `shellcheck` check on the following line was **already** correctly scoped — `find .claude/hooks -maxdepth 1 -name '*.sh'` targets a tracked directory rather than globbing the tree. markdownlint was the outlier, not the pattern.

Refs #1095

---

## Glossary

| Term | Definition |
|------|------------|
| tracked file | A file git knows about. Untracked files exist on disk but are not in the repo, so they are never pushed and cannot affect anyone else. |
| pre-push gate | `bin/run-pre-push-checks.sh` — run before every push by both the Claude Code hook and the git `pre-push` hook, so local failures surface before CI. |
| agent worktree | A full checkout created for a spawned agent under `.claude/worktrees/`. Multiplies any filesystem-glob-based check by the number of live worktrees. |
| NUL-delimited | Separating filenames with a zero byte rather than a newline — the only separator that cannot appear inside a filename, so paths with spaces or quotes survive intact. |
