### PR TITLE
feat(#1128): require browser evidence in QA and design-review records

### DIFF
--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -12,6 +12,18 @@ Read and adopt `@roles/engineering/qa-engineer.md` for full identity, responsibi
 
 The QA Engineer is read-only by mechanical contract: this agent ships **without** Edit/Write tools because QA's job is to verify acceptance criteria, file bug tickets, and sign off — not to ship code. When QA finds a defect, the fix flows back to a Backend / Frontend Engineer through a fresh ticket (per `roles/engineering/qa-engineer.md` § "If QA Finds Issues" and `workflows/sdlc.md` § "Phase 5: QA Verification").
 
+## Browser evidence is a named deliverable
+
+If the ticket touches a rendered surface, verify each rendered acceptance criterion in a browser. Do not substitute a database query, a source read, or a passing test. **Reject a PASS whose evidence does not match the criterion.**
+
+Report the browser-verification status of every acceptance criterion. The not-verified list is **mandatory**: if you cannot boot the surface, say so and name every affected criterion. Never return a report that leaves the question unanswered — a record claiming verification that did not happen is worse than no QA record, because it stops a human from re-checking.
+
+Use a browser-automation MCP server, such as Playwright MCP, when the operator has granted one. This wrapper's `allowed-tools` list does not include browser tooling, so if no browser MCP server is available to you, do not improvise with a headless-browser CLI: report the affected criteria as not browser-verified and hand the gap back to the orchestrator.
+
+Prefer an accessibility-tree snapshot over a screenshot when asserting what a page says. If you take a screenshot, wait until the page settles — a chart or transition captured at frame 0 renders empty and produces a confident, wrong finding.
+
+Full requirement and the sign-off table: `@roles/engineering/qa-engineer.md` § "Browser Evidence (rendered surfaces only)".
+
 ## MCP-first code search
 
 When reading a managed-project codebase, **prefer `mcp__apexyard-search__search_code` (and `search_docs` for docs) over `grep` + `Read`** — it's semantic, returns targeted excerpts, and costs ~3–5× fewer tokens. Fall back to `grep`/`Read` only when an MCP query returns nothing relevant (e.g. the project isn't indexed). This mirrors the main loop's standing rule; sub-agents must follow it too (apexyard#475).

--- a/.claude/agents/ui-designer.md
+++ b/.claude/agents/ui-designer.md
@@ -26,6 +26,18 @@ You are a build-class sub-agent. You cannot nest the Agent tool, so you cannot s
 
 **DO:** Report your build results plainly — what you designed, what deliverables you produced, what acceptance criteria you verified. The orchestrator runs the real, independent Rex review after you hand off.
 
+## Browser evidence is a named deliverable
+
+Render the component before you review it. A review that only reads source cannot see spacing, contrast, overflow, empty states, or loading states. **Reject a PASS whose evidence does not match the criterion.**
+
+Report the browser-verification status of every design criterion. The not-verified list is **mandatory**: if you could not render the component, say so and name every affected criterion.
+
+Use a browser-automation MCP server, such as Playwright MCP, when the operator has granted one. This wrapper's `allowed-tools` list does not include browser tooling, so if no browser MCP server is available to you, do not improvise with a headless-browser CLI: report the affected criteria as not browser-verified.
+
+Prefer an accessibility-tree snapshot over a screenshot when asserting what a component says. If you take a screenshot, wait until the page settles — a transition captured at frame 0 produces a confident, wrong finding.
+
+Full requirement: `@roles/design/ui-designer.md` § "Browser evidence is a named deliverable". This applies to UI work only.
+
 ## Design tooling (on demand)
 
 - Sync the design system to **claude.ai/design** via the **`/design-sync`** skill (built-in `DesignSync` tool; authorize via claude.ai login / `/design-login`, not `.mcp.json`). Incremental, one component at a time.

