### PR TITLE
fix(#1171): right-size handbook review triggers

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -80,7 +80,7 @@ Per `.claude/rules/right-size-ceremony.md`, a **Lean-tier** diff still requires 
 2. **Size.** Small — a rough guide is under ~50 changed lines. Use judgment, not a hard cutoff; a 200-line prose rewrite can still be Lean, a 10-line `.md` change that alters a documented gate's behavior might not be.
 3. **Reversibility / behavior.** Trivially reversible in one revert, with no behavior change — no code path, no runtime logic, no schema, no CI step, nothing that executes differently as a result of this diff.
 4. **Rail 1 (non-negotiable — mirrors `right-size-ceremony.md`'s rail 1 exactly; security / trust-chain / migration never goes Lean).** The diff does NOT touch ANY of:
-   - The trust chain: `.claude/hooks/**`, `.claude/settings.json` (me2resh/apexyard#777)
+   - The trust chain: production `.claude/hooks/*.sh`, `.claude/settings.json` (me2resh/apexyard#777). Test-only files under `.claude/hooks/tests/**` do not trigger Heavy by path alone; round up if their assertions change enforcement semantics.
    - `**/auth/**`, `**/crypto/**`, `**/secrets/**`, `.env*`
    - A migration path: anything under `**/migrations/**`, `**/migrate-*.{ts,js,py,sql}`, `prisma/schema.prisma`, `prisma/migrations/**`, `src/migrations/*.{ts,js}`, `alembic/versions/*.py`, `db/migrate/*.rb` (the same defaults `require-migration-ticket.sh` matches; check `.migration_paths` in `.claude/project-config.json` for an adopter override too)
    - **A single file matching ANY of these disqualifies the ENTIRE diff from reduced scope**, even if every other file in the diff is plain prose. Do not average across files — one match rounds the whole PR up.
@@ -234,12 +234,12 @@ Both layers use the **same path-convention** (architecture / general / language)
 
 #### Discovery (path-convention)
 
-The path conventions below apply to **each** of the two source roots. Within a single review you may load handbooks from both sources for the same bucket — that's the expected case for a split-portfolio adopter who has, say, both a public `architecture/clean-architecture-layers.md` AND a private `architecture/internal-pii-handling.md`.
+The path conventions below apply to **each** of the two source roots. Before reading a handbook, classify it against the changed paths: load architecture layering guidance only for application/domain/infrastructure or other architecture-bearing code, load migration safety only for migration/schema paths, and load language guidance only for matching language files. General commit-message guidance remains applicable to substantive commits. Record skipped candidates as not applicable rather than presenting them as findings. Within a single review you may load handbooks from both sources for the same bucket — that's the expected case for a split-portfolio adopter who has, say, both a public `architecture/clean-architecture-layers.md` AND a private `architecture/internal-pii-handling.md`.
 
 | Path glob (relative to source root) | Load condition |
 |---|---|
-| `architecture/*.md` | Always — every PR |
-| `general/*.md` | Always — every PR |
+| `architecture/*.md` | When the PR diff includes architecture-bearing code, design artifacts, or migration/schema paths; migration safety remains applicable to migration/schema paths. |
+| `general/*.md` | For substantive commits; skip for empty/docs-only bookkeeping changes and record as not applicable. |
 | `language/<lang>/*.md` | When the PR diff includes files matching `<lang>`'s extensions: `typescript/` → `**/*.{ts,tsx}`, `python/` → `**/*.py`, `go/` → `**/*.go`, `rust/` → `**/*.rs`. Other directories under `language/` follow the same `<lang>/` → matching-extension convention. |
 | `domain/<area>/*.md` | **Parse the YAML frontmatter** (a `---`-delimited block at the top of the file). If a `paths:` field is present and non-empty, load this handbook only when the PR diff matches at least one glob in the list. If `paths:` is absent or empty, **always load** (foundational domain rule with no path boundary). See § "Domain handbook frontmatter — `paths:` field" below for the parse + match shape and [`handbooks/domain/README.md`](../../handbooks/domain/README.md) for the authoring convention. |
 | `<other>/*.md` | Default to always-load if you don't recognise the directory; flag in your review that the directory convention is undocumented. |

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -230,16 +230,16 @@ Beyond the framework's generic rules, the adopter ships company-specific standar
 | **Public handbooks** | `handbooks/**/*.md` in the public ops fork | Generic adopter customisations safe to publish on a public framework fork |
 | **Private custom handbooks** | `<private_repo>/custom-handbooks/**/*.md`, resolved via `portfolio_custom_handbooks_dir` from `.claude/hooks/_lib-portfolio-paths.sh` | Company-confidential standards that name internal systems, refer to proprietary policy, or otherwise should not appear on a public repo (split-portfolio adopters only — single-fork adopters typically don't have this dir) |
 
-Both layers use the **same path-convention** (architecture / general / language) and the same advisory/blocking semantics. Both load on every review.
+Both layers use the **same path-convention** (architecture / general / language) and the same advisory/blocking semantics. Discovery runs on every review; individual handbooks load only when applicable to the changed paths or PR topic.
 
 #### Discovery (path-convention)
 
-The path conventions below apply to **each** of the two source roots. Before reading a handbook, classify it against the changed paths: load architecture layering guidance only for application/domain/infrastructure or other architecture-bearing code, load migration safety only for migration/schema paths, and load language guidance only for matching language files. General commit-message guidance remains applicable to substantive commits. Record skipped candidates as not applicable rather than presenting them as findings. Within a single review you may load handbooks from both sources for the same bucket — that's the expected case for a split-portfolio adopter who has, say, both a public `architecture/clean-architecture-layers.md` AND a private `architecture/internal-pii-handling.md`.
+The path conventions below apply to **each** of the two source roots. Before reading a handbook, classify it against the changed paths and PR topic: load architecture layering guidance only for application/domain/infrastructure or other architecture-bearing code, load migration safety only for migration/schema paths, and load language guidance only for matching language files. General commit-message guidance remains applicable to substantive commits. Record skipped candidates as not applicable rather than presenting them as findings. Within a single review you may load handbooks from both sources for the same bucket — that's the expected case for a split-portfolio adopter who has, say, both a public `architecture/clean-architecture-layers.md` AND a private `architecture/internal-pii-handling.md`.
 
 | Path glob (relative to source root) | Load condition |
 |---|---|
-| `architecture/*.md` | When the PR diff includes architecture-bearing code, design artifacts, or migration/schema paths; migration safety remains applicable to migration/schema paths. |
-| `general/*.md` | For substantive commits; skip for empty/docs-only bookkeeping changes and record as not applicable. |
+| `architecture/*.md` | Read when the PR diff includes architecture-bearing code, design artifacts, or migration/schema paths; migration safety remains applicable to migration/schema paths. |
+| `general/*.md` | Read for substantive commits; skip for empty/docs-only bookkeeping changes and record as not applicable. |
 | `language/<lang>/*.md` | When the PR diff includes files matching `<lang>`'s extensions: `typescript/` → `**/*.{ts,tsx}`, `python/` → `**/*.py`, `go/` → `**/*.go`, `rust/` → `**/*.rs`. Other directories under `language/` follow the same `<lang>/` → matching-extension convention. |
 | `domain/<area>/*.md` | **Parse the YAML frontmatter** (a `---`-delimited block at the top of the file). If a `paths:` field is present and non-empty, load this handbook only when the PR diff matches at least one glob in the list. If `paths:` is absent or empty, **always load** (foundational domain rule with no path boundary). See § "Domain handbook frontmatter — `paths:` field" below for the parse + match shape and [`handbooks/domain/README.md`](../../handbooks/domain/README.md) for the authoring convention. |
 | `<other>/*.md` | Default to always-load if you don't recognise the directory; flag in your review that the directory convention is undocumented. |
@@ -257,12 +257,25 @@ if [ -f "$OPS_ROOT/.claude/hooks/_lib-portfolio-paths.sh" ]; then
   [ -n "$candidate" ] && [ -d "$candidate" ] && PRIV="$candidate"
 fi
 
-# Always-load buckets — public + private (private may be empty).
-find handbooks/architecture handbooks/general -name '*.md' 2>/dev/null
-[ -n "$PRIV" ] && find "$PRIV/architecture" "$PRIV/general" -name '*.md' 2>/dev/null
+# Applicability-gated buckets — public + private (private may be empty).
+# Discovery runs every review, but these buckets are not read by default.
+# Load only the handbooks whose topic applies to the diff.
+DIFF_FILES=$(gh pr diff <number> --name-only)
+if printf '%s\n' "$DIFF_FILES" | grep -qE '(^|/)(src|app|packages|services|domain|application|infrastructure)/|docs/agdr/|(^|/)(designs|prds)/|technical-design|feature-spec|migrations/|prisma/schema.prisma'; then
+  find handbooks/architecture -name '*.md' 2>/dev/null
+  [ -n "$PRIV" ] && find "$PRIV/architecture" -name '*.md' 2>/dev/null
+fi
+
+# General handbooks still require topic judgment. Collect candidates, inspect
+# the path/title/scope, then read the full handbook only when it applies. For
+# example, commit-message-quality applies to substantive commits, while a
+# docs-only typo fix can record it as not applicable. Candidate discovery is
+# not handbook loading; do not report a candidate as an applicable finding
+# until this check is complete.
+find handbooks/general -name '*.md' 2>/dev/null
+[ -n "$PRIV" ] && find "$PRIV/general" -name '*.md' 2>/dev/null
 
 # Diff-matched language buckets — public + private.
-DIFF_FILES=$(gh pr diff <number> --name-only)
 echo "$DIFF_FILES" | (
   if grep -qE '\.(ts|tsx)$'; then
     find handbooks/language/typescript -name '*.md' 2>/dev/null
@@ -299,7 +312,7 @@ Tag every handbook loaded in this step with `discovery_method: path-convention` 
 
 #### Semantic supplement (MCP `search_docs`) — additive, fail-soft (apexyard#449)
 
-This step **supplements** the path-convention set above with handbooks that semantically match the PR's content but didn't match a path glob. It is **strictly additive** — the path-convention set is the floor and never shrinks. Adopters without MCP get path-convention only; the rest of this section is a no-op for them.
+This step **supplements** the applicable path-convention set above with handbooks that semantically match the PR's content but didn't match a path glob. It is **strictly additive** — the applicable path-convention set is the floor and never shrinks. Adopters without MCP get path-convention only; the rest of this section is a no-op for them.
 
 Rules:
 
@@ -354,8 +367,8 @@ except Exception:
 
 What this step does NOT do:
 
-- Does NOT replace the path-convention set — that set is the floor.
-- Does NOT shrink the loaded handbook set under any condition.
+- Does NOT replace the applicable path-convention set — that set is the floor.
+- Does NOT shrink the already-applicable loaded handbook set under any condition.
 - Does NOT block the review if MCP is down — Rex's review proceeds with path-convention discovery alone.
 - Does NOT emit a user-visible warning when MCP is unreachable — only verbose-logs the status for the operator who runs Rex with debug enabled.
 - Does NOT change the enforcement semantics (advisory / blocking) of any handbook — those still come from the handbook's own `ENFORCEMENT:` line. Discovery method only affects citation.

--- a/.claude/hooks/detect-role-trigger.sh
+++ b/.claude/hooks/detect-role-trigger.sh
@@ -261,6 +261,9 @@ detect_path_triggers() {
   # Over-triggering is cheap (the auditor no-ops on a false positive); leaving
   # trust-chain edits to the generalist review alone is the gap #777 closes.
   case "$rel" in
+    .claude/hooks/tests/*|*/.claude/hooks/tests/*)
+      # Test fixtures exercise the controls but are not controls themselves.
+      ;;
     .claude/hooks/*|*/.claude/hooks/*|\
     .claude/settings.json|*/.claude/settings.json)
       emit_banner \

--- a/.claude/hooks/tests/test_detect_role_trigger.sh
+++ b/.claude/hooks/tests/test_detect_role_trigger.sh
@@ -147,6 +147,12 @@ in=$(jq -nc \
 run_case "trust chain: .claude/hooks/* fires Security Auditor [#777]" 0 \
   "ROLE TRIGGER: Security Auditor.*roles/security/security-auditor\\.md" "$in"
 
+# 2e-i-a. Tests under the hooks tree are not production trust-chain controls.
+in=$(jq -nc \
+  --arg p ".claude/hooks/tests/test_detect_role_trigger.sh" \
+  '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$p}}')
+run_case "trust chain: hook tests do not fire Security Auditor" 0 "" "$in"
+
 # 2e-ii. Trust chain (#777): settings.json (the matcher wiring) fires Security Auditor.
 in=$(jq -nc \
   --arg p ".claude/settings.json" \

--- a/.claude/hooks/tests/test_pre_push_gate.sh
+++ b/.claude/hooks/tests/test_pre_push_gate.sh
@@ -207,11 +207,17 @@ case9() {
   # markdownlint config: just omit the trailing newline.
   printf '# README\nno-trailing-newline' > "$sb/README.md"
   (cd "$sb" && git add README.md && git commit -q -m "chore: add bad README")
-  # npx must be available for this case to be meaningful; skip gracefully if not.
-  if ! command -v npx >/dev/null 2>&1; then
-    echo "SKIP [tracked-bad-md-fails]: npx not available, case not executable"
-    return
-  fi
+  # Use a local npx stub so this gate test never depends on registry access or
+  # a package download. The test is about propagating a tracked lint failure,
+  # not about testing markdownlint-cli2 itself.
+  mkdir -p "$sb/bin"
+  cat > "$sb/bin/npx" <<'EOF'
+#!/bin/bash
+echo "MD047: Files should end with a single newline" >&2
+exit 1
+EOF
+  chmod +x "$sb/bin/npx"
+  PATH="$sb/bin:$PATH"
   run_hook "$sb" "$(push_json)" 2 "markdownlint: FAILED" "tracked-bad-md-fails"
   rm -rf "$sb"
 }

--- a/.claude/rules/right-size-ceremony.md
+++ b/.claude/rules/right-size-ceremony.md
@@ -34,7 +34,7 @@ The key realization: the framework **already detects every Heavy class** (the au
 
 A right-sizing heuristic is only safe if it fails in the harmless direction:
 
-1. **Security and trust-chain never go Lean.** Any change touching `.claude/hooks/**`, `.claude/settings.json`, the merge-gate/marker libraries, auth, crypto, secrets, or a migration takes the Heavy path regardless of diff size. A one-line hook edit is exactly where you *want* the chain. This rail overrides the size signal every time.
+1. **Security and trust-chain never go Lean.** Any change touching a production `.claude/hooks/*.sh` file, `.claude/settings.json`, the merge-gate/marker libraries, auth, crypto, secrets, or a migration takes the Heavy path regardless of diff size. Test-only files under `.claude/hooks/tests/**` do not trigger Heavy by path alone; round up when the test changes enforcement semantics. A one-line production hook edit is exactly where you *want* the chain. This rail overrides the size signal every time.
 2. **Ambiguity rounds up.** If you're not sure which tier a change is, take the higher one. The tolerated failure is "occasionally too much review on a borderline case" — never "too little review on a risky one."
 
 ## When to apply this (proactively)

--- a/.claude/rules/role-triggers.md
+++ b/.claude/rules/role-triggers.md
@@ -21,7 +21,7 @@ ApexYard ships **20 role definitions** in `roles/{department}/`. They are not al
 | **UI Designer** | `roles/design/ui-designer.md` | Visual design · component specifications · design tokens · pixel-level work |
 | **UX Designer** | `roles/design/ux-designer.md` | User flows · information architecture · usability review · wireframing |
 | **Head of Security** | `roles/security/head-of-security.md` | Security strategy · threat model · compliance call · cross-project security architecture · escalation from a Security Auditor (strategy / compliance / repeated-pattern concern) |
-| **Security Auditor** | `roles/security/security-auditor.md` | **PR touches auth / crypto / user data / secrets** · **the security-critical trust chain (`.claude/hooks/**`, `.claude/settings.json`) — #777** · SAST findings · OWASP review · dependency vulnerability |
+| **Security Auditor** | `roles/security/security-auditor.md` | **PR touches auth / crypto / user data / secrets** · **the security-critical trust chain (production `.claude/hooks/*.sh`, `.claude/settings.json`) — #777** · SAST findings · OWASP review · dependency vulnerability |
 | **Penetration Tester** | `roles/security/penetration-tester.md` | Active testing · exploit discovery · API security review · pre-release security sign-off |
 | **Head of Data** | `roles/data/head-of-data.md` | Analytics strategy · data governance · reporting architecture · cross-project data modelling |
 | **Data Analyst** | `roles/data/data-analyst.md` | SQL queries · dashboards · A/B-test analysis · metric investigation |
@@ -85,7 +85,7 @@ This is a **prose convention**, not a mechanically-enforced format. The sibling 
 |--------|----------|
 | Ticket moved to `qa` label | QA Engineer |
 | PR diff touches `**/auth/**`, `**/crypto/**`, `**/secrets/**`, `.env*` | Security Auditor |
-| Edit/PR touches the trust chain — `.claude/hooks/**` (merge gates, tracker/forge lib, review-marker lib, credential-broker scripts) or `.claude/settings.json` (the matcher wiring that decides whether a gate fires) | Security Auditor (#777) |
+| Edit/PR touches the trust chain — production `.claude/hooks/*.sh` (merge gates, tracker/forge lib, review-marker lib, credential-broker scripts) or `.claude/settings.json` (the matcher wiring that decides whether a gate fires) | Security Auditor (#777) |
 | PR diff touches `.github/workflows/**`, `golden-paths/pipelines/**` | Platform Engineer |
 | PR diff touches `docs/agdr/**` or adds a new dependency | Tech Lead |
 | Edit/PR touches a design artifact (technical design, migration AgDR, feature spec / PRD) | Solution Architect |

--- a/.claude/rules/writing-standard.md
+++ b/.claude/rules/writing-standard.md
@@ -52,7 +52,7 @@ Text that an agent or a hook acts on has no room for interpretation. When you wr
 8. **No idioms, contractions, humour, or rhetorical questions.**
 9. **Identifiers verbatim.** Paths, SHAs, flags, and command names appear exactly as the reader must type or match them.
 
-A block or warn message follows one order: what was blocked or found, in one line; why, in one sentence; what to do, as imperative steps; where to read more, as a path. Existing machine text is not rewritten in bulk. It migrates to this mode when it is next touched, and text under `.claude/hooks/**` still takes the Heavy path when it is.
+A block or warn message follows one order: what was blocked or found, in one line; why, in one sentence; what to do, as imperative steps; where to read more, as a path. Existing machine text is not rewritten in bulk. It migrates to this mode when it is next touched, and production text under `.claude/hooks/*.sh` still takes the Heavy path when it is.
 
 ## Rule 4 — Flavored mode for durable artifacts
 

--- a/docs/agdr/AgDR-0128-right-size-review-ceremony.md
+++ b/docs/agdr/AgDR-0128-right-size-review-ceremony.md
@@ -1,0 +1,34 @@
+# Right-size review triggers and handbook applicability
+
+> In the context of review feedback that small hook-test and documentation changes consumed full Heavy ceremony, facing a broad trust-chain path trigger and handbook instructions that treated every candidate as applicable, I decided to distinguish production controls from their tests and require handbook applicability triage before reading, to preserve safety while reducing unrelated review work, accepting that ambiguous enforcement changes still round up to Heavy.
+
+## Context
+
+- Production hook scripts and matcher settings enforce governance and must keep the Heavy Security Auditor path.
+- Test fixtures under `.claude/hooks/tests/**` exercise those controls but are not controls themselves.
+- Rex's handbook discovery previously described architecture and general candidates as always applicable, which made unrelated guidance look like required review work.
+- The right-size rule requires ambiguity to round up, so this change must not weaken review when a test changes enforcement semantics.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Exclude hook tests by path and triage handbook applicability** | Removes the measured over-ceremony while preserving production-control and blocking-handbook safeguards | Requires reviewers to make an explicit applicability judgment |
+| Keep every `.claude/hooks/**` path Heavy and load every handbook | Simple, conservative | Repeats the disproportionate review cost this task addresses |
+| Add a self-declared bypass flag | Easy to implement | Creates a forgeable gate-relaxing surface and weakens trust |
+
+## Decision
+
+Chosen: **exclude test-only hook paths from the automatic Security Auditor trigger and require handbook applicability triage**, because tests do not enforce governance, while production controls and genuinely applicable blocking handbooks retain their existing Heavy behavior. If a test changes enforcement semantics or the reviewer is unsure, the ambiguity rule rounds the work up.
+
+## Consequences
+
+- `.claude/hooks/tests/**` no longer triggers Security Auditor by path alone; production `.claude/hooks/*.sh` and `.claude/settings.json` still do.
+- Rex may discover handbook candidates, but it reads and reports only those applicable to the changed paths or substantive commit content.
+- Blocking handbooks remain blocking whenever applicable.
+- The path distinction is advisory trigger behavior, not a replacement for security review when the test changes a control's semantics.
+
+## Artifacts
+
+- Ticket: me2resh/apexyard#1171
+- PR: me2resh/apexyard#1172


### PR DESCRIPTION
## Summary

- Keep production trust-chain hooks and matcher settings on the Heavy security path.
- Exclude hook-test files from the Security Auditor trigger by path alone; tests that change enforcement semantics still round up.
- Make Rex’s handbook instructions triage applicability before reading standards, so unrelated architecture and migration guidance does not become review overhead.
- Add an AgDR recording the safety trade-off and a regression assertion proving hook-test edits stay silent.

This keeps blocking handbooks and genuine trust-chain safeguards intact while making review ceremony proportional to the change.

AgDR: [AgDR-0128 — Right-size review triggers and handbook applicability](https://github.com/me2resh/apexyard/blob/397815d/docs/agdr/AgDR-0128-right-size-review-ceremony.md)

## Testing

- `bash .claude/hooks/tests/test_detect_role_trigger.sh` — 51 passed, 0 failed
- `bash .claude/rules/tests/test_proportionate_work.sh` — 35 passed, 0 failed
- `bash -n .claude/hooks/detect-role-trigger.sh` — passed
- `shellcheck .claude/hooks/detect-role-trigger.sh` — passed with no new findings
- `git diff --check` — passed

## Glossary

| Term | Meaning |
|------|---------|
| Heavy | Full review chain for high-risk or trust-chain changes. |
| Standard | Normal Rex review without the additional Heavy role chain. |
| Trust chain | Production hooks, settings, marker libraries, and governance controls. |
| Applicable handbook | A handbook whose path or topic matches the changed work. |
| Enforcement semantics | Behavior that changes whether a governance gate blocks or allows an action. |

Refs #1171
