### PR TITLE
fix(#1146): block heredoc compound commands

### DIFF
--- a/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
+++ b/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
@@ -148,6 +148,12 @@ run_case "heredoc followed by pipe commit: block" \
   "$HEREDOC_CMD | git commit -m \"invalid subject\"" 2 \
   "does not accept compound commit commands"
 
+HEREDOC_CONTINUED_COMMIT_CMD="$HEREDOC_CMD \\
+&& git commit -m \"invalid subject\""
+run_case "heredoc followed by continued and commit: block" \
+  "$HEREDOC_CONTINUED_COMMIT_CMD" 2 \
+  "does not accept compound commit commands"
+
 BACKTICK=$(printf '\140')
 run_case "backtick command substitution: block" \
   "git commit -m \"fix: valid subject\" $BACKTICK git commit -m \"invalid subject\" $BACKTICK" 2 \

--- a/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
+++ b/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
@@ -113,6 +113,24 @@ HEREDOC_DASH_CMD='git commit -m "$(cat <<-'\''EOF'\''
 run_case "heredoc-substitution <<-: skip with INFO" \
   "$HEREDOC_DASH_CMD" 0 "heredoc-substitution detected"
 
+# Shell-looking text in a heredoc is part of the commit message. It must not
+# be mistaken for a command chained after the outer `git commit` invocation.
+for operator in ';' '&&' '|'; do
+  BODY_OPERATOR_CMD="git commit -m \"\$(cat <<'EOF'
+body text ${operator} git commit -m \\\"not a command\\\"
+EOF
+)\""
+  run_case "heredoc body containing ${operator} git commit: skip with INFO" \
+    "$BODY_OPERATOR_CMD" 0 "heredoc-substitution detected"
+done
+
+BODY_CLOSER_TEXT_CMD='git commit -m "$(cat <<'"'"'EOF'"'"'
+) && git commit -m "still literal body text"
+EOF
+)"'
+run_case "heredoc body resembling a substitution close: skip with INFO" \
+  "$BODY_CLOSER_TEXT_CMD" 0 "heredoc-substitution detected"
+
 HEREDOC_THEN_COMMIT_CMD="$HEREDOC_CMD
 git commit -m \"invalid subject\""
 run_case "heredoc followed by newline commit: block" \

--- a/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
+++ b/.claude/hooks/tests/test_validate_commit_format_heredoc.sh
@@ -118,6 +118,18 @@ git commit -m \"invalid subject\""
 run_case "heredoc followed by newline commit: block" \
   "$HEREDOC_THEN_COMMIT_CMD" 2 "newline compound commit commands"
 
+run_case "heredoc followed by semicolon commit: block" \
+  "$HEREDOC_CMD ; git commit -m \"invalid subject\"" 2 \
+  "does not accept compound commit commands"
+
+run_case "heredoc followed by and commit: block" \
+  "$HEREDOC_CMD && git commit -m \"invalid subject\"" 2 \
+  "does not accept compound commit commands"
+
+run_case "heredoc followed by pipe commit: block" \
+  "$HEREDOC_CMD | git commit -m \"invalid subject\"" 2 \
+  "does not accept compound commit commands"
+
 BACKTICK=$(printf '\140')
 run_case "backtick command substitution: block" \
   "git commit -m \"fix: valid subject\" $BACKTICK git commit -m \"invalid subject\" $BACKTICK" 2 \

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -46,6 +46,11 @@ if printf '%s' "$COMMAND" | grep -qF "$(printf '\140')"; then
   exit 2
 fi
 
