### PR TITLE
docs(#1148): point live site references to apexyard.ai

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ The rest of this file is for an agent extending **apexyard itself** — its hook
 - `docs/` — adopter docs (`getting-started.md`, `multi-project.md`, `release-process.md`, `agdr/`, `harnesses/`)
 - `projects/<name>/` — per-managed-project docs (committed to the ops fork)
 - `workspace/<name>/` — managed-project clones (gitignored — each project has its own remote)
-- `site/` — **moved** to [me2resh/apexyard-site](https://github.com/me2resh/apexyard-site); live at yard.apexscript.com
+- `site/` — **moved** to [me2resh/apexyard-site](https://github.com/me2resh/apexyard-site); live at apexyard.ai
 - `golden-paths/pipelines/` — reusable GitHub Actions workflows for adopter projects
 - `bin/` — small CLI shims (e.g. `bin/apexyard` for the `apexyard status` briefing)
 
@@ -176,9 +176,9 @@ The framework is plain markdown + shell — no build step, no SaaS, no lock-in. 
 
 ### Related entry-point conventions
 
-- **[yard.apexscript.com/skill.md](https://yard.apexscript.com/skill.md)** — capability manifest for AI coding agents (served from me2resh/apexyard-site)
-- **[yard.apexscript.com/llms.txt](https://yard.apexscript.com/llms.txt)** — llmstxt.org manifest; index for AI crawlers (served from me2resh/apexyard-site)
-- **[yard.apexscript.com/llms-full.txt](https://yard.apexscript.com/llms-full.txt)** — full content concatenation for one-shot LLM consumption (served from me2resh/apexyard-site)
+- **[apexyard.ai/skill.md](https://apexyard.ai/skill.md)** — capability manifest for AI coding agents (served from me2resh/apexyard-site)
+- **[apexyard.ai/llms.txt](https://apexyard.ai/llms.txt)** — llmstxt.org manifest; index for AI crawlers (served from me2resh/apexyard-site)
+- **[apexyard.ai/llms-full.txt](https://apexyard.ai/llms-full.txt)** — full content concatenation for one-shot LLM consumption (served from me2resh/apexyard-site)
 - **`README.md`** — public-facing intro (humans + agents)
 - **`SYSTEM.md`** — optional custom system prompt pi reads alongside `AGENTS.md`; a short operating-posture primer, not a duplicate of this file
 - **`docs/harnesses/pi.md`** — what works / doesn't yet for pi specifically

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://yard.apexscript.com"><img src="https://yard.apexscript.com/brand/apexyard-avatar-512.png" alt="ApexYard" width="88"></a>
+  <a href="https://apexyard.ai"><img src="https://apexyard.ai/brand/apexyard-avatar-512.png" alt="ApexYard" width="88"></a>
 </p>
 
 <h1 align="center">ApexYard</h1>
@@ -12,7 +12,7 @@
   <a href="https://github.com/me2resh/apexyard/releases"><img src="https://img.shields.io/github/v/release/me2resh/apexyard?color=2F6DF6&label=release" alt="Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://claude.com/claude-code"><img src="https://img.shields.io/badge/built%20for-Claude%20Code-8A63D2" alt="Built for Claude Code"></a>
-  <a href="https://yard.apexscript.com"><img src="https://img.shields.io/badge/site-yard.apexscript.com-2F6DF6" alt="Site"></a>
+  <a href="https://apexyard.ai"><img src="https://img.shields.io/badge/site-apexyard.ai-2F6DF6" alt="Site"></a>
   <a href="https://github.com/me2resh/apexyard/stargazers"><img src="https://img.shields.io/github/stars/me2resh/apexyard?style=social" alt="Stars"></a>
 </p>
 
@@ -55,7 +55,7 @@ ApexYard is a set of plain-text primitives Claude Code reads automatically — n
 
 **Full directory tree and the complete role / hook / skill / agent breakdown → [`docs/whats-inside.md`](docs/whats-inside.md).**
 
-> **Marketing site:** the site that was previously bundled here has moved to its own repo ([me2resh/apexyard-site](https://github.com/me2resh/apexyard-site)) and is deployed independently at [yard.apexscript.com](https://yard.apexscript.com).
+> **Marketing site:** the site that was previously bundled here has moved to its own repo ([me2resh/apexyard-site](https://github.com/me2resh/apexyard-site)) and is deployed independently at [apexyard.ai](https://apexyard.ai).
 >
 > **Built for Claude Code first**, but opencode, pi, and Codex run the same enforcement through a small adapter (Cursor partially) — see [Using another AI coding tool?](#using-another-ai-coding-tool) below.
 >

--- a/docs/harnesses/README.md
+++ b/docs/harnesses/README.md
@@ -60,7 +60,7 @@ The headline stays **"for Claude Code"** until this condition is met, verbatim:
 
 "Live end-to-end conformance proof" means the credentialed run described above: a real model turn under that harness actually blocked by a gate (e.g. a `git add -A` refused by the unmodified bash hook), not a mock or a by-construction test.
 
-**As of 2026-07-09 the trigger condition is MET** — three adapters (**opencode**, **pi**, and **Codex**) have recorded that proof. That does **not** auto-flip the headline: the flip is a **separate, deliberate decision** that moves the site (yard.apexscript.com) and channel positioning in one coordinated pass, and it hasn't been taken. Until it is, the framework keeps the Claude-Code tagline and describes multi-harness support in the precise, per-harness terms above rather than as a blanket claim. (Cursor remains below the bar — it fails closed rather than running the delegated gate — so the count is opencode + pi + Codex, not all four.)
+**As of 2026-07-09 the trigger condition is MET** — three adapters (**opencode**, **pi**, and **Codex**) have recorded that proof. That does **not** auto-flip the headline: the flip is a **separate, deliberate decision** that moves the site (apexyard.ai) and channel positioning in one coordinated pass, and it hasn't been taken. Until it is, the framework keeps the Claude-Code tagline and describes multi-harness support in the precise, per-harness terms above rather than as a blanket claim. (Cursor remains below the bar — it fails closed rather than running the delegated gate — so the count is opencode + pi + Codex, not all four.)
 
 ---
 

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -1054,7 +1054,7 @@ If your tracker has no CLI, use `kind: "custom"` with a `view_command` that call
 
 **What if I only have one repo?** Fork apexyard anyway and register that one repo. The skills work the same way. When you add a second project, just append to the registry — no migration, no re-setup.
 
-**Where is the marketing site?** The landing page that used to live in `site/` has moved to its own repo ([me2resh/apexyard-site](https://github.com/me2resh/apexyard-site)) and is deployed at yard.apexscript.com. It is no longer bundled in the framework fork.
+**Where is the marketing site?** The landing page that used to live in `site/` has moved to its own repo ([me2resh/apexyard-site](https://github.com/me2resh/apexyard-site)) and is deployed at apexyard.ai. It is no longer bundled in the framework fork.
 
 **Can I rename my fork?** Yes. GitHub handles rename redirects cleanly. Your local clone will need `git remote set-url origin` after the rename.
 


### PR DESCRIPTION
## Summary
- **Point the live site references to apexyard.ai** — apexyard.ai is now the canonical site domain (yard.apexscript.com 301-redirects to it), so the framework's "where is the site" pointers should name the new domain for anyone reading them cold.
- Updated four live-pointer files: `README.md` (site badge, avatar image, marketing-site link), `AGENTS.md` (site link + the `skill.md` / `llms.txt` / `llms-full.txt` manifest URLs), `docs/multi-project.md` (the "deployed at …" pointer), and `docs/harnesses/README.md` (the site-move reference). 9 refs in total.
- **Historical records deliberately left unchanged** — CHANGELOG entries, the AgDR-0004 / AgDR-0047 narratives, and two spike docs are dated statements accurate to when written; rewriting them would make the record misstate its own past, and the old links still 301-redirect. (Scope decision confirmed by the maintainer: live pointers only.)

## Testing
- `git grep yard.apexscript.com` now returns hits only in the five historical files; the four live-pointer files return none.
- apexyard.ai serves the same paths as the old domain (the apexyard-site marketing repo was already migrated), and yard.apexscript.com 301-redirects — so no link breaks.

Refs #1148

## Glossary
| Term | Definition |
|------|------------|
| Live pointer | A current-facing reference that tells a reader where the site *is* right now (README badge, docs "deployed at …"), as opposed to a dated historical record. |
| 301 redirect | A permanent HTTP redirect; yard.apexscript.com now 301s to apexyard.ai, so old links keep working. |
| llms.txt / skill.md | Machine-readable manifests served from the marketing site for AI crawlers / coding agents. |