--- a/.claude/rules/workflow-gates.md
+++ b/.claude/rules/workflow-gates.md
@@ -142,6 +142,12 @@ In Progress → In Review → QA → Done
                     QA must verify
 ```
 
+### What counts as QA evidence
+
+If the ticket touches a rendered surface, the QA record must state, per acceptance criterion, whether it was verified in a browser. The not-verified list is mandatory: a QA agent that could not boot the surface must name the affected criteria rather than stay silent. A database query, a source read, or a green test suite is not evidence that a rendered criterion is met. **Reject a PASS whose evidence does not match the criterion.**
+
+A ticket with no rendered surface needs no browser evidence. Full requirement and sign-off shape: `roles/engineering/qa-engineer.md` § "Browser Evidence (rendered surfaces only)"; the design-gate equivalent is `roles/design/ui-designer.md` § "Browser evidence is a named deliverable". No hook enforces this — a `PreToolUse` hook cannot see whether a sub-agent opened a browser, so the orchestrator must reject a report that skips the breakdown.
+
 ---
 
 *Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -187,6 +187,8 @@ Each appendix carries the stack-specific surface-evidence requirements (step 1),
 - Browser DevTools Console — any errors, including the stack trace
 - The exact URL in the address bar at the moment of failure (often differs from what the user typed — note both)
 
+**Capture that evidence with a browser-automation MCP server** (Playwright MCP or equivalent) rather than an ad-hoc headless-browser CLI invocation. Prefer an accessibility-tree snapshot over a screenshot when the hypothesis is about what the page *says* — a snapshot returns rendered text and roles, and it does not depend on animation timing. If you take a screenshot, wait until the page settles: a chart's draw-in animation captured at frame 0 renders empty, and that frame has already produced at least one confident, wrong root-cause finding.
+
 **Architecture-surface map (step 2).** Read the file at every layer the request touches:
 
 | Layer | What to read | What you're looking for |

--- a/roles/design/ui-designer.md
+++ b/roles/design/ui-designer.md
@@ -79,6 +79,18 @@ System-level standards, cross-product visual direction, and design disagreements
 
 Part of that review is **design-QA of AI/agent-generated UI** — a current baseline duty: confirm the generated code used the right components and design tokens rather than one-off magic values.
 
+### Browser evidence is a named deliverable
+
+Render the component before you review it. A design review that only reads source is reviewing source, not design — spacing, contrast, overflow, empty states, and loading states are all visible only once the component renders with real data.
+
+**Reject a PASS whose evidence does not match the criterion.** If a criterion describes what a person sees, the evidence must be what appeared on screen, at which URL, against which data.
+
+State the browser-verification status of every design criterion you reviewed. The **not-verified list is mandatory**: if you could not render the component, say so and name every affected criterion. Silence on the question reads as verification that did not happen.
+
+**Mechanism.** Use a browser-automation MCP server, such as Playwright MCP or an equivalent, over an ad-hoc headless-browser CLI invocation. Prefer an accessibility-tree snapshot over a screenshot when you assert what a component says, because a snapshot returns rendered text and roles and does not depend on animation timing. If you take a screenshot, wait until the page settles — a transition or draw-in animation captured at frame 0 produces a confident, wrong finding.
+
+This applies to UI work only. A PR with no rendered surface needs no browser evidence.
+
 ## Accessibility (WCAG 2.2 AA)
 
 Visual accessibility is yours to own at the component level. Hold components to **WCAG 2.2 AA** — now published as **ISO 40500:2025** and enforceable under the EU's European Accessibility Act (EAA), so it's a compliance floor, not a nice-to-have. Run **`/accessibility-audit`** on user-facing work (or when `/launch-check`'s accessibility row warns) and fold the findings back into token and component specs.

--- a/roles/engineering/qa-engineer.md
+++ b/roles/engineering/qa-engineer.md
@@ -174,6 +174,7 @@ What actually happens.
 Before release:
 
 - [ ] All acceptance criteria verified
+- [ ] Rendered-surface criteria browser-verified, or listed as not verified
 - [ ] Unit test coverage > 80%
 - [ ] Integration tests pass
 - [ ] E2E critical paths pass
@@ -195,6 +196,26 @@ In Progress --> In Review --> QA --> Done
 
 A merged PR references its ticket with `Refs #N` (not `Closes #N`) and the ticket gets the `qa` label, so it lands in QA — not auto-closed to Done. Gate 6 (`.claude/rules/workflow-gates.md`) requires your sign-off before Done; if you find a defect, file it with `/bug` linked to the original ticket, which stays in QA until the fix is re-verified.
 
