### PR TITLE
chore(#1088): record AgDR-0115 (accept residual, forge-native check)

### DIFF
--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -262,6 +262,74 @@ Which harness(es) will drive work on {name}?
 
 Record the pick as `$SELECTED_HARNESSES` (comma-separated, or `claude-code` if 1/default) for the step 10 summary.
 
+### 1.7. Check server-side branch protection (advisory, default: always attempt)
+
+> Why this exists. AgDR-0115 records the decision that ApexYard does NOT install any client-side push protection into a managed-project clone — doing so would mean pointing `core.hooksPath` at that clone's own tracked `.githooks/`, which is precisely the HIGH-risk wiring #1087's security review removed (see the "1.5-clone" note above and `bin/install-git-hooks.sh`'s header). The accepted consequence: a human running `git push origin main` from a terminal inside this clone is not blocked by anything ApexYard installs — only agent-driven pushes stay covered, via the ops-fork's own `PreToolUse` hooks. For that residual, the managed repo's own **server-side branch protection** is the actual control, not a client-side backstop ApexYard ships. This step only checks whether that control is turned on and nudges the operator if it looks like it isn't — it is advisory, forge-agnostic, and fail-open: a missing check, a network failure, or an unsupported tracker kind never blocks the rest of `/handover`.
+
+Only run this check when the target repo's `<owner/name>` is known (a Git URL was given in step 1). A plain local path with no resolvable remote host has nothing to query: set `BRANCH_PROTECTION_STATUS="skipped (no remote host)"`, print nothing, and continue straight to step 2.
+
+Otherwise, resolve the default branch (prefer the local clone when available; fall back to the API) and the tracker kind, dispatching the protection check the same way `tracker_review_submit` / `tracker_pr_merge` already dispatch on `tracker_kind` (`.claude/hooks/_lib-tracker.sh`) rather than hardcoding one forge's CLI:
+
+```bash
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
+source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-tracker.sh"
+
+kind=$(tracker_kind "<owner/name>")
+
+default_branch=""
+if [ "$CLONE_STATUS" = "cloned" ] || [ "$CLONE_STATUS" = "preserved" ]; then
+  default_branch=$(git -C "$WORKSPACE_DIR/<name>" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')
+fi
+if [ -z "$default_branch" ] && [ "$kind" = "gh" ]; then
+  default_branch=$(gh api "repos/<owner/name>" --jq .default_branch 2>/dev/null)
+fi
+
+BRANCH_PROTECTION_STATUS="skipped (default branch unknown)"
+if [ -n "$default_branch" ]; then
+  case "$kind" in
+    gh)
+      # gh api exits non-zero on BOTH "404 not protected" and a real
+      # failure (auth/network/no-permission/rate-limit). This check does
+      # not need to tell those apart — the response is the same either
+      # way: advise, never block. Fail-open by construction, not by
+      # accident.
+      if gh api "repos/<owner/name>/branches/${default_branch}/protection" >/dev/null 2>&1; then
+        BRANCH_PROTECTION_STATUS="protected"
+      else
+        BRANCH_PROTECTION_STATUS="not protected (or could not be verified)"
+      fi
+      ;;
+    glab)
+      encoded=$(printf '%s' "<owner/name>" | sed 's#/#%2F#')
+      if glab api "projects/${encoded}/protected_branches/${default_branch}" >/dev/null 2>&1; then
+        BRANCH_PROTECTION_STATUS="protected"
+      else
+        BRANCH_PROTECTION_STATUS="not protected (or could not be verified)"
+      fi
+      ;;
+    none|custom|*)
+      # No queryable, generically-shaped REST endpoint for these kinds —
+      # a `custom` tracker's PR/MR host is unknown, and `none` has no host
+      # at all. Say so plainly rather than guessing at an API shape.
+      BRANCH_PROTECTION_STATUS="skipped (no queryable forge for tracker.kind=${kind} — check your forge's branch protection settings manually)"
+      ;;
+  esac
+fi
+```
+
+If `$BRANCH_PROTECTION_STATUS` is `"not protected (or could not be verified)"`, print this nudge once (non-blocking — continue straight to step 2 regardless):
+
+```
+⚠ <name>'s default branch (<default_branch>) has no server-side branch
+protection turned on (or it couldn't be confirmed). ApexYard's own hooks
+only cover agent-driven pushes in this clone — a human running `git push`
+from a terminal here is not blocked. Server-side branch protection on the
+forge is the actual control for that gap (see AgDR-0115). Recommended:
+require a pull request before merging to <default_branch>.
+```
+
+If `$BRANCH_PROTECTION_STATUS` is `"protected"` or either `"skipped"` variant, print nothing further — the step 10 summary line is enough.
+
 ### 2. Read the surface area
 
 Use `$WORKSPACE_DIR/<name>/` as `<repo>` when available (clone succeeded or path was given). Fall back to GitHub API reads only when `$CLONE_STATUS` is `declined` or `failed`. Local reads are preferred — they are cheaper and more complete.
@@ -1556,6 +1624,7 @@ Registry updated:            apexyard.projects.yaml ({added | skipped})
 Next-step tickets filed:     {N filed of M offered | none offered (zero risks) | declined (skipped all) | skipped (registry not appended)}
 Workspace clone:             workspace/{name}/ ({cloned at step 1.5 | preserved (already existed) | declined (--no-clone) | failed: <reason> | n/a (local path given)})
 Harness:                     {"Claude Code (native)" | "<harness list> — install command(s) printed, see docs/harnesses/<harness>.md" | "other / not sure — no adapter yet"}
+Branch protection:           {"protected" | "not protected (or could not be verified) — nudge printed" | "skipped (default branch unknown)" | "skipped (no queryable forge for tracker.kind=<kind>)" | "skipped (no remote host)"}
 Validation:                  {"completed — verdict <GREEN|YELLOW|RED>" | "skipped" | "not offered (project is active)"}
 
 Tech stack: {one-liner}
@@ -1602,6 +1671,7 @@ Filed follow-up tickets:
 22. **`AGENTS.md` and `handover-assessment.md` don't duplicate — they split by reader** — `handover-assessment.md` (ops fork) is the **operator's** full analysis: risks, harnessability verdict, integration plan, next-step tickets. `AGENTS.md` (in the target repo) is the **agent's** concise operating manual: stable commands, layout, conventions, and the up-front gotchas an agent needs to start working. The volatile risk/integration analysis stays in the assessment; it is not copied into `AGENTS.md`. For low-harnessability repos, `AGENTS.md`'s Gotchas section surfaces what's fragile/missing (no strict types, no lint baseline, no coverage signal) — the in-repo echo of the assessment's LOW warning.
 23. **The "Governed by ApexYard" badge (step 8.6) is opt-in, PR-delivered, idempotent, and never a default** — row 9 of the step 5.6 checklist is **default-OFF** in every mode (checklist default, `--all`, and interactive `all`); it is only generated when explicitly ticked or comma-listed. Every run confirms with the operator by name (`Add a "Governed by ApexYard" badge to <name>'s README?`) before touching the target repo — there is no silent or bulk-implied consent for an externally-visible README edit. The badge is delivered via a branch + PR exactly like `AGENTS.md` (never a direct commit). It is **idempotent**: if either badge variant (`governed_by` or `built_with`) is already present in the README, the step skips and reports `already present` rather than adding a duplicate or swapping variants. The badge markdown itself (URL, color `#2F6DF6`, `flat-square` style) is fixed and quoted verbatim in step 8.6 — don't re-derive it. See AgDR-0090.
 24. **`docs/harnesses/README.md` is the single source of truth for harness support — step 1.6 summarises and links it, never duplicates the matrix.** Read the doc fresh when printing a harness's install command, precondition, or tier rather than trusting a stale table baked into this skill. Never round a harness's tier up — Cursor is failClosed-only, not live-proven, and the skill says so verbatim. Step 1.6 is informational only: it prints the adapter install command but never runs it against the target repo.
+25. **The branch-protection check (step 1.7) is advisory and fail-open, never a gate.** It never blocks the rest of `/handover`, never retries, and never escalates a check failure into anything stronger than the one-line nudge. It exists because AgDR-0115 accepted that ApexYard installs no client-side push protection into a managed-project clone — the nudge is the only signal the operator gets that the *actual* control (the forge's own server-side branch protection) might be off. Dispatch on `tracker_kind` (`.claude/hooks/_lib-tracker.sh`), the same pattern `tracker_review_submit`/`tracker_pr_merge` use — never hardcode one forge's CLI or REST shape. `custom` and `none` tracker kinds get a generic manual-check note, not a guessed API call.
 
 ## When to use this
 

--- a/bin/install-git-hooks.sh
+++ b/bin/install-git-hooks.sh
@@ -13,9 +13,20 @@
 # `core.hooksPath` is a PER-CLONE git config value, not a repo property —
 # it lives in `.git/config`, never committed, so every fresh clone starts
 # unset regardless of how many times a sibling clone has run this script.
-# That's exactly why this needs to be invoked from `/setup` (for the ops
-# fork) and `/handover` (for each newly-cloned managed-project workspace),
-# not run once and forgotten.
+# That's exactly why this needs to be invoked from `/setup`, every time it
+# configures the ops fork's own clone — a config value that isn't repeated
+# per clone doesn't stick.
+#
+# ONLY `/setup` invokes this script. `/handover` deliberately does NOT —
+# running it against an arbitrary, just-cloned managed-project workspace
+# would point core.hooksPath at THAT repo's own tracked .githooks/ (whatever
+# it ships), handing it silent execution with no provenance check (PR #1087
+# review, HIGH-1). See .claude/skills/handover/SKILL.md's "1.5-clone" note
+# for the full reasoning and AgDR-0115 for the accepted-residual decision
+# this leaves in place for a human's terminal `git push` inside a managed
+# project's clone. Do not re-add a `/handover` call to this script without
+# re-reading both first — that is precisely the footgun this comment exists
+# to block.
 #
 # This script is idempotent and safe to re-run: unset -> set, already
 # correct -> no-op, stale (missing dir, or a leftover pointer into a
@@ -27,9 +38,11 @@
 #
 # Options:
 #   --repo-dir <path>   Target repo (default: the repo containing the
-#                       current working directory). Lets /handover call
-#                       this against a freshly-cloned managed-project
-#                       workspace instead of the ops fork.
+#                       current working directory). Exists for tests and
+#                       for pointing the installer at a repo other than
+#                       the cwd's — NOT an invitation to call this against
+#                       a managed-project clone; see the `/handover`
+#                       note above.
 #   --hooks-dir <name>  Tracked hooks dir name, relative to the repo root
 #                       (default: .githooks). Mainly useful for tests.
 #   --force             Overwrite a core.hooksPath an adopter set to a
@@ -62,7 +75,8 @@
 # third-party repo, because doing so points git at THAT repo's own
 # scripts with no operator confirmation. Callers MUST NOT invoke this
 # against an untrusted clone. See .claude/skills/handover/SKILL.md's
-# explicit note on why /handover deliberately does not call this script.
+# explicit note on why /handover deliberately does not call this script,
+# and AgDR-0115 for the residual this leaves accepted.
 #
 # See me2resh/apexyard#1086 for the full driver and the two follow-up
 # steps (enforcement inside .githooks/pre-push; demoting block-main-push.sh

--- a/docs/agdr/AgDR-0115-managed-clone-terminal-push-accept-residual.md
+++ b/docs/agdr/AgDR-0115-managed-clone-terminal-push-accept-residual.md
@@ -1,0 +1,73 @@
+---
+id: AgDR-0115
+timestamp: 2026-08-01T06:57:51Z
+agent: claude (Platform Engineer — Adel)
+model: claude-sonnet-5
+trigger: user-prompt
+status: executed
+category: security
+projects: [apexyard]
+---
+
+# Managed-project clones: accept the terminal-push residual, lean on forge-native branch protection
+
+> In the context of #1087 (step 1 of #1086) shipping `bin/install-git-hooks.sh` for the ops fork's own repo but deliberately NOT wiring it into `/handover` — because pointing `core.hooksPath` at an arbitrary just-cloned repo's own tracked `.githooks/` hands that repo's committed scripts silent execution on the very next `git fetch`/`checkout`, no push required — facing the resulting gap that a human running `git push origin main` from a terminal inside a `workspace/<project>/` clone is not blocked by anything client-side, I decided to **accept the residual (Option D)** rather than build a new client-side mechanism to close it, and to add a forge-native, advisory, fail-open check at `/handover` time that nudges the operator to turn on the managed repo's own server-side branch protection — to achieve an honest, non-overclaiming security posture consistent with AgDR-0104's controls-vs-backstops framing, accepting that terminal pushes in managed-project clones stay genuinely unprotected by ApexYard itself until either a future untracked-hook mechanism (Option A) or the operator's own forge-side branch protection covers them.
+
+## Context
+
+`.githooks/pre-push` is tracked in the **ops fork** and, once `core.hooksPath` is set (via `bin/install-git-hooks.sh`, invoked from `/setup`), protects the ops fork's own protected branches from a terminal push. #1086/#1087 built that installer and proved it works — but also proved, by direct reproduction against a scratch repo, that running the *same* installer against a repo `/handover` has just cloned is a distinct and much worse act: it points `core.hooksPath` at **that repo's own committed `.githooks/`**, and git hooks fire on ordinary, non-push operations too (`post-checkout`, `reference-transaction` both fired in the repro, with no push involved). Git deliberately never clones `$GIT_DIR/hooks` — that is precisely what makes cloning an untrusted repository a safe, read-only act. Repointing `core.hooksPath` at *tracked* content removes that property and hands the just-cloned repo's own scripts execution, with no operator confirmation and no provenance check. The security review on #1087 rated this HIGH, and the `/handover` call was removed before merge (see `.claude/skills/handover/SKILL.md`'s existing note on the clone step, and `bin/install-git-hooks.sh`'s own header).
+
+That leaves a real, load-bearing gap, stated plainly on #1088:
+
+| Push path | Protected today? |
+|---|---|
+| Agent-driven push in a managed project (Claude Code session) | Yes — the ops-fork `PreToolUse` hooks (`pre-push-gate.sh` and friends) fire because the *agent* runs in the ops-fork context, regardless of which repo it's writing to |
+| **Human terminal push in a managed-project clone** (`cd workspace/<name> && git push origin main`) | **No — nothing in ApexYard covers this** |
+
+This AgDR is the design decision #1088 asked for: how (or whether) a managed-project clone should gain protection for that second row, without the framework ever pointing git at tracked content it doesn't control.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Install the framework's own hook into the clone's *untracked* `.git/hooks/pre-push`** | Closes the trust-boundary problem entirely — nothing tracked ever executes; the mechanism is the same shape as the ops fork's own (proven) `.githooks/pre-push` model, just delivered a different way | Not version-controlled, so it must be re-applied on every fresh clone/re-clone (drift); needs an explicit collision policy for a clone that already has its own `.git/hooks/pre-push` (overwrite is destructive, skip leaves it unprotected); still `--no-verify`-bypassable like any client-side git hook; needs its own design (payload content, install trigger, drift detection) and its own ticket — genuinely unscoped today, not a five-line change |
+| **B. Point `core.hooksPath` at a framework-controlled directory *outside* the clone** | The clone's own `.githooks/` never runs, so the specific #1087 finding doesn't recur | Requires an absolute, per-machine path baked into `core.hooksPath` — which is *exactly* the stale-absolute-path failure mode #1086/#1087 exist to repair for the ops fork itself. Adopting the same shape for every managed-project clone multiplies that failure mode by the number of clones. **Rejected.** |
+| **C. Prompt the operator at clone time, showing what would execute** | Puts a real decision in front of a human before anything runs | Weak in isolation — clone time is when the operator has the *least* context about a repo they're still evaluating (`/handover`'s whole point). Only defensible as a secondary confirmation layered on top of A, never as a standalone control |
+| **D. Accept the residual — do nothing new client-side; lean on the forge's own server-side branch protection** | Honest about what ApexYard's client-side mechanism can and can't cover for a repo it doesn't own; zero new attack surface; the dominant real-world path (agent-driven pushes) is already covered; server-side branch protection is portable across every contributor and every clone, present or future, with no per-clone re-install and no `--no-verify` bypass | The gap is real and stays open for the one path it covers (a human, at a terminal, choosing to push straight to a protected branch, on a repo where the operator hasn't turned on forge-side protection) |
+
+## Decision
+
+Chosen: **Option D — accept the residual**, refined with a forge-native advisory check.
+
+A human running `git push origin main` from a terminal inside a `workspace/<project>/` clone is **not blocked client-side** by anything ApexYard installs. Agent-driven pushes in that same clone remain gated by the ops-fork's own `PreToolUse` hooks, because those fire on the *agent's* context regardless of which repo it's writing to — that is the dominant path in practice, per #1088's own framing. For the residual — the terminal-push path — **the managed repo's server-side branch protection is THE control**, not a backstop to some client-side mechanism ApexYard doesn't ship. This is the same "controls vs backstops, honestly named" logic AgDR-0104 already established for the ops fork's own trust chain, applied here to a repo ApexYard doesn't own at all: a client-side hook the framework doesn't (and structurally can't safely) install cannot be the control, so don't describe it as one.
+
+Because Option D alone leaves the operator with no signal that the gap exists on *their* specific repo, this decision pairs it with a lightweight, forge-native, **advisory** nudge: `/handover` now checks whether the managed repo's default branch has server-side branch protection turned on, and prints a one-time nudge if it's absent or can't be confirmed. This is not a new client-side control — it is a visibility improvement at exactly the moment (adoption) an operator is positioned to act on it. See `.claude/skills/handover/SKILL.md` § "1.7. Check server-side branch protection" for the implementation, dispatched by `tracker_kind` the same way `tracker_review_submit`/`tracker_pr_merge` already dispatch (`.claude/hooks/_lib-tracker.sh`).
+
+### Load-bearing guardrail (record prominently — this is the rail, not a footnote)
+
+**No configuration ApexYard writes into a cloned repo may ever cause that repo's own TRACKED content to execute.** Concretely: **never point `core.hooksPath` at a clone's tracked `.githooks/`** (or any tracked directory) from a skill or hook the framework runs against a repo it does not itself author. That is precisely the #1087 HIGH finding, and it must never recur regardless of which option a future iteration of this decision picks. Option B is rejected above in part *because* it edges toward this same shape (a path a future refactor could accidentally point back at tracked content) — the rail is about the entire class, not just the one instance already caught.
+
+### Not pre-committing to Option A
+
+This AgDR does **not** adopt Option A as the mechanism, now or as a committed next step. It records only this: **if** the terminal-push gap is ever shown to actually bite (a real incident, not a hypothetical), Option A — installing into the clone's *untracked* `.git/hooks/pre-push`, never `core.hooksPath` — is the only trust-safe *direction* available on the client side. Even then, a forge-native fix (verifying/enforcing branch protection programmatically, rather than only nudging) should be compared first and preferred if it clears the bar: it survives re-clone with no per-clone re-install, and it is not defeated by `git push --no-verify` the way any client-side git hook structurally is. Building Option A speculatively, before the gap has actually bitten, is exactly the kind of unscoped client-side mechanism this AgDR declines to commit to today.
+
+### Risk-direction correctness (the invariant this AgDR exists to keep visible)
+
+For any mechanism in this space, past or future: **a block, or any non-zero/error exit, is the SAFE outcome. Exit 0 (silent success) against a third-party clone is the outcome that transfers code execution to that clone's own content.** The original #1087 finding was exactly an inversion of this — treating `exit 3` ("nothing to install, hooks dir absent") as the unremarkable case and `exit 0` as the success worth reporting, when `exit 0` against an untrusted clone is the dangerous one. `bin/install-git-hooks.sh` was corrected to state this the right way round (see its own header comment) as part of closing #1087's findings. Nothing adopted in a future revision of this decision may re-invert it.
+
+## Consequences
+
+- Terminal `git push` to a protected branch inside a `workspace/<project>/` clone remains genuinely unprotected by ApexYard. This is a **documented, accepted residual**, not an oversight — operators who need it closed today must turn on server-side branch protection on the managed repo themselves (which `/handover`'s new step 1.7 now nudges them toward).
+- `/handover` gains one new advisory, fail-open step (1.7) that checks server-side branch protection on the target repo's default branch and nudges if it's absent or unverifiable. It never blocks the rest of the handover flow, and it degrades silently to a generic note for tracker kinds it can't query (`none`, `custom`).
+- `bin/install-git-hooks.sh`'s header is corrected so it no longer claims `/handover` invokes it — a stale claim left over from before #1087's finding, which is exactly the footgun that could lead a future agent to re-add the removed HIGH-risk wiring. The corrected header points at `.claude/skills/handover/SKILL.md`'s own explicit note and this AgDR.
+- Options A and B remain on the table for a *future* decision, explicitly not this one. B is rejected outright (reintroduces the stale-absolute-path class #1086 exists to fix). A is the only client-side direction left, gated behind an actual incident and a comparison against a forge-native alternative first.
+- The load-bearing guardrail (never point `core.hooksPath` at a clone's tracked content) and the risk-direction invariant (block = safe, silent exit 0 against a third party = dangerous) are recorded here so they survive independently of whatever mechanism, if any, eventually closes the gap.
+
+## Artifacts
+
+- #1086 (parent epic: install git pre-push hooks, then move protected-branch enforcement into them)
+- #1087 (step 1 — installer for the ops fork's own repo; the HIGH finding that removed the `/handover` wiring)
+- #1088 (this design question)
+- AgDR-0104 (trust-chain controls vs. backstops, honestly named — the framing this decision applies to a repo ApexYard doesn't own)
+- `bin/install-git-hooks.sh` (installer + corrected header)
+- `.claude/skills/handover/SKILL.md` § "1.5-clone" (existing note on why `/handover` doesn't call the installer) and § "1.7. Check server-side branch protection" (new advisory nudge)


### PR DESCRIPTION
## Summary

- **Decision recorded: accept the terminal-push residual (Option D).** `docs/agdr/AgDR-0115-managed-clone-terminal-push-accept-residual.md` closes #1088 by choosing NOT to build a new client-side mechanism for a human's terminal `git push` inside a managed-project (`workspace/<name>/`) clone. Agent-driven pushes there already stay covered by the ops-fork's own `PreToolUse` hooks — this decision is about the one path that isn't: a human typing `git push origin main` directly. For that path, the managed repo's own **server-side branch protection** is now recorded as the actual control, not a gap ApexYard's client-side hooks are pretending to cover.
- **Why D, not a new client-side hook (Option A/B/C).** The AgDR weighs all four options the issue asked for. B is rejected outright — it reintroduces the exact stale-absolute-path failure #1086/#1087 exist to fix. A (installing into the clone's untracked `.git/hooks/pre-push`) is the only trust-safe *direction* if this is ever revisited, but it's deliberately NOT pre-committed here — it needs its own design and its own ticket, and a forge-native fix should be compared first since it survives re-clone and isn't `--no-verify`-bypassable. C (prompt at clone time) is named as weak-alone. The AgDR also restates, prominently, the load-bearing rail from #1087's HIGH finding: no config ApexYard writes may ever point a clone's `core.hooksPath` at that clone's own tracked content — and the risk-direction invariant (block = safe; silent `exit 0` against a third-party clone = the dangerous outcome) so neither can quietly re-invert in a future change.
- **A forge-native nudge, not a new gate.** `.claude/skills/handover/SKILL.md` gains step 1.7: an advisory, fail-open check that queries whether the managed repo's default branch has server-side branch protection turned on, and prints a one-line nudge if it's absent or can't be confirmed. It dispatches on `tracker_kind` (gh / glab / a generic manual-check note for `custom`/`none`) — the same pattern `tracker_review_submit`/`tracker_pr_merge` already use — rather than hardcoding one forge's CLI. It never blocks the rest of `/handover`; a network failure, missing auth, or unsupported tracker kind just skips with a note.
- **Fixed a footgun in `bin/install-git-hooks.sh`'s own header.** The "Background" section still said the installer "needs to be invoked from `/setup` ... and `/handover`," even though the `/handover` wiring was removed on a HIGH security finding in #1087. A later paragraph (added while closing #1089) already correctly said `/handover` does NOT call it — so the file was internally contradicting itself, which is exactly the kind of stale claim a future agent could read as license to re-add the removed wiring. Corrected both the "Background" paragraph and the `--repo-dir` option description to state plainly that ONLY `/setup` invokes this script, pointing at `handover/SKILL.md`'s own note and AgDR-0115.

## Testing

1. `shellcheck --severity=warning bin/install-git-hooks.sh` — clean, no findings.
2. `npx markdownlint-cli2` against the new AgDR and the edited `handover/SKILL.md` — 0 issues.
3. `bash .claude/hooks/tests/test_handover_clone_prompt.sh` — 18/18 passed (the new step 1.7 content sits between two of the test's pinned literal-substring assertions and doesn't disturb any of them).
4. `bash .claude/hooks/tests/test_install_git_hooks.sh` — 43/43 passed (header-only change; no behavioral edit to the installer's logic).

## Glossary

| Term | Definition |
|------|------------|
| `core.hooksPath` | Per-clone git config naming the directory git executes hooks from. Not inherited by cloning — every fresh clone starts unset, which is why `/setup` re-runs the installer on every ops-fork configuration. |
| tracked vs untracked hooks | Hooks committed to the repo (`.githooks/`, travels with a clone) versus hooks in `$GIT_DIR/hooks` (never cloned). Pointing `core.hooksPath` at *tracked* content in a repo you don't control hands that repo's own committed scripts execution — the #1087 HIGH finding. |
| residual (accepted) | A known gap in coverage that a decision explicitly chooses NOT to close right now, with the reasoning for why written down (here: AgDR-0115) rather than silently left unrecorded. |
| server-side branch protection | A forge-hosted (GitHub/GitLab) setting on a repo's default branch requiring PRs/reviews before a push lands. It runs on the forge, not the client, so it isn't defeated by `git push --no-verify` or a missing client-side hook. |
| advisory / fail-open | A check that warns but never blocks, and treats "couldn't determine the answer" the same as "the answer was concerning" rather than risking a false "all clear". Step 1.7 is advisory and fail-open by design — it must never stop `/handover` from completing. |

Refs #1088
