### PR TITLE
fix(#1233): keep review agents read-only

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -51,6 +51,10 @@ The verdict that drives the merge gate is the **local marker**, NOT the host's "
 
 ---
 
+## Repository mutation boundary
+
+You are a review-class agent. Treat the repository and its remotes as read-only. Do not run `git add`, `git commit`, `git push`, `git restore`, `git reset`, `git stash`, `git clean`, `git checkout`, `git switch`, `git mv`, `git rm`, `git rebase`, `git merge`, or other commands that alter tracked files, refs, or remotes. Do not use shell editors or redirections to modify repository files. Report findings and proposed fixes to the orchestrator; a build agent or the orchestrator applies changes after your review. A blocking hook enforces this boundary while the active-reviewer marker is present.
+
 ## Trigger
 
 Invoked when a PR is ready for review.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -42,6 +42,10 @@ tracker_review_submit "$PR_HOST_REPO" {number} comment "$REVIEW_BODY_FILE"
 
 ---
 
+## Repository mutation boundary
+
+You are a review-class agent. Treat the repository and its remotes as read-only. Do not run `git add`, `git commit`, `git push`, `git restore`, `git reset`, `git stash`, `git clean`, `git checkout`, `git switch`, `git mv`, `git rm`, `git rebase`, `git merge`, or other commands that alter tracked files, refs, or remotes. Do not use shell editors or redirections to modify repository files. Report findings and proposed fixes to the orchestrator; a build agent or the orchestrator applies changes after your review. A blocking hook enforces this boundary while the active-reviewer marker is present.
+
 ## Trigger
 
 Invoked when a PR needs security review, especially for:

--- a/.claude/agents/solution-architect.md
+++ b/.claude/agents/solution-architect.md
@@ -43,6 +43,10 @@ tracker_review_submit "$PR_HOST_REPO" {number} comment "$REVIEW_BODY_FILE"
 
 ---
 
+## Repository mutation boundary
+
+You are a review-class agent. Treat the repository and its remotes as read-only. Do not run `git add`, `git commit`, `git push`, `git restore`, `git reset`, `git stash`, `git clean`, `git checkout`, `git switch`, `git mv`, `git rm`, `git rebase`, `git merge`, or other commands that alter tracked files, refs, or remotes. Do not use shell editors or redirections to modify repository files. Report findings and proposed fixes to the orchestrator; a build agent or the orchestrator applies changes after your review. A blocking hook enforces this boundary while the active-reviewer marker is present.
+
 ## Trigger
 
 Invoked when a design artifact is ready for review — a PR (or a doc) carrying a technical design, a migration AgDR, or a feature spec / PRD. Auto-fires via `detect-role-trigger.sh` when an Edit/Write touches:

--- a/.claude/hooks/block-reviewer-repo-mutation.sh
+++ b/.claude/hooks/block-reviewer-repo-mutation.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# CLASS: CONTROL — blocks repository-mutating git commands while a sanctioned
+# review-class agent is active (me2resh/apexyard#1233, AgDR-0145).
+#
+# The active-reviewer marker is written by the review skill immediately before
+# Rex, Hakim, or Tariq is spawned. It is a narrow session signal: when present,
+# review-class work is in flight, so Bash git mutations must be rejected before
+# they can alter the reviewed branch or working tree. Read-only git commands
+# remain available for evidence gathering and review submission.
+
+set -u
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+
+# If the hook cannot parse the tool payload, do not invent a block when there
+# is no active review. With an active marker, fail closed for payloads that
+# visibly contain a git mutation.
+ROOT="${APEXYARD_REVIEW_OPS_ROOT:-}"
+if [ -z "$ROOT" ] || [ ! -d "$ROOT/.claude/session" ]; then
+  ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  while [ -n "$ROOT" ] && [ "$ROOT" != / ]; do
+    if [ -f "$ROOT/.apexyard-fork" ] || { [ -f "$ROOT/onboarding.yaml" ] && [ -f "$ROOT/apexyard.projects.yaml" ]; }; then
+      break
+    fi
+    ROOT=$(dirname "$ROOT")
+  done
+fi
+
+[ -n "$ROOT" ] || exit 0
+ACTIVE="$ROOT/.claude/session/active-reviewer"
+[ -f "$ACTIVE" ] || exit 0
+
+if [ -z "$COMMAND" ]; then
+  if printf '%s' "$INPUT" | grep -qE '(^|[^[:alnum:]_-])git[[:space:]]+([^;&|]*[[:space:]])?(add|commit|push|restore|reset|stash|clean|checkout|switch|mv|rm|rebase|cherry-pick|merge|tag|branch)([[:space:]]|$)'; then
+    echo "BLOCKED: review-class agent cannot mutate the repository while an active review is in flight; use read-only git commands and report findings." >&2
+    exit 2
+  fi
+  exit 0
+fi
+
+# Remove confirmed heredoc bodies before inspecting command text. Review prose
+# often mentions git verbs; only the command portion should be classified.
+HOOK_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)
+if [ -f "$HOOK_DIR/_lib-strip-heredoc.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-strip-heredoc.sh"
+  COMMAND=$(strip_heredoc_bodies "$COMMAND")
+fi
+
+# A git subcommand is mutating when it can change the index, worktree, refs, or
+# remote. The command-position anchor avoids matching quoted review prose such
+# as `echo 'git commit is forbidden'`. Options such as `git -C repo commit` are
+# accepted by the middle token span.
+MUTATING='add|commit|push|restore|reset|stash|clean|checkout|switch|mv|rm|rebase|cherry-pick|merge|tag|branch'
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\\|\\||;|\\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?(${MUTATING})([[:space:]]|$)"; then
+  echo "BLOCKED: review-class agent is read-only while an active review is in flight. Do not stage, commit, push, restore, stash, or otherwise mutate the repository; report the finding to the orchestrator." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/block-reviewer-repo-mutation.sh
+++ b/.claude/hooks/block-reviewer-repo-mutation.sh
@@ -52,7 +52,7 @@ fi
 # remote. The command-position anchor avoids matching quoted review prose such
 # as `echo 'git commit is forbidden'`. Options such as `git -C repo commit` are
 # accepted by the middle token span.
-MUTATING='add|commit|push|restore|reset|stash|clean|checkout|checkout-index|switch|mv|rm|rebase|cherry-pick|merge|tag|branch|update-ref|fetch|apply|submodule|worktree|notes|revert|am|bisect|config|reflog|replace|sparse-checkout|filter-branch|gc|init|repack|prune|fast-import'
+MUTATING='add|commit|push|restore|reset|stash|clean|checkout|checkout-index|switch|mv|rm|rebase|cherry-pick|merge|tag|branch|update-ref|fetch|apply|submodule|worktree|notes|revert|am|bisect|config|reflog|replace|sparse-checkout|filter-branch|gc|init|repack|prune|fast-import|fast-export|pull|remote|read-tree|write-tree|commit-tree|update-index|hash-object|index-pack|pack-refs|mktag|mktree|rerere|maintenance|clone|init-db|stage|subtree|replay|format-patch|archive'
 if printf '%s' "$COMMAND" | grep -qE "(^|&&|\\|\\||;|\\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?(${MUTATING})([[:space:];|&]|$)"; then
   echo "BLOCKED: review-class agent is read-only while an active review is in flight. Do not stage, commit, push, restore, stash, or otherwise mutate the repository; report the finding to the orchestrator." >&2
   exit 2

--- a/.claude/hooks/block-reviewer-repo-mutation.sh
+++ b/.claude/hooks/block-reviewer-repo-mutation.sh
@@ -109,6 +109,14 @@ if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]
   echo "BLOCKED: review-class agent cannot alter maintenance state during an active review." >&2
   exit 2
 fi
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?fast-export([^;&|]*[[:space:]])--export-marks(=|[[:space:]])"; then
+  echo "BLOCKED: review-class agent cannot write fast-export marks during an active review." >&2
+  exit 2
+fi
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?archive([^;&|]*[[:space:]])(--output=|--output[[:space:]])"; then
+  echo "BLOCKED: review-class agent cannot write archive output during an active review." >&2
+  exit 2
+fi
 if printf '%s' "$COMMAND" | grep -qE "(^|&&|\\|\\||;|\\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?(${MUTATING})([[:space:];|&]|$)"; then
   echo "BLOCKED: review-class agent is read-only while an active review is in flight. Do not stage, commit, push, restore, stash, or otherwise mutate the repository; report the finding to the orchestrator." >&2
   exit 2

