### PR TITLE
fix(#1094): unlock /decide and /audit-deps, and assert over every locked skill

### DIFF
--- a/.claude/hooks/tests/test_skill_invocability_gates.sh
+++ b/.claude/hooks/tests/test_skill_invocability_gates.sh
@@ -37,14 +37,23 @@ SKILLS="$REPO_ROOT/.claude/skills"
 PASS=0
 FAIL=0
 
-# Read the frontmatter value. Only the frontmatter block counts, so the key
-# is matched at line-start and only before the closing `---`.
+# Read the frontmatter value, RAW — exactly as written. Only the frontmatter
+# block counts, so the key is matched at line-start and only before the
+# closing `---`.
 #
 # Trailing \r is stripped first: a CRLF-committed SKILL.md would otherwise
 # yield "true\r", which compares unequal to "true" and fails this test for a
 # line-ending reason rather than a real one. This repo has been bitten by
 # exactly that before (#1019, where config_get left an embedded \r on Windows
 # checkouts), so the guard is cheap insurance rather than theory.
+#
+# The value is deliberately NOT normalised here. The per-family assertions
+# below must stay strict: for the three approval skills, only the canonical
+# bare `true` counts as locked. A quoted scalar (`"true"`) is a YAML *string*,
+# not a boolean, and whether the harness coerces it is unverified — accepting
+# it would let this test report "locked" for a value the runtime may treat as
+# unlocked. Strict comparison fails LOUDLY on any unrecognised spelling, the
+# safe direction for the most safety-critical assertion in this file.
 invocation_flag() {
   local file="$1"
   awk '
@@ -57,6 +66,27 @@ invocation_flag() {
       exit
     }
   ' "$file"
+}
+
+# NORMALISED value — trailing `# comment`, surrounding quotes, whitespace and
+# capitalisation removed. Used ONLY by the every-skill sweep at the bottom.
+#
+# The two accessors exist because the same spelling needs opposite treatment at
+# the two call sites (#1094 review, security finding). In the per-family checks
+# an unrecognised spelling fails loudly — annoying but safe. In the sweep it
+# made a LOCKED skill read as unlocked and be skipped SILENTLY, which is exactly
+# the case that assertion exists to catch. Normalising only the sweep closes
+# that fail-open without loosening the strict path.
+invocation_flag_normalised() {
+  local file="$1"
+  invocation_flag "$file" | awk '
+    {
+      sub(/[[:space:]]*#.*$/, "")          # strip a trailing comment
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+      gsub(/^["\x27]|["\x27]$/, "")        # strip surrounding quotes
+      print tolower($0)
+    }
+  '
 }
 
 expect_flag() {
@@ -132,6 +162,55 @@ if [ "$REVIEW_UNLOCKED" = "1" ] && [ "$APPROVAL_LOCKED" = "0" ]; then
   FAIL=$((FAIL + 1))
 else
   echo "PASS: no autonomous open -> review -> approve -> merge path"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Every LOCKED skill must be justified (#1094).
+#
+# The family checks above pin the six skills someone thought about. They
+# structurally cannot catch a SEVENTH skill acquiring the flag — which is
+# exactly what happened: /decide and /audit-deps were human-only outside
+# AgDR-0110's reasoning and outside this test's coverage, and nobody noticed
+# because nothing asserted over the whole set.
+#
+# /decide's lock was the costly one. `.claude/rules/agdr-decisions.md` opens
+# with "HARD STOP … run /decide" and repeats "→ /decide" four more times, so
+# the framework was ordering an action it had mechanically forbidden. That is
+# the same self-contradiction the review-skill justification above names for
+# auto-code-review.sh — one skill over, and undetected.
+#
+# So assert the inverse: iterate EVERY skill, and require any that is locked to
+# appear in an explicit allow-list. Adding a lock now means editing this list
+# and stating why, which is the point.
+# ---------------------------------------------------------------------------
+
+# Only skills whose INVOCATION IS THE APPROVAL belong here (AgDR-0110).
+# A skill that merely writes a document, reads state, or reports does not.
+LOCK_ALLOWED="approve-merge approve-design approve-architecture"
+
+UNJUSTIFIED=0
+for f in "$SKILLS"/*/SKILL.md; do
+  [ -f "$f" ] || continue
+  name=$(basename "$(dirname "$f")")
+  [ "$(invocation_flag_normalised "$f")" = "true" ] || continue
+  case " $LOCK_ALLOWED " in
+    *" $name "*) ;;
+    *)
+      echo "FAIL: /$name is human-only but is not in the justified lock list."
+      echo "   Only approval skills may be locked — the ones where invoking the"
+      echo "   skill IS the human approval (AgDR-0110). If this lock is"
+      echo "   deliberate, add /$name to LOCK_ALLOWED with a stated reason, AND"
+      echo "   check that no rule instructs the agent to invoke it — a rule that"
+      echo "   does is a contradiction the agent cannot resolve (#1094)."
+      FAIL=$((FAIL + 1))
+      UNJUSTIFIED=1
+      ;;
+  esac
+done
+
+if [ "$UNJUSTIFIED" = "0" ]; then
+  echo "PASS: every human-only skill is in the justified lock list"
   PASS=$((PASS + 1))
 fi
 

--- a/.claude/skills/audit-deps/SKILL.md
+++ b/.claude/skills/audit-deps/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: audit-deps
 description: Audit dependencies for vulnerabilities, outdated packages, and license compliance.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[project-path]"
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/.claude/skills/decide/SKILL.md
+++ b/.claude/skills/decide/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: decide
 description: Make a technical decision with structured reasoning and create an Agent Decision Record (AgDR).
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "<what you're deciding>"
 ---
 


### PR DESCRIPTION
## Summary

- **A rule ordered an action the framework had forbidden.** `.claude/rules/agdr-decisions.md` opens with *"**HARD STOP**: … run `/decide`"* and repeats `→ /decide` four more times, but `/decide` carried `disable-model-invocation: true`, so the agent could not invoke it. Every one of those instructions was unactionable.
- **AgDR-0110's lock is sound and is unchanged.** The three *approval* skills stay human-only, because for those the invocation **is** the approval — without that lock, unlocking the review skills would open an autonomous `open → review → approve → merge` path. That reasoning simply does not reach `/decide`: an AgDR is a decision **record**, writing no marker, satisfying no merge gate, authorising nothing. Nor `/audit-deps`, which reads manifests and reports. No AgDR or rule names either as needing a lock.
- **Both are set to `false` rather than having the key removed** — the existing test treats an absent key as a failure for the families it covers, since absent defaults to model-invocable, which is how `/approve-architecture` was once silently unguarded. Stating the posture is the convention here.
- **The durable half is the test.** `test_skill_invocability_gates.sh` pinned three review skills unlocked and three approval skills locked — it structurally could not catch a *seventh* skill acquiring the flag, which is exactly how these two went unnoticed. It now iterates **every** `SKILL.md` and requires any locked one to appear in an explicit `LOCK_ALLOWED` list. Adding a lock means editing that list and stating why.

## Why the contradiction is the bug, not the lock

The framework already knows this failure mode. The same test's justification for keeping review skills unlocked reads: *"…contradicting `auto-code-review.sh`, which explicitly instructs the orchestrator to run `/code-review`."* This is that defect one skill over, and undetected because nothing asserted over the whole set.

The new failure message tells whoever adds a future lock to check that no rule instructs the agent to invoke it — the condition that turns a preference into a contradiction.

If `/decide`'s lock turns out to have been deliberate, the fix is the mirror image: change `agdr-decisions.md` so it tells the agent to *prepare* a decision and hand it to the operator. Either resolution is fine. The contradiction is not.

## Correction from the first review round

The first version of the every-skill loop was **fail-open in exactly the direction the assertion exists to prevent**. `invocation_flag` returned the raw frontmatter value, so a lock spelled `"true"`, `TRUE`, `True`, `true # comment`, or with trailing whitespace compared unequal to `true` and was **silently skipped as unlocked**.

The asymmetry was the dangerous part: that same raw value makes `expect_flag` fail *loudly* for the six named skills — annoying but safe — while it made the new loop pass *silently* for an eighth.

**The first attempt fixed it in the wrong place**, and the security review caught that as a MEDIUM. Normalising inside the shared `invocation_flag` also relaxed the approval-skill assertion: `disable-model-invocation: "TRUE"` on `approve-merge` went from failing loudly to passing silently — and a quoted YAML scalar is a *string*, not a boolean, so the test could report "locked" for a value the runtime may not treat that way. Same shape as the bug being fixed: one function, two call sites, opposite needs.

Now split. `invocation_flag` stays **raw and strict** for the per-family checks; `invocation_flag_normalised` is used **only** by the every-skill sweep, where a silently-skipped lock is the failure the assertion exists to catch. Verified in both directions: `"TRUE"` on `approve-merge` fails loudly on the strict path, `"TRUE"` on `/decide` is caught by the sweep.

**The strongest argument against this change resolves the other way.** The AgDR gates never depended on `/decide`: `require-agdr-for-arch-changes.sh` passes on a staged `docs/agdr/` file **or** a commit message merely containing `AgDR-<n>`, and `require-agdr-for-arch-pr.sh` checks the PR title/body for the same pattern and **never verifies the referenced file exists**. (`require-agdr-for-arch-pr.sh` additionally carries a documented not-applicable bypass; `require-agdr-for-arch-changes.sh` does not — its only exemption is spike/prototype class, and it closes by telling the author to write a minimal AgDR rather than bypass.) So the agent could always satisfy them without the skill — the lock's real effect was to push it toward a hand-rolled file or a bare string instead of `/decide`'s enforced Y-statement, options table, and justification. It made compliance worse, not safer.

## Testing

1. **Mutation-proven discriminating.** Re-applying the lock to `/decide` makes the new assertion fail with `/decide is human-only but is not in the justified lock list`; restoring gives 8/8. Re-run across five lock spellings — `true`, `"true"`, `TRUE`, `True`, `true # locked`, trailing-space — **all five now caught**; before normalisation only the bare form was.
2. The six existing family assertions and the autonomous-path coupling check are untouched and still pass.
3. `shellcheck --severity=warning` and `bash -n` clean.
4. Full suite `PASS=127 FAIL=3` — `test_suggest_mcp_search`, `test_token_efficiency_wave1`, `test_harnessability_scoring`. All three pass on clean `upstream/dev` (verified in a worktree) and fail only in a working tree carrying untracked local skills, because the skill-count assertion counts tracked skills. Unrelated to this change.

Refs #1094

---

## Glossary

| Term | Definition |
|------|------------|
| `disable-model-invocation` | SKILL.md frontmatter making a skill human-only. The model cannot invoke it at all. |
| AgDR | Agent Decision Record — the durable write-up of a material technical decision and its trade-offs. A record, not an approval. |
| approval marker | A file under `.claude/session/reviews/` that a merge gate reads. What makes the approval skills load-bearing, and what `/decide` conspicuously does not write. |
| inverted assertion | Checking a property across the whole set rather than a named subset, so a new member cannot slip in unasserted. |
