### PR TITLE
fix(#1147): preserve workspace README in split setup

### DIFF
--- a/.claude/hooks/tests/test_split_portfolio_v2_migration.sh
+++ b/.claude/hooks/tests/test_split_portfolio_v2_migration.sh
@@ -149,7 +149,8 @@ run_migration() {
     # Update .gitignore
     NEEDS=()
     grep -qxF onboarding.yaml .gitignore 2>/dev/null || NEEDS+=(onboarding.yaml)
-    grep -qxF workspace .gitignore 2>/dev/null || NEEDS+=(workspace)
+    grep -qxF 'workspace/*' .gitignore 2>/dev/null || NEEDS+=('workspace/*')
+    grep -qxF '!workspace/README.md' .gitignore 2>/dev/null || NEEDS+=('!workspace/README.md')
     if [ "${#NEEDS[@]}" -gt 0 ]; then
       {
         echo ""
@@ -236,9 +237,13 @@ grep -qxF onboarding.yaml "$SB/public/.gitignore" \
   && mark_pass "onboarding.yaml added to public-fork .gitignore" \
   || mark_fail "gitignore onboarding" "not added"
 
-grep -qxF workspace "$SB/public/.gitignore" \
-  && mark_pass "workspace added to public-fork .gitignore" \
-  || mark_fail "gitignore workspace" "not added"
+grep -qxF 'workspace/*' "$SB/public/.gitignore" \
+  && mark_pass "workspace entries added to public-fork .gitignore" \
+  || mark_fail "gitignore workspace entries" "not added"
+
+grep -qxF '!workspace/README.md' "$SB/public/.gitignore" \
+  && mark_pass "workspace README exception added to public-fork .gitignore" \
+  || mark_fail "gitignore workspace README" "exception not added"
 
 ONB_KEY=$(jq -r '.portfolio.onboarding // empty' "$SB/public/.claude/project-config.json")
 WS_KEY=$(jq -r '.portfolio.workspace_dir // empty' "$SB/public/.claude/project-config.json")
@@ -280,12 +285,13 @@ run_migration "$SB/public"
 POST_LIST=$(find "$SB/public" "$SB/private" -type f 2>/dev/null | sort)
 
 # .gitignore should have exactly one entry per v2 file class even after re-run.
-GI_ONB=$(grep -cxF onboarding.yaml "$SB/public/.gitignore" 2>/dev/null || echo 0)
-GI_WS=$(grep -cxF workspace "$SB/public/.gitignore" 2>/dev/null || echo 0)
-if [ "$GI_ONB" -eq 1 ] && [ "$GI_WS" -eq 1 ]; then
+GI_ONB=$(grep -cxF onboarding.yaml "$SB/public/.gitignore" 2>/dev/null || true)
+GI_WS=$(grep -cxF 'workspace/*' "$SB/public/.gitignore" 2>/dev/null || true)
+GI_README=$(grep -cxF '!workspace/README.md' "$SB/public/.gitignore" 2>/dev/null || true)
+if [ "${GI_ONB:-0}" -eq 1 ] && [ "${GI_WS:-0}" -eq 1 ] && [ "${GI_README:-0}" -eq 1 ]; then
   mark_pass "idempotence: .gitignore has exactly one entry per file class"
 else
-  mark_fail "idempotence gitignore" "got onboarding=$GI_ONB workspace=$GI_WS (expected 1 each)"
+  mark_fail "idempotence gitignore" "got onboarding=${GI_ONB:-0} workspace=${GI_WS:-0} readme=${GI_README:-0} (expected 1 each)"
 fi
 
 if [ "$PRE_LIST" = "$POST_LIST" ]; then

--- a/.claude/hooks/tests/test_split_portfolio_v2_migration.sh
+++ b/.claude/hooks/tests/test_split_portfolio_v2_migration.sh
@@ -22,8 +22,9 @@ LIB_OPS="$SRC_ROOT/.claude/hooks/_lib-ops-root.sh"
 LIB_PORT="$SRC_ROOT/.claude/hooks/_lib-portfolio-paths.sh"
 LIB_CFG="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
 DEFAULTS="$SRC_ROOT/.claude/project-config.defaults.json"
+MIGRATION="$SRC_ROOT/.claude/migrations/v1.2.0-to-v1.3.0.sh"
 
-for f in "$LIB_OPS" "$LIB_PORT" "$LIB_CFG" "$DEFAULTS"; do
+for f in "$LIB_OPS" "$LIB_PORT" "$LIB_CFG" "$DEFAULTS" "$MIGRATION"; do
   [ -f "$f" ] || { echo "FAIL: missing $f" >&2; exit 1; }
 done
 
@@ -479,6 +480,46 @@ else
 fi
 
 rm -f "$STDERR_OUT"
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# Case 6: the shipped migration preserves and keeps tracking workspace/README.
+#
+# Case 5 exercises the recipe documented in /update. This case deliberately
+# executes the production migration script so its .gitignore behavior cannot
+# drift behind the duplicated recipe again.
+# ---------------------------------------------------------------------------
+echo "== Case 6: shipped migration keeps workspace/README.md visible to git"
+SB=$(mktemp -d)
+SB=$(cd "$SB" && pwd -P)
+build_pre_v2 "$SB"
+cat > "$SB/public/workspace/README.md" <<'README'
+# workspace/ — live working copies of managed projects
+README
+( cd "$SB/public" && git add workspace/README.md && git commit -q -m "add workspace framework readme" )
+
+( cd "$SB/public" && APEXYARD_MIGRATION_PROMPT=workspace APEXYARD_MIGRATION_QUIET=1 bash "$MIGRATION" )
+RC=$?
+
+if [ "$RC" = "0" ] && [ -f "$SB/public/workspace/README.md" ]; then
+  mark_pass "shipped migration preserves workspace/README.md"
+else
+  mark_fail "shipped migration preserves README" "rc=$RC; README missing after production migration"
+fi
+
+if ( cd "$SB/public" && ! git check-ignore -q workspace/README.md ); then
+  mark_pass "shipped migration does not ignore workspace/README.md"
+else
+  mark_fail "shipped migration keeps README trackable" "workspace/README.md is ignored by the generated rules"
+fi
+
+if grep -qxF 'workspace/*' "$SB/public/.gitignore" \
+  && grep -qxF '!workspace/README.md' "$SB/public/.gitignore"; then
+  mark_pass "shipped migration writes scoped workspace ignore rules"
+else
+  mark_fail "shipped migration writes scoped ignore rules" "expected workspace/* plus !workspace/README.md"
+fi
+
 rm -rf "$SB"
 
 # ---------------------------------------------------------------------------

--- a/.claude/migrations/v1.2.0-to-v1.3.0.sh
+++ b/.claude/migrations/v1.2.0-to-v1.3.0.sh
@@ -157,7 +157,8 @@ fi
 # --- update .gitignore in the public fork ------------------------------------
 NEEDS=()
 grep -qxF onboarding.yaml .gitignore 2>/dev/null || NEEDS+=(onboarding.yaml)
-grep -qxF workspace .gitignore 2>/dev/null || NEEDS+=(workspace)
+grep -qxF 'workspace/*' .gitignore 2>/dev/null || NEEDS+=('workspace/*')
+grep -qxF '!workspace/README.md' .gitignore 2>/dev/null || NEEDS+=('!workspace/README.md')
 if [ "${#NEEDS[@]}" -gt 0 ]; then
   {
     echo ""

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -155,8 +155,8 @@ The full setup lives in `docs/multi-project.md` § "Split-portfolio mode — pub
    - `.gitignore` with `workspace/*/` so the inner clones don't get double-tracked in the private repo either
    - initial commit + push
 6. **Configure path resolution in the fork** (recommended — v2 config-block mode):
-   - Append `.gitignore` lines for `apexyard.projects.yaml`, `projects`, `onboarding.yaml`, AND `workspace` so none of them get accidentally staged in the public fork even on a stray `git add -A`. (The first two cover registry + per-project docs; the last two are the v2 additions.)
-   - Untrack any tracked `projects/README.md`, `onboarding.yaml`, or `workspace/README.md` from the upstream framework: `git rm --cached -r projects onboarding.yaml workspace 2>/dev/null || true`.
+   - Append `.gitignore` lines for `apexyard.projects.yaml`, `projects`, and `onboarding.yaml`. Keep the framework's `workspace/*` + `!workspace/README.md` pair: it ignores every adopter workspace entry while leaving the committed convention README visible and re-includable. Do not add a broad `workspace` rule; Git cannot re-include the README when its parent directory is excluded.
+   - Untrack the upstream framework's tracked `projects/README.md` and `onboarding.yaml`: `git rm --cached -r projects onboarding.yaml 2>/dev/null || true`. **Do not untrack `workspace/README.md`** — it is a public framework artefact and stays in the fork per AgDR-0021 § G.
    - Write `.claude/project-config.json` with the v2 `portfolio:` block pointing at the sibling repo. Substitute the actual sibling-dir name the operator chose for `apexyard-portfolio` below:
 
      ```json

--- a/.claude/skills/setup/tests/test_setup_split_portfolio_v2.sh
+++ b/.claude/skills/setup/tests/test_setup_split_portfolio_v2.sh
@@ -13,8 +13,8 @@
 #      custom_skills_dir, custom_handbooks_dir)
 #   - .apexyard-fork presence marker exists at the public-fork root with
 #     the expected commented preamble (presence-only readers, AgDR-0021 § B)
-#   - .gitignore has the 4 v2 paths excluded
-#     (apexyard.projects.yaml, projects, onboarding.yaml, workspace)
+#   - .gitignore excludes private v2 data while preserving the public
+#     workspace/README.md framework artefact (AgDR-0021 § G)
 #   - portfolio_validate succeeds on the post-state
 #
 # Companion to test_split_portfolio_v2_migration.sh (which tests the
@@ -69,7 +69,7 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 # ---------------------------------------------------------------------------
 build_pre_setup_v2() {
   local sb="$1"
-  mkdir -p "$sb/public/.claude/hooks" "$sb/public/.claude"
+  mkdir -p "$sb/public/.claude/hooks" "$sb/public/.claude" "$sb/public/workspace"
   mkdir -p "$sb/private/projects" "$sb/private/workspace"
 
   # Public fork: framework files only — onboarding.yaml is still the
@@ -79,6 +79,9 @@ build_pre_setup_v2() {
 company:
   name: "Your Company Name"
 YAML
+  cat > "$sb/public/workspace/README.md" <<'MD'
+# Managed-project workspaces
+MD
 
   cp "$LIB_OPS"  "$sb/public/.claude/hooks/_lib-ops-root.sh"
   cp "$LIB_PORT" "$sb/public/.claude/hooks/_lib-portfolio-paths.sh"
@@ -147,8 +150,13 @@ apply_setup_v2() {
       echo "apexyard.projects.yaml"
       echo "projects"
       echo "onboarding.yaml"
-      echo "workspace"
+      echo "workspace/*"
+      echo "!workspace/README.md"
     } >> .gitignore
+
+    # The public framework README survives setup; only portfolio-owned root
+    # files are untracked from the public fork.
+    git rm --cached -r projects onboarding.yaml >/dev/null 2>&1 || true
 
     # 2. Write the v2 config block (8 keys including agent_routing
     #    per #351 PR 3).
@@ -224,15 +232,31 @@ else
   mark_fail "marker content" "preamble line missing or wrong"
 fi
 
-# Assertion 3: .gitignore has 4 v2 paths excluded
+# Assertion 3: .gitignore excludes private v2 paths but can re-include the
+# public workspace README because the parent directory itself is not ignored.
 GI="$SB/public/.gitignore"
-for path in apexyard.projects.yaml projects onboarding.yaml workspace; do
+for path in apexyard.projects.yaml projects onboarding.yaml 'workspace/*'; do
   if grep -qxF "$path" "$GI"; then
     mark_pass ".gitignore excludes '$path'"
   else
     mark_fail "gitignore exclude $path" "missing from $GI"
   fi
 done
+if grep -qxF '!workspace/README.md' "$GI"; then
+  mark_pass ".gitignore re-includes 'workspace/README.md'"
+else
+  mark_fail "gitignore README exception" "missing from $GI"
+fi
+if (cd "$SB/public" && git check-ignore -q workspace/README.md); then
+  mark_fail "workspace README visible" "workspace/README.md is still ignored"
+else
+  mark_pass "workspace/README.md is not ignored after split-portfolio setup"
+fi
+if [ "$(cd "$SB/public" && git ls-files workspace/README.md)" = "workspace/README.md" ]; then
+  mark_pass "workspace/README.md remains tracked after split-portfolio setup"
+else
+  mark_fail "workspace README tracked" "workspace/README.md was untracked"
+fi
 
 # Assertion 4: portfolio_validate succeeds on the post-state
 (

--- a/.claude/skills/split-portfolio/SKILL.md
+++ b/.claude/skills/split-portfolio/SKILL.md
@@ -424,12 +424,13 @@ Idempotence: empty `workspace/` (no entries to move, or only `README.md` left) i
 ```bash
 NEEDS=()
 grep -qxF onboarding.yaml .gitignore 2>/dev/null || NEEDS+=(onboarding.yaml)
-grep -qxF workspace .gitignore 2>/dev/null || NEEDS+=(workspace)
+grep -qxF 'workspace/*' .gitignore 2>/dev/null || NEEDS+=('workspace/*')
+grep -qxF '!workspace/README.md' .gitignore 2>/dev/null || NEEDS+=('!workspace/README.md')
 
 if [ "${#NEEDS[@]}" -gt 0 ]; then
   {
     echo ""
-    echo "# Split-portfolio v2 (framework ≥ #242): onboarding + workspace live in the private sibling repo."
+    echo "# Split-portfolio v2 (framework ≥ #242): onboarding + workspace entries live in the private sibling repo."
     for n in "${NEEDS[@]}"; do echo "$n"; done
   } >> .gitignore
   git add .gitignore

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -610,12 +610,13 @@ Idempotence: empty `workspace/` (no entries to move) is a no-op.
 ```bash
 NEEDS=()
 grep -qxF onboarding.yaml .gitignore 2>/dev/null || NEEDS+=(onboarding.yaml)
-grep -qxF workspace .gitignore 2>/dev/null || NEEDS+=(workspace)
+grep -qxF 'workspace/*' .gitignore 2>/dev/null || NEEDS+=('workspace/*')
+grep -qxF '!workspace/README.md' .gitignore 2>/dev/null || NEEDS+=('!workspace/README.md')
 
 if [ "${#NEEDS[@]}" -gt 0 ]; then
   {
     echo ""
-    echo "# Split-portfolio v2 (framework ≥ #242): onboarding + workspace live in the private sibling repo."
+    echo "# Split-portfolio v2 (framework ≥ #242): onboarding + workspace entries live in the private sibling repo."
     for n in "${NEEDS[@]}"; do echo "$n"; done
   } >> .gitignore
   git add .gitignore

--- a/.claude/skills/update/tests/test_step_8a_wiring.sh
+++ b/.claude/skills/update/tests/test_step_8a_wiring.sh
@@ -378,7 +378,8 @@ fi
   # gitignore additions
   NEEDS=()
   grep -qxF onboarding.yaml .gitignore 2>/dev/null || NEEDS+=(onboarding.yaml)
-  grep -qxF workspace .gitignore 2>/dev/null || NEEDS+=(workspace)
+  grep -qxF 'workspace/*' .gitignore 2>/dev/null || NEEDS+=('workspace/*')
+  grep -qxF '!workspace/README.md' .gitignore 2>/dev/null || NEEDS+=('!workspace/README.md')
   if [ "${#NEEDS[@]}" -gt 0 ]; then
     {
       echo ""

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ onboarding.yaml
 
 # Live working copies of managed projects. Each is its own git repo — they
 # must not be double-tracked from the ops repo.
-workspace/*/
+workspace/*
 !workspace/README.md
 
 # Adopter-specific agent routing (single-fork mode; split-portfolio mode

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -284,8 +284,8 @@ The recommended path is the **config block** (framework version ≥ #145). The s
 ```bash
 cd ~/ops/apexyard
 
-# Tell the fork to ignore everything that lives in the private repo:
-# registry, per-project docs, onboarding config, and the workspace dir.
+# Tell the fork to ignore everything that lives in the private repo.
+# Keep workspace/ itself visible so the framework README can stay public.
 cat >> .gitignore <<'EOF'
 
 # Portfolio data lives in a separate private repo (split-portfolio v2).
@@ -293,12 +293,14 @@ cat >> .gitignore <<'EOF'
 apexyard.projects.yaml
 projects
 onboarding.yaml
-workspace
+workspace/*
+!workspace/README.md
 EOF
 
 # If any of these are currently tracked from the upstream framework,
 # untrack them so the config-block resolution can take their place:
-git rm -r --cached projects onboarding.yaml workspace 2>/dev/null || true
+git rm -r --cached projects onboarding.yaml 2>/dev/null || true
+# workspace/README.md deliberately stays tracked (AgDR-0021 § G).
 
 # Write the v2 portfolio: config block pointing at the sibling repo.
 # Paths resolve relative to the ops-fork root (this directory).
@@ -707,7 +709,8 @@ cat >> .gitignore <<'IGNORE'
 
 # Split-portfolio v2 (framework ≥ #242)
 onboarding.yaml
-workspace
+workspace/*
+!workspace/README.md
 IGNORE
 
 # Write the v2 anchor

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -57,7 +57,7 @@ If you're not sure where a doc belongs, ask: "Would I want this doc to follow th
 
 ```
 # Don't commit live working copies — they have their own remotes
-workspace/*/
+workspace/*
 !workspace/README.md
 ```
 


### PR DESCRIPTION
## Summary

- Keep `workspace/README.md` tracked during fresh split-portfolio v2 setup so setup now follows AgDR-0021's recorded decision.
- Replace broad or directory-only workspace ignores with `workspace/*` plus an effective README exception, preventing future setup and update churn.
- Add regression coverage that verifies the README remains both visible to Git and tracked after setup, while migration recipes remain idempotent.

Closes #1147

## Testing

- `bash .claude/skills/setup/tests/test_setup_split_portfolio_v2.sh`
- `bash .claude/hooks/tests/test_split_portfolio_v2_migration.sh`
- `bash .claude/skills/update/tests/test_step_8a_wiring.sh`
- `bash bin/run-hook-tests.sh`
- `shellcheck -S warning .claude/hooks/tests/test_split_portfolio_v2_migration.sh .claude/skills/setup/tests/test_setup_split_portfolio_v2.sh .claude/skills/update/tests/test_step_8a_wiring.sh`
- Pre-push markdownlint, shellcheck, and subpack checks

## Glossary

| Term | Definition |
|------|------------|
| Split-portfolio v2 | Layout where public framework code and private portfolio data live in sibling repositories. |
| Workspace README | Public framework documentation at `workspace/README.md` that explains where managed-project clones belong. |
| Gitignore negation | A `!pattern` rule that re-includes a path excluded by an earlier pattern, provided its parent directory remains traversable. |