### PR TITLE
fix(#1151): resolve merge repo before cd heuristic

### DIFF
--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -724,6 +724,70 @@ resolve_ci_status_glab() {
   esac
 }
 
+# Echoes an owner/repo EXPLICITLY named in the merge command, or empty when
+# the command carries no literal repo. This intentionally excludes ambient
+# forge/CWD fallbacks so callers can apply the precedence "explicit command
+# target > cd-target heuristic > ambient checkout" without duplicating the
+# command parser (me2resh/apexyard#1151).
+extract_explicit_repo_from_command() {
+  local cmd="$1"
+  local repo=""
+
+  # 1. --repo/-R on the merge-command span only. A flag is the clearest
+  # explicit declaration and therefore outranks any URL text elsewhere.
+  local mspan
+  mspan=$(echo "$cmd" | grep -oE '\b(gh\s+pr|glab\s+mr)\s+merge\b[^|;&]*')
+  repo=$(echo "$mspan" | sed -nE 's/.*(--repo|-R)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
+
+  # 2. gh api path extraction.
+  if [ -z "$repo" ]; then
+    repo=$(echo "$cmd" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' \
+      | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
+  fi
+
+  # 2b. glab api path extraction (#767).
+  if [ -z "$repo" ]; then
+    repo=$(echo "$cmd" | grep -oE 'projects/[^/[:space:]]+/merge_requests/[0-9]+/merge' \
+      | sed -nE 's|projects/([^/]+)/merge_requests/.*|\1|p' | head -1)
+    if [ -n "$repo" ]; then
+      repo=$(echo "$repo" | sed -e 's/%2[Ff]/\//g')
+    fi
+  fi
+
+  # 3. tracker_pr_merge positional repo argument (#759).
+  if [ -z "$repo" ]; then
+    local wspan wargs
+    wspan=$(echo "$cmd" | grep -oE '\btracker_pr_merge\b[^|;&)]*')
+    if [ -n "$wspan" ]; then
+      wargs=$(echo "$wspan" | sed -E 's/^tracker_pr_merge[[:space:]]+//')
+      repo=$(_extract_wrapper_arg "$wargs" 1)
+    fi
+  fi
+
+  echo "$repo"
+}
+
+# Resolves the merge target with one precedence shared by all four gates:
+# explicit command target, then a leading cd target's origin, then ambient
+# forge/CWD discovery. pr_cmd_cd_target + git_origin_repo are supplied by
+# _lib-pr-repo.sh, which each merge-gate hook sources before calling this.
+resolve_merge_repo() {
+  local cmd="$1" repo="" cd_target=""
+
+  repo=$(extract_explicit_repo_from_command "$cmd")
+  if [ -z "$repo" ] && command -v pr_cmd_cd_target >/dev/null 2>&1 && command -v git_origin_repo >/dev/null 2>&1; then
+    cd_target=$(pr_cmd_cd_target "$cmd")
+    if [ -n "$cd_target" ] && git -C "$cd_target" rev-parse --git-dir >/dev/null 2>&1; then
+      repo=$(git_origin_repo "$cd_target")
+    fi
+  fi
+  if [ -z "$repo" ]; then
+    repo=$(extract_repo_from_command "$cmd")
+  fi
+
+  echo "$repo"
+}
+
 # Echoes the owner/repo extracted from the merge command, or empty if not found.
 #
 # This is a SIBLING function to extract_pr_number — same parsing approach,
@@ -745,47 +809,7 @@ extract_repo_from_command() {
   local cmd="$1"
   local repo=""
 
-  # 1. gh api path extraction.
-  repo=$(echo "$cmd" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' \
-    | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
-
-  # 1b. glab api path extraction (#767). GitLab's API takes the project as a
-  #     single URL-encoded path segment — `projects/<owner>%2F<repo>` (nested
-  #     subgroups become `<a>%2F<b>%2F<repo>`). There are no literal slashes in
-  #     the encoded segment, so [^/[:space:]]+ captures the whole project; then
-  #     decode %2F/%2f back to `/` so the result matches the owner/repo form the
-  #     markers and `glab mr view -R` expect.
-  if [ -z "$repo" ]; then
-    repo=$(echo "$cmd" | grep -oE 'projects/[^/[:space:]]+/merge_requests/[0-9]+/merge' \
-      | sed -nE 's|projects/([^/]+)/merge_requests/.*|\1|p' | head -1)
-    if [ -n "$repo" ]; then
-      repo=$(echo "$repo" | sed -e 's/%2[Ff]/\//g')
-    fi
-  fi
-
-  # 2. Repo flag on the merge command: gh/glab `--repo` or the short `-R` alias
-  #    (both gh and glab accept `-R`) (#764). Search ONLY within the merge-command
-  #    span (fenced at the first shell separator, like extract_pr_number) so a
-  #    trailing unrelated `-R` in a compound command — e.g. `... && grep -R foo` —
-  #    cannot be mistaken for the merge target's repo.
-  if [ -z "$repo" ]; then
-    local mspan
-    mspan=$(echo "$cmd" | grep -oE '\b(gh\s+pr|glab\s+mr)\s+merge\b[^|;&]*')
-    repo=$(echo "$mspan" | sed -nE 's/.*(--repo|-R)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
-  fi
-
-  # 2b. tracker_pr_merge wrapper positional arg (#759): `<owner/repo>` is the
-  #     FIRST argument — `tracker_pr_merge <owner/repo> <pr> <strategy> [<del>]`.
-  #     Same fencing-at-`)` discipline as extract_pr_number's wrapper step
-  #     (the real call site is a `$(...)` command substitution).
-  if [ -z "$repo" ]; then
-    local wspan wargs
-    wspan=$(echo "$cmd" | grep -oE '\btracker_pr_merge\b[^|;&)]*')
-    if [ -n "$wspan" ]; then
-      wargs=$(echo "$wspan" | sed -E 's/^tracker_pr_merge[[:space:]]+//')
-      repo=$(_extract_wrapper_arg "$wargs" 1)
-    fi
-  fi
+  repo=$(extract_explicit_repo_from_command "$cmd")
 
   # 3. Last resort: ask the forge which repo the current branch's PR/MR belongs
   #    to. Forge-aware (#764): a glab command falls back to `glab repo view`.

--- a/.claude/hooks/block-merge-on-red-ci.sh
+++ b/.claude/hooks/block-merge-on-red-ci.sh
@@ -79,6 +79,11 @@ INPUT=$(cat)
 # the jq-independent fallback detector when the parse can't be trusted —
 # see #965.
 . "$(dirname "$0")/_lib-extract-pr.sh"
+# Leading cd-target recovery for shared merge-repo resolution (#687/#1151).
+# Optional only for standalone hook-test sandboxes that copy a minimal lib set.
+if [ -f "$(dirname "$0")/_lib-pr-repo.sh" ]; then
+  . "$(dirname "$0")/_lib-pr-repo.sh"
+fi
 
 # _registry_glab_fallback <owner/repo>
 # -------------------------------------
@@ -260,7 +265,7 @@ fi
 # owner/repo`). Uses the shared extractor, which also recovers the repo from a
 # `gh api .../pulls/<N>/merge` or `glab api .../merge_requests/<N>/merge` URL
 # path so the CI-status check below is still scoped correctly.
-CMD_REPO=$(extract_repo_from_command "$COMMAND")
+CMD_REPO=$(resolve_merge_repo "$COMMAND")
 REPO_FLAG=""
 if [ -n "$CMD_REPO" ]; then
   REPO_FLAG="--repo $CMD_REPO"

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -63,6 +63,11 @@ INPUT=$(cat)
 . "$(dirname "$0")/_lib-extract-pr.sh"
 # Repo-qualified marker path helper (#485).
 . "$(dirname "$0")/_lib-review-markers.sh"
+# Leading cd-target recovery for shared merge-repo resolution (#687/#1151).
+# Optional only for standalone hook-test sandboxes that copy a minimal lib set.
+if [ -f "$(dirname "$0")/_lib-pr-repo.sh" ]; then
+  . "$(dirname "$0")/_lib-pr-repo.sh"
+fi
 
 # Parse .tool_input.command via jq. #965: this used to be the ONLY parse
 # path, and an empty/failed result — jq missing from PATH, or jq erroring
@@ -120,6 +125,11 @@ if ! is_merge_command "$COMMAND"; then
   exit 0
 fi
 
+if merge_command_uses_variable "$COMMAND"; then
+  echo "BLOCKED: merge gate cannot resolve a merge command containing an unexpanded PR or repo variable. Re-run with literal values." >&2
+  exit 2
+fi
+
 # --- Configurable human-approver DISPLAY title (me2resh/apexyard#957) ---
 # DISPLAY ONLY: this substitutes the printed word for the human per-PR
 # merge approver in the messages below. It does NOT affect the marker
@@ -136,28 +146,8 @@ else
 fi
 [ -z "$APPROVER_TITLE" ] && APPROVER_TITLE="CEO"
 
-# Parse --repo (for `gh pr merge --repo owner/repo`). The API-shape encodes
-# the repo in its URL path so we don't need the flag there — downstream
-# `gh pr view` / `gh pr checks` calls still benefit when the flag was passed.
-CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
-# If the command uses the API shape, recover owner/repo from the URL path
-# so other gh calls below can still be scoped correctly.
-if [ -z "$CMD_REPO" ]; then
-  CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
-fi
-
 PR_NUMBER=$(extract_pr_number "$COMMAND")
-# Also extract the repo so markers are scoped to (repo, pr) — #485.
-# CMD_REPO already parsed above; resolve via helper if blank (e.g. current-branch fallback).
-# NOTE (#765): approval markers are keyed on the PR's BASE repo. CMD_REPO is the base
-# for the sanctioned paths — the --repo value of `gh pr merge --repo` (you cannot merge
-# a fork's copy) and the `gh api .../pulls/N/merge` path. The extract_repo_from_command
-# fallback below resolves headRepository (the FORK) for a no---repo current-branch merge;
-# that residual path is NOT produced by /approve-merge (which always passes --repo), so it
-# only affects unsanctioned manual merges. Left as-is to keep the gate core untouched.
-if [ -z "$CMD_REPO" ]; then
-  CMD_REPO=$(extract_repo_from_command "$COMMAND")
-fi
+CMD_REPO=$(resolve_merge_repo "$COMMAND")
 
 if [ -z "$PR_NUMBER" ]; then
   echo "BLOCKED: Could not determine PR number for merge. Run from a PR branch or pass an explicit PR number." >&2

--- a/.claude/hooks/require-architecture-review.sh
+++ b/.claude/hooks/require-architecture-review.sh
@@ -114,39 +114,13 @@ if ! is_merge_command "$COMMAND"; then
   exit 0
 fi
 
-# Resolve the PR's repo. Each step runs only if the prior left CMD_REPO empty:
-#   1. --repo flag      (`gh pr merge --repo owner/repo`)
-#   2. gh api URL path  (`gh api repos/<owner>/<repo>/pulls/<N>/merge`)
-#   3. cd-target origin (`cd <portfolio> && gh pr merge <N>` with NO --repo —
-#                        the split-portfolio v2 pattern; the hook fires BEFORE
-#                        the in-command `cd`, so its own cwd is the ops fork,
-#                        not the PR's repo. me2resh/apexyard#687, the merge-time
-#                        sibling of the create-time fix #669.)
-#   4. extract_repo_from_command fallback (current-branch `gh pr view`)
-CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
-if [ -z "$CMD_REPO" ]; then
-  CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
-fi
-if [ -z "$CMD_REPO" ]; then
-  # Recover the repo from a leading `cd <path> &&` prefix — only when the path
-  # resolves to a real git tree (relative paths resolve against the hook's cwd,
-  # which is correct: the hook runs pre-`cd`). Otherwise fall through.
-  CD_TARGET=$(pr_cmd_cd_target "$COMMAND")
-  if [ -n "$CD_TARGET" ] && git -C "$CD_TARGET" rev-parse --git-dir >/dev/null 2>&1; then
-    CMD_REPO=$(git_origin_repo "$CD_TARGET")
-  fi
+if merge_command_uses_variable "$COMMAND"; then
+  echo "BLOCKED: architecture-review gate cannot resolve a merge command containing an unexpanded PR or repo variable. Re-run with literal values." >&2
+  exit 2
 fi
 
 PR_NUMBER=$(extract_pr_number "$COMMAND")
-# Resolve the repo for qualified marker paths (#485).
-# CMD_REPO already resolved above; fall back via helper if still blank.
-# NOTE (#765): the architecture marker is keyed on the BASE repo. CMD_REPO is the base via
-# --repo / API-path / cd-target origin; the extract_repo_from_command fallback below resolves
-# headRepository (the FORK) on a no---repo current-branch merge — a residual edge affecting
-# unsanctioned merges only (/design-review + /approve-architecture thread the base repo). Left as-is.
-if [ -z "$CMD_REPO" ]; then
-  CMD_REPO=$(extract_repo_from_command "$COMMAND")
-fi
+CMD_REPO=$(resolve_merge_repo "$COMMAND")
 
 # Derive REPO_FLAG from the FULLY-resolved CMD_REPO (#687) so the `gh pr diff`
 # below targets the PR's real repo. If this were set before the cd-target /
@@ -194,9 +168,10 @@ fi
 
 # Get the PR's changed files
 CHANGED=$(gh pr diff "$PR_NUMBER" $REPO_FLAG --name-only 2>/dev/null)
-if [ -z "$CHANGED" ]; then
-  # Couldn't determine files — skip rather than false-positive
-  exit 0
+CHANGED_RC=$?
+if [ "$CHANGED_RC" -ne 0 ] || [ -z "$CHANGED" ]; then
+  echo "BLOCKED: architecture-review gate could not determine the PR's changed files. Refusing to merge until the diff can be verified." >&2
+  exit 2
 fi
 
 TOUCHED_DESIGN=""

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -122,39 +122,13 @@ if ! is_merge_command "$COMMAND"; then
   exit 0
 fi
 
-# Resolve the PR's repo. Each step runs only if the prior left CMD_REPO empty:
-#   1. --repo flag      (`gh pr merge --repo owner/repo`)
-#   2. gh api URL path  (`gh api repos/<owner>/<repo>/pulls/<N>/merge`)
-#   3. cd-target origin (`cd <portfolio> && gh pr merge <N>` with NO --repo —
-#                        the split-portfolio v2 pattern; the hook fires BEFORE
-#                        the in-command `cd`, so its own cwd is the ops fork,
-#                        not the PR's repo. me2resh/apexyard#687, the merge-time
-#                        sibling of the create-time fix #669.)
-#   4. extract_repo_from_command fallback (current-branch `gh pr view`)
-CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
-if [ -z "$CMD_REPO" ]; then
-  CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
-fi
-if [ -z "$CMD_REPO" ]; then
-  # Recover the repo from a leading `cd <path> &&` prefix — only when the path
-  # resolves to a real git tree (relative paths resolve against the hook's cwd,
-  # which is correct: the hook runs pre-`cd`). Otherwise fall through.
-  CD_TARGET=$(pr_cmd_cd_target "$COMMAND")
-  if [ -n "$CD_TARGET" ] && git -C "$CD_TARGET" rev-parse --git-dir >/dev/null 2>&1; then
-    CMD_REPO=$(git_origin_repo "$CD_TARGET")
-  fi
+if merge_command_uses_variable "$COMMAND"; then
+  echo "BLOCKED: design-review gate cannot resolve a merge command containing an unexpanded PR or repo variable. Re-run with literal values." >&2
+  exit 2
 fi
 
 PR_NUMBER=$(extract_pr_number "$COMMAND")
-# Resolve the repo for qualified marker paths (#485).
-# CMD_REPO already resolved above; fall back via helper if still blank.
-# NOTE (#765): the design marker is keyed on the BASE repo. CMD_REPO is the base via
-# --repo / API-path / cd-target origin; the extract_repo_from_command fallback below resolves
-# headRepository (the FORK) on a no---repo current-branch merge — a residual edge affecting
-# unsanctioned merges only (/design-review + /approve-design thread the base repo). Left as-is.
-if [ -z "$CMD_REPO" ]; then
-  CMD_REPO=$(extract_repo_from_command "$COMMAND")
-fi
+CMD_REPO=$(resolve_merge_repo "$COMMAND")
 
 # Derive REPO_FLAG from the FULLY-resolved CMD_REPO (#687) so the `gh pr diff`
 # below targets the PR's real repo. If this were set before the cd-target /
@@ -206,9 +180,10 @@ fi
 
 # Get the PR's changed files
 CHANGED=$(gh pr diff "$PR_NUMBER" $REPO_FLAG --name-only 2>/dev/null)
-if [ -z "$CHANGED" ]; then
-  # Couldn't determine files — skip rather than false-positive
-  exit 0
+CHANGED_RC=$?
+if [ "$CHANGED_RC" -ne 0 ] || [ -z "$CHANGED" ]; then
+  echo "BLOCKED: design-review gate could not determine the PR's changed files. Refusing to merge until the diff can be verified." >&2
+  exit 2
 fi
 
 TOUCHED_UI=""

--- a/.claude/hooks/tests/test_forge_aware_extract_pr.sh
+++ b/.claude/hooks/tests/test_forge_aware_extract_pr.sh
@@ -234,6 +234,14 @@ assert_true  merge_command_uses_variable 'MERGE_RESULT=$(tracker_pr_merge "$REPO
 assert_true  merge_command_uses_variable 'MERGE_RESULT=$(tracker_pr_merge "me2resh/apexyard" "$PR" "squash" true)'
 assert_false merge_command_uses_variable "$WRAPPER_CMD_REAL"
 
+# #1151: every gate now consumes resolve_merge_repo's single precedence.
+# A literal wrapper repo must win before the leading-cd heuristic is even
+# consulted; these stubs make any accidental cd lookup return the wrong repo.
+pr_cmd_cd_target() { echo "/wrong/ops"; }
+git_origin_repo() { echo "wrong/ops"; }
+assert_eq "#1151 explicit wrapper repo outranks cd-target" "me2resh/apexyard" \
+  "$(resolve_merge_repo "cd /wrong/ops && $WRAPPER_CMD_REAL")"
+
 # The wrapper form correctly resolves the FORGE via the registry (tracker_kind),
 # not the command text — this is the whole point of the wrapper: its own text
 # never says "gh" or "glab". resolve_pr_head / resolve_pr_head_branch already

--- a/.claude/hooks/tests/test_require_architecture_review.sh
+++ b/.claude/hooks/tests/test_require_architecture_review.sh
@@ -364,6 +364,32 @@ assert_eq "#1091 control: gh healthy, marker at forge HEAD -> still ALLOWED" "0"
 rm -rf "$sb"
 
 echo ""
+echo "F) #1151 explicit wrapper repo outranks a leading cd target"
+sb=$(make_sandbox); pf=$(make_portfolio "me2resh/wrong-ops-repo")
+install_mock_gh_splitportfolio "$sb" '"projects/foo/docs/technical-design-x.md"' "$SHA" "$PF_SLUG"
+code=$(run_gate "$sb" "cd $pf && tracker_pr_merge \"$PF_SLUG\" \"77\" \"squash\" true")
+assert_eq "#1151 wrapper repo wins over cd-target and blocks" "2" "$code"
+rm -rf "$sb" "$pf"
+
+echo ""
+echo "F) #1151 unexpanded wrapper repo fails closed"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"projects/foo/docs/technical-design-x.md"' "$SHA"
+code=$(run_gate "$sb" 'tracker_pr_merge "$PR_HOST_REPO" "77" "squash" true')
+assert_eq "#1151 variable wrapper target blocks" "2" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "F) #1151 unavailable diff fails closed"
+sb=$(make_sandbox)
+mkdir -p "$sb/bin"
+printf '%s\n' '#!/bin/bash' 'exit 1' > "$sb/bin/gh"
+chmod +x "$sb/bin/gh"
+code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
+assert_eq "#1151 unresolvable diff blocks" "2" "$code"
+rm -rf "$sb"
+
+echo ""
 echo "==================================="
 echo "  PASS: $PASS   FAIL: $FAIL"
 echo "==================================="

--- a/.claude/hooks/tests/test_require_design_review_for_ui.sh
+++ b/.claude/hooks/tests/test_require_design_review_for_ui.sh
@@ -353,6 +353,32 @@ assert_eq "#1091 control: gh healthy, marker at forge HEAD -> still ALLOWED" "0"
 rm -rf "$sb"
 
 echo ""
+echo "F) #1151 explicit wrapper repo outranks a leading cd target"
+sb=$(make_sandbox); pf=$(make_portfolio "me2resh/wrong-ops-repo")
+install_mock_gh_splitportfolio "$sb" '"src/components/Button.tsx"' "$SHA" "$PF_SLUG"
+code=$(run_gate "$sb" "cd $pf && tracker_pr_merge \"$PF_SLUG\" \"77\" \"squash\" true")
+assert_eq "#1151 wrapper repo wins over cd-target and blocks" "2" "$code"
+rm -rf "$sb" "$pf"
+
+echo ""
+echo "F) #1151 unexpanded wrapper repo fails closed"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"src/components/Button.tsx"' "$SHA"
+code=$(run_gate "$sb" 'tracker_pr_merge "$PR_HOST_REPO" "77" "squash" true')
+assert_eq "#1151 variable wrapper target blocks" "2" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "F) #1151 unavailable diff fails closed"
+sb=$(make_sandbox)
+mkdir -p "$sb/bin"
+printf '%s\n' '#!/bin/bash' 'exit 1' > "$sb/bin/gh"
+chmod +x "$sb/bin/gh"
+code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
+assert_eq "#1151 unresolvable diff blocks" "2" "$code"
+rm -rf "$sb"
+
+echo ""
 echo "==================================="
 echo "  PASS: $PASS   FAIL: $FAIL"
 echo "==================================="

--- a/docs/agdr/AgDR-0123-merge-gate-repo-resolution-precedence.md
+++ b/docs/agdr/AgDR-0123-merge-gate-repo-resolution-precedence.md
@@ -1,0 +1,52 @@
+# Merge-Gate Repo Resolution Precedence
+
+> In the context of multi-repo merge gates evaluating sanctioned `/approve-merge` wrapper commands, facing a fail-open bug where a leading `cd` could make architecture and design gates inspect the wrong repository, I decided to centralize merge-target resolution with explicit command targets outranking cd-target heuristics and to fail closed when the target or diff cannot be resolved, to achieve consistent gating of the actual PR being merged, accepting stricter blocking when the operator supplies unexpanded variables or forge state is temporarily unavailable.
+
+## Context
+
+- Ticket: [me2resh/apexyard#1151](https://github.com/me2resh/apexyard/issues/1151)
+- PR: [me2resh/apexyard#1155](https://github.com/me2resh/apexyard/pull/1155)
+- The sanctioned merge path can call `tracker_pr_merge "<owner/repo>" "<pr>" ...` from a shell command that begins with `cd <ops-fork> && ...`; architecture and UI gates previously let that `cd` target outrank the wrapper's explicit positional repo argument.
+- The four merge gates had drifted: approval and red-CI gates resolved the wrapper target correctly, while architecture and UI gates could query a same-number PR in the ops fork and then silently allow the merge if the wrong diff had no gated files.
+- These hooks are control gates under AgDR-0104's fail-closed posture. An unexpanded `$PR_HOST_REPO`, missing forge auth, network failure, or unresolvable PR diff means the gate cannot evaluate the precondition it exists to enforce.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Patch only `require-architecture-review.sh` and `require-design-review-for-ui.sh` locally | Smallest immediate diff; directly addresses the two failing gates from the report | Preserves resolver drift across the four merge gates; future wrapper or forge shapes can reintroduce inconsistent answers; duplicates precedence logic |
+| Centralize a shared `resolve_merge_repo` in `_lib-extract-pr.sh` and route all merge gates through it | One precedence contract; all gates evaluate the same PR; regression tests can exercise the resolver once plus each caller; matches the existing shared-parser direction in `_lib-extract-pr.sh` | Wider hook surface touched; existing hooks must adapt to the shared resolver contract |
+| Precedence: `cd` target before wrapper positional repo | Preserves the recovery behavior added for no-`--repo` split-portfolio merges | Keeps the reported bug: a shell working-directory heuristic can override the repo explicitly named in the command being evaluated |
+| Precedence: explicit command target before cd-target origin before ambient fallback | Matches operator intent and CLI semantics; keeps `cd` recovery only for commands that do not name a repo; avoids ambient checkout state unless no stronger signal exists | Requires distinguishing explicit extraction branches from ambient fallback instead of blindly promoting the old `extract_repo_from_command` call |
+| Keep empty/unresolvable diff as no-op | Avoids blocking during transient forge failures; reduces false positives for non-gated PRs | Fails open exactly when the gate cannot know whether gated files exist; contradicts the hooks' control classification |
+| Fail closed on unexpanded variables or unresolvable diffs | Maintains the gate's trust contract; makes ambiguous merge commands visible and retryable; prevents silent bypass through `$PR_HOST_REPO` or forge failures | Operators must rerun with literal repo/PR values or fix forge auth/connectivity before merging |
+
+## Decision
+
+Chosen: **central shared resolver with explicit-over-heuristic precedence and fail-closed evaluation failures**, because merge gates are only meaningful if every gate binds to the same live PR and blocks when it cannot determine the PR's repository or changed files.
+
+The resolver precedence is:
+
+1. Explicit CLI repo target: `--repo` / `-R`.
+2. Explicit forge API path target: `repos/<owner>/<repo>/pulls/<n>/merge` or forge equivalent.
+3. Explicit wrapper positional target: `tracker_pr_merge <owner/repo> <pr> ...`.
+4. Leading `cd` target's git origin, used as a heuristic only when the command itself does not name a repository.
+5. Ambient fallback, used last because it is the weakest signal.
+
+The architecture and UI gates should also reject merge commands containing unexpanded repo or PR variables, and should block when `gh pr diff` / equivalent diff resolution fails or returns no evaluable file list for a merge command.
+
+## Consequences
+
+- `block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, `require-architecture-review.sh`, and `require-design-review-for-ui.sh` share one repo-resolution contract instead of carrying hook-local precedence variants.
+- The reported `cd <ops-fork> && tracker_pr_merge "managed/repo" "42" ...` shape evaluates `managed/repo#42`, not `ops-fork#42`.
+- The `cd` recovery behavior remains available for no-explicit-repo split-portfolio commands, but it can no longer outrank a repo named in the command under review.
+- Failures to expand `$PR_HOST_REPO` / `$PR_NUMBER`, authenticate to the forge, or retrieve the PR diff become visible merge blocks rather than silent design or architecture gate no-ops.
+- Some transient failures now require operator remediation and retry, but the direction of failure matches the hook headers and AgDR-0104's control-gate posture.
+
+## Artifacts
+
+- Ticket: [me2resh/apexyard#1151](https://github.com/me2resh/apexyard/issues/1151)
+- PR: [me2resh/apexyard#1155](https://github.com/me2resh/apexyard/pull/1155)
+- Implementation anchor: `.claude/hooks/_lib-extract-pr.sh` centralizes `resolve_merge_repo`.
+- Gate callers: `.claude/hooks/block-unreviewed-merge.sh`, `.claude/hooks/block-merge-on-red-ci.sh`, `.claude/hooks/require-architecture-review.sh`, `.claude/hooks/require-design-review-for-ui.sh`.
+- Regression coverage: `.claude/hooks/tests/test_extract_pr.sh`, `.claude/hooks/tests/test_forge_aware_extract_pr.sh`, `.claude/hooks/tests/test_require_architecture_review.sh`, `.claude/hooks/tests/test_require_design_review_for_ui.sh`, `.claude/hooks/tests/test_block_unreviewed_merge.sh`, `.claude/hooks/tests/test_block_merge_on_red_ci.sh`.


### PR DESCRIPTION
## Summary

- Centralizes merge-target resolution so an explicitly named repository wins over a leading `cd` target, preventing architecture and UI gates from inspecting a same-number PR in the wrong repository.
- Routes all four merge gates through the shared precedence, eliminating resolver drift between approval, CI, architecture, and design controls.
- Makes the architecture and UI gates fail closed when wrapper arguments remain unexpanded or the forge diff cannot be determined, so evaluation failures cannot silently permit a merge.
- Adds regression coverage for the exact `cd ... && tracker_pr_merge ...` bypass, variable-based wrapper calls, and unavailable diffs.

Closes #1151

AgDR: `docs/agdr/AgDR-0123-merge-gate-repo-resolution-precedence.md`

## Testing

- `bash .claude/hooks/tests/test_extract_pr.sh`
- `bash .claude/hooks/tests/test_forge_aware_extract_pr.sh`
- `bash .claude/hooks/tests/test_require_architecture_review.sh`
- `bash .claude/hooks/tests/test_require_design_review_for_ui.sh`
- `bash .claude/hooks/tests/test_block_unreviewed_merge.sh`
- `bash .claude/hooks/tests/test_block_merge_on-red-ci.sh`
- Pre-push markdownlint, shellcheck, and subpack checks

## Glossary

| Term | Definition |
|---|---|
| Merge gate | A pre-merge control that blocks a merge until its required condition is verified. |
| Explicit repo | A repository named directly by `--repo`, a forge API path, or `tracker_pr_merge` positional argument. |
| cd-target | The repository inferred from a leading `cd <path> &&` shell prefix. |
| Fail closed | Blocking the merge when the control cannot reliably determine the target or precondition. |