--- a/.claude/hooks/block-reviewer-repo-mutation.sh
+++ b/.claude/hooks/block-reviewer-repo-mutation.sh
@@ -52,7 +52,7 @@ fi
 # remote. The command-position anchor avoids matching quoted review prose such
 # as `echo 'git commit is forbidden'`. Options such as `git -C repo commit` are
 # accepted by the middle token span.
-MUTATING='add|commit|push|restore|reset|stash|clean|checkout|checkout-index|switch|mv|rm|rebase|cherry-pick|merge|tag|branch|update-ref|fetch|apply|submodule|worktree|notes'
+MUTATING='add|commit|push|restore|reset|stash|clean|checkout|checkout-index|switch|mv|rm|rebase|cherry-pick|merge|tag|branch|update-ref|fetch|apply|submodule|worktree|notes|revert|am|bisect|config|reflog|replace|sparse-checkout|filter-branch|gc|init|repack|prune|fast-import'
 if printf '%s' "$COMMAND" | grep -qE "(^|&&|\\|\\||;|\\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?(${MUTATING})([[:space:];|&]|$)"; then
   echo "BLOCKED: review-class agent is read-only while an active review is in flight. Do not stage, commit, push, restore, stash, or otherwise mutate the repository; report the finding to the orchestrator." >&2
   exit 2

--- a/.claude/hooks/block-reviewer-repo-mutation.sh
+++ b/.claude/hooks/block-reviewer-repo-mutation.sh
@@ -113,7 +113,7 @@ if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]
   echo "BLOCKED: review-class agent cannot write fast-export marks during an active review." >&2
   exit 2
 fi
-if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?archive([^;&|]*[[:space:]])(-o=|-o[[:space:]]|--output=|--output[[:space:]])"; then
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?archive([^;&|]*[[:space:]])(-o=|-o[^[:space:];|&]+|-o[[:space:]]|--output=|--output[[:space:]])"; then
   echo "BLOCKED: review-class agent cannot write archive output during an active review." >&2
   exit 2
 fi

--- a/.claude/hooks/block-reviewer-repo-mutation.sh
+++ b/.claude/hooks/block-reviewer-repo-mutation.sh
@@ -52,7 +52,7 @@ fi
 # remote. The command-position anchor avoids matching quoted review prose such
 # as `echo 'git commit is forbidden'`. Options such as `git -C repo commit` are
 # accepted by the middle token span.
