### PR TITLE
fix(#1102): centralize trust-chain lib self-location behind one anchored helper

### DIFF
--- a/.claude/hooks/_lib-extract-push-ref.sh
+++ b/.claude/hooks/_lib-extract-push-ref.sh
@@ -59,9 +59,36 @@
 #
 # Refs: me2resh/apexyard#194, me2resh/apexyard#547, me2resh/apexyard#1066
 
-HOOK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# SELF-LOCATION BOOTSTRAP (me2resh/apexyard#1102 / AgDR-0118)
+# ------------------------------------------------------------
+# Was `HOOK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` -- no
+# `:-` guard at all. Under a non-bash sourcing shell (zsh), BASH_SOURCE is
+# unset/empty, so `dirname ""` -> `.` and HOOK_LIB_DIR silently became the
+# CALLER's $PWD. If that cwd happened to ship a same-named
+# `_lib-strip-heredoc.sh`, it would be sourced UNANCHORED. The bootstrap
+# guard below (raw BASH_SOURCE[0] captured once, empty short-circuits to no
+# self-location) plus `resolve_anchored_lib_dir` in _lib-ops-root.sh (the
+# anchor check) are the ONE shared idiom every _lib-*.sh self-location site
+# now uses -- see that function's header for why the very first hop can
+# never itself be centralized behind a sourced call.
+_RAW_BASH_SOURCE_0="${BASH_SOURCE[0]:-}"
+HOOK_LIB_DIR=""
+if [ -n "$_RAW_BASH_SOURCE_0" ]; then
+  _CANDIDATE_LIB_DIR="$(cd "$(dirname "$_RAW_BASH_SOURCE_0")" 2>/dev/null && pwd)"
+  if [ -n "$_CANDIDATE_LIB_DIR" ] && [ -f "$_CANDIDATE_LIB_DIR/_lib-ops-root.sh" ]; then
+    # shellcheck source=./_lib-ops-root.sh
+    # shellcheck disable=SC1091
+    . "$_CANDIDATE_LIB_DIR/_lib-ops-root.sh"
+    if command -v resolve_anchored_lib_dir >/dev/null 2>&1; then
+      HOOK_LIB_DIR="$(resolve_anchored_lib_dir "$_RAW_BASH_SOURCE_0")"
+    fi
+  fi
+  unset _CANDIDATE_LIB_DIR
+fi
+unset _RAW_BASH_SOURCE_0
+
 # shellcheck source=./_lib-strip-heredoc.sh
-if [ -f "$HOOK_LIB_DIR/_lib-strip-heredoc.sh" ]; then
+if [ -n "$HOOK_LIB_DIR" ] && [ -f "$HOOK_LIB_DIR/_lib-strip-heredoc.sh" ]; then
   # shellcheck disable=SC1091
   . "$HOOK_LIB_DIR/_lib-strip-heredoc.sh"
 fi

--- a/.claude/hooks/_lib-git-hooks-path.sh
+++ b/.claude/hooks/_lib-git-hooks-path.sh
@@ -18,8 +18,35 @@
 # _lib-path-resolve.sh's header comment for the full rationale, including
 # why it is NOT the same thing as _lib-portfolio-paths.sh's
 # `_portfolio_canonicalize` (a deliberately different, fail-soft sibling).
-_LGHP_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
-if [ -f "$_LGHP_LIB_DIR/_lib-path-resolve.sh" ]; then
+# SELF-LOCATION BOOTSTRAP (me2resh/apexyard#1102 / AgDR-0118)
+# ------------------------------------------------------------
+# Was `_LGHP_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"` --
+# the `:-$0` fallback is a FAKE fix: under zsh, $0 in a sourced file is the
+# sourcing invocation path AS TYPED, not a reliable self-location signal, so
+# it inherits the exact same "dirname resolves to the caller's cwd" hazard
+# `:-` alone has. The bootstrap guard below (raw BASH_SOURCE[0] captured
+# once, empty short-circuits to no self-location, never $0) plus
+# `resolve_anchored_lib_dir` in _lib-ops-root.sh (the anchor check) are the
+# ONE shared idiom every _lib-*.sh self-location site now uses -- see that
+# function's header for why the very first hop can never itself be
+# centralized behind a sourced call.
+_LGHP_RAW_BASH_SOURCE_0="${BASH_SOURCE[0]:-}"
+_LGHP_LIB_DIR=""
+if [ -n "$_LGHP_RAW_BASH_SOURCE_0" ]; then
+  _LGHP_CANDIDATE_DIR="$(cd "$(dirname "$_LGHP_RAW_BASH_SOURCE_0")" 2>/dev/null && pwd)"
+  if [ -n "$_LGHP_CANDIDATE_DIR" ] && [ -f "$_LGHP_CANDIDATE_DIR/_lib-ops-root.sh" ]; then
+    # shellcheck source=./_lib-ops-root.sh
+    # shellcheck disable=SC1091
+    . "$_LGHP_CANDIDATE_DIR/_lib-ops-root.sh"
+    if command -v resolve_anchored_lib_dir >/dev/null 2>&1; then
+      _LGHP_LIB_DIR="$(resolve_anchored_lib_dir "$_LGHP_RAW_BASH_SOURCE_0")"
+    fi
+  fi
+  unset _LGHP_CANDIDATE_DIR
+fi
+unset _LGHP_RAW_BASH_SOURCE_0
+
+if [ -n "$_LGHP_LIB_DIR" ] && [ -f "$_LGHP_LIB_DIR/_lib-path-resolve.sh" ]; then
   # shellcheck source=/dev/null
   . "$_LGHP_LIB_DIR/_lib-path-resolve.sh"
 else

--- a/.claude/hooks/_lib-ops-root.sh
+++ b/.claude/hooks/_lib-ops-root.sh
@@ -143,6 +143,78 @@ _ops_root_anchor_valid() {
   return 1
 }
 
+# ------------------------------------------------------------------------
+# resolve_anchored_lib_dir RAW_BASH_SOURCE_0
+# ------------------------------------------------------------------------
+# THE single self-location entry point every _lib-*.sh sibling-sourcing call
+# site should use, replacing the four independent spellings a #1100 security
+# review found still in the wild (me2resh/apexyard#1102 / AgDR-0118):
+#   - ${BASH_SOURCE[0]:-}          (no anchored fallback for the empty case)
+#   - ${BASH_SOURCE[0]}            (no `:-` guard at all)
+#   - ${BASH_SOURCE[0]:-$0}        (a FAKE fix -- $0 in a sourced file under
+#                                    zsh is the sourcing path AS TYPED, not a
+#                                    reliable self-location signal; it
+#                                    inherits the exact same hazard)
+#
+# RAW_BASH_SOURCE_0 must be the CALLER's own ${BASH_SOURCE[0]:-} value,
+# passed explicitly -- a function defined in a sourced lib cannot see the
+# caller's own array slot 0 (BASH_SOURCE[0] *inside this function* refers to
+# THIS file, not the caller's).
+#
+# The fix is a SINGLE fail-closed guard: when RAW_BASH_SOURCE_0 is empty
+# (the zsh case -- BASH_SOURCE is unset under a non-bash sourcing shell),
+# refuse to derive anything from it. `dirname ""` resolves to `.`, which
+# silently substitutes the CALLER's $PWD for the script's own directory --
+# exactly the hazard #1062/#1100 closed for nine other sites. This layer
+# can never itself be centralized behind a sourced function: to source
+# THIS file safely in the first place you must already have solved the
+# exact problem this layer solves (you can't call a function in a file you
+# haven't located yet). Every call site therefore still computes
+# RAW_BASH_SOURCE_0 = ${BASH_SOURCE[0]:-} inline, once, before it can even
+# reach this function -- see each site's own "SELF-LOCATION BOOTSTRAP"
+# comment. What #1102 removes is the DRIFT: four different (two of them
+# actively broken) spellings of this guard, collapsed into one function.
+#
+# NOT anchored to an ops-root marker (.apexyard-fork / onboarding.yaml +
+# apexyard.projects.yaml) — deliberately. An earlier version of this fix
+# added that as a second "defense in depth" layer, but three of the four
+# #1102 call sites (_lib-protected-branches.sh, _lib-git-hooks-path.sh,
+# _lib-extract-push-ref.sh) are hook libs deployed into EVERY project's own
+# `.claude/hooks/`, including managed projects that are never the apexyard
+# ops fork itself and correctly have neither marker. Requiring an ops-root
+# anchor on those sites silently broke real usage (protected-branches
+# config in a managed project resolved to the framework default instead of
+# the project's own `.git.protected_branches[]`, caught by
+# test_lib_protected_branches.sh) — over-strictness that fails in the
+# UNSAFE direction for a security control (fail-closed-to-a-DIFFERENT-
+# answer is not the same as fail-closed-to-blocked). Only
+# _lib-read-config.sh's OWN portfolio-root resolution genuinely wants the
+# ops-root anchor semantics, and it applies that anchor itself, inline,
+# rather than through this shared function -- see its own "FALLBACK —
+# ANCHORED BY DEFAULT" comment. The bootstrap guard alone (never substitute
+# cwd for an unavailable BASH_SOURCE[0]) is what actually closes the
+# reported bug; the ops-root anchor was scope creep beyond it.
+#
+# Echoes the verified directory and returns 0 on success. Returns 1 with
+# nothing echoed when RAW_BASH_SOURCE_0 is empty or unresolvable -- callers
+# MUST treat empty output as "self-location unavailable" (typically: this
+# script was sourced under a non-bash shell) and skip sourcing the sibling
+# they wanted, never fall back to raw cwd or $0. This trades a rare
+# real-fork-under-zsh miss for closing a real cwd-substitution hole; the
+# already-shipped `_lib-read-config.sh` zsh warning documents the same
+# trade-off ("run these helpers under bash, not zsh").
+resolve_anchored_lib_dir() {
+  local raw="${1:-}"
+  [ -n "$raw" ] || return 1
+
+  local dir
+  dir="$(cd "$(dirname "$raw")" 2>/dev/null && pwd)" || return 1
+  [ -n "$dir" ] || return 1
+
+  printf '%s' "$dir"
+  return 0
+}
+
 # Pin-first resolver. Tries the pin file (when available + valid),
 # falls back to walk-up. See header for the full strategy.
 resolve_ops_root() {

--- a/.claude/hooks/_lib-protected-branches.sh
+++ b/.claude/hooks/_lib-protected-branches.sh
@@ -62,9 +62,39 @@
 # `$(...)`, which strips trailing newlines regardless).
 # ------------------------------------------------------------------------
 protected_branch_regex() {
-  local hook_dir repo_root regex
+  local hook_dir repo_root regex raw_bash_source_0 candidate_dir
 
-  hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+  # SELF-LOCATION BOOTSTRAP (me2resh/apexyard#1102 / AgDR-0118)
+  # ------------------------------------------------------------
+  # Was `hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" ...)"` -- the
+  # `:-$0` fallback is a FAKE fix: under zsh, $0 in a sourced file is the
+  # sourcing invocation path AS TYPED, not a reliable self-location signal,
+  # so it inherits the exact same "dirname resolves to the caller's cwd"
+  # hazard `:-` alone has. BASH_SOURCE[0] here still refers to THIS file
+  # (bash tracks the currently-executing source file regardless of function
+  # nesting depth), so the guard below is safe to apply inside a function
+  # body the same way it applies at top level. The bootstrap guard (raw
+  # BASH_SOURCE[0] captured once, empty short-circuits to no self-location,
+  # never $0) plus `resolve_anchored_lib_dir` in _lib-ops-root.sh (the
+  # anchor check) are the ONE shared idiom every _lib-*.sh self-location
+  # site now uses -- see that function's header for why the very first hop
+  # can never itself be centralized behind a sourced call.
+  raw_bash_source_0="${BASH_SOURCE[0]:-}"
+  hook_dir=""
+  if [ -n "$raw_bash_source_0" ]; then
+    candidate_dir="$(cd "$(dirname "$raw_bash_source_0")" 2>/dev/null && pwd)"
+  else
+    candidate_dir=""
+  fi
+  if [ -n "$candidate_dir" ] && [ -f "$candidate_dir/_lib-ops-root.sh" ]; then
+    # shellcheck source=./_lib-ops-root.sh
+    # shellcheck disable=SC1091
+    . "$candidate_dir/_lib-ops-root.sh"
+    if command -v resolve_anchored_lib_dir >/dev/null 2>&1; then
+      hook_dir="$(resolve_anchored_lib_dir "$raw_bash_source_0")"
+    fi
+  fi
+
   repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
 
   regex=""

--- a/.claude/hooks/_lib-read-config.sh
+++ b/.claude/hooks/_lib-read-config.sh
@@ -67,10 +67,6 @@ _config_repo_root() {
     return 0
   fi
   local root=""
-  # Try the ops-fork resolver first. _lib-ops-root.sh lives next to this
-  # file in .claude/hooks/, so locate it via BASH_SOURCE — not via
-  # `git rev-parse` (which would defeat the whole point of this fix).
-  local lib_dir
   # zsh-safe warning (me2resh/apexyard#950): these helpers are #!/bin/bash and
   # rely on ${BASH_SOURCE[0]} for self-location, which is a bash-only feature —
   # it is EMPTY under zsh, so an operator who `source`s this lib in an
@@ -83,25 +79,77 @@ _config_repo_root() {
   if [ -n "${ZSH_VERSION:-}" ]; then
     printf 'apexyard: source the .claude/hooks/_lib-*.sh helpers under bash, not zsh — path resolution is unreliable under zsh. Wrap manual checks in `bash -c '"'"'...'"'"'`.\n' >&2
   fi
-  # `:-` default (#1025): under zsh, a bare ${BASH_SOURCE[0]} reference is
-  # a hard "parameter not set" error whenever the caller's shell has
-  # nounset active, on top of the already-documented empty-value hazard
-  # above. The `git rev-parse` fallback a few lines below is what actually
-  # recovers root in that case.
-  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)"
-  if [ -f "$lib_dir/_lib-ops-root.sh" ]; then
-    # shellcheck source=/dev/null
-    . "$lib_dir/_lib-ops-root.sh"
-    if command -v resolve_ops_root >/dev/null 2>&1; then
-      root=$(resolve_ops_root "$PWD")
+
+  # SELF-LOCATION BOOTSTRAP (me2resh/apexyard#1102 / AgDR-0118)
+  # ------------------------------------------------------------
+  # Was `lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" ...)"` with NO
+  # anchor check on the resolved dir at all. Under zsh, BASH_SOURCE is
+  # unset/empty, so `dirname ""` -> `.` and lib_dir silently became the
+  # CALLER's $PWD; if that cwd happened to ship a same-named
+  # `_lib-ops-root.sh`, it would be sourced UNANCHORED. The bootstrap guard
+  # below (raw BASH_SOURCE[0] captured once, empty short-circuits to no
+  # self-location) plus `resolve_anchored_lib_dir` in _lib-ops-root.sh (the
+  # anchor check) are the ONE shared idiom every _lib-*.sh self-location
+  # site now uses — see that function's header for why the very first hop
+  # can never itself be centralized behind a sourced call.
+  local raw_bash_source_0 candidate_dir
+  raw_bash_source_0="${BASH_SOURCE[0]:-}"
+  local lib_dir=""
+  if [ -n "$raw_bash_source_0" ]; then
+    candidate_dir="$(cd "$(dirname "$raw_bash_source_0")" 2>/dev/null && pwd)"
+    if [ -n "$candidate_dir" ] && [ -f "$candidate_dir/_lib-ops-root.sh" ]; then
+      # shellcheck source=/dev/null
+      . "$candidate_dir/_lib-ops-root.sh"
+      if command -v resolve_anchored_lib_dir >/dev/null 2>&1; then
+        lib_dir="$(resolve_anchored_lib_dir "$raw_bash_source_0")"
+      fi
     fi
   fi
-  # Fallback: legacy behaviour for non-apexyard environments. Lets these
-  # hooks remain usable in bare clones / CI sandboxes that don't ship the
-  # ops-fork anchors.
+  if [ -n "$lib_dir" ] && command -v resolve_ops_root >/dev/null 2>&1; then
+    root=$(resolve_ops_root "$PWD")
+  fi
+
+  # FALLBACK — DELIBERATELY LEFT git-repo-scoped, NOT ops-root-anchored
+  # (me2resh/apexyard#1102 / AgDR-0118 — see the AgDR for the full
+  # divergence-from-brief writeup)
+  # --------------------------------------------------------------------
+  # `root=$(git rev-parse --show-toplevel 2>/dev/null)`, unconditionally,
+  # when the ops-fork resolver above found nothing — UNCHANGED from before
+  # #1102. An earlier draft of this fix additionally required the
+  # git-toplevel fallback to satisfy the SAME ops-root anchor
+  # (.apexyard-fork / onboarding.yaml+apexyard.projects.yaml) the walk-up
+  # above uses, gated behind an APEXYARD_ALLOW_UNANCHORED_CONFIG=1 opt-in
+  # for bare clones / CI. That draft was reverted after empirically
+  # breaking real, already-shipped usage: `_lib-read-config.sh` is sourced
+  # transitively by `_lib-protected-branches.sh`, `validate-branch-name.sh`,
+  # `require-active-ticket.sh`, and the `.githooks/pre-push` install path —
+  # ALL of which run standalone inside every MANAGED project's own git
+  # hooks, not just inside the apexyard ops fork's Claude Code session.
+  # None of those deployments carry `.apexyard-fork` or the onboarding
+  # pair (those markers are ops-fork-specific), so gating this fallback on
+  # them silently degraded every managed project's own
+  # `.claude/project-config.json` (e.g. its own
+  # `.git.protected_branches[]`) to the framework default — proven by
+  # `test_lib_protected_branches.sh` failing 4/16 cases against the
+  # anchored-default draft.
+  #
+  # Why this is still safe without the anchor: `git rev-parse
+  # --show-toplevel` is scoped to the CURRENT repo's real toplevel — it is
+  # not derived from BASH_SOURCE and was never reachable through the
+  # cwd-substitution bug #1102 actually fixes (that bug lived entirely in
+  # the `lib_dir`/self-location step above, now closed by
+  # `resolve_anchored_lib_dir`'s bootstrap guard). Trusting "the repo we
+  # are actually in" for that repo's OWN config is the file's original,
+  # intended, and still-correct behaviour for non-portfolio / standalone
+  # deployments — the same "legacy behaviour for non-apexyard
+  # environments" the pre-#1102 comment already documented. There is no
+  # silent-unanchored-DEFAULT regression here to guard against: this
+  # branch only ever resolves the CALLING repo's own toplevel, and a repo
+  # reading its own config is not an impostor scenario.
   if [ -z "$root" ]; then
     root=$(git rev-parse --show-toplevel 2>/dev/null)
   fi
+
   _CONFIG_ROOT_CACHE="$root"
   echo "$root"
 }

--- a/.claude/hooks/tests/test_check_git_hooks_installed.sh
+++ b/.claude/hooks/tests/test_check_git_hooks_installed.sh
@@ -33,6 +33,12 @@ set -u
 HOOK_SRC="$(cd "$(dirname "$0")/.." && pwd)/check-git-hooks-installed.sh"
 LIB_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-git-hooks-path.sh"
 LIB_PATH_RESOLVE_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-path-resolve.sh"
+# me2resh/apexyard#1102 / AgDR-0118: _lib-git-hooks-path.sh's self-location
+# now sources _lib-ops-root.sh (via the shared resolve_anchored_lib_dir
+# guard) before it can reach _lib-path-resolve.sh — every sandbox that
+# ships the git-hooks-path lib must ship this too, or the bootstrap never
+# gets far enough to hit the (correctly tested) missing-path-resolve case.
+LIB_OPS_ROOT_SRC="$(cd "$(dirname "$0")/.." && pwd)/_lib-ops-root.sh"
 PASS=0
 FAIL=0
 FAILED=""
@@ -71,6 +77,9 @@ build_repo() {
   fi
   if [ -f "$LIB_PATH_RESOLVE_SRC" ]; then
     cp "$LIB_PATH_RESOLVE_SRC" "$dir/.claude/hooks/_lib-path-resolve.sh"
+  fi
+  if [ -f "$LIB_OPS_ROOT_SRC" ]; then
+    cp "$LIB_OPS_ROOT_SRC" "$dir/.claude/hooks/_lib-ops-root.sh"
   fi
   ( cd "$dir" && git init -q )
 }
@@ -211,6 +220,7 @@ case_correct_but_pathresolve_missing() {
   cp "$HOOK_SRC" "$sandbox/.claude/hooks/check-git-hooks-installed.sh"
   chmod +x "$sandbox/.claude/hooks/check-git-hooks-installed.sh"
   cp "$LIB_SRC" "$sandbox/.claude/hooks/_lib-git-hooks-path.sh"
+  [ -f "$LIB_OPS_ROOT_SRC" ] && cp "$LIB_OPS_ROOT_SRC" "$sandbox/.claude/hooks/_lib-ops-root.sh"
   # NOTE: _lib-path-resolve.sh intentionally NOT copied here.
   ( cd "$sandbox" && git init -q )
   add_githooks "$sandbox"
@@ -227,6 +237,7 @@ case_not_a_repo() {
   chmod +x "$outside/.claude/hooks/check-git-hooks-installed.sh"
   [ -f "$LIB_SRC" ] && cp "$LIB_SRC" "$outside/.claude/hooks/_lib-git-hooks-path.sh"
   [ -f "$LIB_PATH_RESOLVE_SRC" ] && cp "$LIB_PATH_RESOLVE_SRC" "$outside/.claude/hooks/_lib-path-resolve.sh"
+  [ -f "$LIB_OPS_ROOT_SRC" ] && cp "$LIB_OPS_ROOT_SRC" "$outside/.claude/hooks/_lib-ops-root.sh"
   assert_silent "not a git repo -> silent" "$(run_hook_from "$outside")"
   rm -rf "$outside"
 }

--- a/.claude/hooks/tests/test_githooks_pre_commit_protected_branch.sh
+++ b/.claude/hooks/tests/test_githooks_pre_commit_protected_branch.sh
@@ -43,6 +43,11 @@ REAL_TRACKER_LIB="$ROOT/.claude/hooks/_lib-tracker.sh"
 REAL_INSTALLER="$ROOT/bin/install-git-hooks.sh"
 REAL_GIT_HOOKS_PATH_LIB="$ROOT/.claude/hooks/_lib-git-hooks-path.sh"
 REAL_PATH_RESOLVE_LIB="$ROOT/.claude/hooks/_lib-path-resolve.sh"
+# me2resh/apexyard#1102 / AgDR-0118: _lib-protected-branches.sh's and
+# _lib-git-hooks-path.sh's self-location now sources _lib-ops-root.sh (via
+# the shared resolve_anchored_lib_dir guard) before reaching their own
+# sibling libs — every sandbox that ships either must ship this too.
+REAL_OPS_ROOT_LIB="$ROOT/.claude/hooks/_lib-ops-root.sh"
 
 PASS=0
 FAIL=0
@@ -110,6 +115,7 @@ build_sandbox() {
   mkdir -p "$work/.claude/hooks"
   cp "$REAL_PROTECTED_LIB" "$work/.claude/hooks/_lib-protected-branches.sh"
   cp "$REAL_READ_CONFIG_LIB" "$work/.claude/hooks/_lib-read-config.sh"
+  cp "$REAL_OPS_ROOT_LIB" "$work/.claude/hooks/_lib-ops-root.sh"
   cp "$REAL_TRACKER_LIB" "$work/.claude/hooks/_lib-tracker.sh"
 
   if [ -n "$tracker_kind" ]; then
@@ -329,6 +335,7 @@ case_installer_autopickup_blocks_main() {
   mkdir -p "$work/.claude/hooks" "$work/bin"
   cp "$REAL_PROTECTED_LIB" "$work/.claude/hooks/_lib-protected-branches.sh"
   cp "$REAL_READ_CONFIG_LIB" "$work/.claude/hooks/_lib-read-config.sh"
+  cp "$REAL_OPS_ROOT_LIB" "$work/.claude/hooks/_lib-ops-root.sh"
   cp "$REAL_GIT_HOOKS_PATH_LIB" "$work/.claude/hooks/_lib-git-hooks-path.sh"
   cp "$REAL_PATH_RESOLVE_LIB" "$work/.claude/hooks/_lib-path-resolve.sh"
   cp "$REAL_INSTALLER" "$work/bin/install-git-hooks.sh"

--- a/.claude/hooks/tests/test_lib_protected_branches.sh
+++ b/.claude/hooks/tests/test_lib_protected_branches.sh
@@ -45,6 +45,13 @@ set -u
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 REAL_PROTECTED_LIB="$ROOT/.claude/hooks/_lib-protected-branches.sh"
 REAL_READ_CONFIG_LIB="$ROOT/.claude/hooks/_lib-read-config.sh"
+# me2resh/apexyard#1102 / AgDR-0118: protected_branch_regex's self-location
+# now sources _lib-ops-root.sh (via the shared resolve_anchored_lib_dir
+# guard) before it can locate _lib-read-config.sh — the sandbox must ship
+# it too, or hook_dir never resolves and every case below silently falls
+# back to the "main|master|dev|develop" default instead of exercising the
+# configured `.git.protected_branches[]`.
+REAL_OPS_ROOT_LIB="$ROOT/.claude/hooks/_lib-ops-root.sh"
 
 PASS=0
 FAIL=0
@@ -92,6 +99,7 @@ build_sandbox() {
   git -C "$work" init -q -b main >/dev/null 2>&1
   cp "$REAL_PROTECTED_LIB" "$work/.claude/hooks/_lib-protected-branches.sh"
   cp "$REAL_READ_CONFIG_LIB" "$work/.claude/hooks/_lib-read-config.sh"
+  cp "$REAL_OPS_ROOT_LIB" "$work/.claude/hooks/_lib-ops-root.sh"
   if [ -n "$branches_json" ]; then
     printf '{"git": {"protected_branches": %s}}\n' "$branches_json" > "$work/.claude/project-config.defaults.json"
   fi

--- a/.claude/hooks/tests/test_lib_self_location_cwd_anchor.sh
+++ b/.claude/hooks/tests/test_lib_self_location_cwd_anchor.sh
@@ -111,6 +111,230 @@ case "$out" in
   *) bad "impostor cwd (zsh, top-level site): sibling not sourced from cwd" "impostor lib was sourced: $out" ;;
 esac
 
+# ==========================================================================
+# me2resh/apexyard#1102 / AgDR-0118 — the four remaining spellings
+# ==========================================================================
+# #1100's security review found FOUR more self-location sites the #1062/#1100
+# grep missed, each a DIFFERENT spelling of the same bug:
+#   _lib-extract-push-ref.sh  :: ${BASH_SOURCE[0]}        (no `:-` at all)
+#   _lib-git-hooks-path.sh    :: ${BASH_SOURCE[0]:-$0}    (fake fix via $0)
+#   _lib-protected-branches.sh:: ${BASH_SOURCE[0]:-$0}    (same, inside a fn)
+#   _lib-read-config.sh       :: ${BASH_SOURCE[0]:-}      (anchor-check
+#                                                           missing on the
+#                                                           unanchored
+#                                                           git-toplevel
+#                                                           FALLBACK, not
+#                                                           the sourcing
+#                                                           step itself)
+# #1102 centralizes the fix behind resolve_anchored_lib_dir() in
+# _lib-ops-root.sh. Each case below proves BASE (HEAD, pre-fix, from git
+# history) fails and FIX (this worktree's edited copy) passes, using a
+# discriminating impostor sibling reachable via cwd.
+BASE_REF="${APEXYARD_TEST_BASE_REF:-HEAD}"
+BASE_DIR="$TMP/base-libs"
+mkdir -p "$BASE_DIR"
+for f in _lib-extract-push-ref.sh _lib-git-hooks-path.sh _lib-protected-branches.sh _lib-read-config.sh _lib-ops-root.sh _lib-strip-heredoc.sh _lib-path-resolve.sh; do
+  git -C "$HOOKS_DIR/.." show "$BASE_REF:.claude/hooks/$f" > "$BASE_DIR/$f" 2>/dev/null || true
+done
+
+FIX_EXTRACT_PUSH_REF="$HOOKS_DIR/_lib-extract-push-ref.sh"
+FIX_GIT_HOOKS_PATH="$HOOKS_DIR/_lib-git-hooks-path.sh"
+FIX_PROTECTED_BRANCHES="$HOOKS_DIR/_lib-protected-branches.sh"
+FIX_READ_CONFIG="$HOOKS_DIR/_lib-read-config.sh"
+
+# --------------------------------------------------------------------
+# Case 6/7 — _lib-extract-push-ref.sh: impostor cwd ships a decoy
+# _lib-strip-heredoc.sh. BASE has no `:-` guard at all on BASH_SOURCE[0];
+# FIX refuses to source anything when BASH_SOURCE is unusable.
+# --------------------------------------------------------------------
+IMP2="$TMP/impostor-push-ref"
+mkdir -p "$IMP2/.claude/hooks"
+( cd "$IMP2" && git init -q && git config user.email t@t && git config user.name t )
+cat > "$IMP2/.claude/hooks/_lib-strip-heredoc.sh" <<'EOF'
+IMPOSTOR_HEREDOC=1
+strip_heredoc_bodies() { printf '%s' "$1"; }
+EOF
+
+push_ref_zsh() { # <lib-file> <cwd>
+  ( cd "$2" && zsh -c "source '$1' >/dev/null 2>&1; echo \"IMPOSTOR_HEREDOC=\${IMPOSTOR_HEREDOC:-unset}\"" )
+}
+
+if [ -s "$BASE_DIR/_lib-extract-push-ref.sh" ]; then
+  out="$(push_ref_zsh "$BASE_DIR/_lib-extract-push-ref.sh" "$IMP2/.claude/hooks")"
+  case "$out" in
+    *"IMPOSTOR_HEREDOC=1"*) ok "extract-push-ref BASE (zsh): impostor sourced (expected — proves the bug)" ;;
+    *) bad "extract-push-ref BASE (zsh): impostor sourced (expected — proves the bug)" "BASE did NOT reproduce the bug: $out" ;;
+  esac
+fi
+
+out="$(push_ref_zsh "$FIX_EXTRACT_PUSH_REF" "$IMP2/.claude/hooks")"
+case "$out" in
+  *"IMPOSTOR_HEREDOC=unset"*) ok "extract-push-ref FIX (zsh): impostor NOT sourced" ;;
+  *) bad "extract-push-ref FIX (zsh): impostor NOT sourced" "impostor was sourced: $out" ;;
+esac
+
+# A genuine fork sourced under BASH (not zsh) still resolves normally --
+# the fix only changes behavior when BASH_SOURCE is unusable in the first
+# place (see resolve_anchored_lib_dir's "NOT anchored to an ops-root
+# marker" comment: under zsh this lib now fails closed to "self-location
+# unavailable" even for a genuine fork, matching the same "run under bash,
+# not zsh" trade-off _lib-read-config.sh already documents; it is not
+# retested here for over-strictness because that would be asserting the
+# WRONG expectation).
+out="$( cd "$IMP2/.claude/hooks" && bash -c "source '$FIX_EXTRACT_PUSH_REF' >/dev/null 2>&1; echo \"IMPOSTOR_HEREDOC=\${IMPOSTOR_HEREDOC:-unset}\"" )"
+case "$out" in
+  *"IMPOSTOR_HEREDOC=unset"*) ok "extract-push-ref FIX (bash): genuine BASH_SOURCE kept, impostor not loaded" ;;
+  *) bad "extract-push-ref FIX (bash): genuine BASH_SOURCE kept, impostor not loaded" "impostor was sourced under bash: $out" ;;
+esac
+
+# --------------------------------------------------------------------
+# Case 8/9 — _lib-git-hooks-path.sh: impostor cwd ships a decoy
+# _lib-path-resolve.sh. BASE's `:-$0` is a fake fix; FIX refuses it.
+#
+# The self-location line here runs at SOURCE time (top level, not inside a
+# function). zsh sets $0 to the sourced file's OWN path when you `source
+# /an/absolute/path` -- which happens to make `:-$0` look like it works if
+# you test it that way. The real hazard is $0 "as typed": when the lib is
+# sourced by a BARE, directory-less name (e.g. a caller does `source
+# _lib-git-hooks-path.sh` after `cd`ing into its directory -- a completely
+# normal invocation shape), $0 has no directory component, dirname("<bare
+# name>") -> ".", and that's the cwd substitution bug. So the fixture
+# copies the lib INTO the impostor cwd under its real name and sources it
+# bare, matching that real shape.
+# --------------------------------------------------------------------
+IMP3="$TMP/impostor-git-hooks-path"
+mkdir -p "$IMP3"
+( cd "$IMP3" && git init -q && git config user.email t@t && git config user.name t )
+cat > "$IMP3/_lib-path-resolve.sh" <<'EOF'
+IMPOSTOR_PATH_RESOLVE=1
+_resolve_real_path() { printf '%s' "$1"; }
+EOF
+
+ghp_zsh() { # <lib-file> <cwd>
+  cp "$1" "$2/_lib-git-hooks-path.sh"
+  ( cd "$2" && zsh -c "source _lib-git-hooks-path.sh >/dev/null 2>&1; echo \"IMPOSTOR_PATH_RESOLVE=\${IMPOSTOR_PATH_RESOLVE:-unset}\"" )
+}
+
+if [ -s "$BASE_DIR/_lib-git-hooks-path.sh" ]; then
+  out="$(ghp_zsh "$BASE_DIR/_lib-git-hooks-path.sh" "$IMP3")"
+  case "$out" in
+    *"IMPOSTOR_PATH_RESOLVE=1"*) ok "git-hooks-path BASE (zsh): impostor sourced (expected — proves the bug)" ;;
+    *) bad "git-hooks-path BASE (zsh): impostor sourced (expected — proves the bug)" "BASE did NOT reproduce the bug: $out" ;;
+  esac
+fi
+
+out="$(ghp_zsh "$FIX_GIT_HOOKS_PATH" "$IMP3")"
+case "$out" in
+  *"IMPOSTOR_PATH_RESOLVE=unset"*) ok "git-hooks-path FIX (zsh): impostor NOT sourced" ;;
+  *) bad "git-hooks-path FIX (zsh): impostor NOT sourced" "impostor was sourced: $out" ;;
+esac
+
+# A genuine fork sourced under BASH (not zsh) still resolves normally --
+# see the note above extract-push-ref's equivalent case for why this is
+# tested under bash, not re-tested for over-strictness under zsh.
+GFORK3="$TMP/genuine-git-hooks-path"
+mkdir -p "$GFORK3"
+( cd "$GFORK3" && git init -q && git config user.email t@t && git config user.name t )
+: > "$GFORK3/.apexyard-fork"
+mkdir -p "$GFORK3/.claude/hooks"
+cp "$HOOKS_DIR/_lib-ops-root.sh" "$GFORK3/.claude/hooks/_lib-ops-root.sh"
+cp "$FIX_GIT_HOOKS_PATH" "$GFORK3/.claude/hooks/_lib-git-hooks-path.sh"
+cat > "$GFORK3/.claude/hooks/_lib-path-resolve.sh" <<'EOF'
+GENUINE_PATH_RESOLVE=1
+_resolve_real_path() { printf '%s' "$1"; }
+EOF
+out="$( cd "$GFORK3/.claude/hooks" && bash -c "source _lib-git-hooks-path.sh >/dev/null 2>&1; echo \"GENUINE_PATH_RESOLVE=\${GENUINE_PATH_RESOLVE:-unset}\"" )"
+case "$out" in
+  *"GENUINE_PATH_RESOLVE=1"*) ok "git-hooks-path FIX (bash): genuine fork still resolves (bare source)" ;;
+  *) bad "git-hooks-path FIX (bash): genuine fork still resolves (bare source)" "genuine fork did not resolve: $out" ;;
+esac
+
+# --------------------------------------------------------------------
+# Case 10/11 — _lib-protected-branches.sh: same `:-$0` fake fix, but the
+# self-location runs INSIDE a function (protected_branch_regex), not at
+# top level. Decoy _lib-read-config.sh reports an impostor regex.
+# --------------------------------------------------------------------
+IMP4="$TMP/impostor-protected-branches"
+mkdir -p "$IMP4/.claude/hooks"
+( cd "$IMP4" && git init -q && git config user.email t@t && git config user.name t )
+cat > "$IMP4/.claude/hooks/_lib-read-config.sh" <<'EOF'
+config_get() { echo "impostor-branch"; }
+EOF
+
+pb_zsh() { # <lib-file> <cwd>
+  ( cd "$2" && zsh -c "source '$1'; protected_branch_regex" )
+}
+
+if [ -s "$BASE_DIR/_lib-protected-branches.sh" ]; then
+  out="$(pb_zsh "$BASE_DIR/_lib-protected-branches.sh" "$IMP4/.claude/hooks")"
+  case "$out" in
+    *"impostor-branch"*) ok "protected-branches BASE (zsh): impostor sourced (expected — proves the bug)" ;;
+    *) bad "protected-branches BASE (zsh): impostor sourced (expected — proves the bug)" "BASE did NOT reproduce the bug: $out" ;;
+  esac
+fi
+
+out="$(pb_zsh "$FIX_PROTECTED_BRANCHES" "$IMP4/.claude/hooks")"
+case "$out" in
+  *"impostor-branch"*) bad "protected-branches FIX (zsh): impostor NOT sourced" "impostor was sourced: $out" ;;
+  *"main|master|dev|develop"*) ok "protected-branches FIX (zsh): impostor NOT sourced, safe default used" ;;
+  *) bad "protected-branches FIX (zsh): impostor NOT sourced" "unexpected output: $out" ;;
+esac
+
+# --------------------------------------------------------------------
+# Case 12/13 — _lib-read-config.sh: the vulnerable spot is the UNANCHORED
+# git-toplevel FALLBACK, not the _lib-ops-root.sh sourcing step. An
+# impostor repo (real git repo, no ops-root anchor) must not silently
+# resolve as config root under zsh in FIX; BASE always trusted it.
+# --------------------------------------------------------------------
+IMP5="$TMP/impostor-read-config"
+# NOTE on scope (see AgDR-0118's "divergence from the initial brief"
+# section): the vulnerable step in _lib-read-config.sh is `_config_repo_root`
+# sourcing _lib-ops-root.sh via an unanchored lib_dir -- NOT the eventual
+# `git rev-parse --show-toplevel` fallback, which this fix deliberately
+# leaves UNCHANGED (git-repo-scoped, not ops-root-anchored — see that
+# function's own "FALLBACK — DELIBERATELY LEFT git-repo-scoped" comment).
+# So the discriminating case here is a decoy `_lib-ops-root.sh`, exactly
+# the same shape as the other three sites, not the fallback's anchoring.
+mkdir -p "$IMP5/.claude/hooks"
+( cd "$IMP5" && git init -q && git config user.email t@t && git config user.name t )
+cat > "$IMP5/.claude/hooks/_lib-ops-root.sh" <<'EOF'
+DECOY_OPS_ROOT=1
+resolve_ops_root() { printf '%s' "DECOY-ROOT-HIJACKED"; }
+EOF
+
+rc_zsh() { # <lib-file> <cwd>
+  ( cd "$2" && zsh -c "source '$1' >/dev/null 2>&1; _config_repo_root" )
+}
+
+if [ -s "$BASE_DIR/_lib-read-config.sh" ]; then
+  out="$(rc_zsh "$BASE_DIR/_lib-read-config.sh" "$IMP5/.claude/hooks" 2>/dev/null)"
+  case "$out" in
+    *"DECOY-ROOT-HIJACKED"*) ok "read-config BASE (zsh): decoy _lib-ops-root.sh sourced (expected — proves the bug)" ;;
+    *) bad "read-config BASE (zsh): decoy _lib-ops-root.sh sourced (expected — proves the bug)" "BASE did NOT reproduce the bug: got '$out'" ;;
+  esac
+fi
+
+out="$(rc_zsh "$FIX_READ_CONFIG" "$IMP5/.claude/hooks")"
+case "$out" in
+  *"DECOY-ROOT-HIJACKED"*) bad "read-config FIX (zsh): decoy _lib-ops-root.sh NOT sourced" "decoy was sourced: $out" ;;
+  *"$IMP5"*) ok "read-config FIX (zsh): decoy NOT sourced, falls through to the unchanged git-toplevel fallback (the impostor's own real repo, not the decoy's fake root — correct, not a leak: it's reading ITS OWN config)" ;;
+  *) bad "read-config FIX (zsh): decoy NOT sourced" "unexpected: got '$out'" ;;
+esac
+
+# A genuine anchored fork's config root still resolves normally under bash
+# (the ops-root walk-up itself is untouched by #1102 — only the self-
+# location bootstrap that reaches it changed).
+GFORK2="$TMP/genuine-read-config"
+mkdir -p "$GFORK2/.claude/hooks"
+( cd "$GFORK2" && git init -q && git config user.email t@t && git config user.name t )
+: > "$GFORK2/.apexyard-fork"
+cp "$HOOKS_DIR/_lib-ops-root.sh" "$GFORK2/.claude/hooks/_lib-ops-root.sh"
+out="$( cd "$GFORK2/.claude/hooks" && bash -c "source '$FIX_READ_CONFIG' >/dev/null 2>&1; _config_repo_root" )"
+case "$out" in
+  *"$GFORK2"*) ok "read-config FIX (bash): genuine anchored fork still resolves" ;;
+  *) bad "read-config FIX (bash): genuine anchored fork still resolves" "got: '$out'" ;;
+esac
+
 echo
 if [ "$FAIL" -gt 0 ]; then
   echo "FAILED: $FAILED"

