### PR TITLE
fix(#1070): fail closed on unreadable gh api body-file and unparseable --input

### DIFF
--- a/.claude/hooks/block-private-refs-in-public-repos.sh
+++ b/.claude/hooks/block-private-refs-in-public-repos.sh
@@ -651,31 +651,71 @@ if [ -n "$BODY_FILE" ]; then
 fi
 
 # `gh api` body field: -F body=@file or -f body='text' or -F body='text'.
+#
+# me2resh/apexyard#1070 — this block also now:
+#   1. recognises the LONG forms of -f/-F — `--raw-field` (alias of -f) and
+#      `--field` (alias of -F). `gh api --help` documents both pairs as
+#      exact equivalents; a hook that only knows the short spelling has a
+#      trivially-taken bypass (an operator, or an agent that copies an
+#      example straight out of `gh api --help`, spells it out in full). Same
+#      class of gap `-R`/`--repo` closed in #1068 round 3 above.
+#   2. fails CLOSED on `-F/--field body=@<path>` when the path is not a
+#      readable file, mirroring the `--body-file` fix from #1039 exactly —
+#      that shape used to fall through to the literal-`body=` branch below,
+#      which cannot match a `body=@path` token either, so API_BODY stayed
+#      empty and the write fell open at the empty-haystack short-circuit.
+#   3. fails CLOSED on `--input <file>` / `--input -` outright, rather than
+#      attempting to parse it. `--input` replaces the ENTIRE request body:
+#      `--input -` reads from STDIN, which is invisible to a PreToolUse hook
+#      (it only ever sees the command string), and `--input <file>` hands
+#      gh a raw JSON (or other) payload rather than one known field, so
+#      pulling `body`/`title` out of it correctly means parsing an
+#      arbitrary, endpoint-specific document — exactly the "enumerate one
+#      more shape" treadmill AgDR-0104 says command-text matching cannot
+#      win. No attempt is made to distinguish the two cases; both are
+#      content this hook cannot honestly claim to have scanned, so both
+#      refuse rather than publish unscanned.
 API_BODY=""
+API_BODY_UNREADABLE=0
+API_INPUT_UNPARSEABLE=0
 if [ "$IS_GH_API" -eq 1 ]; then
-  # Handle -F body=@<path> (file ref) and -f/-F body=<literal>.
-  API_BODY_PATH=$(echo "$COMMAND" | sed -nE "s/.*-F[[:space:]]+body=@([^[:space:]\"']+).*/\1/p" | head -1)
-  if [ -n "$API_BODY_PATH" ] && [ -f "$API_BODY_PATH" ]; then
-    API_BODY=$(cat "$API_BODY_PATH" 2>/dev/null)
+  if echo "$COMMAND" | grep -qE -- '(^|[[:space:]])--input([[:space:]]|=)'; then
+    API_INPUT_UNPARSEABLE=1
+  fi
+
+  # Handle -F/--field body=@<path> (file ref) and -f/-F/--raw-field/--field
+  # body=<literal>.
+  API_BODY_PATH=$(echo "$COMMAND" | sed -nE "s/.*(-F|--field)[[:space:]]+body=@([^[:space:]\"']+).*/\2/p" | head -1)
+  if [ -n "$API_BODY_PATH" ]; then
+    if [ -f "$API_BODY_PATH" ]; then
+      API_BODY=$(cat "$API_BODY_PATH" 2>/dev/null)
+      # Readable-but-unslurpable (permissions, race): treat as unreadable,
+      # same guard #1039 uses for BODY_FILE_UNREADABLE below.
+      if [ -z "$API_BODY" ] && [ -s "$API_BODY_PATH" ]; then
+        API_BODY_UNREADABLE=1
+      fi
+    else
+      API_BODY_UNREADABLE=1
+    fi
   else
     # Literal body=... — may be quoted. Strip surrounding quotes.
-    API_BODY=$(echo "$COMMAND" | sed -nE "s/.*-[fF][[:space:]]+body=\"([^\"]*)\".*/\1/p" | head -1)
+    API_BODY=$(echo "$COMMAND" | sed -nE "s/.*(-f|-F|--field|--raw-field)[[:space:]]+body=\"([^\"]*)\".*/\2/p" | head -1)
     if [ -z "$API_BODY" ]; then
-      API_BODY=$(echo "$COMMAND" | sed -nE "s/.*-[fF][[:space:]]+body='([^']*)'.*/\1/p" | head -1)
+      API_BODY=$(echo "$COMMAND" | sed -nE "s/.*(-f|-F|--field|--raw-field)[[:space:]]+body='([^']*)'.*/\2/p" | head -1)
     fi
     if [ -z "$API_BODY" ]; then
-      API_BODY=$(echo "$COMMAND" | sed -nE "s/.*-[fF][[:space:]]+body=([^[:space:]]+).*/\1/p" | head -1)
+      API_BODY=$(echo "$COMMAND" | sed -nE "s/.*(-f|-F|--field|--raw-field)[[:space:]]+body=([^[:space:]]+).*/\2/p" | head -1)
     fi
   fi
 
   # Also pick up a `title` field on api-shape issue creation.
   if [ -z "$TITLE" ]; then
-    API_TITLE=$(echo "$COMMAND" | sed -nE "s/.*-[fF][[:space:]]+title=\"([^\"]*)\".*/\1/p" | head -1)
+    API_TITLE=$(echo "$COMMAND" | sed -nE "s/.*(-f|-F|--field|--raw-field)[[:space:]]+title=\"([^\"]*)\".*/\2/p" | head -1)
     if [ -z "$API_TITLE" ]; then
-      API_TITLE=$(echo "$COMMAND" | sed -nE "s/.*-[fF][[:space:]]+title='([^']*)'.*/\1/p" | head -1)
+      API_TITLE=$(echo "$COMMAND" | sed -nE "s/.*(-f|-F|--field|--raw-field)[[:space:]]+title='([^']*)'.*/\2/p" | head -1)
     fi
     if [ -z "$API_TITLE" ]; then
-      API_TITLE=$(echo "$COMMAND" | sed -nE "s/.*-[fF][[:space:]]+title=([^[:space:]]+).*/\1/p" | head -1)
+      API_TITLE=$(echo "$COMMAND" | sed -nE "s/.*(-f|-F|--field|--raw-field)[[:space:]]+title=([^[:space:]]+).*/\2/p" | head -1)
     fi
     TITLE="$API_TITLE"
   fi
@@ -717,6 +757,73 @@ read out of body content this hook has actually scanned; it cannot be read
 out of a file that could not be opened. There is deliberately no bypass for
 an unreadable body: the marker means "I looked, and this reference is
 intentional", which is not a claim anyone can make about unread bytes.
+======================================================================
+EOF
+  exit 2
+fi
+
+# me2resh/apexyard#1070 — `gh api ... --input <file|->` replaces the ENTIRE
+# request body with content this hook does not parse (see the comment above
+# where API_INPUT_UNPARSEABLE is set, near the top of the IS_GH_API block).
+# Checked BEFORE the empty-haystack short-circuit below, same placement as
+# BODY_FILE_UNREADABLE just above and for the identical reason: an empty
+# HAYSTACK must never read as "scanned clean" when it is actually "never
+# looked at".
+if [ "$API_INPUT_UNPARSEABLE" -eq 1 ]; then
+  cat >&2 <<EOF
+======================================================================
+[apexyard] BLOCKED: gh api --input body cannot be scanned
+======================================================================
+
+This command targets a PUBLIC framework repo (${TARGET_REPO}) and supplies
+its request body via --input, which this hook does not parse.
+
+  - --input - reads the body from STDIN, which a PreToolUse hook cannot
+    see at all — it only ever sees the command string.
+  - --input <file> reads the body from a file, but the content is a raw
+    JSON (or other) request payload rather than one known field —
+    correctly pulling a body/title string out of it would mean parsing an
+    arbitrary, endpoint-specific document, which this hook does not
+    attempt (see docs/agdr/AgDR-0104-trust-chain-controls-vs-backstops.md:
+    pattern-matching command text cannot be made sound by enumerating ever
+    more shapes).
+
+This command is refused rather than published unscanned. Fix: use
+--title/--body/--body-file, or -f/-F (and their --raw-field/--field long
+forms) instead of --input.
+
+The <!-- private-refs: allow --> skip marker does NOT apply here, for the
+same reason it does not apply to an unreadable --body-file: it can only be
+honoured for content this hook has actually read.
+======================================================================
+EOF
+  exit 2
+fi
+
+# me2resh/apexyard#1070 — a `-F/--field body=@<path>` was named but could not
+# be read. Same fail-closed posture as BODY_FILE_UNREADABLE above (#1039):
+# checked before the empty-haystack short-circuit, so a missing/unreadable
+# file blocks loudly instead of silently scanning nothing (the shape used to
+# fall through to the literal-body branch, which cannot match `body=@path`
+# either, leaving API_BODY empty and the write open at that short-circuit).
+if [ "$API_BODY_UNREADABLE" -eq 1 ]; then
+  cat >&2 <<EOF
+======================================================================
+[apexyard] BLOCKED: gh api body=@file named but not readable
+======================================================================
+
+  body=@ path: ${API_BODY_PATH}
+
+This command targets a PUBLIC framework repo (${TARGET_REPO}), but the
+referenced body file could not be read, so its contents were never scanned
+for private project references. Allowing the write would mean asserting the
+body is clean without having looked at it.
+
+Fix the path and retry — that is the only way past this block.
+
+The <!-- private-refs: allow --> skip marker does NOT apply here, for the
+same reason it does not apply to an unreadable --body-file (#1039): it can
+only be honoured for content this hook has actually read.
 ======================================================================
 EOF
   exit 2

--- a/.claude/hooks/tests/test_block_private_refs.sh
+++ b/.claude/hooks/tests/test_block_private_refs.sh
@@ -722,6 +722,97 @@ run_case "#1068 round 3: -R (short flag for --repo) must be recognised" \
   "gh issue create -R me2resh/apexyard --title \"T\" --body \"zebrafish leak\""
 
 # ---------------------------------------------------------------------------
+# me2resh/apexyard#1070 — uncovered `gh api` body shapes, and a missing
+# `-F body=@file` fails OPEN unlike `--body-file` (#1039 established fail
+# closed for the identical condition one code path over).
+#
+# Three fixes, all in the IS_GH_API body-extraction block:
+#   1. `-F/--field body=@<path>` now shares the same fail-closed posture as
+#      `--body-file`: a missing/unreadable file BLOCKS instead of silently
+#      falling through to an empty scan (cases 38-39).
+#   2. The LONG forms `--field` (alias of -F) and `--raw-field` (alias of
+#      -f) are now recognised alongside the short forms, closing the same
+#      class of gap `-R`/`--repo` closed above for #1068 round 3 (case 40).
+#   3. `--input <file>` / `--input -` now fail CLOSED outright rather than
+#      being silently unextracted. `--input -` reads STDIN, invisible to a
+#      PreToolUse hook; `--input <file>` hands gh a raw, endpoint-specific
+#      JSON payload rather than one known field, so correctly pulling a
+#      body/title out of it would mean parsing an arbitrary document —
+#      exactly the "enumerate one more shape" treadmill AgDR-0104 says
+#      command-text matching cannot win. Both shapes are refused rather
+#      than published unscanned (cases 41-42); case 42 (`--input -`) is the
+#      one the issue calls out as the case that MUST fail closed, since
+#      there is no readability question to resolve for stdin at all.
+# ---------------------------------------------------------------------------
+
+# 38. The exact first repro from the issue: `-F body=@missing` used to fall
+#     through to the literal-`body=` branch (which cannot match a `body=@`
+#     token either), leaving API_BODY empty and the write open (rc=0) at
+#     the empty-haystack short-circuit. Mirrors case 18's `--body-file`
+#     assertion, one code path over.
+run_case "#1070: gh api -F body=@<missing file> → blocked, not silently open" \
+  2 "gh api body=@file named but not readable" \
+  "gh api repos/me2resh/apexyard/issues -f title=t -F body=@/nonexistent-zzz-1070.md"
+
+# 39. Same shape via the `--field` long form.
+run_case "#1070: gh api --field body=@<missing file> → blocked" \
+  2 "gh api body=@file named but not readable" \
+  "gh api repos/me2resh/apexyard/issues --field body=@/nonexistent-zzz-1070.md"
+
+# 40. `--field` / `--raw-field` long forms — previously unrecognised
+#     entirely, so a leak sent through them went unscanned. Now equivalent
+#     to -F/-f.
+run_case "#1070: gh api --raw-field/--field long forms are recognised" \
+  2 "project name: curios-dog" \
+  "gh api repos/me2resh/apexyard/issues --raw-field title=bug --field body='discovered during curios-dog rebuild'"
+
+# 41. The second repro from the issue: `--input <file>` was not extracted
+#     at all, so a leak sent through it went unscanned (rc=0). Now refused
+#     outright rather than chasing JSON-field parse coverage.
+run_case "#1070: gh api --input <file> → blocked (was unscanned, rc=0)" \
+  2 "gh api --input body cannot be scanned" \
+  "gh api repos/me2resh/apexyard/issues --input /nonexistent-zzz-1070.json"
+
+# 42. `--input -` (STDIN) — the shape the issue singles out as the one that
+#     MUST fail closed: the hook cannot see stdin at PreToolUse time under
+#     any circumstance, so there is no readability question to resolve —
+#     refusal is the only sound answer.
+run_case "#1070: gh api --input - (stdin) → MUST fail closed" \
+  2 "gh api --input body cannot be scanned" \
+  "gh api repos/me2resh/apexyard/issues --input -"
+
+# 43. Regression guard — a public-repo `gh api` write with no --input and a
+#     readable body=@file must still be SCANNED (and blocked on a leak),
+#     not swept up by the new --input refusal.
+LEAK_FILE_1070="$TMPDIR/leak-body-1070.md"
+printf 'Discovered during the curios-dog rebuild.\n' > "$LEAK_FILE_1070"
+run_case "#1070: --field body=@<readable leak file> is still read and scanned" \
+  2 "project name: curios-dog" \
+  "gh api repos/me2resh/apexyard/issues --field body=@$LEAK_FILE_1070"
+
+# 44. False-positive guard for the readable-file path above — a clean body
+#     read from a real file must pass, not be swept up by the new checks.
+CLEAN_FILE_1070="$TMPDIR/clean-body-1070.md"
+printf 'A generic framework bug. No project named.\n' > "$CLEAN_FILE_1070"
+run_case "#1070: --field body=@<readable clean file> → pass (no false positive)" \
+  0 "" \
+  "gh api repos/me2resh/apexyard/issues --field body=@$CLEAN_FILE_1070"
+
+# 45. `--input` on a NON-public target must stay a no-op — the fail-closed
+#     refusal only applies once TARGET_REPO has already resolved to a
+#     public-class repo (step 3, upstream of this block).
+run_case "#1070: --input on a non-public target → still a no-op" \
+  0 "" \
+  "gh api repos/me2resh/curios-dog/issues --input /nonexistent-zzz-1070.json"
+
+# 46. Regression guard — the pre-existing SHORT forms (-f/-F) must still
+#     work exactly as before; #1070 only adds coverage, it does not change
+#     the short-form behaviour case 10 above already pins.
+run_case "#1070: existing -f/-F short forms are unaffected" \
+  2 "project name: curios-dog" \
+  "gh api repos/me2resh/apexyard/issues -f title=bug -f body='discovered during curios-dog rebuild'"
+
+# ---------------------------------------------------------------------------
 # Portability lock: no ERE intervals in the hook's awk program.
 #
 # `{n,m}` support is not universal in awk — mawk 1.3.3 lacks it, BWK awk only


### PR DESCRIPTION
## Summary

- **`-F/--field body=@<path>` now fails closed when the file is missing or unreadable** — previously this exact shape fell through to the literal-`body=` branch (which can't match a `body=@path` token either), leaving `API_BODY` empty and the write allowed through at the empty-haystack short-circuit. #1039 already made an unreadable `--body-file` fail closed; this brings `gh api`'s equivalent path in line with that same decision instead of leaving a quieter twin of the bug it fixed.
- **`--field`/`--raw-field` (the documented long forms of `-F`/`-f`) are now recognised** for both the `body=`/`title=` literal extraction and the `body=@file` path extraction. Before this, a leak sent through the long spelling — which `gh api --help` documents as an exact equivalent of the short flags — went completely unscanned. Closes the same class of gap #1068 round 3 closed for `-R`/`--repo`.
- **`gh api ... --input <file|->` now fails closed outright** rather than being silently unextracted. `--input` replaces the *entire* request body: `--input -` reads from STDIN, which a `PreToolUse` hook cannot see under any circumstance (it only ever gets the command string), and `--input <file>` hands `gh` a raw, endpoint-specific JSON payload rather than one known field — correctly pulling `body`/`title` out of that would mean parsing an arbitrary document, which is exactly the "enumerate one more shape" treadmill [AgDR-0104](../blob/dev/docs/agdr/AgDR-0104-trust-chain-controls-vs-backstops.md) says command-text pattern matching cannot win. Both shapes now refuse rather than publish unscanned.

None of these three change any *already-working* path — the existing short-form `-f`/`-F` behaviour, and the readable-`--body-file`/readable-`body=@file` scanning, are unchanged (and explicitly pinned by regression cases below).

## Testing

Ran the hook's own test suite — 74/74 pass (65 pre-existing + 9 new for this PR):

```
bash .claude/hooks/tests/test_block_private_refs.sh
...
Passed: 74  Failed: 0
```

`shellcheck --severity=warning` clean on both edited files.

The two repros from the issue, run directly against the fixed hook:

```
$ gh api repos/me2resh/apexyard/issues -f title=t -F body=@/nonexistent-zzz.md
[apexyard] BLOCKED: gh api body=@file named but not readable
exit 2   # was exit 0 (silent leak risk) before this PR

$ gh api repos/me2resh/apexyard/issues --input /nonexistent-zzz.json
[apexyard] BLOCKED: gh api --input body cannot be scanned
exit 2   # was exit 0 (unscanned, --input not extracted at all) before this PR
```

And the stdin shape the issue calls out as the one that *must* fail closed:

```
$ gh api repos/me2resh/apexyard/issues --input -
[apexyard] BLOCKED: gh api --input body cannot be scanned
exit 2
```

New test cases (`.claude/hooks/tests/test_block_private_refs.sh`, cases 38–46):

| # | Case | Expected |
|---|------|----------|
| 38 | `-F body=@<missing file>` | blocked (fail closed) |
| 39 | `--field body=@<missing file>` | blocked (fail closed) |
| 40 | `--raw-field`/`--field` literal leak | blocked |
| 41 | `--input <file>` | blocked (fail closed) |
| 42 | `--input -` | blocked (fail closed — the issue's must-have case) |
| 43 | `--field body=@<readable leak file>` | blocked (file IS read and scanned) |
| 44 | `--field body=@<readable clean file>` | pass (no false positive) |
| 45 | `--input` on a non-public target | no-op (regression: target resolution still gates this block) |
| 46 | existing short `-f`/`-F` forms | unchanged (regression guard) |

Refs #1070

---

## Glossary

| Term | Definition |
|------|------------|
| `gh api` | GitHub CLI's low-level REST API passthrough — used to hit endpoints `gh issue create`/`gh pr create` don't cover |
| `-F` / `--field` | `gh api` flag for a typed request parameter; also the only flag that supports `@<file>` to read a value from a file |
| `-f` / `--raw-field` | `gh api` flag for a string request parameter (no `@file` support) |
| `--input` | `gh api` flag that replaces the entire request body with the contents of a file, or with STDIN when the value is `-` |
| fail closed | On error or ambiguity, deny the action — the correct default for a protective security gate |
| PreToolUse hook | A Claude Code hook that runs before a tool call executes and can block it; it only ever sees the command's text, never STDIN |
