### PR TITLE
test(#1099): pin fail-closed behaviour of the architecture + design merge gates

### DIFF
--- a/.claude/hooks/tests/test_require_architecture_review.sh
+++ b/.claude/hooks/tests/test_require_architecture_review.sh
@@ -293,6 +293,77 @@ assert_eq "#687 wrong-qualifier marker still blocks" "2" "$code"
 rm -rf "$sb" "$pf"
 
 echo ""
+echo "E) #1091/#1099 sibling: forge HEAD unresolvable -> the gate must FAIL CLOSED"
+#
+# require-architecture-review.sh carried the SAME local-HEAD fallback that
+# block-unreviewed-merge.sh had (see #1091, fixed for all three gates by
+# #1098, which shipped a regression test only for block-unreviewed-merge.sh).
+# This is the missing discriminating case for THIS gate (#1099), built on the
+# exact construction from test_block_unreviewed_merge.sh's #1091 case
+# (~line 832): the mock gh answers `pr diff` (a design artifact is found)
+# and `pr view ... headRepository`, but FAILS `pr view ... headRefOid` — the
+# one call resolve_pr_head makes. `headRefName` is also wired to answer even
+# though this hook never queries it, mirroring the sibling gate's mock so the
+# "forge reachable but this ONE field is missing" shape is explicit rather
+# than "the whole gh binary is gone".
+#
+# DISCRIMINATING BY CONSTRUCTION: the marker is written to match THIS
+# sandbox's LOCAL HEAD (`git rev-parse HEAD`) — the value the pre-#1098
+# fallback would have substituted for the unresolvable forge HEAD. Under the
+# removed fallback that makes the SHA comparison succeed and the merge
+# ALLOWED (rc=0). Under fail-closed it is BLOCKED (rc=2) regardless of what
+# the local HEAD says. A marker at a MISMATCHING local HEAD would block both
+# before and after, proving nothing — the exact trap #1099's own issue body
+# calls out.
+
+install_mock_gh_headrefoid_fails() {
+  local sb="$1" diff_files="$2" repo="${3:-o/r}"
+  mkdir -p "$sb/bin"
+  cat > "$sb/bin/gh" <<EOF
+#!/bin/bash
+args="\$*"
+case "\$args" in
+  *"pr diff"*"--name-only"*)
+    printf '%s\n' $diff_files
+    ;;
+  *"pr view"*headRefOid*)
+    exit 1
+    ;;
+  *"pr view"*headRefName*)
+    printf '%s\n' "feature/GH-99-test"
+    ;;
+  *"pr view"*headRepository*)
+    printf '%s\n' "$repo"
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$sb/bin/gh"
+}
+
+sb=$(make_sandbox)
+install_mock_gh_headrefoid_fails "$sb" '"projects/foo/docs/technical-design-x.md"'
+# The sandbox's local HEAD — the value the OLD fallback would have used.
+local_head=$(cd "$sb" && git rev-parse HEAD 2>/dev/null)
+# Marker written to MATCH that local HEAD: the setup most favourable to a
+# bypass, where every comparison passes under the old code.
+printf '%s\n' "$local_head" > "$(review_marker_path "o/r" 77 architecture "$sb")"
+code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
+assert_eq "#1091: forge HEAD unresolvable + marker matching LOCAL head -> BLOCKED" "2" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "E) #1091/#1099 control: forge healthy, marker at forge HEAD -> still ALLOWED"
+# Guards against over-blocking: proves the fail-closed change didn't also
+# start blocking the ordinary healthy-forge path.
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"projects/foo/docs/technical-design-x.md"' "$SHA"
+printf '%s\n' "$SHA" > "$(review_marker_path "o/r" 77 architecture "$sb")"
+code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
+assert_eq "#1091 control: gh healthy, marker at forge HEAD -> still ALLOWED" "0" "$code"
+rm -rf "$sb"
+
+echo ""
 echo "==================================="
 echo "  PASS: $PASS   FAIL: $FAIL"
 echo "==================================="

