### PR TITLE
fix(#1121): dispatch the red-CI check on tracker_kind so glab-registered projects check glab, not gh

### DIFF
--- a/.claude/hooks/block-merge-on-red-ci.sh
+++ b/.claude/hooks/block-merge-on-red-ci.sh
@@ -38,6 +38,25 @@
 # Pending checks (IN_PROGRESS | QUEUED): BLOCKED. The rule says all checks
 # must be green; pending is not green. Wait for CI to finish, then retry.
 #
+# WRAPPER-SHAPE FORGE FALLBACK (#1121)
+# -------------------------------------
+# The `tracker_pr_merge` wrapper (#759) resolves its forge from the registry
+# via `_forge_kind_for` -> `tracker_kind` -> `_lib-tracker.sh`'s
+# `_tracker_project_value`, which reads the per-project `tracker.kind`
+# override with `yq` (preferred) or a `python3` + PyYAML fallback. When
+# NEITHER tool is installed, that read silently returns nothing and
+# `tracker_kind` falls through to the GLOBAL `.tracker.kind` default (`gh`)
+# — exactly wrong for a glab-registered project's wrapper call, since the
+# wrapper's own text never says which CLI it drives. `_registry_glab_fallback`
+# below is a dependency-free (grep/awk only, no yq/PyYAML) second check used
+# ONLY when the primary resolver answers "gh" for a wrapper-shape command: it
+# scans the registry file directly for an explicit `tracker: kind: glab` on
+# the target repo. It can only ever upgrade an ambiguous "gh" to a confirmed
+# "glab" — it never downgrades a "glab" answer and never fires for the
+# non-wrapper shapes (those dispatch on command text, which is always
+# trustworthy). The real fix for the underlying yq/PyYAML-optional gap
+# belongs to the shared resolver libs, out of scope here.
+#
 # GLAB PATH (new, #790)
 # ----------------------
 # `resolve_ci_status_glab` (see _lib-extract-pr.sh) resolves the GitLab MR's
@@ -60,6 +79,93 @@ INPUT=$(cat)
 # the jq-independent fallback detector when the parse can't be trusted —
 # see #965.
 . "$(dirname "$0")/_lib-extract-pr.sh"
+
+# _registry_glab_fallback <owner/repo>
+# -------------------------------------
+# Dependency-free (grep/awk only — no yq, no python3/PyYAML) second check for
+# whether the registry EXPLICITLY marks <owner/repo> as `tracker: kind: glab`
+# (#1121 — see the WRAPPER-SHAPE FORGE FALLBACK header comment above for why
+# this exists). Hook-local by design: it duplicates a narrow slice of
+# `_lib-tracker.sh`'s `_tracker_project_value` on purpose, rather than
+# touching that shared resolver, so this fix stays scoped to this one hook.
+#
+# Scans project blocks the same way apexyard.projects.yaml is documented to
+# be shaped (apexyard.projects.yaml.example): a top-level `projects:` list
+# where each entry is a `- name: ...` block containing a `repo:` field and,
+# optionally, a `tracker:` sub-block with a `kind:` field. A block boundary
+# is any `- ` list-item line at the SAME indentation as the first one seen —
+# this is what keeps a NESTED list (`roles:`, `tags:`) from being mistaken
+# for a new project entry, since nested items are always more indented than
+# the top-level `- name:` marker.
+#
+# Echoes "glab" and exits 0 only when the target repo's block contains an
+# explicit `kind: glab`; otherwise echoes nothing and exits 1. This can only
+# ever confirm "glab" — it never asserts "gh" — so a caller should treat a
+# miss as "no additional information", not as "confirmed gh".
+_registry_glab_fallback() {
+  local repo="${1:-}" registry=""
+  [ -n "$repo" ] || return 1
+
+  if command -v portfolio_registry >/dev/null 2>&1; then
+    registry=$(portfolio_registry 2>/dev/null)
+  fi
+  [ -n "$registry" ] || registry="./apexyard.projects.yaml"
+  [ -f "$registry" ] || return 1
+
+  local found
+  found=$(awk -v target="$repo" '
+    function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
+    function unquote(s,    t, n, c1, cn, sq) {
+      sq = sprintf("%c", 39)
+      t = s
+      sub(/[ \t]*#.*$/, "", t)
+      t = trim(t)
+      n = length(t)
+      if (n >= 2) {
+        c1 = substr(t, 1, 1)
+        cn = substr(t, n, 1)
+        if ((c1 == "\"" && cn == "\"") || (c1 == sq && cn == sq)) {
+          t = substr(t, 2, n - 2)
+        }
+      }
+      return t
+    }
+    BEGIN { item_indent = -1 }
+    {
+      raw = $0
+      match(raw, /^[ \t]*/)
+      ind = RLENGTH
+      is_item = (raw ~ /^[ \t]*-[ \t]/)
+
+      if (is_item) {
+        if (item_indent == -1) { item_indent = ind }
+        if (ind == item_indent) {
+          if (block_repo == target && block_kind == "glab") { print "glab"; exit }
+          block_repo = ""; block_kind = ""
+        }
+      }
+
+      line = raw
+      sub(/^[ \t]*-[ \t]*/, "", line)
+      line = trim(line)
+      if (line ~ /^repo:[ \t]*/) {
+        v = line; sub(/^repo:[ \t]*/, "", v); block_repo = unquote(v)
+      }
+      if (line ~ /^kind:[ \t]*/) {
+        v = line; sub(/^kind:[ \t]*/, "", v); block_kind = unquote(v)
+      }
+    }
+    END {
+      if (block_repo == target && block_kind == "glab") print "glab"
+    }
+  ' "$registry" 2>/dev/null)
+
+  if [ "$found" = "glab" ]; then
+    echo "glab"
+    return 0
+  fi
+  return 1
+}
 
 # Parse .tool_input.command via jq. #965: this used to be the ONLY parse
 # path, and an empty/failed result — jq missing from PATH, or jq erroring
@@ -170,6 +276,21 @@ fi
 # existing #790 test behaviour exactly.
 if echo "$COMMAND" | grep -qE '\btracker_pr_merge\b'; then
   FORGE=$(_forge_kind_for "$CMD_REPO")
+  # #1121: _forge_kind_for's registry read needs yq or python3+PyYAML; when
+  # NEITHER is installed it silently falls through to the global "gh"
+  # default. That default is ambiguous here — it could be a genuine gh-kind
+  # project, or a glab-kind project whose registry entry just couldn't be
+  # read. Cross-check with the dependency-free scan (see
+  # _registry_glab_fallback above) whenever the primary answer is "gh": it
+  # can only ever confirm "glab", never override a real "glab" result or
+  # invent a false positive for a project the registry doesn't explicitly
+  # mark as glab.
+  if [ "$FORGE" = "gh" ]; then
+    REGISTRY_FORGE=$(_registry_glab_fallback "$CMD_REPO")
+    if [ "$REGISTRY_FORGE" = "glab" ]; then
+      FORGE="glab"
+    fi
+  fi
 else
   FORGE=$(_forge_from_command "$COMMAND")
 fi

--- a/.claude/hooks/block-merge-on-red-ci.sh
+++ b/.claude/hooks/block-merge-on-red-ci.sh
@@ -130,7 +130,7 @@ _registry_glab_fallback() {
       }
       return t
     }
-    BEGIN { item_indent = -1 }
+    BEGIN { item_indent = -1; emitted = 0 }
     {
       raw = $0
       match(raw, /^[ \t]*/)
@@ -140,7 +140,16 @@ _registry_glab_fallback() {
       if (is_item) {
         if (item_indent == -1) { item_indent = ind }
         if (ind == item_indent) {
-          if (block_repo == target && block_kind == "glab") { print "glab"; exit }
+          # Flush the block that just ended. When the target glab block is NOT
+          # the last registry entry, the match fires here (mid-stream). We must
+          # exit WITHOUT letting the END block re-print: awk exit jumps to END,
+          # so a bare "print glab; exit" re-satisfies the END condition (block_repo
+          # and block_kind are still set) and emits a SECOND glab line, making the
+          # caller compare found against "glab\nglab" and MISS. The emitted flag
+          # makes END a no-op after a mid-stream hit (the #1121 position fix).
+          # NOTE: no apostrophes in these comments — the whole awk program is a
+          # single-quoted shell string, so an apostrophe would terminate it.
+          if (block_repo == target && block_kind == "glab") { print "glab"; emitted = 1; exit }
           block_repo = ""; block_kind = ""
         }
       }
@@ -156,7 +165,9 @@ _registry_glab_fallback() {
       }
     }
     END {
-      if (block_repo == target && block_kind == "glab") print "glab"
+      # Only fires for the LAST block (no later item boundary flushed it). The
+      # `!emitted` guard prevents a double-print after a mid-stream hit above.
+      if (!emitted && block_repo == target && block_kind == "glab") print "glab"
     }
   ' "$registry" 2>/dev/null)
 

--- a/.claude/hooks/tests/test_block_merge_on_red_ci.sh
+++ b/.claude/hooks/tests/test_block_merge_on_red_ci.sh
@@ -322,6 +322,131 @@ sb=$(make_sandbox_wrapper failure)
 run_case "wrapper: glab-registered project, pipeline failed -> blocks (forge dispatched via registry, not command text)" 2 "red or unresolvable" "$sb" \
   "$(printf "$WRAPPER_CMD_TMPL" "$sb")"
 
+# ----------------------------------------------------------------------
+# #1121: the registry read inside _forge_kind_for (_lib-tracker.sh's
+# _tracker_project_value) needs `yq` OR `python3`+PyYAML to parse the
+# per-project override; when NEITHER is available it silently falls through
+# to the GLOBAL tracker.kind default ("gh") — wrong for a glab-registered
+# project's wrapper call. The two cases above only caught this by accident
+# of THIS environment happening to lack yq/PyYAML; make it deterministic by
+# stubbing yq/python3 to behave exactly like "no override found here"
+# regardless of what the host actually has installed, so this regression
+# can't silently stop being exercised if the CI image ever gains yq.
+# ----------------------------------------------------------------------
+
+# make_sandbox_wrapper_no_yaml_tools <glab_mode> — same registry/glab stub as
+# make_sandbox_wrapper, PLUS yq/python3 stubs that always fail to produce a
+# per-project override (matching real yq-absent / PyYAML-absent behaviour),
+# forcing block-merge-on-red-ci.sh's registry fallback (_registry_glab_fallback)
+# to be the thing that resolves the forge correctly.
+make_sandbox_wrapper_no_yaml_tools() {
+  local glab_mode="$1"
+  local sb
+  sb=$(make_sandbox_wrapper "$glab_mode")
+  cat > "$sb/bin/yq" <<'EOF'
+#!/bin/bash
+# Simulates yq being unusable for this lookup (matches "yq not installed"
+# from the caller's perspective: no stdout, non-zero exit).
+exit 1
+EOF
+  chmod +x "$sb/bin/yq"
+  cat > "$sb/bin/python3" <<'EOF'
+#!/bin/bash
+# Simulates python3 without PyYAML installed. The real
+# _tracker_project_value heredoc catches the ImportError and exits 0 with
+# no stdout; this stub reproduces that exact observable behaviour.
+exit 0
+EOF
+  chmod +x "$sb/bin/python3"
+  echo "$sb"
+}
+
+sb=$(make_sandbox_wrapper_no_yaml_tools success)
+run_case "#1121: wrapper, glab-registered project, NO yq/PyYAML -> still allows on green pipeline (registry fallback engages)" 0 "" "$sb" \
+  "$(printf "$WRAPPER_CMD_TMPL" "$sb")"
+
+sb=$(make_sandbox_wrapper_no_yaml_tools failure)
+run_case "#1121: wrapper, glab-registered project, NO yq/PyYAML -> still blocks on red pipeline (registry fallback engages)" 2 "red or unresolvable" "$sb" \
+  "$(printf "$WRAPPER_CMD_TMPL" "$sb")"
+
+# make_sandbox_wrapper_gh_no_yaml_tools <gh_mode> — a GENUINELY gh-kind
+# project (no tracker: override at all — relies on the global default),
+# with yq/python3 stubbed the same unusable way. Proves the #1121 fallback
+# never produces a FALSE positive: it must not flip a real gh-kind project
+# to glab just because the registry lookup came back empty for other
+# reasons. `glab` fails loudly if ever invoked, mirroring the existing
+# "gh must NOT be consulted" pattern in reverse.
+make_sandbox_wrapper_gh_no_yaml_tools() {
+  local gh_mode="$1"
+  local sb
+  sb=$(mktemp -d)
+  mkdir -p "$sb/.claude/hooks" "$sb/bin"
+  cp "$HOOK_SRC"      "$sb/.claude/hooks/block-merge-on-red-ci.sh"
+  cp "$LIB_PR"        "$sb/.claude/hooks/_lib-extract-pr.sh"
+  cp "$TRACKER_LIB"   "$sb/.claude/hooks/_lib-tracker.sh"
+  cp "$CONFIG_LIB"    "$sb/.claude/hooks/_lib-read-config.sh"
+  cp "$PORTFOLIO_LIB" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  [ -f "$OPSROOT_LIB" ] && cp "$OPSROOT_LIB" "$sb/.claude/hooks/_lib-ops-root.sh"
+  chmod +x "$sb/.claude/hooks/block-merge-on-red-ci.sh"
+  touch "$sb/onboarding.yaml"
+  cat > "$sb/.claude/project-config.defaults.json" <<'JSON'
+{ "tracker": { "kind": "gh" } }
+JSON
+  cat > "$sb/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: gh-proj
+    repo: g/p2
+    roles:
+      - backend-engineer
+      - platform-engineer
+    tags:
+      - customer-facing
+YAML
+  cat > "$sb/bin/gh" <<EOF
+#!/bin/bash
+case "\$*" in
+  *"pr checks"*)
+    case "$gh_mode" in
+      green) printf 'build\tpass\t1m\thttps://x\n'; exit 0 ;;
+      red)   printf 'build\tfail\t1m\thttps://x\n'; exit 1 ;;
+      *)     exit 0 ;;
+    esac
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$sb/bin/gh"
+  cat > "$sb/bin/glab" <<'EOF'
+#!/bin/bash
+echo "WRONG: glab should not be called for a gh-registered project" >&2
+exit 1
+EOF
+  chmod +x "$sb/bin/glab"
+  cat > "$sb/bin/yq" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+  chmod +x "$sb/bin/yq"
+  cat > "$sb/bin/python3" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+  chmod +x "$sb/bin/python3"
+  echo "$sb"
+}
+
+WRAPPER_CMD_TMPL2='. "%s/.claude/hooks/_lib-tracker.sh"
+MERGE_RESULT=$(tracker_pr_merge "g/p2" "501" "squash" true)'
+
+sb=$(make_sandbox_wrapper_gh_no_yaml_tools green)
+run_case "#1121: wrapper, gh-kind project (no tracker override), NO yq/PyYAML -> allows on green CI (no false-positive glab)" 0 "" "$sb" \
+  "$(printf "$WRAPPER_CMD_TMPL2" "$sb")"
+
+sb=$(make_sandbox_wrapper_gh_no_yaml_tools red)
+run_case "#1121: wrapper, gh-kind project (no tracker override), NO yq/PyYAML -> blocks on red CI (no false-positive glab)" 2 "red CI" "$sb" \
+  "$(printf "$WRAPPER_CMD_TMPL2" "$sb")"
+
 # --- Fail-closed on jq-unavailable/unparseable input (#965) ------------
 #
 # Reuses make_sandbox's green gh mock, then shadows jq with a stub that

