### PR TITLE
fix(#1218): scan staged private references

### DIFF
--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -790,9 +790,6 @@ tracker_create() {
 
   local kind
   kind=$(tracker_kind "$repo")
-  if [ "$kind" != "none" ]; then
-    _tracker_check_private_refs "$repo" "" "$body_file" || return $?
-  fi
   case "$kind" in
     none)
       # Shape-only mode (tracker.kind=none): no tracker CLI to call. Emit the
@@ -1062,9 +1059,6 @@ tracker_list() {
   # override, else the global block (never cwd, never a session marker).
   local kind
   kind=$(tracker_kind "$repo")
-  if [ "$kind" != "none" ]; then
-    _tracker_check_private_refs "$repo" "$subject" "$body_file" || return $?
-  fi
   case "$kind" in
     none)
       printf '[]\n'
@@ -1314,6 +1308,7 @@ tracker_review_submit() {
 
   local kind
   kind=$(tracker_kind "$repo")
+  [ "$kind" = "none" ] || _tracker_check_private_refs "$repo" "" "$body_file" || return $?
   case "$kind" in
     none)
       # Shape-only mode: no git-host CLI to call. Emit the review body (if given)
@@ -1654,6 +1649,7 @@ tracker_pr_merge() {
 
   local kind
   kind=$(tracker_kind "$repo")
+  [ "$kind" = "none" ] || _tracker_check_private_refs "$repo" "$subject" "$body_file" || return $?
   case "$kind" in
     none)
       # Shape-only mode: no git-host CLI to call. Nothing to echo (unlike

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -681,9 +681,22 @@ _tracker_extract_ref_url() {
   jq -nc --arg ref "$ref" --arg url "$url" '{ref:$ref, url:$url}' 2>/dev/null
 }
 
+_tracker_check_private_refs() {
+  local repo="$1" title="${2:-}" body_file="${3:-}"
+  local tracker_lib_dir
+  tracker_lib_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || return 2
+  local scanner="$tracker_lib_dir/check-private-refs-runtime.sh"
+  if [ ! -x "$scanner" ]; then
+    echo "BLOCKED: private-reference runtime scanner is missing or not executable." >&2
+    return 2
+  fi
+  "$scanner" "$repo" "$title" "$body_file"
+}
+
 # Internal adapter: gh → run `gh issue create` with safe arg passing.
 _tracker_create_gh() {
   local repo="$1" title="$2" body_file="$3" labels="$4"
+  _tracker_check_private_refs "$repo" "$title" "$body_file" || return $?
   local -a args
   args=(issue create --repo "$repo" --title "$title")
   if [ -n "$body_file" ] && [ -f "$body_file" ]; then
@@ -1182,6 +1195,7 @@ tracker_label_ensure() {
 # expected self-approval refusal noise; gh's exit status still propagates.
 _tracker_review_gh() {
   local repo="$1" pr="$2" verdict="$3" body_file="$4"
+  _tracker_check_private_refs "$repo" "" "$body_file" || return $?
   local -a args
   args=(pr review "$pr" --repo "$repo")
   case "$verdict" in
@@ -1462,6 +1476,7 @@ _tracker_merge_normalise_delete_branch() {
 # string), so neither can be mistaken for a flag or shell syntax.
 _tracker_merge_gh() {
   local repo="$1" pr="$2" strategy="$3" delete_branch="$4" subject="${5:-}" body_file="${6:-}"
+  _tracker_check_private_refs "$repo" "$subject" "$body_file" || return $?
   local -a args
   args=(pr merge "$pr" --repo "$repo")
   case "$strategy" in

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -696,7 +696,6 @@ _tracker_check_private_refs() {
 # Internal adapter: gh → run `gh issue create` with safe arg passing.
 _tracker_create_gh() {
   local repo="$1" title="$2" body_file="$3" labels="$4"
-  _tracker_check_private_refs "$repo" "$title" "$body_file" || return $?
   local -a args
   args=(issue create --repo "$repo" --title "$title")
   if [ -n "$body_file" ] && [ -f "$body_file" ]; then
@@ -791,6 +790,9 @@ tracker_create() {
 
   local kind
   kind=$(tracker_kind "$repo")
+  if [ "$kind" != "none" ]; then
+    _tracker_check_private_refs "$repo" "" "$body_file" || return $?
+  fi
   case "$kind" in
     none)
       # Shape-only mode (tracker.kind=none): no tracker CLI to call. Emit the
@@ -803,6 +805,8 @@ tracker_create() {
       return 3
       ;;
   esac
+
+  _tracker_check_private_refs "$repo" "$title" "$body_file" || return $?
 
   local raw rc
   case "$kind" in
@@ -1058,6 +1062,9 @@ tracker_list() {
   # override, else the global block (never cwd, never a session marker).
   local kind
   kind=$(tracker_kind "$repo")
+  if [ "$kind" != "none" ]; then
+    _tracker_check_private_refs "$repo" "$subject" "$body_file" || return $?
+  fi
   case "$kind" in
     none)
       printf '[]\n'

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -683,8 +683,16 @@ _tracker_extract_ref_url() {
 
 _tracker_check_private_refs() {
   local repo="$1" title="${2:-}" body_file="${3:-}"
-  local tracker_lib_dir
-  tracker_lib_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || return 2
+  local tracker_lib_dir="" root
+  if [ -n "${BASH_SOURCE[0]:-}" ]; then
+    tracker_lib_dir=$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd) || tracker_lib_dir=""
+  fi
+  if [ -z "$tracker_lib_dir" ] || [ ! -f "$tracker_lib_dir/check-private-refs-runtime.sh" ]; then
+    root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    if [ -n "$root" ] && { [ -f "$root/.apexyard-fork" ] || { [ -f "$root/onboarding.yaml" ] && [ -f "$root/apexyard.projects.yaml" ]; }; }; then
+      tracker_lib_dir="$root/.claude/hooks"
+    fi
+  fi
   local scanner="$tracker_lib_dir/check-private-refs-runtime.sh"
   if [ ! -x "$scanner" ]; then
     echo "BLOCKED: private-reference runtime scanner is missing or not executable." >&2

--- a/.claude/hooks/check-private-refs-runtime.sh
+++ b/.claude/hooks/check-private-refs-runtime.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Checks resolved tracker-wrapper values for private portfolio references.
+
+set -u
+
+repo="${1:-}"
+text="${2:-}"
+body_file="${3:-}"
+[ -n "$repo" ] || exit 2
+
+hook_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ops_root=$(cd "$hook_dir/../.." && pwd)
+cd "$ops_root" || exit 2
+
+public_repos="me2resh/apexyard"
+if [ -f "$hook_dir/_lib-read-config.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$hook_dir/_lib-read-config.sh"
+  configured=$(config_get '.leak_protection.public_framework_repos[]' 2>/dev/null | tr '\n' ' ')
+  [ -n "$configured" ] && public_repos="$configured"
+fi
+upstream=$(git remote get-url upstream 2>/dev/null || true)
+upstream=$(printf '%s' "$upstream" | sed -nE 's|.*github\.com[:/]([^/]+/[^/]+)(\.git)?$|\1|p' | sed 's/\.git$//')
+[ -n "$upstream" ] && public_repos="$public_repos $upstream"
+
+is_public=0
+for public_repo in $public_repos; do
+  [ "$repo" = "$public_repo" ] && is_public=1 && break
+done
+[ "$is_public" -eq 1 ] || exit 0
+
+registry="$ops_root/apexyard.projects.yaml"
+if [ -f "$hook_dir/_lib-portfolio-paths.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$hook_dir/_lib-portfolio-paths.sh"
+  resolved_registry=$(portfolio_registry 2>/dev/null || true)
+  [ -n "$resolved_registry" ] && registry="$resolved_registry"
+fi
+[ -f "$registry" ] || exit 0
+
+if [ -n "$body_file" ] && [ ! -f "$body_file" ]; then
+  echo "BLOCKED: tracker wrapper body file cannot be read for private-reference scanning." >&2
+  exit 2
+fi
+haystack="$text"
+[ -n "$body_file" ] && haystack="$(printf '%s\n' "$haystack"; cat "$body_file")"
+
+escape_regex() { printf '%s' "$1" | sed -E 's/[][\\/.^$*+?(){}|]/\\&/g'; }
+block() {
+  echo "BLOCKED: tracker wrapper content contains a private portfolio reference. The matched identifier is intentionally withheld." >&2
+  exit 2
+}
+
+while IFS= read -r entry; do
+  case "$entry" in
+    NAME=*)
+      token=${entry#NAME=}; [ -n "$token" ] || continue
+      [ "$token" = "${repo##*/}" ] && continue
+      escaped=$(escape_regex "$token")
+      printf '%s' "$haystack" | grep -qiE "(^|[^[:alnum:]_])${escaped}([^[:alnum:]_]|$)" && block
+      ;;
+    REPO=*)
+      token=${entry#REPO=}; [ -n "$token" ] || continue
+      [ "$token" = "$repo" ] && continue
+      escaped=$(escape_regex "$token")
+      printf '%s' "$haystack" | grep -qiE "(^|[^A-Za-z0-9_/-])${escaped}(#[0-9]+)?([^A-Za-z0-9_/-]|$)" && block
+      ;;
+    WORKSPACE=*)
+      token=${entry#WORKSPACE=}; [ -n "$token" ] || continue
+      escaped=$(escape_regex "$token")
+      printf '%s' "$haystack" | grep -qE "(^|[^A-Za-z0-9_-])${escaped}([^A-Za-z0-9_-]|$)" && block
+      ;;
+  esac
+done < <(awk '
+  function unquote(value) { gsub(/^['\''\"]|['\''\"]$/, "", value); return value }
+  /^[[:space:]]*- name:/ { print "NAME=" unquote($3); next }
+  /^[[:space:]]*repo:/ { print "REPO=" unquote($2); next }
+  /^[[:space:]]*workspace:/ { print "WORKSPACE=" unquote($2); next }
+' "$registry")
+
+exit 0

--- a/.claude/hooks/check-private-refs-runtime.sh
+++ b/.claude/hooks/check-private-refs-runtime.sh
@@ -73,8 +73,34 @@ while IFS= read -r entry; do
   esac
 done < <(awk '
   function unquote(value) { gsub(/^['\''\"]|['\''\"]$/, "", value); return value }
+  function emit_repos(value,    n, parts, i, item) {
+    gsub(/^[[:space:]]*\[[[:space:]]*/, "", value)
+    gsub(/[[:space:]]*\][[:space:]]*$/, "", value)
+    n = split(value, parts, ",")
+    for (i = 1; i <= n; i++) {
+      item = unquote(parts[i])
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", item)
+      if (item != "") print "REPO=" item
+    }
+  }
+  in_repos = 0
   /^[[:space:]]*- name:/ { print "NAME=" unquote($3); next }
   /^[[:space:]]*repo:/ { print "REPO=" unquote($2); next }
+  /^[[:space:]]*repos:[[:space:]]*\[/ {
+    value = $0
+    sub(/^[^:]*:[[:space:]]*/, "", value)
+    emit_repos(value)
+    in_repos = 0
+    next
+  }
+  /^[[:space:]]*repos:[[:space:]]*$/ { in_repos = 1; next }
+  in_repos && /^[[:space:]]*-[[:space:]]+/ {
+    value = $0
+    sub(/^[[:space:]]*-[[:space:]]*/, "", value)
+    if (value !~ /^[[:alnum:]_.-]+:/) print "REPO=" unquote(value)
+    next
+  }
+  /^[^[:space:]-]/ { in_repos = 0 }
   /^[[:space:]]*workspace:/ { print "WORKSPACE=" unquote($2); next }
 ' "$registry")
 

--- a/.claude/hooks/check-private-refs-staged.sh
+++ b/.claude/hooks/check-private-refs-staged.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Blocks a commit when a staged file contains a private portfolio identifier.
+#
+# Git invokes this from the repository that owns the index. The scanner reads
+# indexed blobs, not a rendered diff, so it protects every commit version.
+
+set -u
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "BLOCKED: cannot resolve the Git root for the staged private-reference scan." >&2
+  exit 2
+}
+
+HOOK_DIR="$ROOT/.claude/hooks"
+REGISTRY="$ROOT/apexyard.projects.yaml"
+if [ -f "$HOOK_DIR/_lib-portfolio-paths.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-portfolio-paths.sh"
+  resolved_registry=$(portfolio_registry 2>/dev/null || true)
+  [ -n "$resolved_registry" ] && REGISTRY="$resolved_registry"
+fi
+
+# A framework checkout without a private portfolio registry has no private
+# identifier set to enforce. A split-portfolio registry can live outside this
+# Git worktree and is still read through portfolio_registry above.
+[ -f "$REGISTRY" ] || exit 0
+
+current_repo=""
+origin_url=$(git remote get-url origin 2>/dev/null || true)
+current_repo=$(printf '%s' "$origin_url" | sed -nE 's|.*github\.com[:/]([^/]+/[^/]+)(\.git)?$|\1|p' | sed 's/\.git$//')
+current_name=${current_repo##*/}
+
+names=()
+repos=()
+workspaces=()
+while IFS= read -r entry; do
+  case "$entry" in
+    NAME=*) names+=("${entry#NAME=}") ;;
+    REPO=*) repos+=("${entry#REPO=}") ;;
+    WORKSPACE=*) workspaces+=("${entry#WORKSPACE=}") ;;
+  esac
+done < <(awk '
+  function unquote(value) { gsub(/^['\''\"]|['\''\"]$/, "", value); return value }
+  /^[[:space:]]*- name:/ {
+    print "NAME=" unquote($3); current_list = ""; next
+  }
+  /^[[:space:]]*repo:/ {
+    print "REPO=" unquote($2); current_list = ""; next
+  }
+  /^[[:space:]]*workspace:/ {
+    print "WORKSPACE=" unquote($2); current_list = ""; next
+  }
+  /^[[:space:]]*repos:[[:space:]]*\[/ {
+    value = $0; sub(/^[^\[]*\[/, "", value); sub(/\].*$/, "", value)
+    count = split(value, items, ",")
+    for (i = 1; i <= count; i++) {
+      item = items[i]; gsub(/^[[:space:]]+|[[:space:]]+$/, "", item)
+      if (item != "") print "REPO=" unquote(item)
+    }
+    current_list = ""; next
+  }
+  /^[[:space:]]*repos:[[:space:]]*(#.*)?$/ { current_list = "repos"; next }
+  /^[[:space:]]*[A-Za-z_][A-Za-z0-9_-]*:/ { current_list = ""; next }
+  /^[[:space:]]*-[[:space:]]+/ {
+    if (current_list == "repos") {
+      value = $0; sub(/^[[:space:]]*-[[:space:]]+/, "", value)
+      gsub(/[[:space:]]+$/, "", value); print "REPO=" unquote(value)
+    }
+  }
+' "$REGISTRY")
+
+[ "${#names[@]}" -gt 0 ] || [ "${#repos[@]}" -gt 0 ] || [ "${#workspaces[@]}" -gt 0 ] || exit 0
+
+registry_rel=""
+case "$REGISTRY" in
+  "$ROOT"/*) registry_rel=${REGISTRY#"$ROOT"/} ;;
+esac
+
+escape_regex() {
+  printf '%s' "$1" | sed -E 's/[][\\/.^$*+?(){}|]/\\&/g'
+}
+
+staged_blob_matches() {
+  local path="$1" regex="$2"
+  git show ":$path" 2>/dev/null | grep -qiE "$regex"
+}
+
+block() {
+  local path="$1"
+  cat >&2 <<MSG
+BLOCKED: staged file content contains a private portfolio reference.
+
+File: $path
+The matched identifier is intentionally withheld. Replace it with an abstract
+description, unstage the file, and retry. See .claude/rules/leak-protection.md
+§ "Remediation" if the identifier has already reached a public repository.
+MSG
+  exit 2
+}
+
+while IFS= read -r -d '' path; do
+  [ -n "$path" ] || continue
+  [ "$path" = "$registry_rel" ] && continue
+  git show ":$path" >/dev/null 2>&1 || continue
+
+  for name in "${names[@]}"; do
+    [ -n "$name" ] || continue
+    [ "$name" = "$current_name" ] && continue
+    escaped=$(escape_regex "$name")
+    staged_blob_matches "$path" "(^|[^[:alnum:]_])${escaped}([^[:alnum:]_]|$)" && block "$path"
+  done
+
+  for repo in "${repos[@]}"; do
+    [ -n "$repo" ] || continue
+    [ "$repo" = "$current_repo" ] && continue
+    escaped=$(escape_regex "$repo")
+    staged_blob_matches "$path" "(^|[^A-Za-z0-9_/-])${escaped}(#[0-9]+)?([^A-Za-z0-9_/-]|$)" && block "$path"
+  done
+
+  for workspace in "${workspaces[@]}"; do
+    [ -n "$workspace" ] || continue
+    escaped=$(escape_regex "$workspace")
+    staged_blob_matches "$path" "(^|[^A-Za-z0-9_-])${escaped}([^A-Za-z0-9_-]|$)" && block "$path"
+  done
+done < <(git diff --cached --name-only --diff-filter=ACMR -z 2>/dev/null)
+
+exit 0

--- a/.claude/hooks/tests/test_check_private_refs_staged.sh
+++ b/.claude/hooks/tests/test_check_private_refs_staged.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Regression tests for the Git-native staged private-reference gate (#1218).
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK_SRC="$ROOT/.claude/hooks/check-private-refs-staged.sh"
+RUNTIME_SRC="$ROOT/.claude/hooks/check-private-refs-runtime.sh"
+PRE_COMMIT_SRC="$ROOT/.githooks/pre-commit"
+
+PASS=0
+FAIL=0
+
+pass() { printf '  ok   %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL %s: %s\n' "$1" "$2" >&2; FAIL=$((FAIL + 1)); }
+
+make_sandbox() {
+  local sandbox
+  sandbox=$(mktemp -d)
+  mkdir -p "$sandbox/.claude/hooks" "$sandbox/.githooks"
+  cp "$HOOK_SRC" "$sandbox/.claude/hooks/check-private-refs-staged.sh"
+  cp "$RUNTIME_SRC" "$sandbox/.claude/hooks/check-private-refs-runtime.sh"
+  cp "$PRE_COMMIT_SRC" "$sandbox/.githooks/pre-commit"
+  chmod +x "$sandbox/.claude/hooks/check-private-refs-staged.sh" "$sandbox/.claude/hooks/check-private-refs-runtime.sh" "$sandbox/.githooks/pre-commit"
+  cat > "$sandbox/apexyard.projects.yaml" <<'YAML'
+projects:
+  - name: amber-lantern
+    repo: acme/amber-lantern
+    workspace: workspace/amber-lantern
+YAML
+  (
+    cd "$sandbox" || exit 1
+    git init -q
+    git config user.email test@example.com
+    git config user.name Test
+    git add apexyard.projects.yaml
+    git commit -q -m baseline
+  )
+  printf '%s\n' "$sandbox"
+}
+
+run_hook() {
+  local sandbox="$1"; shift
+  local out rc
+  out=$(cd "$sandbox" && "$HOOK_SRC" 2>&1); rc=$?
+  printf '%s\n%s\n' "$rc" "$out"
+}
+
+assert_hook() {
+  local label="$1" sandbox="$2" expected_rc="$3" expected_text="$4" forbidden_text="$5"
+  local result rc output
+  result=$(run_hook "$sandbox")
+  rc=$(printf '%s\n' "$result" | head -1)
+  output=$(printf '%s\n' "$result" | sed '1d')
+  if [ "$rc" != "$expected_rc" ]; then
+    fail "$label" "expected exit $expected_rc, got $rc: $output"
+  elif [ -n "$expected_text" ] && ! printf '%s' "$output" | grep -qF -- "$expected_text"; then
+    fail "$label" "missing diagnostic: $expected_text"
+  elif [ -n "$forbidden_text" ] && printf '%s' "$output" | grep -qF -- "$forbidden_text"; then
+    fail "$label" "diagnostic disclosed private identifier"
+  else
+    pass "$label"
+  fi
+}
+
+echo "== Staged private-reference gate (#1218)"
+
+sandbox=$(make_sandbox)
+printf 'Private reference: amber-lantern\n' > "$sandbox/leak.md"
+git -C "$sandbox" add leak.md
+assert_hook "staged project name blocks without disclosing token" "$sandbox" 2 "File: leak.md" "amber-lantern"
+rm -rf "$sandbox"
+
+sandbox=$(make_sandbox)
+printf 'Reference: acme/amber-lantern#42\n' > "$sandbox/repo.md"
+git -C "$sandbox" add repo.md
+assert_hook "staged repository slug blocks" "$sandbox" 2 "File: repo.md" "acme/amber-lantern"
+rm -rf "$sandbox"
+
+sandbox=$(make_sandbox)
+printf 'Path: workspace/amber-lantern/src\n' > "$sandbox/path.md"
+git -C "$sandbox" add path.md
+assert_hook "staged workspace path blocks" "$sandbox" 2 "File: path.md" "workspace/amber-lantern"
+rm -rf "$sandbox"
+
+sandbox=$(make_sandbox)
+printf 'The generic workspace term is safe.\n' > "$sandbox/clean.md"
+git -C "$sandbox" add clean.md
+assert_hook "generic workspace word remains allowed" "$sandbox" 0 "" ""
+rm -rf "$sandbox"
+
+sandbox=$(make_sandbox)
+printf 'Private reference: amber-lantern\n' > "$sandbox/history.md"
+git -C "$sandbox" add history.md
+assert_hook "first add blocks before a later removal can hide it" "$sandbox" 2 "File: history.md" "amber-lantern"
+git -C "$sandbox" restore --staged history.md
+printf 'Private reference removed.\n' > "$sandbox/history.md"
+git -C "$sandbox" add history.md
+assert_hook "clean replacement is evaluated from its staged blob" "$sandbox" 0 "" ""
+rm -rf "$sandbox"
+
+sandbox=$(make_sandbox)
+printf 'Private reference: amber-lantern\n' > "$sandbox/working-only.md"
+assert_hook "unstaged content does not block a different staged commit" "$sandbox" 0 "" ""
+rm -rf "$sandbox"
+
+sandbox=$(make_sandbox)
+git -C "$sandbox" config core.hooksPath .githooks
+printf 'Private reference: amber-lantern\n' > "$sandbox/commit.md"
+git -C "$sandbox" add commit.md
+commit_output=$(git -C "$sandbox" commit -m 'test private reference' 2>&1); commit_rc=$?
+if [ "$commit_rc" = "0" ]; then
+  fail "installed pre-commit hook blocks the commit" "commit unexpectedly succeeded"
+elif printf '%s' "$commit_output" | grep -qF 'File: commit.md' && ! printf '%s' "$commit_output" | grep -qF 'amber-lantern'; then
+  pass "installed pre-commit hook blocks the commit"
+else
+  fail "installed pre-commit hook blocks the commit" "$commit_output"
+fi
+rm -rf "$sandbox"
+
+sandbox=$(make_sandbox)
+resolved_repo="me2resh/apexyard"
+runtime_output=$(cd "$sandbox" && .claude/hooks/check-private-refs-runtime.sh "$resolved_repo" 'Reviewed amber-lantern' '' 2>&1); runtime_rc=$?
+if [ "$runtime_rc" = "2" ] && ! printf '%s' "$runtime_output" | grep -qF 'amber-lantern'; then
+  pass "resolved wrapper values block without disclosing token"
+else
+  fail "resolved wrapper values block without disclosing token" "$runtime_output"
+fi
+rm -rf "$sandbox"
+
+echo
+echo "===== test_check_private_refs_staged.sh ====="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/tests/test_check_private_refs_staged.sh
+++ b/.claude/hooks/tests/test_check_private_refs_staged.sh
@@ -128,6 +128,16 @@ else
 fi
 rm -rf "$sandbox"
 
+sandbox=$(make_sandbox)
+printf '%s\n' 'projects:' '  - name: amber-secondary' '    repos:' '      - acme/amber-primary' '      - acme/amber-secondary' '    workspace: workspace/amber-secondary' > "$sandbox/apexyard.projects.yaml"
+runtime_output=$(cd "$sandbox" && .claude/hooks/check-private-refs-runtime.sh "$resolved_repo" 'Reviewed acme/amber-secondary#7' '' 2>&1); runtime_rc=$?
+if [ "$runtime_rc" = "2" ] && ! printf '%s' "$runtime_output" | grep -qF 'acme/amber-secondary'; then
+  pass "plural repos entries block secondary repository references"
+else
+  fail "plural repos entries block secondary repository references" "$runtime_output"
+fi
+rm -rf "$sandbox"
+
 echo
 echo "===== test_check_private_refs_staged.sh ====="
 echo "Passed: $PASS"

--- a/.claude/hooks/tests/test_githooks_pre_commit_protected_branch.sh
+++ b/.claude/hooks/tests/test_githooks_pre_commit_protected_branch.sh
@@ -37,6 +37,7 @@ set -u
 
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 REAL_PRE_COMMIT="$ROOT/.githooks/pre-commit"
+REAL_PRIVATE_REFS_HOOK="$ROOT/.claude/hooks/check-private-refs-staged.sh"
 REAL_PROTECTED_LIB="$ROOT/.claude/hooks/_lib-protected-branches.sh"
 REAL_READ_CONFIG_LIB="$ROOT/.claude/hooks/_lib-read-config.sh"
 REAL_TRACKER_LIB="$ROOT/.claude/hooks/_lib-tracker.sh"
@@ -113,6 +114,8 @@ build_sandbox() {
   chmod +x "$work/.githooks/pre-commit"
 
   mkdir -p "$work/.claude/hooks"
+  cp "$REAL_PRIVATE_REFS_HOOK" "$work/.claude/hooks/check-private-refs-staged.sh"
+  chmod +x "$work/.claude/hooks/check-private-refs-staged.sh"
   cp "$REAL_PROTECTED_LIB" "$work/.claude/hooks/_lib-protected-branches.sh"
   cp "$REAL_READ_CONFIG_LIB" "$work/.claude/hooks/_lib-read-config.sh"
   cp "$REAL_OPS_ROOT_LIB" "$work/.claude/hooks/_lib-ops-root.sh"
@@ -333,6 +336,8 @@ case_installer_autopickup_blocks_main() {
   chmod +x "$work/.githooks/pre-commit"
 
   mkdir -p "$work/.claude/hooks" "$work/bin"
+  cp "$REAL_PRIVATE_REFS_HOOK" "$work/.claude/hooks/check-private-refs-staged.sh"
+  chmod +x "$work/.claude/hooks/check-private-refs-staged.sh"
   cp "$REAL_PROTECTED_LIB" "$work/.claude/hooks/_lib-protected-branches.sh"
   cp "$REAL_READ_CONFIG_LIB" "$work/.claude/hooks/_lib-read-config.sh"
   cp "$REAL_OPS_ROOT_LIB" "$work/.claude/hooks/_lib-ops-root.sh"

--- a/.claude/hooks/tests/test_tracker_create.sh
+++ b/.claude/hooks/tests/test_tracker_create.sh
@@ -27,6 +27,7 @@ TRACKER_LIB="$HOOK_DIR/_lib-tracker.sh"
 CONFIG_LIB="$HOOK_DIR/_lib-read-config.sh"
 PORTFOLIO_LIB="$HOOK_DIR/_lib-portfolio-paths.sh"
 OPSROOT_LIB="$HOOK_DIR/_lib-ops-root.sh"
+RUNTIME_SCANNER="$HOOK_DIR/check-private-refs-runtime.sh"
 
 PASS=0
 FAIL=0
@@ -47,6 +48,8 @@ make_sandbox() {
   cp "$TRACKER_LIB"   "$sb/.claude/hooks/_lib-tracker.sh"
   cp "$CONFIG_LIB"    "$sb/.claude/hooks/_lib-read-config.sh"
   cp "$PORTFOLIO_LIB" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  cp "$RUNTIME_SCANNER" "$sb/.claude/hooks/check-private-refs-runtime.sh"
+  chmod +x "$sb/.claude/hooks/check-private-refs-runtime.sh"
   [ -f "$OPSROOT_LIB" ] && cp "$OPSROOT_LIB" "$sb/.claude/hooks/_lib-ops-root.sh"
   cat > "$sb/.claude/project-config.defaults.json" <<'JSON'
 { "tracker": { "kind": "gh" } }

--- a/.claude/hooks/tests/test_tracker_pr_merge.sh
+++ b/.claude/hooks/tests/test_tracker_pr_merge.sh
@@ -41,6 +41,7 @@ TRACKER_LIB="$HOOK_DIR/_lib-tracker.sh"
 CONFIG_LIB="$HOOK_DIR/_lib-read-config.sh"
 PORTFOLIO_LIB="$HOOK_DIR/_lib-portfolio-paths.sh"
 OPSROOT_LIB="$HOOK_DIR/_lib-ops-root.sh"
+RUNTIME_SCANNER="$HOOK_DIR/check-private-refs-runtime.sh"
 
 PASS=0
 FAIL=0
@@ -61,6 +62,8 @@ make_sandbox() {
   cp "$TRACKER_LIB"   "$sb/.claude/hooks/_lib-tracker.sh"
   cp "$CONFIG_LIB"    "$sb/.claude/hooks/_lib-read-config.sh"
   cp "$PORTFOLIO_LIB" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  cp "$RUNTIME_SCANNER" "$sb/.claude/hooks/check-private-refs-runtime.sh"
+  chmod +x "$sb/.claude/hooks/check-private-refs-runtime.sh"
   [ -f "$OPSROOT_LIB" ] && cp "$OPSROOT_LIB" "$sb/.claude/hooks/_lib-ops-root.sh"
   cat > "$sb/.claude/project-config.defaults.json" <<'JSON'
 { "tracker": { "kind": "gh" } }

--- a/.claude/hooks/tests/test_tracker_review_submit.sh
+++ b/.claude/hooks/tests/test_tracker_review_submit.sh
@@ -29,6 +29,7 @@ TRACKER_LIB="$HOOK_DIR/_lib-tracker.sh"
 CONFIG_LIB="$HOOK_DIR/_lib-read-config.sh"
 PORTFOLIO_LIB="$HOOK_DIR/_lib-portfolio-paths.sh"
 OPSROOT_LIB="$HOOK_DIR/_lib-ops-root.sh"
+RUNTIME_SCANNER="$HOOK_DIR/check-private-refs-runtime.sh"
 
 PASS=0
 FAIL=0
@@ -49,6 +50,8 @@ make_sandbox() {
   cp "$TRACKER_LIB"   "$sb/.claude/hooks/_lib-tracker.sh"
   cp "$CONFIG_LIB"    "$sb/.claude/hooks/_lib-read-config.sh"
   cp "$PORTFOLIO_LIB" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  cp "$RUNTIME_SCANNER" "$sb/.claude/hooks/check-private-refs-runtime.sh"
+  chmod +x "$sb/.claude/hooks/check-private-refs-runtime.sh"
   [ -f "$OPSROOT_LIB" ] && cp "$OPSROOT_LIB" "$sb/.claude/hooks/_lib-ops-root.sh"
   cat > "$sb/.claude/project-config.defaults.json" <<'JSON'
 { "tracker": { "kind": "gh" } }

--- a/.claude/hooks/tests/test_tracker_zsh_self_location.sh
+++ b/.claude/hooks/tests/test_tracker_zsh_self_location.sh
@@ -46,6 +46,7 @@ TRACKER_LIB="$HOOK_DIR/_lib-tracker.sh"
 CONFIG_LIB="$HOOK_DIR/_lib-read-config.sh"
 PORTFOLIO_LIB="$HOOK_DIR/_lib-portfolio-paths.sh"
 OPSROOT_LIB="$HOOK_DIR/_lib-ops-root.sh"
+RUNTIME_SCANNER="$HOOK_DIR/check-private-refs-runtime.sh"
 
 PASS=0
 FAIL=0
@@ -78,6 +79,8 @@ make_sandbox() {
   cp "$TRACKER_LIB"   "$sb/.claude/hooks/_lib-tracker.sh"
   cp "$CONFIG_LIB"    "$sb/.claude/hooks/_lib-read-config.sh"
   cp "$PORTFOLIO_LIB" "$sb/.claude/hooks/_lib-portfolio-paths.sh"
+  cp "$RUNTIME_SCANNER" "$sb/.claude/hooks/check-private-refs-runtime.sh"
+  chmod +x "$sb/.claude/hooks/check-private-refs-runtime.sh"
   [ -f "$OPSROOT_LIB" ] && cp "$OPSROOT_LIB" "$sb/.claude/hooks/_lib-ops-root.sh"
   cat > "$sb/.claude/project-config.defaults.json" <<'JSON'
 { "tracker": { "kind": "gh" } }

--- a/.claude/rules/leak-protection.md
+++ b/.claude/rules/leak-protection.md
@@ -71,11 +71,22 @@ matchers for `gh pr review`, `gh pr merge`, or any of the three wrapper
 names before #1206. A private reference posted through any of these five
 shapes reached a public repo unscanned.
 
-**Known gap, not yet closed here:** No hook scans a private reference
-committed directly to a file. This gap covers content that never passes
-through a `gh` command's title, body, or subject. me2resh/apexyard#1206
-tracks the fix as a new, dedicated enforcement point. It will not extend
-this hook.
+**Staged-content gate:** `check-private-refs-staged.sh` scans complete staged
+blobs during Git's native `pre-commit` hook. It blocks a project name, repo
+slug, or workspace path before that version can enter commit history. The
+check reads the index rather than a rendered net diff. An add-then-remove
+sequence cannot hide the first commit because the first commit is blocked.
+The diagnostic names the file and withholds the matched identifier.
+
+The tracker adapters also run `check-private-refs-runtime.sh` after resolving
+their arguments. This covers `tracker_create`, `tracker_review_submit`, and
+`tracker_pr_merge` when their repository or body-file argument comes from a
+shell variable. The command-text hook still protects direct `gh` calls.
+
+Git's `--no-verify` option and a clone without `core.hooksPath=.githooks`
+can bypass the staged-content gate. The command-layer hook remains a backstop
+for agent-driven writes. Treat either bypass as reduced protection, not as a
+reason to commit private identifiers.
 
 **Scope limit:** this hook matches `gh` command text only. It does not
 match `glab`. A GitLab adopter's `tracker.kind: glab` project sends review
@@ -158,6 +169,7 @@ The leak-protection hook is a **sibling to `check-secrets.sh`** — both scan ou
 |------|----------|------|
 | `check-secrets.sh` | API keys, passwords, tokens | `git commit` time (staged diff) |
 | `block-private-refs-in-public-repos.sh` | Project names, repo slugs, workspace paths | `gh` tracker-write time (issue/PR title + body, review body, merge-commit subject/body) |
+| `check-private-refs-staged.sh` | Project names, repo slugs, workspace paths in complete files | Git-native `pre-commit` time (staged blobs) |
 
 Both are backstops against routine-but-damaging leaks. Self-discipline is the primary defence; the hook catches the cases where the agent had the private information right in front of it while writing the upstream content and didn't actively suppress it.
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -74,6 +74,13 @@ if [ -z "$REPO_ROOT" ]; then
   exit 0
 fi
 
+PRIVATE_REFS_HOOK="$REPO_ROOT/.claude/hooks/check-private-refs-staged.sh"
+if [ ! -x "$PRIVATE_REFS_HOOK" ]; then
+  echo "BLOCKED: $PRIVATE_REFS_HOOK is missing or not executable. Restore the staged private-reference gate before committing." >&2
+  exit 2
+fi
+"$PRIVATE_REFS_HOOK" || exit $?
+
 BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
 if [ -z "$BRANCH" ]; then
   # Detached HEAD (a rebase, a bisect, a `git commit` onto no branch at

--- a/docs/agdr/AgDR-0142-staged-private-reference-commit-gate.md
+++ b/docs/agdr/AgDR-0142-staged-private-reference-commit-gate.md
@@ -1,0 +1,36 @@
+# Staged private-reference commit gate
+
+> In the context of a public framework repository, facing irreversible disclosure of private portfolio identifiers in commit history, I decided to scan complete staged file content in a Git-native pre-commit hook to block publication before a commit exists, accepting that users can bypass local Git hooks and need the existing command-layer backstop as defence in depth.
+
+## Context
+
+- Issue #1218 requires detection of private identifiers in any staged file. A net diff cannot find a reference that is added and removed in separate commits.
+- The existing command-text hook protects tracker writes. It cannot inspect content committed to a file.
+- Git invokes a pre-commit hook inside the repository that owns the staged index. This avoids parsing a shell command to find the target repository.
+
+## Options considered
+
+| Option | Benefits | Costs |
+|---|---|---|
+| Extend the command-text hook | Reuses an existing scanner. | Cannot reliably obtain complete staged content or cover direct Git commits outside the harness. |
+| Scan the net PR diff | Runs in a central review path. | Misses add-then-remove history and acts after a commit exists. |
+| Scan staged blobs in a Git pre-commit hook | Reads the exact indexed content before commit creation and detects each committed version. | `--no-verify` and clones without installed Git hooks can bypass the local control. |
+
+## Decision
+
+Chosen: **scan staged blobs from a Git-native pre-commit hook**, because the Git index is the only local boundary that contains every file version about to become reachable history without depending on a rendered diff or a parsed shell command.
+
+The hook will resolve the existing portfolio registry, derive the same private identifier classes that leak protection already defines, inspect added, copied, modified, and renamed staged blobs, and report only the file path. It will not print a matched private identifier.
+
+## Consequences
+
+- Every staged file revision is checked before its commit can create public history.
+- A later removal cannot erase the earlier blocked commit because the earlier commit cannot be made through the protected path.
+- The command-layer hook remains necessary for tracker text and as a backstop against `git commit --no-verify` in agent-driven sessions.
+- The control needs Git-hook wiring and end-to-end tests for the installed-hook path.
+
+## Artifacts
+
+- Issue #1218
+- `.githooks/pre-commit`
+- `.claude/hooks/check-private-refs-staged.sh`


### PR DESCRIPTION
## Summary

- **Blocks private identifiers before commit history exists** — the Git-native pre-commit hook scans complete staged blobs, so a later removal cannot hide an earlier public commit.
- **Protects normal tracker-wrapper workflows** — the runtime scanner receives resolved repository, subject, and body-file values from the GitHub adapters, so variable-based calls receive the same protection as literal `gh` commands.
- **Documents the decision and recovery path** — AgDR-0142 records why the Git index is the enforcement boundary, while leak-protection guidance explains coverage and residual bypasses.
- **Adds regression coverage** — focused tests cover names, repo slugs, workspace paths, staged-versus-unstaged content, add-then-remove prevention, resolved wrapper values, and the installed Git-hook lifecycle.

## Testing

- `bash .claude/hooks/tests/test_check_private_refs_staged.sh`
- `bash .claude/hooks/tests/test_block_private_refs.sh`
- `bash .claude/hooks/tests/test_fail_closed_json.sh`
- `bash .claude/hooks/tests/test_githooks_pre_commit_protected_branch.sh`
- `shellcheck .claude/hooks/check-private-refs-staged.sh .claude/hooks/check-private-refs-runtime.sh .claude/hooks/_lib-tracker.sh .githooks/pre-commit`

Refs #1218

## Glossary

| Term | Definition |
|---|---|
| Staged blob | The complete version of a file in Git’s index that a commit will record. |
| Net diff | The final difference between two tree states; it does not show a value that was added and later removed in separate commits. |
| Runtime scanner | The check run by a tracker adapter after shell variables have resolved to their actual repository and content values. |
