### PR TITLE
fix(#1146): parse first commit message argument

### DIFF
--- a/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
+++ b/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
@@ -140,6 +140,10 @@ run_case "newline command with later invalid commit: block" \
   $'git commit -m "fix: valid subject"\ngit commit -m "invalid subject"' 2 \
   "does not accept compound commit commands"
 
+run_case "nested commit command substitution: block" \
+  'git commit -m "fix: valid subject"$(git commit -m "invalid subject")' 2 \
+  "does not accept command substitutions"
+
 # A quoted value for another option must not impersonate a -m argument.
 run_case "trailer decoy with equals syntax: invalid subject blocks" \
   "git commit --trailer='-m \"fix: decoy\"' -m \"invalid subject\"" 2 "BLOCKED: Commit subject"

--- a/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
+++ b/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
@@ -136,6 +136,10 @@ run_case "semicolon command with later invalid commit: block" \
   'git commit -m "fix: valid subject" ; git commit -m "invalid subject"' 2 \
   "does not accept compound commit commands"
 
+run_case "newline command with later invalid commit: block" \
+  $'git commit -m "fix: valid subject"\ngit commit -m "invalid subject"' 2 \
+  "does not accept compound commit commands"
+
 # A quoted value for another option must not impersonate a -m argument.
 run_case "trailer decoy with equals syntax: invalid subject blocks" \
   "git commit --trailer='-m \"fix: decoy\"' -m \"invalid subject\"" 2 "BLOCKED: Commit subject"

--- a/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
+++ b/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
@@ -127,6 +127,15 @@ run_case "plain -m '\''quoted'\'' valid subject: pass" \
 run_case "multiple -m: valid subject and body pass" \
   'git commit -m "chore: valid subject" -m "body text"' 0 ""
 
+# A later commit in a compound command must not bypass validation.
+run_case "compound command with later invalid commit: block" \
+  'git commit -m "fix: valid subject" && git commit -m "invalid subject"' 2 \
+  "does not accept compound commit commands"
+
+run_case "semicolon command with later invalid commit: block" \
+  'git commit -m "fix: valid subject" ; git commit -m "invalid subject"' 2 \
+  "does not accept compound commit commands"
+
 # A quoted value for another option must not impersonate a -m argument.
 run_case "trailer decoy with equals syntax: invalid subject blocks" \
   "git commit --trailer='-m \"fix: decoy\"' -m \"invalid subject\"" 2 "BLOCKED: Commit subject"

--- a/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
+++ b/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
@@ -113,6 +113,16 @@ HEREDOC_DASH_CMD='git commit -m "$(cat <<-'\''EOF'\''
 run_case "heredoc-substitution <<-: skip with INFO" \
   "$HEREDOC_DASH_CMD" 0 "heredoc-substitution detected"
 
+HEREDOC_THEN_COMMIT_CMD="$HEREDOC_CMD
+git commit -m \"invalid subject\""
+run_case "heredoc followed by newline commit: block" \
+  "$HEREDOC_THEN_COMMIT_CMD" 2 "newline compound commit commands"
+
+BACKTICK=$(printf '\140')
+run_case "backtick command substitution: block" \
+  "git commit -m \"fix: valid subject\" $BACKTICK git commit -m \"invalid subject\" $BACKTICK" 2 \
+  "backtick command substitutions"
+
 # Plain non-substitution -m → still validated as before.
 run_case "plain -m valid subject: pass silently" \
   'git commit -m "feat(#194): valid subject"' 0 ""
@@ -138,7 +148,7 @@ run_case "semicolon command with later invalid commit: block" \
 
 run_case "newline command with later invalid commit: block" \
   $'git commit -m "fix: valid subject"\ngit commit -m "invalid subject"' 2 \
-  "does not accept compound commit commands"
+  "newline compound commit commands"
 
 run_case "nested commit command substitution: block" \
   'git commit -m "fix: valid subject"$(git commit -m "invalid subject")' 2 \

--- a/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
+++ b/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
@@ -123,6 +123,20 @@ run_case "plain -m bad subject: BLOCK" \
 run_case "plain -m '\''quoted'\'' valid subject: pass" \
   "git commit -m 'fix: a fix'" 0 ""
 
+# The first -m value is the subject. A later -m value becomes the body.
+run_case "multiple -m: valid subject and body pass" \
+  'git commit -m "chore: valid subject" -m "body text"' 0 ""
+
+# A quoted value for another option must not impersonate a -m argument.
+run_case "trailer decoy with equals syntax: invalid subject blocks" \
+  "git commit --trailer='-m \"fix: decoy\"' -m \"invalid subject\"" 2 "BLOCKED: Commit subject"
+
+run_case "trailer decoy with separate value: invalid subject blocks" \
+  'git commit --trailer "-m fix: decoy" -m "invalid subject"' 2 "BLOCKED: Commit subject"
+
+run_case "quoted subject text containing -m: valid subject passes" \
+  'git commit -m "fix: describe -m safely"' 0 ""
+
 # -F file path → no heredoc substitution involved, full validation runs.
 # The skip pattern is anchored on `-m \$(cat <<` literally, so -F is never
 # affected.

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -167,6 +167,11 @@ if [ "$commit_index" -lt 0 ]; then
   exit 0
 fi
 
+if printf '%s' "$COMMAND" | grep -qF '$('; then
+  echo "BLOCKED: commit-format hook does not accept command substitutions." >&2
+  exit 2
+fi
+
 token_count=${#COMMAND_TOKENS[@]}
 for ((i=0; i < token_count; i++)); do
   case "${COMMAND_TOKENS[i]}" in

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -95,12 +95,20 @@ tokenize_shell_command() {
       fi
     else
       case "$char" in
-        " "|$'\t'|$'\n')
+        " "|$'\t')
           if [ "$token_started" -eq 1 ]; then
             COMMAND_TOKENS+=("$token")
             token=""
             token_started=0
           fi
+          ;;
+        $'\n')
+          if [ "$token_started" -eq 1 ]; then
+            COMMAND_TOKENS+=("$token")
+            token=""
+            token_started=0
+          fi
+          COMMAND_TOKENS+=(";")
           ;;
         "'")
           quote="'"

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -36,6 +36,16 @@ if ! echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
   exit 0
 fi
 