-MUTATING='add|commit|push|restore|reset|stash|clean|checkout|checkout-index|switch|mv|rm|rebase|cherry-pick|merge|tag|update-ref|fetch|apply|submodule|revert|am|bisect|replace|sparse-checkout|filter-branch|gc|init|repack|prune|fast-import|fast-export|pull|read-tree|write-tree|commit-tree|update-index|hash-object|index-pack|pack-refs|mktag|mktree|rerere|maintenance|clone|init-db|stage|subtree|replay|format-patch'
+MUTATING='add|commit|push|restore|reset|stash|clean|checkout|checkout-index|switch|mv|rm|rebase|cherry-pick|merge|tag|update-ref|fetch|apply|revert|am|bisect|replace|filter-branch|gc|init|repack|prune|fast-import|pull|read-tree|write-tree|commit-tree|update-index|hash-object|index-pack|pack-refs|mktag|mktree|clone|init-db|stage|subtree|replay'
 
 # `git remote get-url` and `git remote -v` are read-only operations used to
 # resolve the review host. Block only remote subcommands that change remotes.
@@ -69,7 +69,7 @@ if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]
   exit 2
 fi
 if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?config([[:space:]]|$)" && \
-   ! printf '%s' "$COMMAND" | grep -qE "git[[:space:]]+config[[:space:]]+(-{1,2}(get|get-all|get-regexp|list|show-origin|show-scope|name-only|includes|null)([[:space:]]|$)|-l([[:space:]]|$))"; then
+   ! printf '%s' "$COMMAND" | grep -qE "git([^;&|]*[[:space:]])config[[:space:]]+(-{1,2}(get|get-all|get-regexp|list|show-origin|show-scope|name-only|includes|null)([[:space:]]|$)|-l([[:space:]]|$))"; then
   echo "BLOCKED: review-class agent cannot change Git configuration during an active review." >&2
   exit 2
 fi
@@ -83,6 +83,30 @@ if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]
 fi
 if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?worktree([[:space:]]|$)([^;&|]*[[:space:]])?(add|lock|move|prune|remove|repair|unlock)([[:space:];|&]|$)"; then
   echo "BLOCKED: review-class agent cannot alter worktrees during an active review." >&2
+  exit 2
+fi
+
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?submodule([[:space:]]|$)" && \
+   ! printf '%s' "$COMMAND" | grep -qE "git([^;&|]*[[:space:]])submodule[[:space:]]+(status|summary)([[:space:];|&]|$)"; then
+  echo "BLOCKED: review-class agent cannot change submodules during an active review." >&2
+  exit 2
+fi
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?sparse-checkout([[:space:]]|$)" && \
+   ! printf '%s' "$COMMAND" | grep -qE "git([^;&|]*[[:space:]])sparse-checkout[[:space:]]+list([[:space:];|&]|$)"; then
+  echo "BLOCKED: review-class agent cannot change sparse-checkout state during an active review." >&2
+  exit 2
+fi
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?format-patch([[:space:]]|$)" && \
+   ! printf '%s' "$COMMAND" | grep -qE "git([^;&|]*[[:space:]])format-patch([^;&|]*[[:space:]])--stdout([[:space:];|&]|$)"; then
+  echo "BLOCKED: review-class agent cannot write patch files during an active review." >&2
+  exit 2
+fi
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?rerere([[:space:]]|$)([^;&|]*[[:space:]])?(forget|clear)([[:space:];|&]|$)"; then
+  echo "BLOCKED: review-class agent cannot alter rerere state during an active review." >&2
+  exit 2
+fi
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?maintenance([[:space:]]|$)([^;&|]*[[:space:]])?(run|start|stop|register|unregister|start)([[:space:];|&]|$)"; then
+  echo "BLOCKED: review-class agent cannot alter maintenance state during an active review." >&2
   exit 2
 fi
 if printf '%s' "$COMMAND" | grep -qE "(^|&&|\\|\\||;|\\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?(${MUTATING})([[:space:];|&]|$)"; then

--- a/.claude/hooks/block-reviewer-repo-mutation.sh
+++ b/.claude/hooks/block-reviewer-repo-mutation.sh
@@ -52,7 +52,7 @@ fi
 # remote. The command-position anchor avoids matching quoted review prose such
 # as `echo 'git commit is forbidden'`. Options such as `git -C repo commit` are
 # accepted by the middle token span.
-MUTATING='add|commit|push|restore|reset|stash|clean|checkout|switch|mv|rm|rebase|cherry-pick|merge|tag|branch'
+MUTATING='add|commit|push|restore|reset|stash|clean|checkout|checkout-index|switch|mv|rm|rebase|cherry-pick|merge|tag|branch|update-ref|fetch|apply|submodule|worktree|notes'
 if printf '%s' "$COMMAND" | grep -qE "(^|&&|\\|\\||;|\\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?(${MUTATING})([[:space:];|&]|$)"; then
   echo "BLOCKED: review-class agent is read-only while an active review is in flight. Do not stage, commit, push, restore, stash, or otherwise mutate the repository; report the finding to the orchestrator." >&2
   exit 2

--- a/.claude/hooks/block-reviewer-repo-mutation.sh
+++ b/.claude/hooks/block-reviewer-repo-mutation.sh
@@ -52,12 +52,37 @@ fi
 # remote. The command-position anchor avoids matching quoted review prose such
 # as `echo 'git commit is forbidden'`. Options such as `git -C repo commit` are
 # accepted by the middle token span.
