### PR TITLE
fix(#1097): anchor the pre-push skip marker to a whole line

### DIFF
--- a/.claude/hooks/pre-push-gate.sh
+++ b/.claude/hooks/pre-push-gate.sh
@@ -50,7 +50,10 @@ fi
 
 SKIP_MARKER='<!-- pre-push: skip -->'
 HEAD_MSG=$(cd "$REPO_ROOT" && git log -1 --format='%B' 2>/dev/null)
-if echo "$HEAD_MSG" | grep -qF -- "$SKIP_MARKER"; then
+# -x: whole-line match only, so prose that mentions the marker inline
+# (e.g. a commit that documents the escape hatch) does not trigger it —
+# only a line consisting of exactly the marker does. See #1097.
+if printf '%s\n' "$HEAD_MSG" | grep -qxF -- "$SKIP_MARKER"; then
   echo "WARN: pre-push gate bypassed by skip marker in HEAD commit message." >&2
   echo "      Skipped commands will run in CI regardless — fix broken state before merging." >&2
   exit 0

--- a/.claude/hooks/tests/test_pre_push_gate.sh
+++ b/.claude/hooks/tests/test_pre_push_gate.sh
@@ -216,7 +216,46 @@ case9() {
   rm -rf "$sb"
 }
 
-case1; case2; case3; case4; case5; case6; case7; case8; case9
+# -------------------- CASE 10: marker MENTIONED in prose → does NOT bypass --------------------
+# Regression guard for #1097: the skip marker used to be grep-matched
+# unanchored, so a commit message that merely *discusses* the marker
+# (documentation, a review comment quoted verbatim, a revert body) matched
+# too and silently disabled every check. The match must be whole-line
+# (grep -x): a sentence that contains the marker string inline is NOT a
+# deliberate bypass, so the check must still run (and still block on a
+# failing command).
+case10() {
+  local sb; sb=$(make_sandbox)
+  cat > "$sb/.claude/project-config.json" <<'EOF'
+{"pre_push": {"commands": [{"name": "should-not-skip", "run": "echo oops; exit 1"}]}}
+EOF
+  # The marker appears INSIDE a sentence, not as its own line — this must
+  # NOT be treated as a deliberate bypass.
+  (cd "$sb" && git commit --amend -q -m "docs: explain the escape hatch
+
+This documents the <!-- pre-push: skip --> marker so contributors know
+it exists. It should not itself act as a bypass.")
+  run_hook "$sb" "$(push_json)" 2 "should-not-skip: FAILED" "marker-mentioned-in-prose-does-not-bypass"
+  rm -rf "$sb"
+}
+
+# -------------------- CASE 11: marker on its OWN LINE → still bypasses --------------------
+# The other direction of #1097's fix: a deliberate bypass — the marker as
+# a line by itself, exactly the shape the documented amend snippet emits —
+# must keep working after anchoring the match to -x.
+case11() {
+  local sb; sb=$(make_sandbox)
+  cat > "$sb/.claude/project-config.json" <<'EOF'
+{"pre_push": {"commands": [{"name": "should-skip", "run": "exit 1"}]}}
+EOF
+  (cd "$sb" && git commit --amend -q -m "fix: emergency hotfix
+
+<!-- pre-push: skip -->")
+  run_hook "$sb" "$(push_json)" 0 "pre-push gate bypassed by skip marker" "marker-own-line-still-bypasses"
+  rm -rf "$sb"
+}
+
+case1; case2; case3; case4; case5; case6; case7; case8; case9; case10; case11
 
 echo ""
 echo "==================================="

--- a/bin/run-pre-push-checks.sh
+++ b/bin/run-pre-push-checks.sh
@@ -46,9 +46,12 @@
 #   1 — one or more checks failed
 #
 # Skip marker:
-#   Include the literal string <!-- pre-push: skip --> in the HEAD commit
-#   message (subject or body) to bypass for a genuine emergency.
-#   The bypass is printed to stderr so it's visible and grep-able.
+#   Include the literal string <!-- pre-push: skip --> as its OWN LINE in
+#   the HEAD commit message (subject or body) to bypass for a genuine
+#   emergency. The match is whole-line (grep -x), so a sentence that merely
+#   mentions the marker does NOT bypass — only a line consisting of exactly
+#   the marker does. The bypass is printed to stderr so it's visible and
+#   grep-able.
 #
 # Usage:
 #   bash bin/run-pre-push-checks.sh
@@ -76,7 +79,10 @@ fi
 
 SKIP_MARKER='<!-- pre-push: skip -->'
 HEAD_MSG=$(cd "$REPO_ROOT" && git log -1 --format='%B' 2>/dev/null)
-if echo "$HEAD_MSG" | grep -qF -- "$SKIP_MARKER"; then
+# -x: whole-line match only, so prose that mentions the marker inline
+# (e.g. a commit that documents the escape hatch) does not trigger it —
+# only a line consisting of exactly the marker does. See #1097.
+if printf '%s\n' "$HEAD_MSG" | grep -qxF -- "$SKIP_MARKER"; then
   echo "WARN: pre-push checks bypassed by skip marker in HEAD commit message." >&2
   echo "      All skipped checks will still run in CI — fix before merging." >&2
   exit 0


### PR DESCRIPTION
## Summary

- **Anchored the pre-push skip marker to a whole line** — `bin/run-pre-push-checks.sh` and `.claude/hooks/pre-push-gate.sh` both used to `grep -qF` the HEAD commit message for `<!-- pre-push: skip -->` anywhere in the text. That meant a commit that merely *described* the marker (documentation, a review comment quoted verbatim, a revert body) matched too, silently disabling markdownlint, shellcheck, and the subpack smoke test with a WARN that scrolls past in normal push noise. Switched both to `grep -qxF` against the message split one-line-per-line (`printf '%s\n' "$HEAD_MSG" | grep -qxF -- "$SKIP_MARKER"`), so only a line that consists of *exactly* the marker now bypasses. The documented emergency-bypass snippet already emits the marker on its own line, so real bypasses are unaffected.
- **Why it matters** — under the release-cut model this repo uses, a squash-merged PR's body becomes the tip commit on `dev`. A branch whose commit message merely discussed the marker would land that string as `HEAD` on a shared branch, silently skipping all three checks for every contributor whose next push happened to still have that commit at `HEAD`. This was observed live while preparing #1095/#1096 — the check reported itself bypassed on the very PR fixing the gate, caught only by code review, not by the author. Two related unanchored-match defects in the same family: #1066 (branch-name/main-push validators matching prose inside heredocs) and AgDR-0104 (pattern-matching command text can't be made sound in general — this one is a narrow, cheap exception because the thing matched is a *fixed marker on its own line*, not free-form intent).
- **Regression tests** — added two cases to `.claude/hooks/tests/test_pre_push_gate.sh`: a commit whose message *mentions* the marker inside a sentence must NOT bypass (checks still run, still block on failure); a commit with the marker as its own line must still bypass, unchanged. 11/11 cases pass.

## Testing

1. `bash .claude/hooks/tests/test_pre_push_gate.sh` — 11/11 pass, including the two new cases (`marker-mentioned-in-prose-does-not-bypass`, `marker-own-line-still-bypasses`).
2. `bash .claude/hooks/tests/test_subpack_extraction.sh` — all sub-pack extraction invariants pass (unaffected by this change, run as part of the pre-push check set itself).
3. Manual two-direction smoke test directly against `bin/run-pre-push-checks.sh` in a scratch git sandbox:
   - HEAD commit message mentions the marker inline in a sentence → all three checks run (markdownlint/shellcheck/subpacks), no bypass WARN printed, exit reflects the check outcome.
   - HEAD commit message has the marker as its own line → `WARN: pre-push checks bypassed by skip marker...` printed, exit 0, no checks run.
4. `shellcheck --severity=warning` clean on all three touched files (`bin/run-pre-push-checks.sh`, `.claude/hooks/pre-push-gate.sh`, `.claude/hooks/tests/test_pre_push_gate.sh`).
5. `bash bin/run-pre-push-checks.sh` run on this branch itself before pushing — all checks (markdownlint, shellcheck, subpacks) pass.

Refs #1097

---

## Glossary

| Term | Definition |
|------|------------|
| skip marker | A documented commit-message token (`<!-- pre-push: skip -->`) that lets a contributor bypass the local pre-push check set for a genuine emergency. Deliberately grep-able so bypasses stay auditable — which only holds if the match can't fire by accident. |
| unanchored match | A `grep` pattern that matches anywhere in the text (a substring anywhere in the message) rather than requiring the whole line to equal the pattern. The root cause here: prose *about* the marker behaved identically to the marker itself. |
| whole-line match (`grep -x`) | Requires the entire line to equal the search string, not just contain it. Fixes the bug because the documented deliberate-bypass usage already places the marker on a line by itself. |
| release-cut model | This repo's branch model: daily PRs squash-merge to `dev`; `main` only receives release PRs from `dev`. The squash step is what carries an accidentally-matching commit message onto the shared `dev` branch. |