+if [[ "$COMMAND" =~ $'\n'[[:space:]]*git[[:space:]]+commit ]]; then
+  echo "BLOCKED: commit-format hook does not accept newline compound commit commands." >&2
+  exit 2
+fi
+
+if printf '%s' "$COMMAND" | grep -qF "$(printf '\140')"; then
+  echo "BLOCKED: commit-format hook does not accept backtick command substitutions." >&2
+  exit 2
+fi
+
 # Heredoc-substitution short-circuit (#194):
 #
 #   git commit -m "$(cat <<'EOF'

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -63,18 +63,141 @@ if echo "$COMMAND" | grep -qE 'git[[:space:]]+commit\b[^|;&]*-m\b[^|;&]*\$\(cat[
   exit 0
 fi
 
-# Extract commit message (multi-line safe)
-COMMAND_FLAT=$(echo "$COMMAND" | tr '\n' ' ')
-MSG=""
-MSG=$(echo "$COMMAND_FLAT" | sed -nE "s/.*-m[[:space:]]+'([^']*)'.*/\1/p" | head -1)
-if [ -z "$MSG" ]; then
-  MSG=$(echo "$COMMAND_FLAT" | sed -nE 's/.*-m[[:space:]]+"([^"]*)".*/\1/p' | head -1)
-fi
-if [ -z "$MSG" ]; then
-  MSG_FILE=$(echo "$COMMAND_FLAT" | sed -nE 's/.*(-F|--file)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
-  if [ -n "$MSG_FILE" ] && [ -f "$MSG_FILE" ]; then
-    MSG=$(cat "$MSG_FILE")
+# Tokenize the command without evaluating it. The hook input is untrusted text.
+# A raw regex can mistake option text for a commit-message option. Keep shell
+# quoting intact while reading tokens, then inspect only real option tokens.
+tokenize_shell_command() {
+  local input="$1"
+  local length char token="" quote="" escaped=0 token_started=0
+  local i=0
+
+  COMMAND_TOKENS=()
+  length=${#input}
+  while [ "$i" -lt "$length" ]; do
+    char=${input:i:1}
+
+    if [ -n "$quote" ]; then
+      if [ "$quote" = "'" ]; then
+        if [ "$char" = "'" ]; then
+          quote=""
+        else
+          token+="$char"
+        fi
+      elif [ "$escaped" -eq 1 ]; then
+        token+="$char"
+        escaped=0
+      elif [ "$char" = "\\" ]; then
+        escaped=1
+      elif [ "$char" = '"' ]; then
+        quote=""
+      else
+        token+="$char"
+      fi
+    else
+      case "$char" in
+        " "|$'\t'|$'\n')
+          if [ "$token_started" -eq 1 ]; then
+            COMMAND_TOKENS+=("$token")
+            token=""
+            token_started=0
+          fi
+          ;;
+        "'")
+          quote="'"
+          token_started=1
+          ;;
+        '"')
+          quote='"'
+          token_started=1
+          ;;
+        "\\")
+          escaped=1
+          token_started=1
+          ;;
+        ";"|"|"|"&"|"<"|">")
+          if [ "$token_started" -eq 1 ]; then
+            COMMAND_TOKENS+=("$token")
+            token=""
+            token_started=0
+          fi
+          COMMAND_TOKENS+=("$char")
+          ;;
+        *)
+          token+="$char"
+          token_started=1
+          ;;
+      esac
+    fi
+
+    i=$((i + 1))
+  done
+
+  if [ -n "$quote" ] || [ "$escaped" -eq 1 ]; then
+    return 1
   fi
