### PR TITLE
chore(#1057): advisory nudge for trust-chain CONTROL adversarial-test coverage (AgDR-0117)

### DIFF
--- a/.claude/hooks/nudge-control-adversarial-test.sh
+++ b/.claude/hooks/nudge-control-adversarial-test.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Non-blocking advisory hook: when a `gh pr create` diff touches a trust-chain
+# hook labelled `# CLASS: CONTROL` (the AgDR-0104 typology), print a one-line
+# reminder to make sure the change has, or updates, a paired adversarial test.
+#
+# This is the shipped outcome of me2resh/apexyard#1057. #1057 asked for a
+# blocking CI meta-gate that fails when a CONTROL hook has no paired
+# adversarial test. AgDR-0117 rejected that gate: every CONTROL hook already
+# has adversarial-test coverage today (zero gap to close), the spec'd gate is
+# defeatable by construction (an omitted entry in a hand-maintained trust-chain
+# list, or a strawman test that merely asserts a token appears), and it would
+# duplicate the #871 conformance framework's job. AgDR-0117 instead ships this
+# lightweight advisory nudge — the same "text-matching can't be made sound,
+# prefer self-discipline + a cheap reminder" lineage as AgDR-0104 and
+# AgDR-0111. See docs/agdr/AgDR-0104-trust-chain-controls-vs-backstops.md,
+# AgDR-0111-marker-gate-plain-advisory.md, and AgDR-0117 itself.
+#
+# NOTE ON TAXONOMY: this hook is NOT itself a CONTROL or a BACKSTOP in the
+# AgDR-0104 sense — it doesn't gate a merge or decide on structured state, it
+# only prints a reminder. That's why it carries no `# CLASS:` header of its
+# own; that header is reserved for hooks that are part of the trust chain's
+# enforcement machinery.
+#
+# How the CONTROL set is derived (the load-bearing design choice, per the
+# Contrarian's challenge on #1057): NOT a hand-maintained config list, which
+# is trivially defeated by omission (add a new CONTROL hook, forget to add it
+# to the list, the gate never fires on it). Instead this hook greps every
+# `.claude/hooks/*.sh` file for its OWN `# CLASS: CONTROL` header at grep time,
+# on every invocation. A hook can only escape detection by removing its own
+# CLASS header — which is a loud, reviewable, self-incriminating edit, not a
+# silent omission in a separate file.
+#
+# Behaviour:
+#   - Matches ONLY on `gh pr create …`. Silent no-op on every other command.
+#   - Computes the diff vs the base branch (parsed from --base; falls back
+#     to origin/dev, upstream/dev, origin/main, upstream/main, main, master —
+#     same fallback order as require-agdr-for-arch-pr.sh, minus that hook's
+#     cross-repo/cd-target machinery, which a BLOCKING gate needs and this
+#     advisory nudge does not: an occasional false negative here just means
+#     one PR doesn't get a reminder it could have used, not a bypassed gate).
+#   - If any changed file is a `.claude/hooks/*.sh` file carrying its own
+#     `# CLASS: CONTROL` header, print ONE line to stderr naming the touched
+#     hook(s) and reminding the author to add/update a paired adversarial
+#     test. Exit 0.
+#   - In every other case (no match, unresolvable base, unreadable hooks dir,
+#     empty diff) — silent exit 0.
+#
+# Exit 0 in EVERY path. This hook must never block `gh pr create`.
+
+set -u
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+[ -z "$COMMAND" ] && exit 0
+
+# Match only `gh pr create …`.
+if ! printf '%s' "$COMMAND" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+create\b'; then
+  exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+[ -z "$REPO_ROOT" ] && exit 0
+
+HOOKS_DIR="$REPO_ROOT/.claude/hooks"
+[ -d "$HOOKS_DIR" ] || exit 0
+
+gitr() { git -C "$REPO_ROOT" "$@"; }
+
+# ---------------------------------------------------------------------------
+# 1. Resolve the base branch and compute the PR's changed files.
+# ---------------------------------------------------------------------------
+
+extract_base_flag() {
+  # Very small extractor: only needs to recover a simple --base/-B value.
+  # Unlike the extractors in require-agdr-for-arch-pr.sh, this hook is
+  # advisory-only, so a missed --base value just falls through to the
+  # fallback candidate list below — no false-block risk.
+  printf '%s' "$COMMAND" | grep -oE -- '(--base|-B)[[:space:]=]+[^[:space:]]+' \
+    | head -1 \
+    | sed -E 's/^(--base|-B)[[:space:]=]+//' \
+    | tr -d "\"'"
+}
+
+resolve_ref() {
+  local ref="$1"
+  gitr rev-parse --verify --quiet "$ref" >/dev/null 2>&1 && printf '%s' "$ref"
+}
+
+BASE_ARG=$(extract_base_flag)
+BASE_REF=""
+
+if [ -n "$BASE_ARG" ]; then
+  for candidate in "origin/$BASE_ARG" "upstream/$BASE_ARG" "$BASE_ARG"; do
+    r=$(resolve_ref "$candidate")
+    [ -n "$r" ] && { BASE_REF="$r"; break; }
+  done
+fi
+
+if [ -z "$BASE_REF" ]; then
+  for candidate in origin/dev upstream/dev origin/main upstream/main main master; do
+    r=$(resolve_ref "$candidate")
+    [ -n "$r" ] && { BASE_REF="$r"; break; }
+  done
+fi
+
+[ -z "$BASE_REF" ] && exit 0
+
+MERGE_BASE=$(gitr merge-base HEAD "$BASE_REF" 2>/dev/null)
+[ -z "$MERGE_BASE" ] && exit 0
+
+CHANGED_FILES=$(gitr diff --name-only "$MERGE_BASE"..HEAD 2>/dev/null)
+[ -z "$CHANGED_FILES" ] && exit 0
+
+# ---------------------------------------------------------------------------
+# 2. Derive the CONTROL set from the hooks' own headers — not a config list.
+# ---------------------------------------------------------------------------
+
+CONTROL_HOOKS=$(grep -l '^# CLASS: CONTROL' "$HOOKS_DIR"/*.sh 2>/dev/null | xargs -n1 basename 2>/dev/null)
+[ -z "$CONTROL_HOOKS" ] && exit 0
+
+# ---------------------------------------------------------------------------
+# 3. Intersect the PR's changed files with the CONTROL set.
+# ---------------------------------------------------------------------------
+
+TOUCHED=""
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  base=$(basename "$file")
+  case "$file" in
+    */.claude/hooks/"$base"|.claude/hooks/"$base") : ;;
+    *) continue ;;
+  esac
+  while IFS= read -r ctrl; do
+    [ -z "$ctrl" ] && continue
+    if [ "$base" = "$ctrl" ]; then
+      TOUCHED="${TOUCHED}${base} "
+    fi
+  done <<CTRL
+$CONTROL_HOOKS
+CTRL
+done <<CHANGED
+$CHANGED_FILES
+CHANGED
+
+[ -z "$TOUCHED" ] && exit 0
+
+printf 'ADVISORY: this PR touches trust-chain CONTROL hook(s) [%s] — ensure each has/updates a paired adversarial test (a test that actively tries to defeat the control, not just exercise the happy path). See AgDR-0104 / AgDR-0117 (docs/agdr/). Non-blocking — this is a reminder, not a gate.\n' \
+  "$(printf '%s' "$TOUCHED" | sed 's/ $//; s/ /, /g')" >&2
+
+exit 0

