### PR TITLE
fix(#1200): fail closed on unresolved PR base

### DIFF
--- a/.claude/hooks/_lib-review-markers.sh
+++ b/.claude/hooks/_lib-review-markers.sh
@@ -138,9 +138,8 @@ review_marker_path() {
 # `gh pr view` exposes no baseRepository field, but the PR URL is ALWAYS rooted
 # on the base repo — parse owner/repo from it (handles GitHub /pull/ and GitLab
 # /-/merge_requests/, including nested GitLab groups). Falls back to the passed
-# <repo> when the URL can't be parsed or the scoped gh call fails — so SAME-REPO
-# PRs (base == head) resolve exactly as before and this change is a provable
-# no-op for them.
+# <repo> when the URL cannot be parsed or the scoped gh call fails. Returning
+# the caller's repo would create a marker that the merge gate cannot read.
 #
 # Args:
 #   pr    — the PR/MR number.
@@ -148,11 +147,9 @@ review_marker_path() {
 #           this PR. Used to SCOPE the gh query (`--repo`), never omitted in
 #           favour of gh's ambient default.
 #
-# Output (stdout): "owner/repo" derived from the resolved PR URL, or the
-# passed-in <repo> when the scoped query fails/is unparseable (fail-soft — the
-# caller's own repo is still the best available answer).
-# Exit code: 0 normally; 1 (with a stderr message, no stdout) when <pr> is
-# given but <repo> is missing — there is nothing safe to scope the query to.
+# Output (stdout): "owner/repo" derived from the resolved PR URL.
+# Exit code: 0 on a parsed PR URL; 1 with no stdout when the query fails, the
+# URL is unparseable, or <repo> is missing.
 pr_base_repo() {
   local pr="${1:-}" repo="${2:-}" url base
   if [ -z "$pr" ]; then
@@ -165,12 +162,16 @@ pr_base_repo() {
   fi
   # ALWAYS scoped to the caller-supplied repo — never an unscoped/ambient gh
   # call. See the WHY-A-REQUIRED-REPO note above.
-  url=$(gh pr view "$pr" --repo "$repo" --json url,baseRefName --jq '.url' 2>/dev/null)
+  url=$(gh pr view "$pr" --repo "$repo" --json url,baseRefName --jq '.url' 2>/dev/null) || {
+    echo "_lib-review-markers.sh: cannot resolve PR #$pr in base repo $repo; no review marker written" >&2
+    return 1
+  }
   base=$(printf '%s' "$url" | sed -E 's#^https?://[^/]+/(.+)/(pull|-/merge_requests)/[0-9].*#\1#')
   if [ -n "$base" ] && [ "$base" != "$url" ]; then
     printf '%s' "$base"
   else
-    printf '%s' "$repo"
+    echo "_lib-review-markers.sh: cannot parse base repo from PR #$pr URL; no review marker written" >&2
+    return 1
   fi
 }
 

--- a/.claude/hooks/tests/test_pr_base_repo.sh
+++ b/.claude/hooks/tests/test_pr_base_repo.sh
@@ -88,15 +88,14 @@ seturl 'https://gitlab.com/grp/sub/proj/-/merge_requests/12'
 assert_eq "glab nested MR → base confirmed via scoped query" "grp/sub/proj" \
   "$(pr_base_repo 12 grp/sub/proj)"
 
-# 4. gh fails (no URL queued) → fall back to the passed-in repo.
+# 4. gh fails (no URL queued) → fail loudly; do not create a gate-invisible marker.
 seturl ''
-assert_eq "gh fail → repo fallback" "me2resh/apexyard" \
+assert_eq "gh fail → no marker repo" "" \
   "$(pr_base_repo 999 me2resh/apexyard)"
 
-# 5. unparseable URL → repo fallback (sed leaves it unchanged → base==url →
-#    the mock's own base/repo comparison fails closed → repo fallback fires).
+# 5. unparseable URL → fail loudly; do not create a gate-invisible marker.
 seturl 'https://github.com/not-a-pr-url'
-assert_eq "bad URL → repo fallback" "owner/repo" \
+assert_eq "bad URL → no marker repo" "" \
   "$(pr_base_repo 1 owner/repo)"
 
 # 6. no pr number → repo (guard, no gh call).
@@ -109,13 +108,11 @@ assert_eq "missing repo w/ pr → empty (error path, not a silent guess)" "" \
   "$(pr_base_repo 5 2>/dev/null)"
 
 # 8. wrong repo passed (e.g. the head/fork of a genuine cross-fork PR) → the
-#    scoped query fails closed and returns the passed repo itself — NOT an
-#    ambient guess at some unrelated repo. Documents the contract: callers
-#    must pass the repo they're confident hosts the PR; passing the wrong one
-#    degrades safely rather than silently returning wrong data.
+#    scoped query fails closed and returns no repo. This prevents a marker from
+#    being written under a path that the merge gate cannot read.
 seturl 'https://github.com/me2resh/apexyard/pull/762'
-assert_eq "wrong (head/fork) repo passed → fails closed, returns itself" \
-  "AbdElrahmaN31/apexyard" "$(pr_base_repo 762 AbdElrahmaN31/apexyard)"
+assert_eq "wrong (head/fork) repo passed → fails closed, returns no repo" \
+  "" "$(pr_base_repo 762 AbdElrahmaN31/apexyard)"
 
 # 9. self-hosted GitHub Enterprise host → base still parsed (host-agnostic),
 #    confirmed via the correct repo.


### PR DESCRIPTION
## Summary

- Stop `pr_base_repo` when the scoped PR lookup fails.
- Stop `pr_base_repo` when the PR URL has no valid base repository.
- Prevent review markers from being written under a repository path that merge gates do not read.

## Validation

- `bash .claude/hooks/tests/test_pr_base_repo.sh` — 12/12 pass.
- `git diff --check` — pass.

## Glossary

| Term | Definition |
|------|------------|
| Base repository | The repository that hosts the pull request. |
| Review marker | A file that records an approved review. |
| Fail closed | Stop the operation when the required repository cannot be verified. |

Refs #1200
