### PR TITLE
refactor(#1174): apply writing standard across artefacts

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -58,7 +58,7 @@ Invoked when a PR is ready for review.
 ## Review writing standard
 
 The GitHub review is a durable, human-facing artefact. Read
-`.claude/rules/writing-standard.md` and use **Flavored mode**. Start with the
+`.claude/rules/writing-standard.md`. Use **Flavored mode**. Start with the
 verdict and the author's next action when one exists. State the reason in plain,
 short sentences. Put checklist evidence and forensic detail after the opening.
 Preserve `TBD`, hedges, numbers, and modality. Do not report a process transcript

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -55,6 +55,15 @@ The verdict that drives the merge gate is the **local marker**, NOT the host's "
 
 Invoked when a PR is ready for review.
 
+## Review writing standard
+
+The GitHub review is a durable, human-facing artefact. Read
+`.claude/rules/writing-standard.md` and use **Flavored mode**. Start with the
+verdict and the author's next action when one exists. State the reason in plain,
+short sentences. Put checklist evidence and forensic detail after the opening.
+Preserve `TBD`, hedges, numbers, and modality. Do not report a process transcript
+as the review, and do not label an author self-check as an independent Rex review.
+
 ## Input
 
 - PR number or URL — `{number}` below

--- a/.claude/hooks/tests/test_quality_regression.sh
+++ b/.claude/hooks/tests/test_quality_regression.sh
@@ -21,8 +21,8 @@ assert() {
 
 assert "runner:exists" test -x "$RUNNER"
 check_out=$(bash "$RUNNER" --check-only --cases all 2>&1)
-assert "runner:parses-20" bash -c "echo \"\$1\" | grep -q '^cases parsed: 20 '" _ "$check_out"
-assert "runner:builds-20-prompts" bash -c "echo \"\$1\" | grep -q '^prompts built: 20'" _ "$check_out"
+assert "runner:parses-22" bash -c "echo \"\$1\" | grep -q '^cases parsed: 22 '" _ "$check_out"
+assert "runner:builds-22-prompts" bash -c "echo \"\$1\" | grep -q '^prompts built: 22'" _ "$check_out"
 rep_out=$(bash "$RUNNER" --check-only 2>&1)
 assert "runner:representative-8" bash -c "echo \"\$1\" | grep -q '^cases selected: 8 '" _ "$rep_out"
 assert "runner:unknown-case-rejected" bash -c "! bash '$RUNNER' --check-only --cases ZZ-99 >/dev/null 2>&1"
@@ -32,7 +32,7 @@ assert "runner:portable-timeout" grep -qF 'gtimeout' "$RUNNER"
 assert "runner:uncapped-fallback" grep -qF 'else' "$RUNNER"
 
 # every case id the runner parsed appears in the index
-for id in $(echo "$check_out" | sed -n 's/^cases parsed: 20 (\(.*\))$/\1/p'); do
+for id in $(echo "$check_out" | sed -n 's/^cases parsed: 22 (\(.*\))$/\1/p'); do
   assert "index:$id" grep -qF "| $id |" "$INDEX"
 done
 

--- a/.claude/rules/pr-quality.md
+++ b/.claude/rules/pr-quality.md
@@ -1,5 +1,14 @@
 # PR Quality Requirements
 
+## Technical writing (MANDATORY)
+
+PR descriptions and review comments are durable, human-facing artefacts. Write
+them in **Flavored mode** from [the central writing standard](writing-standard.md):
+lead with the outcome, reason, decision, and next action when they exist; use
+short, plain, precise sentences; preserve uncertainty and modality; and omit
+empty or process-only sections. Keep detailed evidence below the opening rather
+than making the reader reconstruct the result from a narrative log.
+
 ## Glossary (MANDATORY)
 
 Every PR description **must** include a Glossary section:

--- a/.claude/rules/tests/fixtures/human-friendly-cases.md
+++ b/.claude/rules/tests/fixtures/human-friendly-cases.md
@@ -53,12 +53,14 @@ These cases are human-adjudicated inputs for `.claude/rules/writing-standard.md`
 
 ## HF-08 — Durable PR and review artefacts use Flavored mode
 
-- **Task**: Draft a PR description and review comment for a small framework fix.
+- **Given**: A small framework fix needs a PR description and review comment.
+- **Prompt**: `Draft both human-facing artefacts.`
 - **Fail if**: The text opens with process logs, repeats internal workflow steps, or uses long dense paragraphs before stating the result.
 - **Pass if**: Both artefacts lead with the outcome and next action, use short plain sentences, preserve uncertainty, and place supporting evidence after the opening.
 
 ## HF-09 — Durable artefact producers carry the central rule
 
-- **Task**: Add or update a ticket, design, audit, threat model, handover, or roadmap document.
+- **Given**: A ticket, design, audit, threat model, handover, or roadmap document is being created.
+- **Prompt**: `Draft the durable artefact.`
 - **Fail if**: The producer has no explicit reference to the central writing standard and silently falls back to its own prose conventions.
 - **Pass if**: The producer names Flavored mode and keeps required, conditional, placeholder, and modality rules aligned with `writing-standard.md`.

--- a/.claude/rules/tests/fixtures/human-friendly-cases.md
+++ b/.claude/rules/tests/fixtures/human-friendly-cases.md
@@ -50,3 +50,15 @@ These cases are human-adjudicated inputs for `.claude/rules/writing-standard.md`
 - **Prompt**: `Why did you go with a single rule file?`
 - **Fail if**: The reply reads like a numbered procedure with no explanation or voice.
 - **Pass if**: The reply is a plain conversational answer that gives the reason.
+
+## HF-08 — Durable PR and review artefacts use Flavored mode
+
+- **Task**: Draft a PR description and review comment for a small framework fix.
+- **Fail if**: The text opens with process logs, repeats internal workflow steps, or uses long dense paragraphs before stating the result.
+- **Pass if**: Both artefacts lead with the outcome and next action, use short plain sentences, preserve uncertainty, and place supporting evidence after the opening.
+
+## HF-09 — Durable artefact producers carry the central rule
+
+- **Task**: Add or update a ticket, design, audit, threat model, handover, or roadmap document.
+- **Fail if**: The producer has no explicit reference to the central writing standard and silently falls back to its own prose conventions.
+- **Pass if**: The producer names Flavored mode and keeps required, conditional, placeholder, and modality rules aligned with `writing-standard.md`.

--- a/.claude/rules/tests/test_writing_standard.sh
+++ b/.claude/rules/tests/test_writing_standard.sh
@@ -65,7 +65,7 @@ assert "template:readme" grep -qF 'Required core and conditional sections' "$SRC
 for consumer in write-spec feature bug task; do
   assert "consumer:$consumer:writing-rule" grep -qF '.claude/rules/writing-standard.md' "$SRC_ROOT/.claude/skills/$consumer/SKILL.md"
 done
-for consumer in code-review release release-sync; do
+for consumer in code-review release release-sync threat-model investigation handover roadmap plan-initiative idea migration spike prototype walking-skeleton stakeholder-update launch-check update tickets-batch request-apexyard-feature report-apexyard-bug design-review dfd; do
   assert "consumer:$consumer:writing-rule" grep -qF 'writing-standard.md' "$SRC_ROOT/.claude/skills/$consumer/SKILL.md"
 done
 assert "consumer:code-reviewer:writing-rule" grep -qF 'writing-standard.md' "$SRC_ROOT/.claude/agents/code-reviewer.md"

--- a/.claude/rules/tests/test_writing_standard.sh
+++ b/.claude/rules/tests/test_writing_standard.sh
@@ -65,10 +65,15 @@ assert "template:readme" grep -qF 'Required core and conditional sections' "$SRC
 for consumer in write-spec feature bug task; do
   assert "consumer:$consumer:writing-rule" grep -qF '.claude/rules/writing-standard.md' "$SRC_ROOT/.claude/skills/$consumer/SKILL.md"
 done
+for consumer in code-review release release-sync; do
+  assert "consumer:$consumer:writing-rule" grep -qF 'writing-standard.md' "$SRC_ROOT/.claude/skills/$consumer/SKILL.md"
+done
+assert "consumer:code-reviewer:writing-rule" grep -qF 'writing-standard.md' "$SRC_ROOT/.claude/agents/code-reviewer.md"
+assert "pr-quality:writing-rule" grep -qF 'Flavored mode' "$SRC_ROOT/.claude/rules/pr-quality.md"
 assert "consumer:tech-lead:writing-rule" grep -qF 'writing-standard guidance' "$SRC_ROOT/roles/engineering/tech-lead.md"
 
 assert "cases:file-exists" test -f "$CASES_FILE"
-assert "cases:seven-cases" bash -c "[ \"\$(grep -cE '^## HF-[0-9]{2} ' '$CASES_FILE')\" -eq 7 ]"
+assert "cases:nine-cases" bash -c "[ \"\$(grep -cE '^## HF-[0-9]{2} ' '$CASES_FILE')\" -eq 9 ]"
 assert "cases:opening" grep -qF 'Opening states the outcome and next action' "$CASES_FILE"
 assert "cases:empty-section" grep -qF 'Empty conditional section is deleted' "$CASES_FILE"
 assert "cases:placeholder" grep -qF 'No placeholder survives' "$CASES_FILE"
@@ -76,6 +81,8 @@ assert "cases:strict-block" grep -qF 'Strict mode block message' "$CASES_FILE"
 assert "cases:strict-brief" grep -qF 'Strict mode spawn brief' "$CASES_FILE"
 assert "cases:flavored" grep -qF 'Flavored mode keeps uncertainty and precision' "$CASES_FILE"
 assert "cases:conversation" grep -qF 'Conversation is not forced into Strict mode' "$CASES_FILE"
+assert "cases:pr-review" grep -qF 'Durable PR and review artefacts use Flavored mode' "$CASES_FILE"
+assert "cases:producer-wiring" grep -qF 'Durable artefact producers carry the central rule' "$CASES_FILE"
 
 assert "agdr:file-exists" test -f "$AGDR_FILE"
 assert "agdr:no-yaml-frontmatter" bash -c "head -n1 '$AGDR_FILE' | grep -qE '^# '"

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -36,8 +36,8 @@ See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the ful
 
 ## Process
 
-Before drafting or posting the review, read `.claude/rules/writing-standard.md`
-and apply **Flavored mode**. The review is a durable, human-facing artefact:
+Before drafting or posting the review, read `.claude/rules/writing-standard.md`.
+Apply **Flavored mode**. The review is a durable, human-facing artefact:
 open with the verdict and next action, then give the reason and supporting
 evidence. Do not turn the review into a process transcript.
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -36,6 +36,11 @@ See [`.claude/rules/role-triggers.md`](../../rules/role-triggers.md) for the ful
 
 ## Process
 
+Before drafting or posting the review, read `.claude/rules/writing-standard.md`
+and apply **Flavored mode**. The review is a durable, human-facing artefact:
+open with the verdict and next action, then give the reason and supporting
+evidence. Do not turn the review into a process transcript.
+
 ### 0. Write the active-reviewer marker (REQUIRED — me2resh/apexyard#843)
 
 Before spawning the Code Reviewer agent (Rex), write the active-reviewer session marker. It records that this review pass is the sanctioned one, and suppresses `warn-review-marker-write.sh`'s advisory warning on Rex's `*-rex.approved` write (that hook warns and never blocks since #1026 — AgDR-0111). At skill entry:

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # /design-review — Solution Architecture Review
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the
 architecture review. Lead with the verdict and next action, then provide evidence.
 
 Review a **design artifact** — a technical design doc, a migration AgDR, or a feature spec / PRD — for architectural soundness before any code is built against it. This is the non-code analog of `/code-review`: where Rex reviews a code PR, **Tariq (the Solution Architect)** reviews the design.

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -8,6 +8,9 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # /design-review — Solution Architecture Review
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+architecture review. Lead with the verdict and next action, then provide evidence.
+
 Review a **design artifact** — a technical design doc, a migration AgDR, or a feature spec / PRD — for architectural soundness before any code is built against it. This is the non-code analog of `/code-review`: where Rex reviews a code PR, **Tariq (the Solution Architect)** reviews the design.
 
 The Tech Lead *authors* the design; Tariq *reviews* it. Authoring and reviewing are deliberately separate — an author reviewing their own design is the gap this role closes.

--- a/.claude/skills/dfd/SKILL.md
+++ b/.claude/skills/dfd/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Grep, Glob, Write
 
 # /dfd — Data Flow Diagram Extractor
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the DFD
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the DFD
 and accompanying explanation. Keep classifications and uncertainty explicit.
 
 Reads a codebase (or a portfolio of codebases for system-wide DFDs) and produces a Data Flow Diagram showing external actors, processes, data stores, data flows, trust boundaries, and per-element data classifications. The DFD is the **input to STRIDE threat modelling** and to GDPR cross-border / DPA-coverage analysis.

--- a/.claude/skills/dfd/SKILL.md
+++ b/.claude/skills/dfd/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Grep, Glob, Write
 
 # /dfd — Data Flow Diagram Extractor
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the DFD
+and accompanying explanation. Keep classifications and uncertainty explicit.
+
 Reads a codebase (or a portfolio of codebases for system-wide DFDs) and produces a Data Flow Diagram showing external actors, processes, data stores, data flows, trust boundaries, and per-element data classifications. The DFD is the **input to STRIDE threat modelling** and to GDPR cross-border / DPA-coverage analysis.
 
 This skill is the **canonical DFD producer** in the apexyard family. `/threat-model` and `/compliance-check` consume the DFD it writes instead of regenerating their own — see AgDR-0026 for the design rationale.

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -7,6 +7,10 @@ allowed-tools: Bash, Read, Grep, Glob, Write
 
 # /handover — External Repo Handover Assessment
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+handover assessment: write for the receiving human, lead with the outcome, and
+omit empty sections.
+
 Adopt an external repo into ApexYard management. The skill reads the target repo, synthesises a structured handover document, and tells you which ApexYard roles, workflows, and hooks should kick in.
 
 This is the bridge between "we just inherited this codebase" and "this codebase is now governed by our normal SDLC".

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Grep, Glob, Write
 
 # /handover — External Repo Handover Assessment
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the
 handover assessment: write for the receiving human, lead with the outcome, and
 omit empty sections.
 

--- a/.claude/skills/idea/SKILL.md
+++ b/.claude/skills/idea/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Edit, Write
 
 # /idea — Submit a New Product Idea
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the idea
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the idea
 record: state the opportunity plainly and preserve uncertainty.
 
 Capture a new product, feature, or internal-tool idea so it lands somewhere durable instead of evaporating in chat. This skill is intentionally lightweight: it adds an entry to the ideas backlog and (optionally) creates a tracking GitHub Issue. It does **not** replace `/write-spec` — that comes later, after the idea has been triaged.

--- a/.claude/skills/idea/SKILL.md
+++ b/.claude/skills/idea/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Edit, Write
 
 # /idea — Submit a New Product Idea
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the idea
+record: state the opportunity plainly and preserve uncertainty.
+
 Capture a new product, feature, or internal-tool idea so it lands somewhere durable instead of evaporating in chat. This skill is intentionally lightweight: it adds an entry to the ideas backlog and (optionally) creates a tracking GitHub Issue. It does **not** replace `/write-spec` — that comes later, after the idea has been triaged.
 
 ## Path resolution

--- a/.claude/skills/investigation/SKILL.md
+++ b/.claude/skills/investigation/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Write
 
 # /investigation — Create an Investigation Ticket + Live-Doc
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the
 ticket and live document: state the outcome and next action first, then evidence.
 
 Creates a structured GitHub Issue + a sibling live-doc markdown file for an **investigation** — sustained root-cause work whose deliverable is a *written artefact* of what was observed, what we concluded, and what's next. Distinct from `/spike` (forward-looking hypothesis with a budget) and `/bug` (immediate-fix) — see the comparison block at the top of `templates/tickets/investigation.md`.

--- a/.claude/skills/investigation/SKILL.md
+++ b/.claude/skills/investigation/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Write
 
 # /investigation — Create an Investigation Ticket + Live-Doc
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+ticket and live document: state the outcome and next action first, then evidence.
+
 Creates a structured GitHub Issue + a sibling live-doc markdown file for an **investigation** — sustained root-cause work whose deliverable is a *written artefact* of what was observed, what we concluded, and what's next. Distinct from `/spike` (forward-looking hypothesis with a budget) and `/bug` (immediate-fix) — see the comparison block at the top of `templates/tickets/investigation.md`.
 
 > **When to use an investigation vs a bug vs a spike.** A `/bug` is filed when you already know what's broken and need to coordinate the fix. A `/spike` is filed when you want to test a forward-looking hypothesis ("will this approach work?") inside a time budget. An `/investigation` is filed when the *question itself* is the unknown — "why did this happen?", "what's actually going on with the metric drift?", "how does competitor X handle this?". The investigation produces a written record; the bug fix that may follow is a downstream artefact.

--- a/.claude/skills/launch-check/SKILL.md
+++ b/.claude/skills/launch-check/SKILL.md
@@ -8,6 +8,9 @@ effort: high
 
 # /launch-check — Production Readiness Audit
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the audit
+report. Lead with the verdict and next action; keep findings below it.
+
 Runs a 10-dimension sweep against a project and outputs a one-page verdict. Designed for milestone boundaries — epic completion, release cuts, launch prep — not per-PR use.
 
 **Invoke from** the project's workspace directory (`cd workspace/<project>/`) or pass the path as an argument: `/launch-check workspace/my-app`.

--- a/.claude/skills/launch-check/SKILL.md
+++ b/.claude/skills/launch-check/SKILL.md
@@ -8,7 +8,7 @@ effort: high
 
 # /launch-check — Production Readiness Audit
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the audit
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the audit
 report. Lead with the verdict and next action; keep findings below it.
 
 Runs a 10-dimension sweep against a project and outputs a one-page verdict. Designed for milestone boundaries — epic completion, release cuts, launch prep — not per-PR use.

--- a/.claude/skills/migration/SKILL.md
+++ b/.claude/skills/migration/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Write
 
 # /migration — Create a Migration Ticket + AgDR
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+migration ticket and AgDR. Lead with the outcome and keep required detail precise.
+
 Migrations are high-blast-radius: data loss, downtime, lock contention, cross-service coordination. ApexYard treats them as a distinct class of change from code — a migration PR needs:
 
 1. A tracker issue with the `migration` label (plus priority) that captures the plan.

--- a/.claude/skills/migration/SKILL.md
+++ b/.claude/skills/migration/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Write
 
 # /migration — Create a Migration Ticket + AgDR
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the
 migration ticket and AgDR. Lead with the outcome and keep required detail precise.
 
 Migrations are high-blast-radius: data loss, downtime, lock contention, cross-service coordination. ApexYard treats them as a distinct class of change from code — a migration PR needs:

--- a/.claude/skills/plan-initiative/SKILL.md
+++ b/.claude/skills/plan-initiative/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<slug>"
 
 # /plan-initiative — Initiative → Milestones → Tasks (dependency-aware)
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the
 initiative document and filed milestones. Open with the outcome and remove empty
 conditional sections.
 

--- a/.claude/skills/plan-initiative/SKILL.md
+++ b/.claude/skills/plan-initiative/SKILL.md
@@ -6,6 +6,10 @@ argument-hint: "<slug>"
 
 # /plan-initiative — Initiative → Milestones → Tasks (dependency-aware)
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+initiative document and filed milestones. Open with the outcome and remove empty
+conditional sections.
+
 The orchestrator surface above `/write-spec` and `/feature`. Quarter-shape planning for the strategic unit above features — usually 1-3 per quarter, multi-feature, multi-week — that decomposes deterministically into the existing ticket primitives the framework already governs.
 
 Slot relative to existing skills:

--- a/.claude/skills/prototype/SKILL.md
+++ b/.claude/skills/prototype/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Write
 
 # /prototype — Create a Throwaway Prototype Ticket
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for prototype
+artefacts: lead with the learning goal and next action.
+
 Creates a structured GitHub Issue for a **prototype** — a disposable UX/demo artifact (clickable mockup, demo flow, interactive proof-of-concept UI) built to answer *"what should this look and feel like?"*. The output is the **learning / chosen direction**, not shippable code: a prototype is thrown away once the direction is decided.
 
 > **The taxonomy — three skills, two axes (throwaway vs kept, technical vs UX).**

--- a/.claude/skills/prototype/SKILL.md
+++ b/.claude/skills/prototype/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Write
 
 # /prototype — Create a Throwaway Prototype Ticket
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for prototype
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for prototype
 artefacts: lead with the learning goal and next action.
 
 Creates a structured GitHub Issue for a **prototype** — a disposable UX/demo artifact (clickable mockup, demo flow, interactive proof-of-concept UI) built to answer *"what should this look and feel like?"*. The output is the **learning / chosen direction**, not shippable code: a prototype is thrown away once the direction is decided.

--- a/.claude/skills/release-sync/SKILL.md
+++ b/.claude/skills/release-sync/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Write
 # /release-sync — Sync main→dev after a release
 
 The sync PR body is a durable, human-facing artefact. Read
-`.claude/rules/writing-standard.md` and use **Flavored mode**: lead with the
+`.claude/rules/writing-standard.md`. Use **Flavored mode**: lead with the
 outcome and next action, use plain concise prose, and remove empty sections.
 
 Every squash-merge release (`dev → main`) creates a SHA divergence: the squash commit on `main` is absent from `dev`, so `dev` still carries the un-squashed equivalents as separate commits. Repeated releases accumulate the divergence until the next `dev → main` release PR becomes a conflict-heavy nightmare (v2.0.0 suffered 99 conflicts because of this). This skill closes the loop: after each release, file a `main→dev` sync PR that makes the squash commit an ancestor of `dev`, so future release PRs only see genuinely-new commits.

--- a/.claude/skills/release-sync/SKILL.md
+++ b/.claude/skills/release-sync/SKILL.md
@@ -7,6 +7,10 @@ allowed-tools: Bash, Read, Write
 
 # /release-sync — Sync main→dev after a release
 
+The sync PR body is a durable, human-facing artefact. Read
+`.claude/rules/writing-standard.md` and use **Flavored mode**: lead with the
+outcome and next action, use plain concise prose, and remove empty sections.
+
 Every squash-merge release (`dev → main`) creates a SHA divergence: the squash commit on `main` is absent from `dev`, so `dev` still carries the un-squashed equivalents as separate commits. Repeated releases accumulate the divergence until the next `dev → main` release PR becomes a conflict-heavy nightmare (v2.0.0 suffered 99 conflicts because of this). This skill closes the loop: after each release, file a `main→dev` sync PR that makes the squash commit an ancestor of `dev`, so future release PRs only see genuinely-new commits.
 
 This skill is **framework-only** — only for the `me2resh/apexyard` framework repo. It has no meaning on managed projects, which are trunk-based and never squash-merge to a separate `main`.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Write
 # /release — Cut an apexyard release
 
 Generated release PR descriptions and release notes are durable, human-facing
-artefacts. Read `.claude/rules/writing-standard.md` and use **Flavored mode**:
+artefacts. Read `.claude/rules/writing-standard.md`. Use **Flavored mode**:
 lead with the outcome and next action, use plain concise prose, and remove empty
 sections.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -7,6 +7,11 @@ allowed-tools: Bash, Read, Write
 
 # /release — Cut an apexyard release
 
+Generated release PR descriptions and release notes are durable, human-facing
+artefacts. Read `.claude/rules/writing-standard.md` and use **Flavored mode**:
+lead with the outcome and next action, use plain concise prose, and remove empty
+sections.
+
 Standardises the `dev` → `main` release flow introduced by AgDR-0007. Reads the conventional-commit log between `main` and `dev`, proposes a semver bump, **generates and writes the CHANGELOG entry**, **opens the release PR** (dev→main), and triggers the `auto-tag-on-release-pr-merge` GitHub Actions workflow that tags the squash commit and creates a GitHub Release after merge. One command drives the operator from "nothing" to "PR open, ready for Rex + CEO". The tag and GitHub Release entry are created automatically by CI when the PR merges. The release PR also records a `Released-From` trailer with the exact `dev` cut-point SHA, and the changelog step warns loudly if commits inside the resolved changelog range aren't all making it into entries — both guard against the #872 changelog-truncation failure mode. Design rationale: AgDR-0076, AgDR-0094.
 
 This skill is **framework-only** — it's for cutting apexyard releases, not for releasing managed projects under governance. Managed projects stay trunk-based and don't have a release-cut flow.

--- a/.claude/skills/report-apexyard-bug/SKILL.md
+++ b/.claude/skills/report-apexyard-bug/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Write
 
 # /report-apexyard-bug — Report a Framework Bug Upstream
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the
 upstream bug report: lead with the observed outcome and reproducible next action.
 
 Files a structured GitHub Issue **about the apexyard framework itself** to the

--- a/.claude/skills/report-apexyard-bug/SKILL.md
+++ b/.claude/skills/report-apexyard-bug/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Write
 
 # /report-apexyard-bug — Report a Framework Bug Upstream
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+upstream bug report: lead with the observed outcome and reproducible next action.
+
 Files a structured GitHub Issue **about the apexyard framework itself** to the
 canonical upstream **`me2resh/apexyard`** — for when a hook misfires, a skill is
 broken, a rule produces a wrong result, or the docs are wrong.

--- a/.claude/skills/request-apexyard-feature/SKILL.md
+++ b/.claude/skills/request-apexyard-feature/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Write
 
 # /request-apexyard-feature — Request a Framework Feature Upstream
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+upstream feature request: state the outcome and reason before detail.
+
 Files a structured GitHub Issue **proposing a feature or enhancement for the
 apexyard framework itself** to the canonical upstream **`me2resh/apexyard`** —
 for a new skill, a new hook, a rule improvement, a better workflow, etc.

--- a/.claude/skills/request-apexyard-feature/SKILL.md
+++ b/.claude/skills/request-apexyard-feature/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Write
 
 # /request-apexyard-feature — Request a Framework Feature Upstream
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the
 upstream feature request: state the outcome and reason before detail.
 
 Files a structured GitHub Issue **proposing a feature or enhancement for the

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 
 # /roadmap — Product Roadmap
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for roadmap
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for roadmap
 artefacts: keep decisions, uncertainty, and next actions clear and concise.
 
 Manage the product roadmap as a single durable file. The skill is intentionally low-ceremony: a roadmap is a markdown file with milestones, each containing a table of items. `/roadmap` reads it, edits it, and renders it.

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 
 # /roadmap — Product Roadmap
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for roadmap
+artefacts: keep decisions, uncertainty, and next actions clear and concise.
+
 Manage the product roadmap as a single durable file. The skill is intentionally low-ceremony: a roadmap is a markdown file with milestones, each containing a table of items. `/roadmap` reads it, edits it, and renders it.
 
 ## Path resolution

--- a/.claude/skills/spike/SKILL.md
+++ b/.claude/skills/spike/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Write
 
 # /spike — Create a Spike Ticket
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the spike
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the spike
 ticket and disposition record. Keep the hypothesis and kill criteria concise.
 
 Creates a structured GitHub Issue for a **spike** — a 1-3 day hypothesis-driven exploration whose goal is to answer a technical question with minimum investment, with the explicit understanding that the code will be discarded or substantially rewritten once the answer is clear.

--- a/.claude/skills/spike/SKILL.md
+++ b/.claude/skills/spike/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Write
 
 # /spike — Create a Spike Ticket
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the spike
+ticket and disposition record. Keep the hypothesis and kill criteria concise.
+
 Creates a structured GitHub Issue for a **spike** — a 1-3 day hypothesis-driven exploration whose goal is to answer a technical question with minimum investment, with the explicit understanding that the code will be discarded or substantially rewritten once the answer is clear.
 
 > **When to use a spike vs a feature.** If you can answer the question through reasoning alone, file a `/feature`. If you genuinely don't know whether an approach will work — does this library scale, does this UX make sense, will this integration handle our load — file a `/spike` first. The spike's output is the answer; once it's in, file a fresh `[Feature]` ticket with production-shaped delivery (or a memo if the answer was no). See `workflows/sdlc.md` § Phase 1 for the gating heuristic.

--- a/.claude/skills/stakeholder-update/SKILL.md
+++ b/.claude/skills/stakeholder-update/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # /stakeholder-update — Stakeholder Update Generator
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the
 stakeholder update: open with the outcome, impact, and next action.
 
 Synthesises recent activity into a stakeholder-facing update. The skill is audience-aware: weekly is dense and tactical for the team, monthly is strategic for leadership, launch is celebratory and metrics-heavy for the broader org or external stakeholders.

--- a/.claude/skills/stakeholder-update/SKILL.md
+++ b/.claude/skills/stakeholder-update/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # /stakeholder-update — Stakeholder Update Generator
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+stakeholder update: open with the outcome, impact, and next action.
+
 Synthesises recent activity into a stakeholder-facing update. The skill is audience-aware: weekly is dense and tactical for the team, monthly is strategic for leadership, launch is celebratory and metrics-heavy for the broader org or external stakeholders.
 
 ## Path resolution

--- a/.claude/skills/threat-model/SKILL.md
+++ b/.claude/skills/threat-model/SKILL.md
@@ -8,7 +8,7 @@ effort: high
 
 # /threat-model — STRIDE Threat Modelling
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the
 threat model and its findings: lead with the outcome, preserve uncertainty, and
 remove empty sections.
 

--- a/.claude/skills/threat-model/SKILL.md
+++ b/.claude/skills/threat-model/SKILL.md
@@ -8,6 +8,10 @@ effort: high
 
 # /threat-model — STRIDE Threat Modelling
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+threat model and its findings: lead with the outcome, preserve uncertainty, and
+remove empty sections.
+
 Deep-dive security analysis using the STRIDE framework. Produces a prioritized threat catalogue with mitigations. This is the expert companion to `/launch-check`'s security row — invoke it when security shows WARN or FAIL, or proactively before any launch.
 
 **Consumes the DFD produced by [`/dfd`](../dfd/SKILL.md).** The Data Flow Diagram at `projects/<project>/architecture/dfd.md` is the source of truth; this skill iterates its trust-boundary crossings rather than rebuilding its own data-flow view. If the DFD doesn't exist, this skill OFFERS to run `/dfd` first (see Step 1). See AgDR-0026 for the single-source-of-truth rationale.

--- a/.claude/skills/tickets-batch/SKILL.md
+++ b/.claude/skills/tickets-batch/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Write
 
 # /tickets-batch — Bulk-File Structured Tickets
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for every
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for every
 filed ticket. Keep each ticket self-contained and concise.
 
 The fast happy path for filing 5–20 tickets in one intent (project kickoff, roadmap decomposition, handover integration plan). Use this **instead of** raw `gh issue create` (non-conformant) or running `/feature` / `/task` / `/bug` N times serially (~10 questions × N tickets).

--- a/.claude/skills/tickets-batch/SKILL.md
+++ b/.claude/skills/tickets-batch/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Write
 
 # /tickets-batch — Bulk-File Structured Tickets
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for every
+filed ticket. Keep each ticket self-contained and concise.
+
 The fast happy path for filing 5–20 tickets in one intent (project kickoff, roadmap decomposition, handover integration plan). Use this **instead of** raw `gh issue create` (non-conformant) or running `/feature` / `/task` / `/bug` N times serially (~10 questions × N tickets).
 
 This skill is the *fast* happy path. Each ticket it produces conforms to the project's `.ticket.required_sections` schema **by construction** — never by post-hoc validation. The matching `validate-issue-structure.sh` hook is a backstop, not the primary fix.

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools: Bash, Read, Write, Edit
 
 # /update — Sync ApexYard Fork from Upstream
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the sync
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the sync
 PR body and migration notes. Lead with the outcome and next action.
 
 Single-command replacement for the manual "fetch → branch → merge → push → PR" dance that fork maintainers do to pull upstream apexyard changes into their ops fork.

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -18,6 +18,9 @@ allowed-tools: Bash, Read, Write, Edit
 
 # /update — Sync ApexYard Fork from Upstream
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the sync
+PR body and migration notes. Lead with the outcome and next action.
+
 Single-command replacement for the manual "fetch → branch → merge → push → PR" dance that fork maintainers do to pull upstream apexyard changes into their ops fork.
 
 ## Path resolution

--- a/.claude/skills/walking-skeleton/SKILL.md
+++ b/.claude/skills/walking-skeleton/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Write
 
 # /walking-skeleton — Scaffold the Thin End-to-End Slice
 
+Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+walking-skeleton ticket and documentation. Remove empty sections.
+
 Creates a structured GitHub Issue for a **walking skeleton** — the thinnest possible end-to-end slice of a new feature or service: one trivial happy path wired through **every** architectural layer (UI → API → domain → store → deploy → back), with **no business logic beyond the thinnest happy path**. The skeleton actually runs and deploys, so integration and architecture are proven early. You then build the real product on top of it.
 
 > **The taxonomy — three skills, two axes (throwaway vs kept, technical vs UX).**

--- a/.claude/skills/walking-skeleton/SKILL.md
+++ b/.claude/skills/walking-skeleton/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Write
 
 # /walking-skeleton — Scaffold the Thin End-to-End Slice
 
-Read `.claude/rules/writing-standard.md` and use **Flavored mode** for the
+Read `.claude/rules/writing-standard.md`. Use **Flavored mode** for the
 walking-skeleton ticket and documentation. Remove empty sections.
 
 Creates a structured GitHub Issue for a **walking skeleton** — the thinnest possible end-to-end slice of a new feature or service: one trivial happy path wired through **every** architectural layer (UI → API → domain → store → deploy → back), with **no business logic beyond the thinnest happy path**. The skeleton actually runs and deploys, so integration and architecture are proven early. You then build the real product on top of it.

--- a/docs/quality-regression/corpus.md
+++ b/docs/quality-regression/corpus.md
@@ -24,5 +24,7 @@ Source of truth for each case is its fixture file; this index adds the run metad
 | HF-05 | Strict mode spawn brief | readability | medium | no | manual |
 | HF-06 | Flavored mode keeps uncertainty and precision | readability | high | yes | PASS if `1b12123` and `may` / `might` both survive |
 | HF-07 | Conversation is not forced into Strict mode | readability | medium | no | manual |
+| HF-08 | Durable PR and review artefacts use Flavored mode | readability | medium | no | manual |
+| HF-09 | Durable artefact producers carry the central rule | readability | medium | no | manual |
 
 Runs are recorded under `runs/<date>/<label>/<harness>/`. The latest release-readiness summary is the newest `runs/<date>/README.md`.


### PR DESCRIPTION
## Summary

- Apply the technical-writing standard to the framework's durable-artefact producers so tickets, designs, audits, threat models, handovers, and release documents use consistent human-facing language.
- Apply Flavored-mode guidance to PR and review outputs so readers see the outcome and next action before supporting detail.
- Expand the wiring test and human-adjudicated corpus so a future producer cannot silently lose the standard.

## Verification

- `bash .claude/rules/tests/test_writing_standard.sh` — 84 passed, 0 failed.
- `git diff --check` — passed.

## Risks and non-goals

This change adds guidance and regression coverage. It does not impose a word-count limit, change the merge gate, or force Strict mode onto conversation. Machine-consumed text remains governed by Strict mode.

Refs #1174

## Glossary

| Term | Definition |
|------|------------|
| Flavored mode | Human-facing artefact writing that is short, plain, precise, and uncertainty-preserving |
| Strict mode | Machine-consumed writing with one clear imperative instruction per sentence |
| Durable artefact | A filed ticket, PR, review, design, audit, or generated document |