+if echo "$COMMAND" | grep -qE '(;|&&|&|\|)[[:space:]]*git[[:space:]]+commit\b'; then
+  echo "BLOCKED: commit-format hook does not accept compound commit commands." >&2
+  exit 2
+fi
+
 # Heredoc-substitution short-circuit (#194):
 #
 #   git commit -m "$(cat <<'EOF'

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -52,10 +52,11 @@ fi
 # that body as executable shell syntax.
 has_heredoc_compound_commit() {
   local cmd="$1" line marker delimiter check_line
-  local in_heredoc=0 strip_tabs=0 awaiting_close=0
+  local in_heredoc=0 strip_tabs=0 awaiting_close=0 awaiting_connector=0
   local tab
   tab="$(printf '\t')"
   local close_compound_re='^[[:space:]]*\)"?[[:space:]]*(;|&&|&|\|)[[:space:]]*git[[:space:]]+commit([[:space:]]|$)'
+  local close_continuation_re='^[[:space:]]*\)"?[[:space:]]*\\[[:space:]]*$'
 
   while IFS= read -r line || [ -n "$line" ]; do
     if [ "$in_heredoc" -eq 1 ]; then
@@ -76,9 +77,23 @@ has_heredoc_compound_commit() {
       if [[ "$line" =~ $close_compound_re ]]; then
         return 0
       fi
+      if [[ "$line" =~ $close_continuation_re ]]; then
+        awaiting_close=0
+        awaiting_connector=1
+        continue
+      fi
       # Blank lines are permitted before the command substitution closes.
       if [[ ! "$line" =~ ^[[:space:]]*$ ]]; then
         awaiting_close=0
+      fi
+    fi
+
+    if [ "$awaiting_connector" -eq 1 ]; then
+      if [[ "$line" =~ ^[[:space:]]*(;|&&|&|\|)[[:space:]]*git[[:space:]]+commit([[:space:]]|$) ]]; then
+        return 0
+      fi
+      if [[ ! "$line" =~ ^[[:space:]]*$ ]]; then
+        awaiting_connector=0
       fi
     fi
 

--- a/.claude/hooks/validate-commit-format.sh
+++ b/.claude/hooks/validate-commit-format.sh
@@ -46,7 +46,61 @@ if printf '%s' "$COMMAND" | grep -qF "$(printf '\140')"; then
   exit 2
 fi
 
-if echo "$COMMAND" | grep -qE '(;|&&|&|\|)[[:space:]]*git[[:space:]]+commit\b'; then
+# Detect a second commit chained *after* a confirmed heredoc substitution.
+# The heredoc body is literal commit-message content, so raw command scans
+# must not interpret `; git commit`, `&& git commit`, or `| git commit` in
+# that body as executable shell syntax.
+has_heredoc_compound_commit() {
+  local cmd="$1" line marker delimiter check_line
+  local in_heredoc=0 strip_tabs=0 awaiting_close=0
+  local tab
+  tab="$(printf '\t')"
+  local close_compound_re='^[[:space:]]*\)"?[[:space:]]*(;|&&|&|\|)[[:space:]]*git[[:space:]]+commit([[:space:]]|$)'
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [ "$in_heredoc" -eq 1 ]; then
+      check_line="$line"
+      if [ "$strip_tabs" -eq 1 ]; then
+        while [ "${check_line:0:1}" = "$tab" ]; do
+          check_line="${check_line:1}"
+        done
+      fi
+      if [ "$check_line" = "$delimiter" ]; then
+        in_heredoc=0
+        awaiting_close=1
+      fi
+      continue
+    fi
+
+    if [ "$awaiting_close" -eq 1 ]; then
+      if [[ "$line" =~ $close_compound_re ]]; then
+        return 0
+      fi
+      # Blank lines are permitted before the command substitution closes.
+      if [[ ! "$line" =~ ^[[:space:]]*$ ]]; then
+        awaiting_close=0
+      fi
+    fi
+
+    # Match only the supported `$(cat <<EOF` shape that this hook already
+    # recognises for the heredoc-substitution skip below. A terminator must
+    # be found before any text is treated as a literal heredoc body.
+    marker=$(printf '%s\n' "$line" | sed -nE "s/.*\\$\\(cat[[:space:]]+<<(-?)[[:space:]]*['\\\"]?([A-Za-z_][A-Za-z0-9_]*)['\\\"]?[[:space:]]*$/\\1:\\2/p")
+    if [ -z "$marker" ]; then
+      continue
+    fi
+    strip_tabs=0
+    case "$marker" in
+      -:*) strip_tabs=1 ;;
+    esac
+    delimiter="${marker#*:}"
+    in_heredoc=1
+  done <<< "$cmd"
+
+  return 1
+}
+
+if has_heredoc_compound_commit "$COMMAND"; then
   echo "BLOCKED: commit-format hook does not accept compound commit commands." >&2
   exit 2
 fi


### PR DESCRIPTION
## Summary

- The commit-format hook now blocks a compound command after a heredoc message. This prevents a later commit from bypassing subject validation.
- Regression cases cover semicolon, AND, and pipe connectors after a heredoc message. This keeps the existing heredoc exception for one commit.

## Testing

1. bash .claude/hooks/tests/test_validate_commit_format_heredoc.sh
2. bash .claude/hooks/tests/test_fail_closed_json.sh
3. bash .claude/hooks/tests/test_quality_regression.sh

## Glossary

| Term | Definition |
|---|---|
| Heredoc | Shell input written between a start marker and an end marker. |
| Compound command | A shell command that joins commands with a connector. |

Closes #1146
