### PR TITLE
chore(#1131): ship the v5.3.0→v5.4.0 migration (untrack project-config.json)

### DIFF
--- a/.claude/hooks/tests/test_v54_migration.sh
+++ b/.claude/hooks/tests/test_v54_migration.sh
@@ -117,7 +117,61 @@ else
   mark_fail "case4 build" "build_fork failed"
 fi
 
-rm -rf "$SB" "$SB2" 2>/dev/null
+# ---------------------------------------------------------------------------
+# Case 5: v1-anchor fork (legacy onboarding.yaml + apexyard.projects.yaml pair,
+#         no .apexyard-fork) → find_ops_root resolves via the legacy branch and
+#         the untrack still works. Gives find_ops_root's non-v2 path coverage.
+# ---------------------------------------------------------------------------
+SB3=$(mktemp -d) && SB3=$(cd "$SB3" && pwd -P)
+mkdir -p "$SB3/.claude"
+: > "$SB3/onboarding.yaml"
+: > "$SB3/apexyard.projects.yaml"
+printf '%s\n' '.claude/project-config.json' > "$SB3/.gitignore"
+printf '%s\n' "$CONFIG_CONTENT" > "$SB3/.claude/project-config.json"
+if (
+    cd "$SB3" || exit 99
+    git init -q && git config user.email t@t.t && git config user.name t || exit 99
+    git add onboarding.yaml apexyard.projects.yaml .gitignore >/dev/null 2>&1 || exit 99
+    git add -f .claude/project-config.json >/dev/null 2>&1 || exit 99
+    git commit -q -m fixture >/dev/null 2>&1 || exit 99
+  ); then
+  is_tracked "$SB3" || mark_fail "case5 precondition" "config should start tracked"
+  ( cd "$SB3" && APEXYARD_MIGRATION_QUIET=1 bash "$MIGRATION" ); rc=$?
+  if [ "$rc" -eq 0 ] && ! is_tracked "$SB3" && [ -f "$SB3/.claude/project-config.json" ]; then
+    mark_pass "v1-anchor fork (legacy pair) → find_ops_root resolves, untrack works"
+  else
+    mark_fail "case5 v1anchor" "rc=$rc tracked=$(is_tracked "$SB3" && echo y || echo n)"
+  fi
+else
+  mark_fail "case5 build" "build failed"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 6: defer-not-force. Staged content differs from BOTH HEAD and the working
+#         tree → `git rm --cached` refuses (no -f), the migration exits 1, the
+#         file stays tracked, and the working-tree content is untouched. Locks
+#         the "never discard a staged change" safety contract.
+# ---------------------------------------------------------------------------
+SB4=$(mktemp -d) && SB4=$(cd "$SB4" && pwd -P)
+if build_fork "$SB4" yes; then
+  (
+    cd "$SB4" || exit 99
+    printf '%s\n' '{"_adopter":"STAGED-version-B"}' > .claude/project-config.json
+    git add -f .claude/project-config.json >/dev/null 2>&1   # index (staged) = B, differs from HEAD
+    printf '%s\n' '{"_adopter":"WORKTREE-version-C"}' > .claude/project-config.json  # working tree = C
+  )
+  ( cd "$SB4" && APEXYARD_MIGRATION_QUIET=1 bash "$MIGRATION" ); rc=$?
+  wt=$(cat "$SB4/.claude/project-config.json")
+  if [ "$rc" -eq 1 ] && is_tracked "$SB4" && [ "$wt" = '{"_adopter":"WORKTREE-version-C"}' ]; then
+    mark_pass "unexpected staged state → exit 1 defer-not-force, still tracked, worktree preserved"
+  else
+    mark_fail "case6 defer" "rc=$rc (want 1), tracked=$(is_tracked "$SB4" && echo y || echo n), wt=$wt"
+  fi
+else
+  mark_fail "case6 build" "build_fork failed"
+fi
+
+rm -rf "$SB" "$SB2" "$SB3" "$SB4" 2>/dev/null
 
 echo ""
 echo "v5.4.0 migration test: PASS=$PASS FAIL=$FAIL"

--- a/.claude/hooks/tests/test_v54_migration.sh
+++ b/.claude/hooks/tests/test_v54_migration.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Focused test for .claude/migrations/v5.3.0-to-v5.4.0.sh
+#
+# The v5.4.0 migration untracks .claude/project-config.json (the #1065
+# data-loss fix, adopter side). It must:
+#   - untrack a currently-tracked project-config.json (git rm --cached)
+#   - leave the working-tree file AND its content exactly in place
+#   - be idempotent (re-run is a no-op; already-untracked is a no-op)
+#   - stage the untrack, not commit it
+#
+# Sandbox-based: builds a synthetic ops fork under mktemp, tracks
+# project-config.json despite a .gitignore entry (reproducing the inert-ignore
+# state #1065 found), runs the real shipped migration, and asserts the end
+# state. Exit 0 if every case passes; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+MIGRATION="$SRC_ROOT/.claude/migrations/v5.3.0-to-v5.4.0.sh"
+
+[ -f "$MIGRATION" ] || { echo "FAIL: missing $MIGRATION" >&2; exit 1; }
+[ -x "$MIGRATION" ] || { echo "FAIL: $MIGRATION not executable" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+FAILED=""
+mark_pass() { echo "  ✓ $1"; PASS=$((PASS+1)); }
+mark_fail() { echo "  ✗ $1: $2" >&2; FAIL=$((FAIL+1)); FAILED="$FAILED\n  - $1"; }
+
+CONFIG_CONTENT='{"portfolio":{"registry":"../private/apexyard.projects.yaml"},"_adopter":"custom value that must survive"}'
+
+# build_fork <root> <track_config: yes|no>
+#   Creates a git repo anchored by .apexyard-fork, with .gitignore listing
+#   .claude/project-config.json. When track_config=yes, the config file is
+#   force-added (tracked despite the ignore) — the exact inert-ignore state.
+build_fork() {
+  local root="$1" track="$2"
+  mkdir -p "$root/.claude"
+  : > "$root/.apexyard-fork"
+  printf '%s\n' '.claude/project-config.json' > "$root/.gitignore"
+  printf '%s\n' "$CONFIG_CONTENT" > "$root/.claude/project-config.json"
+  (
+    cd "$root" || exit 99
+    git init -q && git config user.email t@t.t && git config user.name t || exit 99
+    git add .apexyard-fork .gitignore >/dev/null 2>&1 || exit 99
+    if [ "$track" = "yes" ]; then
+      git add -f .claude/project-config.json >/dev/null 2>&1 || exit 99
+    fi
+    git commit -q -m fixture >/dev/null 2>&1 || exit 99
+  ) || return 1
+}
+
+is_tracked() { git -C "$1" ls-files --error-unmatch .claude/project-config.json >/dev/null 2>&1; }
+
+# ---------------------------------------------------------------------------
+# Case 1: tracked config → untracked after run, working-tree file + content preserved
+# ---------------------------------------------------------------------------
+SB=$(mktemp -d) && SB=$(cd "$SB" && pwd -P)
+if build_fork "$SB" yes; then
+  is_tracked "$SB" || mark_fail "case1 precondition" "config should start tracked"
+  ( cd "$SB" && APEXYARD_MIGRATION_QUIET=1 bash "$MIGRATION" ); rc=$?
+  if [ "$rc" -ne 0 ]; then
+    mark_fail "case1 exit" "expected 0, got $rc"
+  elif is_tracked "$SB"; then
+    mark_fail "case1 untrack" "config still tracked after migration"
+  elif [ ! -f "$SB/.claude/project-config.json" ]; then
+    mark_fail "case1 worktree" "working-tree file was removed (must be preserved)"
+  elif [ "$(cat "$SB/.claude/project-config.json")" != "$CONFIG_CONTENT" ]; then
+    mark_fail "case1 content" "working-tree content changed (customisations lost)"
+  else
+    mark_pass "tracked config → untracked, working-tree file + content preserved, exit 0"
+  fi
+else
+  mark_fail "case1 build" "build_fork failed"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: the untrack is STAGED (not committed) — operator owns the commit
+# ---------------------------------------------------------------------------
+# Reuses the Case 1 sandbox: after the run, a staged index deletion should exist
+# and HEAD should still contain the file (nothing was committed).
+if [ -d "$SB" ]; then
+  staged=$(git -C "$SB" diff --cached --name-only -- .claude/project-config.json)
+  in_head=$(git -C "$SB" ls-tree --name-only HEAD -- .claude/project-config.json)
+  if [ "$staged" = ".claude/project-config.json" ] && [ -n "$in_head" ]; then
+    mark_pass "untrack is staged (index), not committed (still in HEAD)"
+  else
+    mark_fail "case2 staged" "staged='$staged' in_head='$in_head' (want staged path present, still in HEAD)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3: idempotent — a second run on the same fork is a clean no-op
+# ---------------------------------------------------------------------------
+if [ -d "$SB" ]; then
+  ( cd "$SB" && APEXYARD_MIGRATION_QUIET=1 bash "$MIGRATION" ); rc=$?
+  if [ "$rc" -eq 0 ] && [ -f "$SB/.claude/project-config.json" ] && ! is_tracked "$SB"; then
+    mark_pass "idempotent re-run → exit 0, still untracked, file present"
+  else
+    mark_fail "case3 idempotent" "rc=$rc, file-present=$([ -f "$SB/.claude/project-config.json" ] && echo y || echo n), tracked=$(is_tracked "$SB" && echo y || echo n)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4: already-untracked fork (never tracked the file) → no-op, exit 0
+# ---------------------------------------------------------------------------
+SB2=$(mktemp -d) && SB2=$(cd "$SB2" && pwd -P)
+if build_fork "$SB2" no; then
+  is_tracked "$SB2" && mark_fail "case4 precondition" "config should start untracked"
+  ( cd "$SB2" && APEXYARD_MIGRATION_QUIET=1 bash "$MIGRATION" ); rc=$?
+  if [ "$rc" -eq 0 ] && [ -f "$SB2/.claude/project-config.json" ] && ! is_tracked "$SB2"; then
+    mark_pass "already-untracked fork → no-op, exit 0, file untouched"
+  else
+    mark_fail "case4 noop" "rc=$rc"
+  fi
+else
+  mark_fail "case4 build" "build_fork failed"
+fi
+
+rm -rf "$SB" "$SB2" 2>/dev/null
+
+echo ""
+echo "v5.4.0 migration test: PASS=$PASS FAIL=$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  # shellcheck disable=SC2059
+  printf "FAILED:$FAILED\n" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/migrations/v5.3.0-to-v5.4.0.sh
+++ b/.claude/migrations/v5.3.0-to-v5.4.0.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# v5.3.0 → v5.4.0 migration: untrack .claude/project-config.json (data-loss fix)
+#
+# v5.4.0 carries the adopter-side completion of #1065 (fix(#1031)). The root
+# cause #1065 found: .gitignore listed .claude/project-config.json, but the
+# file was ALSO tracked in the index — and git ignores .gitignore for
+# already-tracked files, so the ignore rule was inert for every adopter fork.
+#
+# Because the file was tracked, a plain `git checkout <branch>` writes the
+# indexed version straight over the working copy, with no warning. For a
+# split-portfolio adopter that silently DESTROYS the private `portfolio` block,
+# which is load-bearing (path resolution is config-only, there is no
+# convention-based sibling discovery) and never in git to restore from. This
+# happened on a real fork.
+#
+# #1065 fixed the framework side: it untracked the file and shipped a tracked
+# project-config.example.json. But an adopter on v5.3.0 STILL has the file
+# tracked in their own fork — the data-loss window stays open for them until
+# the file is untracked there too. That is what this migration does.
+#
+# What it does: if .claude/project-config.json is currently tracked in the ops
+# fork, `git rm --cached` it — removing it from the index while leaving the
+# working-tree file (and the adopter's customisations in it) exactly in place.
+# The existing .gitignore entry then finally applies. Nothing is committed; the
+# untrack is staged for the operator to commit, matching the rest of /update's
+# "operator owns each material change" stance.
+#
+# Idempotent: if the file is already untracked (e.g. the sync merge already
+# resolved it that way, or the migration already ran), this is a no-op. Never
+# forces — if the file has staged content that differs from both HEAD and the
+# working tree, it defers to the operator (exit 1) rather than risk discarding
+# a staged change.
+#
+# Exit codes:
+#   0 — applied or skipped (success either way — untracked, or already untracked)
+#   1 — conflict requires operator (unexpected staged state on the file)
+#   2 — hard error (not in a git repo / ops root unresolvable)
+#
+# Env knobs:
+#   APEXYARD_MIGRATION_QUIET  1 to suppress informational stdout (real errors
+#                             still go to stderr)
+
+set -u
+
+QUIET="${APEXYARD_MIGRATION_QUIET:-0}"
+info() { [ "$QUIET" = "1" ] || echo "$@"; }
+warn() { echo "$@" >&2; }
+
+# --- find the ops fork root --------------------------------------------------
+# Anchored by EITHER .apexyard-fork (split-portfolio v2 — onboarding.yaml and
+# apexyard.projects.yaml live in the sibling private repo, not the fork) OR the
+# legacy v1 pair (onboarding.yaml AND apexyard.projects.yaml in one dir).
+# .claude/project-config.json lives at the ops fork root in BOTH modes.
+find_ops_root() {
+  local r cur
+  r=$(git rev-parse --show-toplevel 2>/dev/null) || r=""
+  [ -z "$r" ] && { echo ""; return 1; }
+  cur="$r"
+  while [ -n "$cur" ] && [ "$cur" != "/" ]; do
+    [ -f "$cur/.apexyard-fork" ] && { echo "$cur"; return 0; }
+    if [ -f "$cur/onboarding.yaml" ] && [ -f "$cur/apexyard.projects.yaml" ]; then
+      echo "$cur"; return 0
+    fi
+    cur=$(dirname "$cur")
+  done
+  # No anchor found — fall back to the git toplevel. project-config.json is
+  # root-relative there too; the tracked-guard below stays the real safety net.
+  echo "$r"
+}
+
+ops_root=$(find_ops_root)
+if [ -z "$ops_root" ]; then
+  warn "migration v5.3.0→v5.4.0: not inside a git repository — cannot resolve the ops fork. Skipping."
+  exit 2
+fi
+cd "$ops_root" || { warn "migration v5.3.0→v5.4.0: cannot cd to ops root '$ops_root'."; exit 2; }
+
+target=".claude/project-config.json"
+
+# --- idempotency guard: only act if the file is currently TRACKED ------------
+if ! git ls-files --error-unmatch "$target" >/dev/null 2>&1; then
+  info "migration v5.3.0→v5.4.0: $target is already untracked — nothing to do."
+  exit 0
+fi
+
+# --- untrack, preserving the working-tree file -------------------------------
+# `git rm --cached` removes the index entry only; the on-disk file (and the
+# adopter's customisations in it) is untouched. It refuses (non-zero) ONLY when
+# the staged content matches neither HEAD nor the working-tree file — a rare
+# state we deliberately do NOT force past.
+if rm_err=$(git rm --cached --quiet "$target" 2>&1); then
+  info "migration v5.3.0→v5.4.0: untracked $target (working-tree file preserved; untrack staged for commit)."
+  info "  Your customisations stay in the on-disk file, now correctly ignored by .gitignore."
+  info "  This closes the #1065 data-loss window (a git checkout can no longer overwrite it)."
+  exit 0
+fi
+
+warn "migration v5.3.0→v5.4.0: could not untrack $target — it has staged content that differs from both HEAD and the working tree."
+[ -n "$rm_err" ] && warn "  git: $rm_err"
+warn "  Resolve manually (commit or reset the staged change), then run: git rm --cached $target"
+exit 1

--- a/docs/agdr/AgDR-0122-v54-migration-untrack-project-config.md
+++ b/docs/agdr/AgDR-0122-v54-migration-untrack-project-config.md
@@ -1,0 +1,40 @@
+# v5.4.0 ships a real migration untracking `project-config.json`
+
+> In the context of cutting the v5.4.0 release, facing the fact that #1065 fixed the `project-config.json` tracking-vs-ignore data-loss bug only on the framework side, I decided to ship a **real** per-adopter migration (`v5.3.0-to-v5.4.0.sh`) that untracks the file on adopter forks, to achieve close the same data-loss window everywhere it exists, accepting that the migration mutates adopter git state and so needs a careful, idempotent, non-forcing guard.
+
+## Context
+
+The last four release hops (`v4.4.0`→`v5.3.0`) are all no-op placeholders backfilled by #1105. v5.4.0 is different: it carries the adopter-side completion of **#1065**.
+
+#1065's finding: `.gitignore` listed `.claude/project-config.json`, but the file was **also tracked in the index**, and git ignores `.gitignore` for already-tracked files — so the ignore rule was inert on every adopter fork. Because the file was tracked, a plain `git checkout <branch>` silently overwrites the working copy with the indexed version. For a split-portfolio adopter that destroys the private `portfolio` block, which is config-only (no convention-based sibling discovery) and never committed to git, so it is unrecoverable. This happened on a real fork.
+
+#1065 fixed the **framework** repo (untracked the file, shipped a tracked `project-config.example.json`). But an adopter sitting on v5.3.0 still has the file tracked in **their own** fork — the data-loss window stays open for them until the file is untracked there too. A framework-side untrack does not propagate to an adopter's index through a normal sync (modify/delete merge semantics are unreliable here), so the release needs an explicit migration.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| A — No-op placeholder (like the last 4 hops) | Simplest; zero risk of touching adopter state | Leaves the #1065 data-loss window open on every adopter fork; the release-time migration check would pass on an empty promise |
+| B — Real migration: `git rm --cached` the file on the adopter fork, idempotent, defer-not-force | Closes the window during the `/update` flow the adopter already runs; preserves working-tree content; safe guard | Mutates adopter git state — needs a correct guard so it never touches an already-untracked file or forces past an unexpected staged state |
+| C — Rely on merge semantics + the SessionStart `check-git-hooks-installed`-style advisory only | No migration script to write | Merge semantics for modify/delete are unreliable; no advisory exists for this file; leaves the fix to chance |
+
+## Decision
+
+Chosen: **Option B**, because the data-loss window is real and only the adopter's own fork can close it, and `/update`'s migration chain is exactly the mechanism designed to apply a per-release adopter-side change. The script:
+
+- Guards on "currently tracked" (`git ls-files --error-unmatch`) — a no-op if already untracked.
+- Runs `git rm --cached`, leaving the working-tree file and the adopter's customisations in place.
+- Stages the untrack rather than committing it (operator owns the commit, matching the rest of `/update`).
+- Defers to the operator (exit 1) rather than `-f`-forcing past an unexpected staged state, so it can never discard a staged change.
+
+## Consequences
+
+- Adopters upgrading past v5.4.0 get the untrack automatically via `/update`; the inert `.gitignore` entry finally applies and a `git checkout` can no longer overwrite their private config.
+- Sets the precedent that a release which changes a config-tracking invariant ships a **real** migration, not a placeholder — the judgement `/release` step 3's soft check exists to prompt.
+- `.claude/migrations/` remains framework release tooling, distinct from the DB-migration gate (`require-migration-ticket.sh`), whose paths deliberately do not match this directory.
+
+## Artifacts
+
+- `.claude/migrations/v5.3.0-to-v5.4.0.sh`, `.claude/hooks/tests/test_v54_migration.sh`, `docs/upgrading.md` (this PR, #1131)
+- Root cause + framework-side fix: #1065 (`fix(#1031)`)
+- Migration-chain design: AgDR-0032; release-time migration check: #1105

--- a/docs/agdr/AgDR-0122-v54-migration-untrack-project-config.md
+++ b/docs/agdr/AgDR-0122-v54-migration-untrack-project-config.md
@@ -6,9 +6,9 @@
 
 The last four release hops (`v4.4.0`→`v5.3.0`) are all no-op placeholders backfilled by #1105. v5.4.0 is different: it carries the adopter-side completion of **#1065**.
 
-#1065's finding: `.gitignore` listed `.claude/project-config.json`, but the file was **also tracked in the index**, and git ignores `.gitignore` for already-tracked files — so the ignore rule was inert on every adopter fork. Because the file was tracked, a plain `git checkout <branch>` silently overwrites the working copy with the indexed version. For a split-portfolio adopter that destroys the private `portfolio` block, which is config-only (no convention-based sibling discovery) and never committed to git, so it is unrecoverable. This happened on a real fork.
+What #1065 found: `.gitignore` listed `.claude/project-config.json`, but the file was **also tracked in the index**, and git ignores `.gitignore` for already-tracked files — so the ignore rule was inert on every adopter fork. Because the file was tracked, a plain `git checkout <branch>` silently overwrites the working copy with the indexed version. For a split-portfolio adopter that destroys the private `portfolio` block, which is config-only (no convention-based sibling discovery) and never committed to git, so it is unrecoverable. This happened on a real fork.
 
-#1065 fixed the **framework** repo (untracked the file, shipped a tracked `project-config.example.json`). But an adopter sitting on v5.3.0 still has the file tracked in **their own** fork — the data-loss window stays open for them until the file is untracked there too. A framework-side untrack does not propagate to an adopter's index through a normal sync (modify/delete merge semantics are unreliable here), so the release needs an explicit migration.
+In #1065 the **framework** repo was fixed (untracked the file, shipped a tracked `project-config.example.json`). But an adopter sitting on v5.3.0 still has the file tracked in **their own** fork — the data-loss window stays open for them until the file is untracked there too. A framework-side untrack does not propagate to an adopter's index through a normal sync (modify/delete merge semantics are unreliable here), so the release needs an explicit migration.
 
 ## Options Considered
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -68,6 +68,7 @@ The override applies once. After a successful sync, the anchor is rewritten from
 | `v5.0.0-to-v5.1.0.sh` | No-op placeholder. Backfilled by #1105. | Nobody (no-op); exists so the chain walks past this hop. |
 | `v5.1.0-to-v5.2.0.sh` | No-op placeholder. Backfilled by #1105. | Nobody (no-op); exists so the chain walks past this hop. |
 | `v5.2.0-to-v5.3.0.sh` | No-op placeholder. Backfilled by #1105. | Nobody (no-op); exists so the chain walks past this hop. |
+| `v5.3.0-to-v5.4.0.sh` | **Real migration.** Untracks `.claude/project-config.json` (`git rm --cached`, working-tree file and its content preserved, untrack staged not committed) so the long-inert `.gitignore` entry finally applies. Closes the #1065 data-loss window: while the file was tracked, a plain `git checkout` could silently overwrite it and destroy a split-portfolio adopter's private `portfolio` block (never in git to restore from). Idempotent — no-op if the file is already untracked; defers to the operator (exit 1) rather than force past an unexpected staged state. | Every adopter whose fork still tracks `.claude/project-config.json` (anyone upgrading from ≤ v5.3.0). No-op once untracked. |
 
 When a future release adds a migration, this table is the source of truth — the release PR template requires a row to be added here.
 


### PR DESCRIPTION
## Summary

- **Ships the v5.3.0→v5.4.0 migration — a real one, not a no-op placeholder.** v5.4.0 is the first release since v5.2.0 that actually needs a per-adopter migration, and it's a data-loss fix. #1065 found that `.gitignore` listed `.claude/project-config.json` while the file was *also tracked in the index*, so the ignore rule was inert on every adopter fork. Because it was tracked, a plain `git checkout` silently overwrites the working copy — and for a split-portfolio adopter that destroys the private `portfolio` block, which is config-only and never in git to restore from (it happened on a real fork). #1065 fixed the framework side; this closes the same window on **adopter** forks, which still track the file until they untrack it.
- **The migration untracks `.claude/project-config.json` safely.** Guards on "currently tracked", runs `git rm --cached` so the working-tree file *and the adopter's customisations in it* stay exactly in place, stages the untrack rather than committing it (operator owns the commit, matching the rest of `/update`). Idempotent — a no-op if the file is already untracked — and it defers to the operator (exit 1) rather than force past an unexpected staged state, so it can never discard a staged change.
- **`docs/upgrading.md`** gets the matching "What each migration does" row so the table stays the source of truth, and `/release` step 3's migration-script check now finds a script for this hop instead of warning.
- **Focused test (`test_v54_migration.sh`, 4 cases)** proves the load-bearing behaviour: untrack + working-tree/content preservation, staged-not-committed, idempotent re-run, and already-untracked no-op. The existing `test_update_chain.sh` still passes (no regression to the chain walker).

The real-vs-no-op call and the guard-design choices are recorded in **AgDR-0122-v54-migration-untrack-project-config** (this release breaks the four-hop no-op streak because #1065 left adopter forks exposed).

## Testing

1. `shellcheck .claude/migrations/v5.3.0-to-v5.4.0.sh .claude/hooks/tests/test_v54_migration.sh` — clean.
2. `bash .claude/hooks/tests/test_v54_migration.sh` — 4/4 pass.
3. `bash .claude/hooks/tests/test_update_chain.sh` — 11/0 pass (chain regression).
4. Ran the migration on this fork (already untracked) → clean no-op, exit 0, `git status` unchanged.

Refs #1131

---

## Glossary

| Term | Definition |
|------|------------|
| Migration chain | The per-release scripts in `.claude/migrations/` that `/update` walks from an adopter's recorded framework version to the latest release tag, applying each in order. |
| `git rm --cached` | Removes a path from git's index (untracks it) while leaving the working-tree file untouched — the exact operation needed to stop tracking a file without deleting the adopter's content. |
| Inert `.gitignore` entry | A `.gitignore` line that has no effect because the path it names is already tracked; git only ignores *untracked* paths. |
| Split-portfolio | Adopter mode where private portfolio config lives in a sibling repo; the `portfolio` block in `project-config.json` is load-bearing and never committed, so overwriting it is unrecoverable. |