+### Browser Evidence (rendered surfaces only)
+
+A ticket touches a **rendered surface** when an acceptance criterion describes what a person sees — a page, a component, a table row, a chart, an email body. For each such criterion, verify the running product in a browser. Do not accept a database query, a source read, or a passing test as evidence that a rendered criterion is met.
+
+**Reject a PASS whose evidence does not match the criterion.** A column can hold an empty string and read as an em-dash on screen. A seeded email template can be 56 bytes of bare markup next to two polished siblings. Every test passes in both cases.
+
+If the ticket has no rendered surface, browser evidence is not required. Do not add an empty browser-evidence section to a backend-only sign-off.
+
+#### Mechanism
+
+Use a browser-automation MCP server, such as Playwright MCP or an equivalent. Prefer it over an ad-hoc headless-browser CLI invocation, which is itself a source of false findings.
+
+Prefer an accessibility-tree snapshot over a screenshot when you assert what a page says. A snapshot returns the rendered text and roles, and it does not depend on animation timing.
+
+If you take a screenshot, wait until the page settles. A chart, a transition, or a draw-in animation can render empty at frame 0, and a screenshot captured at frame 0 produces a confident, wrong finding.
+
+#### Report the gaps
+
+State the browser-verification status of every acceptance criterion. The **not-verified list is mandatory**, not optional. If you cannot boot the surface, say so and name every affected criterion. An honest "AC1–AC3 were database checks, not browser checks" is a good QA record. Silence on the question is not.
+
 ### QA Sign-off Format
 
 ```markdown
@@ -203,10 +224,16 @@ A merged PR references its ticket with `Refs #N` (not `Closes #N`) and the ticke
 **Verified by**: QA Engineer
 **Date**: YYYY-MM-DD
 **Environment**: Staging
+**Rendered surface**: Yes / No
 
 ### Acceptance Criteria Verification
-- [x] AC1: [description] - PASS
-- [x] AC2: [description] - PASS
+| AC | Description | Result | Evidence | Browser-verified |
+|----|-------------|--------|----------|------------------|
+| AC1 | [description] | PASS | [URL + what appeared on screen] | Yes |
+| AC2 | [description] | PASS | [query or test that proves it] | No |
+
+### Not Browser-Verified
+- AC2 — [why, e.g. the staging build did not boot]
 
 ### Additional Testing
 - [x] Regression: No issues found
