### PR TITLE
fix(#1184): normalize linked worktree ops roots

### DIFF
--- a/.claude/hooks/_lib-ops-root.sh
+++ b/.claude/hooks/_lib-ops-root.sh
@@ -108,6 +108,16 @@ resolve_ops_root_walk() {
   canon=$(cd "$start" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || canon=""
   [ -n "$canon" ] && start="$canon"
 
+  # A linked worktree has a worktree-local .git file, but its common git
+  # directory belongs to the main checkout. Use that shared directory to
+  # normalize the starting point before looking for ops-root anchors.
+  local common main
+  common=$(git -C "$start" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || common=""
+  if [ -n "$common" ] && [ "$common" != "$start/.git" ]; then
+    main=$(dirname "$common")
+    [ -d "$main" ] && start="$main"
+  fi
+
   local r="$start"
   while [ -n "$r" ] && [ "$r" != "/" ]; do
     # v2 anchor (preferred): the explicit .apexyard-fork marker file.

--- a/.claude/hooks/_lib-ops-root.sh
+++ b/.claude/hooks/_lib-ops-root.sh
@@ -81,6 +81,19 @@
 [ -n "${_LIB_OPS_ROOT_SOURCED:-}" ] && return 0
 _LIB_OPS_ROOT_SOURCED=1
 
+# Return the main worktree for a path inside a Git worktree. Return the input
+# path when Git cannot provide a shared directory.
+_ops_root_main_worktree() {
+  local path="${1:-}" common main
+  [ -n "$path" ] || return 1
+  common=$(git -C "$path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
+    printf '%s' "$path"
+    return 0
+  }
+  main=$(dirname "$common")
+  [ -d "$main" ] && printf '%s' "$main" || printf '%s' "$path"
+}
+
 # Pure walk-up. Recognises BOTH the v2 .apexyard-fork marker AND the
 # legacy v1 (onboarding.yaml + apexyard.projects.yaml) pair. Never
 # touches the pin.
@@ -111,12 +124,7 @@ resolve_ops_root_walk() {
   # A linked worktree has a worktree-local .git file, but its common git
   # directory belongs to the main checkout. Use that shared directory to
   # normalize the starting point before looking for ops-root anchors.
-  local common main
-  common=$(git -C "$start" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || common=""
-  if [ -n "$common" ] && [ "$common" != "$start/.git" ]; then
-    main=$(dirname "$common")
-    [ -d "$main" ] && start="$main"
-  fi
+  start=$(_ops_root_main_worktree "$start")
 
   local r="$start"
   while [ -n "$r" ] && [ "$r" != "/" ]; do
@@ -242,8 +250,10 @@ resolve_ops_root() {
       # literal. The single read is the whole file; we ignore any
       # subsequent lines (defensive against future format expansion).
       IFS= read -r pinned < "$pin_file" || pinned=""
-      if [ -n "$pinned" ] && _ops_root_anchor_valid "$pinned"; then
-        printf '%s' "$pinned"
+      local normalized_pin
+      normalized_pin=$(_ops_root_main_worktree "$pinned")
+      if [ -n "$normalized_pin" ] && _ops_root_anchor_valid "$normalized_pin"; then
+        printf '%s' "$normalized_pin"
         return 0
       fi
       # Pin present but stale (path no longer satisfies anchors).

--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -100,6 +100,10 @@ _portfolio_root() {
   fi
 
   # Prefer the shared, pin-aware resolver when available
+  # Worktree audit (#1184): `r` can be a linked-worktree root. The shared
+  # resolver normalizes it to the main worktree before checking anchors. Keep
+  # this fallback walk only for environments where that library is unavailable;
+  # it preserves the managed-project behavior documented below.
   # (me2resh/apexyard#1013): resolve_ops_root() already has its own
   # cross-process cache (the ops-root-<session> pin, #381), so consulting
   # it here avoids redoing the walk-up below on every process when a pin

--- a/.claude/hooks/tests/test_resolve_ops_root_pin.sh
+++ b/.claude/hooks/tests/test_resolve_ops_root_pin.sh
@@ -313,9 +313,15 @@ case_9() {
   git -C "$sb" worktree add -q -b outside "$outside"
   (
     unset CLAUDE_CODE_SESSION_ID APEXYARD_OPS_DISABLE_PIN
+    # shellcheck source=/dev/null
     . "$LIB"
     [ "$(cd "$nested" && resolve_ops_root_walk)" = "$expected" ] || return 1
     [ "$(cd "$outside" && resolve_ops_root_walk)" = "$expected" ] || return 1
+    pin_dir=$(mktemp -d)
+    printf '%s\n' "$nested" > "$pin_dir/ops-root-linked"
+    export CLAUDE_CODE_SESSION_ID=linked
+    export APEXYARD_OPS_PIN_DIR="$pin_dir"
+    [ "$(cd "$nested" && resolve_ops_root)" = "$expected" ] || return 1
   )
   if [ "$?" -ne 0 ]; then
     mark_fail "$case_name" "linked worktree did not normalize to '$expected'"

--- a/.claude/hooks/tests/test_resolve_ops_root_pin.sh
+++ b/.claude/hooks/tests/test_resolve_ops_root_pin.sh
@@ -296,8 +296,36 @@ case_8() {
   mark_pass "$case_name"
 }
 
+# Case 9: nested and out-of-tree linked worktrees resolve to the main root.
+case_9() {
+  local case_name="linked worktrees: nested and out-of-tree resolve to main root"
+  local sb nested outside expected
+  sb=$(mktemp -d)
+  nested="$sb/.claude/worktrees/nested"
+  outside=$(mktemp -d)/linked
+  mkdir -p "$sb/.claude/worktrees"
+  git -C "$sb" init -q
+  : > "$sb/.apexyard-fork"
+  git -C "$sb" add .apexyard-fork
+  git -C "$sb" -c user.email=test@example.invalid -c user.name=test commit -qm init
+  expected=$(git -C "$sb" rev-parse --show-toplevel)
+  git -C "$sb" worktree add -q -b nested "$nested"
+  git -C "$sb" worktree add -q -b outside "$outside"
+  (
+    unset CLAUDE_CODE_SESSION_ID APEXYARD_OPS_DISABLE_PIN
+    . "$LIB"
+    [ "$(cd "$nested" && resolve_ops_root_walk)" = "$expected" ] || return 1
+    [ "$(cd "$outside" && resolve_ops_root_walk)" = "$expected" ] || return 1
+  )
+  if [ "$?" -ne 0 ]; then
+    mark_fail "$case_name" "linked worktree did not normalize to '$expected'"
+    return
+  fi
+  mark_pass "$case_name"
+}
+
 echo "Running pin-first resolve_ops_root tests..."
-for fn in case_1 case_2 case_3 case_4 case_5 case_6 case_7 case_8; do
+for fn in case_1 case_2 case_3 case_4 case_5 case_6 case_7 case_8 case_9; do
   run_case "$fn"
 done
 

--- a/docs/agdr/AgDR-0135-normalize-linked-worktree-ops-root.md
+++ b/docs/agdr/AgDR-0135-normalize-linked-worktree-ops-root.md
@@ -1,0 +1,40 @@
+---
+id: AgDR-0135
+timestamp: 2026-09-08T06:00:00Z
+agent: Codex
+model: GPT-6
+session: issue-1184
+trigger: user-prompt
+status: executed
+category: architecture
+---
+
+# Normalize linked worktrees to the main ops root
+
+> In the context of linked worktrees for an ops fork, facing split review-marker state, I decided to resolve the main worktree from Git's common directory data to keep gate state in one location, accepting the need to handle stale pins.
+
+## Context
+
+`resolve_ops_root` can return a linked worktree instead of the main ops-fork checkout. Review markers then use different roots depending on the worktree. A merge gate can miss a valid approval. The resolver must work for nested and out-of-tree linked worktrees.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Remove the tracked `.apexyard-fork` anchor | Simple walk-up change | Does not fix out-of-tree worktrees and requires migration. |
+| Normalize linked worktrees to the main worktree | Uses Git metadata and covers all worktree locations | Requires resolver and pin tests. |
+| Copy markers between worktrees | No resolver change | Creates ambiguous and unsafe approval state. |
+
+## Decision
+
+Chosen: **Normalize linked worktrees to the main worktree**, because Git provides authoritative common-directory data and one root keeps review markers consistent.
+
+## Consequences
+
+- Resolver callers receive one ops-fork root from main and linked worktrees.
+- Existing stale pins must normalize or fail closed.
+- Tests must cover nested, out-of-tree, pinned, and pinless worktrees.
+
+## Artifacts
+
+- Issue: https://github.com/me2resh/apexyard/issues/1184


### PR DESCRIPTION
## Summary

- Resolve linked worktrees to the main repository worktree before finding the ops root.
- Cover nested and out-of-tree linked worktrees.
- Add regression tests and record the architecture decision in AgDR-0135.

This keeps review markers in one shared root when work runs in an isolated worktree.

## Validation

- `bash .claude/hooks/tests/test_resolve_ops_root_pin.sh` — 9/9 pass.
- `git diff --check` — pass.

## Glossary

| Term | Definition |
|------|------------|
| Linked worktree | An extra checkout that shares Git data with the main checkout. |
| Main worktree | The original checkout that owns the shared Git directory. |
| Ops root | The directory that stores framework state and review markers. |

Refs #1184