--- a/.claude/hooks/tests/test_require_design_review_for_ui.sh
+++ b/.claude/hooks/tests/test_require_design_review_for_ui.sh
@@ -282,6 +282,77 @@ assert_eq "#687 wrong-qualifier marker still blocks" "2" "$code"
 rm -rf "$sb" "$pf"
 
 echo ""
+echo "E) #1091/#1099 sibling: forge HEAD unresolvable -> the gate must FAIL CLOSED"
+#
+# require-design-review-for-ui.sh carried the SAME local-HEAD fallback that
+# block-unreviewed-merge.sh had (see #1091, fixed for all three gates by
+# #1098, which shipped a regression test only for block-unreviewed-merge.sh).
+# This is the missing discriminating case for THIS gate (#1099), built on the
+# exact construction from test_block_unreviewed_merge.sh's #1091 case
+# (~line 832): the mock gh answers `pr diff` (a UI file is found) and
+# `pr view ... headRepository`, but FAILS `pr view ... headRefOid` — the one
+# call resolve_pr_head makes. `headRefName` is also wired to answer even
+# though this hook never queries it, mirroring the sibling gate's mock so the
+# "forge reachable but this ONE field is missing" shape is explicit rather
+# than "the whole gh binary is gone".
+#
+# DISCRIMINATING BY CONSTRUCTION: the marker is written to match THIS
+# sandbox's LOCAL HEAD (`git rev-parse HEAD`) — the value the pre-#1098
+# fallback would have substituted for the unresolvable forge HEAD. Under the
+# removed fallback that makes the SHA comparison succeed and the merge
+# ALLOWED (rc=0). Under fail-closed it is BLOCKED (rc=2) regardless of what
+# the local HEAD says. A marker at a MISMATCHING local HEAD would block both
+# before and after, proving nothing — the exact trap #1099's own issue body
+# calls out.
+
+install_mock_gh_headrefoid_fails() {
+  local sb="$1" diff_files="$2" repo="${3:-o/r}"
+  mkdir -p "$sb/bin"
+  cat > "$sb/bin/gh" <<EOF
+#!/bin/bash
+args="\$*"
+case "\$args" in
+  *"pr diff"*"--name-only"*)
+    printf '%s\n' $diff_files
+    ;;
+  *"pr view"*headRefOid*)
+    exit 1
+    ;;
+  *"pr view"*headRefName*)
+    printf '%s\n' "feature/GH-99-test"
+    ;;
+  *"pr view"*headRepository*)
+    printf '%s\n' "$repo"
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$sb/bin/gh"
+}
+
+sb=$(make_sandbox)
+install_mock_gh_headrefoid_fails "$sb" '"src/components/Button.tsx"'
+# The sandbox's local HEAD — the value the OLD fallback would have used.
+local_head=$(cd "$sb" && git rev-parse HEAD 2>/dev/null)
+# Marker written to MATCH that local HEAD: the setup most favourable to a
+# bypass, where every comparison passes under the old code.
+printf '%s\n' "$local_head" > "$(review_marker_path "o/r" 77 design "$sb")"
+code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
+assert_eq "#1091: forge HEAD unresolvable + marker matching LOCAL head -> BLOCKED" "2" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "E) #1091/#1099 control: forge healthy, marker at forge HEAD -> still ALLOWED"
+# Guards against over-blocking: proves the fail-closed change didn't also
+# start blocking the ordinary healthy-forge path.
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"src/components/Button.tsx"' "$SHA"
+printf '%s\n' "$SHA" > "$(review_marker_path "o/r" 77 design "$sb")"
+code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
+assert_eq "#1091 control: gh healthy, marker at forge HEAD -> still ALLOWED" "0" "$code"
+rm -rf "$sb"
+
+echo ""
 echo "==================================="
 echo "  PASS: $PASS   FAIL: $FAIL"
 echo "==================================="


### PR DESCRIPTION
## Summary

