### PR TITLE
fix(#1091): block instead of falling back to local HEAD when the forge is unreachable

### DIFF
--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -226,12 +226,34 @@ CEO_APPROVAL=$(review_marker_path "${CMD_REPO:-unknown}" "$PR_NUMBER" ceo "$MARK
 # branch. Asking gh directly removes the need for `gh pr checkout <N>`
 # before every `gh pr merge <N>`.
 #
-# Fallback to local HEAD if the gh call fails, with a visible warning, so
-# a transient network / auth issue doesn't brick merges entirely.
+# If the forge call fails we BLOCK (#1091). Falling back to the local HEAD
+# would compare markers against an agent-controlled value, which is exactly
+# the property this gate exists to deny.
 CURRENT_SHA=$(resolve_pr_head "$PR_NUMBER" "$CMD_REPO")
 if [ -z "$CURRENT_SHA" ]; then
-  echo "WARN: Could not resolve PR #${PR_NUMBER} HEAD via gh — falling back to local HEAD. If this merge fails, run 'gh pr checkout ${PR_NUMBER}' first or re-authenticate gh." >&2
-  CURRENT_SHA=$(git rev-parse HEAD 2>/dev/null)
+  cat >&2 <<MSG
+BLOCKED: could not resolve PR #${PR_NUMBER}'s HEAD from the forge.
+
+This gate compares the recorded approval SHA against the PR's HEAD **as the
+forge reports it** — state that a local file write cannot fabricate. That
+comparison IS the property the gate exists to provide.
+
+Until me2resh/apexyard#1091 this fell back to the LOCAL HEAD
+(\`git rev-parse HEAD\`) with only a warning. That substituted an
+agent-controlled value for the one value in this system an agent cannot
+author, so on any forge hiccup the gate silently stopped meaning anything.
+A gate that cannot evaluate its precondition must BLOCK, not guess — the same
+principle already applied to the jq-unavailable path in #965 (AgDR-0104).
+
+Likely causes: expired or absent forge token, network failure, API rate
+limit, or the forge CLI not installed.
+
+To unblock:
+  1. Check auth — \`gh auth status\` (or \`glab auth status\`), re-login if needed
+  2. Confirm connectivity to the forge
+  3. Retry the merge — no approval needs re-recording; the markers are still valid
+MSG
+  exit 2
 fi
 
 # --- Rex marker check ---

--- a/.claude/hooks/require-architecture-review.sh
+++ b/.claude/hooks/require-architecture-review.sh
@@ -275,14 +275,36 @@ MSG
   exit 2
 fi
 
-# SHA consistency check — resolve the PR's real HEAD via GitHub rather than
-# local HEAD (see #55). Falls back to local HEAD with a warning if the
-# gh call fails (network, auth).
+# SHA consistency check — resolve the PR's real HEAD via the forge rather than
+# local HEAD (see #55). If that resolution fails we BLOCK rather than fall back
+# to the local HEAD (#1091) — a local value is agent-controlled, so falling
+# back would silently void the check.
 APPROVED_SHA=$(tr -d '[:space:]' < "$APPROVAL")
 CURRENT_SHA=$(resolve_pr_head "$PR_NUMBER" "$CMD_REPO")
 if [ -z "$CURRENT_SHA" ]; then
-  echo "WARN: Could not resolve PR #${PR_NUMBER} HEAD via gh — falling back to local HEAD. If this merge fails, run 'gh pr checkout ${PR_NUMBER}' first or re-authenticate gh." >&2
-  CURRENT_SHA=$(git rev-parse HEAD 2>/dev/null)
+  cat >&2 <<MSG
+BLOCKED: could not resolve PR #${PR_NUMBER}'s HEAD from the forge.
+
+This gate compares the recorded approval SHA against the PR's HEAD **as the
+forge reports it** — state that a local file write cannot fabricate. That
+comparison IS the property the gate exists to provide.
+
+Until me2resh/apexyard#1091 this fell back to the LOCAL HEAD
+(\`git rev-parse HEAD\`) with only a warning. That substituted an
+agent-controlled value for the one value in this system an agent cannot
+author, so on any forge hiccup the gate silently stopped meaning anything.
+A gate that cannot evaluate its precondition must BLOCK, not guess — the same
+principle already applied to the jq-unavailable path in #965 (AgDR-0104).
+
+Likely causes: expired or absent forge token, network failure, API rate
+limit, or the forge CLI not installed.
+
+To unblock:
+  1. Check auth — \`gh auth status\` (or \`glab auth status\`), re-login if needed
+  2. Confirm connectivity to the forge
+  3. Retry the merge — no approval needs re-recording; the markers are still valid
+MSG
+  exit 2
 fi
 if [ -n "$APPROVED_SHA" ] && [ -n "$CURRENT_SHA" ] && [ "$APPROVED_SHA" != "$CURRENT_SHA" ]; then
   cat >&2 <<MSG

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -298,14 +298,36 @@ MSG
   exit 2
 fi
 
-# SHA consistency check — resolve the PR's real HEAD via GitHub rather than
-# local HEAD (see #55). Falls back to local HEAD with a warning if the
-# gh call fails (network, auth).
+# SHA consistency check — resolve the PR's real HEAD via the forge rather than
+# local HEAD (see #55). If that resolution fails we BLOCK rather than fall back
+# to the local HEAD (#1091) — a local value is agent-controlled, so falling
+# back would silently void the check.
 APPROVED_SHA=$(tr -d '[:space:]' < "$APPROVAL")
 CURRENT_SHA=$(resolve_pr_head "$PR_NUMBER" "$CMD_REPO")
 if [ -z "$CURRENT_SHA" ]; then
-  echo "WARN: Could not resolve PR #${PR_NUMBER} HEAD via gh — falling back to local HEAD. If this merge fails, run 'gh pr checkout ${PR_NUMBER}' first or re-authenticate gh." >&2
-  CURRENT_SHA=$(git rev-parse HEAD 2>/dev/null)
+  cat >&2 <<MSG
+BLOCKED: could not resolve PR #${PR_NUMBER}'s HEAD from the forge.
+
+This gate compares the recorded approval SHA against the PR's HEAD **as the
+forge reports it** — state that a local file write cannot fabricate. That
+comparison IS the property the gate exists to provide.
+
+Until me2resh/apexyard#1091 this fell back to the LOCAL HEAD
+(\`git rev-parse HEAD\`) with only a warning. That substituted an
+agent-controlled value for the one value in this system an agent cannot
+author, so on any forge hiccup the gate silently stopped meaning anything.
+A gate that cannot evaluate its precondition must BLOCK, not guess — the same
+principle already applied to the jq-unavailable path in #965 (AgDR-0104).
+
+Likely causes: expired or absent forge token, network failure, API rate
+limit, or the forge CLI not installed.
+
+To unblock:
+  1. Check auth — \`gh auth status\` (or \`glab auth status\`), re-login if needed
+  2. Confirm connectivity to the forge
+  3. Retry the merge — no approval needs re-recording; the markers are still valid
+MSG
+  exit 2
 fi
 if [ -n "$APPROVED_SHA" ] && [ -n "$CURRENT_SHA" ] && [ "$APPROVED_SHA" != "$CURRENT_SHA" ]; then
   cat >&2 <<MSG

--- a/.claude/hooks/tests/test_block_unreviewed_merge.sh
+++ b/.claude/hooks/tests/test_block_unreviewed_merge.sh
@@ -829,6 +829,74 @@ else
   FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}jq-broken-tab-nonmerge-noop "
 fi
 
+# --- #1091: forge HEAD unresolvable -> the gate must FAIL CLOSED -------
+#
+# The gate's integrity property is that marker SHAs are compared against the
+# FORGE-reported PR HEAD — state an agent cannot author. Before #1091 the hook
+# fell back to `git rev-parse HEAD` (a local, agent-controlled value) when the
+# gh call failed, with only a warning. That degraded the one adversarially
+# sound boundary into a local read.
+#
+# DISCRIMINATING BY CONSTRUCTION: the local HEAD and the markers are made to
+# AGREE. Under the old fallback the comparison therefore SUCCEEDS and the merge
+# is ALLOWED (rc=0). Under fail-closed it is BLOCKED (rc=2). A test using a
+# mismatching local HEAD would block both before and after, proving nothing.
+
+make_sandbox_gh_fails() {
+  local sb
+  sb=$(make_sandbox)
+  # gh cannot resolve the HEAD: transient network, expired token, rate limit,
+  # and gh-not-installed all surface identically as a failed/empty result.
+  # headRefName + headRepository still answer, so exactly ONE thing fails.
+  cat > "$sb/bin/gh" <<'GHEOF'
+#!/bin/bash
+case "$*" in
+  *"pr view"*"headRefOid"*)     exit 1 ;;
+  *"pr view"*"headRefName"*)    echo "feature/GH-99-test" ;;
+  *"pr view"*"headRepository"*) echo "me2resh/apexyard" ;;
+  *) ;;
+esac
+exit 0
+GHEOF
+  chmod +x "$sb/bin/gh"
+  echo "$sb"
+}
+
+sb=$(make_sandbox_gh_fails)
+# The sandbox's local HEAD — the value the OLD fallback would have used.
+local_head=$(cd "$sb" && git rev-parse HEAD 2>/dev/null)
+# Markers written to MATCH that local HEAD: the setup most favourable to a
+# bypass, where every comparison passes under the old code.
+write_rex_marker "$sb" 99 "$local_head"
+write_ceo_marker_structured "$sb" 99 "$local_head"
+input=$(jq -nc --arg c "gh pr merge 99 --repo me2resh/apexyard --squash" '{tool_name:"Bash", tool_input:{command:$c}}')
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c \
+  "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+if [ "$got_rc" = "2" ] && echo "$got_stderr" | grep -qi "resolve"; then
+  echo "PASS [#1091: forge HEAD unresolvable + markers matching LOCAL head -> BLOCKED]"; PASS=$((PASS+1))
+else
+  echo "FAIL [#1091: forge HEAD unresolvable + markers matching LOCAL head -> BLOCKED]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}1091-fail-closed "
+fi
+
+# Control: gh healthy -> behaviour unchanged, markers at the forge HEAD pass.
+sb=$(make_sandbox)
+write_rex_marker "$sb" 99
+write_ceo_marker_structured "$sb" 99
+input=$(jq -nc --arg c "gh pr merge 99 --repo me2resh/apexyard --squash" '{tool_name:"Bash", tool_input:{command:$c}}')
+got_stderr=$(cd "$sb" && APEXYARD_OPS_DISABLE_PIN=1 PATH="$sb/bin:$PATH" bash -c \
+  "echo '$input' | bash .claude/hooks/block-unreviewed-merge.sh" 2>&1 >/dev/null)
+got_rc=$?
+rm -rf "$sb"
+if [ "$got_rc" = "0" ]; then
+  echo "PASS [#1091 control: gh healthy, markers at forge HEAD -> still ALLOWED]"; PASS=$((PASS+1))
+else
+  echo "FAIL [#1091 control: gh healthy, markers at forge HEAD -> still ALLOWED]: rc=$got_rc stderr=${got_stderr:0:300}" >&2
+  FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}1091-control-healthy "
+fi
+
 # --- Summary ----------------------------------------------------------
 
 echo ""


### PR DESCRIPTION
## Summary

- **Three merge gates fell back to the local HEAD when the forge call failed, which voids the check they exist to perform.** They compare a recorded approval SHA against the PR's HEAD *as the forge reports it* — the one value in this framework an agent cannot author. On any expired token, network failure, or rate limit, `block-unreviewed-merge.sh`, `require-design-review-for-ui.sh`, and `require-architecture-review.sh` printed a warning and substituted `git rev-parse HEAD`, a local value the agent fully controls.
- **All three now block.** Each carried the fallback byte-for-byte identically. The new message names the likely causes and states that no approval needs re-recording, since the markers remain valid.
- **Neither gate newly blocks anything it wasn't already governing**, though the two cases differ and the distinction matters:
  - The **two review gates** reach this code only *after* an `exit 0` on out-of-scope and an `exit 2` on missing marker. A *total* forge outage never reaches the new block at all — `gh pr diff` returns empty and the hook exits 0 at the scope check. The block is reachable only on a partial failure where the diff answers and `headRefOid` does not.
  - **`block-unreviewed-merge.sh` resolves the SHA unconditionally**, before the marker check, so a forge outage does block every merge. That is correct rather than incidental: this gate already governs every merge, and a merge whose HEAD cannot be established is precisely what it should refuse.
- **This applies the principle #965 already established** for the `jq`-unavailable path ([AgDR-0104](https://github.com/me2resh/apexyard/blob/dev/docs/agdr/AgDR-0104-trust-chain-controls-vs-backstops.md)): a gate that cannot evaluate its precondition must block, not guess. That fix landed on one path; this is its sibling.

## Why the safe outcome was previously accidental

In practice the local working tree is rarely the PR branch, so the fallback usually produced a mismatch and blocked anyway. That is luck, not design — the outcome depended on whatever the tree happened to point at. Check out the PR branch first and the comparison passes against agent-controlled state.

## Testing

The new test is built to expose exactly that, and is discriminating by construction: it makes the local HEAD and the markers **agree** — the setup most favourable to a bypass — so the old code allows the merge and the new code blocks it. A test using a mismatching local HEAD would have blocked both before and after and proved nothing.

Measured, same test file, same fixture:

```
before: FAIL rc=0  "falling back to local HEAD"   <- merge ALLOWED
after:  PASS rc=2                                  <- blocked
control (forge healthy): rc=0 both before and after
```

1. `bash .claude/hooks/tests/test_block_unreviewed_merge.sh` → **41/41**, including the two new cases.
2. Full suite → `PASS=127 FAIL=3`. The three are `test_suggest_mcp_search`, `test_token_efficiency_wave1`, `test_harnessability_scoring` — **all three pass on clean `upstream/dev`**, verified in a worktree. They fail only in a working tree carrying untracked local skills, because the skill-count assertion counts tracked skills. Not framework failures, and unrelated to this change.
3. `shellcheck --severity=warning` clean on all four files; `bash -n` clean on all three hooks.

## Context

Filed from the threat model run against the framework's own control plane (finding **T2**), which identified the local ↔ forge boundary as the only adversarially sound control in the system — and this fallback as the thing that silently removes it.

Refs #1091

---

## Glossary

| Term | Definition |
|------|------------|
| fail open / fail closed | A degraded control that permits (open) versus one that blocks (closed). For a gate, closed is the safe direction — it over-blocks rather than letting something through unchecked. |
| forge-reported HEAD | The PR's head commit as the server reports it. Load-bearing because a local file write cannot change it, unlike anything on disk. |
| discriminating test | One that fails against the pre-change code and passes after. A test green in both directions proves nothing. |
| approval marker | A file under `.claude/session/reviews/` recording a review at a specific SHA. Only meaningful if compared against a SHA the author cannot choose. |