--- a/.claude/hooks/tests/test_block_merge_on_red_ci.sh
+++ b/.claude/hooks/tests/test_block_merge_on_red_ci.sh
@@ -447,6 +447,76 @@ sb=$(make_sandbox_wrapper_gh_no_yaml_tools red)
 run_case "#1121: wrapper, gh-kind project (no tracker override), NO yq/PyYAML -> blocks on red CI (no false-positive glab)" 2 "red CI" "$sb" \
   "$(printf "$WRAPPER_CMD_TMPL2" "$sb")"
 
+# ----------------------------------------------------------------------
+# #1121 (position-dependence): _registry_glab_fallback's awk emitted the
+# match BOTH mid-stream (`print "glab"; exit`) AND again in its END block
+# (awk's `exit` runs END, and block_repo/block_kind were still set), so
+# `found` became "glab\nglab" and the caller's exact `= "glab"` compare
+# FAILED — a false miss whenever the glab target block was NOT the last
+# registry entry. The single-project registry in make_sandbox_wrapper only
+# ever exercised the "sole/last entry" shape, hiding the bug. These cases
+# put a gh-kind block AFTER the glab target (g/p) so the mid-stream branch
+# fires; on the buggy code the fallback misses -> forge stays gh -> the
+# loud `gh` stub is (wrongly) consulted -> unresolvable -> BLOCK even on a
+# green glab pipeline. On the fixed code the fallback resolves glab and the
+# green pipeline ALLOWS / a red one BLOCKS, position-independently.
+# ----------------------------------------------------------------------
+
+# make_sandbox_wrapper_no_yaml_tools_glab_not_last <glab_mode> <position>
+# Same yq/PyYAML-absent glab sandbox as make_sandbox_wrapper_no_yaml_tools,
+# but the glab target (g/p) is NOT the last registry entry. position:
+# "first"  = glab first of two (gh-kind block after it);
+# "middle" = glab middle of three (gh-kind block before AND after it).
+make_sandbox_wrapper_no_yaml_tools_glab_not_last() {
+  local glab_mode="$1" position="$2"
+  local sb
+  sb=$(make_sandbox_wrapper_no_yaml_tools "$glab_mode")
+  if [ "$position" = "middle" ]; then
+    cat > "$sb/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: gh-before
+    repo: g/before
+    tracker:
+      kind: gh
+  - name: gl
+    repo: g/p
+    tracker:
+      kind: glab
+  - name: gh-after
+    repo: g/after
+    tracker:
+      kind: gh
+YAML
+  else
+    cat > "$sb/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: gl
+    repo: g/p
+    tracker:
+      kind: glab
+  - name: gh-after
+    repo: g/after
+    tracker:
+      kind: gh
+YAML
+  fi
+  echo "$sb"
+}
+
+sb=$(make_sandbox_wrapper_no_yaml_tools_glab_not_last success first)
+run_case "#1121: wrapper, glab project FIRST of two, NO yq/PyYAML -> allows on green pipeline (fallback position-independent)" 0 "" "$sb" \
+  "$(printf "$WRAPPER_CMD_TMPL" "$sb")"
+
+sb=$(make_sandbox_wrapper_no_yaml_tools_glab_not_last failure first)
+run_case "#1121: wrapper, glab project FIRST of two, NO yq/PyYAML -> blocks on red pipeline (fallback position-independent)" 2 "red or unresolvable" "$sb" \
+  "$(printf "$WRAPPER_CMD_TMPL" "$sb")"
+
+sb=$(make_sandbox_wrapper_no_yaml_tools_glab_not_last success middle)
+run_case "#1121: wrapper, glab project MIDDLE of three, NO yq/PyYAML -> allows on green pipeline (fallback position-independent)" 0 "" "$sb" \
+  "$(printf "$WRAPPER_CMD_TMPL" "$sb")"
+
 # --- Fail-closed on jq-unavailable/unparseable input (#965) ------------
 #
 # Reuses make_sandbox's green gh mock, then shadows jq with a stub that