--- a/.claude/hooks/tests/test_nudge_control_adversarial_test.sh
+++ b/.claude/hooks/tests/test_nudge_control_adversarial_test.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+# Test fixtures for nudge-control-adversarial-test.sh (AgDR-0117).
+#
+# The hook is a plain ADVISORY nudge (per AgDR-0117's rejection of #1057's
+# proposed blocking CI meta-gate): on `gh pr create`, if the PR's diff touches
+# a `.claude/hooks/*.sh` file whose OWN header carries `# CLASS: CONTROL`
+# (the AgDR-0104 typology), print a one-line reminder to pair the change with
+# an adversarial test. It must NEVER block — every assertion below checks
+# exit code 0, including the case where the nudge fires.
+#
+# Cases covered:
+#   1. PR touches a CONTROL hook               → nudge fires, exit 0
+#   2. PR touches a non-CONTROL hook            → silent, exit 0
+#   3. PR touches an unrelated file              → silent, exit 0
+#   4. Command is not `gh pr create`             → silent, exit 0
+#   5. PR touches TWO CONTROL hooks              → nudge names both, exit 0
+#   6. Unresolvable base branch                   → silent, exit 0 (no crash)
+#
+# To run:  ./.claude/hooks/tests/test_nudge_control_adversarial_test.sh
+# Exit 0 = all pass, 1 = at least one failure.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../.." && pwd)
+HOOK="$REPO_ROOT/.claude/hooks/nudge-control-adversarial-test.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not found or not executable at $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+make_payload() {
+  local cmd="$1"
+  jq -n --arg c "$cmd" '{tool_input: {command: $c}}'
+}
+
+# setup_repo <base-setup-fn> <feature-setup-fn>
+#   base-setup-fn    : runs on main, commits the starting state
+#   feature-setup-fn : runs on a feature branch, commits the PR's changes
+setup_repo() {
+  local base_fn="$1"
+  local feat_fn="$2"
+  local dir
+  dir=$(mktemp -d -t nudge-control.XXXXXX)
+  (
+    cd "$dir" || exit 1
+    git init -q -b main
+    git config user.email t@t.test
+    git config user.name test
+    echo "company: test" > onboarding.yaml
+    mkdir -p .claude/hooks
+    git add onboarding.yaml
+    git commit -q -m init
+    "$base_fn"
+    git checkout -q -b feature
+    "$feat_fn"
+  )
+  echo "$dir"
+}
+
+# run_case <name> <dir> <expected_exit> <expected_stderr_substr|""> <command>
+run_case() {
+  local name="$1" dir="$2" expected_exit="$3" expected_substr="$4" cmd="$5"
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  ( cd "$dir" && echo "$(make_payload "$cmd")" | "$HOOK" ) 2> "$stderr_file"
+  local actual_exit=$?
+  local stderr_content
+  stderr_content=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+
+  local ok=1
+  if [ "$actual_exit" != "$expected_exit" ]; then ok=0; fi
+  if [ -n "$expected_substr" ]; then
+    echo "$stderr_content" | grep -qF -- "$expected_substr" || ok=0
+  else
+    [ -n "$stderr_content" ] && ok=0
+  fi
+
+  if [ "$ok" = 1 ]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name"
+    echo "   expected exit=$expected_exit, got $actual_exit"
+    [ -n "$expected_substr" ] && echo "   expected stderr to contain: $expected_substr"
+    echo "   stderr was: $stderr_content"
+    FAIL=$((FAIL + 1))
+  fi
+
+  rm -rf "$dir"
+}
+
+write_control_hook() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+#!/bin/bash
+# CLASS: CONTROL (AgDR-0104 labelling). Test fixture placeholder.
+echo hi
+EOF
+}
+
+write_plain_hook() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+#!/bin/bash
+# A plain advisory hook, no CLASS header.
+echo hi
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: PR touches a CONTROL hook → nudge fires, exit 0.
+# ---------------------------------------------------------------------------
+c1_base() {
+  write_control_hook .claude/hooks/block-unreviewed-merge.sh
+  git add .claude/hooks/block-unreviewed-merge.sh
+  git commit -q -m "base: add control hook"
+}
+c1_feat() {
+  echo "# tweak" >> .claude/hooks/block-unreviewed-merge.sh
+  git add .claude/hooks/block-unreviewed-merge.sh
+  git commit -q -m "feat: tweak control hook"
+}
+dir=$(setup_repo c1_base c1_feat)
+run_case "PR touching a CONTROL hook fires the nudge (exit 0)" "$dir" 0 \
+  "ADVISORY: this PR touches trust-chain CONTROL hook(s) [block-unreviewed-merge.sh]" \
+  "gh pr create --base main --title t --body b"
+
+# ---------------------------------------------------------------------------
+# Case 2: PR touches a non-CONTROL hook → silent, exit 0.
+# ---------------------------------------------------------------------------
+c2_base() {
+  write_plain_hook .claude/hooks/suggest-ticket-template.sh
+  git add .claude/hooks/suggest-ticket-template.sh
+  git commit -q -m "base: add plain hook"
+}
+c2_feat() {
+  echo "# tweak" >> .claude/hooks/suggest-ticket-template.sh
+  git add .claude/hooks/suggest-ticket-template.sh
+  git commit -q -m "feat: tweak plain hook"
+}
+dir=$(setup_repo c2_base c2_feat)
+run_case "PR touching a non-CONTROL hook is silent (exit 0)" "$dir" 0 "" \
+  "gh pr create --base main --title t --body b"
+
+# ---------------------------------------------------------------------------
+# Case 3: PR touches an unrelated file (not under .claude/hooks/) → silent.
+# ---------------------------------------------------------------------------
+c3_base() {
+  write_control_hook .claude/hooks/block-unreviewed-merge.sh
+  mkdir -p src
+  echo "export const x = 1" > src/widget.ts
+  git add .claude/hooks/block-unreviewed-merge.sh src/widget.ts
+  git commit -q -m "base: add control hook + widget"
+}
+c3_feat() {
+  echo "export const x = 2" > src/widget.ts
+  git add src/widget.ts
+  git commit -q -m "feat: tweak widget only"
+}
+dir=$(setup_repo c3_base c3_feat)
+run_case "PR touching an unrelated file is silent (exit 0)" "$dir" 0 "" \
+  "gh pr create --base main --title t --body b"
+
+# ---------------------------------------------------------------------------
+# Case 4: command is not `gh pr create` → silent, exit 0, regardless of diff.
+# ---------------------------------------------------------------------------
+dir=$(setup_repo c1_base c1_feat)
+run_case "non-'gh pr create' command is silent (exit 0)" "$dir" 0 "" \
+  "gh pr list --state open"
+
+# ---------------------------------------------------------------------------
+# Case 5: PR touches TWO CONTROL hooks → nudge names both, exit 0.
+# ---------------------------------------------------------------------------
+c5_base() {
+  write_control_hook .claude/hooks/block-unreviewed-merge.sh
+  write_control_hook .claude/hooks/block-merge-on-red-ci.sh
+  git add .claude/hooks/block-unreviewed-merge.sh .claude/hooks/block-merge-on-red-ci.sh
+  git commit -q -m "base: add two control hooks"
+}
+c5_feat() {
+  echo "# tweak" >> .claude/hooks/block-unreviewed-merge.sh
+  echo "# tweak" >> .claude/hooks/block-merge-on-red-ci.sh
+  git add .claude/hooks/block-unreviewed-merge.sh .claude/hooks/block-merge-on-red-ci.sh
+  git commit -q -m "feat: tweak both control hooks"
+}
+dir=$(setup_repo c5_base c5_feat)
+stderr_file=$(mktemp)
+( cd "$dir" && echo "$(make_payload "gh pr create --base main --title t --body b")" | "$HOOK" ) 2> "$stderr_file"
+rc=$?
+content=$(cat "$stderr_file")
+rm -f "$stderr_file"
+if [ "$rc" = 0 ] && echo "$content" | grep -qF "block-unreviewed-merge.sh" && echo "$content" | grep -qF "block-merge-on-red-ci.sh"; then
+  echo "PASS: PR touching two CONTROL hooks names both in the nudge (exit 0)"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: PR touching two CONTROL hooks names both in the nudge (exit 0)"
+  echo "   rc=$rc stderr=$content"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$dir"
+
+# ---------------------------------------------------------------------------
+# Case 6: unresolvable base branch (AND no fallback candidate resolves
+# either — the repo's default branch is deliberately named "trunk", not
+# "main"/"master", so origin/dev, upstream/dev, origin/main, upstream/main,
+# main, and master all miss too) → silent, exit 0 (no crash).
+# ---------------------------------------------------------------------------
+dir=$(mktemp -d -t nudge-control.XXXXXX)
+(
+  cd "$dir" || exit 1
+  git init -q -b trunk
+  git config user.email t@t.test
+  git config user.name test
+  echo "company: test" > onboarding.yaml
+  mkdir -p .claude/hooks
+  git add onboarding.yaml
+  git commit -q -m init
+  c1_base
+  git checkout -q -b feature
+  c1_feat
+)
+run_case "unresolvable --base branch (no fallback ref either) is silent (exit 0)" "$dir" 0 "" \
+  "gh pr create --base nonexistent-branch-xyz --title t --body b"
+
+# ---------------------------------------------------------------------------
+# Case 7: the hook NEVER exits non-zero, even when it fires. This is the
+# load-bearing property (advisory, not a gate) — assert it explicitly beyond
+# case 1's exit-code check, scanning across every case run above implicitly
+# already covers this, but pin it once more with an unambiguous name so a
+# future edit that flips the hook to `exit 2` fails loudly here too.
+# ---------------------------------------------------------------------------
+dir=$(setup_repo c1_base c1_feat)
+run_case "hook is non-blocking: exit 0 even when the nudge fires" "$dir" 0 \
+  "Non-blocking — this is a reminder, not a gate." \
+  "gh pr create --base main --title t --body b"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "== $PASS passed, $FAIL failed =="
+[ "$FAIL" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -210,6 +210,11 @@
           },
           {
             "type": "command",
+            "if": "Bash(gh pr create *)",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/nudge-control-adversarial-test.sh\"'"
+          },
+          {
+            "type": "command",
             "if": "Bash(gh issue comment *)",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-private-refs-in-public-repos.sh\"'"
           },

