### PR TITLE
feat(#1178): add build-time handbook discovery

### DIFF
--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -14,6 +14,10 @@ Read and adopt `@roles/engineering/backend-engineer.md` for full identity, respo
 
 When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_code` (and `search_docs` for docs) over `grep` + `Read`** — it's semantic, returns targeted excerpts, and costs ~3–5× fewer tokens. Fall back to `grep`/`Read` only when an MCP query returns nothing relevant (e.g. the project isn't indexed). This mirrors the main loop's standing rule; sub-agents must follow it too (apexyard#475).
 
+## Build-time handbooks
+
+Before implementation, read and follow `@.claude/rules/build-handbook-discovery.md`. Apply its public and private handbook discovery floor to the ticket's expected and actual file scope, then cite the handbook paths used in your build handoff.
+
 ## Activation context
 
 This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Backend Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/data-engineer.md
+++ b/.claude/agents/data-engineer.md
@@ -14,6 +14,10 @@ Read and adopt `@roles/data/data-engineer.md` for full identity, responsibilitie
 
 When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_code` (and `search_docs` for docs) over `grep` + `Read`** — it's semantic, returns targeted excerpts, and costs ~3–5× fewer tokens. Fall back to `grep`/`Read` only when an MCP query returns nothing relevant (e.g. the project isn't indexed). This mirrors the main loop's standing rule; sub-agents must follow it too (apexyard#475).
 
+## Build-time handbooks
+
+Before implementation, read and follow `@.claude/rules/build-handbook-discovery.md`. Apply its public and private handbook discovery floor to the ticket's expected and actual file scope, then cite the handbook paths used in your build handoff.
+
 ## Activation context
 
 This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Data Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -14,6 +14,10 @@ Read and adopt `@roles/engineering/frontend-engineer.md` for full identity, resp
 
 When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_code` (and `search_docs` for docs) over `grep` + `Read`** — it's semantic, returns targeted excerpts, and costs ~3–5× fewer tokens. Fall back to `grep`/`Read` only when an MCP query returns nothing relevant (e.g. the project isn't indexed). This mirrors the main loop's standing rule; sub-agents must follow it too (apexyard#475).
 
+## Build-time handbooks
+
+Before implementation, read and follow `@.claude/rules/build-handbook-discovery.md`. Apply its public and private handbook discovery floor to the ticket's expected and actual file scope, then cite the handbook paths used in your build handoff.
+
 ## Activation context
 
 This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Frontend Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/platform-engineer.md
+++ b/.claude/agents/platform-engineer.md
@@ -14,6 +14,10 @@ Read and adopt `@roles/engineering/platform-engineer.md` for full identity, resp
 
 When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_code` (and `search_docs` for docs) over `grep` + `Read`** — it's semantic, returns targeted excerpts, and costs ~3–5× fewer tokens. Fall back to `grep`/`Read` only when an MCP query returns nothing relevant (e.g. the project isn't indexed). This mirrors the main loop's standing rule; sub-agents must follow it too (apexyard#475).
 
+## Build-time handbooks
+
+Before implementation, read and follow `@.claude/rules/build-handbook-discovery.md`. Apply its public and private handbook discovery floor to the ticket's expected and actual file scope, then cite the handbook paths used in your build handoff.
+
 ## Activation context
 
 This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Platform Engineer"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.

