### PR TITLE
fix(#1212): restore fixture heading

### DIFF
--- a/.claude/rules/tests/fixtures/human-friendly-cases.md
+++ b/.claude/rules/tests/fixtures/human-friendly-cases.md
@@ -1,4 +1,4 @@
-# a third-party controlled-language standard Artifact Cases
+# Controlled technical writing regression cases
 
 These cases test the writing rule for new and changed artifacts. A reviewer
 judges the text. Static tests check that each producer and reviewer loads the


### PR DESCRIPTION
## Summary

- Restores the fixture H1 to a complete title.
- The title now names the controlled technical writing regression cases.

## Testing

- `bash .claude/rules/tests/test_writing_standard.sh`
- `bash .claude/hooks/tests/test_quality_regression.sh`
- `git diff --check dev...HEAD`

Closes #1212

## Glossary

| Term | Definition |
|------|------------|
| Fixture | A file that contains fixed regression cases for a test. |
| H1 | The top-level Markdown heading. |