### PR TITLE
fix(hooks): anchor the cwd-derived branch of trust-chain self-location (#1062)

### DIFF
--- a/.claude/hooks/_lib-audit-history.sh
+++ b/.claude/hooks/_lib-audit-history.sh
@@ -54,6 +54,11 @@ _LIB_AUDIT_HISTORY_SOURCED=1
 # is the actual portability fix (works under any shell, since it only depends
 # on `git`, not on a bash-only parameter).
 _AUDIT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+# me2resh/apexyard#1062: under a non-bash shell BASH_SOURCE is empty, so the resolution above
+# degrades to the CALLER's cwd (dirname "" -> "."). Discard a cwd-derived path so the anchored
+# git-root check below must validate it; a genuine BASH_SOURCE path is where this file lives and
+# is kept as-is (#1061 only anchored the git-derived fallback, not this cwd-derived branch).
+if [ -z "${BASH_SOURCE[0]:-}" ]; then _AUDIT_LIB_DIR=""; fi
 if [ -z "$_AUDIT_LIB_DIR" ] || [ ! -f "$_AUDIT_LIB_DIR/_lib-read-config.sh" ]; then
   _audit_root="$(git rev-parse --show-toplevel 2>/dev/null)"
   # me2resh/apexyard#1033: only accept a git-derived root that is actually

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -140,6 +140,11 @@ if ! command -v tracker_kind >/dev/null 2>&1; then
   # this lib's real directory, which usually (harmlessly) misses the `-f`
   # check below. The git-rev-parse fallback is the actual portability fix.
   _lib_extract_pr_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd 2>/dev/null)"
+  # me2resh/apexyard#1062: under a non-bash shell BASH_SOURCE is empty, so the resolution above
+  # degrades to the CALLER's cwd (dirname "" -> "."). Discard a cwd-derived path so the anchored
+  # git-root check below must validate it; a genuine BASH_SOURCE path is where this file lives and
+  # is kept as-is (#1061 only anchored the git-derived fallback, not this cwd-derived branch).
+  if [ -z "${BASH_SOURCE[0]:-}" ]; then _lib_extract_pr_dir=""; fi
   if [ -z "$_lib_extract_pr_dir" ] || [ ! -f "$_lib_extract_pr_dir/_lib-tracker.sh" ]; then
     _lib_extract_pr_root="$(git rev-parse --show-toplevel 2>/dev/null)"
     # me2resh/apexyard#1033: only accept a git-derived root that is actually

--- a/.claude/hooks/_lib-fresh-fork.sh
+++ b/.claude/hooks/_lib-fresh-fork.sh
@@ -51,6 +51,11 @@ _LIB_FRESH_FORK_SOURCED=1
 # default avoids a hard "parameter not set" error; the git-rev-parse
 # fallback is the actual portability fix (works under any shell).
 _FRESH_FORK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+# me2resh/apexyard#1062: under a non-bash shell BASH_SOURCE is empty, so the resolution above
+# degrades to the CALLER's cwd (dirname "" -> "."). Discard a cwd-derived path so the anchored
+# git-root check below must validate it; a genuine BASH_SOURCE path is where this file lives and
+# is kept as-is (#1061 only anchored the git-derived fallback, not this cwd-derived branch).
+if [ -z "${BASH_SOURCE[0]:-}" ]; then _FRESH_FORK_LIB_DIR=""; fi
 if [ -z "$_FRESH_FORK_LIB_DIR" ] || [ ! -f "$_FRESH_FORK_LIB_DIR/_lib-read-config.sh" ]; then
   _fresh_fork_root="$(git rev-parse --show-toplevel 2>/dev/null)"
   # me2resh/apexyard#1033: only accept a git-derived root that is actually

