### PR TITLE
docs(#1064): make the Lean tier reachable (accept+document, reduced-scope Rex)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -70,6 +70,34 @@ When the `apexyard-search` MCP is connected, **prefer `mcp__apexyard-search__sea
 
 It also lowers review token cost (targeted semantic excerpts vs. broad `grep` + full-file reads). **Graceful-degrade:** if the MCP server is absent the tool simply isn't available — fall back to `grep`/`Glob`/`Read` with no change in behaviour (same pattern as `search_docs`, `/handover`, and `/code-review`). Adopters who don't run the premium MCP are unaffected.
 
+## Reduced-Scope Review — Lean-tier diffs (Option 4, AgDR-0116)
+
+Per `.claude/rules/right-size-ceremony.md`, a **Lean-tier** diff still requires a Rex pass — the merge gate (`block-unreviewed-merge.sh`) requires the `*-rex.approved` marker on EVERY PR, regardless of tier, unconditionally, because it is a CONTROL that reads structured state (a marker vs. the forge-reported HEAD) and structurally cannot itself inspect a diff's content to decide a tier. What changes for a Lean diff is the **depth** of your pass, never whether one happens.
+
+### Eligibility — ALL of these must hold, or run the full review
+
+1. **Path class.** The diff touches only docs / comments / config-text — `.md`, `.txt`, issue/PR templates, non-executable config values. NOT `.yml`/`.yaml` workflow logic, NOT scripts of any kind, NOT source code in any language.
+2. **Size.** Small — a rough guide is under ~50 changed lines. Use judgment, not a hard cutoff; a 200-line prose rewrite can still be Lean, a 10-line `.md` change that alters a documented gate's behavior might not be.
+3. **Reversibility / behavior.** Trivially reversible in one revert, with no behavior change — no code path, no runtime logic, no schema, no CI step, nothing that executes differently as a result of this diff.
+4. **Rail 1 (non-negotiable — mirrors `right-size-ceremony.md`'s rail 1 exactly; security / trust-chain / migration never goes Lean).** The diff does NOT touch ANY of:
+   - The trust chain: `.claude/hooks/**`, `.claude/settings.json` (me2resh/apexyard#777)
+   - `**/auth/**`, `**/crypto/**`, `**/secrets/**`, `.env*`
+   - A migration path: anything under `**/migrations/**`, `**/migrate-*.{ts,js,py,sql}`, `prisma/schema.prisma`, `prisma/migrations/**`, `src/migrations/*.{ts,js}`, `alembic/versions/*.py`, `db/migrate/*.rb` (the same defaults `require-migration-ticket.sh` matches; check `.migration_paths` in `.claude/project-config.json` for an adopter override too)
+   - **A single file matching ANY of these disqualifies the ENTIRE diff from reduced scope**, even if every other file in the diff is plain prose. Do not average across files — one match rounds the whole PR up.
+5. **Rail 2 (mirrors `right-size-ceremony.md`'s rail 2 exactly — ambiguity rounds up).** If you are unsure whether ANY of conditions 1–4 holds, run the full review. The tolerated failure is an occasional full review on a diff that could have been reduced-scope — never a reduced-scope pass on something that needed the full one.
+
+### What "reduced scope" means
+
+When, and only when, all five conditions above hold, you may skip the deep line-by-line pass over architecture, performance, and test-design nuance, and instead run a FOCUSED pass:
+
+- A correctness read of the actual prose/config change — does it say what it means to say, is it internally consistent, does it match the codebase state it describes.
+- The **mandatory checks that never shrink, at any tier**: PR description quality + Glossary (§ 6), AgDR detection (§ 7, blocking), handbook discovery (§ 8), and the approval-marker mechanics (unchanged — same file, same exact-SHA format, same "APPROVED only" rule).
+- Skip: the Architecture & Design, Code Quality, Testing, Performance checklist items (§§ 1–5) — there is no code here for them to apply to. If any of those sections turns out to have something to say about this diff, that is itself a sign eligibility condition 1 or 3 was wrong — stop and fall back to the full review rather than force a finding into the reduced-scope format.
+
+**Reduced scope changes DEPTH, never the required OUTPUTS.** You still post the human-visible review via `tracker_review_submit`, and you still write the `*-rex.approved` marker on an APPROVED verdict, in the exact same format, at the exact same gate, as every other review. State `(reduced-scope pass — Lean tier, AgDR-0116)` in your review body so the record is honest about which pass ran, and set the `**Scope**` line in the Output Format (below) to `Reduced-scope`.
+
+If any of conditions 1–5 fails, this section does not apply — run the full review from § 1 onward, exactly as you would for a Standard or Heavy diff.
+
 ## Review Checklist
 
 ### 1. Architecture & Design
@@ -779,6 +807,7 @@ Report the failure in plain text with the exact command the caller needs to run.
 ## Code Review: PR #{number}
 
 **Commit**: `{headRefOid}`  ← REQUIRED — always include this.
+**Scope**: `[Full / Reduced-scope — Lean tier, AgDR-0116]`  ← REQUIRED — see § "Reduced-Scope Review".
 
 ### Summary
 [Brief summary of what the PR does]
@@ -831,6 +860,7 @@ Report the failure in plain text with the exact command the caller needs to run.
 8. **Approval marker format is BLOCKING** — on APPROVED verdicts, write the marker at `$REX_MARKER` (the repo-qualified path from `review_marker_path`; form: `.claude/session/reviews/<owner>__<repo>__<pr>-rex.approved`) containing exactly the 40-char HEAD SHA + newline. No labels, no JSON, no extra text. See the "Approval marker — EXACT FORMAT REQUIRED" section above. A malformed marker blocks the merge and forces a rule-violating hand-edit, so getting the format right is as important as the review content.
 9. **Handbooks layer on top of framework rules** — discover and apply handbooks from BOTH the public `handbooks/**/*.md` tree AND (for split-portfolio adopters) the private custom-handbooks dir resolved via `portfolio_custom_handbooks_dir`. See § 8 for the path-convention rules and the discovery shape. Advisory handbooks generate `nit:` / `suggestion:` comments; blocking handbooks (containing `ENFORCEMENT: blocking` at the top of the file) become REQUEST CHANGES verdicts regardless of whether they live in the public or private layer. Adopters extend the standards by adding handbook files; you don't need a code change to teach Rex a new rule.
 10. **Fallow is advisory and fail-soft** — on JS/TS diffs, run the fallow CLI (§ 9) changed-scope and surface a `### Fallow Findings` table + dry-run fix preview. Findings are `nit:` / `suggestion:` only and NEVER flip the verdict on their own. If the `fallow` CLI isn't on PATH, or the diff isn't JS/TS, or `quality.fallow_review` is `false`, skip the step silently and omit the section — no new failure mode. Never run `fallow fix --yes`; the review previews fixes, it doesn't apply them.
+11. **Reduced-scope (Lean tier) changes DEPTH, never REQUIRED OUTPUTS or RAIL 1** — see § "Reduced-Scope Review — Lean-tier diffs" above. The PR description/Glossary check (§ 6), AgDR detection (§ 7, blocking), handbook findings (§ 8), and the approval-marker mechanics are unchanged at every tier — only the depth of the architecture/quality/testing/performance analysis (§§ 1–5) may be skipped, and only when ALL FIVE eligibility conditions hold, with a security / trust-chain / migration path match disqualifying the whole diff unconditionally (rail 1) and any ambiguity falling back to the full review (rail 2). `block-unreviewed-merge.sh` requires your marker regardless of scope — reduced scope is never a reason to skip writing it, and never a reason to skip posting the review.
 
 ## Example Invocation
 

--- a/.claude/hooks/auto-code-review.sh
+++ b/.claude/hooks/auto-code-review.sh
@@ -35,6 +35,18 @@
 # the marker now suppresses a spurious warning rather than unblocking a write.
 # Set it anyway: the convention is what keeps a real review distinguishable
 # from an author reviewing their own work, and the merge gate is what enforces.
+#
+# TIER-AWARE NOTE (me2resh/apexyard#1064, AgDR-0116): the banner below keeps
+# "Rex runs on every PR" completely unconditional — that instruction is
+# NEVER softened by tier, because block-unreviewed-merge.sh requires the Rex
+# marker regardless of tier and is not touched by this change. What IS
+# tier-conditional, per .claude/rules/right-size-ceremony.md, is the ROLE
+# CHAIN around Rex (Security Auditor / Solution Architect / UI Designer) —
+# those already only fire on their own diff/path triggers. Do not read the
+# tier note below as license to skip Rex on a Lean diff; it only ever
+# changes Rex's OWN review depth (reduced-scope, per
+# .claude/agents/code-reviewer.md § "Reduced-Scope Review"), never whether
+# Rex runs.
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
@@ -121,6 +133,15 @@ build sub-agent just handed this PR back to you):
   warning on Rex's own marker write, but that is a side effect, not the
   reason — the hook warns and never blocks since #1026.)
 --------------------------------------------------------------------------
+
+CEREMONY TIER (.claude/rules/right-size-ceremony.md, AgDR-0116): Rex runs on
+EVERY PR, full stop — that instruction above is unconditional and does not
+change by tier. What varies by tier is the ROLE CHAIN layered around Rex
+(Security Auditor / Solution Architect / UI Designer) — those already only
+activate on their own diff/path triggers, never on a self-declared tier. A
+Lean-tier diff (docs / config-text, small, reversible, no behavior change,
+non-security-path) still gets a Rex pass — in REDUCED SCOPE per
+.claude/agents/code-reviewer.md § "Reduced-Scope Review" — never a bypass.
 
 The merge-gate hook will block \`gh pr merge\` for this PR until a Rex approval
 file exists at .claude/session/reviews/${PR_NUMBER:-<pr>}-rex.approved.

--- a/.claude/hooks/tests/test_lean_tier_reachable.sh
+++ b/.claude/hooks/tests/test_lean_tier_reachable.sh
@@ -1,0 +1,361 @@
+#!/bin/bash
+# Tests for me2resh/apexyard#1064 / AgDR-0116 — "the Lean tier is unreachable
+# because the merge gate requires a Rex marker regardless of tier".
+#
+# The maintainer's chosen resolution is Direction 3 (accept & document) +
+# Option 4 (reduced-scope Rex): block-unreviewed-merge.sh is NOT touched and
+# stays unconditional; right-size-ceremony.md and code-reviewer.md are edited
+# instead so the Lean tier's own prose stops promising something the gate
+# forbids, and Rex gets a reduced-scope mode for eligible Lean diffs.
+#
+# Acceptance criterion #5 on the issue: "Tests cover that a security /
+# trust-chain / migration path cannot reach the Lean path under any
+# configuration." This suite pins that at THREE independent points, each
+# with a discriminating assertion (proven to catch a regression, not just a
+# presence check):
+#
+#   1. block-unreviewed-merge.sh's Rex-marker-check block carries no
+#      lean/tier-conditional bypass — proven discriminating by injecting a
+#      synthetic bypass and confirming the SAME detector flags it (case 2).
+#   2. code-reviewer.md's reduced-scope eligibility bar states rail 1
+#      (security/trust-chain/migration disqualifies) and rail 2 (ambiguity
+#      rounds up) explicitly, with the concrete path patterns present —
+#      proven discriminating by stripping the rail-1 list and confirming the
+#      SAME detector then fails (case 5).
+#   3. A pure-bash matcher mirroring code-reviewer.md's documented Lean
+#      eligibility rail 1 rejects every security/trust-chain/migration path
+#      class, even when mixed into an otherwise all-docs diff (cases 11-17).
+#
+# Also pins: the merge gate's unconditional presence-check line is untouched
+# (case 3), right-size-ceremony.md no longer promises "no review sub-agent"
+# for Lean (case 7) while rails 1 & 2 remain verbatim (case 8), and
+# auto-code-review.sh keeps "Rex on every PR" unconditional while adding the
+# tier-aware role-chain note (case 9).
+#
+# Exit 0 = all pass. Exit 1 on any failure.
+
+set -u
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"        # .../.claude/hooks
+CLAUDE_DIR="$(cd "$HOOK_DIR/.." && pwd)"             # .../.claude
+REPO_ROOT="$(cd "$CLAUDE_DIR/.." && pwd)"            # repo root
+
+MERGE_GATE="$HOOK_DIR/block-unreviewed-merge.sh"
+CODE_REVIEWER="$CLAUDE_DIR/agents/code-reviewer.md"
+RIGHT_SIZE_RULE="$CLAUDE_DIR/rules/right-size-ceremony.md"
+AUTO_REVIEW_HOOK="$HOOK_DIR/auto-code-review.sh"
+AGDR_FILE=""
+if [ -d "$REPO_ROOT/docs/agdr" ]; then
+  AGDR_FILE=$(find "$REPO_ROOT/docs/agdr" -maxdepth 1 -iname "AgDR-*-lean-tier-reachable.md" 2>/dev/null | head -1)
+fi
+
+for f in "$MERGE_GATE" "$CODE_REVIEWER" "$RIGHT_SIZE_RULE" "$AUTO_REVIEW_HOOK"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: required file not found: $f" >&2
+    exit 1
+  fi
+done
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+record_pass() { PASS=$((PASS + 1)); echo "PASS: $1"; }
+record_fail() {
+  FAIL=$((FAIL + 1))
+  FAILED_CASES="$FAILED_CASES\n  - $1"
+  echo "FAIL: $1"
+  [ -n "${2:-}" ] && echo "  $2"
+}
+
+# =============================================================================
+# Helper: extract the Rex-marker-check block from block-unreviewed-merge.sh —
+# the exact text between the "--- Rex marker check ---" comment and the next
+# "--- Posted-review check" comment. This is the block that decides whether a
+# merge is blocked for lack of a Rex marker; a tier-conditional bypass would
+# have to live here (or short-circuit before it) to actually relax the gate.
+# =============================================================================
+extract_rex_check_block() {
+  sed -n '/# --- Rex marker check ---/,/# --- Posted-review check/p' "$MERGE_GATE"
+}
+
+# A tier/lean-conditional bypass would introduce one of these tokens into the
+# block that decides whether the merge is blocked. Case-insensitive.
+BYPASS_TOKENS='lean|LEAN|tier|TIER|skip_rex|SKIP_REX|reduced.scope|reduced_scope|REDUCED_SCOPE'
+
+# =============================================================================
+# Case 1: the REAL merge-gate's Rex-check block carries no tier/lean bypass.
+# =============================================================================
+BLOCK=$(extract_rex_check_block)
+if [ -z "$BLOCK" ]; then
+  record_fail "case1: could not extract the Rex-marker-check block from block-unreviewed-merge.sh" \
+    "the anchor comments may have moved — update extract_rex_check_block()"
+elif echo "$BLOCK" | grep -qEi "$BYPASS_TOKENS"; then
+  record_fail "case1: block-unreviewed-merge.sh's Rex-check block contains a tier/lean-conditional token" \
+    "rail 1 requires the merge gate to stay unconditional (AgDR-0116) — it must not be touched by this change"
+else
+  record_pass "case1: block-unreviewed-merge.sh's Rex-check block has no tier/lean bypass"
+fi
+
+# =============================================================================
+# Case 2 (discriminating): prove case 1's detector actually catches a
+# regression. Inject a synthetic tier-conditional bypass into a COPY of the
+# same block and confirm the identical detector flags it. If this case
+# failed, case 1 would be a tautology (a check that can never fail).
+# =============================================================================
+MUTATED_BLOCK="${BLOCK}
+if [ \"\${LEAN_TIER:-}\" = \"lean\" ]; then
+  exit 0
+fi"
+if echo "$MUTATED_BLOCK" | grep -qEi "$BYPASS_TOKENS"; then
+  record_pass "case2: the case-1 detector correctly flags an injected lean-tier bypass (discriminating)"
+else
+  record_fail "case2: the case-1 detector did NOT flag an injected lean-tier bypass" \
+    "this means case 1 could never fail — it is not actually testing anything"
+fi
+
+# =============================================================================
+# Case 3: the merge gate's unconditional presence-check line is intact —
+# `if [ ! -f "$REX_APPROVAL" ]` with no surrounding tier guard. This is the
+# literal line that makes the gate refuse to merge without a Rex marker.
+# =============================================================================
+if grep -qF 'if [ ! -f "$REX_APPROVAL" ]; then' "$MERGE_GATE"; then
+  record_pass "case3: block-unreviewed-merge.sh's unconditional Rex-marker presence check is present"
+else
+  record_fail "case3: block-unreviewed-merge.sh no longer has the unconditional Rex-marker presence check" \
+    "this is the literal gate — its absence or a guard around it would be a rail-1 violation"
+fi
+
+# =============================================================================
+# Helper: extract code-reviewer.md's Reduced-Scope Review section (Option 4).
+# =============================================================================
+extract_reduced_scope_section() {
+  sed -n '/^## Reduced-Scope Review/,/^## Review Checklist/p' "$CODE_REVIEWER"
+}
+
+# The concrete rail-1 path patterns that MUST appear in the eligibility bar —
+# same defaults require-migration-ticket.sh matches (workflow-gates.md §
+# Migration Gate) plus the trust-chain / auth-crypto-secrets patterns from
+# role-triggers.md's Security Auditor trigger table.
+RAIL1_PATTERNS=(
+  '.claude/hooks'
+  '.claude/settings.json'
+  'auth'
+  'crypto'
+  'secrets'
+  '.env'
+  'migrations'
+  'migrate-'
+  'prisma'
+  'alembic'
+  'db/migrate'
+)
+
+# =============================================================================
+# Case 4: code-reviewer.md's Reduced-Scope Review section lists every rail-1
+# path pattern above. Missing even one means a diff touching that path class
+# could be waved through as "eligible" by an agent following the doc literally.
+# =============================================================================
+RS_SECTION=$(extract_reduced_scope_section)
+if [ -z "$RS_SECTION" ]; then
+  record_fail "case4: could not find '## Reduced-Scope Review' section in code-reviewer.md" \
+    "Option 4 (reduced-scope Rex) is required by the AgDR-0116 decision"
+else
+  MISSING=""
+  for pat in "${RAIL1_PATTERNS[@]}"; do
+    if ! echo "$RS_SECTION" | grep -qF "$pat"; then
+      MISSING="$MISSING $pat"
+    fi
+  done
+  if [ -n "$MISSING" ]; then
+    record_fail "case4: code-reviewer.md's Reduced-Scope Review section is missing rail-1 pattern(s)" \
+      "missing:$MISSING"
+  else
+    record_pass "case4: code-reviewer.md's Reduced-Scope Review section lists all rail-1 path patterns"
+  fi
+fi
+
+# =============================================================================
+# Case 5 (discriminating): prove case 4's detector actually catches a
+# regression. Strip the rail-1 pattern list out of a COPY of the section
+# (simulating someone silently deleting it) and confirm the SAME detector
+# then reports missing patterns.
+# =============================================================================
+STRIPPED_SECTION=$(echo "$RS_SECTION" | grep -viE 'auth|crypto|secrets|\.env|migrat|prisma|alembic|hooks|settings\.json')
+STRIPPED_MISSING=""
+for pat in "${RAIL1_PATTERNS[@]}"; do
+  if ! echo "$STRIPPED_SECTION" | grep -qF "$pat"; then
+    STRIPPED_MISSING="$STRIPPED_MISSING $pat"
+  fi
+done
+if [ -n "$STRIPPED_MISSING" ]; then
+  record_pass "case5: the case-4 detector correctly reports missing patterns once the rail-1 list is stripped (discriminating)"
+else
+  record_fail "case5: the case-4 detector still found every pattern after stripping the rail-1 list" \
+    "this means case 4 could never fail — it is not actually testing anything"
+fi
+
+# =============================================================================
+# Case 6: rail 1 and rail 2 language is stated explicitly in the eligibility
+# bar (not just the path list) — "disqualifies the ENTIRE diff" (rail 1) and
+# an explicit fallback to the full review on ambiguity (rail 2).
+# =============================================================================
+if echo "$RS_SECTION" | grep -qi 'disqualif' && echo "$RS_SECTION" | grep -qi 'ambig'; then
+  record_pass "case6: code-reviewer.md's eligibility bar states both rail 1 (disqualifies) and rail 2 (ambiguity) explicitly"
+else
+  record_fail "case6: code-reviewer.md's eligibility bar is missing explicit rail 1 and/or rail 2 language"
+fi
+
+# =============================================================================
+# Case 7: right-size-ceremony.md's Lean row no longer promises "no review
+# sub-agent" (the unfollowable prescription #1064 filed against).
+# =============================================================================
+LEAN_ROW=$(grep -i '^\| \*\*Lean\*\*' "$RIGHT_SIZE_RULE")
+if [ -z "$LEAN_ROW" ]; then
+  record_fail "case7: could not find the Lean row in right-size-ceremony.md's tier table"
+elif echo "$LEAN_ROW" | grep -qi 'no review sub-agent'; then
+  record_fail "case7: right-size-ceremony.md's Lean row still promises 'no review sub-agent'" \
+    "this is the exact unfollowable prescription #1064 was filed against"
+else
+  record_pass "case7: right-size-ceremony.md's Lean row no longer promises 'no review sub-agent'"
+fi
+
+# =============================================================================
+# Case 8: rails 1 & 2 in right-size-ceremony.md remain VERBATIM — the task
+# explicitly required these untouched. Pin two exact sentences.
+# =============================================================================
+RAIL1_SENTENCE='Security and trust-chain never go Lean.'
+RAIL2_SENTENCE='Ambiguity rounds up.'
+if grep -qF "$RAIL1_SENTENCE" "$RIGHT_SIZE_RULE" && grep -qF "$RAIL2_SENTENCE" "$RIGHT_SIZE_RULE"; then
+  record_pass "case8: right-size-ceremony.md's rails 1 & 2 sentences are present verbatim, unchanged"
+else
+  record_fail "case8: right-size-ceremony.md's rail 1 and/or rail 2 sentence was altered or removed" \
+    "the task required rails 1 & 2 to stay verbatim"
+fi
+
+# =============================================================================
+# Case 9: auto-code-review.sh keeps the unconditional Rex-on-every-PR
+# instruction AND adds the tier-aware role-chain note.
+# =============================================================================
+if grep -qi 'requires the code-reviewer agent (Rex)' "$AUTO_REVIEW_HOOK" \
+   && grep -qi 'to run on every PR' "$AUTO_REVIEW_HOOK"; then
+  record_pass "case9a: auto-code-review.sh's unconditional 'Rex on every PR' instruction is present"
+else
+  record_fail "case9a: auto-code-review.sh no longer states the unconditional Rex-on-every-PR instruction"
+fi
+if grep -qi 'CEREMONY TIER' "$AUTO_REVIEW_HOOK" && grep -qi 'ROLE CHAIN' "$AUTO_REVIEW_HOOK"; then
+  record_pass "case9b: auto-code-review.sh's banner adds the tier-aware role-chain note"
+else
+  record_fail "case9b: auto-code-review.sh's banner is missing the tier-aware role-chain note"
+fi
+
+# =============================================================================
+# Case 10: the AgDR-0116 file exists and records the chosen directions.
+# =============================================================================
+if [ -z "$AGDR_FILE" ] || [ ! -f "$AGDR_FILE" ]; then
+  record_fail "case10: could not find docs/agdr/AgDR-*-lean-tier-reachable.md"
+else
+  if grep -qi 'Direction 3' "$AGDR_FILE" && grep -qi 'Option 4' "$AGDR_FILE" \
+     && grep -qi 'unconditional' "$AGDR_FILE"; then
+    record_pass "case10: AgDR-0116 file exists and records Direction 3 + Option 4 + the unconditional gate"
+  else
+    record_fail "case10: AgDR-0116 file exists but is missing expected content (Direction 3 / Option 4 / unconditional)"
+  fi
+fi
+
+# =============================================================================
+# Cases 11-17: a pure-bash matcher mirroring code-reviewer.md's documented
+# Lean eligibility rail 1 (§ "Reduced-Scope Review" condition 4). This
+# operationalizes the prose into a checkable function — since Direction 3
+# ships no mechanical gate exemption (the merge gate itself stays
+# unconditional, per case 1-3 above), this is the closest thing to a
+# "classification helper" the decision produces, and it must fail closed on
+# every security / trust-chain / migration path class, even when mixed into
+# an otherwise all-docs diff.
+# =============================================================================
+is_lean_eligible_pathset() {
+  # Prints "eligible" or "not-eligible: <reason>" for a newline-separated
+  # list of changed file paths, mirroring code-reviewer.md's rail 1 list.
+  local paths="$1" p
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    case "$p" in
+      .claude/hooks/*|.claude/settings.json) echo "not-eligible: trust-chain ($p)"; return ;;
+      */auth/*|auth/*)                       echo "not-eligible: auth ($p)"; return ;;
+      */crypto/*|crypto/*)                   echo "not-eligible: crypto ($p)"; return ;;
+      */secrets/*|secrets/*)                 echo "not-eligible: secrets ($p)"; return ;;
+      .env|.env.*|*/.env|*/.env.*)           echo "not-eligible: dotenv ($p)"; return ;;
+      */migrate-*.ts|*/migrate-*.js|*/migrate-*.py|*/migrate-*.sql) echo "not-eligible: migration-script ($p)"; return ;;
+      */prisma/schema.prisma|*/prisma/migrations/*) echo "not-eligible: prisma ($p)"; return ;;
+      */alembic/versions/*.py)               echo "not-eligible: alembic ($p)"; return ;;
+      */db/migrate/*.rb)                     echo "not-eligible: rails-migration ($p)"; return ;;
+      */migrations/*|migrations/*)           echo "not-eligible: migration-dir ($p)"; return ;;
+      *.md|*.txt)                            : ;;  # docs — eligible on its own
+      *) echo "not-eligible: non-docs path ($p) [condition 1 — not path-class-eligible]"; return ;;
+    esac
+  done <<< "$paths"
+  echo "eligible"
+}
+
+check_not_eligible() {
+  local desc="$1" paths="$2"
+  local result
+  result=$(is_lean_eligible_pathset "$paths")
+  if echo "$result" | grep -q '^not-eligible'; then
+    record_pass "$desc → correctly rejected ($result)"
+  else
+    record_fail "$desc → WAS marked eligible, expected rejection" "result: $result"
+  fi
+}
+
+check_not_eligible "case11: all-docs diff + one file under .claude/hooks/" \
+"README.md
+docs/notes.md
+.claude/hooks/block-unreviewed-merge.sh"
+
+check_not_eligible "case12: all-docs diff + .claude/settings.json" \
+"README.md
+.claude/settings.json"
+
+check_not_eligible "case13: all-docs diff + a file under src/auth/" \
+"docs/guide.md
+src/auth/login.ts"
+
+check_not_eligible "case14: all-docs diff + a migrations/ file" \
+"README.md
+db/migrations/2026_add_column.sql"
+
+check_not_eligible "case15: all-docs diff + prisma/schema.prisma" \
+"docs/notes.md
+prisma/schema.prisma"
+
+check_not_eligible "case16: all-docs diff + alembic/versions migration" \
+"README.md
+alembic/versions/0007_add_index.py"
+
+check_not_eligible "case17: all-docs diff + a bare .env file" \
+"docs/setup.md
+.env"
+
+# Control: a genuinely all-docs diff with no rail-1 hits IS eligible — proves
+# cases 11-17 aren't just failing everything by construction.
+CONTROL_RESULT=$(is_lean_eligible_pathset "README.md
+docs/onboarding/glossary.md
+CHANGELOG.md")
+if [ "$CONTROL_RESULT" = "eligible" ]; then
+  record_pass "case18 (control): a genuinely all-docs diff with no rail-1 hits is marked eligible"
+else
+  record_fail "case18 (control): a genuinely all-docs diff was incorrectly rejected" "result: $CONTROL_RESULT"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo
+echo "===== test_lean_tier_reachable.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failed cases:$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/.claude/rules/right-size-ceremony.md
+++ b/.claude/rules/right-size-ceremony.md
@@ -20,11 +20,13 @@ The signals map to three tiers of ceremony:
 
 | Tier | What it is | Ceremony |
 |------|-----------|----------|
-| **Lean** | docs / comments / config-text, small, trivially reversible, no behavior change | An **inline** correctness read + one approval. **No review sub-agent, no role chain.** |
+| **Lean** | docs / comments / config-text, small, trivially reversible, no behavior change | **No role chain** — no design / security / architecture review sub-agents. One **lightweight Rex pass** (reduced-scope — see `.claude/agents/code-reviewer.md` § "Reduced-Scope Review") + the human merge nod. |
 | **Standard** | ordinary code changes | Rex (one review) + the human merge nod. Unchanged from today. |
 | **Heavy** | trust-chain, auth / crypto / secrets, migrations, design artifacts, large diffs, releases | The **full chain stays** — Rex + Security Auditor / Solution Architect / design review as the paths dictate. Unchanged from today. |
 
 The key realization: the framework **already detects every Heavy class** (the auto-fire triggers in [`role-triggers.md`](role-triggers.md), the migration gate, the architecture-review gate, the design gate). What was missing is the **Lean floor** — so everything not-Heavy was silently treated as Standard-full-ceremony. This rule adds only that floor.
+
+**Why Rex still runs at Lean (AgDR-0116).** The merge gate (`block-unreviewed-merge.sh`) requires a Rex approval marker on every PR, unconditionally, regardless of tier — it is a control that reads structured state (the marker's recorded SHA vs. the PR's HEAD as the forge reports it) and structurally cannot itself inspect a diff's content to decide a tier. Letting the gate skip the marker on a self-declared "Lean" attestation would mean trusting either a self-issued attestation or a path allowlist to gate a merge — both considered and rejected as new forgeable gate-relaxing surfaces (me2resh/apexyard#1064). So the Lean tier's ceremony reduction lives entirely in the **role chain** (Security Auditor / Solution Architect / UI Designer, suppressed) and in **Rex's own review depth** (reduced-scope) — never in whether a review happens at all.
 
 ## Two safety rails (non-negotiable)
 
@@ -37,7 +39,7 @@ A right-sizing heuristic is only safe if it fails in the harmless direction:
 
 Before spinning up review ceremony for a change, classify it:
 
-- **Lean** → do the inline read yourself, state your verdict plainly, and take it to the merge nod. Don't spawn a review sub-agent for a docs-only, small, reversible change.
+- **Lean** → Rex still runs (reduced-scope — a focused correctness read, not the full deep pass) and still writes the approval marker; take it straight to the merge nod afterward. What you skip is the **role chain** — don't spawn Security Auditor / Solution Architect / UI Designer for a docs-only, small, reversible change that doesn't independently trigger one of their own diff/path triggers.
 - **Standard** → the normal Rex + nod flow.
 - **Heavy** → the full chain, unchanged. Never shortcut it.
 
@@ -53,7 +55,7 @@ The other half of the operator's ask ("something to watch the overengineering") 
 
 ```
 [ ] What tier is this change — Lean / Standard / Heavy? (path class + blast radius + behavior)
-[ ] If I'm about to spawn a review sub-agent or role chain, does the change actually warrant it, or is it Lean?
+[ ] If I'm about to spawn a role-chain sub-agent (Security Auditor / Solution Architect / UI Designer) beyond Rex, does the change actually warrant it, or is it Lean? (Rex itself always runs — the merge gate requires it unconditionally; see AgDR-0116.)
 [ ] Does it touch security / trust-chain / a migration? → Heavy, no exceptions (rail 1).
 [ ] Am I unsure of the tier? → round UP (rail 2).
 [ ] Is the process cost (agents, tokens, latency) proportionate to the change size?

--- a/docs/agdr/AgDR-0116-lean-tier-reachable.md
+++ b/docs/agdr/AgDR-0116-lean-tier-reachable.md
@@ -1,0 +1,63 @@
+---
+id: AgDR-0116
+timestamp: 2026-08-01T12:00:00Z
+agent: claude (Platform Engineer — Adel)
+model: claude-sonnet-5
+trigger: user-prompt
+status: executed
+---
+
+# The Lean tier's ceremony is "reduced-scope Rex", not "no Rex" — the merge gate is a control and stays unconditional
+
+> In the context of me2resh/apexyard#1064 (the Lean tier's own rule prescribed "no review sub-agent" for a class of change the merge gate mechanically requires a Rex marker for, making the tier's defining instruction unfollowable in practice), facing a maintainer-scoped choice between four directions surfaced by a Solution-Architect design and stress-tested by a Contrarian challenge, I decided to **accept and document that the merge gate's Rex-marker requirement is unconditional by design (Direction 3), and layer a reduced-scope Rex pass on top for diffs that clear a strict, rail-1-gated eligibility bar (Option 4)** — to achieve a Lean tier the framework can actually deliver work through, without adding any new forgeable gate-relaxing surface, accepting that the shipping-speed benefit is now bounded by "cheaper Rex, not absent Rex" and that for a pure-docs PR the Lean/Standard distinction is mostly about suppressing the role chain, not the merge gate itself.
+
+## Context
+
+- me2resh/apexyard#1064: `right-size-ceremony.md`'s Lean tier prescribed *"inline check + one approval, no review sub-agent"*, but `block-unreviewed-merge.sh` refuses every merge — Lean, Standard, or Heavy — without a `*-rex.approved` marker at HEAD. A documented tier the framework's own delivery path could not satisfy.
+- Observed cost on one static-HTML, docs-only session: 4 PRs, 6 Rex sub-agent runs, ~850k review-agent tokens, ~41 minutes of review wall-clock, entirely on copy/presentation changes with no runtime behavior. SHA-bound markers compounded this — two of the four PRs paid for a full second review to land a one-word wording fix.
+- `block-unreviewed-merge.sh` is a CONTROL in the AgDR-0104 sense: it reads structured state (a marker's recorded SHA vs. the PR's HEAD **as the forge reports it**) rather than pattern-matching command text. That is exactly the property that makes it trustworthy, and exactly the property that makes it structurally incapable of inspecting the diff's own content to decide a tier — tier classification needs to read the diff; the gate deliberately does not.
+- The issue itself named the trap: any direction that lets the gate skip the marker on a self-declared "Lean" attestation mints a **new forgeable surface** — the same shape of hole #843, #1011, and #1026 spent multiple rounds closing. Rail 1 (security / trust-chain / migration never Lean) has to hold **mechanically**, not just in prose, for any tier-aware gate change to be acceptable — and a marker whose trustworthiness depends on the model's own tier self-report cannot deliver that.
+- A Solution-Architect design pass and a Contrarian challenge (`/challenge`) were run on the four directions before this decision; the Contrarian's central point survives into this record as the "Honesty note" below.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **1 — Tier-aware attestation marker.** A new marker kind recording "checked inline by the orchestrator, Lean tier, path class X" that the gate accepts in place of a Rex marker. | Makes the rule's own prescription literally executable; cheapest ceremony reduction | **Rejected.** A self-issued attestation is exactly the gate-relaxing forgeable surface #843/#1011/#1026 spent multiple rounds closing. The party best positioned to mis-tier a change under token/time pressure is the same party issuing the attestation that exempts it. |
+| **2 — Path-class exemption.** Config-listed path globs whose PRs never require a Rex marker. | Cheap, inspectable, no new marker kind | **Rejected.** Still a gate-relaxing surface — a config edit (or a diff that merely touches a listed path alongside something else) becomes a merge-gate bypass. Rail 1 would have to be re-implemented as a second, independent path-exclusion check inside the merge gate itself, duplicating logic the gate doesn't currently need to have. Both 1 and 2 are deferred as explicit **Heavy** trust-chain projects, pursued only if re-review churn proves intolerable, and only under the AgDR-0104/0111/0112 constraints: forge-derived tier (never self-reported), fail-closed to full ceremony on any doubt, rail 1 enforced *inside* the gate itself (not just in prose), the CEO nod preserved, and a paired adversarial bypass test before merge, not after. |
+| **3 — Accept & document. (CHOSEN)** Decide the marker requirement is unconditional by design; amend `right-size-ceremony.md` so the Lean tier stops promising something the gates will not permit. | Cheapest, safest, adds zero new gate-relaxing surface, honest about what the rule actually controls | Loses the shipping-speed benefit the rule was written to deliver, on its own — see Option 4 |
+| **4 — Reduced-scope Rex on Lean diffs. (CHOSEN, layered on 3)** Rex runs a focused pass (correctness read + the mandatory checks) instead of the full deep review, when a diff clears a strict eligibility bar. | Recovers most of the token/latency cost Option 3 alone leaves on the table, without touching the gate at all — the reduction lives entirely inside Rex's own review depth, a decision Rex already makes every run | The eligibility bar is itself agent judgment (Rex's own classification), same enforcement shape as the rest of `right-size-ceremony.md` — bounded by rail 1 stated explicitly in Rex's own instructions, and by rail 2 (ambiguity falls back to the full review) |
+
+## Decision
+
+Chosen: **Direction 3 (accept & document) + Option 4 (reduced-scope Rex), layered.**
+
+The merge gate (`block-unreviewed-merge.sh`) requires a Rex marker **regardless of tier — unconditionally, by design, unchanged by this decision.** It is a control, and a control that reads structured state (marker SHA vs. forge-reported HEAD) cannot also be the thing deciding whether a diff qualifies for lighter treatment; letting it try would mean trusting either a self-issued attestation (Option 1) or a config-path allowlist (Option 2) to gate a merge — both rejected above as new forgeable surfaces.
+
+What *does* change: `right-size-ceremony.md`'s Lean-tier ceremony is redefined from "no review sub-agent" (unfollowable, per #1064) to "no role chain — no design / security / architecture review sub-agents — one lightweight Rex pass + the human merge nod." Rex's own instructions (`.claude/agents/code-reviewer.md`) gain a reduced-scope mode: on a diff that clears a strict, rail-1-gated eligibility bar (docs/config-text only, small, trivially reversible, no behavior change, AND — non-negotiably — no security / trust-chain / migration path touched, with ambiguity always falling back to the full review), Rex runs a focused correctness read instead of the full architecture/quality/testing/performance pass. The **required outputs never shrink**: the human-visible review is still posted, the `*-rex.approved` marker is still written in the exact same format, on the exact same conditions, at the exact same gate. Only the *depth* of the review varies.
+
+`auto-code-review.sh`'s banner is updated to say this precisely: Rex runs on every PR, full stop, unconditionally — that instruction stays crisp and is not softened. What is now tier-conditional is the **role chain** layered around Rex (Security Auditor / Solution Architect / UI Designer), which already only activates on its own triggers.
+
+### Honesty note (from the Contrarian challenge)
+
+For a **pure `.md` diff**, Lean and Standard were already mechanically identical before this decision, and remain so after it: only Rex auto-fires on a docs PR (`auto-code-review.sh` fires on every `gh pr create`, full stop); Tariq, the Security Auditor, and the UI design gate do not auto-fire on `.md` paths at all (see `role-triggers.md`'s diff/path trigger table — none of their trigger globs match plain markdown). So the tier delta this decision actually buys is narrower than "Lean means less ceremony" suggests in the abstract: it mainly (a) suppresses the role chain on **non-.md Lean paths** that would otherwise trigger a role (a small `.yml` config tweak, a UI copy string, a config-text file under a path a role trigger's glob happens to match), and (b) reduces Rex's own review depth via Option 4, which applies uniformly regardless of file extension. Recording this precisely, rather than letting "Lean tier" read as a bigger win than it is, is the corrective this AgDR owes the record — `right-size-ceremony.md`'s own value for a pure-docs change was always going to be the Standard/Heavy distinction and the disproportion nudge, not a Lean-specific gate exemption, exactly as the issue's own Risk section anticipated.
+
+## Consequences
+
+- `block-unreviewed-merge.sh` is **not touched** by this decision and stays exactly as strict as before — no new marker kind, no path-exemption logic, no tier-conditional branch of any kind added to the gate. Rail 1 and rail 2 in `right-size-ceremony.md` are unchanged verbatim.
+- `right-size-ceremony.md` no longer prescribes something the gate forbids — the Lean row and the "When to apply" guidance now describe a reduced-scope Rex pass, not an absent one.
+- `.claude/agents/code-reviewer.md` gains an explicit, rail-1-gated eligibility bar for reduced-scope review, with **any** security / trust-chain / migration path match disqualifying the whole diff, and ambiguity always falling back to the full review (rail 2). The required review outputs (posted review, marker format, AgDR/glossary/handbook checks) are unchanged at every tier.
+- `auto-code-review.sh`'s banner keeps the unconditional "Rex runs on every PR" instruction crisp (preserving the #843 fix's dual-reader clarity) and adds, without diluting it, that the role chain around Rex is what varies by tier.
+- The per-run cost reduction is real but bounded: a Lean diff still spawns a Rex sub-agent, still produces a review, still writes a marker — the savings are in review depth (tokens, wall-clock), not in whether a review happens at all. Options 1 and 2 remain the deferred path to a bigger reduction, gated on the constraints stated above and a genuine third incident of re-review churn proving this insufficient.
+- Tests (`.claude/hooks/tests/test_lean_tier_reachable.sh`) pin rail 1 at three independent points — the merge gate's Rex-check block (no lean/tier bypass), Rex's own eligibility bar (security / trust-chain / migration paths always disqualify), and the rule text itself — each with a discriminating (proven-would-catch-a-regression) assertion, not just a presence check.
+
+## Artifacts
+
+- me2resh/apexyard#1064 (the gap this decision closes)
+- `.claude/rules/right-size-ceremony.md` (Lean row + "When to apply" + self-check; rails 1 & 2 unchanged)
+- `.claude/hooks/auto-code-review.sh` (tier-aware banner note; Rex-unconditional instruction unchanged)
+- `.claude/agents/code-reviewer.md` (Reduced-Scope Review section, Output Format `Scope` line, Rule 11)
+- `.claude/hooks/tests/test_lean_tier_reachable.sh`
+- AgDR-0104 (control vs. backstop framing — why the gate can't also be the tier classifier)
+- AgDR-0107 (the original Lean-tier rule this decision corrects)
+- AgDR-0111 / AgDR-0112 (prior rounds establishing that gate trust must rest on forge-reported state, never a local self-report)


### PR DESCRIPTION
## Summary

- **Records the maintainer's decision on #1064 as AgDR-0116** — Direction 3 (accept & document), layered with Option 4 (reduced-scope Rex). The Lean tier's own rule promised "no review sub-agent," but `block-unreviewed-merge.sh` requires a Rex marker on **every** PR regardless of tier — a documented tier the framework's own delivery path couldn't satisfy. This decision says why the gate stays unconditional (it's a control that reads structured state and structurally can't inspect a diff to pick a tier), rejects the two gate-relaxing options (a self-issued attestation marker, a path-class exemption) as new forgeable surfaces in the shape of #843/#1011/#1026, and records the Contrarian-surfaced honesty note: for a pure `.md` diff, Lean and Standard were already mechanically identical before this change (only Rex auto-fires on docs; Tariq/Security/UI design don't).
- **`block-unreviewed-merge.sh` is untouched — zero diff.** The merge gate stays exactly as strict as it was; this PR does not add a new marker kind, a path-exemption branch, or any tier-conditional logic to the gate. Verified with `git diff --stat` (empty) and pinned by the new test suite (case 1–3).
- **`right-size-ceremony.md`'s Lean row stops promising what the gate forbids.** It now reads "no role chain — no design/security/architecture review sub-agents — one lightweight Rex pass + the human merge nod," and the "When to apply" / self-check sections were updated to match. Rails 1 & 2 (security/trust-chain never Lean; ambiguity rounds up) are kept **verbatim** — this PR only touches the Lean-tier prescription, never the rails.
- **`auto-code-review.sh`'s banner gets a tier-aware note without softening the #843 fix.** "Rex runs on every PR" stays completely unconditional and crisp for both banner readers (build sub-agent / orchestrator); the new note clarifies that what actually varies by tier is the **role chain** around Rex (Security Auditor / Solution Architect / UI Designer), which already only fires on its own diff/path triggers.
- **`code-reviewer.md` gains "Reduced-Scope Review" (Option 4).** On a diff that clears a strict 5-condition eligibility bar (docs/config-text only, small, trivially reversible, no behavior change, **and** no security/trust-chain/migration path touched — a single match disqualifies the whole diff), Rex may run a focused correctness pass instead of the full architecture/quality/testing/performance review. The required outputs never shrink: the posted review, the exact-SHA marker, the Glossary/AgDR/handbook checks are unchanged at every tier — only review *depth* varies, which is the actual lever behind the token/latency savings the issue's Observed Cost section documented (~850k tokens / ~41 min across 4 docs-only PRs).
- **New test — `test_lean_tier_reachable.sh`, 19 cases** — pins AC#5 (a security/trust-chain/migration path can never reach the Lean path) at three independent points, each with a *discriminating* pair (a check plus a companion case proving the check would actually catch a regression, not just pass tautologically): the merge gate's Rex-check block carries no lean/tier bypass token (cases 1–2), `code-reviewer.md`'s eligibility bar lists every rail-1 path pattern (cases 4–5), and a fail-closed path matcher mirroring the documented rail correctly rejects every security/trust-chain/migration path class even mixed into an otherwise all-docs diff (cases 11–18).

## Testing

```
bash .claude/hooks/tests/test_lean_tier_reachable.sh
# 19 passed, 0 failed

shellcheck --severity=warning .claude/hooks/auto-code-review.sh .claude/hooks/tests/test_lean_tier_reachable.sh
# clean, exit 0

npx --yes markdownlint-cli2 docs/agdr/AgDR-0116-lean-tier-reachable.md \
  .claude/rules/right-size-ceremony.md .claude/agents/code-reviewer.md
# 0 issues in 3 files

bash bin/run-hook-tests.sh
# PASS=132 FAIL=1 SKIP=0 TOTAL=133
# the one failure (2 sub-cases) is test_block_merge_on_red_ci.sh's
# "glab-registered project" wrapper-dispatch cases — a file this PR does
# not touch, about CI-status forge dispatch via the project registry,
# unrelated to the Lean-tier/AgDR-0116 change. Confirmed pre-existing and
# unrelated by running it in isolation and inspecting the failure (registry
# dispatch resolving to gh instead of glab for a glab-registered project —
# nothing to do with Rex, tiers, or review scope).
```

`git diff --stat -- .claude/hooks/block-unreviewed-merge.sh` is empty — the merge gate is not part of this diff.

Refs #1064

## Glossary

| Term | Definition |
|------|------------|
| Lean tier | `right-size-ceremony.md`'s lightest ceremony class — small, reversible, no-behavior-change diffs. Previously prescribed "no review sub-agent"; this PR redefines it to "no role chain, reduced-scope Rex." |
| Rail 1 | The right-size-ceremony rule's non-negotiable: security / trust-chain / migration diffs never go Lean, regardless of size. Unchanged by this PR; also now stated explicitly in Rex's own reduced-scope eligibility bar. |
| Rail 2 | The rule's other non-negotiable: ambiguity always rounds up to more ceremony, never down. |
| Control vs. backstop | AgDR-0104's distinction — a control reads structured state to make a decision (e.g. `block-unreviewed-merge.sh` comparing a marker SHA to the forge-reported HEAD); a backstop is advisory text-matching. The merge gate is a control, which is why it can't also be the thing deciding a diff's tier. |
| Reduced-scope Rex | Option 4 — Rex running a focused correctness pass instead of the full deep review, on a diff that clears the 5-condition eligibility bar. Changes review *depth*, never whether a review happens or what it's required to output. |
| Role chain | The set of role sub-agents (Security Auditor, Solution Architect, UI Designer) layered around Rex on Standard/Heavy diffs. This is what the Lean tier actually suppresses — Rex itself always runs. |
