### PR TITLE
fix(#1152): fail closed on unreadable hook payloads

### DIFF
--- a/.claude/hooks/_lib-fail-closed-json.sh
+++ b/.claude/hooks/_lib-fail-closed-json.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Raw-payload trigger checks for hooks whose jq parse failed. These checks are
+# deliberately narrow: they block only when the JSON still contains the hook's
+# own command shape, and leave unrelated or genuinely empty payloads alone.
+
+raw_payload_command_matches() {
+  local payload="$1" pattern="$2"
+  printf '%s' "$payload" | grep -qE '"command"[[:space:]]*:[[:space:]]*"([^"\\]|\\.)*'"$pattern"
+}
+
+raw_payload_tool_matches() {
+  local payload="$1" tool="$2"
+  printf '%s' "$payload" | grep -qE '"tool_name"[[:space:]]*:[[:space:]]*"'"$tool"'"'
+}

--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -76,6 +76,11 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 if [ -z "$COMMAND" ]; then
+  . "$(dirname "$0")/_lib-fail-closed-json.sh"
+  if raw_payload_command_matches "$INPUT" 'git[[:space:]]+push'; then
+    echo "BLOCKED: protected-branch hook cannot parse this push command. Restore jq and retry." >&2
+    exit 2
+  fi
   exit 0
 fi
 

--- a/.claude/hooks/block-private-refs-in-public-repos.sh
+++ b/.claude/hooks/block-private-refs-in-public-repos.sh
@@ -34,6 +34,11 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 if [ -z "$COMMAND" ]; then
+  . "$(dirname "$0")/_lib-fail-closed-json.sh"
+  if raw_payload_command_matches "$INPUT" 'gh[[:space:]]+(issue|pr)[[:space:]]+(create|comment)'; then
+    echo "BLOCKED: leak-protection hook cannot parse this tracker write. Restore jq and retry." >&2
+    exit 2
+  fi
   exit 0
 fi
 

--- a/.claude/hooks/check-secrets.sh
+++ b/.claude/hooks/check-secrets.sh
@@ -6,6 +6,11 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 if [ -z "$COMMAND" ]; then
+  . "$(dirname "$0")/_lib-fail-closed-json.sh"
+  if raw_payload_command_matches "$INPUT" 'git[[:space:]]+commit'; then
+    echo "BLOCKED: secrets hook cannot parse this commit command. Restore jq and retry so staged content can be scanned." >&2
+    exit 2
+  fi
   exit 0
 fi
 

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -606,6 +606,11 @@ if [ -z "$TOOL_NAME" ]; then
     echo "BLOCKED: active-ticket hook cannot parse this file-write request. Restore jq and retry." >&2
     exit 2
   fi
+  if raw_payload_tool_matches "$INPUT" 'Bash' && \
+     raw_payload_command_matches "$INPUT" '(tee[[:space:]]|write_(text|bytes)|>[[:space:]]*[A-Za-z0-9_./${-])'; then
+    echo "BLOCKED: active-ticket hook cannot parse this Bash write request. Restore jq and retry." >&2
+    exit 2
+  fi
 fi
 
 # Bash-tool path: extract the target file(s) from the command if it appears

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -595,6 +595,19 @@ INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
 
+# If jq cannot decode the envelope, do not silently allow an edit/write tool
+# call. The raw check is intentionally limited to tool names whose payloads can
+# change files; unrelated tool calls remain no-ops.
+if [ -z "$TOOL_NAME" ]; then
+  . "$(dirname "$0")/_lib-fail-closed-json.sh"
+  if raw_payload_tool_matches "$INPUT" 'Edit' || \
+     raw_payload_tool_matches "$INPUT" 'Write' || \
+     raw_payload_tool_matches "$INPUT" 'MultiEdit'; then
+    echo "BLOCKED: active-ticket hook cannot parse this file-write request. Restore jq and retry." >&2
+    exit 2
+  fi
+fi
+
 # Bash-tool path: extract the target file(s) from the command if it appears
 # to be a write. Closes the bypass surface where Bash file-writes
 # (`echo > file`, `tee file`, `sed -i ... file`, `python -c

--- a/.claude/hooks/tests/test_fail_closed_json.sh
+++ b/.claude/hooks/tests/test_fail_closed_json.sh
@@ -27,6 +27,12 @@ check "private tracker write" .claude/hooks/block-private-refs-in-public-repos.s
   '{"tool_name":"Bash","tool_input":{"command":"gh issue create --repo me2resh/apexyard"}}'
 check "active Edit" .claude/hooks/require-active-ticket.sh \
   '{"tool_name":"Edit","tool_input":{"file_path":"src/app.ts"}}'
+check "active Bash write" .claude/hooks/require-active-ticket.sh \
+  '{"tool_name":"Bash","tool_input":{"command":"printf x > src/app.ts"}}'
+
+read_rc=$(printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git status"}}' | PATH="$TMP:$PATH" bash "$ROOT/.claude/hooks/require-active-ticket.sh" >/dev/null 2>&1; echo $?)
+if [ "$read_rc" -eq 0 ]; then echo "PASS [active Bash read]"; PASS=$((PASS+1));
+else echo "FAIL [active Bash read] expected rc=0 got rc=$read_rc" >&2; FAIL=$((FAIL+1)); fi
 
 echo "fail-closed JSON smoke tests: PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.claude/hooks/tests/test_fail_closed_json.sh
+++ b/.claude/hooks/tests/test_fail_closed_json.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Regression tests for #1152 slice 1: jq failure must not turn covered writes
+# into silent passes.
+set -u
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cat > "$TMP/jq" <<'EOF'
+#!/bin/bash
+exit 127
+EOF
+chmod +x "$TMP/jq"
+
+PASS=0; FAIL=0
+check() {
+  local name="$1" hook="$2" payload="$3" rc
+  rc=$(printf '%s' "$payload" | PATH="$TMP:$PATH" bash "$ROOT/$hook" >/dev/null 2>&1; echo $?)
+  if [ "$rc" -eq 2 ]; then echo "PASS [$name]"; PASS=$((PASS+1));
+  else echo "FAIL [$name] expected rc=2 got rc=$rc" >&2; FAIL=$((FAIL+1)); fi
+}
+
+check "secrets commit" .claude/hooks/check-secrets.sh \
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}'
+check "protected push" .claude/hooks/block-main-push.sh \
+  '{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}'
+check "private tracker write" .claude/hooks/block-private-refs-in-public-repos.sh \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue create --repo me2resh/apexyard"}}'
+check "active Edit" .claude/hooks/require-active-ticket.sh \
+  '{"tool_name":"Edit","tool_input":{"file_path":"src/app.ts"}}'
+
+echo "fail-closed JSON smoke tests: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/docs/agdr/AgDR-0130-fail-closed-json-payloads.md
+++ b/docs/agdr/AgDR-0130-fail-closed-json-payloads.md
@@ -1,0 +1,25 @@
+# Fail-closed handling for unreadable hook payloads
+
+## Context
+
+Blocking hooks used `jq` to read tool payloads. When `jq` was unavailable or the payload was malformed, several hooks treated the empty result as an unrelated command and returned success. This silently disabled controls.
+
+## Options Considered
+
+| Option | Result |
+|--------|--------|
+| Exit 2 for every unreadable payload | Rejected; broad Bash matchers would block unrelated commands. |
+| Keep returning 0 | Rejected; a matching operation could bypass its control. |
+| Scan the raw payload for each hook's narrow trigger shape | Chosen; matching writes fail closed while unrelated payloads remain no-ops. |
+
+## Decision
+
+Use a shared jq-free raw-payload matcher. The first implementation covers secret scans, protected-branch pushes, public-repo leak checks, and active-ticket edits or Bash writes. A matching unreadable payload returns exit 2. An unrelated or read-only payload returns exit 0.
+
+## Consequences
+
+The controls remain available when `jq` cannot parse the envelope. Trigger patterns must stay narrow and receive regression tests for both blocking and no-op cases. Remaining blocking hooks will adopt the same pattern in separate slices.
+
+## References
+
+- me2resh/apexyard#1152


### PR DESCRIPTION
## Summary

- Fail closed when jq cannot parse payloads for four high-risk controls, including Bash file writes handled by the active-ticket gate.
- Keep unrelated and read-only payloads as no-ops, with jq-failure regression coverage for both paths.

## Verification

- `bash .claude/hooks/tests/test_fail_closed_json.sh` — 6 passed, 0 failed.
- `bash .claude/hooks/tests/test_require_active_ticket_bash.sh` — passed.
- `bash -n` and `git diff --check` — passed.

## Scope and follow-up

This is the first focused slice of #1152. Remaining blocking hooks require separate trigger-class slices.

AgDR: docs/agdr/AgDR-0130-fail-closed-json-payloads.md

Refs #1152

## Glossary

| Term | Definition |
|------|------------|
| Fail closed | Block when a control cannot evaluate its precondition |
| Raw-payload check | A jq-free scan of the original hook input for a known trigger shape |
| Trigger shape | The command or tool pattern that activates one hook |