@@ -214,6 +241,8 @@ A merged PR references its ticket with `Refs #N` (not `Closes #N`) and the ticke
 
 **Status**: APPROVED - Ready for Done
 ```
+
+Delete the "Not Browser-Verified" section when every rendered criterion was browser-verified. Delete it when the ticket has no rendered surface. Never delete it while an unverified rendered criterion remains.
 
 ## Escalate When
 


### PR DESCRIPTION
## Summary

- **QA sign-off now names its evidence per criterion** — `roles/engineering/qa-engineer.md` gains a "Browser Evidence (rendered surfaces only)" section and a sign-off table with an explicit `Browser-verified` column. Today a QA agent can satisfy Gate 6 entirely from database queries and source reading, and return a record that reads as full verification. That record is worse than no QA at all, because it stops a human from re-checking.
- **The not-verified list is mandatory, not optional** — an agent that could not boot the surface must say so and name the affected criteria. An honest "AC1–AC3 were database checks" is a good QA record; silence on the question is the failure this ticket documents. The framing sentence carried through every file is: **reject a PASS whose evidence does not match the criterion.**
- **Design review gets the same requirement** — `roles/design/ui-designer.md` and its agent wrapper now require the component to be rendered before review. It matters more here than in QA: a design review that never renders is only reviewing source, so spacing, contrast, overflow, and empty states are invisible to it.
- **Mechanism guidance names the trap that produced a wrong finding** — all four files recommend a browser-automation MCP server (Playwright MCP or equivalent) over ad-hoc headless-browser CLI invocation, prefer accessibility-tree snapshots over screenshots for asserting what a page says, and warn that a screenshot captured at frame 0 of a draw-in animation renders empty. Ticket #1128 records that exact false positive reaching a permanent record before correction.
- **Both agent wrappers state the tool reality plainly** — neither `qa-engineer` nor `ui-designer` has browser tooling in its `allowed-tools`. Rather than leave that as a silent contradiction, each wrapper instructs the agent not to improvise with a headless CLI and instead to report the affected criteria as not browser-verified and hand the gap back to the orchestrator.
- **Gate 6 and `/debug` each get one paragraph** — `workflow-gates.md` § "What counts as QA evidence" states the requirement where orchestrators read it, and says plainly that no hook enforces it. The `/debug` web appendix gets the same mechanism warning, since hypothesis-driven UI debugging has the identical evidence problem.

Deliberately **not** included: any hook, matcher, or `settings.json` entry. A `PreToolUse` hook cannot see whether a sub-agent opened a browser or inspect a report's contents — the same limitation AgDR-0056 documents for the spawn boundary. This is a role-definition change backed by orchestrator discipline. The requirement is also conditional on the ticket touching a rendered surface; requiring it on backend-only tickets would train agents to write "N/A" without thinking, which is the same substitution failure the ticket is trying to fix.

**AgDR decision: none written.** Read against `.claude/rules/agdr-decisions.md`, this misses every threshold row — no new dependency (Playwright MCP is a recommendation, not something added to a manifest), no new service, no data-model change, no security control, no CI/CD design, and no repo-wide pattern (two roles plus two cross-references). It adds no gate mechanism and changes no hook, so rail 1 does not apply, and it is fully reversible inside this PR. The practical test also comes out negative: the reasoning lives in the role files themselves and in #1128, so a teammate reading either in six months is not confused and repeats no expensive work. Ambiguity here is about *cross-cutting-ness*, and the honest reading is that a prose clarification of what an existing gate's output must contain is not the same as adopting a new pattern across the repo.

## Testing

1. `npx --yes markdownlint-cli --config .markdownlint.json` on all six changed files — exit 0, no output.
2. `bash bin/run-hook-tests.sh` — `PASS=145 FAIL=2 SKIP=0 TOTAL=147`. The two failures (`test_lib_self_location_cwd_anchor.sh`, `test_validate_search_config.sh`) reproduce identically on the clean base commit `a300c98` with the branch stashed, so they are pre-existing and unrelated to this diff.
3. `git diff --check` — exit 0, no whitespace errors.
4. Behavioural check is by reading: the QA sign-off template, the UI Designer review section, the Gate 6 paragraph, and the `/debug` appendix each state the conditional trigger (rendered surface), the mandatory not-verified list, and the mechanism recommendation.

Refs #1128

## Glossary

| Term | Definition |
|------|------------|
| Browser evidence | Verification performed against the running product in a real browser — what appeared on screen, at which URL, against which data — as opposed to inference from source code or database state. |
| Accessibility-tree snapshot | A structured text representation of a rendered page's semantic content. More reliable than a screenshot for asserting what a page says, and immune to animation timing. |
| Rendered surface | Any part of a ticket whose acceptance criteria describe what a person sees — a page, component, table row, chart, or email body. The conditional trigger for this requirement. |
| Gate 6 | The framework's mandatory QA stop: a merged PR moves a ticket to QA, not Done, and QA verification is required before it closes. |
| Self-concealing failure | A defect whose own output suppresses further investigation — here, a QA record asserting verification that did not occur, which stops anyone else from checking. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012h94rrcgYvaS8ytMfgAHPD