--- a/.claude/hooks/_lib-onboarding-depth-mode.sh
+++ b/.claude/hooks/_lib-onboarding-depth-mode.sh
@@ -57,6 +57,11 @@ _LIB_ONBOARDING_DEPTH_MODE_SOURCED=1
 # default avoids a hard "parameter not set" error; the git-rev-parse
 # fallback is the actual portability fix (works under any shell).
 _DEPTH_MODE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+# me2resh/apexyard#1062: under a non-bash shell BASH_SOURCE is empty, so the resolution above
+# degrades to the CALLER's cwd (dirname "" -> "."). Discard a cwd-derived path so the anchored
+# git-root check below must validate it; a genuine BASH_SOURCE path is where this file lives and
+# is kept as-is (#1061 only anchored the git-derived fallback, not this cwd-derived branch).
+if [ -z "${BASH_SOURCE[0]:-}" ]; then _DEPTH_MODE_LIB_DIR=""; fi
 if [ -z "$_DEPTH_MODE_LIB_DIR" ] || [ ! -f "$_DEPTH_MODE_LIB_DIR/_lib-ops-root.sh" ]; then
   _depth_mode_root="$(git rev-parse --show-toplevel 2>/dev/null)"
   # me2resh/apexyard#1033: only accept a git-derived root that is actually

--- a/.claude/hooks/_lib-onboarding-glossary-seen.sh
+++ b/.claude/hooks/_lib-onboarding-glossary-seen.sh
@@ -77,6 +77,11 @@ _LIB_ONBOARDING_GLOSSARY_SEEN_SOURCED=1
 # default avoids a hard "parameter not set" error; the git-rev-parse
 # fallback is the actual portability fix (works under any shell).
 _GLOSSARY_SEEN_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+# me2resh/apexyard#1062: under a non-bash shell BASH_SOURCE is empty, so the resolution above
+# degrades to the CALLER's cwd (dirname "" -> "."). Discard a cwd-derived path so the anchored
+# git-root check below must validate it; a genuine BASH_SOURCE path is where this file lives and
+# is kept as-is (#1061 only anchored the git-derived fallback, not this cwd-derived branch).
+if [ -z "${BASH_SOURCE[0]:-}" ]; then _GLOSSARY_SEEN_LIB_DIR=""; fi
 if [ -z "$_GLOSSARY_SEEN_LIB_DIR" ] || [ ! -f "$_GLOSSARY_SEEN_LIB_DIR/_lib-ops-root.sh" ]; then
   _glossary_seen_root="$(git rev-parse --show-toplevel 2>/dev/null)"
   # me2resh/apexyard#1033: only accept a git-derived root that is actually

