### PR TITLE
feat(#1086): migrate block-main-push onto the shared lib, add --no-verify block, relabel as blocking backstop

### DIFF
--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -1,8 +1,45 @@
 #!/bin/bash
-# Blocks direct pushes and commits to long-lived integration branches.
-# All changes must go through pull requests.
+# CLASS: BACKSTOP — blocking, but not the primary control (AgDR-0114).
 #
-# Protected branches (default): main / master / dev / develop.
+# Blocks direct pushes and commits to long-lived integration branches from
+# Claude Code sessions (a PreToolUse hook, evaluated before the shell ever
+# runs). All changes must go through pull requests.
+#
+# THE controls for protected-branch enforcement are the git-native hooks:
+#   .githooks/pre-push     — terminal `git push`, ground truth via git's own
+#                             stdin ref resolution (me2resh/apexyard#1086
+#                             step 2)
+#   .githooks/pre-commit    — terminal `git commit`, ground truth via
+#                             `git symbolic-ref --short HEAD` (step 3,
+#                             AgDR-0114)
+# Both need no command-text parsing at all — immune by construction to every
+# heredoc/decoy/quoting shape docs/agdr/AgDR-0113-heredoc-stripper-additive-only.md
+# catalogues for THIS file's text-matching approach.
+#
+# THIS file stays a BLOCKING backstop (AgDR-0114 — relabel + keep blocking,
+# not demote to advisory), because it is the only layer that covers two
+# gaps the git-native hooks structurally cannot close:
+#
+#   1. `--no-verify` bypasses every git-native hook by git's own design.
+#      This file is a Claude Code PreToolUse hook — it intercepts the Bash
+#      tool call BEFORE the shell (and therefore before git, and therefore
+#      before --no-verify's effect) ever runs, so it stays effective
+#      regardless of that flag. See the "--no-verify" note attached to
+#      each blocked-push/blocked-commit message below.
+#   2. `core.hooksPath` is not installed by default on managed-project
+#      clones (me2resh/apexyard#1088, deliberately unresolved) — this file
+#      fires process-wide regardless of which repo's clone the command's
+#      cwd targets, where the git-native hooks never fire at all.
+#
+# See docs/agdr/AgDR-0114-block-main-push-honest-naming-blocking-backstop.md
+# for the full decision record and docs/agdr/AgDR-0104-trust-chain-controls-vs-backstops.md
+# for the "control vs backstop, honestly named" framing this file follows.
+#
+# Protected branches (default): main / master / dev / develop, resolved via
+# the shared `.claude/hooks/_lib-protected-branches.sh` predicate
+# (`is_protected_branch`) — the same lib `.githooks/pre-push` and
+# `.githooks/pre-commit` use, so all three layers agree on one source of
+# truth instead of three copies that have to be trusted to stay in sync.
 # `dev` was added in apexyard#116 (release-cut model — see AgDR-0007). Forks
 # that legitimately use `dev` as a daily-work trunk under their own
 # convention can override the protected list via
@@ -61,16 +98,59 @@ HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # _lib-strip-heredoc.sh's governance comment and
 # docs/agdr/AgDR-0113-heredoc-stripper-additive-only.md.
 
-# Resolve protected-branch list from project config (shared reader, #109).
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-PROTECTED=""
-if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.claude/hooks/_lib-read-config.sh" ]; then
+# Resolve the protected-branch predicate from the shared lib (me2resh/apexyard#1086
+# step 2/3, AgDR-0114) instead of resolving `.git.protected_branches[]` a
+# second time inline. This file previously carried its own copy of the same
+# three lines `_lib-protected-branches.sh` already implements — the
+# "duplicate that has to be trusted to agree" pattern AgDR-0113 catalogues as
+# this file family's dominant defect generator. Sourcing the lib means this
+# file, .githooks/pre-push, and .githooks/pre-commit all resolve the SAME
+# list, and all three inherit is_protected_branch()'s fail-closed hardening
+# (a malformed `.git.protected_branches[]` entry, or a renamed/missing
+# protected_branch_regex function, is treated as PROTECTED, never as a
+# silent allow).
+PROTECTED_LIB="$HOOK_DIR/_lib-protected-branches.sh"
+if [ -f "$PROTECTED_LIB" ]; then
   # shellcheck disable=SC1090,SC1091
-  . "$REPO_ROOT/.claude/hooks/_lib-read-config.sh"
-  PROTECTED=$(config_get '.git.protected_branches[]' 2>/dev/null | paste -sd'|' -)
+  . "$PROTECTED_LIB"
 fi
-if [ -z "$PROTECTED" ]; then
-  PROTECTED="main|master|dev|develop"
+if ! declare -F is_protected_branch > /dev/null 2>&1; then
+  # Old clone that hasn't pulled the lib file yet (or it's syntactically
+  # broken). Fail closed on the documented default list rather than
+  # skipping protected-branch enforcement entirely — this file is a
+  # blocking backstop; a missing lib must not turn it into a no-op.
+  echo "WARN: $PROTECTED_LIB not found or is_protected_branch unavailable -- falling back to the default protected-branch list (main/master/dev/develop only; .git.protected_branches[] override not applied)." >&2
+  is_protected_branch() {
+    local b="$1"
+    [ -n "$b" ] && echo "$b" | grep -qE '^(main|master|dev|develop)$'
+  }
+  protected_branch_regex() { echo "main|master|dev|develop"; }
+fi
+
+# Display-only rendering of the protected list for BLOCKED messages below
+# (e.g. "Protected branches: main, master, dev, develop").
+PROTECTED_DISPLAY=$(protected_branch_regex 2>/dev/null)
+if [ -z "$PROTECTED_DISPLAY" ]; then
+  PROTECTED_DISPLAY="main|master|dev|develop"
+fi
+
+# --no-verify note (me2resh/apexyard#1086 step 3, AgDR-0114): --no-verify
+# does not bypass THIS file (a PreToolUse hook, not a git hook), but an
+# operator seeing a block after passing --no-verify may reasonably wonder
+# why the flag "didn't work". Detected once, appended to every BLOCKED
+# message below so the reason is explicit rather than left to be
+# rediscovered. Detection is deliberately simple (a whitespace-bounded
+# literal match) -- this is an explanatory note, not a new gate; the
+# existing push/commit checks above and below already block the command
+# regardless of --no-verify, with or without this note.
+NO_VERIFY_NOTE=""
+if echo "$COMMAND" | grep -qE '(^|[[:space:]])--no-verify([[:space:]]|$)'; then
+  NO_VERIFY_NOTE="
+NOTE: --no-verify does not bypass this check. This hook is a Claude Code
+PreToolUse hook (AgDR-0114) that runs BEFORE the shell -- and therefore
+before git, and therefore before --no-verify's effect -- ever executes.
+The git-native .githooks/pre-push and .githooks/pre-commit hooks WOULD be
+skipped by --no-verify; this backstop is not."
 fi
 
 # ---------------------------------------------------------------------------
@@ -112,12 +192,12 @@ if echo "$COMMAND" | grep -qE '\bgit\s+push\b'; then
     if declare -F _extract_all_push_refs_core > /dev/null 2>&1; then
       while IFS= read -r ANY_PUSH_DST; do
         [ -z "$ANY_PUSH_DST" ] && continue
-        if echo "$ANY_PUSH_DST" | grep -qE "^(${PROTECTED})$"; then
+        if is_protected_branch "$ANY_PUSH_DST"; then
           cat >&2 <<MSG
 BLOCKED: Cannot push directly to a protected branch ('${ANY_PUSH_DST}').
 
 All changes must go through a PR (.claude/rules/git-conventions.md
-§ "No Direct Main"). Protected branches: ${PROTECTED//|/, }.
+§ "No Direct Main"). Protected branches: ${PROTECTED_DISPLAY//|/, }.
 
 This command contains more than one push-shaped occurrence of text, and
 at least one names a protected branch. If that text is inside a heredoc
@@ -131,6 +211,7 @@ To unblock a genuine push:
        git checkout -b feature/GH-<ticket>-<short-description>
   2. Push the feature branch:
        git push -u origin feature/GH-<ticket>-<short-description>
+${NO_VERIFY_NOTE}
 MSG
           exit 2
         fi
@@ -282,12 +363,12 @@ MSG
       fi
     fi
 
-    if [ -n "$TARGET_PUSH_BRANCH" ] && echo "$TARGET_PUSH_BRANCH" | grep -qE "^(${PROTECTED})$"; then
+    if is_protected_branch "$TARGET_PUSH_BRANCH"; then
       cat >&2 <<MSG
 BLOCKED: Cannot push directly to a protected branch ('${TARGET_PUSH_BRANCH}').
 
 All changes must go through a PR (.claude/rules/git-conventions.md
-§ "No Direct Main"). Protected branches: ${PROTECTED//|/, }.
+§ "No Direct Main"). Protected branches: ${PROTECTED_DISPLAY//|/, }.
 
 To unblock:
   1. Create a feature branch from your current work:
@@ -303,6 +384,7 @@ protection from a default-protected branch (e.g. you legitimately use
 'dev' as your trunk), write the array with that branch OMITTED. To ADD
 protection to a new branch, write the array INCLUDING it. The hook
 trusts whichever list you provide — get the direction right.
+${NO_VERIFY_NOTE}
 MSG
       exit 2
     fi
@@ -354,7 +436,7 @@ if echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
     CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
   fi
 
-  if [ -n "$CURRENT_BRANCH" ] && echo "$CURRENT_BRANCH" | grep -qE "^(${PROTECTED})$"; then
+  if is_protected_branch "$CURRENT_BRANCH"; then
     cat >&2 <<MSG
 BLOCKED: Cannot commit directly on protected branch '${CURRENT_BRANCH}'.
 
@@ -377,6 +459,7 @@ locally, then check out the recovery branch.
        git branch feature/GH-<ticket>-recovery
        git reset --hard HEAD~1   # drops the commit from ${CURRENT_BRANCH}
        git checkout feature/GH-<ticket>-recovery
+${NO_VERIFY_NOTE}
 MSG
     exit 2
   fi

--- a/.claude/hooks/tests/test_block_main_push.sh
+++ b/.claude/hooks/tests/test_block_main_push.sh
@@ -33,8 +33,9 @@ LIB_SRC="$SRC_ROOT/.claude/hooks/_lib-extract-push-ref.sh"
 LIB_STRIP_HEREDOC_SRC="$SRC_ROOT/.claude/hooks/_lib-strip-heredoc.sh"
 LIB_CONFIG_SRC="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
 LIB_OPS_ROOT_SRC="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
+LIB_PROTECTED_SRC="$SRC_ROOT/.claude/hooks/_lib-protected-branches.sh"
 
-for f in "$HOOK_SRC" "$LIB_SRC" "$LIB_STRIP_HEREDOC_SRC"; do
+for f in "$HOOK_SRC" "$LIB_SRC" "$LIB_STRIP_HEREDOC_SRC" "$LIB_PROTECTED_SRC"; do
   if [ ! -f "$f" ]; then
     echo "FAIL: required source missing: $f" >&2
     exit 1
@@ -84,6 +85,7 @@ make_sandbox() {
   mkdir -p "$sb/.claude/hooks"
   cp "$HOOK_SRC"        "$sb/.claude/hooks/block-main-push.sh"
   cp "$LIB_SRC"         "$sb/.claude/hooks/_lib-extract-push-ref.sh"
+  cp "$LIB_PROTECTED_SRC" "$sb/.claude/hooks/_lib-protected-branches.sh"
   if [ -f "$LIB_STRIP_HEREDOC_SRC" ]; then
     cp "$LIB_STRIP_HEREDOC_SRC" "$sb/.claude/hooks/_lib-strip-heredoc.sh"
   fi
@@ -304,6 +306,97 @@ run_case "non-git command is no-op" \
   "$SB" "$SB" "echo hello" 0
 run_case "gh pr create is no-op" \
   "$SB" "$SB" "gh pr create --base dev --head feature/GH-1-foo" 0
+rm -rf "$SB"
+
+# run_case_stderr <label> <sandbox-root> <cwd-for-hook> <command> <want-rc> <want-substring>
+# Like run_case, but additionally asserts stderr contains <want-substring>.
+run_case_stderr() {
+  local label="$1" sb="$2" hook_cwd="$3" cmd="$4" want_rc="$5" want_substr="$6"
+  local input
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  local got_rc got_stderr
+  got_stderr=$(cd "$hook_cwd" && echo "$input" | bash .claude/hooks/block-main-push.sh 2>&1 >/dev/null)
+  got_rc=$?
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc" >&2
+    echo "    cmd:    $cmd" >&2
+    echo "    stderr: ${got_stderr:0:300}" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  if ! echo "$got_stderr" | grep -qF "$want_substr"; then
+    echo "FAIL [$label]: rc matched but stderr missing substring '$want_substr'" >&2
+    echo "    stderr: ${got_stderr:0:400}" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# ---------------------------------------------------------------------------
+# me2resh/apexyard#1086 step 3 (PR-2, AgDR-0114): migration onto the shared
+# _lib-protected-branches.sh lib, plus the new --no-verify note.
+#
+# (g) The migration must not demote any former exit-2 site: every case in
+#     sections (a)-(e) above already re-proves this (identical rc=2/0
+#     expectations, now running against the migrated hook). This section
+#     adds NEW coverage the migration specifically introduces.
+# ---------------------------------------------------------------------------
+
+# --no-verify on a protected-branch push still blocks, AND the message
+# names --no-verify explicitly (the one shape with no git-native
+# replacement -- .githooks/pre-push would be skipped by this flag, this
+# PreToolUse hook is not).
+SB=$(make_sandbox "feature/GH-1-safe")
+run_case_stderr "push --no-verify to main blocks + message names --no-verify" \
+  "$SB" "$SB" "git push --no-verify origin main" 2 "does not bypass this check"
+rm -rf "$SB"
+
+# --no-verify on a protected-branch commit still blocks, same message.
+SB=$(make_sandbox "main")
+run_case_stderr "commit --no-verify on main blocks + message names --no-verify" \
+  "$SB" "$SB" "git commit --no-verify -m 'bad'" 2 "does not bypass this check"
+rm -rf "$SB"
+
+# A legitimate, non-protected push/commit with --no-verify must still pass
+# (the note only appears on an already-blocked command -- --no-verify never
+# manufactures a NEW block on its own).
+SB=$(make_sandbox "feature/GH-1-safe")
+run_case "push --no-verify to feature branch passes (no new block introduced)" \
+  "$SB" "$SB" "git push --no-verify origin feature/GH-2-bar" 0
+run_case "commit --no-verify on feature branch passes (no new block introduced)" \
+  "$SB" "$SB" "git commit --no-verify -m 'wip'" 0
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# (h) Migrated hook resolves the SAME protected set as
+#     _lib-protected-branches.sh, driven by the SAME config key
+#     (.git.protected_branches[]) -- proves the lib migration is real, not
+#     cosmetic. An override that REPLACES the default list must be honoured
+#     identically to how .githooks/pre-push and .githooks/pre-commit honour
+#     it (they already source the same lib function).
+# ---------------------------------------------------------------------------
+SB=$(make_sandbox "main")
+mkdir -p "$SB/.claude"
+cat > "$SB/.claude/project-config.json" <<'CFG'
+{
+  "git": {
+    "protected_branches": ["release"]
+  }
+}
+CFG
+# main is no longer in the overridden list -> must be ALLOWED now.
+run_case "config override REPLACES default list: push to main now passes" \
+  "$SB" "$SB" "git push origin main" 0
+run_case "config override REPLACES default list: commit on main now passes" \
+  "$SB" "$SB" "git commit -m 'ok now'" 0
+# release IS in the overridden list -> must BLOCK.
+run_case "config override REPLACES default list: push to release blocks" \
+  "$SB" "$SB" "git push origin release" 2
 rm -rf "$SB"
 
 # ---------------------------------------------------------------------------

--- a/.claude/hooks/tests/test_block_main_push_heredoc.sh
+++ b/.claude/hooks/tests/test_block_main_push_heredoc.sh
@@ -42,8 +42,9 @@ LIB_SRC="$SRC_ROOT/.claude/hooks/_lib-extract-push-ref.sh"
 LIB_STRIP_HEREDOC_SRC="$SRC_ROOT/.claude/hooks/_lib-strip-heredoc.sh"
 LIB_CONFIG_SRC="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
 LIB_OPS_ROOT_SRC="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
+LIB_PROTECTED_SRC="$SRC_ROOT/.claude/hooks/_lib-protected-branches.sh"
 
-for f in "$HOOK_SRC" "$LIB_SRC" "$LIB_STRIP_HEREDOC_SRC"; do
+for f in "$HOOK_SRC" "$LIB_SRC" "$LIB_STRIP_HEREDOC_SRC" "$LIB_PROTECTED_SRC"; do
   if [ ! -f "$f" ]; then
     echo "FAIL: required source missing: $f" >&2
     exit 1
@@ -77,6 +78,7 @@ make_sandbox() {
   mkdir -p "$sb/.claude/hooks"
   cp "$HOOK_SRC" "$sb/.claude/hooks/block-main-push.sh"
   cp "$LIB_SRC"  "$sb/.claude/hooks/_lib-extract-push-ref.sh"
+  cp "$LIB_PROTECTED_SRC" "$sb/.claude/hooks/_lib-protected-branches.sh"
   if [ -f "$LIB_STRIP_HEREDOC_SRC" ]; then
     cp "$LIB_STRIP_HEREDOC_SRC" "$sb/.claude/hooks/_lib-strip-heredoc.sh"
   fi

--- a/.claude/hooks/tests/test_heredoc_bypass_shapes.sh
+++ b/.claude/hooks/tests/test_heredoc_bypass_shapes.sh
@@ -66,8 +66,9 @@ LIB_STRIP_HEREDOC_SRC="$SRC_ROOT/.claude/hooks/_lib-strip-heredoc.sh"
 LIB_CONFIG_SRC="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
 LIB_OPS_ROOT_SRC="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
 LIB_PR_REPO_SRC="$SRC_ROOT/.claude/hooks/_lib-pr-repo.sh"
+LIB_PROTECTED_SRC="$SRC_ROOT/.claude/hooks/_lib-protected-branches.sh"
 
-for f in "$BLOCK_HOOK" "$BRANCH_HOOK" "$LIB_SRC" "$LIB_STRIP_HEREDOC_SRC"; do
+for f in "$BLOCK_HOOK" "$BRANCH_HOOK" "$LIB_SRC" "$LIB_STRIP_HEREDOC_SRC" "$LIB_PROTECTED_SRC"; do
   if [ ! -f "$f" ]; then
     echo "FAIL: required source missing: $f" >&2
     exit 1
@@ -97,6 +98,7 @@ make_sandbox() {
   cp "$BRANCH_HOOK" "$sb/.claude/hooks/validate-branch-name.sh"
   cp "$LIB_SRC" "$sb/.claude/hooks/_lib-extract-push-ref.sh"
   cp "$LIB_STRIP_HEREDOC_SRC" "$sb/.claude/hooks/_lib-strip-heredoc.sh"
+  cp "$LIB_PROTECTED_SRC" "$sb/.claude/hooks/_lib-protected-branches.sh"
   if [ -f "$LIB_CONFIG_SRC" ]; then
     cp "$LIB_CONFIG_SRC" "$sb/.claude/hooks/_lib-read-config.sh"
   fi

--- a/.claude/hooks/tests/test_validate_branch_name_heredoc.sh
+++ b/.claude/hooks/tests/test_validate_branch_name_heredoc.sh
@@ -138,6 +138,48 @@ git push origin feature/GH-1066-heredoc-fix
 CMD
 )" 0
 
+# ---- me2resh/apexyard#1081: decoy tag-push evidence must not hide a real,
+#      non-conforming push from validation --------------------------------
+#
+# The bug (fixed here the same way #1075 fixed it for block-main-push.sh):
+# is_tag_push's TRUE verdict is a WHOLE-COMMAND signal, so decoy tag-push
+# evidence sitting in prose the heredoc stripper correctly declines to
+# strip (an unconfirmed delimiter) made this hook `exit 0` before ever
+# validating the REAL push's destination in the same command. Both cases
+# below are proven RED against the pre-fix code (git stash) before the fix,
+# per this repo's own governance rule for this bug class.
+
+# Shape 1 — the ticket's own repro: dotted-delimiter heredoc carries decoy
+# "--tags" prose, immediately followed by a real, non-conforming push.
+# Pre-fix: is_tag_push("--tags" in decoy) -> true -> exit 0 (ALLOWED, wrong).
+# Post-fix: the real push has no tag evidence of its own and no OTHER
+# occurrence to lean on -> untrusted -> validated -> BLOCKS.
+run_case "#1081: decoy --tags in unconfirmed heredoc must not hide a non-conforming push" \
+"$(cat <<'CMD'
+cat > /tmp/m.txt <<END.OF
+we always use git push --tags for releases
+END.OF
+git push origin bogus-branch
+CMD
+)" 2
+
+# Shape 2 — same decoy shape, but the real push IS conforming. Must still
+# pass (the fix must not over-block a legitimate push just because a decoy
+# is present elsewhere in the command).
+run_case "#1081: decoy --tags in unconfirmed heredoc, real push conforms -> still passes" \
+"$(cat <<'CMD'
+cat > /tmp/m.txt <<END.OF
+we always use git push --tags for releases
+END.OF
+git push origin feature/GH-1081-decoy-fix
+CMD
+)" 0
+
+# Control: a genuine tag push with NO decoy and no heredoc must remain
+# exempt (the fix must not make is_tag_push untrustworthy in general).
+run_case "#1081 control: genuine tag push, no decoy -> still a no-op" \
+  "git push origin --tags" 0
+
 # ---- Regression: plain (no heredoc) cases from #194/#547 must be intact --
 run_case "regression: plain conforming push still passes" \
   "git push origin feature/GH-194-worktree-cwd-hooks" 0

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -56,11 +56,85 @@ if [ -f "$HOOK_DIR/_lib-extract-push-ref.sh" ]; then
   # This guard runs before extract_push_ref so shell redirections appended
   # to a tag-push command (e.g. `git push --tags 2>&1 | tail`) don't cause
   # is_tag_push() to miss the --tags flag. See me2resh/apexyard#547.
+  #
+  # me2resh/apexyard#1081 (the naming-gate's parallel exposure to the bug
+  # #1075 fixed for block-main-push.sh): is_tag_push's TRUE verdict is a
+  # WHOLE-COMMAND signal ("some push somewhere looks tag-shaped"), not
+  # proof the ACTUAL push in this command is a tag push. Trusting it
+  # unconditionally let decoy tag-push evidence sitting in prose a heredoc
+  # `strip_heredoc_bodies` correctly declines to strip (unconfirmed —
+  # backslash/multi-word/dotted delimiter) -- or plain non-heredoc prose --
+  # make this hook `exit 0` before ever validating the REAL, separate,
+  # non-conforming push destination in the same command. Repro:
+  #
+  #   cat > /tmp/m.txt <<END.OF
+  #   we always use git push --tags for releases
+  #   END.OF
+  #   git push origin bogus-branch
+  #
+  # Fix, mirroring the per-occurrence philosophy #1075 landed for
+  # block-main-push.sh's own decoy-ref hijack: before trusting
+  # is_tag_push's exit-0 verdict, walk every RAW push-shaped occurrence
+  # (independent of heredoc parsing -- doesn't care whether any heredoc was
+  # confirmed or declined) and check EACH occurrence individually for its
+  # OWN tag evidence (`--tags`, `tag <name>`, `refs/tags/` within that
+  # segment's own text) versus its own explicit positional ref.
+  #
+  # This must be per-occurrence, not whole-command, for the same reason
+  # `_command_has_untagged_refless_push`'s doc comment gives: a genuine
+  # tag push's own trailing token (e.g. the "v1.2.3" in
+  # `git push upstream tag v1.2.3`) is itself a positional ref by the
+  # naive token walk, so a whole-command "does ANY occurrence have an
+  # explicit ref" check would distrust a perfectly genuine single tag push
+  # too. The correct question per occurrence is: does THIS segment's ref
+  # (if any) come with ITS OWN tag evidence, or is it a bare, evidence-less
+  # occurrence hiding behind is_tag_push's decoy verdict? Only the latter
+  # is unaddressed by anything else in this hook.
+  #
+  # SCAN_LAST_REF takes the LAST such evidence-less, ref-bearing occurrence
+  # (not the first): `extract_push_ref`'s own first-match semantics is
+  # exactly what the decoy exploits -- decoy prose sitting BEFORE the real
+  # command (the "write the heredoc body, then run the real git command"
+  # shape this whole file's shell convention produces) wins the
+  # first-match race, so trusting the first hit here would repeat the same
+  # bug from the other direction. The LAST such occurrence is the one
+  # actually about to execute.
+  #
+  # Only when every occurrence is either evidence-bearing (a genuine tag
+  # push) or carries no explicit ref at all does this hook exit 0 —
+  # nothing for a branch-name validator to check.
+  SCAN_LAST_REF=""
   if is_tag_push "$COMMAND"; then
-    exit 0
+    STRIPPED_FOR_SCAN=$(echo "$COMMAND" | sed 's/[[:space:]][0-9]*[>|].*$//')
+    while IFS= read -r SEGMENT; do
+      [ -z "$SEGMENT" ] && continue
+      HAS_EVIDENCE=0
+      if echo "$SEGMENT" | grep -qE '\s--tags(\s|$)' \
+         || echo "$SEGMENT" | grep -qE '\stag\s+\S' \
+         || echo "$SEGMENT" | grep -qE 'refs/tags/'; then
+        HAS_EVIDENCE=1
+      fi
+      [ "$HAS_EVIDENCE" = "1" ] && continue
+      if declare -F _extract_push_ref_core > /dev/null 2>&1; then
+        SEG_REF=$(_extract_push_ref_core "$SEGMENT")
+        [ -n "$SEG_REF" ] && SCAN_LAST_REF="$SEG_REF"
+      fi
+    done < <(echo "$STRIPPED_FOR_SCAN" | grep -oE '\bgit\s+push\b[^|;&]*')
+
+    if [ -z "$SCAN_LAST_REF" ]; then
+      exit 0
+    fi
   fi
 
-  PUSH_REF=$(extract_push_ref "$COMMAND")
+  if [ -n "$SCAN_LAST_REF" ]; then
+    # An evidence-less, ref-bearing occurrence was found by the
+    # untrusted-tag-signal scan above -- validate it directly rather than
+    # re-deriving via extract_push_ref (whose heredoc-aware first-match
+    # would repeat the same hijack).
+    PUSH_REF="$SCAN_LAST_REF"
+  else
+    PUSH_REF=$(extract_push_ref "$COMMAND")
+  fi
 
   # Fail closed rather than silently falling back to local HEAD when the
   # heredoc-aware extraction found nothing BUT a naive, unstripped parse of

--- a/.claude/rules/git-conventions.md
+++ b/.claude/rules/git-conventions.md
@@ -53,7 +53,7 @@ This is enforced by the `block-git-add-all.sh` hook.
 
 ## No Direct Main
 
-Every change must go through a PR. Zero exceptions. No commits directly to `main`/`master`. Enforced by the `block-main-push.sh` hook.
+Every change must go through a PR. Zero exceptions. No commits directly to `main`/`master`. Enforced at the git layer by `.githooks/pre-push` (terminal `git push`) and `.githooks/pre-commit` (terminal `git commit`) — both read git's own ground-truth ref/branch resolution, no command-text parsing (me2resh/apexyard#1086). `.claude/hooks/block-main-push.sh` is a blocking **backstop** on top: a Claude Code PreToolUse hook, so it stays effective against `--no-verify` (which structurally bypasses the two git-native hooks above) and on managed-project clones that haven't installed `core.hooksPath` (#1088). See [AgDR-0114](../../docs/agdr/AgDR-0114-block-main-push-honest-naming-blocking-backstop.md) for the full control-vs-backstop rationale.
 
 ## No Hardcoded Secrets
 

--- a/docs/agdr/AgDR-0104-trust-chain-controls-vs-backstops.md
+++ b/docs/agdr/AgDR-0104-trust-chain-controls-vs-backstops.md
@@ -53,3 +53,15 @@ Concretely, in order:
 
 - Challenged by Naqid (The Contrarian) — verdict **proceed-with-changes**; three HIGH findings absorbed: (1) test the wrong layer → narrow trust to the server-side gate; (2) anti-rot column would itself rot → CI meta-gate (deferred); (3) SoD over-claim in single-account mode → scope the claim to a separate-identity config. The GitLab forge-awareness refinement was added on top during ratification.
 - Related: #962, #964, #965 (the concrete holes/drift), AgDR-0062 (author-independence deferred in single-account setups), AgDR-0038 (jq as hard dependency).
+
+## Update (me2resh/apexyard#1086, AgDR-0114) — first executed protected-branch application
+
+This record's "narrow what's trusted, label each hook THE control or a backstop, then say so" framing sat as labeling guidance until #1086 gave it a concrete, executed case: protected-branch enforcement (`.claude/hooks/block-main-push.sh` vs the git-native `.githooks/pre-push` / `.githooks/pre-commit` pair).
+
+[AgDR-0114](AgDR-0114-block-main-push-honest-naming-blocking-backstop.md) resolves that case in three PRs:
+
+1. **#1090 (step 2, merged)** — `.githooks/pre-push` ships as the git-native, ground-truth control for terminal `git push`, reading git's own resolved stdin refs instead of parsing command text.
+2. **#1117 (step 3, PR-1, merged)** — `.githooks/pre-commit` ships as the git-native control for terminal `git commit` (`git symbolic-ref --short HEAD`, no parsing at all), and the shared `_lib-protected-branches.sh` gains a fail-closed `is_protected_branch()` predicate both git-native hooks call.
+3. **#1086 step 3, PR-2 (this update)** — `block-main-push.sh` migrates onto the same shared predicate (removing the inline duplicate this AgDR's "narrow trust" framing would otherwise leave standing as a second, drift-prone copy), gains a `--no-verify`-aware blocking check (the one shape with no git-native replacement — see AgDR-0114's Context), and is relabelled in its own header comment as a **blocking backstop**, honestly, per this record's original vocabulary.
+
+This is the first case where this AgDR's "control vs backstop" distinction was applied to a NEW hook family rather than to the two originating bypasses (#962, #965). It is also the case AgDR-0114 uses to **narrow** this record's own "backstop → advisory" leap: that step is only safe when a strictly *stronger* control already covers everything the backstop covered (true for `block-unreviewed-merge.sh` leaning on the forge's branch protection, the case this record was written for). It is not true here — `--no-verify` and unconfigured `core.hooksPath` on managed-project clones are real gaps the git-native hooks cannot close — so `block-main-push.sh` stays blocking rather than following the merge-gate precedent all the way to advisory. See AgDR-0114's Context section for the full reasoning.


### PR DESCRIPTION
## Summary

**PR-2 of 2** for the #1086 "relabel + keep blocking" epic (PR-1 was #1117, merged — it shipped `.githooks/pre-commit` + `is_protected_branch()`). This PR finishes step 3 per [AgDR-0114](docs/agdr/AgDR-0114-block-main-push-honest-naming-blocking-backstop.md): **keep `block-main-push.sh` blocking**, migrate it onto the same shared lib the git-native hooks already use, close the one gap it was still missing, and stop the framework's own docs from overstating what the hook is.

- **Removed the duplicate protected-branch resolution.** `block-main-push.sh` had its own inline copy of the three lines `.claude/hooks/_lib-protected-branches.sh` already implements — the "duplicate that has to be trusted to agree" pattern [AgDR-0113](docs/agdr/AgDR-0113-heredoc-stripper-additive-only.md) names as this file family's dominant defect generator. It now sources the lib and calls `is_protected_branch()`, so this file, `.githooks/pre-push`, and `.githooks/pre-commit` all resolve the *same* protected-branch list from *one* place, and this file inherits the lib's fail-closed hardening (a malformed `.git.protected_branches[]` entry, or a renamed/missing lib function, is now treated as protected here too, not just in the two git-native hooks).
- **Added the `--no-verify` note — the one gap with no git-native replacement.** `--no-verify` bypasses `.githooks/pre-push` and `.githooks/pre-commit` by git's own design; it does *not* bypass `block-main-push.sh`, because this is a Claude Code PreToolUse hook that runs before the shell (and therefore before git) ever executes. That protection already existed implicitly (the hook never looked at the flag one way or the other), but nothing explained it — an operator seeing a block after passing `--no-verify` had no way to know the flag "didn't work" on purpose. Every BLOCKED message now names this explicitly when `--no-verify` is present on the command.
- **Kept every existing `exit 2` site — none demoted.** This is the load-bearing part of AgDR-0114: the git-native hooks are objectively stronger on *which ref* (no command-text parsing at all), but they can't cover `--no-verify` or managed-project clones that never installed `core.hooksPath` (#1088, still open). Demoting `block-main-push.sh` would remove real coverage with nothing replacing it for those two cases, so this PR only relabels — it never turns a block into a warning.
- **Relabelled honestly.** The hook's header now states plainly that `.githooks/pre-push` / `.githooks/pre-commit` are *the* protected-branch controls and this file is a blocking *backstop*. `git-conventions.md` and AgDR-0104 (the "control vs backstop, honestly named" record this whole epic traces back to) are updated to match — AgDR-0104 also gets a short "Update" section recording this as its first executed application to a new hook family.
- **Fixes #1081** — a real, separate bug in `validate-branch-name.sh`: decoy tag-push evidence sitting in prose a heredoc's stripper correctly declines to strip (an unconfirmed delimiter) made `is_tag_push` return true for the *whole command*, so the hook exited 0 before ever validating a real, non-conforming push sitting right after it. Fixed the same way #1075 fixed `block-main-push.sh`'s own decoy-ref hijack: walk every push-shaped occurrence individually and only trust the tag-exemption for an occurrence that carries its own tag evidence — a bare, evidence-less occurrence (the real push hiding behind the decoy) forces validation instead of a silent skip. Kept in its own commit-worthy section of the diff, isolated from the block-main-push.sh work.

## Testing

Full affected suite is green (`shellcheck --severity=warning` clean on every edited `.sh`; `markdownlint-cli2` clean on both edited `.md`):

| Suite | Result |
|---|---|
| `test_block_main_push.sh` (37 pre-existing + 7 new) | **44/44 PASS** |
| `test_block_main_push_heredoc.sh` | 7/7 PASS |
| `test_heredoc_bypass_shapes.sh` (both hooks) | 36/36 PASS |
| `test_lib_protected_branches.sh` | 16/16 PASS |
| `test_extract_push_ref_arrow.sh` / `_heredoc.sh` | 9/9, 12/12 PASS |
| `test_validate_branch_name_pushref.sh` | 39/39 PASS |
| `test_validate_branch_name_heredoc.sh` (7 pre-existing + 3 new) | **10/10 PASS** |

New coverage added this PR:

- **Still-blocks proof** — every former `exit 2` site (push to main/dev/master/develop, plain commit on a protected branch) is re-asserted against the migrated hook; all still block. This is the direct proof the migration didn't demote anything.
- **`--no-verify` fires** — `git push --no-verify origin main` and `git commit --no-verify -m bad` on a protected branch both still block (rc=2) *and* the stderr message names `--no-verify` explicitly. A legitimate `--no-verify` push/commit to a *non*-protected branch still passes — the flag never manufactures a new block on its own.
- **Config-override parity** — with `.git.protected_branches` overridden to `["release"]`, `main` now passes and `release` now blocks, proving the migrated hook actually resolves through the shared lib rather than a stale inline copy.
- **#1081 regression (2 new cases + 1 control)** — the ticket's own repro (`git push origin bogus-branch` behind a dotted-delimiter heredoc carrying decoy `--tags` prose) now blocks; the same decoy shape with a *conforming* real push still passes; a genuine tag push with no decoy stays exempt.

## What closes on merge

- **#1086** — the epic itself; step 3 (both PRs) is now complete.
- **#1081** — fixed directly in this PR.
- **#1083, #1084, #1085** — `block-main-push.sh`'s / the shared parser's text-parsing residuals, catalogued in AgDR-0113. These close as *superseded at the git layer*: the git-native hooks (`.githooks/pre-push`, `.githooks/pre-commit`) that fully replace text-parsing for the *which-ref* / *which-branch* question are now live and this PR's tests confirm parity, so the parsing bugs these tickets tracked no longer have live exploit paths against the primary control (they remain theoretically present in `block-main-push.sh`'s own backstop parsing, same as before — AgDR-0114 accepted that residual explicitly).

Refs #1086 #1081 #1083 #1084 #1085

## Glossary

| Term | Definition |
|---|---|
| **Backstop** (vs. control) | A control is the layer decisions actually rely on (here: the git-native hooks, which read ground-truth git state). A backstop is a second, weaker-in-general-but-covers-different-gaps layer kept blocking specifically because it closes cases the control can't reach — here, `--no-verify` and clones without `core.hooksPath` installed. |
| `is_protected_branch()` | The shared, fail-closed predicate in `_lib-protected-branches.sh` that answers "is this branch name protected" — a malformed config entry or a missing helper function is treated as protected, never as a silent allow. |
| `--no-verify` | A native git flag that skips git's own hook mechanism (`pre-push`, `pre-commit`, etc.) entirely. It has no effect on a Claude Code PreToolUse hook, because that hook runs before the shell — and therefore before git — ever executes. |
| Decoy tag-push evidence | Text that matches a tag-push pattern (`--tags`, `tag <name>`, `refs/tags/`) but sits in prose (a heredoc body, an unrelated comment) unrelated to the actual `git push` in the same command — the root cause both #1075 (block-main-push.sh) and #1081 (validate-branch-name.sh) fixed. |
