### PR TITLE
docs(#1062): credit aniketshukla1 in the contributors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Thanks to everyone who has helped forge ApexYard:
     <td align="center"><a href="https://github.com/HishamM1"><img src="https://github.com/HishamM1.png?size=100" width="64" alt="HishamM1"><br><sub>HishamM1</sub></a></td>
     <td align="center"><a href="https://github.com/tifa64"><img src="https://github.com/tifa64.png?size=100" width="64" alt="tifa64"><br><sub>tifa64</sub></a></td>
     <td align="center"><a href="https://github.com/hossam-96"><img src="https://github.com/hossam-96.png?size=100" width="64" alt="hossam-96"><br><sub>hossam-96</sub></a></td>
+    <td align="center"><a href="https://github.com/aniketshukla1"><img src="https://github.com/aniketshukla1.png?size=100" width="64" alt="aniketshukla1"><br><sub>aniketshukla1</sub></a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Summary

- **Credits `aniketshukla1` in the README contributors list** for fixing #1062 in #1100 — the cwd-derived branch of trust-chain self-location, which #1033/#1061 left unanchored because they anchored only the *fallback* branch. Nine sites across eight libs, plus a new zsh-guarded regression test.
- **This list is the only durable record.** The README says so itself: squash-merges hide contributors from GitHub's graph, so a name that isn't here effectively isn't credited anywhere.
- **Table-only change** — one `<td>` added to the existing row, matching the established entry format exactly. No prose, structure, or other entry touched.

## Why it's worth a PR of its own

#1100 comes from an external contributor's fork, so adding them to our README from inside their branch isn't something to do to someone else's PR. A separate maintainer PR keeps the credit clean and their diff untouched.

Worth noting what the contribution actually was, since the review found more than the ticket asked for: the fix is correct at all nine sites (each guard clears the same variable its own self-location line assigned — checked pairwise), the new test is genuinely discriminating against the real base commit, and the contributor **correctly deviated from #1062's acceptance criterion**. That AC said to extend `test_lib_self_location_anchor.sh`; the review established that file exits 0 even with every guard stripped, so it structurally cannot catch this defect. A separate zsh-guarded file was the right call and the AC was wrong.

## Testing

1. `npx markdownlint-cli2 README.md` — clean, 0 issues.
2. Contributors table parses to six distinct entries, `aniketshukla1` appearing exactly once.
3. Avatar and profile URLs follow the identical `https://github.com/<user>.png?size=100` / `https://github.com/<user>` pattern as the five existing entries.

Refs #1062

---

## Glossary

| Term | Definition |
|------|------------|
| squash-merge | Collapsing a branch's commits into one on merge. Keeps history readable, but attributes the result to whoever merged — which is why GitHub's contributor graph misses people and this list exists. |
| contributors list | The hand-maintained README table crediting every human who has landed a change. Manual precisely because the automatic mechanism doesn't work under squash-merges. |
| trust chain | The libraries and hooks enforcing apexyard's SDLC gates — the subsystem this contributor's fix hardened. |