### PR DESCRIPTION
## Summary

- **Wrong-forge bug**: for a project registered as `glab`-kind in `apexyard.projects.yaml`, `block-merge-on-red-ci.sh` dispatched the CI-status check via `gh pr checks <N>` instead of the GitLab pipeline-status check when merged through the tracker-agnostic `tracker_pr_merge <owner/repo> <pr>` wrapper (#759). The hook already resolves the forge from the registry for this shape (`_forge_kind_for` → `tracker_kind` → `_lib-tracker.sh`'s `_tracker_project_value`, added in #790/#794) — but that registry read needs `yq` or `python3` + PyYAML to parse the per-project `tracker.kind` override, and when **neither** is installed it silently falls through to the global `.tracker.kind` default (`gh`). For a mixed-forge portfolio that's exactly wrong for the glab-registered project, and it reproduces on any box (including, plausibly, the CI runner — it only installs `jq`, not `yq`, and doesn't guarantee PyYAML) that lacks both tools.
- **Fix — registry fallback, scoped to this one hook**: added `_registry_glab_fallback`, a dependency-free (`grep`/`awk` only) scan of `apexyard.projects.yaml` that answers "does this exact repo have an explicit `tracker: kind: glab`?". It's consulted **only** when the primary resolver answers `"gh"` for a wrapper-shape command — it can only ever upgrade an ambiguous `gh` to a confirmed `glab`, never override a genuine `glab` result or invent a false positive for a project the registry doesn't explicitly mark `glab`. This is deliberately hook-local rather than a change to `_lib-tracker.sh`/`_lib-extract-pr.sh` (out of scope for this fix — that's the shared-resolver epic's territory).
- **Fail-closed posture preserved for both forges** — nothing about the existing gh-path or glab-path blocking behaviour changed; the fallback only ever affects which forge gets *checked*, never the allow/block decision logic itself.
- **Deterministic regression coverage**: the two originally-failing tests only caught this by accident of the *local* environment lacking `yq`/PyYAML. Added 7 new cases that stub `yq`/`python3` to always fail so the fix is exercised regardless of what a given CI/dev box happens to have installed — 2 proving the glab-registered project still resolves correctly (allow on green pipeline, block on red), 2 proving a genuinely `gh`-kind project (no `tracker:` override at all) is never false-positived into the `glab` path, and 3 (added in review) proving the fallback is **position-independent** in the registry (glab first-of-two green→allow / red→block, glab middle-of-three green→allow).
- **Review fix — position-independent fallback (commit 2)**: Rex's review caught that `_registry_glab_fallback`'s awk printed its match twice whenever the glab block was NOT the last registry entry — a mid-stream `print "glab"; exit`, then a second print in the `END` block (awk's `exit` runs `END` with `block_repo`/`block_kind` still set), so the caller compared against `"glab\nglab"` and MISSED. That made the fix work only for a single-/last-entry registry (the shape the initial tests happened to use). Fixed with an `emitted` flag so `END` is a no-op after a mid-stream hit — exactly one `"glab"` regardless of position. The 3 new position cases fail on the pre-fix hook and pass on the fix, proving they exercise the real defect.

## Testing

- `.claude/hooks/tests/test_block_merge_on_red_ci.sh`: **34 passed, 0 failed**. Verified against the base hook the 3 position cases genuinely fail (31 passed / 3 failed — a glab project with a *green* pipeline is wrongly BLOCKED via the gh path), and against the fix all pass — so the tests distinguish *which forge was dispatched*, not just the exit code. Also verified with `yq` absent (original repro conditions) and with `yq` installed — both paths pass.
- `shellcheck --severity=warning` clean on both changed files.
- No regressions in the sibling suites that exercise the same shared resolver lib (`_lib-extract-pr.sh`) or other merge gates: `test_block_unreviewed_merge.sh` (41/41), `test_extract_pr.sh` (24/24), `test_extract_repo_fork_scoping.sh` (3/3), `test_forge_aware_extract_pr.sh` (48/48), `test_require_architecture_review.sh` (24/24), `test_require_design_review_for_ui.sh` (24/24), `test_require_posted_review.sh` (12/12).

Refs #1121

## Glossary

| Term | Definition |
|------|------------|
| Forge | The git hosting platform a project uses — GitHub (`gh` CLI) or GitLab (`glab` CLI). ApexYard supports mixed-forge portfolios via a per-project `tracker.kind` registry override. |
| `tracker_pr_merge` wrapper | A tracker-agnostic shell function (`_lib-tracker.sh`, #759) that `/approve-merge` calls to merge a PR/MR without hardcoding `gh` or `glab` in its own command text — the forge is resolved from the registry at call time instead. |
| CONTROL-class hook | A merge-gate hook (AgDR-0104/0109) that decides on structured state (a CI conclusion, a review marker) rather than on the text of a command, and must fail closed when it can't evaluate its precondition. |
| Fail closed | When a hook can't determine the safe answer, it blocks rather than allows — the existing posture for both the gh and glab paths, unchanged by this PR. |

