### PR TITLE
fix(#1152): close command validation parse bypasses

### DIFF
--- a/.claude/hooks/block-git-add-all.sh
+++ b/.claude/hooks/block-git-add-all.sh
@@ -8,6 +8,11 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 if [ -z "$COMMAND" ]; then
+  . "$(dirname "$0")/_lib-fail-closed-json.sh"
+  if raw_payload_command_matches "$INPUT" 'git[[:space:]]+add[[:space:]]+(-A|--all|\.)'; then
+    echo "BLOCKED: staging guard cannot parse this git add command. Restore jq and retry." >&2
+    exit 2
+  fi
   exit 0
 fi
 

--- a/.claude/hooks/block-onboarding-in-git.sh
+++ b/.claude/hooks/block-onboarding-in-git.sh
@@ -22,7 +22,14 @@
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
-[ -z "$COMMAND" ] && exit 0
+if [ -z "$COMMAND" ]; then
+  . "$(dirname "$0")/_lib-fail-closed-json.sh"
+  if raw_payload_command_matches "$INPUT" 'git[[:space:]]+commit'; then
+    echo "BLOCKED: onboarding guard cannot parse this commit command. Restore jq and retry." >&2
+    exit 2
+  fi
+  exit 0
+fi
 
 # Only check on git commit
 echo "$COMMAND" | grep -qE '\bgit\s+commit\b' || exit 0

--- a/.claude/hooks/tests/test_fail_closed_json.sh
+++ b/.claude/hooks/tests/test_fail_closed_json.sh
@@ -34,5 +34,14 @@ read_rc=$(printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git status"}
 if [ "$read_rc" -eq 0 ]; then echo "PASS [active Bash read]"; PASS=$((PASS+1));
 else echo "FAIL [active Bash read] expected rc=0 got rc=$read_rc" >&2; FAIL=$((FAIL+1)); fi
 
+check "staging" .claude/hooks/block-git-add-all.sh \
+  '{"tool_name":"Bash","tool_input":{"command":"git add -A"}}'
+check "onboarding" .claude/hooks/block-onboarding-in-git.sh \
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}'
+check "branch" .claude/hooks/validate-branch-name.sh \
+  '{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}'
+check "commit-format" .claude/hooks/validate-commit-format.sh \
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}'
+
 echo "fail-closed JSON smoke tests: PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.claude/hooks/validate-branch-name.sh
+++ b/.claude/hooks/validate-branch-name.sh
@@ -10,6 +10,11 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 if [ -z "$COMMAND" ]; then
+  . "$(dirname "$0")/_lib-fail-closed-json.sh"
+  if raw_payload_command_matches "$INPUT" 'git[[:space:]]+push'; then
+    echo "BLOCKED: branch-name hook cannot parse this push command. Restore jq and retry." >&2
+    exit 2
+  fi
   exit 0
 fi
 

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -24,6 +24,11 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 if [ -z "$COMMAND" ]; then
+  . "$(dirname "$0")/_lib-fail-closed-json.sh"
+  if raw_payload_command_matches "$INPUT" 'git[[:space:]]+commit'; then
+    echo "BLOCKED: commit-format hook cannot parse this commit command. Restore jq and retry." >&2
+    exit 2
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Extend the jq-failure fail-closed guard to command-validation hooks for staging, onboarding commits, branch names, and commit messages. Matching operations now block instead of silently bypassing validation.
- Reuse the narrow raw-payload matcher and add regression coverage for each trigger class while preserving unrelated-payload no-ops.

## Verification

- `bash .claude/hooks/tests/test_fail_closed_json.sh` — 10 passed, 0 failed.
- `bash -n` and `git diff --check` — passed.

## Scope

This is the second focused slice of #1152. It does not change repository resolution or the remaining content and tracker gates.

AgDR: docs/agdr/AgDR-0130-fail-closed-json-payloads.md

Refs #1152

## Glossary

| Term | Definition |
|------|------------|
| Fail closed | Block when a control cannot evaluate its precondition |
| Raw-payload check | A jq-free scan of the original hook input for a known trigger shape |
| Trigger class | A group of hooks activated by the same command family |