+  if [ "$token_started" -eq 1 ]; then
+    COMMAND_TOKENS+=("$token")
+  fi
+  return 0
+}
+
+if ! tokenize_shell_command "$COMMAND"; then
+  echo "BLOCKED: commit-format hook cannot safely parse this commit command." >&2
+  exit 2
+fi
+
+token_count=${#COMMAND_TOKENS[@]}
+commit_index=-1
+for ((i=0; i + 1 < token_count; i++)); do
+  if [ "${COMMAND_TOKENS[i]}" = "git" ] && [ "${COMMAND_TOKENS[i + 1]}" = "commit" ]; then
+    commit_index=$((i + 2))
+    break
+  fi
+done
+
+if [ "$commit_index" -lt 0 ]; then
+  exit 0
+fi
+
+MSG=""
+MSG_FILE=""
+for ((i=commit_index; i < token_count; i++)); do
+  token="${COMMAND_TOKENS[i]}"
+  case "$token" in
+    ";"|"|"|"&"|"<"|">")
+      break
+      ;;
+    -m|--message)
+      next=$((i + 1))
+      if [ "$next" -ge "$token_count" ]; then
+        echo "BLOCKED: commit-format hook found -m without a message." >&2
+        exit 2
+      fi
+      MSG="${COMMAND_TOKENS[next]}"
+      break
+      ;;
+    --message=*)
+      MSG="${token#--message=}"
+      break
+      ;;
+    -F|--file)
+      next=$((i + 1))
+      if [ "$next" -ge "$token_count" ]; then
+        echo "BLOCKED: commit-format hook found -F without a file." >&2
+        exit 2
+      fi
+      MSG_FILE="${COMMAND_TOKENS[next]}"
+      break
+      ;;
+    --file=*)
+      MSG_FILE="${token#--file=}"
+      break
+      ;;
+  esac
+done
+
+if [ -z "$MSG" ] && [ -n "$MSG_FILE" ] && [ -f "$MSG_FILE" ]; then
+  MSG=$(cat "$MSG_FILE")
 fi
 
 if [ -z "$MSG" ]; then

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -159,6 +159,16 @@ if [ "$commit_index" -lt 0 ]; then
   exit 0
 fi
 