--- a/.claude/hooks/_lib-premium-hook.sh
+++ b/.claude/hooks/_lib-premium-hook.sh
@@ -154,6 +154,11 @@ _premium_hook_dir() {
     # `:-` default neutralises that; the git-rev-parse fallback is the
     # actual portability fix (works under any shell).
     _PREMIUM_HOOK_DIR_CACHE="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+    # me2resh/apexyard#1062: under a non-bash shell BASH_SOURCE is empty, so the resolution above
+    # degrades to the CALLER's cwd (dirname "" -> "."). Discard a cwd-derived path so the anchored
+    # git-root check below must validate it; a genuine BASH_SOURCE path is where this file lives and
+    # is kept as-is (#1061 only anchored the git-derived fallback, not this cwd-derived branch).
+    if [ -z "${BASH_SOURCE[0]:-}" ]; then _PREMIUM_HOOK_DIR_CACHE=""; fi
     if [ -z "$_PREMIUM_HOOK_DIR_CACHE" ] || [ ! -f "$_PREMIUM_HOOK_DIR_CACHE/_lib-premium-hook.sh" ]; then
       local _premium_root
       _premium_root="$(git rev-parse --show-toplevel 2>/dev/null)"

--- a/.claude/hooks/_lib-project-board.sh
+++ b/.claude/hooks/_lib-project-board.sh
@@ -63,6 +63,11 @@ _LIB_PROJECT_BOARD_SOURCED=1
 # under any shell because it depends on `git`, not on a bash-only parameter.
 # ---------------------------------------------------------------------------
 _lib_board_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+# me2resh/apexyard#1062: under a non-bash shell BASH_SOURCE is empty, so the resolution above
+# degrades to the CALLER's cwd (dirname "" -> "."). Discard a cwd-derived path so the anchored
+# git-root check below must validate it; a genuine BASH_SOURCE path is where this file lives and
+# is kept as-is (#1061 only anchored the git-derived fallback, not this cwd-derived branch).
+if [ -z "${BASH_SOURCE[0]:-}" ]; then _lib_board_dir=""; fi
 if [ -z "$_lib_board_dir" ] || [ ! -f "$_lib_board_dir/_lib-ops-root.sh" ]; then
   _lib_board_root="$(git rev-parse --show-toplevel 2>/dev/null)"
   # me2resh/apexyard#1033: only accept a git-derived root that is actually

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -88,6 +88,11 @@ _tracker_load_config_lib() {
   fi
   local root hook_dir
   hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+  # me2resh/apexyard#1062: under a non-bash shell BASH_SOURCE is empty, so the resolution above
+  # degrades to the CALLER's cwd (dirname "" -> "."). Discard a cwd-derived path so the anchored
+  # git-root check below must validate it; a genuine BASH_SOURCE path is where this file lives and
+  # is kept as-is (#1061 only anchored the git-derived fallback, not this cwd-derived branch).
+  if [ -z "${BASH_SOURCE[0]:-}" ]; then hook_dir=""; fi
   if [ -z "$hook_dir" ] || [ ! -f "$hook_dir/_lib-read-config.sh" ]; then
     root=$(git rev-parse --show-toplevel 2>/dev/null)
     # me2resh/apexyard#1033: only accept a git-derived root that is actually
@@ -134,6 +139,11 @@ _tracker_load_portfolio_lib() {
   fi
   local hook_dir root
   hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
+  # me2resh/apexyard#1062: under a non-bash shell BASH_SOURCE is empty, so the resolution above
+  # degrades to the CALLER's cwd (dirname "" -> "."). Discard a cwd-derived path so the anchored
+  # git-root check below must validate it; a genuine BASH_SOURCE path is where this file lives and
+  # is kept as-is (#1061 only anchored the git-derived fallback, not this cwd-derived branch).
+  if [ -z "${BASH_SOURCE[0]:-}" ]; then hook_dir=""; fi
   if [ -z "$hook_dir" ] || [ ! -f "$hook_dir/_lib-portfolio-paths.sh" ]; then
     root=$(git rev-parse --show-toplevel 2>/dev/null)
     # me2resh/apexyard#1033: only accept a git-derived root that is actually

--- a/.claude/hooks/tests/test_lib_self_location_cwd_anchor.sh
+++ b/.claude/hooks/tests/test_lib_self_location_cwd_anchor.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Regression test for me2resh/apexyard#1062 — the cwd-derived branch of the
+# trust-chain self-location must be anchored, not only the git-derived fallback.
+#
+# #1033/#1061 anchored the `git rev-parse` FALLBACK branch. But the cwd branch runs
+# FIRST: under a non-bash shell BASH_SOURCE is unset, so `dirname "" -> "."` and the
+# derived dir becomes the CALLER's cwd. If that cwd directly contains the sibling lib,
+# the `[ ! -f "$dir/<sibling>" ]` guard is false, the anchored fallback never runs, and
+# an impostor cwd wins UNANCHORED. #1062 discards a cwd-derived dir when BASH_SOURCE is
+# empty, forcing it through the same anchor; a genuine BASH_SOURCE path is kept as-is.
+#
+# This bug only reproduces under a shell that leaves BASH_SOURCE unset (zsh). The #1033
+# test's `. /dev/stdin` trick yields BASH_SOURCE[0]=/dev/stdin (dirname -> /dev), which
+# does NOT reproduce the cwd degradation — so this regression lives in its own
+# zsh-guarded file, alongside test_tracker_zsh_self_location.sh.
+#
+# Representative site: _lib-tracker.sh :: _tracker_load_config_lib (sources
+# _lib-read-config.sh) plus _lib-fresh-fork.sh (a top-level self-location). The same
+# guard is applied uniformly to all nine self-location sites (see the #1062 diff).
+set -u
+
+HOOKS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TRACKER_LIB="$HOOKS_DIR/_lib-tracker.sh"
+FRESH_FORK_LIB="$HOOKS_DIR/_lib-fresh-fork.sh"
+
+PASS=0
+FAIL=0
+FAILED=""
+ok()  { PASS=$((PASS + 1)); echo "PASS [$1]"; }
+bad() { FAIL=$((FAIL + 1)); FAILED="${FAILED}$1 "; echo "FAIL [$1]: $2" >&2; }
+
+if ! command -v zsh >/dev/null 2>&1; then
+  echo "SKIP: zsh not installed — #1062 needs a non-bash sourcing shell to reproduce"
+  exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# A decoy sibling that shouts if it is sourced. Placed in each fixture's .claude/hooks/.
+decoy_read_config() { # <dir> <marker-var> <marker-val>
+  cat > "$1/_lib-read-config.sh" <<EOF
+$2=$3
+config_get_or() { :; }
+EOF
+}
+
+# impostor NON-fork repo: ships .claude/hooks/_lib-read-config.sh but no fork anchor
+IMP="$TMP/impostor"
+mkdir -p "$IMP/.claude/hooks"
+( cd "$IMP" && git init -q && git config user.email t@t && git config user.name t )
+decoy_read_config "$IMP/.claude/hooks" IMPOSTOR_CONFIG 1
+
+# genuine fork, v2 layout: .apexyard-fork anchor
+FORK2="$TMP/fork-v2"
+mkdir -p "$FORK2/.claude/hooks"
+( cd "$FORK2" && git init -q && git config user.email t@t && git config user.name t )
+: > "$FORK2/.apexyard-fork"
+decoy_read_config "$FORK2/.claude/hooks" FORK_CONFIG v2
+
+# genuine fork, v1 layout: onboarding.yaml + apexyard.projects.yaml pair
+FORK1="$TMP/fork-v1"
+mkdir -p "$FORK1/.claude/hooks"
+( cd "$FORK1" && git init -q && git config user.email t@t && git config user.name t )
+: > "$FORK1/onboarding.yaml"
+: > "$FORK1/apexyard.projects.yaml"
+decoy_read_config "$FORK1/.claude/hooks" FORK_CONFIG v1
+
+# Source the lib under zsh from <cwd>, call the loader, report which sibling won.
+tracker_zsh() {
+  ( cd "$1" && zsh -c "source '$TRACKER_LIB'; _tracker_load_config_lib >/dev/null 2>&1; \
+      echo \"IMPOSTOR_CONFIG=\${IMPOSTOR_CONFIG:-unset} FORK_CONFIG=\${FORK_CONFIG:-unset}\"" )
+}
+
+# Case 1 — the #1062 regression: an impostor cwd must NOT load its sibling (zsh).
+out="$(tracker_zsh "$IMP/.claude/hooks")"
+case "$out" in
+  *"IMPOSTOR_CONFIG=unset"*) ok "impostor cwd (zsh): sibling not sourced from cwd" ;;
+  *) bad "impostor cwd (zsh): sibling not sourced from cwd" "impostor lib was sourced: $out" ;;
+esac
+
+# Case 2 — a genuine v2 fork must still resolve under zsh (over-strictness guard).
+out="$(tracker_zsh "$FORK2/.claude/hooks")"
+case "$out" in
+  *"FORK_CONFIG=v2"*) ok "v2 fork cwd (zsh): sibling still loads via the anchor" ;;
+  *) bad "v2 fork cwd (zsh): sibling still loads via the anchor" "v2 fork did not resolve: $out" ;;
+esac
+
+# Case 3 — a genuine v1 fork must still resolve under zsh (both layouts).
+out="$(tracker_zsh "$FORK1/.claude/hooks")"
+case "$out" in
+  *"FORK_CONFIG=v1"*) ok "v1 fork cwd (zsh): sibling still loads via the anchor" ;;
+  *) bad "v1 fork cwd (zsh): sibling still loads via the anchor" "v1 fork did not resolve: $out" ;;
+esac
+
+# Case 4 — under bash a genuine BASH_SOURCE path is kept (never gated): sourcing the
+# real lib from an impostor cwd loads the REAL sibling, never the impostor's.
+out="$( cd "$IMP/.claude/hooks" && bash -c "source '$TRACKER_LIB'; _tracker_load_config_lib >/dev/null 2>&1; \
+    echo \"IMPOSTOR_CONFIG=\${IMPOSTOR_CONFIG:-unset}\"" )"
+case "$out" in
+  *"IMPOSTOR_CONFIG=unset"*) ok "impostor cwd (bash): genuine BASH_SOURCE kept, impostor not loaded" ;;
+  *) bad "impostor cwd (bash): genuine BASH_SOURCE kept" "impostor lib was sourced under bash: $out" ;;
+esac
+
+# Case 5 — a top-level self-location site (_lib-fresh-fork.sh runs at source time)
+# is guarded too: sourcing it from an impostor cwd under zsh must not load the cwd sibling.
+out="$( cd "$IMP/.claude/hooks" && zsh -c "source '$FRESH_FORK_LIB' >/dev/null 2>&1; \
+    echo \"IMPOSTOR_CONFIG=\${IMPOSTOR_CONFIG:-unset}\"" )"
+case "$out" in
+  *"IMPOSTOR_CONFIG=unset"*) ok "impostor cwd (zsh, top-level site): sibling not sourced from cwd" ;;
+  *) bad "impostor cwd (zsh, top-level site): sibling not sourced from cwd" "impostor lib was sourced: $out" ;;
+esac
+
+echo
+if [ "$FAIL" -gt 0 ]; then
+  echo "FAILED: $FAILED"
+  exit 1
+fi
+echo "All $PASS checks passed."