--- a/.claude/agents/tests/test_build_handbook_discovery.sh
+++ b/.claude/agents/tests/test_build_handbook_discovery.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Pins proactive handbook discovery for every build-class agent named by #1178.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+CONTRACT="$ROOT/.claude/rules/build-handbook-discovery.md"
+FAIL=0
+
+pass() { printf '  ok   %s\n' "$1"; }
+fail() { printf '  FAIL %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+
+if [ -f "$CONTRACT" ]; then
+  pass "shared build handbook contract exists"
+else
+  fail "shared build handbook contract exists"
+  exit 1
+fi
+
+for agent in backend-engineer frontend-engineer platform-engineer data-engineer; do
+  file="$ROOT/.claude/agents/$agent.md"
+  if grep -qF '@.claude/rules/build-handbook-discovery.md' "$file"; then
+    pass "$agent loads the shared contract"
+  else
+    fail "$agent loads the shared contract"
+  fi
+done
+
+for required in \
+  'architecture/*.md' \
+  'general/*.md' \
+  'language/<lang>/*.md' \
+  'domain/<area>/*.md' \
+  'portfolio_custom_handbooks_dir' \
+  'mcp__apexyard-search__search_docs' \
+  'Semantic discovery is fail-soft' \
+  'expected or actual implementation'; do
+  if grep -qF "$required" "$CONTRACT"; then
+    pass "contract pins: $required"
+  else
+    fail "contract pins: $required"
+  fi
+done
+
+if grep -qF 'do not issue a review verdict or write approval markers' "$CONTRACT"; then
+  pass "build-time semantics remain separate from review approval"
+else
+  fail "build-time semantics remain separate from review approval"
+fi
+
+printf '\nPassed contract checks with %s failure(s).\n' "$FAIL"
+exit "$FAIL"

--- a/.claude/rules/build-handbook-discovery.md
+++ b/.claude/rules/build-handbook-discovery.md
@@ -1,0 +1,35 @@
+# Build-time handbook discovery
+
+Build-class agents must consult adopter-authored standards before changing code. This is the proactive counterpart to Rex's review-time handbook pass: the same handbook is authoritative during Build and Review, so avoidable violations are caught before a review round trip.
+
+## Required discovery floor
+
+Before implementation, determine the ticket's expected file scope, then load relevant handbooks from both layers:
+
+1. Public: `<ops-root>/handbooks/`
+2. Private: the directory returned by `portfolio_custom_handbooks_dir` from `<ops-root>/.claude/hooks/_lib-portfolio-paths.sh`, when configured and present
+
+Apply the same path convention independently to each layer:
+
+- `architecture/*.md` and `general/*.md`: always load.
+- `language/<lang>/*.md`: load when the expected or actual implementation scope contains that language (`typescript` for `.ts`/`.tsx`, `python` for `.py`, `go` for `.go`, `rust` for `.rs`, and the equivalent direct extension mapping for other language buckets).
+- `domain/<area>/*.md`: parse the optional YAML-frontmatter `paths:` list and load when any expected or actual implementation path matches a listed glob. A domain handbook with no `paths:` field, or an empty list, always loads.
+
+Resolve the ops root and private layer with the portfolio helpers; do not assume the current repository is the ops fork:
+
+```bash
+source "<ops-root>/.claude/hooks/_lib-portfolio-paths.sh"
+private_handbooks=$(portfolio_custom_handbooks_dir 2>/dev/null || true)
+```
+
+Read every selected handbook in full before editing. Re-run language/domain selection if the implementation expands into files outside the expected scope.
+
+## Optional semantic supplement
+
+When `mcp__apexyard-search__search_docs` is available, make one additive semantic query using the ticket goal and expected implementation paths. Keep only results under `handbooks/` or `custom-handbooks/`, take at most the top five chunks, group by file, and read each unique handbook in full. De-duplicate files already loaded by path convention.
+
+Semantic discovery is fail-soft: if the tool is unavailable, errors, or returns no handbook chunks, continue silently with the deterministic path-convention set. It must never replace or shrink the required discovery floor.
+
+## Build-time semantics
+
+Handbook rules are implementation guidance during Build. Follow both advisory and blocking rules while writing code, but do not issue a review verdict or write approval markers. If a handbook conflicts with the ticket, another handbook, or a framework rule, stop and surface the exact paths and conflicting statements to the orchestrator; do not silently choose one. Cite the handbook paths applied in the build handoff so Rex can verify the same standards independently.

--- a/docs/agdr/AgDR-0131-shared-build-handbook-discovery.md
+++ b/docs/agdr/AgDR-0131-shared-build-handbook-discovery.md
@@ -1,0 +1,45 @@
+---
+id: AgDR-0131
+timestamp: 2026-09-05T08:20:02Z
+agent: codex
+model: gpt-5
+trigger: user-prompt
+status: executed
+category: patterns
+projects: [apexyard]
+---
+
+# Share handbook discovery across build agents
+
+> In the context of adding proactive adopter-handbook guidance to four build-class agents, facing drift and token-cost risk from copying Rex's review procedure into every wrapper, I decided to centralize a build-specific discovery contract and reference it from each wrapper to achieve one extensible standard across Build and Review, accepting that agent prompts depend on one additional imported rule file.
+
+## Context
+
+- Rex and Tariq already discover public `handbooks/` and private `custom-handbooks/`, but backend, frontend, platform, and data engineers do not.
+- Build agents need the same deterministic bucket selection and optional semantic supplement, while review verdict and enforcement mechanics remain reviewer-owned.
+- Agent wrapper files are intentionally thin and already delegate stable behavior to canonical role/rule documents.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Duplicate Rex's full handbook section into all four wrappers | Self-contained prompts; exact review algorithm visible locally | Four large copies drift independently; review-only verdict language can leak into Build; high prompt cost |
+| Add one shared build-time discovery rule referenced by all four wrappers | One source of truth; concise wrappers; explicitly separates build guidance from review enforcement | Adds one prompt import dependency; tests must pin that every build wrapper references it |
+| Put discovery only in role files | Keeps wrapper metadata minimal | Role files describe human responsibilities and are also read outside agent execution; runtime/tool-specific MCP behavior does not belong there |
+
+## Decision
+
+Chosen: **one shared build-time discovery rule referenced by all four wrappers**, because it reuses Rex's public/private and path-convention semantics without copying review-only ceremony or creating four future maintenance surfaces.
+
+## Consequences
+
+- Architecture/general handbooks always load; language/domain handbooks load from expected or actual implementation paths in both public and private layers.
+- Semantic search remains additive and fail-soft, so adopters without MCP retain deterministic discovery.
+- Build agents follow handbook guidance and cite it in handoff, but never produce review verdicts or approval markers.
+- A regression test fails if any of the four wrappers drops the shared contract or if its required discovery guarantees disappear.
+
+## Artifacts
+
+- Issue: https://github.com/me2resh/apexyard/issues/1178
+- `.claude/rules/build-handbook-discovery.md`
+- `.claude/agents/tests/test_build_handbook_discovery.sh`


### PR DESCRIPTION
Closes #1178

## Summary

- Adds one shared build-time handbook discovery contract so adopter standards influence implementation before Rex catches violations at review time.
- Wires backend, frontend, platform, and data engineer wrappers to the contract, keeping all four agents aligned without copying Rex's large review-only procedure.
- Preserves deterministic public/private path-convention discovery while making semantic search additive and fail-soft for adopters without MCP.
- Separates Build from Review explicitly: build agents follow and cite handbook guidance but never issue verdicts or write approval markers.
- Records the centralisation decision in AgDR-0131 and adds regression coverage that fails if any build wrapper drops the contract or the discovery guarantees drift.

## Verification

- `bash .claude/agents/tests/test_build_handbook_discovery.sh`
- `bash .claude/agents/tests/test_agent_wrap_shape.sh`
- `bash -n .claude/agents/tests/test_build_handbook_discovery.sh`
- `npx --yes markdownlint-cli2 ...` for all changed Markdown files
- `git diff --check`
- Pre-push markdownlint, shellcheck, and sub-pack checks

## Decision record

- [AgDR-0131](docs/agdr/AgDR-0131-shared-build-handbook-discovery.md)

## Glossary

| Term | Meaning |
|------|---------|
| Build-class agent | An implementation agent such as the backend, frontend, platform, or data engineer |
| Handbook | An adopter-authored coding or architecture standard loaded by agents |
| Discovery floor | Deterministic handbooks that must load based on their directory and the implementation paths |
| Semantic supplement | Optional MCP search that adds relevant handbooks without replacing deterministic discovery |
| Private layer | Company-confidential handbooks stored in the split-portfolio sibling repository |
