### PR TITLE
fix(#1092): stop /dfd discovery from walking into workspace and worktrees

### DIFF
--- a/.claude/skills/dfd/classify.sh
+++ b/.claude/skills/dfd/classify.sh
@@ -37,9 +37,34 @@ TARGET=$(cd "$TARGET" && pwd -P)
 
 SKIP_DIRS="node_modules vendor .venv venv target dist build coverage .next .nuxt .turbo .cache __pycache__ .git .svn"
 
+# ---------------------------------------------------------------------------
+# Portfolio-workspace exclusion (me2resh/apexyard#1092) — same rationale as
+# discover.sh: when TARGET is an apexyard ops fork, `workspace/` and
+# `.claude/worktrees/` hold full clones/checkouts of OTHER projects and must
+# not be attributed to the target's own data-classification scan.
+# ---------------------------------------------------------------------------
+EXTRA_PRUNE_PATHS=""
+_LIB_PORTFOLIO_PATHS="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../../hooks/_lib-portfolio-paths.sh"
+
+if { [ -f "$TARGET/.apexyard-fork" ] || { [ -f "$TARGET/onboarding.yaml" ] && [ -f "$TARGET/apexyard.projects.yaml" ]; }; } \
+  && [ -f "$_LIB_PORTFOLIO_PATHS" ]; then
+  # shellcheck source=/dev/null
+  . "$_LIB_PORTFOLIO_PATHS" 2>/dev/null || true
+  if command -v portfolio_workspace_dir >/dev/null 2>&1; then
+    WS_DIR=$(cd "$TARGET" && portfolio_workspace_dir 2>/dev/null) || WS_DIR=""
+    if [ -n "$WS_DIR" ] && [ -d "$WS_DIR" ]; then
+      EXTRA_PRUNE_PATHS="$WS_DIR"
+    fi
+  fi
+  WT_DIR="$TARGET/.claude/worktrees"
+  if [ -d "$WT_DIR" ]; then
+    EXTRA_PRUNE_PATHS="$EXTRA_PRUNE_PATHS $WT_DIR"
+  fi
+fi
+
 scoped_grep() {
   local pattern="$1"; shift
-  local prune_args="" first=1 d
+  local prune_args="" first=1 d p
   for d in $SKIP_DIRS; do
     if [ $first -eq 1 ]; then
       prune_args="-name $d"
@@ -47,6 +72,9 @@ scoped_grep() {
     else
       prune_args="$prune_args -o -name $d"
     fi
+  done
+  for p in $EXTRA_PRUNE_PATHS; do
+    prune_args="$prune_args -o -path $p"
   done
   # shellcheck disable=SC2086
   find "$TARGET" \( $prune_args \) -prune -o -type f -print 2>/dev/null \

--- a/.claude/skills/dfd/discover.sh
+++ b/.claude/skills/dfd/discover.sh
@@ -35,11 +35,44 @@ TARGET=$(cd "$TARGET" && pwd -P)
 
 SKIP_DIRS="node_modules vendor .venv venv target dist build coverage .next .nuxt .turbo .cache __pycache__ .git .svn .idea .vscode"
 
-# scoped_grep <pattern>: greps the target dir for <pattern>, pruning vendored dirs.
+# ---------------------------------------------------------------------------
+# Portfolio-workspace exclusion (me2resh/apexyard#1092).
+#
+# When TARGET is an apexyard ops fork itself, `workspace/` holds full clones
+# of OTHER registered projects, and `.claude/worktrees/` holds agent
+# worktrees — both are full checkouts of unrelated (or duplicate) code.
+# Rule 4 of the skill says discovery is "reachability-bounded"; neither of
+# these directories is reachable from the fork's own code, so they must be
+# pruned from the walk. Resolve the CONCRETE paths (rather than an any-depth
+# basename match) so a legitimately-named `workspace/` dir in a non-fork
+# target is never over-pruned.
+# ---------------------------------------------------------------------------
+EXTRA_PRUNE_PATHS=""
+_LIB_PORTFOLIO_PATHS="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../../hooks/_lib-portfolio-paths.sh"
+
+if { [ -f "$TARGET/.apexyard-fork" ] || { [ -f "$TARGET/onboarding.yaml" ] && [ -f "$TARGET/apexyard.projects.yaml" ]; }; } \
+  && [ -f "$_LIB_PORTFOLIO_PATHS" ]; then
+  # shellcheck source=/dev/null
+  . "$_LIB_PORTFOLIO_PATHS" 2>/dev/null || true
+  if command -v portfolio_workspace_dir >/dev/null 2>&1; then
+    WS_DIR=$(cd "$TARGET" && portfolio_workspace_dir 2>/dev/null) || WS_DIR=""
+    if [ -n "$WS_DIR" ] && [ -d "$WS_DIR" ]; then
+      EXTRA_PRUNE_PATHS="$WS_DIR"
+    fi
+  fi
+  WT_DIR="$TARGET/.claude/worktrees"
+  if [ -d "$WT_DIR" ]; then
+    EXTRA_PRUNE_PATHS="$EXTRA_PRUNE_PATHS $WT_DIR"
+  fi
+fi
+
+# scoped_grep <pattern>: greps the target dir for <pattern>, pruning vendored
+# dirs (by basename) and, on an ops-fork target, the concrete workspace/ and
+# .claude/worktrees/ paths resolved above (by exact path).
 # Outputs `file:line:match` (grep -nH format), capped at 500 lines.
 scoped_grep() {
   local pattern="$1"; shift
-  local prune_args="" first=1 d
+  local prune_args="" first=1 d p
   for d in $SKIP_DIRS; do
     if [ $first -eq 1 ]; then
       prune_args="-name $d"
@@ -47,6 +80,9 @@ scoped_grep() {
     else
       prune_args="$prune_args -o -name $d"
     fi
+  done
+  for p in $EXTRA_PRUNE_PATHS; do
+    prune_args="$prune_args -o -path $p"
   done
   # shellcheck disable=SC2086
   find "$TARGET" \( $prune_args \) -prune -o -type f -print 2>/dev/null \

--- a/.claude/skills/dfd/tests/smoke.sh
+++ b/.claude/skills/dfd/tests/smoke.sh
@@ -279,6 +279,77 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Fixture 2b: workspace/ and .claude/worktrees/ pruned from discovery
+# (me2resh/apexyard#1092)
+#
+# Reuses the ops-fork sandbox ($SB) built for Fixture 2 — it already has
+# onboarding.yaml + apexyard.projects.yaml at its root, which is exactly
+# what discover.sh's ops-fork detection looks for. Plants a distinctive
+# Stripe-SDK marker under workspace/other-project/ (a sibling registered
+# project's clone) and a second marker under .claude/worktrees/ (an agent
+# worktree), then asserts discover.sh run against $SB attributes NEITHER
+# to the target.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "================================================================"
+echo "Fixture 2b: workspace/ and .claude/worktrees/ pruned from discovery (#1092)"
+echo "================================================================"
+
+mkdir -p "$SB/workspace/other-project/packages/design-system/tests"
+cat > "$SB/workspace/other-project/packages/design-system/tests/Card.test.tsx" <<'JS'
+// belongs to a DIFFERENT registered project's clone — must never be
+// attributed to $SB (the target) as one of its own external actors.
+import Stripe from "stripe";
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+JS
+
+mkdir -p "$SB/.claude/worktrees/some-agent-worktree"
+cat > "$SB/.claude/worktrees/some-agent-worktree/marker.js" <<'JS'
+// distinctive worktree-only marker — an agent worktree is a full checkout,
+// so it must be pruned the same way workspace/ is.
+// marker: WORKTREE_LEAK_MARKER_9f3c
+const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
+JS
+
+OUT2B="$TMPROOT/discover-f2b.yaml"
+bash "$DFD_DIR/discover.sh" "$SB" > "$OUT2B" 2>/dev/null
+
+if grep -q "workspace/other-project" "$OUT2B"; then
+  echo "  FAIL: Fixture 2b: workspace/other-project evidence leaked into discovery output"
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  Fixture 2b: workspace leak"
+else
+  echo "  PASS: Fixture 2b: workspace/other-project pruned from discovery"
+  PASS=$((PASS + 1))
+fi
+
+if grep -q "WORKTREE_LEAK_MARKER_9f3c" "$OUT2B"; then
+  echo "  FAIL: Fixture 2b: .claude/worktrees/ evidence leaked into discovery output"
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  Fixture 2b: worktrees leak"
+else
+  echo "  PASS: Fixture 2b: .claude/worktrees/ pruned from discovery"
+  PASS=$((PASS + 1))
+fi
+
+# classify.sh shares the same pruning — assert it too, using the same
+# stripe/SDK marker's presence as a stand-in for "any evidence at all
+# from the wrong project" (classify.sh doesn't classify SDK imports
+# specifically, so this checks the raw scoped_grep boundary instead).
+CLASSIFY_OUT2B="$TMPROOT/classify-f2b.yaml"
+bash "$DFD_DIR/classify.sh" "$SB" > "$CLASSIFY_OUT2B" 2>/dev/null
+
+if grep -q "other-project\|WORKTREE_LEAK_MARKER_9f3c" "$CLASSIFY_OUT2B"; then
+  echo "  FAIL: Fixture 2b: classify.sh leaked workspace/worktrees evidence"
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  Fixture 2b: classify.sh leak"
+else
+  echo "  PASS: Fixture 2b: classify.sh also prunes workspace/ and .claude/worktrees/"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
 # Fixture 3: classification pathways — annotations + env vars + schema
 # ---------------------------------------------------------------------------
 

--- a/.claude/skills/dfd/tests/smoke.sh
+++ b/.claude/skills/dfd/tests/smoke.sh
@@ -284,11 +284,32 @@ fi
 #
 # Reuses the ops-fork sandbox ($SB) built for Fixture 2 — it already has
 # onboarding.yaml + apexyard.projects.yaml at its root, which is exactly
-# what discover.sh's ops-fork detection looks for. Plants a distinctive
-# Stripe-SDK marker under workspace/other-project/ (a sibling registered
-# project's clone) and a second marker under .claude/worktrees/ (an agent
-# worktree), then asserts discover.sh run against $SB attributes NEITHER
-# to the target.
+# what discover.sh's ops-fork detection looks for. Plants an SDK marker
+# under workspace/other-project/ (a sibling registered project's clone)
+# and a DIFFERENT SDK marker under .claude/worktrees/ (an agent worktree)
+# — deliberately different vendors, because discover.sh emits only the
+# FIRST evidence line per vendor key (see the TP_SEEN_FILE dedup in
+# discover.sh); if both fixtures used the same vendor, one hit could mask
+# the other and the assertion would pass for the wrong reason.
+#
+# The two vendors are scoped npm-style imports (@sendgrid/mail, @sentry/)
+# rather than bare words (stripe, twilio, ...) on purpose: $SB/.claude/hooks
+# already carries a real copy of _lib-multi-repo-trace.sh (copied in by
+# Fixture 2 above), whose known-third-party-hostname table literally
+# contains "api.stripe.com", "api.twilio.com", etc. — a bare-word vendor
+# pattern matches those hostname strings too, so ext_stripe or ext_twilio
+# gets "first evidence"-deduped against a hit in that legitimate file
+# instead of the fixture, silently defeating the assertion. The scoped
+# `@vendor/...` patterns don't collide with anything in that hostname
+# table (confirmed by grep), so they can't be masked the same way.
+#
+# IMPORTANT: discover.sh's and classify.sh's `evidence:` field is always
+# `<rel-path>:<line>` — the matched line's PATH, never its file CONTENT.
+# An earlier version of this fixture asserted on a content-only marker
+# comment, which could never appear in the output regardless of whether
+# pruning worked, making that assertion pass even against the unfixed
+# scripts (caught in Rex's #1107 review). Assert on the PATH substring
+# instead, which is what pruning actually controls.
 # ---------------------------------------------------------------------------
 
 echo ""
@@ -299,24 +320,30 @@ echo "================================================================"
 mkdir -p "$SB/workspace/other-project/packages/design-system/tests"
 cat > "$SB/workspace/other-project/packages/design-system/tests/Card.test.tsx" <<'JS'
 // belongs to a DIFFERENT registered project's clone — must never be
-// attributed to $SB (the target) as one of its own external actors.
-import Stripe from "stripe";
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+// attributed to $SB (the target) as one of its own external actors or
+// classified data elements.
+// @PII — belongs to other-project, not the target
+import sgMail from "@sendgrid/mail";
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 JS
 
 mkdir -p "$SB/.claude/worktrees/some-agent-worktree"
 cat > "$SB/.claude/worktrees/some-agent-worktree/marker.js" <<'JS'
-// distinctive worktree-only marker — an agent worktree is a full checkout,
-// so it must be pruned the same way workspace/ is.
-// marker: WORKTREE_LEAK_MARKER_9f3c
-const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
+// an agent worktree is a full checkout of unrelated code; must be pruned
+// the same way workspace/ is. Uses a DIFFERENT third-party vendor than the
+// workspace/other-project fixture (@sentry/node, not @sendgrid/mail) so
+// discovery's per-vendor dedup (first evidence wins) can't mask this hit
+// behind the workspace hit above.
+// @Sensitive — belongs to the worktree, not the target
+import * as Sentry from "@sentry/node";
+Sentry.init({ dsn: process.env.SENTRY_DSN });
 JS
 
 OUT2B="$TMPROOT/discover-f2b.yaml"
 bash "$DFD_DIR/discover.sh" "$SB" > "$OUT2B" 2>/dev/null
 
-if grep -q "workspace/other-project" "$OUT2B"; then
-  echo "  FAIL: Fixture 2b: workspace/other-project evidence leaked into discovery output"
+if grep -qF "workspace/other-project" "$OUT2B"; then
+  echo "  FAIL: Fixture 2b: workspace/other-project evidence (path) leaked into discovery output"
   FAIL=$((FAIL + 1))
   FAILED_CASES="$FAILED_CASES\n  Fixture 2b: workspace leak"
 else
@@ -324,24 +351,27 @@ else
   PASS=$((PASS + 1))
 fi
 
-if grep -q "WORKTREE_LEAK_MARKER_9f3c" "$OUT2B"; then
-  echo "  FAIL: Fixture 2b: .claude/worktrees/ evidence leaked into discovery output"
+if grep -qF ".claude/worktrees" "$OUT2B"; then
+  echo "  FAIL: Fixture 2b: .claude/worktrees evidence (path) leaked into discovery output"
   FAIL=$((FAIL + 1))
   FAILED_CASES="$FAILED_CASES\n  Fixture 2b: worktrees leak"
 else
-  echo "  PASS: Fixture 2b: .claude/worktrees/ pruned from discovery"
+  echo "  PASS: Fixture 2b: .claude/worktrees pruned from discovery"
   PASS=$((PASS + 1))
 fi
 
-# classify.sh shares the same pruning — assert it too, using the same
-# stripe/SDK marker's presence as a stand-in for "any evidence at all
-# from the wrong project" (classify.sh doesn't classify SDK imports
-# specifically, so this checks the raw scoped_grep boundary instead).
+# classify.sh shares the same EXTRA_PRUNE_PATHS pruning, but only its
+# annotation pathway (@PII / @Sensitive / CLASSIFIED: / classification:)
+# runs through scoped_grep — the env-var and schema pathways use unguarded
+# `find -maxdepth N` calls that don't go through scoped_grep (or
+# EXTRA_PRUNE_PATHS) at all, a separate pre-existing gap out of scope for
+# #1092. Re-use the @PII / @Sensitive annotations already planted above so
+# this exercises the pathway the fix actually touches.
 CLASSIFY_OUT2B="$TMPROOT/classify-f2b.yaml"
 bash "$DFD_DIR/classify.sh" "$SB" > "$CLASSIFY_OUT2B" 2>/dev/null
 
-if grep -q "other-project\|WORKTREE_LEAK_MARKER_9f3c" "$CLASSIFY_OUT2B"; then
-  echo "  FAIL: Fixture 2b: classify.sh leaked workspace/worktrees evidence"
+if grep -qF "workspace/other-project" "$CLASSIFY_OUT2B" || grep -qF ".claude/worktrees" "$CLASSIFY_OUT2B"; then
+  echo "  FAIL: Fixture 2b: classify.sh leaked workspace/worktrees evidence (path)"
   FAIL=$((FAIL + 1))
   FAILED_CASES="$FAILED_CASES\n  Fixture 2b: classify.sh leak"
 else


### PR DESCRIPTION
## Summary
- **`/dfd` discovery no longer walks into `workspace/` or `.claude/worktrees/`** — when the discovery target is the apexyard ops fork itself, `workspace/` holds full clones of *other* registered projects and `.claude/worktrees/` holds agent worktrees. Both are full checkouts of unrelated (or duplicate) code, so `discover.sh` and `classify.sh` were attributing other projects' dependencies (a Stripe import in another project's test fixture, an auth mention in another project's docs) to the target as if they were its own external actors — the exact failure #1092 describes.
- **Prunes the CONCRETE resolved paths, not a basename pattern** — rather than adding `workspace`/`worktrees` to the any-depth `SKIP_DIRS` basename list (which risks over-pruning a project that legitimately has a directory named `workspace`), both scripts now resolve `portfolio_workspace_dir()` (via `_lib-portfolio-paths.sh`) and `.claude/worktrees/` as exact paths, and only do so when the resolved `TARGET` is itself an ops fork (has `.apexyard-fork`, or both `onboarding.yaml` + `apexyard.projects.yaml`, at its root). A non-fork target is completely unaffected.
- **Regression fixture proves the leak is gone — and is genuinely load-bearing** — `tests/smoke.sh` Fixture 2b reuses the ops-fork sandbox built for Fixture 2, plants a distinct SDK import under `workspace/other-project/` and a second, *different* SDK import under `.claude/worktrees/`, then asserts neither evidence **path** appears in `discover.sh`'s or `classify.sh`'s output when the sandbox is the scan target. An earlier version of this fixture asserted on a content-only marker string that `discover.sh`/`classify.sh` never emit (evidence is always `path:line`, never file content) — Rex caught it in review as non-load-bearing. It's now fixed: path-based assertions, and two *different* vendor SDKs so discovery's per-vendor "first evidence wins" dedup can't mask one fixture behind the other (the sandbox's own copy of `_lib-multi-repo-trace.sh` also contains several bare vendor names as hostname literals, which was the second, subtler way the original fixture could pass for the wrong reason).

## Testing
- `bash .claude/skills/dfd/tests/smoke.sh` — all 55 checks pass, including the three Fixture 2b assertions.
- **Verified load-bearing, before and after**: checked out the pre-fix `discover.sh`/`classify.sh` (the parent commit) with the current test file, and confirmed all three new assertions correctly FAIL (52/55, 3 failures) — reproducing the exact #1092 leak. Restored the fix and confirmed 55/55 green again.
- `shellcheck --severity=warning` on all three edited files — no new warnings versus the pre-fix baseline (the four pre-existing SC2038/SC2221/SC2222 warnings in `discover.sh`/`classify.sh` are unrelated to this change and were present before it; the test file itself is shellcheck-clean).

```
$ bash .claude/skills/dfd/tests/smoke.sh
...
Fixture 2b: workspace/ and .claude/worktrees/ pruned from discovery (#1092)
================================================================
  PASS: Fixture 2b: workspace/other-project pruned from discovery
  PASS: Fixture 2b: .claude/worktrees pruned from discovery
  PASS: Fixture 2b: classify.sh also prunes workspace/ and .claude/worktrees/
...
Total: 55   Passed: 55   Failed: 0
OK: all /dfd smoke checks passed.
```

```
$ git show ac9053b:.claude/skills/dfd/discover.sh > .claude/skills/dfd/discover.sh   # pre-fix
$ git show ac9053b:.claude/skills/dfd/classify.sh > .claude/skills/dfd/classify.sh   # pre-fix
$ bash .claude/skills/dfd/tests/smoke.sh | tail -8
Fixture 2b: workspace/ and .claude/worktrees/ pruned from discovery (#1092)
================================================================
  FAIL: Fixture 2b: workspace/other-project evidence (path) leaked into discovery output
  FAIL: Fixture 2b: .claude/worktrees evidence (path) leaked into discovery output
  FAIL: Fixture 2b: classify.sh leaked workspace/worktrees evidence (path)
...
Total: 55   Passed: 52   Failed: 3
$ git checkout HEAD -- .claude/skills/dfd/discover.sh .claude/skills/dfd/classify.sh   # restored
```

### Known follow-up not addressed in this PR

Rex's review also flagged a nit on the production fix itself: `EXTRA_PRUNE_PATHS` (in `discover.sh`/`classify.sh`) is word-split via a plain `for p in $EXTRA_PRUNE_PATHS`, which is fragile if a resolved workspace/worktrees path contains a space. Per the review instruction this round was test-only ("do NOT touch discover.sh/classify.sh"), so it's left as-is here and called out for a follow-up rather than folded into this PR silently.

Refs #1092

---

## Glossary

| Term | Definition |
|------|------------|
| reachability-bounded | Discovery follows only what the target actually connects to, rather than everything under its directory — the property this bug broke. |
| ops fork | The apexyard fork that governs a portfolio; its `workspace/` dir holds clones of the projects it governs. |
| `scoped_grep` | The `discover.sh`/`classify.sh` helper that greps the target tree while pruning vendored/irrelevant directories via `find ... -prune`. |
| `portfolio_workspace_dir()` | A resolver in `_lib-portfolio-paths.sh` that returns the absolute path to the ops fork's `workspace/` directory, honouring any adopter override. |
| load-bearing (assertion) | A test assertion that actually fails when the bug it's meant to catch is present — as opposed to one that passes regardless of whether the fix exists. |