### PR DESCRIPTION
## Summary

Closes #1062.

Every trust-chain lib locates its own directory to source sibling libs from it:

```sh
_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
if [ -z "$_lib_dir" ] || [ ! -f "$_lib_dir/<sibling>" ]; then
  # anchored git-root fallback (#1033/#1061)
fi
```

The cwd-derived first branch has a gap. Under a non-bash shell `BASH_SOURCE` is unset, so `dirname "" -> "."` and `_lib_dir` resolves to the **caller's cwd**. When that cwd directly contains the sibling lib, the `-f` guard is satisfied, the anchored fallback never runs, and the lib is sourced **unanchored** out of whatever repo the cwd happens to be inside (a `workspace/<project>` clone, or an unrelated checkout).

#1033/#1061 anchored the `git rev-parse` **fallback** branch, but not this cwd-derived branch — which runs first.

## Fix

Discard a cwd-derived path when `BASH_SOURCE` is empty, forcing it through the same fork anchor:

```sh
if [ -z "${BASH_SOURCE[0]:-}" ]; then _lib_dir=""; fi
```

- Under **bash**, `BASH_SOURCE[0]` is the real file path — the guard is a strict no-op and the genuine path is kept as-is (no added filesystem checks).
- Under a **non-bash shell**, the cwd-derived path is dropped and resolution falls to the existing anchored git-root check, which only accepts a genuine apexyard fork.