-MUTATING='add|commit|push|restore|reset|stash|clean|checkout|checkout-index|switch|mv|rm|rebase|cherry-pick|merge|tag|branch|update-ref|fetch|apply|submodule|worktree|notes|revert|am|bisect|config|reflog|replace|sparse-checkout|filter-branch|gc|init|repack|prune|fast-import|fast-export|pull|read-tree|write-tree|commit-tree|update-index|hash-object|index-pack|pack-refs|mktag|mktree|rerere|maintenance|clone|init-db|stage|subtree|replay|format-patch'
+MUTATING='add|commit|push|restore|reset|stash|clean|checkout|checkout-index|switch|mv|rm|rebase|cherry-pick|merge|tag|update-ref|fetch|apply|submodule|revert|am|bisect|replace|sparse-checkout|filter-branch|gc|init|repack|prune|fast-import|fast-export|pull|read-tree|write-tree|commit-tree|update-index|hash-object|index-pack|pack-refs|mktag|mktree|rerere|maintenance|clone|init-db|stage|subtree|replay|format-patch'
 
 # `git remote get-url` and `git remote -v` are read-only operations used to
 # resolve the review host. Block only remote subcommands that change remotes.
 if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?remote[[:space:]]+(add|remove|set-url|rename|prune|update|set-branches|set-head)([[:space:];|&]|$)"; then
   echo "BLOCKED: review-class agent is read-only while an active review is in flight. Do not mutate repository remotes; report the finding to the orchestrator." >&2
+  exit 2
+fi
+
+# These commands have read-only subcommands that reviewers use for evidence;
+# block their write-capable forms while preserving the read forms.
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?branch([[:space:]]|$)" && \
+   ! printf '%s' "$COMMAND" | grep -qE "git[[:space:]]+branch([[:space:]]*$|[[:space:]]+(-a|--all|--show-current|--list|-l|-r|--remotes|-v|-vv|--verbose|--contains|--merged|--no-merged|--points-at|--format=|--sort=|--column|--color))"; then
+  echo "BLOCKED: review-class agent cannot create or alter branches during an active review." >&2
+  exit 2
+fi
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?config([[:space:]]|$)" && \
+   ! printf '%s' "$COMMAND" | grep -qE "git[[:space:]]+config[[:space:]]+(-{1,2}(get|get-all|get-regexp|list|show-origin|show-scope|name-only|includes|null)([[:space:]]|$)|-l([[:space:]]|$))"; then
+  echo "BLOCKED: review-class agent cannot change Git configuration during an active review." >&2
+  exit 2
+fi
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?reflog([[:space:]]|$)([^;&|]*[[:space:]])?(expire|delete|drop)([[:space:];|&]|$)"; then
+  echo "BLOCKED: review-class agent cannot alter reflogs during an active review." >&2
+  exit 2
+fi
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?notes([[:space:]]|$)([^;&|]*[[:space:]])?(add|append|copy|edit|merge|prune|remove|rewrite|strip)([[:space:];|&]|$)"; then
+  echo "BLOCKED: review-class agent cannot alter Git notes during an active review." >&2
+  exit 2
+fi
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?worktree([[:space:]]|$)([^;&|]*[[:space:]])?(add|lock|move|prune|remove|repair|unlock)([[:space:];|&]|$)"; then
+  echo "BLOCKED: review-class agent cannot alter worktrees during an active review." >&2
   exit 2
 fi
 if printf '%s' "$COMMAND" | grep -qE "(^|&&|\\|\\||;|\\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?(${MUTATING})([[:space:];|&]|$)"; then

--- a/.claude/hooks/block-reviewer-repo-mutation.sh
+++ b/.claude/hooks/block-reviewer-repo-mutation.sh
@@ -113,7 +113,7 @@ if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]
   echo "BLOCKED: review-class agent cannot write fast-export marks during an active review." >&2
   exit 2
 fi
-if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?archive([^;&|]*[[:space:]])(--output=|--output[[:space:]])"; then
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?archive([^;&|]*[[:space:]])(-o=|-o[[:space:]]|--output=|--output[[:space:]])"; then
   echo "BLOCKED: review-class agent cannot write archive output during an active review." >&2
   exit 2
 fi

--- a/.claude/hooks/block-reviewer-repo-mutation.sh
+++ b/.claude/hooks/block-reviewer-repo-mutation.sh
@@ -32,7 +32,7 @@ ACTIVE="$ROOT/.claude/session/active-reviewer"
 [ -f "$ACTIVE" ] || exit 0
 
 if [ -z "$COMMAND" ]; then
-  if printf '%s' "$INPUT" | grep -qE '(^|[^[:alnum:]_-])git[[:space:]]+([^;&|]*[[:space:]])?(add|commit|push|restore|reset|stash|clean|checkout|switch|mv|rm|rebase|cherry-pick|merge|tag|branch)([[:space:]]|$)'; then
+  if printf '%s' "$INPUT" | grep -qE '(^|[^[:alnum:]_-])git[[:space:]]+([^;&|]*[[:space:]])?(add|commit|push|restore|reset|stash|clean|checkout|switch|mv|rm|rebase|cherry-pick|merge|tag|branch)([[:space:];|&]|$)'; then
     echo "BLOCKED: review-class agent cannot mutate the repository while an active review is in flight; use read-only git commands and report findings." >&2
     exit 2
   fi
@@ -53,7 +53,7 @@ fi
 # as `echo 'git commit is forbidden'`. Options such as `git -C repo commit` are
 # accepted by the middle token span.
 MUTATING='add|commit|push|restore|reset|stash|clean|checkout|switch|mv|rm|rebase|cherry-pick|merge|tag|branch'
-if printf '%s' "$COMMAND" | grep -qE "(^|&&|\\|\\||;|\\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?(${MUTATING})([[:space:]]|$)"; then
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\\|\\||;|\\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?(${MUTATING})([[:space:];|&]|$)"; then
   echo "BLOCKED: review-class agent is read-only while an active review is in flight. Do not stage, commit, push, restore, stash, or otherwise mutate the repository; report the finding to the orchestrator." >&2
   exit 2
 fi

