### PR TITLE
fix(#1189): require Rex to verify cited criteria

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -78,6 +78,10 @@ When the `apexyard-search` MCP is connected, **prefer `mcp__apexyard-search__sea
 
 It also lowers review token cost (targeted semantic excerpts vs. broad `grep` + full-file reads). **Graceful-degrade:** if the MCP server is absent the tool simply isn't available — fall back to `grep`/`Glob`/`Read` with no change in behaviour (same pattern as `search_docs`, `/handover`, and `/code-review`). Adopters who don't run the premium MCP are unaffected.
 
+## Evidence citations — read the criterion
+
+When citing a file as evidence — prior art, precedent, a counterexample, or a claim about how another part of the framework behaves — read the cited region in full before asserting what it does. A section header, scope line, table heading, or gate lead-in is not the mechanism. Verify the applicable criterion, including its conditions and exceptions, and cite the line where that criterion lives. Do not assert that a condition is absent until you have read the region where it could be defined.
+
 ## Reduced-Scope Review — Lean-tier diffs (Option 4, AgDR-0116)
 
 Per `.claude/rules/right-size-ceremony.md`, a **Lean-tier** diff still requires a Rex pass — the merge gate (`block-unreviewed-merge.sh`) requires the `*-rex.approved` marker on EVERY PR, regardless of tier, unconditionally, because it is a CONTROL that reads structured state (a marker vs. the forge-reported HEAD) and structurally cannot itself inspect a diff's content to decide a tier. What changes for a Lean diff is the **depth** of your pass, never whether one happens.

--- a/.claude/agents/tests/test_code_reviewer_evidence_grounding.sh
+++ b/.claude/agents/tests/test_code_reviewer_evidence_grounding.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Pins Rex's evidence-citation grounding contract (me2resh/apexyard#1189).
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+REX="$ROOT/.claude/agents/code-reviewer.md"
+FAIL=0
+
+pass() { printf '  ok   %s\n' "$1"; }
+fail() { printf '  FAIL %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+
+require_text() {
+  local text="$1" description="$2"
+  if grep -qF "$text" "$REX"; then
+    pass "$description"
+  else
+    fail "$description"
+  fi
+}
+
+if [ ! -f "$REX" ]; then
+  fail "Rex agent prompt exists"
+  exit "$FAIL"
+fi
+
+require_text '## Evidence citations — read the criterion' \
+  'Rex has an evidence-citation grounding section'
+require_text 'read the cited region in full before asserting what it does' \
+  'Rex reads cited evidence before making a mechanism claim'
+require_text 'A section header, scope line, table heading, or gate lead-in is not the mechanism.' \
+  'Rex does not treat a header or lead-in as a criterion'
+require_text 'Verify the applicable criterion, including its conditions and exceptions' \
+  'Rex verifies all applicable criterion clauses'
+require_text 'cite the line where that criterion lives' \
+  'Rex cites the line containing the criterion'
+require_text 'Do not assert that a condition is absent until you have read the region where it could be defined.' \
+  'Rex verifies a condition before asserting its absence'
+
+printf '\nEvidence-grounding checks completed with %s failure(s).\n' "$FAIL"
+exit "$FAIL"


### PR DESCRIPTION
## Summary

- Rex now reads a cited region in full before asserting how a framework file behaves, so review findings cannot mistake a header or scope line for the actual rule.
- The prompt requires Rex to verify conditions and exceptions and cite the line containing the criterion, which prevents unsupported claims that a condition is absent.
- A focused regression test pins this evidence-grounding contract so later prompt edits retain the safeguard.

## Testing

- `bash .claude/agents/tests/test_agent_wrap_shape.sh`
- `bash .claude/agents/tests/test_build_handbook_discovery.sh`
- `bash .claude/agents/tests/test_code_reviewer_evidence_grounding.sh`
- `markdownlint-cli2 .claude/agents/code-reviewer.md`

Closes #1189

## Glossary

| Term | Definition |
|---|---|
| Rex | The framework Code Reviewer agent. |
| Criterion | The concrete condition that determines whether a rule applies. |
| Evidence citation | A reference to a file used to support a review claim. |