### PR TITLE
fix(#1196): keep release PR variables in one shell block

### DIFF
--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -38,18 +38,18 @@
 #                                      merges a PR/MR via the git host. strategy is one of
 #                                      squash|merge|rebase (default squash, normalised — never
 #                                      eval'd raw); delete_branch is true|false (default true).
-#                                      subject/body_file are OPTIONAL (gh kind only): when BOTH are
-#                                      non-empty, the merge passes `--subject "$subject" --body-file
-#                                      "$body_file"` so the squash commit carries that exact
-#                                      subject/body instead of the repo's default squash-body
-#                                      assembly (see #1136 — under
+#                                      subject/body_file are OPTIONAL (gh kind only): each non-empty
+#                                      value adds its matching `--subject "$subject"` or `--body-file
+#                                      "$body_file"` flag, so a caller can preserve either field
+#                                      independently instead of relying on the repo's default
+#                                      squash-body assembly (see #1136 — under
 #                                      `squash_merge_commit_message=COMMIT_MESSAGES` a bare squash
 #                                      concatenates every commit message on the PR branch, burying
 #                                      any trailer that isn't in the final paragraph). body_file
-#                                      MUST be a readable, non-empty file when supplied — an
-#                                      unreadable/empty body_file with a non-empty subject fails
-#                                      closed (returns 1) rather than silently falling back to a
-#                                      bare squash. gh + glab adapters built in, `custom`
+#                                      MUST be a regular, readable, non-empty file when supplied —
+#                                      the guard tests `-f`, `-r`, and `-s` on body_file alone and
+#                                      fails closed (returns 1) rather than silently falling back to
+#                                      a bare squash. gh + glab adapters built in, `custom`
 #                                      merge_command template, `none` no-op (returns 3). Exit 0 =
 #                                      merged, emits normalised JSON {"sha":...} (the merge commit,
 #                                      best-effort — empty for `custom`); non-zero = CLI errored /
@@ -1200,8 +1200,8 @@ tracker_label_ensure() {
 # ------------------------------------------------------------------------------
 
 # Internal adapter: gh → `gh pr review`. Args passed as an array (never an eval'd
-# string) so a body full of shell metacharacters is inert. 2>/dev/null hides the
-# expected self-approval refusal noise; gh's exit status still propagates.
+# string) so a body full of shell metacharacters is inert. Stdout and stderr both
+# propagate: the caller needs the host's diagnostic when a review is rejected.
 _tracker_review_gh() {
   local repo="$1" pr="$2" verdict="$3" body_file="$4"
   _tracker_check_private_refs "$repo" "" "$body_file" || return $?
@@ -1215,7 +1215,7 @@ _tracker_review_gh() {
   if [ -n "$body_file" ] && [ -f "$body_file" ]; then
     args+=(--body-file "$body_file")
   fi
-  gh "${args[@]}" 2>/dev/null
+  gh "${args[@]}"
 }
 
 # Internal adapter: glab (GitLab) → `glab mr approve` / `glab mr note create`.
@@ -1476,9 +1476,9 @@ _tracker_merge_normalise_delete_branch() {
 # contract in `/approve-merge`'s SKILL.md — the failure message the operator
 # sees is meant to be the CLI's own, not silently swallowed).
 #
-# subject/body_file (#1136, AgDR-0132): OPTIONAL, empty by default. When both
-# are non-empty, `--subject "$subject" --body-file "$body_file"` are appended
-# so the squash commit carries the caller's own reviewed subject/body instead
+# subject/body_file (#1136, AgDR-0132): OPTIONAL, empty by default. Each
+# non-empty value appends its own `--subject "$subject"` or `--body-file
+# "$body_file"` flag so the squash commit preserves the supplied field instead
 # of GitHub's repo-default squash body (which, under
 # `squash_merge_commit_message=COMMIT_MESSAGES`, concatenates every commit
 # message on the PR branch — see #1136). `$subject` and `$body_file` are
@@ -1551,16 +1551,16 @@ _tracker_merge_template() {
 
 # Internal adapter: custom → operator-supplied merge_command template.
 #
-# Injection model: unlike _tracker_review_custom / _tracker_create_custom,
-# there is no arbitrary/untrusted free-text value in a merge call at all — pr
-# is numeric-guarded and repo is charset-guarded by the public function below
-# (both checked BEFORE any adapter, not just this one), and strategy/
-# delete_branch are both normalised to a closed enum before this function
-# ever sees them. So all four placeholders — {owner_repo} (registry slug,
+# Injection model: this adapter receives only the four validated dispatch
+# values. `pr` is numeric-guarded and `repo` is charset-guarded by the public
+# function below (both checked BEFORE every adapter), while `strategy` and
+# `delete_branch` are normalised to closed enums before this function sees
+# them. So all four placeholders — {owner_repo} (registry slug,
 # charset-guarded), {pr} (numeric-guarded), {strategy} (squash|merge|rebase),
 # {delete_branch} (true|false) — are safe to substitute directly into the
-# eval'd template; none of them can carry shell metacharacters by the time
-# they arrive here.
+# eval'd template. `subject` is fork-controlled PR-title text, but dispatch
+# deliberately does not forward it here. Any future forwarding of subject or
+# body content into this eval requires sanitising it before substitution.
 #
 # Stdout discarded, stderr left to propagate — same rationale as
 # _tracker_merge_gh/_tracker_merge_glab above: the operator-supplied CLI's

--- a/.claude/hooks/tests/test_tracker_review_submit.sh
+++ b/.claude/hooks/tests/test_tracker_review_submit.sh
@@ -14,7 +14,7 @@
 #   1. gh happy path → correct `gh pr review` verb + --body-file
 #   2. gh verdict verbs → approve / request-changes map to the right flag
 #   3. gh verdict normalisation → an unknown verdict falls back to --comment
-#   4. gh failure → the CLI's non-zero exit propagates
+#   4. gh failure → the CLI's non-zero exit and stderr diagnostic propagate
 #   5. kind=none → returns 3, echoes the body (shape-only, not a CLI error)
 #   6. per-project glab override → mr approve / mr note create dispatch [needs YAML]
 #   7. per-project custom review_command → env-passed body, injection-safe [needs YAML]
@@ -108,15 +108,19 @@ PATH="$SB/bin:$PATH" GH_CAPTURE="$SB/c3" tracker_review_submit "o/r" 42 'bogus; 
 assert_eq "gh unknown verdict → normalised to --comment"      "1" "$(grep -c -- '--comment' "$SB/c3")"
 assert_eq "gh unknown verdict → no stray --approve"           "0" "$(grep -c -- '--approve' "$SB/c3")"
 
-# Case 4 — the CLI's non-zero exit propagates (2>/dev/null must not mask it).
+# Case 4 — the CLI's non-zero exit and diagnostic both propagate. The caller
+# needs this message to distinguish a self-review refusal from auth or repo
+# failures without reproducing the command by hand.
 cat > "$SB/bin/gh" <<'EOF'
 #!/bin/bash
+echo 'mock gh review rejection' >&2
 exit 1
 EOF
 chmod +x "$SB/bin/gh"
 tracker_clear_cache
-PATH="$SB/bin:$PATH" tracker_review_submit "o/r" 42 comment "$BODY"; rc=$?
+err=$(PATH="$SB/bin:$PATH" tracker_review_submit "o/r" 42 comment "$BODY" 2>&1 >/dev/null); rc=$?
 assert_eq "gh failure → non-zero exit propagates" "1" "$rc"
+assert_eq "gh failure → stderr diagnostic propagates" "mock gh review rejection" "$err"
 
 # Case 4b — a non-numeric PR id is rejected before any dispatch/eval (matches the
 # documented "{pr} is numeric" contract; defense-in-depth for the custom eval).

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -211,12 +211,16 @@ approval_summary="${summary}"
 EOF
 ```
 
-### 6. Determine merge strategy
+### 6. Determine merge strategy and release metadata
 
 Before running the merge, check whether this is a **sync-class PR**. A PR is sync-class if either:
 
 - Its head branch matches `sync/main-to-dev-after-*` (the canonical `/release-sync` branch prefix), OR
 - Its PR title starts with `sync(` (the canonical `/release-sync` PR title prefix)
+
+Run this entire block in one shell. The release subject and body file are
+intentionally derived immediately before `tracker_pr_merge`; a separate code
+block is not a shell scope and must not carry either value (#1196).
 
 ```bash
 PR_HEAD_BRANCH=$(gh pr view <pr> --repo "$PR_HOST_REPO" --json headRefName -q '.headRefName' 2>/dev/null)
@@ -227,20 +231,10 @@ if echo "$PR_HEAD_BRANCH" | grep -qE '^sync/main-to-dev-after-' || \
    echo "$PR_TITLE" | grep -qE '^sync\('; then
   MERGE_STRATEGY="merge"
 fi
-```
 
-Sync-class detection stays on `gh pr view` deliberately — sync PRs are a `/release-sync` concept, and `/release-sync` only ever runs against the `gh`-hosted apexyard framework fork itself, never a downstream GitLab-forge managed project. There's nothing to make forge-aware here.
-
-**Why auto-detect instead of a flag:** a `--merge-strategy` flag would require the operator to remember to pass it on every sync PR merge. Sync PRs squashed silently — the v2.2.0 incident — show that operator ceremony is not a reliable safeguard. Auto-detection makes the correct behaviour the default; an operator who wants to override can do so via the CLI directly. See `AgDR-0053`.
-
-**Why `merge` (not `squash`) for sync PRs:** the sync branch's top commit is a true two-parent merge commit (branch = dev, second parent = main's release squash). That two-parent relationship is the ancestry link that makes future `dev → main` release PRs conflict-free. Squash-merging discards the second parent permanently, defeating the skill's entire purpose. See `AgDR-0053`.
-
-Next, check whether this is a **release-class PR** — the sibling special-case for `/release` (#1136, `AgDR-0132`). A PR is release-class if either:
-
-- Its head branch matches `release/v[0-9]+.[0-9]+.[0-9]+` (the canonical `/release` branch shape), OR
-- Its PR title starts with `release(` (the canonical `/release` PR title prefix)
-
-```bash
+# Next, check whether this is a release-class PR — the sibling special-case
+# for /release (#1136, AgDR-0132). A release-class PR has a head branch that
+# matches release/v[0-9]+.[0-9]+.[0-9]+, or a title that starts with release(.
 RELEASE_SUBJECT=""
 RELEASE_BODY_FILE=""
 if echo "$PR_HEAD_BRANCH" | grep -qE '^release/v[0-9]+\.[0-9]+\.[0-9]+$' || \
@@ -266,17 +260,7 @@ if echo "$PR_HEAD_BRANCH" | grep -qE '^release/v[0-9]+\.[0-9]+\.[0-9]+$' || \
     exit 1
   fi
 fi
-```
 
-**Why this exists:** this repo has `squash_merge_commit_message=COMMIT_MESSAGES` — GitHub's default squash body concatenates every commit message on the PR branch. A release branch is cut from `dev`, so from `main`'s perspective it "contains" the entire dev↔main divergence (hundreds of commits); a bare `gh pr merge --squash` buries the release commit's `Released-From` trailer mid-body, where `%(trailers:...)` can no longer see it. `/release` Rule 11 already prescribes the fix for its own manual merge step (an explicit `--subject`/`--body-file`); this block makes `/approve-merge` — the mandated human-only merge path since #1042 — apply the same fix automatically, so the two skills stop conflicting. See `AgDR-0132`.
-
-**Fail-safe, not fallback:** if the PR body can't be read (network/auth failure, empty body), the block above STOPS the merge rather than silently degrading to a bare squash — a silent degrade here is exactly how #1136 happened. Fix the read failure and retry `/approve-merge`; the CEO marker written in step 5 is unaffected and does not need to be re-approved.
-
-### 7. Run the merge — DEFAULT FLOW
-
-Unless `--no-merge` was passed, run the merge in the same turn via the tracker-agnostic adapter — `tracker_pr_merge` in `_lib-tracker.sh` (#759, the same kind-dispatch pattern `tracker_review_submit` uses for review submission, #758) — using the strategy determined in step 6:
-
-```bash
 # _lib-tracker.sh lives alongside _lib-review-markers.sh, already sourced in
 # step 4 from $MARKER_HOME (the ops fork root, not necessarily git toplevel).
 # shellcheck source=/dev/null
@@ -305,7 +289,21 @@ MERGE_SHA=$(printf '%s' "$MERGE_RESULT" | jq -r '.sha // empty' 2>/dev/null)
 rm -f "$MERGE_RESULT_FILE" "$RELEASE_BODY_FILE"
 ```
 
-`$RELEASE_SUBJECT` and `$RELEASE_BODY_FILE` are empty strings for every non-release PR (step 6 only sets them inside the release-class branch), so this line is byte-for-byte the pre-#1136 behaviour — a bare squash/merge/rebase with no `--subject`/`--body-file` — for every PR that isn't release-class. `tracker_pr_merge` treats a `""` body_file the same as an omitted one (see `_lib-tracker.sh`'s fail-safe check, which only fires when `body_file` is non-empty).
+Sync-class detection stays on `gh pr view` deliberately — sync PRs are a `/release-sync` concept, and `/release-sync` only ever runs against the `gh`-hosted apexyard framework fork itself, never a downstream GitLab-forge managed project. There's nothing to make forge-aware here.
+
+**Why auto-detect instead of a flag:** a `--merge-strategy` flag would require the operator to remember to pass it on every sync PR merge. Sync PRs squashed silently — the v2.2.0 incident — show that operator ceremony is not a reliable safeguard. Auto-detection makes the correct behaviour the default; an operator who wants to override can do so via the CLI directly. See `AgDR-0053`.
+
+**Why `merge` (not `squash`) for sync PRs:** the sync branch's top commit is a true two-parent merge commit (branch = dev, second parent = main's release squash). That two-parent relationship is the ancestry link that makes future `dev → main` release PRs conflict-free. Squash-merging discards the second parent permanently, defeating the skill's entire purpose. See `AgDR-0053`.
+
+**Why release metadata is inline:** this repo has `squash_merge_commit_message=COMMIT_MESSAGES` — GitHub's default squash body concatenates every commit message on the PR branch. A release branch is cut from `dev`, so from `main`'s perspective it "contains" the entire dev↔main divergence (hundreds of commits); a bare `gh pr merge --squash` buries the release commit's `Released-From` trailer mid-body, where `%(trailers:...)` can no longer see it. `/release` Rule 11 already prescribes the fix for its own manual merge step (an explicit `--subject`/`--body-file`); this block makes `/approve-merge` — the mandated human-only merge path since #1042 — apply the same fix automatically, so the two skills stop conflicting. See `AgDR-0132`.
+
+**Fail-safe, not fallback:** if the PR body can't be read (network/auth failure, empty body), the block STOPS the merge rather than silently degrading to a bare squash — a silent degrade here is exactly how #1136 happened. Keeping its creation and use in this one block also prevents a lost shell variable from bypassing that check (#1196). Fix the read failure and retry `/approve-merge`; the CEO marker written in step 5 is unaffected and does not need to be re-approved.
+
+### 7. Process the merge result — DEFAULT FLOW
+
+Unless `--no-merge` was passed, the preceding block runs the merge in the same turn via the tracker-agnostic adapter — `tracker_pr_merge` in `_lib-tracker.sh` (#759, the same kind-dispatch pattern `tracker_review_submit` uses for review submission, #758) — using the strategy and release metadata it determined.
+
+`$RELEASE_SUBJECT` and `$RELEASE_BODY_FILE` are empty strings for every non-release PR, so the invocation remains the pre-#1136 bare squash/merge/rebase with no `--subject`/`--body-file` for those PRs. `tracker_pr_merge` treats a `""` body_file the same as an omitted one (see `_lib-tracker.sh`'s fail-safe check, which only fires when `body_file` is non-empty).
 
 `tracker_pr_merge` dispatches on the project's `tracker_kind <owner/repo>` (the same per-project resolution `tracker_review_submit` and `tracker_create` use): a `gh`-kind project runs `gh pr merge <pr> --repo <owner/repo> --squash|--merge|--rebase --delete-branch`; a `glab`-kind project runs the `glab mr merge` equivalent (`--squash`/`--rebase`/no-flag-for-a-plain-merge, `--remove-source-branch`). **Note what actually gates this call:** the `gh`/`glab` command above runs *inside* `_lib-tracker.sh`, a sourced shell function — the merge-gate hooks (`block-unreviewed-merge.sh`, `block-merge-on-red-ci.sh`, `require-design-review-for-ui.sh`, `require-architecture-review.sh`) match the OUTER Bash command text this step actually submits (the `tracker_pr_merge "<owner/repo>" "<pr>" "${MERGE_STRATEGY}" true > "$MERGE_RESULT_FILE"` line above), and that text never literally contains `gh pr merge` or `glab mr merge` — those strings live inside already-sourced library code, not in this step's command. So the wrapper call itself is a dedicated, gate-recognised merge shape in its own right: `is_merge_command` and the PR/repo extractors in `_lib-extract-pr.sh` have a `tracker_pr_merge <owner/repo> <pr> ...` branch (#759), and `settings.json` carries a matching `Bash(tracker_pr_merge *)` matcher for all four hooks, alongside the existing `gh`/`glab` matchers (#764/#767/#793). The gates fire on the wrapper form directly — not by recognising the inner CLI command it happens to run, and ONLY when that form is issued as the bare top-level statement shown above — never inside a `$(...)`.
 

--- a/.claude/skills/approve-merge/tests/test_merge_invocation_not_substituted.sh
+++ b/.claude/skills/approve-merge/tests/test_merge_invocation_not_substituted.sh
@@ -45,6 +45,9 @@
 #      is actually wired, not just the top-level call in isolation
 #   6. The prose explicitly documents the "never wrap in $(...)" rule, so a
 #      human editing this file by hand still sees the warning inline
+#   7. Release metadata creation and the merge invocation occupy the same
+#      fenced bash block, so a harness cannot lose the values at a code-block
+#      boundary (#1196)
 #
 # Exit 0 if all cases pass; 1 on first failure.
 
@@ -129,6 +132,29 @@ if grep -qE 'NEVER be invoked.*\$\(|MUST be invoked.*top-level|never wrap.*\$\('
   pass "SKILL.md prose documents the never-wrap-in-\$(...) rule inline"
 else
   fail "SKILL.md prose documents the never-wrap-in-\$(...) rule inline"
+fi
+
+# --- Case 7: release metadata and merge call share one code block ----------
+# A fenced block can execute in a separate shell. The body-file variable is
+# therefore only safe when its creation and tracker_pr_merge use are in the
+# same block. Extract the block containing the merge invocation and require
+# both release assignments in it.
+MERGE_BLOCK=$(awk '
+  /^```bash[[:space:]]*$/ { inblock=1; block=""; next }
+  /^```[[:space:]]*$/ {
+    if (inblock && block ~ /tracker_pr_merge/) print block
+    inblock=0
+    next
+  }
+  inblock { block=block $0 "\n" }
+' "$SKILL_MD")
+
+if printf '%s' "$MERGE_BLOCK" | grep -qF 'RELEASE_SUBJECT=""' \
+  && printf '%s' "$MERGE_BLOCK" | grep -qF "RELEASE_BODY_FILE=\$(mktemp)" \
+  && printf '%s' "$MERGE_BLOCK" | grep -qE '^[[:space:]]*tracker_pr_merge\b'; then
+  pass "release metadata and tracker_pr_merge share one fenced bash block"
+else
+  fail "release metadata and tracker_pr_merge share one fenced bash block"
 fi
 
 echo

--- a/docs/agdr/AgDR-0132-approve-merge-release-pr-body-trailer.md
+++ b/docs/agdr/AgDR-0132-approve-merge-release-pr-body-trailer.md
@@ -63,21 +63,24 @@ Chosen: **Option A**. `tracker_pr_merge` (`_lib-tracker.sh`) gains two
 OPTIONAL trailing parameters, `<subject>` and `<body_file>` — empty by
 default, so every existing call site (every non-release merge) is
 byte-for-byte unchanged. `/approve-merge` step 6 gains a release-class
-detection block, structurally identical to the existing sync-class block:
-head branch matches `release/v[0-9]+\.[0-9]+\.[0-9]+`, or title starts with
-`release(`. When matched, it reads the PR's own title (as `--subject`) and
-body (written to a temp file, as `--body-file`) via `gh pr view`, and passes
-both through to `tracker_pr_merge`.
+detection block, structurally identical to the existing sync-class block,
+and keeps that detection, title/body-file creation, and `tracker_pr_merge`
+invocation in one fenced shell block (#1196). A fenced block is the unit of
+shell execution; values must not cross from one documented block to another.
+The release-class check uses a head branch that matches
+`release/v[0-9]+\.[0-9]+\.[0-9]+`, or a title that starts with `release(`.
+When matched, it reads the PR's own title (as `--subject`) and body (written
+to a temp file, as `--body-file`) via `gh pr view`, and passes both through to
+`tracker_pr_merge`.
 
 **Fail-safe, not fallback.** If the PR body can't be read (`gh pr view`
 fails, or the body is empty), `/approve-merge` STOPS before merging rather
 than silently falling back to a bare squash — a silent fallback here would
-just reproduce #1136 under a different trigger (a transient API failure
-instead of a forgotten flag). `tracker_pr_merge` itself carries the same
-fail-safe as a second layer: if `body_file` is non-empty but unreadable or
-empty, it returns 1 without attempting the merge — so even a caller that
-skips `/approve-merge`'s own check can't accidentally slip a bare squash
-through.
+reproduce #1136. `tracker_pr_merge` is a narrower second layer: if a
+non-empty `body_file` is unreadable or empty, it returns 1 without attempting
+the merge. It cannot distinguish an intentionally omitted body file from a
+lost empty shell variable, so it cannot backstop a cross-code-block scope
+failure. The one-block instruction is the prevention for that failure mode.
 
 **Scope: `gh` kind only.** The subject/body_file parameters are only wired
 into `_tracker_merge_gh`. `/release` — and therefore this bug — only ever
@@ -92,6 +95,9 @@ caller ever passes them for a non-gh project, which is the safe default
 - Merging a `release/vA.B.C` PR via `/approve-merge` now produces a squash
   commit whose final paragraph is the `Released-From` trailer, matching what
   `/release` Rule 11 has always promised.
+- The release subject and body-file variables are created and consumed in the
+  same documented shell block, so a harness that executes fenced blocks in
+  separate shells cannot silently omit the body file.
 - `/release` Rule 11 and `/approve-merge` step 6 now cross-reference each
   other directly, so a future reader of either skill sees the other half of
   the picture instead of two independently-plausible, silently-conflicting
@@ -110,8 +116,10 @@ caller ever passes them for a non-gh project, which is the safe default
 - `.claude/hooks/_lib-tracker.sh` — `_tracker_merge_gh`, `tracker_pr_merge`
 - `.claude/hooks/tests/test_tracker_pr_merge.sh` — release-PR body-file
   coverage
-- `.claude/skills/approve-merge/SKILL.md` — step 6 release-class detection,
-  step 7 wiring
+- `.claude/skills/approve-merge/SKILL.md` — one-block release-class
+  detection and merge wiring
+- `.claude/skills/approve-merge/tests/test_merge_invocation_not_substituted.sh`
+  — release metadata and merge-invocation co-location coverage
 - `.claude/skills/release/SKILL.md` — Rule 11 cross-reference
 - Issue: me2resh/apexyard#1136
 - Sibling decision: `AgDR-0053` (the `sync/`-class precedent this mirrors)


### PR DESCRIPTION
## Summary

- The `/approve-merge` release-class flow now derives release metadata and invokes `tracker_pr_merge` in one fenced shell block. A harness that executes blocks in separate shells cannot silently drop the release body file.
- The tracker merge contract now documents independently appended subject and body-file flags, and it explains why custom merge templates receive only validated values before `eval`. This keeps future changes from relying on stale security assumptions.
- GitHub review submission now preserves host stderr on failure. The new regression assertion makes self-review refusals, authentication failures, and repository errors diagnosable without reproducing the command.

## Validation

- `bash .claude/skills/approve-merge/tests/test_merge_invocation_not_substituted.sh`
- `bash .claude/hooks/tests/test_tracker_pr_merge.sh`
- `bash .claude/hooks/tests/test_tracker_review_submit.sh`
- `bash .claude/hooks/tests/test_skill_invocability_gates.sh`
- `shellcheck .claude/hooks/_lib-tracker.sh .claude/hooks/tests/test_tracker_review_submit.sh .claude/hooks/tests/test_tracker_pr_merge.sh .claude/skills/approve-merge/tests/test_merge_invocation_not_substituted.sh`

Refs #1196

## Glossary

| Term | Definition |
| --- | --- |
| Release-class PR | A PR whose branch matches `release/vX.Y.Z` or whose title begins with `release(`. |
| Release body file | The temporary file passed to `gh pr merge --body-file` so the squash commit retains the `Released-From` trailer. |
| Fenced shell block | One documented Bash block that a harness may execute in a separate shell. |
| Merge template | A configured custom command evaluated only with validated repository, pull-request, strategy, and branch-deletion values. |

AgDR: [AgDR-0132 approve-merge release PR body trailer](https://github.com/me2resh/apexyard/blob/dev/docs/agdr/AgDR-0132-approve-merge-release-pr-body-trailer.md)
