### PR TITLE
fix(#1161): make the merge gate satisfiable through the sanctioned path

### DIFF
--- a/.claude/hooks/auto-code-review.sh
+++ b/.claude/hooks/auto-code-review.sh
@@ -137,6 +137,17 @@ build sub-agent just handed this PR back to you):
   author grading their own work. (The marker also suppresses an advisory
   warning on Rex's own marker write, but that is a side effect, not the
   reason — the hook warns and never blocks since #1026.)
+
+  ONE EXCEPTION, and only for you (me2resh/apexyard#1161). After the review
+  returns, confirm the approval marker exists. If the review ran "in the
+  background" and posted nothing to the PR, the harness ran its OWN bundled
+  /code-review instead of ApexYard's skill. That bundled skill knows nothing
+  about these markers, so re-running it cannot help. Only in that case: set
+  the active-reviewer marker yourself, then spawn the code-reviewer agent
+  (Rex) directly with the Agent tool. A CHANGES REQUESTED verdict is NOT this
+  case — a real review that requests changes writes no approval marker by
+  design, and the fix is to address the findings. Never write the approval
+  marker yourself in either case.
 --------------------------------------------------------------------------
 
 CEREMONY TIER (.claude/rules/right-size-ceremony.md, AgDR-0116): Rex runs on
@@ -153,13 +164,6 @@ marker exists. Do NOT quote a marker path when you invoke the review — the
 reviewer resolves its own repo-qualified path (me2resh/apexyard#1144); a path
 handed to it in a prompt overrides that and lands the marker where no gate
 reads it.
-
-After the review returns, confirm the marker exists. If the review ran "in the
-background" and returned findings but wrote no marker, the harness ran its own
-bundled /code-review instead of ApexYard's skill (me2resh/apexyard#1161). The
-bundled skill knows nothing about these markers, so re-running it cannot help.
-Set the active-reviewer marker, then spawn the code-reviewer agent (Rex)
-directly with the Agent tool. Do not write the approval marker yourself.
 
 This message is a reminder from the PostToolUse hook, not a tool error. The PR
 was created successfully.

--- a/.claude/hooks/auto-code-review.sh
+++ b/.claude/hooks/auto-code-review.sh
@@ -154,6 +154,13 @@ reviewer resolves its own repo-qualified path (me2resh/apexyard#1144); a path
 handed to it in a prompt overrides that and lands the marker where no gate
 reads it.
 
+After the review returns, confirm the marker exists. If the review ran "in the
+background" and returned findings but wrote no marker, the harness ran its own
+bundled /code-review instead of ApexYard's skill (me2resh/apexyard#1161). The
+bundled skill knows nothing about these markers, so re-running it cannot help.
+Set the active-reviewer marker, then spawn the code-reviewer agent (Rex)
+directly with the Agent tool. Do not write the approval marker yourself.
+
 This message is a reminder from the PostToolUse hook, not a tool error. The PR
 was created successfully.
 MSG

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -276,6 +276,16 @@ To unblock:
      /approve-merge ${PR_NUMBER} — that skill is human-only, you cannot
   4. Their invocation records the approval and performs the merge
 
+If you already ran /code-review for this PR and got a full review back, the
+harness may have run its OWN bundled /code-review instead of ApexYard's skill.
+The bundled skill runs as a background agent. It reports findings and writes no
+marker, so this gate can never pass from it. Two signs identify it: the run
+reports "Running in the background", and the review never posts to the PR.
+If you see those signs, do not re-run /code-review. Set the active-reviewer
+marker, then spawn the code-reviewer agent (Rex) directly with the Agent tool.
+Do not write the approval marker yourself. See .claude/rules/pr-workflow.md
+section "When the harness bundled skill shadows /code-review".
+
 Never skip this check — even for typo fixes. See .claude/rules/pr-workflow.md.
 MSG
   # Name the gate-invisible near-miss, if one is sitting on disk under the

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -281,10 +281,13 @@ harness may have run its OWN bundled /code-review instead of ApexYard's skill.
 The bundled skill runs as a background agent. It reports findings and writes no
 marker, so this gate can never pass from it. Two signs identify it: the run
 reports "Running in the background", and the review never posts to the PR.
-If you see those signs, do not re-run /code-review. Set the active-reviewer
-marker, then spawn the code-reviewer agent (Rex) directly with the Agent tool.
-Do not write the approval marker yourself. See .claude/rules/pr-workflow.md
-section "When the harness bundled skill shadows /code-review".
+A CHANGES REQUESTED verdict is NOT this case. A real review that requests
+changes writes no approval marker by design. Address its findings instead.
+If you see both signs above, do not re-run /code-review. Set the
+active-reviewer marker, then spawn the code-reviewer agent (Rex) directly with
+the Agent tool. Do not write the approval marker yourself. See
+.claude/rules/pr-workflow.md section "When the harness bundled skill shadows
+/code-review".
 
 Never skip this check — even for typo fixes. See .claude/rules/pr-workflow.md.
 MSG

--- a/.claude/hooks/tests/test_validate_branch_name_handover.sh
+++ b/.claude/hooks/tests/test_validate_branch_name_handover.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Tests for validate-branch-name.sh's /handover branch exemption
+# (me2resh/apexyard#1161, AgDR-0129).
+#
+# /handover steps 8.5 and 8.6 push two hardcoded branches INTO AN ADOPTED REPO:
+#
+#   docs/agents-md        — the generated AGENTS.md operating manual
+#   docs/apexyard-badge   — the "Governed by ApexYard" README badge
+#
+# Neither carries a ticket-ID, and neither can: /handover is bootstrap-class and
+# runs before the adopted repo has any ticket to name — that repo may have no
+# tracker at all. Before #1161 the gate rejected both (exit 2), so the skill's
+# own prescribed branch could not satisfy the fork's own gate.
+#
+# The exemption is an EXACT LITERAL match on the two names. These tests pin both
+# directions, and the negative direction is the load-bearing half: a
+# near-miss like `docs/agents-md-v2` must still be BLOCKED. If someone later
+# loosens the anchored regex to a prefix or a `docs/*` glob, the "near-miss"
+# cases below fail — which is the point.
+#
+# Exit 0 if all cases pass; 1 on first failure.
+
+set -u
+
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$SRC_ROOT/.claude/hooks/validate-branch-name.sh"
+LIB_SRC="$SRC_ROOT/.claude/hooks/_lib-extract-push-ref.sh"
+LIB_STRIP_HEREDOC_SRC="$SRC_ROOT/.claude/hooks/_lib-strip-heredoc.sh"
+LIB_CONFIG_SRC="$SRC_ROOT/.claude/hooks/_lib-read-config.sh"
+LIB_PR_REPO_SRC="$SRC_ROOT/.claude/hooks/_lib-pr-repo.sh"
+
+for f in "$HOOK_SRC" "$LIB_SRC"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL: required source missing: $f" >&2
+    exit 1
+  fi
+done
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# Sandbox whose LOCAL branch intentionally fails validation, so a case that
+# passes proves the hook read the push-ref from the command, not local HEAD.
+make_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    : > onboarding.yaml
+    git add onboarding.yaml
+    git commit -q -m "init"
+    git checkout -q -B "not-conforming-branch-name"
+  )
+  mkdir -p "$sb/.claude/hooks"
+  cp "$HOOK_SRC" "$sb/.claude/hooks/validate-branch-name.sh"
+  cp "$LIB_SRC"  "$sb/.claude/hooks/_lib-extract-push-ref.sh"
+  [ -f "$LIB_STRIP_HEREDOC_SRC" ] && cp "$LIB_STRIP_HEREDOC_SRC" "$sb/.claude/hooks/_lib-strip-heredoc.sh"
+  [ -f "$LIB_CONFIG_SRC" ] && cp "$LIB_CONFIG_SRC" "$sb/.claude/hooks/_lib-read-config.sh"
+  [ -f "$LIB_PR_REPO_SRC" ] && cp "$LIB_PR_REPO_SRC" "$sb/.claude/hooks/_lib-pr-repo.sh"
+  [ -f "$SRC_ROOT/.claude/project-config.defaults.json" ] && \
+    cp "$SRC_ROOT/.claude/project-config.defaults.json" "$sb/.claude/project-config.defaults.json"
+  chmod +x "$sb/.claude/hooks/validate-branch-name.sh"
+  echo "$sb"
+}
+
+run_case() {
+  local label="$1" cmd="$2" want_rc="$3"
+  local sb; sb=$(make_sandbox)
+  local input got_rc got_stderr
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  got_stderr=$(cd "$sb" && echo "$input" | bash .claude/hooks/validate-branch-name.sh 2>&1 >/dev/null)
+  got_rc=$?
+  rm -rf "$sb"
+
+  if [ "$got_rc" != "$want_rc" ]; then
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc" >&2
+    echo "    cmd: $cmd" >&2
+    echo "    stderr: ${got_stderr:0:300}" >&2
+    FAIL=$((FAIL+1)); FAILED_CASES="${FAILED_CASES}${label} "
+    return
+  fi
+  echo "PASS [$label]"
+  PASS=$((PASS+1))
+}
+
+# -- Exempt: the two names /handover actually prescribes --------------------
+
+run_case "8.5 branch docs/agents-md is exempt" \
+  "git push -u origin docs/agents-md" 0
+
+run_case "8.6 branch docs/apexyard-badge is exempt" \
+  "git push -u origin docs/apexyard-badge" 0
+
+run_case "exempt branch still exempt without -u" \
+  "git push origin docs/agents-md" 0
+
+run_case "exempt branch still exempt with --force-with-lease" \
+  "git push --force-with-lease origin docs/apexyard-badge" 0
+
+# -- NOT exempt: near-misses must still require a ticket-ID -----------------
+#
+# This is the half that keeps the exemption narrow. Each of these differs from
+# an exempt name by a suffix, a prefix, or a path segment.
+
+run_case "near-miss docs/agents-md-v2 is BLOCKED" \
+  "git push -u origin docs/agents-md-v2" 2
+
+run_case "near-miss docs/agents-md/foo is BLOCKED" \
+  "git push -u origin docs/agents-md/foo" 2
+
+run_case "near-miss docs/agents is BLOCKED" \
+  "git push -u origin docs/agents" 2
+
+run_case "near-miss feature/agents-md is BLOCKED" \
+  "git push -u origin feature/agents-md" 2
+
+run_case "near-miss docs/apexyard-badge-2 is BLOCKED" \
+  "git push -u origin docs/apexyard-badge-2" 2
+
+run_case "unrelated ticketless docs branch still BLOCKED" \
+  "git push -u origin docs/update-readme" 2
+
+# -- Regression: the pre-existing exemptions and the normal path -----------
+
+run_case "release branch still exempt" \
+  "git push -u origin release/v5.4.0" 0
+
+run_case "sync branch still exempt" \
+  "git push -u origin sync/main-to-dev-after-v5.4.0" 0
+
+run_case "conforming ticket branch still passes" \
+  "git push -u origin fix/GH-1161-code-review-fork-marker" 0
+
+# -- Summary ---------------------------------------------------------------
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  echo "failed cases: $FAILED_CASES" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -254,6 +254,23 @@ if echo "$CURRENT_BRANCH" | grep -qE '^sync/main-to-dev-after-v[0-9]+\.[0-9]+\.[
   exit 0
 fi
 
+# Allow the two branches /handover prescribes for its opt-in writes INTO AN
+# ADOPTED REPO (me2resh/apexyard#1161). Steps 8.5 and 8.6 push `docs/agents-md`
+# (the generated AGENTS.md) and `docs/apexyard-badge` (the README badge) into
+# the target repo. Both are hardcoded in the skill, so the skill's own
+# prescribed branch could never satisfy this gate: /handover is bootstrap-class
+# and runs before the adopted repo has any tracker ticket to name, and the
+# adopted repo may have no tracker at all. Same narrow, intentional exception
+# as the release and sync branches above — the work itself is the ticket.
+#
+# The match is an exact literal on each of the two names, so this exempts
+# nothing else: a `docs/agents-md-v2` or any other `docs/*` branch still needs
+# a ticket-id. These branches also live in the ADOPTED repo, not the ops fork,
+# and land as a PR the repo owner reviews. See AgDR-0129.
+if echo "$CURRENT_BRANCH" | grep -qE '^docs/(agents-md|apexyard-badge)$'; then
+  exit 0
+fi
+
 # Load the branch-type whitelist from project config.
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 # shellcheck source=./_lib-read-config.sh

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -206,12 +206,27 @@ and "Build agents cannot self-review" above exist to prevent.
 **Two signs identify it.** The run reports "Running in the background", and no
 review appears on the PR.
 
-**The recovery.** Do not re-run `/code-review`; it will do the same thing. Do
-not write the approval marker by hand; that is marker forging regardless of how
-good the review was. Instead, set the active-reviewer marker, then spawn the
-`code-reviewer` agent (Rex) **directly with the Agent tool**. Rex resolves its
-own repo-qualified marker path and writes the marker on an APPROVED verdict, so
-the sanctioned path is restored without touching a gate signal by hand.
+**A CHANGES REQUESTED verdict is not this case.** A real review that requests
+changes also returns findings and writes no approval marker — by design. Both
+signs above must hold. If a genuine review posted to the PR and asked for
+changes, address the findings; the missing marker is the gate working, not
+failing.
+
+**The recovery, and only the orchestrator performs it.** Do not re-run
+`/code-review`; it will do the same thing. Do not write the approval marker by
+hand; that is marker forging regardless of how good the review was. Instead,
+set the active-reviewer marker, then spawn the `code-reviewer` agent (Rex)
+**directly with the Agent tool**. Rex resolves its own repo-qualified marker
+path and writes the marker on an APPROVED verdict, so the sanctioned path is
+restored without touching a gate signal by hand.
+
+This is the one sanctioned exception to "use the skill, don't spawn Rex
+directly" and to "don't set the active-reviewer marker by hand". It applies
+only when the skill cannot run at all. A **build-class sub-agent is not the
+audience for it** — it cannot nest the Agent tool, so it must hand the PR back
+to the orchestrator, exactly as it would normally. Note that the active-reviewer
+marker is a provenance signal at `.claude/session/active-reviewer`; it is not an
+approval marker, and setting it grants no gate-passing power.
 
 Adopters who hit this every session can settle the name collision permanently
 with the `skillOverrides` setting, or by turning bundled skills off

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -186,6 +186,37 @@ Both markers' SHAs must match the PR's HEAD as reported by GitHub (`gh pr view <
 
 Claude can technically `rm` or `touch` these files by hand, or fabricate the structured fields. Doing so is a visible, auditable, grep-able rule violation — and the whole point of recording the rule mechanically is so that the failure mode is "Claude ignored a hook" (visible) instead of "Claude inferred approval from something vague" (invisible). The structured-marker format raises the visibility bar one more notch by requiring the model to type `approved_by=user` etc. on purpose.
 
+### When the harness bundled skill shadows /code-review (me2resh/apexyard#1161)
+
+Claude Code ships its **own** bundled `/code-review`. It is a different thing
+from ApexYard's skill of the same name: it runs as a **background subagent**,
+reports findings through the harness, posts nothing to the PR, and knows nothing
+about approval markers. A project skill normally wins the name, but when the
+bundled one runs instead, every gate-bookkeeping step in ApexYard's SKILL.md is
+skipped — because that file is never loaded.
+
+The result is a session that cannot satisfy its own merge gate. The review
+content is genuine and often excellent, so nothing looks wrong until
+`gh pr merge` is refused. That refusal then tells the orchestrator to run
+`/code-review`, which runs the bundled skill again, which writes no marker
+again. Left there, the only ways forward are merging outside the gate or forging
+the marker — the exact pressure [#1144](#never-put-a-marker-path-in-a-reviewers-spawn-prompt-me2reshapexyard1144)
+and "Build agents cannot self-review" above exist to prevent.
+
+**Two signs identify it.** The run reports "Running in the background", and no
+review appears on the PR.
+
+**The recovery.** Do not re-run `/code-review`; it will do the same thing. Do
+not write the approval marker by hand; that is marker forging regardless of how
+good the review was. Instead, set the active-reviewer marker, then spawn the
+`code-reviewer` agent (Rex) **directly with the Agent tool**. Rex resolves its
+own repo-qualified marker path and writes the marker on an APPROVED verdict, so
+the sanctioned path is restored without touching a gate signal by hand.
+
+Adopters who hit this every session can settle the name collision permanently
+with the `skillOverrides` setting, or by turning bundled skills off
+(`disableBundledSkills`). Neither is required — the recovery above works as-is.
+
 ### The approval skills are human-only (#1042, AgDR-0110)
 
 "Explicit per-PR approval" is now enforced **mechanically**, not only in prose. `/approve-merge`, `/approve-design`, and `/approve-architecture` carry `disable-model-invocation: true`, so **only a human can invoke them**. Saying "approved" in conversation is no longer sufficient on its own — the operator types the command, and that invocation *is* the approval moment this rule has always described.

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -1461,6 +1461,7 @@ BODY
 
 Notes:
 
+- **Keep the branch name `docs/agents-md` exactly.** `validate-branch-name.sh` carries an exact-literal exemption for it (and for step 8.6's `docs/apexyard-badge`), because `/handover` runs before the adopted repo has a ticket to name — and that repo may have no tracker at all. Renaming it to anything else, `docs/agents-md-v2` included, re-arms the ticket-ID gate and blocks the push. See me2resh/apexyard#1161 and AgDR-0129.
 - **Specific-file staging only** — `git add AGENTS.md` (and `CLAUDE.md` only when newly created). Never `git add -A` / `git add .`.
 - **Branch + PR, never a direct commit to the default branch.** The repo owner reviews before merge — `/handover` does not merge the PR.
 - This PR lives in the **target repo's** tracker/SDLC, not the ops fork's. The ops-fork merge gates (Rex/CEO markers) don't apply — this is the target repo's own review.
@@ -1587,6 +1588,7 @@ BODY
 
 Notes:
 
+- **Keep the branch name `docs/apexyard-badge` exactly** — same exact-literal exemption in `validate-branch-name.sh` as step 8.5's `docs/agents-md`. A renamed branch re-arms the ticket-ID gate and blocks the push. See me2resh/apexyard#1161 and AgDR-0129.
 - **Specific-file staging only** — `git add "$README_FILE"`. Never `git add -A` / `git add .`.
 - **Branch + PR, never a direct commit to the default branch.** The repo owner reviews before merge — `/handover` does not merge the PR.
 - This PR lives in the **target repo's** tracker/SDLC, not the ops fork's. The ops-fork merge gates (Rex/CEO markers) don't apply.

--- a/docs/agdr/AgDR-0129-handover-branch-exemption-and-shadowed-skill-recovery.md
+++ b/docs/agdr/AgDR-0129-handover-branch-exemption-and-shadowed-skill-recovery.md
@@ -1,0 +1,54 @@
+# Exempt /handover's two prescribed branches, and name the shadowed-skill recovery in the gates
+
+> In the context of me2resh/apexyard#1161, facing a reported session where `/code-review` returned a full review but never wrote its approval marker, I decided to add an exact-literal branch exemption for `/handover`'s two prescribed branches and to name the bundled-skill shadowing failure mode in the two banners the orchestrator already reads, to achieve a merge gate that stays satisfiable through a sanctioned path, accepting that the shadowing itself is a harness-side name collision this framework cannot detect mechanically.
+
+## Context
+
+Issue #1161 reported three defects. Validation separated them, because they have different causes and only two are still live.
+
+**The reported primary defect is real, and its cause is outside this repository.** ApexYard's `.claude/skills/code-review/SKILL.md` carries no `context: fork`, so it cannot run as a background subagent. Claude Code ships its own bundled `/code-review`, which has run as a background subagent since harness v2.1.218 and gained the `/review` alias in v2.1.223. The reporter's whole symptom set — a background run, findings returned through the harness rather than posted to the pull request, `ReportFindings` present in the agent's expectations, no marker, no active-reviewer marker — matches the bundled skill and cannot be produced by ApexYard's. A project skill normally overrides a bundled skill of the same name, and it does so in this fork on harness 2.1.260. It did not in the reporter's session.
+
+The consequence is what makes this an ApexYard concern rather than someone else's bug. When the bundled skill wins the name, `block-unreviewed-merge.sh` refuses the merge and instructs the orchestrator to run `/code-review` — which runs the bundled skill again, and writes no marker again. The framework prescribes a remedy that silently cannot work, and leaves the orchestrator holding a genuine APPROVED verdict with no legitimate way to record it. The two ways out of that position are merging outside the gate and forging the marker. Both are behaviours the framework spends considerable machinery preventing, so it must not manufacture the pressure toward them.
+
+**The reported handover defect is real and live.** `/handover` steps 8.5 and 8.6 hardcode `docs/agents-md` and `docs/apexyard-badge`. Both are rejected by `validate-branch-name.sh` (exit 2) on the current `dev`. The skill's own prescribed branch cannot satisfy the fork's own gate.
+
+**The reported hook false-positive is real but already fixed.** On v5.1.0 the hook blocked two of three realistic tracker-create shapes that merely described a marker path in prose. On `dev` all three exit 0 silently. #1000 and #1026 fixed it in v5.3.0; #1026 made the hook advisory per AgDR-0111.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Detect the shadowed skill mechanically | Would catch it without operator judgment | Not possible. A `PreToolUse` hook sees tool calls, not which skill the harness resolved a name to; the `Agent` spawn boundary has no matcher (AgDR-0056) |
+| Rename ApexYard's skill to avoid the collision | Removes the collision outright | Breaks every banner, rule, and doc that names `/code-review`, and breaks operator muscle memory, to work around a harness-version-specific resolution bug |
+| Tell adopters to set `disableBundledSkills` | Settles the collision permanently | A global setting disabling every bundled skill, imposed on all adopters, to fix a failure most never hit |
+| **Name the failure and the recovery in the two banners the orchestrator already reads** | Reaches the reader at the exact moment they are stuck, costs nothing when the bug is absent, needs no new surface | Advisory. It informs a decision; it cannot force one |
+| Relax the merge gate when no marker can be obtained | Unblocks the session | Rejected outright. A gate that yields to "I could not get a marker" is not a gate |
+| **Exact-literal branch exemption for the two `/handover` names** | Mirrors the existing `release/` and `sync/` precedent; anchored regex exempts nothing else | Slightly widens a gate-relaxing surface |
+| Give `/handover` a ticket-carrying branch name | No hook change | There is no ticket to name. `/handover` is bootstrap-class, runs before the adopted repo has tickets, and the adopted repo may have no tracker |
+
+## Decision
+
+Chosen: **the exact-literal branch exemption plus the banner-level recovery**, because each addresses its defect at the smallest surface that can carry it.
+
+The branch exemption follows a precedent this repository already set twice. `release/vN.N.N` and `sync/main-to-dev-after-vN.N.N` are exempt for the same stated reason: a framework-prescribed, canonical, ticketless branch where the work itself is the ticket. `/handover`'s two branches share that shape and add a stronger argument — they are pushed into an **adopted** repository that ApexYard does not govern the SDLC of, and they land as a pull request its owner reviews. The regex is anchored on both ends against the two names, so `docs/agents-md-v2` and every other `docs/*` branch still require a ticket ID.
+
+The shadowed-skill recovery is deliberately advisory, because no sound mechanical detection exists. It states two identifying signs, and it states the recovery: set the active-reviewer marker, then spawn Rex directly with the Agent tool. That path restores the sanctioned review without anyone touching a gate signal by hand. Both banners say plainly not to write the marker, because a good review does not make a hand-written marker legitimate.
+
+The already-fixed hook false-positive gets no code change. It is reported back to the issue with the fixing version.
+
+## Consequences
+
+- `/handover` steps 8.5 and 8.6 can complete. Both skill steps now carry a note that the branch name is load-bearing, so a later reader does not "tidy" it and silently re-arm the gate.
+- An orchestrator stuck behind a marker-less review is told what happened and what to do, at the moment the merge is refused and again when the pull request is created.
+- The exemption widens the branch gate by exactly two names. It cannot be extended by accident: matching more names requires editing the anchored regex.
+- The shadowing itself remains undetected. An operator who ignores both banners is in the same position as before, minus the false impression that re-running `/code-review` will help.
+- Adopters who hit the collision every session have two settled options named in the rule, neither of them required.
+
+## Artifacts
+
+- me2resh/apexyard#1161
+- `.claude/hooks/validate-branch-name.sh`, `.claude/hooks/block-unreviewed-merge.sh`, `.claude/hooks/auto-code-review.sh`
+- `.claude/rules/pr-workflow.md` section "When the harness bundled skill shadows /code-review"
+- `.claude/skills/handover/SKILL.md` steps 8.5 and 8.6
+- `.claude/hooks/tests/test_validate_branch_name_handover.sh`
+- Prior art: AgDR-0007 (release branches), AgDR-0052 (sync branches), AgDR-0111 (marker gate advisory), AgDR-0056 (no spawn-boundary matcher)


### PR DESCRIPTION
Two of the three defects reported in #1161 are real and live on `dev`; the third was real at v5.1.0 and is already fixed. This PR fixes the two live ones and leaves the merge gate strictly as strong as it was.

## Summary

- **`/handover`'s own branches could not pass the fork's own branch gate.** Steps 8.5 and 8.6 hardcode `docs/agents-md` and `docs/apexyard-badge`, and `validate-branch-name.sh` rejected both with exit 2. Neither can carry a ticket-ID: `/handover` is bootstrap-class and runs before the adopted repo has a ticket to name, and that repo may have no tracker at all. Now exempt by **exact literal**, mirroring the `release/vN.N.N` and `sync/main-to-dev-after-vN.N.N` precedents this repo already set for the same reason. `docs/agents-md-v2` and every other `docs/*` branch still require a ticket.
- **A shadowed `/code-review` left the merge gate unsatisfiable, and the gate's own advice made it worse.** When Claude Code's *bundled* `/code-review` wins the name over ApexYard's skill, it runs as a background agent, posts nothing to the PR, and writes no marker. `block-unreviewed-merge.sh` then refuses the merge and tells the orchestrator to run `/code-review` — which runs the bundled skill again, writing no marker again. Both `block-unreviewed-merge.sh` and `auto-code-review.sh` now name the two identifying signs and give the recovery: set the active-reviewer marker, then spawn Rex directly with the Agent tool. Both say plainly not to hand-write the approval marker.
- **13 regression cases** pin the exemption in both directions. The six near-miss cases are the load-bearing half — they fail if anyone later loosens the anchored regex into a `docs/*` glob.
- **AgDR-0129** records why the mechanical option was rejected: a `PreToolUse` hook sees tool calls, not which skill the harness resolved a name to, and the `Agent` spawn boundary has no matcher (AgDR-0056). The shadowed-skill half is therefore advisory by necessity, not by preference.

## What this deliberately does not do

No gate is relaxed. The merge gate still requires both markers, still compares each against the forge-reported HEAD, and still refuses when either is absent. The branch gate widens by exactly two names, both anchored, both only ever created by `/handover`, both landing as a PR in a repo ApexYard does not govern.

## On the third reported defect (already fixed)

The reporter also found `warn-review-marker-write.sh` blocking a `gh issue create` whose body merely *described* a marker path. Reproduced against v5.1.0: it exits 2 on two of three realistic tracker-create shapes. On current `dev` all three exit 0 silently. Fixed by #1000/#1011 (narrowed to actual write intent) and #1026 (returned to advisory, AgDR-0111), both shipped in **v5.3.0**. No change needed here.

## Testing

```bash
bash .claude/hooks/tests/test_validate_branch_name_handover.sh   # 13/13 pass
```

Full hook suite: 116 pass, 11 fail. All 11 failures reproduce identically with these three hook edits stashed, so they are pre-existing and fork-local (untracked premium skills and split-portfolio state), not regressions from this PR. `bash -n` and `shellcheck -S warning` are clean on all three edited hooks and the new test.

Manual check of the reported repro:

```bash
# before: exit 2, BLOCKED.  after: exit 0
echo '{"tool_input":{"command":"git push -u origin docs/agents-md"}}' \
  | bash .claude/hooks/validate-branch-name.sh
```

Refs #1161

---

## Glossary

| Term | Definition |
|------|------------|
| Approval marker | The per-PR file under `.claude/session/reviews/` that `block-unreviewed-merge.sh` reads as proof an independent code review happened |
| active-reviewer marker | A session file naming the sanctioned review pass in flight, written before spawning the reviewer |
| Bundled skill | A skill Claude Code ships itself, distinct from a project skill of the same name in `.claude/skills/` |
| Shadowing | A name collision where one skill definition wins `/code-review` over another, deciding which body actually runs |
| Bootstrap-class skill | A skill that runs before a portfolio or tracker exists, and is therefore exempt from the ticket-first gate |
| Exact-literal exemption | A fully anchored regex matching one whole name, so it cannot widen to a prefix or glob by accident |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
