### PR TITLE
fix(#1104): make portfolio path comparison case-insensitive-filesystem aware

### DIFF
--- a/.claude/hooks/_lib-ops-root.sh
+++ b/.claude/hooks/_lib-ops-root.sh
@@ -86,6 +86,28 @@ _LIB_OPS_ROOT_SOURCED=1
 # touches the pin.
 resolve_ops_root_walk() {
   local start="${1:-$PWD}"
+
+  # Case-insensitive-filesystem safety (me2resh/apexyard#1104): a literal
+  # $start/$PWD string can carry a different case than the on-disk
+  # directory name — bash's `cd`/`pwd -P` do NOT re-case (verified: `cd
+  # lowercase-path && pwd -P` returns "lowercase-path" unchanged on both
+  # GNU bash 5.x and macOS's stock /bin/bash 3.2), so whatever case the
+  # operator typed or the harness launched with survives untouched.
+  # `_lib-portfolio-paths.sh`'s `_portfolio_root()` anchors on `git
+  # rev-parse --show-toplevel` instead, which resolves via the OS and
+  # always returns the canonical on-disk case regardless of the case used
+  # to invoke it. Anchor THIS walk on the exact same base so the two
+  # independent ops-root resolvers can't disagree purely on case — when
+  # they did, a case-only difference between a pinned/cwd-derived root
+  # and a git-rev-parse-derived portfolio path got misread as "two
+  # distinct repos" (a phantom split-portfolio banner on a plain
+  # single-fork setup). Falls back to the raw (possibly non-canonical)
+  # `start` unchanged when not inside a git repo — same contract as
+  # before; there is nothing to canonicalize against in that case.
+  local canon
+  canon=$(cd "$start" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || canon=""
+  [ -n "$canon" ] && start="$canon"
+
   local r="$start"
   while [ -n "$r" ] && [ "$r" != "/" ]; do
     # v2 anchor (preferred): the explicit .apexyard-fork marker file.

--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -446,6 +446,102 @@ portfolio_agent_routing() {
 }
 
 # ------------------------------------------------------------------------------
+# Public: portfolio_path_eq <a> <b>
+#   Case-insensitive-filesystem-aware equality check for two absolute
+#   paths — do they name the SAME filesystem entry?
+#
+#   Why this exists (me2resh/apexyard#1104): on a case-insensitive
+#   filesystem (macOS/APFS default, Windows), two path strings that
+#   differ only in letter-case can be the identical on-disk directory.
+#   `git rev-parse --show-toplevel` resolves via the OS and always
+#   returns the canonical on-disk case (verified: `git -C
+#   /path/to/lowercase rev-parse --show-toplevel` still returns the
+#   canonical-cased path), but bash's `cd`/`pwd -P` do NOT re-case —
+#   verified empirically: `cd lowercase-path && pwd -P` returns
+#   "lowercase-path" unchanged, not the on-disk canonical case, on both
+#   GNU bash 5.x and macOS's stock `/bin/bash` 3.2. So a path resolved
+#   via `git rev-parse` (canonical) and a path resolved via a raw
+#   `$PWD`-derived string (whatever case the operator or harness
+#   originally typed) can be the SAME directory yet compare unequal with
+#   a plain `=`/`case` string match — which is exactly how a case-only
+#   difference between the ops-fork root and a portfolio path used to
+#   get misread as "two distinct repos" (a phantom split-portfolio /
+#   broken-config banner on a plain single-fork setup).
+#
+#   Strategy: prefer `-ef` (device+inode identity — the POSIX `test`
+#   operator, immune to case entirely) when both paths exist. Fall back
+#   to a case-folded string comparison when one/both don't exist yet
+#   (e.g. a workspace_dir that hasn't been created) — `-ef` needs a
+#   stat(2) on both sides. The fallback intentionally folds case
+#   UNCONDITIONALLY rather than trying to detect "is this filesystem
+#   case-insensitive": a false-positive fold on a case-SENSITIVE
+#   filesystem (treating two genuinely-different directories as equal)
+#   is the rarer, lower-cost failure mode next to the false "split
+#   portfolio" this helper exists to eliminate on every case-insensitive
+#   Mac/Windows setup — and the fold only ever applies to the
+#   non-existent-path fallback, where there is no inode to be wrong
+#   about in the first place.
+# ------------------------------------------------------------------------------
+portfolio_path_eq() {
+  local a="$1" b="$2"
+
+  [ "$a" = "$b" ] && return 0
+
+  if [ -e "$a" ] && [ -e "$b" ] && [ "$a" -ef "$b" ]; then
+    return 0
+  fi
+
+  local a_lc b_lc
+  a_lc=$(printf '%s' "$a" | tr '[:upper:]' '[:lower:]')
+  b_lc=$(printf '%s' "$b" | tr '[:upper:]' '[:lower:]')
+  [ "$a_lc" = "$b_lc" ]
+}
+
+# ------------------------------------------------------------------------------
+# Public: portfolio_path_under <path> <dir>
+#   Case-insensitive-filesystem-aware containment check — is <path> equal
+#   to <dir>, or does it live somewhere under <dir>? The prefix-match
+#   sibling of portfolio_path_eq, for the same reason (see its header
+#   comment above).
+#
+#   Strategy: walk UP from <path> (via dirname) to each ancestor that
+#   actually exists, and -ef-compare it against <dir> — this correctly
+#   handles <path> not existing yet (a file/dir that hasn't been created)
+#   by climbing past the non-existent tail, the same existing-ancestor
+#   pattern _portfolio_canonicalize already uses. Falls back to a
+#   case-folded string prefix match when <dir> itself doesn't exist
+#   (nothing to -ef against) or no existing ancestor of <path> matched.
+# ------------------------------------------------------------------------------
+portfolio_path_under() {
+  local path="$1" dir="$2"
+
+  [ -z "$dir" ] && return 1
+
+  portfolio_path_eq "$path" "$dir" && return 0
+
+  if [ -e "$dir" ]; then
+    local cur="$path"
+    while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+      if [ -e "$cur" ] && [ "$cur" -ef "$dir" ]; then
+        return 0
+      fi
+      local parent
+      parent=$(dirname "$cur")
+      [ "$parent" = "$cur" ] && break
+      cur="$parent"
+    done
+  fi
+
+  local path_lc dir_lc
+  path_lc=$(printf '%s' "$path" | tr '[:upper:]' '[:lower:]')
+  dir_lc=$(printf '%s' "$dir" | tr '[:upper:]' '[:lower:]')
+  case "$path_lc" in
+    "$dir_lc"|"$dir_lc"/*) return 0 ;;
+  esac
+  return 1
+}
+
+# ------------------------------------------------------------------------------
 # Public: portfolio_validate
 #   Sanity-check that resolved paths are actually usable.
 #   On success: prints nothing, returns 0.
@@ -534,11 +630,13 @@ portfolio_validate() {
   root_real=$(cd "$root" 2>/dev/null && pwd -P) || root_real="$root"
   wd_real=$(cd "$workspace_dir" 2>/dev/null && pwd -P) || wd_real="$workspace_dir"
 
+  # Case-insensitive-filesystem-aware containment check (me2resh/apexyard#1104).
+  # A plain string prefix match here misreads a case-only difference (e.g.
+  # $root resolved via git rev-parse's canonical case vs a path built from
+  # a raw, differently-cased cwd) as "outside the fork" — see
+  # portfolio_path_under's header comment for the full mechanism.
   _outside_fork() {
-    case "$1" in
-      "$root_real"|"$root_real"/*) return 1 ;;
-    esac
-    return 0
+    ! portfolio_path_under "$1" "$root_real"
   }
 
   if _outside_fork "$registry" || _outside_fork "$projects_dir"; then
@@ -575,50 +673,44 @@ portfolio_validate() {
   # needs no (root-resolution-sensitive) config-key read.
   local pd_real
   pd_real=$(cd "$projects_dir" 2>/dev/null && pwd -P) || pd_real="$projects_dir"
-  if ! _outside_fork "$pd_real" && [ "$pd_real" != "$root_real/projects" ]; then
+  if ! _outside_fork "$pd_real" && ! portfolio_path_eq "$pd_real" "$root_real/projects"; then
     echo "broken: split-portfolio v2 misconfig — portfolio.projects_dir resolved to $projects_dir, which is INSIDE the ops fork ($root_real) rather than the sibling private-portfolio repo. Check for a '../' depth mismatch (or a missing leading '../') in .claude/project-config.json's portfolio.projects_dir override. See me2resh/apexyard#951."
     return 1
   fi
 
-  if ! _outside_fork "$wd_real" && [ "$wd_real" != "$root_real/workspace" ]; then
+  if ! _outside_fork "$wd_real" && ! portfolio_path_eq "$wd_real" "$root_real/workspace"; then
     echo "broken: split-portfolio v2 misconfig — portfolio.workspace_dir resolved to $workspace_dir, which is INSIDE the ops fork ($root_real) rather than the sibling private-portfolio repo. Check for a '../' depth mismatch (or a missing leading '../') in .claude/project-config.json's portfolio.workspace_dir override. See me2resh/apexyard#951."
     return 1
   fi
 
-  case "$onboarding" in
-    "$root"/*|"$root")
-      # In-fork path — leave it to onboarding-check.sh.
-      ;;
-    *)
-      if [ ! -f "$onboarding" ]; then
-        echo "broken: portfolio.onboarding resolved to $onboarding — file does not exist"
-        return 1
-      fi
-      ;;
-  esac
+  if portfolio_path_under "$onboarding" "$root"; then
+    : # In-fork path — leave it to onboarding-check.sh.
+  else
+    if [ ! -f "$onboarding" ]; then
+      echo "broken: portfolio.onboarding resolved to $onboarding — file does not exist"
+      return 1
+    fi
+  fi
 
   # workspace_dir: same shape — only validate explicit overrides. The
   # in-fork default may legitimately not exist yet (no managed projects
   # cloned). Callers that need the dir should mkdir on demand.
-  case "$workspace_dir" in
-    "$root"/*|"$root")
-      # In-fork path — optional; skip.
-      ;;
-    *)
-      if [ ! -d "$workspace_dir" ]; then
-        echo "broken: portfolio.workspace_dir resolved to $workspace_dir — directory does not exist"
-        return 1
-      fi
-      # Writability check — read-only mounts (NFS / SMB / nested-container
-      # bind-mounts that drop write perms) would otherwise silent-fail when
-      # /handover or the v2 migration tries to write into workspace/.
-      # Surface the failure here so SessionStart catches it.
-      if [ ! -w "$workspace_dir" ]; then
-        echo "broken: portfolio.workspace_dir at $workspace_dir is not writable"
-        return 1
-      fi
-      ;;
-  esac
+  if portfolio_path_under "$workspace_dir" "$root"; then
+    : # In-fork path — optional; skip.
+  else
+    if [ ! -d "$workspace_dir" ]; then
+      echo "broken: portfolio.workspace_dir resolved to $workspace_dir — directory does not exist"
+      return 1
+    fi
+    # Writability check — read-only mounts (NFS / SMB / nested-container
+    # bind-mounts that drop write perms) would otherwise silent-fail when
+    # /handover or the v2 migration tries to write into workspace/.
+    # Surface the failure here so SessionStart catches it.
+    if [ ! -w "$workspace_dir" ]; then
+      echo "broken: portfolio.workspace_dir at $workspace_dir is not writable"
+      return 1
+    fi
+  fi
 
   return 0
 }

--- a/.claude/hooks/print-portfolio-primer.sh
+++ b/.claude/hooks/print-portfolio-primer.sh
@@ -102,11 +102,17 @@ ONBOARDING=$(portfolio_onboarding_path)
 # this matches portfolio_validate's own outside-fork check.
 ROOT_REAL=$(cd "$ROOT" 2>/dev/null && pwd -P) || ROOT_REAL="$ROOT"
 
+# Case-insensitive-filesystem-aware containment check (me2resh/apexyard#1104).
+# $ROOT can come from the pin-first resolve_ops_root() (see
+# _lib-ops-root.sh), which on a case-insensitive filesystem may carry a
+# different case than $REGISTRY/$WORKSPACE_DIR/$ONBOARDING (resolved via
+# _lib-portfolio-paths.sh, which anchors on git rev-parse's always-canonical
+# case). A plain string prefix match then misreads a case-only difference
+# as "outside the fork" — see portfolio_path_under's header comment in
+# _lib-portfolio-paths.sh for the full mechanism. portfolio_path_under is
+# defined by $PORTFOLIO_LIB, already sourced above.
 _outside_root() {
-  case "$1" in
-    "$ROOT_REAL"|"$ROOT_REAL"/*) return 1 ;;
-  esac
-  return 0
+  ! portfolio_path_under "$1" "$ROOT_REAL"
 }
 
 IS_SPLIT=1

--- a/.claude/hooks/tests/test_portfolio_paths_case_insensitive_fs.sh
+++ b/.claude/hooks/tests/test_portfolio_paths_case_insensitive_fs.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+# Regression tests for me2resh/apexyard#1104 — portfolio path-resolution
+# treating case-only path differences as a split-portfolio / broken
+# config, on a case-insensitive filesystem (macOS/APFS default, Windows).
+#
+# Root cause: `_lib-ops-root.sh`'s pin-first resolve_ops_root() can
+# return a path string sourced from a raw, non-canonicalized cwd (or a
+# stale pin file written before this fix), while
+# `_lib-portfolio-paths.sh`'s functions always anchor on `git rev-parse
+# --show-toplevel`, which resolves via the OS and always returns the
+# on-disk canonical case regardless of the case used to invoke it —
+# VERIFIED empirically (see _lib-portfolio-paths.sh's portfolio_path_eq
+# header comment): bash's own `cd`/`pwd -P` do NOT re-case a path,
+# unlike `git rev-parse`. Comparing a canonical-cased path against a
+# raw-cased one with a plain `=`/`case` string match then misreads a
+# case-only difference as "two distinct repositories" — a phantom
+# split-portfolio-v2 banner (print-portfolio-primer.sh) on a plain
+# single-fork setup.
+#
+# This file:
+#   - detects whether the CURRENT filesystem is case-insensitive first,
+#     and skips (exit 0, not a failure) when it is not — the bug and
+#     its fix only mean anything where "Foo" and "foo" name the same
+#     on-disk entry, which is false on Linux's default ext4/etc.
+#   - unit-tests the new portfolio_path_eq / portfolio_path_under
+#     helpers directly: case-only variants of the SAME real directory
+#     compare equal/contained; a genuinely DIFFERENT directory does not
+#     (negative control — the helpers must not degrade into "always
+#     true").
+#   - end-to-end: simulates a stale/case-divergent ops-root pin (the
+#     exact mechanism print-portfolio-primer.sh consumes) against an
+#     otherwise-plain single-fork sandbox, and asserts NO false
+#     split-portfolio banner fires.
+#   - negative control: a GENUINE split-portfolio v2 setup (a real
+#     sibling directory, not just a case variant) still fires the
+#     banner — the fix must not suppress a real split.
+#
+# Exit 0 if all cases pass (or the environment is case-sensitive and
+# every case is skipped); 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/print-portfolio-primer.sh"
+LIB_OPS="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
+LIB_PORT="$SRC_ROOT/.claude/hooks/_lib-portfolio-paths.sh"
+LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+
+for f in "$HOOK_SRC" "$LIB_OPS" "$LIB_PORT" "$LIB_CFG" "$DEFAULTS"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: missing $f" >&2
+    exit 1
+  fi
+done
+
+PASS=0
+FAIL=0
+FAILED=""
+
+mark_pass() { echo "PASS [$1]"; PASS=$((PASS+1)); }
+mark_fail() { echo "FAIL [$1] — $2" >&2; FAIL=$((FAIL+1)); FAILED="${FAILED}${1}; "; }
+
+assert_silent() {
+  local label="$1" output="$2"
+  if [ -z "$output" ]; then
+    mark_pass "$label"
+  else
+    mark_fail "$label" "expected silent, got: $output"
+  fi
+}
+
+assert_contains() {
+  local label="$1" output="$2" pattern="$3"
+  if printf '%s' "$output" | grep -qF -- "$pattern"; then
+    mark_pass "$label"
+  else
+    mark_fail "$label" "expected output to contain '$pattern', got: $output"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case-insensitive-filesystem probe. Creates Probe/probe under a fresh
+# temp dir and checks whether the lower-case spelling names the SAME
+# on-disk entry (device+inode identity via -ef). Skips the whole suite
+# (exit 0) when the filesystem is case-sensitive — nothing here is
+# meaningful there.
+# ---------------------------------------------------------------------------
+PROBE_BASE=$(mktemp -d)
+mkdir -p "$PROBE_BASE/CaseProbeXYZ"
+if [ ! "$PROBE_BASE/CaseProbeXYZ" -ef "$PROBE_BASE/caseprobexyz" ]; then
+  echo "SKIP: filesystem at $PROBE_BASE is case-sensitive — me2resh/apexyard#1104 only reproduces on a case-insensitive filesystem (macOS/APFS default, Windows). Nothing to test here."
+  rm -rf "$PROBE_BASE"
+  exit 0
+fi
+rm -rf "$PROBE_BASE"
+
+# ---------------------------------------------------------------------------
+# make_single_fork_sandbox: a real git repo, single-fork layout (the
+# .apexyard-fork marker + in-fork registry/projects_dir/onboarding — no
+# portfolio.* override), at a MIXED-CASE directory name so there is a
+# meaningful lower-case string variant to compare against. Mirrors
+# test_print_portfolio_primer.sh's make_public_fork_base(), plus the
+# case-mixing this file specifically needs.
+# ---------------------------------------------------------------------------
+make_single_fork_sandbox() {
+  local base sb
+  base=$(mktemp -d)
+  sb="$base/CaseForkXYZ"
+  mkdir -p "$sb/.claude/hooks" "$sb/projects"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/print-portfolio-primer.sh"
+  cp "$LIB_OPS" "$sb/.claude/hooks/_lib-ops-root.sh"
+  cp "$LIB_PORT" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  cp "$LIB_CFG" "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$DEFAULTS" "$sb/.claude/project-config.defaults.json"
+  chmod +x "$sb/.claude/hooks/print-portfolio-primer.sh"
+  (
+    cd "$sb" || exit 1
+    echo "# v2 marker, single-fork adopter" > .apexyard-fork
+    cat > apexyard.projects.yaml <<'YAML'
+version: 1
+projects: []
+YAML
+    echo "# Ideas" > projects/ideas-backlog.md
+    touch onboarding.yaml
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    git add -A
+    git commit -q -m "fixture: single-fork, mixed-case root"
+  )
+  echo "$sb"
+}
+
+# Runs print-portfolio-primer.sh from $1 with a PINNED ops-root of $2 —
+# simulating pin-ops-root.sh having captured (or a stale pre-fix pin
+# file already holding) a differently-cased path for the SAME
+# directory. Session id + pin dir are test-scoped so this never touches
+# a real operator's pin state.
+run_hook_with_pin() {
+  local dir="$1" pinned_root="$2"
+  local pin_dir sess
+  pin_dir=$(mktemp -d)
+  sess="test-1104-$$-$RANDOM"
+  printf '%s\n' "$pinned_root" > "$pin_dir/ops-root-$sess"
+  (
+    cd "$dir" || exit 1
+    CLAUDE_CODE_SESSION_ID="$sess" APEXYARD_OPS_PIN_DIR="$pin_dir" \
+      bash .claude/hooks/print-portfolio-primer.sh 2>&1
+  )
+  local rc=$?
+  rm -rf "$pin_dir"
+  return $rc
+}
+
+# ---------------------------------------------------------------------------
+# Unit tests: portfolio_path_eq / portfolio_path_under directly.
+# ---------------------------------------------------------------------------
+# Sourced once, at top level (not inside a subshell) — mark_pass/mark_fail
+# increment the script's global PASS/FAIL counters, and a subshell would
+# isolate those increments from the parent. Safe to source directly here:
+# portfolio_path_eq/portfolio_path_under are pure path-string + stat(2)
+# helpers with no cwd/caching state (unlike _portfolio_root(), which IS
+# cached per-process — not exercised by this case).
+# shellcheck source=/dev/null
+. "$LIB_CFG"
+# shellcheck source=/dev/null
+. "$LIB_PORT"
+
+case_path_eq_case_variants() {
+  local sb
+  sb=$(make_single_fork_sandbox)
+  local lc
+  lc=$(printf '%s' "$sb" | tr '[:upper:]' '[:lower:]')
+
+  if portfolio_path_eq "$sb" "$lc"; then
+    mark_pass "portfolio_path_eq: canonical vs lowercase string, same dir → equal"
+  else
+    mark_fail "portfolio_path_eq: canonical vs lowercase string, same dir → equal" "expected equal, got not-equal ($sb vs $lc)"
+  fi
+
+  if portfolio_path_under "$sb/apexyard.projects.yaml" "$lc"; then
+    mark_pass "portfolio_path_under: file under canonical dir, compared against lowercase root → under"
+  else
+    mark_fail "portfolio_path_under: file under canonical dir, compared against lowercase root → under" "expected under, got not-under"
+  fi
+
+  # Negative control: a genuinely DIFFERENT directory (not a case
+  # variant) must NOT compare equal / under — the helpers must not
+  # degrade into "always true" once they fold case.
+  local other
+  other=$(mktemp -d)
+  if portfolio_path_eq "$sb" "$other"; then
+    mark_fail "portfolio_path_eq: genuinely different dir → NOT equal (negative control)" "incorrectly reported equal ($sb vs $other)"
+  else
+    mark_pass "portfolio_path_eq: genuinely different dir → NOT equal (negative control)"
+  fi
+  if portfolio_path_under "$sb/apexyard.projects.yaml" "$other"; then
+    mark_fail "portfolio_path_under: file NOT under a genuinely different dir (negative control)" "incorrectly reported under ($other)"
+  else
+    mark_pass "portfolio_path_under: file NOT under a genuinely different dir (negative control)"
+  fi
+  rm -rf "$other"
+
+  rm -rf "$(dirname "$sb")"
+}
+
+# ---------------------------------------------------------------------------
+# End-to-end: a plain single-fork setup (no portfolio.* override at
+# all — the registry/projects_dir/onboarding all resolve to their
+# in-fork defaults) must stay SILENT even when the pinned ops-root
+# string carries a different case than the canonical git-toplevel the
+# portfolio_* resolvers use. This is the exact me2resh/apexyard#1104
+# repro: "Ops-fork root" (pinned, lowercase) vs "Portfolio (sibling)"
+# (canonical) differing only in case must NOT read as a split.
+# ---------------------------------------------------------------------------
+case_no_false_split_on_case_only_pin() {
+  local sb lc out
+  sb=$(make_single_fork_sandbox)
+  lc=$(printf '%s' "$sb" | tr '[:upper:]' '[:lower:]')
+
+  out=$(run_hook_with_pin "$sb" "$lc")
+  assert_silent "no false split-portfolio banner: case-only pin vs canonical root" "$out"
+
+  rm -rf "$(dirname "$sb")"
+}
+
+# ---------------------------------------------------------------------------
+# Negative control: a REAL split (a genuine sibling directory, not a
+# case variant of the fork root) must still fire the banner. The fix
+# must not suppress a real split-portfolio v2 detection.
+# ---------------------------------------------------------------------------
+case_real_split_still_detected() {
+  local sb priv
+  sb=$(make_single_fork_sandbox)
+  priv=$(mktemp -d)
+  priv="$priv/acme-portfolio"
+  mkdir -p "$priv/projects" "$priv/workspace"
+  cat > "$priv/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: demo
+    repo: example/demo
+YAML
+  echo "# Ideas" > "$priv/projects/ideas-backlog.md"
+  echo "company: {name: Acme}" > "$priv/onboarding.yaml"
+
+  (
+    cd "$sb" || exit 1
+    cat > .claude/project-config.json <<JSON
+{
+  "portfolio": {
+    "registry": "$priv/apexyard.projects.yaml",
+    "projects_dir": "$priv/projects",
+    "ideas_backlog": "$priv/projects/ideas-backlog.md",
+    "onboarding": "$priv/onboarding.yaml",
+    "workspace_dir": "$priv/workspace"
+  }
+}
+JSON
+    git add -A
+    git commit -q -m "fixture: real split-portfolio v2 config"
+  )
+
+  # Pin the (canonically-cased) fork root itself — no case games here,
+  # this case only proves the fix didn't break genuine split detection.
+  local out
+  out=$(run_hook_with_pin "$sb" "$sb")
+  assert_contains "real split-portfolio v2 (genuine sibling dir) still fires the banner" "$out" "split-portfolio v2 detected"
+
+  rm -rf "$sb" "$(dirname "$priv")"
+}
+
+case_path_eq_case_variants
+case_no_false_split_on_case_only_pin
+case_real_split_still_detected
+
+echo ""
+echo "==================================="
+echo "  PASS: $PASS   FAIL: $FAIL"
+echo "==================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed: $FAILED" >&2
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **Root cause pinned down empirically, not guessed at** — on a case-insensitive filesystem (macOS/APFS default, Windows), bash's own `cd`/`pwd -P` do **not** re-case a path string (`cd lowercase-path && pwd -P` returns `lowercase-path` unchanged, verified on both GNU bash 5.x and macOS's stock `/bin/bash` 3.2), while `git rev-parse --show-toplevel` always resolves to the on-disk canonical case regardless of the case used to invoke it. `_lib-ops-root.sh`'s pin-first `resolve_ops_root()` can therefore return a raw, non-canonical root string (from a stale pin, or a differently-cased launch cwd), while every `_lib-portfolio-paths.sh` resolver anchors on `git rev-parse` (canonical). Comparing the two with a plain `=`/`case` string match misread the case-only difference as "two distinct repos" — the exact false `split-portfolio v2 detected` banner from #1104.
- **New shared helpers: `portfolio_path_eq` / `portfolio_path_under`** in `_lib-portfolio-paths.sh` — case-insensitive-filesystem-aware equality/containment checks. They prefer `-ef` (device+inode identity, immune to case entirely) when both paths exist, falling back to a case-folded string compare only for the non-existent-path case (nothing to `-ef` against there, so nothing to be wrong about).
- **Every path comparison in `portfolio_validate()` and `print-portfolio-primer.sh` now goes through the new helpers** instead of raw `case`/`!=` string matching — `_outside_fork`, the `pd_real`/`wd_real` default-location checks, and the onboarding/workspace_dir in-fork checks. This closes the false "split" banner *and* any analogous false "broken config" path in one sweep, since they all shared the same string-comparison bug shape.
- **`_lib-ops-root.sh`'s `resolve_ops_root_walk()` now anchors on `git rev-parse`'s canonical toplevel before walking up** — the same base `_portfolio_root()` already used — so the framework's two independent ops-root resolvers can't disagree on case going forward. Falls back to the raw start unchanged outside a git repo (no behavior change there).
- **Regression test added**: `test_portfolio_paths_case_insensitive_fs.sh` skips gracefully on a case-sensitive filesystem (the bug only exists where "Foo" and "foo" name the same on-disk entry), unit-tests the new helpers with a negative control (a genuinely different directory must *not* compare equal), reproduces the pin-vs-canonical-root false split end-to-end against `print-portfolio-primer.sh`, and confirms a real split-portfolio v2 setup still fires the banner — the fix suppresses only the case-only false positive, not a genuine split or a genuinely broken registry.

## Testing

1. `env -u CLAUDE_CODE_SESSION_ID bash .claude/hooks/tests/test_ops_root.sh` — 8/8 pass
2. `env -u CLAUDE_CODE_SESSION_ID bash .claude/hooks/tests/test_resolve_ops_root_pin.sh` — 8/8 pass
3. `env -u CLAUDE_CODE_SESSION_ID bash .claude/hooks/tests/test_portfolio_paths.sh` — 45/45 pass
4. `env -u CLAUDE_CODE_SESSION_ID bash .claude/hooks/tests/test_print_portfolio_primer.sh` — 3/3 pass
5. `env -u CLAUDE_CODE_SESSION_ID bash .claude/hooks/tests/test_portfolio_paths_windows_drive_letter.sh` — 19/19 pass
6. `env -u CLAUDE_CODE_SESSION_ID bash .claude/hooks/tests/test_split_portfolio_v2_migration.sh` — 25/25 pass
7. `env -u CLAUDE_CODE_SESSION_ID bash .claude/hooks/tests/test_portfolio_agent_routing.sh` — 6/6 pass
8. `env -u CLAUDE_CODE_SESSION_ID bash .claude/hooks/tests/test_portfolio_paths_case_insensitive_fs.sh` (new) — 6/6 pass. Verified this test genuinely catches the regression by stashing the fix and re-running: it fails with the exact false "split-portfolio v2 detected" banner from the ticket, confirming it exercises the real bug rather than being a tautology.
9. `shellcheck --severity=warning` on all four changed/added files — clean, no findings.

Note on the `env -u CLAUDE_CODE_SESSION_ID` prefix: these tests are sensitive to a **pre-existing, unrelated** test-isolation gap — when run inside a live Claude Code session, `CLAUDE_CODE_SESSION_ID` is set to a real value and `resolve_ops_root()`'s pin-first lookup picks up the *real* session's already-written pin file instead of each test's synthetic sandbox. This reproduces identically against the unmodified `dev` code (confirmed by stashing this PR's changes and re-running), so it is not a regression introduced here — CI runners without a live session pin are unaffected either way.

## Glossary

| Term | Definition |
|------|------------|
| Case-insensitive filesystem | A filesystem (macOS APFS/HFS+ default, Windows NTFS) where `Foo` and `foo` name the same on-disk file or directory — two differently-cased path strings can point at one identical entry. |
| Case-preserving | The filesystem remembers the case a name was created with (so `ls` shows `Foo`), even though lookups ignore case — distinct from case-insensitive-and-*folding* filesystems that would normalize the name itself. |
| `-ef` | The POSIX `test`/`[` operator that compares two paths by device + inode number — true when they name the identical filesystem entry, regardless of the path strings used or the case involved. |
| Ops-fork root | The forked apexyard repo that governs a portfolio, anchored by the `.apexyard-fork` marker file or (legacy) the `onboarding.yaml` + `apexyard.projects.yaml` pair. |
| Pin (ops-root pin) | A per-session file at `~/.claude/apexyard/ops-root-<session-id>` written by `pin-ops-root.sh` at SessionStart, capturing the launch-cwd ops root so later hooks/sub-agents resolve consistently even if they later `cd` elsewhere. |
| Split-portfolio v2 | Mode where the private portfolio (registry, projects docs) lives in a separate sibling repo from the public framework fork, distinguished from a plain single-fork setup that merely carries the same `.apexyard-fork` marker. |

Refs #1104