+token_count=${#COMMAND_TOKENS[@]}
+for ((i=0; i < token_count; i++)); do
+  case "${COMMAND_TOKENS[i]}" in
+    ";"|"|"|"&"|"<"|">")
+      echo "BLOCKED: commit-format hook does not accept compound commit commands." >&2
+      exit 2
+      ;;
+  esac
+done
+
 MSG=""
 MSG_FILE=""
 for ((i=commit_index; i < token_count; i++)); do

--- a/docs/agdr/AgDR-0135-safe-commit-command-tokenization.md
+++ b/docs/agdr/AgDR-0135-safe-commit-command-tokenization.md
@@ -1,0 +1,38 @@
+# AgDR-0135: Parse Commit Options Without Evaluation
+
+## Context
+
+Issue [#1146](https://github.com/me2resh/apexyard/issues/1146) reports that the
+commit-format hook validates the last message paragraph. Git uses the first
+-m value as the subject.
+
+A raw-pattern change can create a bypass. Text in another option can resemble
+a message option. The hook input must not be evaluated.
+
+## Options Considered
+
+1. Keep the greedy raw-pattern extractor.
+2. Search the raw command for the first -m pattern.
+3. Tokenize the command without evaluation.
+
+## Decision
+
+Use a small Bash tokenizer. It preserves quoted values and identifies actual
+Git option tokens. It does not execute command text.
+
+The hook reads the first -m or --message option after git commit. It keeps the
+existing file-message support. It blocks an incomplete option and an unsafe
+command shape.
+
+## Consequences
+
+A normal subject plus body command now passes. A quoted value in --trailer
+cannot impersonate a message option. The tests cover both outcomes.
+
+The tokenizer supports the command shapes that the hook already supports.
+Complex shell syntax remains subject to the existing heredoc exception.
+
+## References
+
+- Ticket: me2resh/apexyard#1146
+- Review: me2resh/apexyard#1194

--- a/docs/agdr/AgDR-0135-safe-commit-command-tokenization.md
+++ b/docs/agdr/AgDR-0135-safe-commit-command-tokenization.md
@@ -27,7 +27,8 @@ command shape.
 ## Consequences
 
 A normal subject plus body command now passes. A quoted value in --trailer
-cannot impersonate a message option. The tests cover both outcomes.
+cannot impersonate a message option. A compound command that contains a
+commit now fails closed. The tests cover these outcomes.
 
 The tokenizer supports the command shapes that the hook already supports.
 Complex shell syntax remains subject to the existing heredoc exception.


### PR DESCRIPTION
## Summary

- The commit-format hook now reads command tokens without evaluating command text. It validates the first actual -m message, which matches Git behavior.
- A quoted value passed to --trailer cannot imitate a commit-message option. This keeps the validation control effective.
- The regression tests cover a valid subject with a body, two trailer decoys, and quoted subject text. AgDR-0135 records the parsing decision.

## Testing

1. bash .claude/hooks/tests/test_validate_commit_format_heredoc.sh
2. bash .claude/hooks/tests/test_fail_closed_json.sh
3. bash .claude/rules/tests/test_writing_standard.sh
4. bash .claude/hooks/tests/test_quality_regression.sh

## Glossary

| Term | Definition |
|---|---|
| Subject | The first line of a commit message. |
| Tokenizer | A reader that separates command arguments without running command text. |
| Decoy | Text in another option that resembles a message option. |

Closes #1146
