### PR TITLE
docs(#1093): publish the framework control-plane DFD and threat model

### DIFF
--- a/docs/architecture/dfd.md
+++ b/docs/architecture/dfd.md
@@ -1,0 +1,185 @@
+<!-- Source: ApexYard · docs/architecture/dfd.md · github.com/me2resh/apexyard · MIT -->
+
+# Data Flow Diagram — ApexYard Control Plane (SDLC Enforcement Machinery)
+
+> **Scope note.** This is the **framework's own** DFD — not a managed project's. It maps the machinery
+> that enforces the SDLC gates described in `.claude/rules/workflow-gates.md` and `.claude/rules/pr-workflow.md`:
+> the PreToolUse hooks, the review-marker files they read and write, and the boundary between local
+> session state and the forge (GitHub). It is the STRIDE input for [`../security/threat-model.md`](../security/threat-model.md).
+>
+> **Provenance.** Authored manually against issue [#1093](https://github.com/me2resh/apexyard/issues/1093)
+> ("ApexYard cannot audit itself"), under the recorded **Option D (interim)** decision on that issue: the
+> audit skills (`/dfd`, `/threat-model`) resolve output to `projects/<name>/` — the private portfolio — so
+> they cannot produce a *public*-facing artefact for the framework itself without registering the framework
+> as a project (bending the `workspace:` field) and accepting polluted dependency discovery (the workspace
+> scan attributes other registered projects' code to the framework — see #1092). Rather than work around
+> both, this document was hand-authored and placed directly under the public `docs/` tree. See the AC
+> scope note in the paired threat model for what this satisfies and what remains open.
+
+## Diagram
+
+```mermaid
+flowchart LR
+    operator(["Operator / CEO<br/>(human, external)"])
+
+    subgraph agent_zone ["Agent Session Zone (untrusted — model-controlled reasoning + tool calls)"]
+        orchestrator["Orchestrator<br/>(top-level agent thread)"]
+        build_agent["Build sub-agent<br/>(backend/frontend/platform/…)"]
+        reviewer_agent["Reviewer sub-agent<br/>(Rex / Hakim / Tariq)"]
+    end
+
+    subgraph local_state ["Local Session State (.claude/session/** — gitignored, filesystem-writable by any tool call)"]
+        review_markers[("Review markers<br/>*-rex/-security/-architecture/-ceo.approved")]
+        active_reviewer[("active-reviewer marker<br/>owner/repo#pr:kind")]
+        ticket_markers[("Ticket markers<br/>current-ticket / tickets/&lt;project&gt;")]
+        proj_config[("project-config.json<br/>untracked, per-fork overrides")]
+    end
+
+    subgraph gate_layer ["Mechanical Gate Layer (PreToolUse hooks — deterministic bash, run before the tool call executes)"]
+        ticket_gate["require-active-ticket.sh"]
+        merge_gate["block-unreviewed-merge.sh"]
+        ci_gate["block-merge-on-red-ci.sh"]
+        design_gates["require-architecture-review.sh<br/>require-design-review-for-ui.sh"]
+        leak_gate["block-private-refs-in-public-repos.sh"]
+        warn_hook["warn-review-marker-write.sh<br/>(advisory backstop, exit 0 always)"]
+    end
+
+    subgraph registry_zone ["Private Portfolio Registry (git-tracked in the ops fork, or a private sibling repo in split-portfolio mode)"]
+        registry[("apexyard.projects.yaml<br/>project name, repo slug, workspace path")]
+    end
+
+    subgraph forge_zone ["The Forge — GitHub (authoritative, external, structured state)"]
+        pr_state[("PR HEAD SHA · diff · CI check status")]
+        posted_reviews[("Posted PR reviews (gh pr review)")]
+        public_repo[("Public framework repo<br/>(me2resh/apexyard / upstream)")]
+    end
+
+    operator -->|"'act as X' / /code-review &lt;pr&gt; (model-invocable)"| orchestrator
+    operator -->|"/approve-merge &lt;pr&gt; (HUMAN-ONLY, disable-model-invocation, #1042)"| orchestrator
+
+    orchestrator -->|"Agent tool spawn"| build_agent
+    orchestrator -->|"Agent tool spawn"| reviewer_agent
+    orchestrator -->|"writes owner/repo#pr:kind before spawning the sanctioned reviewer"| active_reviewer
+
+    build_agent -->|"source diff (PR content)"| forge_zone
+    build_agent -.->|"FORBIDDEN: attempted rex/security/architecture marker write<br/>(self-review impersonation, AgDR-0062/0109)"| warn_hook
+    warn_hook -.->|"prints a VIOLATION banner — never blocks (exit 0 always)"| review_markers
+
+    reviewer_agent -->|"gh pr review --comment, verdict stated in body"| posted_reviews
+    reviewer_agent -->|"bare-SHA marker on an APPROVED verdict"| review_markers
+
+    operator -->|"structured marker: sha=&lt;head&gt;, approved_by=user, skill_version=2 + gh pr merge, one turn"| review_markers
+
+    build_agent -->|"Edit / Write / MultiEdit / Bash-write on a code path"| ticket_gate
+    ticket_gate -->|"looks up per-worktree / per-project / ops-fallback marker"| ticket_markers
+    ticket_gate -->|"ALLOW (marker found or path exempt) / BLOCK (exit 2)"| build_agent
+
+    orchestrator -->|"gh pr merge &lt;n&gt; / gh api .../pulls/&lt;n&gt;/merge / glab mr merge"| merge_gate
+    merge_gate -->|"reads rex-SHA + ceo-SHA + structured fields"| review_markers
+    merge_gate -->|"reads PR HEAD SHA (forge-reported, never local git)"| pr_state
+    merge_gate -->|"optional: verifies a review was actually posted at HEAD"| posted_reviews
+    merge_gate -->|"ALLOW / BLOCK (exit 2) the merge"| forge_zone
+    ci_gate -->|"reads CI check status at HEAD"| pr_state
+    ci_gate -->|"ALLOW / BLOCK on red or pending CI"| forge_zone
+    design_gates -->|"reads PR diff (design-artifact / UI paths) + approval marker"| pr_state
+    design_gates -->|"reads architecture / design marker"| review_markers
+    design_gates -->|"ALLOW / BLOCK"| forge_zone
+
+    orchestrator -->|"gh issue create / gh pr create / *comment --repo &lt;public&gt;"| leak_gate
+    leak_gate -->|"reads project name, repo slug, workspace path scrub list"| registry
+    leak_gate -->|"ALLOW (clean or skip-marker) / BLOCK (leak detected, exit 2)"| public_repo
+
+    proj_config -.->|"review_markers.require_posted_review, human_approver_title, …<br/>read at gate time, no git trail if edited"| merge_gate
+
+    style agent_zone stroke-dasharray: 5 5
+    style local_state stroke-dasharray: 5 5
+    style gate_layer stroke-dasharray: 5 5
+    style registry_zone stroke-dasharray: 5 5
+    style forge_zone stroke-dasharray: 5 5
+```
+
+The dashed subgraph borders mark **trust boundaries**. Four crossings carry the load-bearing security
+properties this diagram exists to surface — each is expanded in the trust-boundary table below and in the
+paired STRIDE threat model:
+
+1. **The merge-approval flow** — Rex's marker (or Hakim's / Tariq's) + the human-only CEO marker both
+   have to exist, both have to SHA-match the PR's **forge-reported** HEAD, before `block-unreviewed-merge.sh`
+   lets a merge command through.
+2. **The marker-forgery surface** — a build sub-agent cannot nest the `Agent` tool to spawn a real
+   reviewer, so the induced failure mode is impersonating one by writing its marker directly. The
+   `warn-review-marker-write.sh` backstop is dashed on purpose: it is advisory only (`exit 0` always,
+   per AgDR-0111) — a warning banner, not a block.
+3. **The ticket gate** — every code-path write is gated on an active-ticket marker in local session
+   state, with documented exemptions (`.claude/`, `docs/`, `*.md`, out-of-governance targets, bootstrap
+   skills).
+4. **The leak-protection boundary** — the private portfolio registry (project names, repo slugs,
+   workspace paths) must never cross into a write targeting a public framework repo. This document
+   itself was written under that boundary: no registered private project is named anywhere in it.
+
+---
+
+## Trust boundaries
+
+| From | To | Authentication mechanism | Data classification |
+|------|-----|--------------------------|---------------------|
+| Operator → Orchestrator (routine) | in-session prompt | None — conversational; the orchestrator is trusted to interpret intent | Instructions, ticket references |
+| Operator → Orchestrator (`/approve-merge`, `/approve-design`, `/approve-architecture`) | `disable-model-invocation: true` (#1042) | Harness-enforced: **only a human keystroke can invoke these skills** — the model cannot | The approval decision itself — the highest-trust signal in the system |
+| Orchestrator → Build sub-agent | `Agent` tool spawn, isolated context/worktree | None beyond the spawn boundary — a build agent runs with the tool restrictions of its `subagent_type` | Ticket scope, source diff |
+| Orchestrator → Reviewer sub-agent | `Agent` tool spawn + `active-reviewer` marker (`owner/repo#pr:kind`) written just before spawn | The marker is the provenance signal `warn-review-marker-write.sh` checks (advisory only) | PR diff, review verdict |
+| Build sub-agent → Review markers store | Filesystem write (Write tool or Bash redirection) | **None that blocks.** `warn-review-marker-write.sh` prints a banner; it never exits non-zero | A forged approval SHA — the marker-forgery threat |
+| Reviewer sub-agent → Review markers store | Filesystem write, bare SHA (rex/security/architecture) | None mechanical — trusted because the agent is the sanctioned reviewer identity spawned by the orchestrator, not because the file format proves anything | Reviewed commit SHA |
+| Operator (`/approve-merge`) → Review markers store | Structured fields: `sha=<40-hex>`, `approved_by=user`, `skill_version>=2` | `block-unreviewed-merge.sh` parses and requires all three fields — a bare-SHA legacy write is rejected | The CEO approval — SHA + explicit human provenance |
+| Merge gates → Review markers store | Local filesystem read | None — this is the read side of the write-side gap above | Approval SHAs compared against forge HEAD |
+| Merge gates → Forge (PR HEAD SHA / CI status / posted reviews) | `gh`/`glab` CLI, the operator's own authenticated session | Whatever auth `gh auth status` / `glab auth status` already holds — the gate trusts the forge's answer completely and **blocks** (does not fall back to local git) if the forge call fails | PR HEAD SHA, CI conclusion, review existence — all forge-authoritative, unforgeable by a local file write |
+| Build/Orchestrator → Ticket gate → Ticket markers | Local filesystem read, `/start-ticket`-written | None mechanical; a marker existing anywhere in the lookup chain (per-worktree / per-project / ops fallback) is sufficient | Ticket ID / repo association |
+| Any agent → Leak-protection gate → Private registry (`apexyard.projects.yaml`) | Local filesystem read of the fork's own registry | None — the registry is read, not authenticated against | Registered project names, repo slugs, workspace paths — the leak-class data |
+| Leak-protection gate → Public framework repo | `gh issue/pr create/comment`, `gh api .../issues` or `.../pulls` | Class-based scan of the write segment for a known public-repo target; `<!-- private-refs: allow -->` is the documented, visible bypass | Issue/PR title + body about to be published, indexed forever |
+| `project-config.json` → any gate that reads it | Local filesystem, **untracked by design** | None — an agent with repo write access can edit this file to disable an opt-in control (e.g. `review_markers.require_posted_review`) and the edit leaves no git trace | Gate configuration — itself a control surface, see AgDR-0112 |
+
+---
+
+## Notes
+
+Each crossing of a trust boundary is where STRIDE threats apply most acutely — see
+[`../security/threat-model.md`](../security/threat-model.md) for the full per-crossing walk. The short
+version, stated here because it's the framework's own central design tension:
+
+- **Spoofing** — can a build sub-agent's marker write pass as a real reviewer's? Only the advisory
+  banner stands between them; the actual protection is that a forged marker alone still cannot merge
+  anything without a *separate*, structurally-harder-to-forge CEO marker.
+- **Tampering** — can an approval's recorded SHA be stretched to cover a later commit? No: every gate
+  resolves the PR's HEAD from the forge, never from local git, and blocks rather than falls back when
+  that resolution fails (#1091).
+- **Repudiation** — local markers are gitignored and carry no cryptographic signature; the opt-in
+  `review_markers.require_posted_review` check (AgDR-0112, default off) is the only way "a review
+  happened" becomes a forge-verifiable, audit-trail fact instead of an inferred local claim.
+- **Information disclosure** — the leak-protection boundary is a command-text scanner, and AgDR-0104
+  already establishes that class of gate "cannot be made sound." Documented, tested gaps remain (see
+  the threat model).
+- **Denial of service** — every merge gate fails **closed** on an unresolvable precondition (`jq`
+  missing, forge unreachable, config unreadable) per AgDR-0104. That is the correct security posture and
+  an accepted availability cost: an outage on GitHub's side, or an unrelated tool going missing, can
+  stall every merge in the fork until it's restored.
+- **Elevation of privilege** — the sharpest EoP surface in this diagram is `project-config.json`: it is
+  deliberately untracked, so an agent that edits it to weaken a gate leaves nothing for `git diff` to
+  show.
+
+This diagram should be re-drawn whenever a new merge gate ships, an existing gate's read/write
+contract changes, or a new class of session-state marker is introduced. It is a manual artefact —
+see the Provenance note above — so unlike a skill-generated DFD it will not self-refresh; re-run
+this by hand against the recorded revisit trigger on issue #1093 (next time the framework's threat
+model or DFD needs to be republished, or the manual-copy drift becomes painful).
+
+---
+
+## References
+
+- [`../security/threat-model.md`](../security/threat-model.md) — the STRIDE threat model this DFD feeds
+- [`../agdr/AgDR-0104-trust-chain-controls-vs-backstops.md`](../agdr/AgDR-0104-trust-chain-controls-vs-backstops.md) — controls vs. backstops, honestly named; the framing this whole diagram follows
+- [`../agdr/AgDR-0062-rex-marker-authenticity.md`](../agdr/AgDR-0062-rex-marker-authenticity.md) — why the Rex marker forgery risk is accepted rather than mechanically closed
+- [`../agdr/AgDR-0112-verify-posted-review-at-head.md`](../agdr/AgDR-0112-verify-posted-review-at-head.md) — the opt-in server-side review-existence check
+- [`../../.claude/rules/pr-workflow.md`](../../.claude/rules/pr-workflow.md) — the prose rules this machinery mechanically enforces
+- [`../../.claude/rules/workflow-gates.md`](../../.claude/rules/workflow-gates.md) — the gate table this diagram's `gate_layer` implements
+- [`../../.claude/rules/leak-protection.md`](../../.claude/rules/leak-protection.md) — the full leak-protection rule this diagram's `leak_gate` enforces
+- [Mermaid `flowchart` syntax](https://mermaid.js.org/syntax/flowchart.html)
+- [STRIDE — Microsoft Security Development Lifecycle](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats)

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,258 @@
+<!-- Source: ApexYard · docs/security/threat-model.md · github.com/me2resh/apexyard · MIT -->
+
+# Threat Model — ApexYard Control Plane
+
+> **Scope note.** This is a threat model of **ApexYard's own SDLC-enforcement machinery** — the
+> PreToolUse hooks that gate merges, code edits, and public-repo writes — not of a managed project.
+> It tells an adopter what the framework's gates actually guarantee, and, just as importantly, what
+> they don't.
+>
+> **Provenance and AC scope.** Authored manually against issue
+> [#1093](https://github.com/me2resh/apexyard/issues/1093), under the recorded **Option D (interim)**
+> decision on that issue (see the DFD's Provenance note for the full reasoning). This document, together
+> with [`../architecture/dfd.md`](../architecture/dfd.md), satisfies **AC #2** ("the framework's control-plane
+> DFD and threat model are reachable by adopters in the public repo") and is written to satisfy **AC #3**
+> (the private-by-default rule for managed projects is unaffected — nothing about publishing this
+> changes how `/dfd` or `/threat-model` resolve output for a managed project) and **AC #4** (no
+> registered private project is named anywhere in this document or its DFD; see "Leak-safety" in the
+> Notes below). **AC #1** (a formal AgDR) and **AC #5** (registry expression without bending
+> `workspace:`) remain **deferred** — the Option-D issue comment is the recorded interim decision, and
+> issue #1093 stays **open** to track them. The automated mechanism (Option A: a `--self`/`--framework`
+> flag on the audit skills) is also deferred, not implemented by this document.
+
+## Data Flow Diagram
+
+Source of truth: [`../architecture/dfd.md`](../architecture/dfd.md). Reproduced here, unmodified, per the
+template convention of anchoring the STRIDE walk directly against the diagram it's drawn from.
+
+```mermaid
+flowchart LR
+    operator(["Operator / CEO<br/>(human, external)"])
+
+    subgraph agent_zone ["Agent Session Zone (untrusted — model-controlled reasoning + tool calls)"]
+        orchestrator["Orchestrator<br/>(top-level agent thread)"]
+        build_agent["Build sub-agent<br/>(backend/frontend/platform/…)"]
+        reviewer_agent["Reviewer sub-agent<br/>(Rex / Hakim / Tariq)"]
+    end
+
+    subgraph local_state ["Local Session State (.claude/session/** — gitignored, filesystem-writable by any tool call)"]
+        review_markers[("Review markers<br/>*-rex/-security/-architecture/-ceo.approved")]
+        active_reviewer[("active-reviewer marker<br/>owner/repo#pr:kind")]
+        ticket_markers[("Ticket markers<br/>current-ticket / tickets/&lt;project&gt;")]
+        proj_config[("project-config.json<br/>untracked, per-fork overrides")]
+    end
+
+    subgraph gate_layer ["Mechanical Gate Layer (PreToolUse hooks — deterministic bash, run before the tool call executes)"]
+        ticket_gate["require-active-ticket.sh"]
+        merge_gate["block-unreviewed-merge.sh"]
+        ci_gate["block-merge-on-red-ci.sh"]
+        design_gates["require-architecture-review.sh<br/>require-design-review-for-ui.sh"]
+        leak_gate["block-private-refs-in-public-repos.sh"]
+        warn_hook["warn-review-marker-write.sh<br/>(advisory backstop, exit 0 always)"]
+    end
+
+    subgraph registry_zone ["Private Portfolio Registry (git-tracked in the ops fork, or a private sibling repo in split-portfolio mode)"]
+        registry[("apexyard.projects.yaml<br/>project name, repo slug, workspace path")]
+    end
+
+    subgraph forge_zone ["The Forge — GitHub (authoritative, external, structured state)"]
+        pr_state[("PR HEAD SHA · diff · CI check status")]
+        posted_reviews[("Posted PR reviews (gh pr review)")]
+        public_repo[("Public framework repo<br/>(me2resh/apexyard / upstream)")]
+    end
+
+    operator -->|"'act as X' / /code-review &lt;pr&gt; (model-invocable)"| orchestrator
+    operator -->|"/approve-merge &lt;pr&gt; (HUMAN-ONLY, disable-model-invocation, #1042)"| orchestrator
+
+    orchestrator -->|"Agent tool spawn"| build_agent
+    orchestrator -->|"Agent tool spawn"| reviewer_agent
+    orchestrator -->|"writes owner/repo#pr:kind before spawning the sanctioned reviewer"| active_reviewer
+
+    build_agent -->|"source diff (PR content)"| forge_zone
+    build_agent -.->|"FORBIDDEN: attempted rex/security/architecture marker write<br/>(self-review impersonation, AgDR-0062/0109)"| warn_hook
+    warn_hook -.->|"prints a VIOLATION banner — never blocks (exit 0 always)"| review_markers
+
+    reviewer_agent -->|"gh pr review --comment, verdict stated in body"| posted_reviews
+    reviewer_agent -->|"bare-SHA marker on an APPROVED verdict"| review_markers
+
+    operator -->|"structured marker: sha=&lt;head&gt;, approved_by=user, skill_version=2 + gh pr merge, one turn"| review_markers
+
+    build_agent -->|"Edit / Write / MultiEdit / Bash-write on a code path"| ticket_gate
+    ticket_gate -->|"looks up per-worktree / per-project / ops-fallback marker"| ticket_markers
+    ticket_gate -->|"ALLOW (marker found or path exempt) / BLOCK (exit 2)"| build_agent
+
+    orchestrator -->|"gh pr merge &lt;n&gt; / gh api .../pulls/&lt;n&gt;/merge / glab mr merge"| merge_gate
+    merge_gate -->|"reads rex-SHA + ceo-SHA + structured fields"| review_markers
+    merge_gate -->|"reads PR HEAD SHA (forge-reported, never local git)"| pr_state
+    merge_gate -->|"optional: verifies a review was actually posted at HEAD"| posted_reviews
+    merge_gate -->|"ALLOW / BLOCK (exit 2) the merge"| forge_zone
+    ci_gate -->|"reads CI check status at HEAD"| pr_state
+    ci_gate -->|"ALLOW / BLOCK on red or pending CI"| forge_zone
+    design_gates -->|"reads PR diff (design-artifact / UI paths) + approval marker"| pr_state
+    design_gates -->|"reads architecture / design marker"| review_markers
+    design_gates -->|"ALLOW / BLOCK"| forge_zone
+
+    orchestrator -->|"gh issue create / gh pr create / *comment --repo &lt;public&gt;"| leak_gate
+    leak_gate -->|"reads project name, repo slug, workspace path scrub list"| registry
+    leak_gate -->|"ALLOW (clean or skip-marker) / BLOCK (leak detected, exit 2)"| public_repo
+
+    proj_config -.->|"review_markers.require_posted_review, human_approver_title, …<br/>read at gate time, no git trail if edited"| merge_gate
+
+    style agent_zone stroke-dasharray: 5 5
+    style local_state stroke-dasharray: 5 5
+    style gate_layer stroke-dasharray: 5 5
+    style registry_zone stroke-dasharray: 5 5
+    style forge_zone stroke-dasharray: 5 5
+```
+
+## Attack surface
+
+- **Entry points (~15):** every PreToolUse hook matcher wired in `.claude/settings.json` — `Edit|Write|MultiEdit`
+  (ticket gate, migration-ticket gate, role-trigger detection), `Write` (marker-write warn), and a dozen
+  `Bash` `if:`-scoped matchers keyed on command shape (`git add`, `git push`, `git commit`, `gh issue
+  create`, `gh pr create`, `gh issue/pr comment`, `gh api`, `gh pr merge`, `glab mr merge`, `glab api`,
+  `tracker_pr_merge`). Each is a place where the *shape of a shell command string* is the only signal
+  the gate has to work with.
+- **Data stores (4 classes):** local session-state markers (`.claude/session/reviews/`,
+  `.claude/session/active-reviewer`, `.claude/session/tickets/`) — gitignored, filesystem-writable by
+  any tool call in the session; the private portfolio registry (`apexyard.projects.yaml`) — git-tracked
+  but private-by-convention; per-fork config (`.claude/project-config.json`) — **untracked by design**,
+  so edits leave no git trail; and the forge itself (GitHub/GitLab) — the only store in this diagram an
+  agent cannot directly write to except through an authenticated, logged API call.
+- **External integrations (2):** `gh` (GitHub CLI, first-class) and `glab` (GitLab CLI, parity coverage
+  on the merge/CI/design gates, second-class on some flows — e.g. `require_posted_review` is GitHub-only
+  today).
+
+## Control vs. backstop classification (AgDR-0104)
+
+Every hook below is labelled in its own source comment (`# CLASS: CONTROL` or no such header, meaning
+backstop) per the framework's own naming discipline. Reproduced here as a single table so an adopter
+doesn't have to open eight files to see the shape:
+
+| Hook | Class | Why |
+|------|-------|-----|
+| `block-unreviewed-merge.sh` | **CONTROL** | Decides on structured state — marker SHA vs. forge-reported PR HEAD — not on command text. Fails closed when the forge can't be reached (#1091) or `jq` is missing (#965). |
+| `block-merge-on-red-ci.sh` | **CONTROL** | Same shape: forge-reported CI conclusion at HEAD, not text-matched. |
+| `require-architecture-review.sh` / `require-design-review-for-ui.sh` | **CONTROL** | Same shape: the PR's real diff from the forge (`gh pr diff`) decides whether the gate applies at all; the marker SHA check is identical to the merge gate's. |
+| `require-active-ticket.sh` | **CONTROL** (for its narrow claim) | Marker-existence is structured state (a file present or not), not a text guess — but note its claim is narrow: it proves *a ticket marker was set*, not that the ticket describes the work being done. |
+| `warn-review-marker-write.sh` | **BACKSTOP** | Decides by pattern-matching Bash command *text* for a marker-shaped write target. AgDR-0104 states plainly that this class of gate "cannot be made sound" — advisory only, `exit 0` always, since AgDR-0111. |
+| `block-private-refs-in-public-repos.sh` | **BACKSTOP** (with real, if imperfect, coverage) | Also a command-text scanner, with the same soundness ceiling — but unlike the marker-write hook it **does** block (`exit 2`) on a detected match. Its own source comments catalogue multiple documented, tested bypass shapes (below) rather than claiming completeness. |
+| `block-main-push.sh` | **BACKSTOP-leaning CONTROL** | Reads the actual push destination / commit branch from git and command text, which is more structured than a marker-write guess, but is still ultimately a parse of command text for `cd`/`git push`/`git commit` shapes — its own header documents several rounds of decoy-ref and heredoc-body hardening (#1066, #1075). |
+
+The load-bearing distinction, straight from AgDR-0104: **a control decides on state the agent cannot
+author** (a forge API response, a file whose *existence* the gate checks rather than trusting its
+content blindly); **a backstop decides on the text of a command**, which — per the ways-to-express-a-path
+argument in that AgDR — cannot be made sound against a determined adversary. The framework accepts this
+and leans real trust onto the forge-verified controls plus the human-in-the-loop CEO nod, rather than
+claiming the backstops are more than they are.
+
+## Threats by STRIDE category
+
+| # | Category | Threat | Severity | Entry point / boundary | Mitigation |
+|---|---|---|---|---|---|
+| T1 | Spoofing | A build sub-agent writes a `*-rex.approved` marker to impersonate a real Rex review it never ran (self-review, AgDR-0062's original finding) | **High** | Build sub-agent → Review markers store (crossing #4/#5 in the DFD trust-boundary table) | **[BACKSTOP]** `warn-review-marker-write.sh` prints a visible banner but never blocks. **[CONTROL, weaker]** the opt-in `review_markers.require_posted_review` (AgDR-0112, default **off**, GitHub-only) verifies a review was actually posted at HEAD — but accepts a review from the PR's own author, so it is explicitly **not** separation of duties (AgDR-0062's independent-reviewer version stays deferred as unsatisfiable single-account). **[CONTROL]** the merge still cannot complete without a *separate* CEO marker. |
+| T2 | Spoofing | A build sub-agent forges the human-only CEO marker to self-approve a merge | **Critical (if it worked) / Low (as shipped)** | Any agent → Review markers store | **[CONTROL]** the marker requires structured fields (`sha=`, `approved_by=user`, `skill_version>=2`) the model *can* type but only by committing a deliberate, visible rule violation; the real control is that `/approve-merge` itself is `disable-model-invocation: true` (#1042) — the model has **no tool path** to invoke the skill that legitimately writes this marker. |
+| T3 | Spoofing | An agent claims a ticket is active by writing a fabricated ticket marker to bypass `require-active-ticket.sh` | Medium | Build sub-agent → Ticket markers store | **[BACKSTOP]** the gate checks marker *existence*, not that the referenced ticket is real or open — an agent that can write the marker file can satisfy the gate with a fictitious ticket ID. The actual defense is that `require-skill-for-issue-create.sh` gates ticket *creation* through structured skills, and human review of the resulting PR would surface a nonsense ticket reference. |
+| T4 | Tampering | A stale approval (SHA for an old commit) is presented against a PR that has since moved | High | Merge gates → Review markers store + Forge PR HEAD | **[CONTROL]** every SHA comparison is against the forge-reported HEAD (`resolve_pr_head`), never local git; a mismatch blocks with an explicit "new commits pushed after approval" message. |
+| T5 | Tampering | The merge gate falls back to a locally-controlled HEAD value when the forge is unreachable, letting an agent-influenced value substitute for the forge's | High (historical) / **Closed** | Merge gates → Forge | **[CONTROL]** closed by #1091 (and its sibling fix landed the same day per the repo's recent commit history): the gate now **blocks** rather than falling back to local git when `resolve_pr_head` fails. This is the single most consequential fix in this hook family — a silent fallback here would have voided every SHA comparison above it. |
+| T6 | Tampering | `sed -i` / `awk -i inplace` rewrites a marker file's SHA in place to match a new HEAD, defeating "new commits invalidate approval" | Medium | Build sub-agent → Review markers store, via an in-place edit rather than a fresh write | **[BACKSTOP, partial]** `warn-review-marker-write.sh`'s own comments document this exact BSD-`sed -i` two-token extraction hazard and the fix that scoped a fallback scan to catch it — but the hook is still advisory-only; nothing blocks the edit. **[CONTROL, downstream]** the merge gate re-derives the forge HEAD independently at merge time, so a stale-then-rewritten marker only succeeds if the rewritten SHA happens to equal the *current* real HEAD — i.e., the tamper has to be accurate, not just present. |
+| T7 | Tampering | An agent edits `.claude/project-config.json` to set `review_markers.require_posted_review` back to `false` (or weaken `human_approver_title`, protected branches, etc.) after an operator turned a control on | Medium–High | `project-config.json` → any gate that reads it | **[GAP, documented]** the file is untracked by design (so per-fork overrides survive `/update`), which means an edit here **leaves no git trace** — AgDR-0112 states this plainly. No control in this diagram detects config tampering; it is a genuine, accepted residual risk of the untracked-config design. |
+| T8 | Repudiation | "A review happened" is only a local file's existence — nothing forces it to correspond to a real, readable review comment | Medium | Reviewer sub-agent → Review markers store | **[CONTROL, opt-in]** `review_markers.require_posted_review` (default off) makes this forge-verifiable — but it's off by default and GitHub-only; on a fresh fork or a GitLab adopter, this is unmitigated by default. |
+| T9 | Repudiation | Local session markers carry no timestamp binding them to a specific reviewer identity or session | Low | Review markers store (all writers) | **[GAP, accepted]** the CEO marker carries an *optional* `approved_at` field the skill writes but the gate does not validate — an audit convenience, not a checked property. |
+| T10 | Information disclosure | A registered private project's name, repo slug, or workspace path leaks into a public framework-repo issue/PR/comment | High | Any agent → Leak-protection gate → Public repo | **[BACKSTOP, real but bounded]** `block-private-refs-in-public-repos.sh` blocks on detection — stronger than the marker-write backstop because it actually exits 2 — but its own source comments catalogue multiple confirmed-against-`upstream/dev` bypass shapes that are **not** fixed: (a) two real writes chained in one Bash call where the leak sits in an earlier write and a later write's `--repo` names a different repo; (b) the `--repo=owner/name` equals-form, unrecognised by either matcher; (c) a repo slug in different case; (d) a slug immediately followed by a shell operator with no separating whitespace; (e) a `gh api` REST path with a trailing `?query` suffix. All five are filed as a documented follow-up, not silently undiscovered. |
+| T11 | Information disclosure | A body-file (`--body-file`) or `gh api` payload contains a leak that the hook can't read (unreadable path, wrong cwd) | Medium | Leak-protection gate | **[CONTROL for this sub-case]** the hook explicitly distinguishes "no body-file" from "body-file I could not read" and **refuses** (blocks) rather than silently scanning nothing — closing what used to be a silent-leak path. |
+| T12 | Information disclosure | Stack traces / hook internals / marker paths leak into a PR or issue body incidentally (e.g. pasting a debug log) | Low | Any write path | **[GAP]** no control specifically strips debug output from ticket/PR bodies; this relies on author self-discipline, same as the framework's general "no hardcoded secrets" rule (`check-secrets.sh` covers credential-shaped strings, not arbitrary internal-state leakage). |
+| T13 | Denial of service | `jq` is missing from `PATH` at merge time | Medium | Every merge gate (all four) | **[CONTROL, by design]** each gate falls back to a `jq`-independent raw-text scan; if the raw payload *looks* merge-shaped, the gate blocks (`exit 2`) rather than silently allowing an unverified merge. This is a deliberate fail-closed trade: an unrelated tooling problem can block all merges in the session until fixed. `check-jq-installed.sh` warns at `SessionStart` to reduce how often this is discovered mid-merge. |
+| T14 | Denial of service | The forge (GitHub/GitLab) is unreachable — network failure, expired token, rate limit | Medium–High | Merge gates → Forge | **[CONTROL, by design, since #1091]** blocks rather than silently falling back to a locally-controlled value. Correct security posture; explicit availability cost — every merge stalls until connectivity or auth is restored. |
+| T15 | Denial of service | A malformed heredoc, decoy ref, or chained shell command is used to make `block-main-push.sh` mis-scan and either false-block a legitimate push or (worse) miss a real one | Low (false-block) / High (missed real push) | `git push`/`git commit` → `block-main-push.sh` | **[BACKSTOP, heavily hardened]** the hook's own history (#1066, #1075, and several later review rounds) documents at least three prior true bypasses found and closed by widening the raw-text scan to check every push-shaped occurrence, not just the first. AgDR-0113 ("heredoc-stripper additive-only") governs how much stripping is safe. Given AgDR-0104's general claim, further bypasses in this family should be assumed possible, not ruled out. |
+| T16 | Elevation of privilege | `gh api repos/<o>/<r>/pulls/<n>/merge` used instead of `gh pr merge` to route around a gate that only recognised the CLI-subcommand shape | High (historical) / **Closed** | Any agent → Merge gates | **[CONTROL]** closed by #47; all four merge-relevant gates (`block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, `require-architecture-review.sh`, `require-design-review-for-ui.sh`) match both the `gh pr merge` and `gh api .../merge` shapes, plus the `glab` equivalents and the `tracker_pr_merge` wrapper (dispatched via registry lookup rather than text, since the wrapper's own text never says "gh" or "glab" by design). |
+| T17 | Elevation of privilege | An out-of-governance write target (a symlink, a path outside the ops fork and every registered workspace, or a target with no git repo in its ancestry) is used to smuggle a code change past `require-active-ticket.sh` | Medium | Build sub-agent → Ticket gate | **[CONTROL, narrow and deliberate]** the out-of-governance exemption (#883/#885) resolves symlinks *before* judging containment, and checks containment on both the raw and resolved path — closing the specific "workspace entry is itself a symlink pointing outside" hole a security review found. The exemption is intentionally narrow: any path inside *some* git repo (even an unregistered one) is NOT exempted, only genuinely out-of-governance targets are. |
+| T18 | Elevation of privilege | A ticket-first bypass via an unextractable Bash write target (e.g. `python -c '...write...'`) | Low | Build sub-agent → Ticket gate | **[CONTROL]** an empty/unextractable `FILE_PATH` is *never* exempted — it falls straight through to the ticket gate and blocks, categorically fail-closed. |
+| T19 | Elevation of privilege | Silent config drift weakens a gate's protected-branch list, migration paths, UI paths, or design paths via `.claude/project-config.json` overrides that REPLACE rather than extend the default list | Medium | `project-config.json` → any path-glob-driven gate | **[GAP, by design trade-off]** most of these keys are documented as REPLACE semantics (not additive), and an operator who overrides `.git.protected_branches[]` and forgets an entry silently un-protects a branch. The `_exclude` sibling keys (`ui_paths_exclude`, `design_paths_exclude`) exist specifically to let an adopter keep the safe defaults while carving out exceptions — using the REPLACE form instead of the exclude form is a footgun the docs warn about but do not prevent. |
+
+## Recommended priority
+
+Ordered by realistic exploitability × blast radius, not raw severity — a Critical threat with no
+practical exploit path (T2) ranks below a High threat with a documented, working bypass (T5's historical
+form, T10):
+
+1. **T7 — untracked config tampering.** No detection exists at all; this is the single largest *actual*
+   gap in the diagram, not a "this could theoretically be forged" caveat. Worth a follow-up: even an
+   advisory diff-against-last-known-good check at `SessionStart` would close the visibility gap without
+   re-introducing the drift-vs-portability trade-off that made the file untracked in the first place.
+2. **T10 — leak-protection bypass shapes.** Five documented, reproduced-against-`upstream/dev` gaps in
+   one hook. Each is individually narrow, but they are catalogued, not hypothetical — a natural next PR
+   for whoever picks up the follow-up ticket referenced in the hook's own comments.
+3. **T1/T8 — marker forgery / unverifiable review.** Already has a real, if opt-in and single-directional,
+   mitigation (`require_posted_review`). Consider defaulting it **on** for adopters who have configured a
+   separate reviewer/bot identity, where it would deliver actual separation of duties rather than the
+   weaker "a review exists" property it provides today.
+4. **T13/T14 — availability cost of fail-closed.** Not a vulnerability to fix — a trade-off to document
+   loudly so adopters aren't surprised when a `gh` auth expiry blocks every merge in the fork.
+5. Everything else — closed, bounded, or accepted with documented rationale.
+
+## Framework-specific cross-check
+
+This system is a CLI/hook harness, not a web application, so the standard OWASP web checklist doesn't
+map cleanly. The adapted equivalents that do apply:
+
+- [x] **Command injection in hooks** — every hook reads `.tool_input.command` via `jq -r`, then parses
+  with `grep`/`sed`/`awk` rather than `eval`ing untrusted text directly. The one deliberate `eval` in the
+  tracker library (`_tracker_create_custom` / `_tracker_list_custom`) is scoped to **operator-authored**
+  `custom` command templates, with untrusted values (title/body/labels) passed via environment variables
+  rather than string-substituted into the eval'd command — documented explicitly in `_lib-tracker.sh` as
+  the injection model.
+- [x] **Path traversal / symlink escape in marker resolution** — `_resolve_real_path` is used before
+  judging out-of-governance containment (T17); a registered workspace entry that is itself a symlink
+  pointing outside `workspace/` is still caught via the raw-path check alongside the resolved-path check.
+- [~] **TOCTOU on marker files** — a marker's SHA is read, then compared; between the read and the
+  `gh pr merge` execution there is a small window where a concurrent session could rewrite the marker.
+  Not analyzed in depth here; likely low-impact given the single-operator-session model this framework
+  assumes, but worth a note for anyone running concurrent fan-out agents against the same PR.
+- [x] **Dependency on external CLIs (`jq`, `gh`, `glab`, `yq`)** — `jq` is treated as a hard prerequisite
+  with an explicit `SessionStart` check (`check-jq-installed.sh`) and fail-closed behavior everywhere
+  else; `yq` has a documented `python3`+PyYAML fallback in the tracker library.
+- [ ] **Secrets in logs** — not evaluated in this pass; the hooks print diagnostic messages to stderr
+  including PR numbers, SHAs, and file paths, none of which are secret-class, but this was not
+  independently verified against every hook's error-path output.
+
+## Notes
+
+**Leak-safety.** No registered private project's name, repo slug, or workspace path appears anywhere in
+this document or its paired DFD. Every example uses the generic placeholder `<managed-project>` or refers
+to registry fields abstractly ("a registered private project"). This document was authored without ever
+reading the fork's actual `apexyard.projects.yaml` contents, so there was nothing to leak by construction.
+
+**What "STRIDE-complete" does not mean here.** This walk is anchored on the DFD's boundary crossings and
+the hooks that guard them, but it is not an exhaustive enumeration of every hook in `.claude/hooks/`
+(there are 49). It covers the control-plane core the task scoped: the merge-approval flow, the
+marker-forgery surface, the ticket gate, and the leak-protection boundary. `check-secrets.sh`,
+`validate-branch-name.sh`, `validate-pr-create.sh`, `require-migration-ticket.sh`, and the various
+`SessionStart` advisory hooks are real parts of the trust chain not walked in depth here.
+
+**Relationship to AgDR-0104's deferred items.** That AgDR explicitly deferred two things until their
+triggers fire: a CI meta-gate that fails the build if any trust-chain hook lacks a paired adversarial
+test (trigger: a third independent bypass incident), and a full compliance mapping to ISO/SOC2/SLSA
+(trigger: an adopter compliance request). Neither trigger is known to have fired as of this document's
+authoring; both remain open per that AgDR, not resolved by this one.
+
+**On this document's own honesty.** Following the same discipline the framework's hooks apply to
+themselves (AgDR-0104 § "name principles honestly"): this is a **threat model**, not a penetration test
+report and not a compliance attestation. Several rows above are marked `[GAP]` deliberately rather than
+rounded up to `[CONTROL]` or `[BACKSTOP, closed]` — the honest state of a residual risk is more useful to
+an adopter than an inflated claim of coverage.
+
+---
+
+## References
+
+- [`../architecture/dfd.md`](../architecture/dfd.md) — the DFD this threat model is anchored on
+- [`../agdr/AgDR-0104-trust-chain-controls-vs-backstops.md`](../agdr/AgDR-0104-trust-chain-controls-vs-backstops.md)
+- [`../agdr/AgDR-0062-rex-marker-authenticity.md`](../agdr/AgDR-0062-rex-marker-authenticity.md)
+- [`../agdr/AgDR-0112-verify-posted-review-at-head.md`](../agdr/AgDR-0112-verify-posted-review-at-head.md)
+- [`../../.claude/rules/pr-workflow.md`](../../.claude/rules/pr-workflow.md)
+- [`../../.claude/rules/workflow-gates.md`](../../.claude/rules/workflow-gates.md)
+- [`../../.claude/rules/leak-protection.md`](../../.claude/rules/leak-protection.md)
+- Issue [#1093](https://github.com/me2resh/apexyard/issues/1093) — the driver for this document, and the
+  Option-D interim decision this document's provenance note describes
+- [STRIDE — Microsoft Security Development Lifecycle](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats)


### PR DESCRIPTION
## Summary

- **Publishes the framework's own control-plane DFD** (`docs/architecture/dfd.md`) — a Mermaid
  data-flow diagram of ApexYard's SDLC-enforcement machinery: the merge-approval flow (Rex/Hakim/Tariq
  markers + the human-only CEO marker → the merge gate), the marker-forgery surface a build sub-agent
  could exploit, the ticket gate, and the leak-protection boundary that keeps private portfolio names
  out of public-repo writes. Every crossing is labelled with its authentication mechanism and data
  classification so an adopter can see exactly what proves what.
- **Publishes the matching STRIDE threat model** (`docs/security/threat-model.md`), anchored on that
  DFD. Nineteen threats (T1–T19), each explicitly tagged **[CONTROL]** or **[BACKSTOP]** per
  [AgDR-0104](docs/agdr/AgDR-0104-trust-chain-controls-vs-backstops.md) rather than blurring the line —
  including the documented, tested bypass shapes already catalogued in the leak-protection hook's own
  source comments, and the honest admission that editing `.claude/project-config.json` to weaken a gate
  currently leaves no git trace at all.
- **Why this matters to an adopter**: until now, the only way to get a threat model or DFD out of
  ApexYard was to run `/threat-model` or `/dfd`, and both resolve their output to the *private* portfolio
  (`projects/<name>/`) — correct for a managed project, but it meant the framework could never audit
  *itself* in a place adopters can actually read. This PR is the interim fix for that gap.
- **Scope note, deliberately**: this is the recorded **Option D (interim, manual)** deliverable from
  #1093 — not a change to the audit skills. The skills still resolve to the private portfolio; nothing
  about how `/dfd` or `/threat-model` behave for a managed project changes here, and the private-by-default
  rule is untouched.

## Testing

1. Open `docs/architecture/dfd.md` and `docs/security/threat-model.md` on GitHub (or any Markdown
   previewer with Mermaid support) — both diagrams render as a single `flowchart LR` with five dashed
   trust-boundary subgraphs.
2. `npx --yes markdownlint-cli2 "docs/architecture/dfd.md" "docs/security/threat-model.md"` — 0 issues.
3. Both Mermaid blocks were checked for structural balance (5 `subgraph` / 5 matching `end` in each) since
   no local Mermaid renderer was available in this environment.
4. Leak-safety was verified programmatically: this worktree has no `apexyard.projects.yaml` present, so
   there was nothing to leak from — both files use only the generic placeholder `<managed-project>` /
   "a registered private project" and never name a real registered repo, project, or workspace path.

## What this does and does not close on #1093

Satisfies:

- **AC #2** — the framework's control-plane DFD and threat model are now reachable by adopters in the
  public repo.
- **AC #3** — nothing about the private-by-default rule for managed projects changes; the audit skills'
  destination resolution is untouched.
- **AC #4** — no registered private project is named anywhere in either document.

Deliberately **not** addressed here, per the recorded Option-D decision on the issue:

- **AC #1** — a formal AgDR recording *where framework self-audit artefacts live* is still owed; the
  issue comment is the interim record, not a substitute.
- **AC #5** — the registry still can't express the framework itself without bending `workspace:` outside
  the portfolio.
- **Option A** (a `--self`/`--framework` flag on the audit skills' shared `audit_resolve_dir` helper) —
  the recommended eventual mechanism, deferred until drift from this manual copy becomes painful.

Because of the above, this PR uses `Refs #1093`, not `Closes #1093` — the issue stays **open** to track
the deferred automation and registry work.

Refs #1093

---

## Glossary

| Term | Definition |
|------|------------|
| DFD (Data Flow Diagram) | A diagram of how data moves between actors, processes, and stores, with explicit trust boundaries — the standard input to a STRIDE threat model. |
| STRIDE | Microsoft's threat-modelling mnemonic: Spoofing, Tampering, Repudiation, Information disclosure, Denial of service, Elevation of privilege — one lens per row of the threat table. |
| Control vs. backstop (AgDR-0104) | A **control** decides on structured state an agent can't author (e.g. the forge's reported PR HEAD SHA); a **backstop** decides by pattern-matching command *text*, which this framework's own prior AgDRs establish "cannot be made sound." Every hook in the threat model is labelled as one or the other, not just called "a security check." |
| Review marker | A local, gitignored file under `.claude/session/reviews/` (e.g. `*-rex.approved`, `*-ceo.approved`) that records a review or approval so the merge gate can check it against the PR's real HEAD on GitHub. |
| Leak-protection gate | `block-private-refs-in-public-repos.sh` — the hook that scrubs registered private project names, repo slugs, and workspace paths out of anything written to a public framework repo. |
| Option D (interim) | The recorded decision on #1093: hand-author the framework's self-audit docs and place them directly under public `docs/`, rather than changing the audit skills' destination resolution (Option A) or the registry schema (Option B) right now. |
