### PR TITLE
test(#1145): cover write detector false positives

### DIFF
--- a/.claude/hooks/tests/test_detect_bash_write.sh
+++ b/.claude/hooks/tests/test_detect_bash_write.sh
@@ -499,6 +499,25 @@ assert_read   "2>&1 fd-dup still excluded alongside the new exclusion (#931)" \
 assert_read   ">&2 fd-dup still excluded alongside the new exclusion (#931)" \
   "echo err >&2"
 
+# #1145: command substitutions and heredoc bodies are data, not file-write
+# targets. Keep the detector from reading ordinary prose as a shell command.
+assert_read "printf in command substitution is read-only (#1145)" \
+  'result="$(printf "%s" "$result" | jq -r .url)"'
+assert_targets "printf substitution has no write target (#1145)" \
+  'result="$(printf "%s" "$result" | jq -r .url)"' ""
+assert_read "git commit heredoc body is not a file write (#1145)" \
+  "git commit -F - <<'MSG'
+chore: subject
+
+Body prose ending in portfolio.
+MSG"
+assert_targets "heredoc prose has no fabricated target (#1145)" \
+  "git commit -F - <<'MSG'
+chore: subject
+
+Body prose ending in portfolio.
+MSG" ""
+
 echo ""
 echo "==================================="
 echo "  PASS: $PASS   FAIL: $FAIL"


### PR DESCRIPTION
## Summary

- Add regression cases for `printf` inside a command substitution.
- Add regression cases for heredoc commit text that contains ordinary prose.
- Confirm both cases stay read-only and produce no write target.

The detector already passes these cases on `dev`; this PR records the protection so later matcher changes cannot reintroduce the false positives.

## Validation

- `bash .claude/hooks/tests/test_detect_bash_write.sh` — 164/164 pass.
- `git diff --check` — pass.

## Glossary

| Term | Definition |
|------|------------|
| Write detector | The helper that identifies Bash commands that write files. |
| Command substitution | Shell syntax that captures command output as a value. |
| Heredoc | Text sent to a command through standard input. |

Refs #1145
