### PR TITLE
fix(#1230): scope protected-branch backstop to target repo

### DIFF
--- a/.claude/hooks/block-main-push.sh
+++ b/.claude/hooks/block-main-push.sh
@@ -127,6 +127,49 @@ if [ -n "$_CANDIDATE_DIR" ] && [ -f "$_CANDIDATE_DIR/_lib-ops-root.sh" ]; then
 fi
 unset _CANDIDATE_DIR
 
+# The settings wrapper normally resolves the hook from the session-pinned ops
+# root. A pin identifies where the hook lives. It does not prove that the
+# command's current repository belongs to that fork. When the wrapper asks for
+# this scope check, resolve the command cwd without consulting the pin and
+# leave unrelated repositories alone. This keeps a protected `main` branch in
+# a scratch repository from being mistaken for the framework's branch.
+if [ "${APEXYARD_OPS_SCOPE_GUARD:-}" = "1" ] &&
+   command -v resolve_ops_root_walk >/dev/null 2>&1; then
+  SCOPE_DIR="$PWD"
+  if echo "$COMMAND" | grep -qE '(^|[;&|[:space:]])cd[[:space:]]+\S'; then
+    SCOPE_DIR=$(echo "$COMMAND" \
+      | grep -oE "cd[[:space:]]+(\"[^\"]*\"|'[^']*'|[^[:space:];&|]+)" \
+      | tail -n 1 \
+      | sed -E "s/^cd[[:space:]]+//; s/^[\"']//; s/[\"']\$//")
+  fi
+  # A managed-project clone can sit below the pinned ops root and still have
+  # an ApexYard-looking ancestor. Resolve the Git repository the command will
+  # actually target and require it to be the pinned hook repository (or one of
+  # its linked worktrees), rather than treating any anchored descendant as an
+  # in-scope target.
+  if echo "$COMMAND" | grep -qE '(^|[;&|[:space:]])git[[:space:]]+-C[[:space:]]+[^[:space:];&|]+'; then
+    TARGET_DIR=$(echo "$COMMAND" \
+      | grep -oE "git[[:space:]]+-C[[:space:]]+(\"[^\"]*\"|'[^']*'|[^[:space:];&|]+)" \
+      | tail -n 1 \
+      | sed -E "s/^git[[:space:]]+-C[[:space:]]+//; s/^[\"']//; s/[\"']\$//")
+    case "$TARGET_DIR" in
+      /*) ;;
+      *) TARGET_DIR="$SCOPE_DIR/$TARGET_DIR" ;;
+    esac
+  else
+    TARGET_DIR="$SCOPE_DIR"
+  fi
+
+  TARGET_ROOT=$(git -C "$TARGET_DIR" rev-parse --show-toplevel 2>/dev/null || true)
+  HOOK_ROOT=$(cd "$HOOK_DIR/../.." 2>/dev/null && pwd -P || true)
+  TARGET_COMMON=$(git -C "$TARGET_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  HOOK_COMMON=$(git -C "$HOOK_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  if [ -z "$TARGET_ROOT" ] || [ -z "$HOOK_ROOT" ] ||
+     { [ "$TARGET_ROOT" != "$HOOK_ROOT" ] && [ "$TARGET_COMMON" != "$HOOK_COMMON" ]; }; then
+    exit 0
+  fi
+fi
+
 # NOTE on heredoc bodies (me2resh/apexyard#1066, #1075): every presence
 # check and cd-target extraction below runs against the RAW $COMMAND, never
 # against heredoc-stripped text. A security review of the first #1066 fix

--- a/.claude/hooks/tests/test_block_main_push.sh
+++ b/.claude/hooks/tests/test_block_main_push.sh
@@ -405,7 +405,7 @@ rm -rf "$SB"
 # The settings wrapper uses the session pin to locate this hook. The pin must
 # not make a protected branch in an unrelated scratch repository look governed
 # by the pinned fork. A real command in the pinned fork must remain blocked.
-if grep -qF 'APEXYARD_OPS_SCOPE_GUARD=1 exec' \
+if grep -qF 'exec env APEXYARD_OPS_SCOPE_GUARD=1' \
   "$SRC_ROOT/.claude/settings.json"; then
   echo "PASS [settings wiring enables ops-root scope guard]"
   PASS=$((PASS+1))

--- a/.claude/hooks/tests/test_block_main_push.sh
+++ b/.claude/hooks/tests/test_block_main_push.sh
@@ -400,6 +400,63 @@ run_case "config override REPLACES default list: push to release blocks" \
 rm -rf "$SB"
 
 # ---------------------------------------------------------------------------
+# (i) Session-pinned ops-root scope (#1230)
+# ---------------------------------------------------------------------------
+# The settings wrapper uses the session pin to locate this hook. The pin must
+# not make a protected branch in an unrelated scratch repository look governed
+# by the pinned fork. A real command in the pinned fork must remain blocked.
+if grep -qF 'APEXYARD_OPS_SCOPE_GUARD=1 exec' \
+  "$SRC_ROOT/.claude/settings.json"; then
+  echo "PASS [settings wiring enables ops-root scope guard]"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [settings wiring enables ops-root scope guard]" >&2
+  FAIL=$((FAIL+1))
+  FAILED_CASES="${FAILED_CASES}settings wiring enables ops-root scope guard "
+fi
+
+OPS_SCOPE=$(make_sandbox "main")
+touch "$OPS_SCOPE/.apexyard-fork"
+SCRATCH_SCOPE=$(mktemp -d)
+make_git_repo "$SCRATCH_SCOPE" "main"
+MANAGED_SCOPE="$OPS_SCOPE/workspace/project"
+mkdir -p "$MANAGED_SCOPE"
+make_git_repo "$MANAGED_SCOPE" "main"
+PIN_SCOPE=$(mktemp -d)
+printf '%s\n' "$OPS_SCOPE" > "$PIN_SCOPE/ops-root-session-1230"
+
+run_scope_case() {
+  local label="$1" cwd="$2" cmd="$3" want_rc="$4"
+  local input got_rc got_stderr
+  input=$(jq -nc --arg c "$cmd" '{tool_input:{command:$c}}')
+  got_stderr=$(cd "$cwd" && \
+    APEXYARD_OPS_SCOPE_GUARD=1 \
+    CLAUDE_CODE_SESSION_ID=session-1230 \
+    APEXYARD_OPS_PIN_DIR="$PIN_SCOPE" \
+    bash "$OPS_SCOPE/.claude/hooks/block-main-push.sh" <<<"$input" 2>&1 >/dev/null)
+  got_rc=$?
+  if [ "$got_rc" = "$want_rc" ]; then
+    echo "PASS [$label]"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [$label]: want rc=$want_rc, got $got_rc" >&2
+    echo "    stderr: ${got_stderr:0:300}" >&2
+    FAIL=$((FAIL+1))
+    FAILED_CASES="${FAILED_CASES}${label} "
+  fi
+}
+
+run_scope_case "pinned hook ignores main in unrelated scratch repo" \
+  "$SCRATCH_SCOPE" "git commit -m scratch" 0
+run_scope_case "pinned hook still blocks main in pinned ops fork" \
+  "$OPS_SCOPE" "git commit -m framework" 2
+run_scope_case "pinned hook ignores protected main in managed-project clone" \
+  "$MANAGED_SCOPE" "git commit -m project" 0
+run_scope_case "git -C target outside pinned ops fork is ignored" \
+  "$OPS_SCOPE" "git -C '$SCRATCH_SCOPE' commit -m scratch" 0
+rm -rf "$OPS_SCOPE" "$SCRATCH_SCOPE" "$PIN_SCOPE"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -126,7 +126,7 @@
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;APEXYARD_OPS_SCOPE_GUARD=1 exec \"$r/.claude/hooks/block-main-push.sh\"'"
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec env APEXYARD_OPS_SCOPE_GUARD=1 \"$r/.claude/hooks/block-main-push.sh\"'"
           },
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -126,7 +126,7 @@
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-main-push.sh\"'"
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;APEXYARD_OPS_SCOPE_GUARD=1 exec \"$r/.claude/hooks/block-main-push.sh\"'"
           },
           {
             "type": "command",

--- a/docs/agdr/AgDR-0143-scope-protected-branch-backstop.md
+++ b/docs/agdr/AgDR-0143-scope-protected-branch-backstop.md
@@ -1,0 +1,49 @@
+---
+id: AgDR-0143
+timestamp: 2026-09-10T00:00:00Z
+agent: codex
+model: gpt-6
+trigger: user-prompt
+status: executed
+category: security
+---
+
+# Scope the protected-branch backstop to its target repository
+
+> In the context of session-pinned ops-root resolution, facing a process-wide protected-branch hook that can inspect an unrelated repository, I decided to scope `block-main-push.sh` to the command's actual Git repository and its linked worktrees, to prevent false blocks without weakening the protected-branch gate, accepting that managed-project clones will no longer use this ops-fork backstop.
+
+## Context
+
+The settings wrapper uses a session pin to find the ops-root hook quickly. That pin identifies where the hook is stored. It does not identify the repository targeted by the Bash command.
+
+Before this change, a plain commit in an unrelated repository could resolve the pinned ApexYard hook and be blocked because the unrelated repository used a protected branch name such as `main`. This was safe-direction enforcement, but it was wrong repository resolution and prevented unrelated work.
+
+The hook remains a blocking trust-chain control for the repository it governs. The scope check is enabled only by the settings wrapper. Direct hook invocations and existing unit fixtures retain their prior behavior. The check resolves `cd` targets and `git -C` targets, compares their Git toplevel and common Git directory with the hook repository, and permits linked worktrees of that repository.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Keep the pin as the repository scope | No code change | Blocks unrelated repositories and cannot distinguish a managed-project clone from the ops fork |
+| Resolve any ApexYard-shaped ancestor | Preserves some managed-project coverage | Still treats nested managed-project clones as the ops fork and repeats the wrong-repository failure |
+| Compare the command target with the pinned hook repository | Matches the command's actual repository; preserves linked worktree coverage; prevents unrelated false blocks | The ops-fork backstop no longer protects managed-project clones that do not share the ops repository |
+| Disable the backstop globally | Removes false blocks | Removes protected-branch protection and violates the existing trust-chain decision |
+
+## Decision
+
+Chosen: **compare the command target with the pinned hook repository**, using Git's toplevel and common Git directory. The settings wrapper sets `APEXYARD_OPS_SCOPE_GUARD=1); the hook then skips commands whose actual target is unrelated. A target is in scope when it is the pinned repository or a linked worktree of that repository.
+
+## Consequences
+
+- Commits and pushes in unrelated repositories are no longer blocked by the ApexYard protected-branch backstop.
+- The pinned ApexYard repository and its linked worktrees retain the existing protected-branch behavior.
+- Managed-project clones outside the ops repository are intentionally outside this repository-scoped backstop. Their own project controls remain responsible for their branches.
+- Regression tests cover unrelated repositories, nested managed-project clones, the pinned repository, and `git -C` targets.
+
+## Artifacts
+
+- me2resh/apexyard#1230
+- `.claude/settings.json`
+- `.claude/hooks/block-main-push.sh`
+- `.claude/hooks/tests/test_block_main_push.sh`
+- AgDR-0114 (blocking backstop decision)


### PR DESCRIPTION
## Summary

- Scope the session-pinned `block-main-push.sh` backstop to the Git repository targeted by the command.
- Resolve `cd` and `git -C` targets and allow the pinned repository plus its linked worktrees.
- Add regression coverage for unrelated repositories, nested managed-project clones, and `git -C` targets.
- Record the trust-chain boundary in AgDR-0143.

## Why it matters

The session pin identifies where the framework hook is stored. It does not prove that a Bash command targets that repository. Before this change, a protected `main` branch in an unrelated scratch repository could be blocked by the pinned ApexYard hook. The backstop still blocks protected branches in the pinned repository, while unrelated repositories proceed normally.

## Validation

- `bash .claude/hooks/tests/test_block_main_push.sh` — 49 passed, 0 failed.
- `shellcheck -S warning --format=gcc .claude/hooks/block-main-push.sh .claude/hooks/tests/test_block_main_push.sh`
- `bash -n .claude/hooks/block-main-push.sh`
- `jq empty .claude/settings.json`
- `git diff --check`

## Glossary

| Term | Definition |
|------|------------|
| session pin | Per-session file that records the ops-root path used to locate framework hooks |
| target repository | Git repository resolved from the command's cwd, `cd` target, or `git -C` target |
| linked worktree | Git worktree that shares the pinned repository's common Git directory |
| protected-branch backstop | Claude Code PreToolUse hook that blocks direct pushes or commits to protected branches |

## Decision record

See [AgDR-0143](https://github.com/me2resh/apexyard/blob/fix/1230-pinned-ops-root-scope/docs/agdr/AgDR-0143-scope-protected-branch-backstop.md).

Closes #1230
