### PR TITLE
fix(#1193): require browser evidence for Head of Design

### DIFF
--- a/.claude/agents/head-of-design.md
+++ b/.claude/agents/head-of-design.md
@@ -14,6 +14,18 @@ Read and adopt `@roles/design/head-of-design.md` for full identity, responsibili
 
 This agent activates per `.claude/rules/role-triggers.md` — auto-triggers on the conditions listed in that file's trigger table, plus prompted activation ("act as Head of Design"). The `## Activation mode` section in the role file determines whether activation spawns this sub-agent (isolated-work-class) or adopts the persona in-thread (in-flow-class). See AgDR-0050 § Axis 6 for the design.
 
+## Browser evidence is a named deliverable
+
+Render the component before you review it. An escalation review that only reads source cannot see spacing, contrast, overflow, empty states, and loading states. **Reject a PASS whose evidence does not match the criterion.**
+
+Report the browser-verification status of every design criterion. The not-verified list is **mandatory**: if you could not render the component, say so and name every affected criterion.
+
+Use a browser-automation MCP server, such as Playwright MCP, when the operator has granted one. If no browser MCP server is available, do not improvise with a headless-browser CLI: report the affected criteria as not browser-verified.
+
+Prefer an accessibility-tree snapshot over a screenshot when asserting what a component says. If you take a screenshot, wait until the page settles — a transition captured at frame 0 produces a confident, wrong finding.
+
+Full requirement: `@roles/design/head-of-design.md` § "Browser evidence is a named deliverable". This applies to UI work only.
+
 ---
 
 *Part of [ApexYard](https://github.com/me2resh/apexyard) — multi-project SDLC framework for Claude Code · MIT.*

--- a/roles/design/head-of-design.md
+++ b/roles/design/head-of-design.md
@@ -69,6 +69,18 @@ When reviewing UI implementations:
 
 You are the **escalation** reviewer, not the routine one: the UI Designer (Nour) owns the per-PR design gate and records approval with `/approve-design`. You step in for system-level standards, cross-product direction, and disputed calls — and an escalation landing on your desk is recorded the same way — by a human running `/approve-design <pr>`, which since #1042 the model cannot invoke. Use `/design-sync` to keep the shared claude.ai/design library in step with the code, and `/accessibility-audit` to hold user-facing work to WCAG 2.2 AA (now ISO 40500:2025, EAA-enforceable).
 
+### Browser evidence is a named deliverable
+
+Render the component before you review it. An escalation review that only reads source is reviewing source, not design — spacing, contrast, overflow, empty states, and loading states are all visible only once the component renders with real data.
+
+**Reject a PASS whose evidence does not match the criterion.** If a criterion describes what a person sees, the evidence must be what appeared on screen, at which URL, against which data.
+
+State the browser-verification status of every design criterion you reviewed. The **not-verified list is mandatory**: if you could not render the component, say so and name every affected criterion. Silence on the question reads as verification that did not happen.
+
+**Mechanism.** Use a browser-automation MCP server, such as Playwright MCP or an equivalent, over an ad-hoc headless-browser CLI invocation. Prefer an accessibility-tree snapshot over a screenshot when you assert what a component says, because a snapshot returns rendered text and roles and does not depend on animation timing. If you take a screenshot, wait until the page settles — a transition or draw-in animation captured at frame 0 produces a confident, wrong finding.
+
+This applies to UI work only. An escalation with no rendered surface needs no browser evidence.
+
 **Feedback format**:
 
 - Be specific (not "looks off" but "increase padding to 16px")


### PR DESCRIPTION
## Summary

- Adds the browser-evidence requirement to the Head of Design role so escalation reviews use the same rendered-surface standard as routine UI Designer reviews.
- Adds the matching runtime-agent guidance, including the mandatory not-verified list and the browser-MCP constraint, so the escalation path cannot imply verification from source alone.

## Validation

- `git diff --check`
- Targeted assertions confirm both Head of Design files contain the browser-evidence, not-verified, and accessibility-tree requirements.
- `bash .claude/rules/tests/test_writing_standard.sh` — 144 passed.
- `bash .claude/agents/tests/test_agent_wrap_shape.sh` — Head of Design and UI Designer checks pass; the suite reports two pre-existing backend/frontend model-matrix failures on the base branch.

Refs #1193

## Glossary

| Term | Definition |
| --- | --- |
| Browser evidence | Verification performed against the rendered product in a real browser, including the URL and data used. |
| Escalation review | A design review performed by the Head of Design when the routine UI Designer path is unavailable or requires escalation. |
| Not-verified list | The explicit list of design criteria that could not be checked in a rendered browser surface. |
| Accessibility tree | A browser representation of rendered roles and text used to verify what assistive technology can perceive. |