--- a/docs/agdr/AgDR-0117-trust-chain-meta-gate-stays-advisory.md
+++ b/docs/agdr/AgDR-0117-trust-chain-meta-gate-stays-advisory.md
@@ -1,0 +1,128 @@
+---
+id: AgDR-0117
+timestamp: 2026-08-01T10:00:00Z
+agent: claude (Platform Engineer — Adel)
+model: claude-sonnet-5
+trigger: user-prompt
+status: executed
+---
+
+# The CI meta-gate stays unbuilt; a lightweight advisory nudge ships instead
+
+> In the context of me2resh/apexyard#1057 asking for a blocking CI check that fails when a
+> trust-chain hook has no paired adversarial test — the one acceptance criterion from #1015
+> that never shipped — I decided to **reject the blocking meta-gate a second time and ship a
+> lightweight, non-blocking advisory nudge instead** to achieve a cheap reminder at PR-creation
+> time without adding a new hard-to-satisfy gate to every future trust-chain edit, accepting
+> that a contributor who ignores the nudge (or removes it) faces no mechanical consequence, and
+> that AgDR-0104's meta-gate deferral stays formally deferred and undischarged.
+
+## Context
+
+- **The unshipped AC.** #1015 (closed after v5.3.0) had six acceptance criteria; five shipped.
+  The sixth — "CI fails when a trust-chain hook has no paired adversarial test" — was split out
+  into #1057 rather than dropped, because it is the AC that matters most for the future: every
+  trust-chain bypass found so far (AgDR-0104's #962/#965, then #1026, then the extraction bug
+  behind #1032) was found by a human reading the hook, not by a test failing.
+- **AgDR-0104 already deferred this exact gate**, with an explicit trigger: "a third *independent*
+  bypass incident proves the class recurs." **AgDR-0111 later narrowed that trigger further**, to
+  "a new **control** (not a backstop) is added to the trust chain" — and explicitly declined to
+  build the meta-gate at that time, on the grounds that a resolver capable of deciding "is this
+  marker write confidently resolved" had just demonstrated it could not be trusted to decide
+  correctly, and a permanent CI cost was the wrong price to pay to manage a defect class a
+  different decision (making the marker-write hook plain-advisory) was simultaneously removing.
+- **AgDR-0111's narrowed trigger has NOT fired.** No new CONTROL-class hook has been added to the
+  trust chain since AgDR-0111. #1057 is not evidence the trigger fired; it is a re-ask of the same
+  question AgDR-0104 and AgDR-0111 already answered, absent new evidence.
+- **A Solution-Architect design pass + a Contrarian (Naqid) challenge on #1057's proposed gate
+  surfaced three independent problems with building it now:**
+  1. **Zero current coverage gap.** All four CONTROL-labelled merge-gate hooks
+     (`block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, `require-architecture-review.sh`,
+     `require-design-review-for-ui.sh`) already ship adversarial tests — tests that try to defeat
+     the control (variable indirection, missing `jq`, stale SHA, wrong role marker), not just
+     confirm the happy path. The gate #1057 asks for would pass, silently, on the exact tree it
+     was filed against. There is nothing to catch today.
+  2. **The spec'd gate is defeatable by construction — the same "text-matching cannot be made
+     sound" finding AgDR-0104 already recorded, one layer up.** #1057's own scope section asks for
+     an "explicit, reviewable list" of trust-chain hooks (to avoid a path glob silently pulling in
+     everything) — but a hand-maintained list is defeated by simple omission: add a new CONTROL
+     hook, forget the list entry, the gate never evaluates it. And "a naming convention plus a
+     required marker comment in the test file" (#1057's own suggested definition of "paired
+     adversarial test") is defeated by a strawman: a test file with the right name and the right
+     marker comment that asserts nothing more than a token string appears in the hook's source.
+     Both holes are the identical shape AgDR-0104 named for `warn-review-marker-write.sh`: a
+     control implemented as pattern-matching over text (a config list, a marker string) cannot be
+     made sound against an adversary who knows the pattern.
+  3. **It duplicates a stronger existing signal.** me2resh/apexyard#871 ships a scheduled,
+     credentialed conformance job that drives a *real agent turn* through opencode, pi, and Codex
+     and asserts the delegated trust-chain hook actually fires — proving the control works in a
+     live harness, not just that a same-named test file exists beside it. A meta-gate that checks
+     "is there a file claiming to be an adversarial test" is a strictly weaker proxy for "does this
+     control actually hold" than a job that already checks the real thing.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Hard CI meta-gate** (#1057 as filed — blocking, fails when a CONTROL hook has no paired adversarial test) | Directly satisfies the unshipped #1015 AC; matches its own stated bar ("gets the same treatment it imposes") | Zero current gap to close (all 4 CONTROL hooks already covered); defeatable by list-omission and by a strawman marker-comment test; duplicates #871's stronger live-conformance signal; permanent tax on every future trust-chain PR — exactly the "ceremony contributors route around" risk #1015's own Risks section warned against |
+| **Label-derived gate** (skip the hand-maintained list; require every `.claude/hooks/tests/test_*.sh` whose target hook has a CLASS header to also carry a matching marker comment, enforced in CI) | Removes the list-omission hole specifically | Still defeatable by the strawman-test hole; still a new permanent CI requirement; still duplicates #871; the label-derivation trick this option borrows is exactly what the shipped nudge below reuses, but as an *advisory* signal, not a blocking one |
+| **Advisory nudge — CHOSEN** (non-blocking hook on `gh pr create`, derives the CONTROL set from each hook's own `# CLASS: CONTROL` header at grep time, prints a one-line reminder when a touched hook is in that set) | No new hard gate; costs nothing when it doesn't fire; the CONTROL set can't be defeated by omission because it isn't a separate list — a hook can only escape detection by removing its own header, which is a loud, reviewable, self-incriminating edit; matches the "self-discipline primary, cheap mechanical reminder secondary" lineage of AgDR-0104/AgDR-0111 | Provides no mechanical consequence if ignored; doesn't prove a test is genuinely adversarial (no gate does, without executing an adversarial harness — see #871) |
+| **Stay deferred, ship nothing** | Cheapest; honest about the trigger not having fired | #1057 asked for *something*; a pure no-op leaves the acceptance-criteria question unanswered a second time and gives future readers no artifact explaining why |
+
+## Decision
+
+Chosen: **the advisory nudge**, with the blocking meta-gate rejected a second time on its merits
+(not merely "deferred by default").
+
+1. **The blocking CI meta-gate is not built.** AgDR-0104's deferral is **not discharged** by this
+   decision — it remains deferred under AgDR-0111's narrowed trigger ("a new CONTROL is added to
+   the trust chain"), which has not fired. #1057 is closed by this AgDR as answered-on-the-merits,
+   not left open awaiting the gate.
+2. **A new advisory hook ships**: `.claude/hooks/nudge-control-adversarial-test.sh`, wired to
+   `PreToolUse` on `Bash(gh pr create *)` in `.claude/settings.json`. On every `gh pr create`, it
+   computes the PR's changed-file diff vs. its base branch; if any changed file is a
+   `.claude/hooks/*.sh` file whose own header carries `# CLASS: CONTROL`, it prints one line to
+   stderr naming the touched hook(s) and pointing at AgDR-0104/AgDR-0117, then **always exits 0**.
+   It never blocks, never writes a marker, and is silent in every other case (wrong command,
+   unresolvable base, no CONTROL hook touched, empty diff).
+3. **The CONTROL set is derived from the hooks' own headers, not a config list** — directly
+   closing the Contrarian's list-omission finding. The hook greps every `.claude/hooks/*.sh` file
+   for `^# CLASS: CONTROL` at invocation time; there is no second place to keep in sync, and no
+   silent-omission failure mode. A hook can only stop being flagged by removing its own header,
+   which is visible in the diff the nudge is reacting to.
+4. **A paired test ships with the hook** (`.claude/hooks/tests/test_nudge_control_adversarial_test.sh`),
+   asserting the nudge fires on a CONTROL-hook diff, stays silent on a non-CONTROL diff, and —
+   the load-bearing property — **never exits non-zero**, including in the case where it fires.
+
+## Consequences
+
+- Contributors touching `block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`,
+  `require-architecture-review.sh`, or `require-design-review-for-ui.sh` (today's CONTROL set) get
+  a one-line reminder at PR-creation time to add or update an adversarial test. Nothing stops the
+  PR if they don't.
+- Adding a fifth CONTROL hook in the future requires no config update to be picked up by the
+  nudge — only the new hook's own `# CLASS: CONTROL` header, which its author is already writing
+  per AgDR-0104's labelling convention.
+- **AgDR-0104's meta-gate deferral remains open**, narrowed by AgDR-0111 to "a new control is
+  added to the trust chain." This AgDR does not change that trigger. If it fires, the meta-gate
+  question should be re-litigated fresh against whatever the new control actually is — not
+  resolved by analogy to this decision.
+- **Accepted exposure:** a contributor can ignore the nudge, or edit the hook to remove its own
+  `# CLASS: CONTROL` header to silence it, with no mechanical consequence either way. Both are
+  visible, reviewable diffs — the same "visible rule violation, not an invisible one" trade-off
+  AgDR-0104 and the framework's other advisory hooks already accept.
+- me2resh/apexyard#1057 is closed as answered by this AgDR: the requested gate is rejected on the
+  merits described above, and the lighter artifact that ships instead is this hook + its test.
+
+## Artifacts
+
+- Ticket: me2resh/apexyard#1057 (this AgDR's driver), me2resh/apexyard#1015 (the parent, closed at
+  v5.3.0), me2resh/apexyard#871 (the conformance framework this would have duplicated)
+- Hook: `.claude/hooks/nudge-control-adversarial-test.sh`
+- Test: `.claude/hooks/tests/test_nudge_control_adversarial_test.sh`
+- Settings wiring: `.claude/settings.json` — `PreToolUse` → `Bash(gh pr create *)`
+- **Re-affirms, does not discharge**: [AgDR-0104](AgDR-0104-trust-chain-controls-vs-backstops.md)'s
+  deferred CI meta-gate, under [AgDR-0111](AgDR-0111-marker-gate-plain-advisory.md)'s narrowed
+  trigger ("a new control is added to the trust chain") — unfired as of this decision.
+- Informed by: a Solution Architect design pass and a Contrarian (Naqid) challenge on #1057's
+  originally-proposed gate design.


### PR DESCRIPTION
## Summary

- **Rejects the blocking CI meta-gate #1057 asked for.** #1015's sixth acceptance criterion — "CI fails when a trust-chain hook has no paired adversarial test" — never shipped and was split into #1057. A Solution-Architect design pass plus a Contrarian (Naqid) challenge found the gate has **zero current value** (all four CONTROL-class merge-gate hooks already carry adversarial tests), is **defeatable by construction** (a hand-maintained trust-chain list is beaten by omission; a "naming convention + marker comment" definition of "adversarial test" is beaten by a strawman test that asserts nothing), and would **duplicate #871**'s stronger live-conformance job, which already proves these hooks fire against a real credentialed agent turn. AgDR-0104's meta-gate deferral (narrowed by AgDR-0111 to "a new control is added to the trust chain") has not had its trigger fire, so this isn't overdue work — it's a second look that confirms the earlier call.
- **Ships a lightweight advisory nudge instead** — `.claude/hooks/nudge-control-adversarial-test.sh`, wired to `PreToolUse` on `gh pr create`. When a PR's diff touches a `.claude/hooks/*.sh` file carrying its own `# CLASS: CONTROL` header, it prints one reminder line pointing at AgDR-0104/AgDR-0117 and **always exits 0** — same non-blocking shape as `detect-role-trigger.sh` and `check-upstream-drift.sh`.
- **Derives the CONTROL set from the hooks' own headers, not a config list** — the exact fix for the Contrarian's list-omission finding. A hook can only escape the nudge by removing its own `# CLASS: CONTROL` header, which is a loud, reviewable, self-incriminating diff rather than a silent gap in a separate file.
- **Records the decision as AgDR-0117** (`docs/agdr/AgDR-0117-trust-chain-meta-gate-stays-advisory.md`), including the options table (hard gate / label-derived gate / advisory nudge [chosen] / stay-deferred) and an explicit note that AgDR-0104's deferral is **not discharged** by this PR — it stays open under AgDR-0111's narrowed, still-unfired trigger.

## Testing

- `bash .claude/hooks/tests/test_nudge_control_adversarial_test.sh` — 7/7 pass, covering: nudge fires on a CONTROL-hook diff, silent on a non-CONTROL hook diff, silent on an unrelated-file diff, silent on a non-`gh pr create` command, nudge names multiple touched CONTROL hooks, silent when neither `--base` nor any fallback ref resolves, and an explicit pin that the hook **never exits non-zero** even when it fires.
- `shellcheck --severity=warning` clean on both `.claude/hooks/nudge-control-adversarial-test.sh` and its test file.
- `jq . .claude/settings.json` — valid JSON after the new hook entry.
- `npx markdownlint-cli2 docs/agdr/AgDR-0117-*.md` — 0 issues.

Refs #1057

## Glossary

| Term | Definition |
|------|------------|
| Trust chain | The hooks and settings wiring that mechanically enforce the merge, ticket, and marker gates |
| CONTROL vs BACKSTOP | AgDR-0104's distinction: a *control* decides on structured state it can see directly (e.g. a marker SHA vs. the forge-reported PR HEAD); a *backstop* is best-effort local defence behind a real control. Only CONTROL-class hooks trigger this PR's nudge |
| Adversarial test | A test that actively tries to defeat a control (wrong SHA, missing dependency, stale marker) rather than merely confirming the happy path |
| Meta-gate | A CI check that gates the gates — asserts a property about the enforcement machinery itself, rather than about application code |
| Advisory hook | A `PreToolUse`/`PostToolUse` hook that always exits 0 and only prints a reminder — never blocks the underlying command |
