### PR TITLE
fix(#1226): accept v-prefixed changelog headings

### DIFF
--- a/.claude/skills/request-apexyard-feature/SKILL.md
+++ b/.claude/skills/request-apexyard-feature/SKILL.md
@@ -87,7 +87,7 @@ carries `main → dev`, so it is always current on `dev`:
 ```bash
 # Primary: top-most `## [X.Y.Z]` heading in CHANGELOG.md (carried main→dev by
 # /release-sync, so always the canonical current version on dev).
-FW_VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$ops_root/CHANGELOG.md" 2>/dev/null \
+FW_VERSION=$(grep -m1 -oE '^## \[v?[0-9]+\.[0-9]+\.[0-9]+\]' "$ops_root/CHANGELOG.md" 2>/dev/null \
   | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 if [ -n "$FW_VERSION" ]; then
   FW_VERSION="v$FW_VERSION"          # keep the `v` prefix the field renders today


### PR DESCRIPTION
## Summary

- Updates `/request-apexyard-feature` to accept both `[X.Y.Z]` and `[vX.Y.Z]` CHANGELOG headings.
- Keeps the existing normalized `vX.Y.Z` value while preventing a v-prefixed current release from falling through to an older heading.

## Validation

- Fixture with a top `[v5.4.0]` heading now captures `v5.4.0`.
- Fixture with a top `[5.4.0]` heading still captures `v5.4.0`.
- `git diff --check` passed.

Refs #1226

## Glossary

| Term | Definition |
| --- | --- |
| FW_VERSION | The framework version recorded in a submitted feature issue. |
| CHANGELOG heading | A release heading in the form `## [X.Y.Z]` or `## [vX.Y.Z]`. |
| Normalized version | The `vX.Y.Z` form used in issue metadata regardless of the heading prefix. |