--- a/.claude/hooks/block-reviewer-repo-mutation.sh
+++ b/.claude/hooks/block-reviewer-repo-mutation.sh
@@ -52,7 +52,14 @@ fi
 # remote. The command-position anchor avoids matching quoted review prose such
 # as `echo 'git commit is forbidden'`. Options such as `git -C repo commit` are
 # accepted by the middle token span.
-MUTATING='add|commit|push|restore|reset|stash|clean|checkout|checkout-index|switch|mv|rm|rebase|cherry-pick|merge|tag|branch|update-ref|fetch|apply|submodule|worktree|notes|revert|am|bisect|config|reflog|replace|sparse-checkout|filter-branch|gc|init|repack|prune|fast-import|fast-export|pull|remote|read-tree|write-tree|commit-tree|update-index|hash-object|index-pack|pack-refs|mktag|mktree|rerere|maintenance|clone|init-db|stage|subtree|replay|format-patch|archive'
+MUTATING='add|commit|push|restore|reset|stash|clean|checkout|checkout-index|switch|mv|rm|rebase|cherry-pick|merge|tag|branch|update-ref|fetch|apply|submodule|worktree|notes|revert|am|bisect|config|reflog|replace|sparse-checkout|filter-branch|gc|init|repack|prune|fast-import|fast-export|pull|read-tree|write-tree|commit-tree|update-index|hash-object|index-pack|pack-refs|mktag|mktree|rerere|maintenance|clone|init-db|stage|subtree|replay|format-patch'
+
+# `git remote get-url` and `git remote -v` are read-only operations used to
+# resolve the review host. Block only remote subcommands that change remotes.
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?remote[[:space:]]+(add|remove|set-url|rename|prune|update|set-branches|set-head)([[:space:];|&]|$)"; then
+  echo "BLOCKED: review-class agent is read-only while an active review is in flight. Do not mutate repository remotes; report the finding to the orchestrator." >&2
+  exit 2
+fi
 if printf '%s' "$COMMAND" | grep -qE "(^|&&|\\|\\||;|\\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?(${MUTATING})([[:space:];|&]|$)"; then
   echo "BLOCKED: review-class agent is read-only while an active review is in flight. Do not stage, commit, push, restore, stash, or otherwise mutate the repository; report the finding to the orchestrator." >&2
   exit 2

--- a/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
+++ b/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
@@ -34,6 +34,10 @@ run_case 'git commit is blocked' 'git commit -m "reviewed"' blocked
 run_case 'git push is blocked' 'cd repo && git push origin fix/1233-review-agent-read-only' blocked
 run_case 'git restore is blocked' 'git -C repo restore tracked.md' blocked
 run_case 'git stash is blocked' 'git stash push -m save' blocked
+run_case 'git commit before separator is blocked' 'git commit;' blocked
+run_case 'git push before separator is blocked' 'git push; echo done' blocked
+run_case 'newline-separated git mutation is blocked' $'echo review\ngit commit' blocked
+run_case 'git tag is blocked' 'git tag release-candidate' blocked
 run_case 'git status remains available' 'git status --short' allowed
 run_case 'git diff remains available' 'git diff --check' allowed
 run_case 'quoted prose is not a mutation' "printf '%s\\n' 'git commit is forbidden'" allowed

--- a/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
+++ b/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
@@ -57,6 +57,9 @@ run_case 'git gc is blocked' 'git gc' blocked
 run_case 'git init is blocked' 'git init' blocked
 run_case 'git status remains available' 'git status --short' allowed
 run_case 'git diff remains available' 'git diff --check' allowed
+run_case 'git rev-parse remains available' 'git rev-parse HEAD' allowed
+run_case 'git remote get-url remains available' 'git remote get-url origin' allowed
+run_case 'git remote add is blocked' 'git remote add backup https://example.invalid/repo.git' blocked
 run_case 'quoted prose is not a mutation' "printf '%s\\n' 'git commit is forbidden'" allowed
 run_case 'heredoc review prose is not a mutation' $'cat <<EOF > /tmp/review-body\nDo not run git commit during review.\nEOF' allowed
 

--- a/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
+++ b/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
@@ -69,6 +69,15 @@ run_case 'git branch create is blocked' 'git branch reviewer-copy' blocked
 run_case 'git config write is blocked' 'git config user.name Reviewer' blocked
 run_case 'git notes add is blocked' 'git notes add -m note HEAD' blocked
 run_case 'git worktree remove is blocked' 'git worktree remove ../review-copy' blocked
+run_case 'git submodule status remains available' 'git submodule status' allowed
+run_case 'git sparse-checkout list remains available' 'git sparse-checkout list' allowed
+run_case 'git format-patch stdout remains available' 'git format-patch --stdout HEAD~1..HEAD' allowed
+run_case 'git fast-export remains available' 'git fast-export HEAD' allowed
+run_case 'git rerere status remains available' 'git rerere status' allowed
+run_case 'git maintenance list remains available' 'git maintenance list' allowed
+run_case 'git C config get remains available' 'git -C repo config --get user.name' allowed
+run_case 'git format-patch file write is blocked' 'git format-patch HEAD~1..HEAD' blocked
+run_case 'git submodule update remains blocked' 'git submodule update --init' blocked
 run_case 'quoted prose is not a mutation' "printf '%s\\n' 'git commit is forbidden'" allowed
 run_case 'heredoc review prose is not a mutation' $'cat <<EOF > /tmp/review-body\nDo not run git commit during review.\nEOF' allowed
 