Applied uniformly to all **nine** self-location sites across the eight trust-chain libs: `_lib-audit-history.sh`, `_lib-extract-pr.sh`, `_lib-fresh-fork.sh`, `_lib-onboarding-depth-mode.sh`, `_lib-onboarding-glossary-seen.sh`, `_lib-premium-hook.sh`, `_lib-project-board.sh`, `_lib-tracker.sh` (×2).

## Test

New `tests/test_lib_self_location_cwd_anchor.sh`. This bug only reproduces under a shell that leaves `BASH_SOURCE` unset — the existing `test_lib_self_location_anchor.sh` uses the `. /dev/stdin` trick, which yields `BASH_SOURCE[0]=/dev/stdin` (`dirname -> /dev`) and therefore cannot reproduce the empty-`BASH_SOURCE` → cwd degradation. So the regression lives in its own zsh-guarded file (skips cleanly when zsh is absent), alongside the existing `test_tracker_zsh_self_location.sh`.

Coverage:
- **Impostor non-fork cwd (zsh)** — a same-named sibling in the cwd is **not** sourced (the #1062 regression; function-based site `_lib-tracker.sh` and top-level site `_lib-fresh-fork.sh`).
- **Genuine fork cwd (zsh)** — both fork layouts (`.apexyard-fork`, and the `onboarding.yaml`+`apexyard.projects.yaml` pair) still resolve via the anchor.
- **Impostor cwd (bash)** — a genuine `BASH_SOURCE` path is kept; the real sibling loads, never the impostor's.

Verified fail-before / pass-after by stripping only the guard lines: the two impostor cases flip to `IMPOSTOR_CONFIG=1` (sibling sourced from cwd) without the fix and pass with it, while the fork/bash cases pass in both states (guards against over-strictness). The existing `test_lib_self_location_anchor.sh` (27) and `test_tracker_zsh_self_location.sh` (9) both remain green.

```
PASS [impostor cwd (zsh): sibling not sourced from cwd]
PASS [v2 fork cwd (zsh): sibling still loads via the anchor]
PASS [v1 fork cwd (zsh): sibling still loads via the anchor]
PASS [impostor cwd (bash): genuine BASH_SOURCE kept, impostor not loaded]
PASS [impostor cwd (zsh, top-level site): sibling not sourced from cwd]
```

## Scope / notes

- Consistent with #1033's framing: this narrows a cwd-driven **misresolution** (an accident surface), not a hostile-library access-control boundary — the anchors remain unauthenticated presence-only files.
- No behavior change under bash; no new filesystem checks on the genuine-path branch.


---

## Glossary

*(Added by a maintainer to satisfy `.claude/rules/pr-quality.md`'s Glossary requirement — no change to the contributor's fix or reasoning.)*

| Term | Definition |
|------|------------|
| self-location | A shell library working out its own directory so it can source sibling libraries from beside itself. Fragile because the mechanism it relies on, `BASH_SOURCE`, is a bash feature that does not exist in other shells. |
| `BASH_SOURCE` | A bash array whose first element is the path of the file currently being sourced. Unset under zsh/sh — which is the whole bug here, since `dirname ""` yields `.`, silently turning "the directory I live in" into "the directory the caller happened to be standing in". |
| anchored resolution | Only accepting a directory that proves it is a genuine apexyard fork: it must be a git root (`git rev-parse --show-toplevel`) **and** carry the `.apexyard-fork` marker or the `onboarding.yaml` + `apexyard.projects.yaml` pair. The git-root half is why a genuine fork that isn't a git repo no longer resolves under zsh — the intended narrowing noted above. |
| impostor sibling | A file sharing a real library's name, sitting in an unrelated directory, which an unanchored load would source instead of the genuine one. The thing the new tests plant deliberately. |
| trust chain | The libraries and hooks that enforce apexyard's SDLC gates. Loading one from the wrong repository is a **misresolution** — an accident surface, per this PR's Scope note and #1033/#1062 — not an access-control boundary. Severity is bounded because hooks launch via `bash -c` with absolute paths, so no gate actually reaches these branches. |
| discriminating test | One that fails against the pre-change code and passes after. The new test file is necessary precisely because the existing `test_lib_self_location_anchor.sh` passes even with every guard stripped — it cannot see this defect at all. |