- **Pins the fail-closed fix from #1098 with a regression test on the two gates that shipped without one.** #1098 removed an identical local-HEAD fallback from three merge gates (`block-unreviewed-merge.sh`, `require-architecture-review.sh`, `require-design-review-for-ui.sh`) but only added a regression test for the first — on the theory that the fallback was byte-identical in all three, so one test covered the risk. Both reviewers on #1098 flagged that as an untested assumption, and the security review went further and built the missing case by hand, confirming the bypass was real and independently reachable in both untested gates. This PR is the "close the loop" work: the same case, landed as a permanent test, so a future refactor can't quietly restore the fallback without a red suite.
- **Each case is discriminating by construction, not just green.** The mock `gh` answers `pr diff` (so a design-artifact / UI file is found) and `pr view ... headRepository`, but fails `pr view ... headRefOid` — the one call `resolve_pr_head` makes to ask the forge for the PR's real HEAD. The approval marker is then written to match the *sandbox's local HEAD*, which is exactly the value the old fallback would have substituted for the unresolvable forge HEAD. That setup is the one most favourable to a bypass: under the removed fallback the SHA comparison succeeds and the merge is **allowed**; under fail-closed it's **blocked** regardless of what local HEAD says. A marker at a mismatching local HEAD would have blocked both before and after and proven nothing — the exact trap called out in #1099's own issue body, and the same one #1098's original test avoided.
- **A control case per gate** (forge healthy, marker at the forge HEAD → still allowed) guards against the fail-closed change over-blocking the ordinary, healthy-forge path — the mirror failure two other predicates in this area have already had to be redesigned for.
- **Test-only change.** No hook logic, no `.claude/settings.json` wiring, nothing behavioural — only new cases in the two existing test files.

## Testing

Ran both edited suites directly:

```
bash .claude/hooks/tests/test_require_architecture_review.sh   # PASS: 24  FAIL: 0
bash .claude/hooks/tests/test_require_design_review_for_ui.sh  # PASS: 24  FAIL: 0
```

**Before/after proof (not just the pass count) — required by the ticket's own acceptance criteria.** I temporarily swapped in the two hooks as they existed one commit before #1098 (`59c3cc6`, the parent of `1712f79`) and re-ran the new section E) cases only, then restored the current hooks and re-ran the full suites to confirm they're back to matching `dev`.

| Gate | Pre-#1098 hook (`59c3cc6`) | Current hook (post-#1098) |
|---|---|---|
| `require-architecture-review.sh` | `FAIL want '2', got '0'` — merge **allowed** | `PASS` — `rc=2`, blocked |
| `require-design-review-for-ui.sh` | `FAIL want '2', got '0'` — merge **allowed** | `PASS` — `rc=2`, blocked |
| Control case (both gates) | `PASS` (healthy forge already allowed) | `PASS` (unchanged) |

That's the discriminating property: the same fixture that fails against the old hook and passes against the new one, with the control case passing in both directions so the change doesn't newly over-block the healthy path.

`shellcheck --severity=warning` on both edited files: clean, exit 0.

Refs #1099

---

## Glossary

| Term | Definition |
|------|------------|
| discriminating test | A test that fails against the pre-change code and passes against the post-change code. A test that's green in both directions proves nothing about the specific behaviour it claims to cover — this is why the marker in the new cases is deliberately written to match the *local* HEAD rather than a mismatching one. |
| fail closed | A control that blocks rather than permits when it can't evaluate its own precondition (here: the forge HEAD is unresolvable). The safe failure direction for a merge gate — the alternative, failing open, silently stops enforcing anything. |
| forge-reported HEAD | The PR's real HEAD commit SHA as GitHub (or another forge) reports it via `gh pr view ... --json headRefOid`, as opposed to `git rev-parse HEAD` on the local working tree — a value only the forge, not a local agent, can author. |
| over-blocking | The mirror failure of fail-closed: a gate so aggressive it also blocks legitimate, healthy-path merges. The control case in this PR exists specifically to catch that regression. |
| review marker | A local file under `.claude/session/reviews/` (e.g. `<pr>-architecture.approved`) recording that a reviewer signed off on a PR at a specific commit SHA. The merge gates compare the marker's recorded SHA against the forge-reported HEAD before allowing a merge. |