--- a/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
+++ b/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
@@ -83,6 +83,8 @@ run_case 'git archive output write is blocked' 'git archive --output=archive.tar
 run_case 'git archive short output write is blocked' 'git archive -o archive.tar HEAD' blocked
 run_case 'git archive short equals output is blocked' 'git archive -o=archive.tar HEAD' blocked
 run_case 'git C archive output write is blocked' 'git -C repo archive -o archive.tar HEAD' blocked
+run_case 'git archive attached short output is blocked' 'git archive -oarchive.tar HEAD' blocked
+run_case 'git C archive attached short output is blocked' 'git -C repo archive -oarchive.tar HEAD' blocked
 run_case 'quoted prose is not a mutation' "printf '%s\\n' 'git commit is forbidden'" allowed
 run_case 'heredoc review prose is not a mutation' $'cat <<EOF > /tmp/review-body\nDo not run git commit during review.\nEOF' allowed
 

--- a/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
+++ b/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
@@ -20,7 +20,7 @@ run_case() {
   input=$(jq -cn --arg command "$command" '{tool_input:{command:$command}}')
   output=$(cd "$TMP" && printf '%s' "$input" | "$TMP/.claude/hooks/block-reviewer-repo-mutation.sh" 2>&1)
   rc=$?
-  if [ "$expected" = blocked ] && [ "$rc" -eq 2 ] && printf '%s' "$output" | grep -q 'review-class agent is read-only'; then
+  if [ "$expected" = blocked ] && [ "$rc" -eq 2 ] && printf '%s' "$output" | grep -q 'BLOCKED:'; then
     echo "PASS: $name"
   elif [ "$expected" = allowed ] && [ "$rc" -eq 0 ]; then
     echo "PASS: $name"
@@ -60,6 +60,15 @@ run_case 'git diff remains available' 'git diff --check' allowed
 run_case 'git rev-parse remains available' 'git rev-parse HEAD' allowed
 run_case 'git remote get-url remains available' 'git remote get-url origin' allowed
 run_case 'git remote add is blocked' 'git remote add backup https://example.invalid/repo.git' blocked
+run_case 'git branch show-current remains available' 'git branch --show-current' allowed
+run_case 'git config get remains available' 'git config --get user.name' allowed
+run_case 'git reflog show remains available' 'git reflog -1' allowed
+run_case 'git notes show remains available' 'git notes show HEAD' allowed
+run_case 'git worktree list remains available' 'git worktree list' allowed
+run_case 'git branch create is blocked' 'git branch reviewer-copy' blocked
+run_case 'git config write is blocked' 'git config user.name Reviewer' blocked
+run_case 'git notes add is blocked' 'git notes add -m note HEAD' blocked
+run_case 'git worktree remove is blocked' 'git worktree remove ../review-copy' blocked
 run_case 'quoted prose is not a mutation' "printf '%s\\n' 'git commit is forbidden'" allowed
 run_case 'heredoc review prose is not a mutation' $'cat <<EOF > /tmp/review-body\nDo not run git commit during review.\nEOF' allowed
 

--- a/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
+++ b/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Regression tests for #1233: review-class agents stay read-only while the
+# active-reviewer marker is present.
+set -u
+
+SRC_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+HOOK="$SRC_ROOT/.claude/hooks/block-reviewer-repo-mutation.sh"
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/apexyard-review-mutation.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/.claude/session" "$TMP/.claude/hooks"
+touch "$TMP/.apexyard-fork"
+git -C "$TMP" init -q
+cp "$HOOK" "$TMP/.claude/hooks/"
+cp "$SRC_ROOT/.claude/hooks/_lib-strip-heredoc.sh" "$TMP/.claude/hooks/"
+printf '%s\n' 'me2resh/apexyard#1233:rex' > "$TMP/.claude/session/active-reviewer"
+
+run_case() {
+  local name="$1" command="$2" expected="$3"
+  local input output rc
+  input=$(jq -cn --arg command "$command" '{tool_input:{command:$command}}')
+  output=$(cd "$TMP" && printf '%s' "$input" | "$TMP/.claude/hooks/block-reviewer-repo-mutation.sh" 2>&1)
+  rc=$?
+  if [ "$expected" = blocked ] && [ "$rc" -eq 2 ] && printf '%s' "$output" | grep -q 'review-class agent is read-only'; then
+    echo "PASS: $name"
+  elif [ "$expected" = allowed ] && [ "$rc" -eq 0 ]; then
+    echo "PASS: $name"
+  else
+    echo "FAIL: $name (rc=$rc output=$output)" >&2
+    return 1
+  fi
+}
+
+run_case 'git commit is blocked' 'git commit -m "reviewed"' blocked
+run_case 'git push is blocked' 'cd repo && git push origin fix/1233-review-agent-read-only' blocked
+run_case 'git restore is blocked' 'git -C repo restore tracked.md' blocked
+run_case 'git stash is blocked' 'git stash push -m save' blocked
+run_case 'git status remains available' 'git status --short' allowed
+run_case 'git diff remains available' 'git diff --check' allowed
+run_case 'quoted prose is not a mutation' "printf '%s\\n' 'git commit is forbidden'" allowed
+run_case 'heredoc review prose is not a mutation' $'cat <<EOF > /tmp/review-body\nDo not run git commit during review.\nEOF' allowed
+
+rm -f "$TMP/.claude/session/active-reviewer"
+run_case 'without active review mutations are unchanged' 'git commit -m "orchestrator work"' allowed
+
+echo 'PASS: all review mutation cases'

--- a/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
+++ b/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
@@ -45,6 +45,16 @@ run_case 'git apply is blocked' 'git apply fix.patch' blocked
 run_case 'git submodule update is blocked' 'git submodule update --init' blocked
 run_case 'git worktree add is blocked' 'git worktree add ../review-copy HEAD' blocked
 run_case 'git notes is blocked' 'git notes add -m note HEAD' blocked
+run_case 'git revert is blocked' 'git revert HEAD' blocked
+run_case 'git am is blocked' 'git am review.patch' blocked
+run_case 'git bisect is blocked' 'git bisect start' blocked
+run_case 'git config is blocked' 'git config user.name Reviewer' blocked
+run_case 'git reflog is blocked' 'git reflog expire --all' blocked
+run_case 'git replace is blocked' 'git replace HEAD HEAD^' blocked
+run_case 'git sparse-checkout is blocked' 'git sparse-checkout set src' blocked
+run_case 'git filter-branch is blocked' 'git filter-branch -- --all' blocked
+run_case 'git gc is blocked' 'git gc' blocked
+run_case 'git init is blocked' 'git init' blocked
 run_case 'git status remains available' 'git status --short' allowed
 run_case 'git diff remains available' 'git diff --check' allowed
 run_case 'quoted prose is not a mutation' "printf '%s\\n' 'git commit is forbidden'" allowed

--- a/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
+++ b/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
@@ -80,6 +80,9 @@ run_case 'git format-patch file write is blocked' 'git format-patch HEAD~1..HEAD
 run_case 'git submodule update remains blocked' 'git submodule update --init' blocked
 run_case 'git fast-export marks write is blocked' 'git fast-export --export-marks=marks.txt HEAD' blocked
 run_case 'git archive output write is blocked' 'git archive --output=archive.tar HEAD' blocked
+run_case 'git archive short output write is blocked' 'git archive -o archive.tar HEAD' blocked
+run_case 'git archive short equals output is blocked' 'git archive -o=archive.tar HEAD' blocked
+run_case 'git C archive output write is blocked' 'git -C repo archive -o archive.tar HEAD' blocked
 run_case 'quoted prose is not a mutation' "printf '%s\\n' 'git commit is forbidden'" allowed
 run_case 'heredoc review prose is not a mutation' $'cat <<EOF > /tmp/review-body\nDo not run git commit during review.\nEOF' allowed
 

--- a/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
+++ b/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
@@ -78,6 +78,8 @@ run_case 'git maintenance list remains available' 'git maintenance list' allowed
 run_case 'git C config get remains available' 'git -C repo config --get user.name' allowed
 run_case 'git format-patch file write is blocked' 'git format-patch HEAD~1..HEAD' blocked
 run_case 'git submodule update remains blocked' 'git submodule update --init' blocked
+run_case 'git fast-export marks write is blocked' 'git fast-export --export-marks=marks.txt HEAD' blocked
+run_case 'git archive output write is blocked' 'git archive --output=archive.tar HEAD' blocked
 run_case 'quoted prose is not a mutation' "printf '%s\\n' 'git commit is forbidden'" allowed
 run_case 'heredoc review prose is not a mutation' $'cat <<EOF > /tmp/review-body\nDo not run git commit during review.\nEOF' allowed
 

--- a/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
+++ b/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
@@ -38,6 +38,13 @@ run_case 'git commit before separator is blocked' 'git commit;' blocked
 run_case 'git push before separator is blocked' 'git push; echo done' blocked
 run_case 'newline-separated git mutation is blocked' $'echo review\ngit commit' blocked
 run_case 'git tag is blocked' 'git tag release-candidate' blocked
+run_case 'git update-ref is blocked' 'git update-ref refs/heads/reviewed HEAD' blocked
+run_case 'git fetch is blocked' 'git fetch origin' blocked
+run_case 'git checkout-index is blocked' 'git checkout-index --all' blocked
+run_case 'git apply is blocked' 'git apply fix.patch' blocked
+run_case 'git submodule update is blocked' 'git submodule update --init' blocked
+run_case 'git worktree add is blocked' 'git worktree add ../review-copy HEAD' blocked
+run_case 'git notes is blocked' 'git notes add -m note HEAD' blocked
 run_case 'git status remains available' 'git status --short' allowed
 run_case 'git diff remains available' 'git diff --check' allowed
 run_case 'quoted prose is not a mutation' "printf '%s\\n' 'git commit is forbidden'" allowed

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -114,6 +114,10 @@ Build agents MUST:
 - Report build results plainly: what was built, what tests ran, what passed or failed
 - Hand off to the orchestrator, which runs the real Rex review as a separate sub-agent call
 
+### Review-class agents are read-only
+
+The mirror direction is also forbidden: a review-class agent (`code-reviewer`, `security-reviewer`, or `solution-architect`) MUST NOT become an author while reviewing a PR. It reports findings and leaves edits, commits, pushes, restores, stashes, and other repository mutations to the orchestrator or a build agent. The `block-reviewer-repo-mutation.sh` PreToolUse control blocks mutating `git` subcommands while the active-reviewer marker is present; the agent prompts carry the same boundary for commands the hook cannot classify. The control is scoped to the marker window so ordinary orchestrator work remains available before and after the review. See AgDR-0145 and #1233.
+
 ### Mechanical backstop
 
 **`warn-review-marker-write.sh` is ADVISORY — it warns, it does not block.** It was a blocking gate from #843 until #1026 returned it to advisory per [AgDR-0111](../../docs/agdr/AgDR-0111-marker-gate-plain-advisory.md). Do not read it as enforcement:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -368,6 +368,15 @@
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/warn-isolated-build-risk.sh\"'"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec env APEXYARD_REVIEW_OPS_ROOT=\"$r\" \"$r/.claude/hooks/block-reviewer-repo-mutation.sh\"'"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/docs/agdr/AgDR-0145-review-class-agents-read-only.md
+++ b/docs/agdr/AgDR-0145-review-class-agents-read-only.md
@@ -1,0 +1,43 @@
+# Review-class agents are read-only during the active review window
+
+> In the context of a review-class agent being able to mutate and push the PR it is reviewing, facing a silent loss of author-reviewer separation, I decided to enforce a read-only repository boundary with a scoped PreToolUse control plus prompt guardrails, to preserve independent review evidence, accepting that command-text classification has a bounded pattern surface and that the active-reviewer marker must remain trustworthy.
+
+## Context
+
+Issue #1233 reproduced a review-class agent editing, committing, and pushing to the PR branch before writing its approval marker. The merge gate rejected the stale marker because the PR head changed, but the review record did not explain that the reviewer had become an author. The three review-class agents use Bash for read-only inspection and review submission, so removing Bash would remove required capability.
+
+The active-reviewer marker already identifies the sanctioned review window for `code-reviewer`, `security-reviewer`, and `solution-architect`. It is written immediately before the reviewer is spawned and cleared after the review. That signal is sufficient to scope a blocking command control without blocking ordinary orchestrator work outside the review window.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| Prompt-only prohibition | Small change; clear agent instruction | Advisory only. A helpful model can still mutate the repository. |
+| Gate-side commit-identity check | Detects authoring after the fact | Single-account operation makes author and reviewer identities indistinguishable; it diagnoses late and does not prevent working-tree collisions. |
+| Remove Bash from review agents | Strong tool reduction | Reviewers need Bash for tracker queries, local inspection, and review submission. It would require a new restricted tool surface. |
+| Scoped PreToolUse control plus prompt guardrails | Blocks common repository-mutating git commands before execution while retaining read-only shell access; prompts explain the boundary | Command classification has a bounded pattern surface; future mutation forms need regression cases. |
+
+## Decision
+
+Chosen: **scoped PreToolUse control plus prompt guardrails**, because the existing active-reviewer marker provides a narrow lifecycle signal and the control prevents the failure before it reaches the worktree or remote. `block-reviewer-repo-mutation.sh` blocks mutating git subcommands while the marker exists, while allowing evidence commands such as `git status` and `git diff`. The three review-agent prompts state the same read-only boundary and direct fixes to the orchestrator or build agent.
+
+The control deliberately does not claim to detect every arbitrary script that can write files. Review agents remain constrained by their `Write`/`Edit` disallow list, and the prompt plus the marker-scoped hook cover the observed git mutation path. New bypass shapes must add a focused test and update this decision record.
+
+## Consequences
+
+- A reviewer cannot stage, commit, push, restore, reset, stash, clean, switch, or otherwise mutate refs through the common `git` command forms while the review marker is active.
+- Read-only Git inspection and tracker commands remain available to the review agents.
+- The orchestrator should wait for the reviewer before making repository changes in the same session, avoiding shared-tree races.
+- A malformed or novel mutation command may require a future matcher extension; the documented limitation is preferable to treating a prompt-only rule as enforcement.
+- The active-reviewer marker remains a trust-chain input and must be cleared after each review, as already required by the review skills.
+
+## Artifacts
+
+- `.claude/hooks/block-reviewer-repo-mutation.sh`
+- `.claude/hooks/tests/test_block_reviewer_repo_mutation.sh`
+- `.claude/settings.json`
+- `.claude/agents/code-reviewer.md`
+- `.claude/agents/security-reviewer.md`
+- `.claude/agents/solution-architect.md`
+- `.claude/rules/pr-workflow.md`
+- Issue #1233


### PR DESCRIPTION
## Summary
- Adds a blocking PreToolUse control that rejects repository-mutating git commands while a review-class agent is active, preserving the reviewed branch and worktree for the independent review.
- Adds explicit read-only boundaries to Rex, Hakim, and Tariq prompts and documents the mirror author-reviewer rule in the workflow policy.
- Adds AgDR-0145 and regression coverage for blocked mutations, allowed evidence commands, quoted review prose, heredocs, and the inactive-review window.

## Why this matters
- A reviewer can no longer silently become a co-author of the PR it approves through the common git mutation commands described in #1233.
- The active-reviewer marker scopes enforcement to the review lifecycle, so the orchestrator can continue ordinary repository work before and after the review.

## Testing
- `bash .claude/hooks/tests/test_block_reviewer_repo_mutation.sh`
- `bash .claude/hooks/tests/test_warn_review_marker_write.sh`
- `bash .claude/hooks/tests/test_hook_exec_bits.sh`
- `bash -n .claude/hooks/block-reviewer-repo-mutation.sh .claude/hooks/tests/test_block_reviewer_repo_mutation.sh`
- `python3 -m json.tool .claude/settings.json`
- ShellCheck passed for the new hook and test when available.

## Glossary

| Term | Definition |
|------|------------|
| Review-class agent | `code-reviewer`, `security-reviewer`, or `solution-architect`, which evaluates work rather than authors it. |
| Active-reviewer marker | Session file that scopes the sanctioned review window to one repository, PR, and reviewer kind. |
| PreToolUse control | A hook that runs before a Claude Code tool call and can reject it. |
| Author-reviewer separation | The property that the person approving a change does not also author the reviewed change. |

Closes #1233