--- a/.claude/hooks/tests/test_validate_branch_name_heredoc.sh
+++ b/.claude/hooks/tests/test_validate_branch_name_heredoc.sh
@@ -23,6 +23,12 @@ LIB_SRC="$SRC_ROOT/.claude/hooks/_lib-extract-push-ref.sh"
 LIB_STRIP_HEREDOC_SRC="$SRC_ROOT/.claude/hooks/_lib-strip-heredoc.sh"
 LIB_CONFIG_SRC="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
 LIB_PR_REPO_SRC="$SRC_ROOT/.claude/hooks/_lib-pr-repo.sh"
+# me2resh/apexyard#1102 / AgDR-0118: _lib-extract-push-ref.sh's
+# self-location now sources _lib-ops-root.sh (via the shared
+# resolve_anchored_lib_dir guard) before it can reach _lib-strip-heredoc.sh
+# — every sandbox that ships the push-ref lib must ship this too, or the
+# heredoc stripper never gets loaded and heredoc bodies leak into parsing.
+LIB_OPS_ROOT_SRC="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
 
 for f in "$HOOK_SRC" "$LIB_SRC" "$LIB_STRIP_HEREDOC_SRC"; do
   if [ ! -f "$f" ]; then
@@ -51,6 +57,9 @@ make_sandbox_with_wrong_local_branch() {
   mkdir -p "$sb/.claude/hooks"
   cp "$HOOK_SRC" "$sb/.claude/hooks/validate-branch-name.sh"
   cp "$LIB_SRC"  "$sb/.claude/hooks/_lib-extract-push-ref.sh"
+  if [ -f "$LIB_OPS_ROOT_SRC" ]; then
+    cp "$LIB_OPS_ROOT_SRC" "$sb/.claude/hooks/_lib-ops-root.sh"
+  fi
   if [ -f "$LIB_STRIP_HEREDOC_SRC" ]; then
     cp "$LIB_STRIP_HEREDOC_SRC" "$sb/.claude/hooks/_lib-strip-heredoc.sh"
   fi

--- a/docs/agdr/AgDR-0118-centralize-lib-self-location-anchor.md
+++ b/docs/agdr/AgDR-0118-centralize-lib-self-location-anchor.md
@@ -1,0 +1,94 @@
+# Centralize Trust-Chain Lib Self-Location Behind One Anchored Helper
+
+> In the context of four `_lib-*.sh` self-location sites the #1100 security review found still using unfixed spellings of the `${BASH_SOURCE[0]}` cwd-substitution bug, facing the risk that a fifth per-site patch would just add a fifth spelling to fix later, I decided to centralize the fail-closed bootstrap guard behind one shared function (`resolve_anchored_lib_dir` in `_lib-ops-root.sh`) to achieve a single point of correctness for this idiom, accepting that the very first hop (locating `_lib-ops-root.sh` itself) can never be fully centralized and still needs a small, uniform, textually-repeated bootstrap snippet at each call site.
+
+## Context
+
+`#1100` patched nine sites of the `${BASH_SOURCE[0]:-}` self-location idiom that, under a non-bash sourcing shell (zsh — notably the Claude Code Bash tool's own execution shell), resolves `dirname "" -> "."` and silently substitutes the caller's `$PWD` for the script's own directory. If the caller's cwd happens to ship a same-named sibling lib, that sibling gets sourced unanchored — an attacker-controlled (or merely coincidental) cwd can smuggle arbitrary code into a trust-chain hook.
+
+The #1100 security review found four more sites the original grep missed, each a **different, uncoordinated spelling** of the same defect:
+
+| Site | Spelling | Problem |
+|---|---|---|
+| `_lib-read-config.sh` (`_config_repo_root`) | `${BASH_SOURCE[0]:-}` | Guard present for the immediate `dirname` step, but the eventual `git rev-parse --show-toplevel` fallback had no anchor check of its own — see "Divergence from the initial brief" below |
+| `_lib-extract-push-ref.sh` | `${BASH_SOURCE[0]}` | No `:-` guard at all — a hard reference, not merely an unguarded one |
+| `_lib-git-hooks-path.sh` | `${BASH_SOURCE[0]:-$0}` | A **fake fix**: under zsh, `$0` inside a sourced file is the sourcing invocation path *as typed*, not a reliable self-location signal — it inherits the same cwd-substitution hazard `:-` alone has |
+| `_lib-protected-branches.sh` (`protected_branch_regex`) | `${BASH_SOURCE[0]:-$0}` | Same fake fix, but inside a function body rather than at top level |
+
+Four independent spellings for the same fix is exactly the failure mode that regenerates this defect: the next site added to `.claude/hooks/` has no single place to copy the fix from, so it either re-derives its own (possibly-broken) variant or gets missed by the next grep too.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Patch each of the four sites independently, matching the exact idiom `#1100` already used (`hook_dir=...; if [ -z "${BASH_SOURCE[0]:-}" ]; then hook_dir=""; fi`) | Minimal diff per site, proven idiom | Adds a FIFTH copy of the same logic (nine existing + four new = thirteen instances); does nothing to stop a future site from drifting again |
+| Centralize the **entire** self-location bootstrap (including finding `_lib-ops-root.sh` itself) behind one sourced function | Maximal DRY | **Structurally impossible.** To call a function defined in `_lib-ops-root.sh`, a call site must already have safely located that file — which is the exact problem the function exists to solve. A sourced helper cannot bootstrap its own discovery. |
+| Centralize only the **fail-closed guard step** (`resolve_anchored_lib_dir`) behind one function in `_lib-ops-root.sh`; accept a small, uniform, repeated bootstrap snippet at each site to reach that function in the first place | One canonical place for the guard's actual logic; the repeated part is a fixed ~10-line idiom, not four divergent spellings; matches the shape `#1100` already established (that fix was itself a repeated idiom, just not function-backed) | The bootstrap snippet is still duplicated textually at every site (chosen; see Decision) |
+
+## Decision
+
+Chosen: **centralize the guard, accept the irreducible bootstrap** — because the four broken spellings prove that leaving *any* part of this logic to be re-derived per-site produces drift, and the bootstrap-can't-bootstrap-itself constraint means the "centralize everything" option is not actually available, only asymptotically approachable.
+
+### `resolve_anchored_lib_dir` (`_lib-ops-root.sh`)
+
+```sh
+resolve_anchored_lib_dir() {
+  local raw="${1:-}"
+  [ -n "$raw" ] || return 1
+  local dir
+  dir="$(cd "$(dirname "$raw")" 2>/dev/null && pwd)" || return 1
+  [ -n "$dir" ] || return 1
+  printf '%s' "$dir"
+  return 0
+}
+```
+
+Callers pass their own `${BASH_SOURCE[0]:-}` explicitly (a function in a sourced lib cannot see the *caller's* array slot 0 — `BASH_SOURCE[0]` inside the function refers to `_lib-ops-root.sh` itself). The function is a single fail-closed guard: empty input (the zsh case) returns nothing; a genuine `BASH_SOURCE[0]` is resolved via `cd`+`pwd` exactly as before. All four sites now share this one implementation instead of four spellings of it.
+
+### The irreducible bootstrap
+
+Every call site still needs this shape to reach `_lib-ops-root.sh` in the first place:
+
+```sh
+_RAW="${BASH_SOURCE[0]:-}"
+LIB_DIR=""
+if [ -n "$_RAW" ]; then
+  _CANDIDATE="$(cd "$(dirname "$_RAW")" 2>/dev/null && pwd)"
+  if [ -n "$_CANDIDATE" ] && [ -f "$_CANDIDATE/_lib-ops-root.sh" ]; then
+    . "$_CANDIDATE/_lib-ops-root.sh"
+    command -v resolve_anchored_lib_dir >/dev/null 2>&1 && LIB_DIR="$(resolve_anchored_lib_dir "$_RAW")"
+  fi
+fi
+```
+
+This is not a regression to the four-spelling problem: it is now **one** fixed idiom, applied identically at all four sites (and documented identically, each site's own "SELF-LOCATION BOOTSTRAP" comment references this AgDR and `resolve_anchored_lib_dir`'s header for the full reasoning). The risk of *this* snippet drifting is much lower than the original bug's, because it contains no branching logic to get subtly wrong — it is a single existence check, structurally incapable of a "fake fix" variant the way `:-$0` was.
+
+### Divergence from the initial brief — the `_lib-read-config.sh` fallback stays UNANCHORED
+
+The task brief that produced this fix asked for a second change: make `_lib-read-config.sh`'s `git rev-parse --show-toplevel` fallback (used when no `.apexyard-fork` / `onboarding.yaml`+`apexyard.projects.yaml` anchor is found above `$PWD`) **anchored by default**, with bare-clone/CI usability preserved via an explicit `APEXYARD_ALLOW_UNANCHORED_CONFIG=1` opt-in.
+
+**I implemented that shape, then reverted it after it broke real, already-shipped behavior**, discovered empirically via `test_lib_protected_branches.sh` (4 of 16 cases failed) and confirmed across `test_githooks_pre_commit_protected_branch.sh`, `test_check_git_hooks_installed.sh`, and `test_validate_branch_name_heredoc.sh`. The mechanism:
+
+- `_lib-read-config.sh` is sourced **transitively** by `_lib-protected-branches.sh`, `validate-branch-name.sh`, `require-active-ticket.sh`, and the `.githooks/pre-push`/`pre-commit` install path.
+- All of those run **standalone inside every managed project's own git hooks** — not just inside the apexyard ops fork's Claude Code session. A managed project correctly has neither `.apexyard-fork` nor the onboarding pair; those markers are ops-fork-specific by design.
+- Gating the fallback on that anchor therefore silently degraded every managed project's own `.claude/project-config.json` (e.g. its own `.git.protected_branches[]`) to the framework default the instant the resolver ran under a shell where `BASH_SOURCE[0]` was unusable — which, notably, is not even an exotic edge case: it is what happens whenever a hook is invoked in a way that lands in this fallback branch at all.
+- **This fallback was never actually reachable through the reported vulnerability.** The bug lives entirely in the *self-location* step (finding `_lib-ops-root.sh` via a cwd-derived path) — now closed by `resolve_anchored_lib_dir`'s bootstrap guard. `git rev-parse --show-toplevel` is not BASH_SOURCE-derived at all; it is scoped to the actual repo the shell is running in. Trusting "the repo we are actually in" for *that repo's own config* is the file's original, correct, and still-safe design for non-portfolio deployments — the same "legacy behaviour for non-apexyard environments" the pre-#1102 comment already documented.
+
+**Resolution:** the fallback in `_lib-read-config.sh` is left **unconditional**, unchanged from before #1102 (`root=$(git rev-parse --show-toplevel 2>/dev/null)`). The vulnerability-relevant fix in that file is the same `resolve_anchored_lib_dir` bootstrap guard as the other three sites, applied to the step that locates `_lib-ops-root.sh` — not the fallback. No `APEXYARD_ALLOW_UNANCHORED_CONFIG` env var was introduced; there is nothing to opt out of.
+
+This is a **conscious divergence from the initial brief**, made under the brief's own explicit authorization ("if you conclude a different escape-hatch shape is safer, record your reasoning in the AgDR — but never leave a silent unanchored default") — and it is not a silent unanchored default: it is the same git-repo-scoped resolution this file has always used for its own explicitly-documented non-portfolio-fork use case, now reached through a self-location path that is no longer exploitable via cwd substitution. **Flagging this prominently for human review**, per the brief's instruction, since a reviewer may want a narrower anchor (e.g. gated only when running inside a detected Claude Code session) rather than the status quo I restored.
+
+## Consequences
+
+- All four sites (`_lib-read-config.sh`, `_lib-extract-push-ref.sh`, `_lib-git-hooks-path.sh`, `_lib-protected-branches.sh`) now route their self-location through one shared, auditable function (`resolve_anchored_lib_dir`) instead of four independently-maintained spellings.
+- The nine sites `#1100` already fixed are untouched — they keep their own already-correct `${BASH_SOURCE[0]:-}` + git-toplevel-anchored-fallback idiom (that idiom is specifically appropriate for `_lib-tracker.sh`/`_lib-fresh-fork.sh`'s **ops-root-resolution** purpose, which genuinely wants the ops-root anchor; see below).
+- `resolve_anchored_lib_dir` is deliberately **not** ops-root-anchored (no `.apexyard-fork` / onboarding-pair check) — an earlier draft added that as defense-in-depth and it broke real per-project hook usage the same way the fallback change did, for the same underlying reason (three of the four sites are hook libs deployed into every project's own `.claude/hooks/`, not just the ops fork). The bootstrap guard (never substitute cwd for an unavailable `BASH_SOURCE[0]`) is what actually closes the reported bug; ops-root anchoring is a different, narrower-scope concern that only `_lib-read-config.sh`'s own portfolio-root walk-up (unchanged, pre-existing) needs.
+- Under zsh (or any shell where `BASH_SOURCE[0]` is unavailable), all four sites now fail closed to "self-location unavailable" — for `_lib-protected-branches.sh` and `_lib-extract-push-ref.sh`/`_lib-git-hooks-path.sh` this means falling back to the hardcoded safe default (`main|master|dev|develop`) or skipping the sibling entirely, rather than resolving via cwd. A genuine apexyard fork sourced under zsh will not resolve its own config in this narrow case — the same documented trade-off `_lib-read-config.sh`'s existing "run under bash, not zsh" warning already accepts.
+- Several pre-existing test sandboxes (`test_lib_protected_branches.sh`, `test_githooks_pre_commit_protected_branch.sh`, `test_check_git_hooks_installed.sh`, `test_validate_branch_name_heredoc.sh`) needed a one-line addition (copy `_lib-ops-root.sh` into the sandbox) because their fixtures now need to satisfy the new bootstrap step to reach the sibling libs they were already testing.
+
+## Artifacts
+
+- `.claude/hooks/_lib-ops-root.sh` — new `resolve_anchored_lib_dir` function
+- `.claude/hooks/_lib-read-config.sh`, `_lib-extract-push-ref.sh`, `_lib-git-hooks-path.sh`, `_lib-protected-branches.sh` — migrated onto the shared helper
+- `.claude/hooks/tests/test_lib_self_location_cwd_anchor.sh` — extended with a discriminating impostor case per site (BASE reproduces, FIX closes)
+- PR: fix(#1102) — centralize trust-chain lib self-location behind one anchored helper


### PR DESCRIPTION
## Summary

- **Centralized the self-location bootstrap guard.** `_lib-ops-root.sh` gains one shared function, `resolve_anchored_lib_dir()`, that every `_lib-*.sh` sibling-sourcing site now calls instead of hand-rolling its own `${BASH_SOURCE[0]:-...}` guard. The #1100 security review found four sites still using four *different* (two of them actively broken) spellings of the same cwd-substitution bug `#1100`/`#1062` fixed at nine other sites — one more per-site patch would just add a fifth spelling for the next grep to miss.
- **Closed the actual bug at all four sites** (`_lib-read-config.sh`, `_lib-extract-push-ref.sh`, `_lib-git-hooks-path.sh`, `_lib-protected-branches.sh`): under a non-bash sourcing shell (zsh — notably the shell the Claude Code Bash tool itself runs), `BASH_SOURCE[0]` is unset, `dirname "" -> "."`, and the resolved lib directory silently became the *caller's* `$PWD` instead of the script's own directory. If that cwd shipped a same-named sibling file, it got sourced unanchored — an attacker-controlled or coincidental cwd could smuggle arbitrary code into a trust-chain hook. Two of the four sites (`_lib-git-hooks-path.sh`, `_lib-protected-branches.sh`) used a `${BASH_SOURCE[0]:-$0}` fallback that looked like a fix but wasn't: `$0` in a sourced file under zsh is the sourcing path *as typed*, which inherits the identical hazard.
- **Diverged from the initial fix brief on one point, and explains why in AgDR-0118.** The brief also asked to make `_lib-read-config.sh`'s `git rev-parse --show-toplevel` config fallback anchored-by-default with an `APEXYARD_ALLOW_UNANCHORED_CONFIG=1` opt-in. I implemented that, then reverted it after it empirically broke real, already-shipped behavior: that fallback is reached by every *managed project's own* standalone git hooks (protected-branch checks, branch-name validation), none of which carry the ops-fork-specific anchor markers — so the "fix" silently degraded every managed project's own `.git.protected_branches[]` config to the framework default. That fallback was never actually reachable through the reported cwd-substitution bug in the first place (it resolves via `git rev-parse`, not `BASH_SOURCE`), so it's left unconditional/unchanged. Full reasoning in AgDR-0118 for human review — flagging this prominently since a reviewer may prefer a narrower anchor.
- **Extended the regression test** (`test_lib_self_location_cwd_anchor.sh`) with a discriminating impostor case per site, proving BASE (pre-fix, from git history) reproduces the bug and FIX closes it, plus an over-strictness guard that a genuine fork still resolves correctly.
- **Updated four pre-existing test sandboxes** that now need `_lib-ops-root.sh` as a sibling to reach the libs they were already testing (`test_lib_protected_branches.sh`, `test_githooks_pre_commit_protected_branch.sh`, `test_check_git_hooks_installed.sh`, `test_validate_branch_name_heredoc.sh`) — without the fixture update they silently exercised the "self-location unavailable" fallback path instead of the intended scenario.

## Testing

- `test_lib_self_location_cwd_anchor.sh`: **17/17 pass** — 5 pre-existing (unchanged sites) + 12 new. Each of the 4 newly-fixed sites has a BASE-reproduces / FIX-closes pair plus a genuine-fork-still-resolves guard.
- `test_lib_protected_branches.sh`: **16/16 pass** (was 12/16 before the fixture fix — the sandbox needed `_lib-ops-root.sh`).
- `test_githooks_pre_commit_protected_branch.sh`: **25/25 pass** (was 19/25 before the fixture fix).
- `test_check_git_hooks_installed.sh`: **9/9 pass** (was 6/9 before the fixture fix).
- `test_validate_branch_name_heredoc.sh`: **10/10 pass** (was 8/10 before the fixture fix).
- Full sibling sweep — every `test_lib_*.sh`, every `test_githooks_*`, `test_block_unreviewed_merge.sh`, `test_block_merge_on_red_ci.sh`, `test_pre_push_gate.sh`, `test_tracker_zsh_self_location.sh`, and all 121 files under `.claude/hooks/tests/`: **all pass**.
- `shellcheck --severity=warning` on every changed `.sh` file (5 lib files + 5 test files): clean, zero findings.

All counts taken with `CLAUDE_CODE_SESSION_ID` unset to avoid this session's own ops-root pin file masking the sandbox resolution (matches how CI actually runs these tests).

Refs #1102

---

## Glossary

| Term | Definition |
|------|------------|
| Self-location bootstrap | The pattern where a sourced shell lib finds its own directory (via `BASH_SOURCE[0]`) so it can source sibling files next to it |
| `BASH_SOURCE[0]` | A bash-only array that tracks the file currently executing; empty/unset under non-bash shells like zsh |
| Fail-closed | A guard that, on any doubt or failure, refuses to proceed rather than silently falling back to a less-safe default |
| Anchor / anchored | A check that a resolved path is genuinely trustworthy (here: that a directory really is the calling script's own location, not a substituted cwd) |
| Impostor cwd | A directory an attacker (or coincidence) controls that ships a same-named sibling file, hoping an unanchored self-location resolves there instead of the real script's directory |
