### PR TITLE
docs(#1024): give isolated-builds worktrees a location, naming, and lifecycle convention

### DIFF
--- a/.claude/rules/isolated-builds.md
+++ b/.claude/rules/isolated-builds.md
@@ -17,30 +17,43 @@ Heuristic: reach for an isolated build whenever the task is **any** of these:
 
 ## The safe pattern
 
-- **Use `git worktree add` off a persistent clone, never `/tmp`.** A worktree is a linked working directory sharing one repo's `.git` — isolation without a second clone, and it lives at a path you control and that survives the session (e.g. `workspace/<name>/` or a dedicated `~/repos/<name>` clone, not `/tmp/...`).
+- **Use `git worktree add` off the fork's own clone, never `/tmp`.** A worktree is a linked working directory sharing one repo's `.git` — isolation without a second clone.
+- **One location convention, no exceptions: `.claude/worktrees/<type>-<ticket>-<short-slug>`.** This is the same root the harness already uses for `Agent(isolation: "worktree")` spawns (`.claude/worktrees/agent-<id>`), it's already gitignored, and it never appears as a sibling of the fork root cluttering the editor's file tree or reading as a second repo. Hand-created worktrees join that one location instead of inventing a new one. `<type>` is the branch type (`fix`, `feature`, `chore`, `docs`, …), `<ticket>` is the tracker ID, `<short-slug>` is a few words of context — e.g. `.claude/worktrees/fix-1024-worktree-hygiene`. A worktree named this way is legible months later without opening it.
 - **Always `cd <dir> || exit 1` in any dir-changing bash block.** A missing or mistyped path must abort the block, not silently continue in the wrong directory. Never chain a bare `cd <dir> &&` — the `|| exit 1` (or equivalent early-return) is not optional ceremony, it's the one line that turns a silent wrong-repo failure into a loud stop.
 - **Never `git reset --hard` (or other destructive git) without first confirming the repo.** Run `git rev-parse --show-toplevel` and check the result names the repo you intend to reset — a bare eyeball check, not a formal ceremony — before any hard reset, forced clean, or forced checkout.
 
 ```bash
-# WRONG — silent wrong-repo risk
+# WRONG — silent wrong-repo risk, AND a stray sibling-of-fork-root worktree
 cd /tmp/sibling-repo
 git reset --hard origin/main   # if the cd silently failed, this just reset the ops fork
 
-# RIGHT — persistent clone, worktree, guarded cd, confirmed toplevel
-git -C ~/repos/sibling-repo worktree add ../sibling-repo-build main
-cd ~/repos/sibling-repo-build || exit 1
-[ "$(git rev-parse --show-toplevel)" = "$HOME/repos/sibling-repo-build" ] || { echo "wrong repo, aborting"; exit 1; }
+# RIGHT — worktree under .claude/worktrees/, ticket-tied name, guarded cd, confirmed toplevel
+git worktree add .claude/worktrees/fix-1024-worktree-hygiene -b fix/GH-1024-worktree-hygiene main
+cd .claude/worktrees/fix-1024-worktree-hygiene || exit 1
+[ "$(git rev-parse --show-toplevel)" = "$(pwd)" ] || { echo "wrong repo, aborting"; exit 1; }
 git reset --hard origin/main
 ```
 
+For a genuinely separate repo (not this one) that still needs a persistent, non-`/tmp` home — a sibling managed project, a premium component — clone it once to a durable path you control (e.g. `workspace/<name>/`, per the portfolio model) and worktree off *that* clone using the same `.claude/worktrees/<type>-<ticket>-<short-slug>` convention inside it.
+
+## Lifecycle — remove the worktree once its PR merges
+
+A worktree is scoped to the ticket it was created for, not kept around after. Once the PR merges:
+
+```bash
+git worktree remove .claude/worktrees/fix-1024-worktree-hygiene
+```
+
+The agent that merges the PR is the one that removes the worktree — the same turn, not a follow-up. This is what keeps `.claude/worktrees/` from accumulating stale checkouts the way the sibling-of-fork-root directories did: nothing prunes those automatically, and `git worktree prune` only clears registry entries whose *directory* is already gone — it does nothing for a worktree that still exists on disk with a long-merged branch. If a squash-merge model is in play, don't use `git branch --merged` / `--is-ancestor` to decide "is this done" — a squashed branch's tip is never an ancestor of the base. Check the PR's actual state (`gh pr view <N> --json state,mergedAt`) instead.
+
 ## Standard for spawned build agents
 
-The `Agent` tool's `isolation: "worktree"` option is the standard for spawned build-class agents (backend-engineer, frontend-engineer, platform-engineer, and similar). It creates a temporary git worktree so the sub-agent works on an isolated copy of the repo — the same safety property this rule asks for by hand, provided automatically. Prefer `isolation: "worktree"` over asking a sub-agent to `cd` into a manually managed clone whenever the harness supports it.
+The `Agent` tool's `isolation: "worktree"` option is the standard for spawned build-class agents (backend-engineer, frontend-engineer, platform-engineer, and similar). It creates a temporary git worktree under `.claude/worktrees/agent-<id>` so the sub-agent works on an isolated copy of the repo — the same location convention and safety property this rule asks for by hand, provided and cleaned up automatically. Prefer `isolation: "worktree"` over asking a sub-agent to `cd` into a manually managed clone whenever the harness supports it.
 
 ## When NOT to bother
 
 - **Single read-only inspection** of another repo (`git -C <path> log`, a one-off `git show`) — no build, no destructive git, no isolation needed.
-- **Work entirely inside the current repo** — this rule is about *other* repos; the current repo's own branch/worktree hygiene is covered by `git-conventions.md`.
+- **Working directly on the current repo's checkout with no destructive git and no build isolation need** — this rule's failure-mode reasoning is about *other* repos and about any hand-created worktree; the current repo's own branch-naming hygiene is covered by `git-conventions.md`. If a worktree is warranted at all (a build, a sub-agent spawn, a destructive-git step), the `.claude/worktrees/<type>-<ticket>-<short-slug>` location convention above still applies even when the worktree is of this same repo.
 
 ## Self-check before responding
 
@@ -48,9 +61,11 @@ Before running a bash block that changes directory into another repo or clone, s
 
 ```
 [ ] Is the target directory a persistent clone/worktree, not /tmp?
+[ ] If it's a hand-created worktree, does it live under `.claude/worktrees/<type>-<ticket>-<short-slug>`?
 [ ] Does every `cd <dir>` in this block end in `|| exit 1` (or equivalent)?
 [ ] Before any `git reset --hard` / forced clean / forced checkout, did I confirm `git rev-parse --show-toplevel` names the intended repo?
 [ ] If this is a spawned build agent, did I pass `isolation: "worktree"`?
+[ ] Once this ticket's PR merges, did I `git worktree remove` it?
 ```
 
 If any box is unchecked and the block runs destructive git or a build, fix it before running — not after.


### PR DESCRIPTION
## Summary

- **Gives hand-created worktrees one location convention instead of six ad-hoc ones** — `.claude/rules/isolated-builds.md` previously told agents to use a worktree "off a persistent clone" but never said where, so every agent invented its own answer. One adopter fork had 9 hand-created worktrees using 6 different naming schemes, sprawled as siblings of the fork root where they clutter the editor's file tree and are indistinguishable from real repos at a glance. The rule now mandates `.claude/worktrees/<type>-<ticket>-<short-slug>` — the same root the harness already uses for `Agent(isolation:"worktree")` spawns, already gitignored, and never a sibling of the fork root.
- **Fixes the worked example that taught the anti-pattern** — the old `git worktree add ../sibling-repo-build` example in the "safe pattern" code block was itself a sibling-of-fork-root checkout, i.e. it modeled the exact thing the ticket found sprawling across a real fork. The example now worktrees under `.claude/worktrees/` with a ticket-tied name.
- **Adds a lifecycle the rule previously had none of** — worktrees are now explicitly removed via `git worktree remove` once their PR merges, by the same agent that does the merge, in the same turn. This matters because `git worktree prune` only clears registry entries whose directory is already gone — it does nothing for a worktree that's still on disk with a long-merged branch, which is exactly how the stale checkouts accumulated. The section also flags the squash-merge trap: `--is-ancestor` / `git branch --merged` report "not merged" for every squash-merged branch, so "is this done" has to come from PR state (`gh pr view --json state,mergedAt`), not git ancestry.
- **Confirms `.claude/worktrees/` was already gitignored** — checked `.gitignore`; the harness-managed entries already cover it, so no `.gitignore` change was needed.

## Out of scope

The ticket's scope item 4 — an optional `/status`-style cleanup listing of worktrees whose PRs are merged/closed — is a separable follow-up, not built here. It would need the PR-state check (not `--is-ancestor`) called out in the Lifecycle section above; left for a future ticket.

## Testing

- Ran `npx --yes markdownlint-cli2 .claude/rules/isolated-builds.md` — 0 issues.
- Manually re-read the full rule file end to end to confirm the location convention, worked example, lifecycle section, and self-check checklist are internally consistent and don't reintroduce the `/tmp` failure mode the rule exists to prevent.
- This is a prose/rule-only change — no code paths, no hooks, no CI-relevant files touched.

Refs #1024

---

## Glossary

| Term | Definition |
|------|------------|
| Git worktree | A second working directory attached to one repository, so a different branch can be checked out without disturbing the main checkout |
| `git worktree remove` | Deletes a worktree's directory and unregisters it from the repo — the lifecycle step this PR adds explicitly |
| `git worktree prune` | Removes registry entries whose directory has already been deleted by hand; it does **not** remove a worktree that still exists on disk |
| Squash merge | Collapses a branch's commits into one new commit on the base branch — the branch's own commits are never ancestors of the result, which breaks naive `--is-ancestor` "is this merged?" checks |
