### PR TITLE
feat(#1225): support split tracker hosts

### DIFF
--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -46,7 +46,7 @@
 # same way the gh CLI shape is paired with `Bash(gh api *)`).
 #
 # The gh path is unchanged byte-for-byte; glab is additive. Forge selection for
-# the CLI-calling resolvers goes through `tracker_kind` from `_lib-tracker.sh`
+# the CLI-calling resolvers goes through `tracker_review_kind` from `_lib-tracker.sh`
 # (gh + glab coincide with github + gitlab per #762); the shape detectors read
 # the command text directly.
 #
@@ -130,10 +130,10 @@
 # this change safe for the jq-present callers: their behaviour is provably
 # unchanged because they never call the new function at all.
 
-# Lazily source the tracker lib so `tracker_kind` is available for forge
+# Lazily source the tracker lib so `tracker_review_kind` is available for forge
 # resolution. Guarded: only source if not already defined and the lib is
-# present. tracker_kind defaults to "gh" with no config, preserving gh behaviour.
-if ! command -v tracker_kind >/dev/null 2>&1; then
+# present. tracker_review_kind defaults to "gh" with no config, preserving gh behaviour.
+if ! command -v tracker_review_kind >/dev/null 2>&1; then
   # ${BASH_SOURCE[0]} is bash-only and unset under zsh (#1025) — the `:-`
   # default avoids a hard "parameter not set" error, but an empty value
   # still makes `dirname` resolve to ".", i.e. the CALLER's cwd rather than
@@ -171,15 +171,15 @@ if ! command -v tracker_kind >/dev/null 2>&1; then
   fi
 fi
 
-# Echoes the forge kind ('gh' | 'glab') for a repo, via tracker_kind. Any
-# non-glab kind (gh / none / jira / linear / unknown / unresolved) → 'gh', so
+# Echoes the forge kind ('gh' | 'glab') for a repo, via tracker_review_kind.
+# Any non-glab kind (gh / none / jira / linear / unknown / unresolved) → 'gh', so
 # the GitHub CLI path stays the default. Used by the CLI-calling resolvers
 # (resolve_pr_head, resolve_pr_head_branch) which only have the repo, not the
 # command text.
 _forge_kind_for() {
   local repo="${1:-}" kind="gh"
-  if command -v tracker_kind >/dev/null 2>&1; then
-    kind=$(tracker_kind "$repo" 2>/dev/null || echo gh)
+  if command -v tracker_review_kind >/dev/null 2>&1; then
+    kind=$(tracker_review_kind "$repo" 2>/dev/null || echo gh)
   fi
   case "$kind" in glab) echo glab ;; *) echo gh ;; esac
 }

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -11,7 +11,9 @@
 #   tracker.id_pattern   — regex for valid ticket-ID shape (no-existence-check fallback)
 #
 # Public functions:
-#   tracker_kind [<owner/repo>]        echoes the configured tracker kind
+#   tracker_issue_kind [<owner/repo>]  echoes the issue-system adapter kind
+#   tracker_review_kind [<owner/repo>] echoes the code-review host adapter kind
+#   tracker_kind [<owner/repo>]        compatibility alias for tracker_issue_kind
 #   tracker_id_pattern [<owner/repo>]  echoes the configured ID regex
 #   tracker_owner_repo_param <slug>    formats the owner/repo parameter (gh: "owner/repo"; others: empty)
 #   tracker_view <id> [<owner_repo>]   dispatches the view command and emits normalised JSON on stdout
@@ -56,7 +58,8 @@
 #                                      blocked / body_file unreadable; 3 = shape-only (kind=none,
 #                                      nothing to call).
 #
-# Per-project resolution (#670 / AgDR-0072): tracker_kind / tracker_id_pattern /
+# Per-project resolution (#670 / AgDR-0072): tracker_issue_kind / tracker_review_kind /
+# tracker_kind / tracker_id_pattern /
 # tracker_view take an OPTIONAL owner/repo. When supplied, a `tracker:` block on
 # that project's apexyard.projects.yaml entry overrides the global config block
 # (per key); when omitted, the global block is used — byte-for-byte the original
@@ -261,36 +264,67 @@ PY
 }
 
 # ------------------------------------------------------------------------------
-# Public: tracker_kind [<owner/repo>]
-#   Echoes the configured tracker kind. With an optional <owner/repo>, a
-#   per-project `tracker.kind` override in the registry wins; otherwise the
-#   global config block (default "gh"). The no-arg path is byte-for-byte the
-#   original behaviour (cached).
+# Public: tracker_issue_kind / tracker_review_kind [<owner/repo>]
+#   Resolve the two independent tracker axes. New config uses
+#   `tracker.issue_kind` and `tracker.review_kind`; legacy `tracker.kind` is
+#   the fallback for both axes, preserving existing projects byte-for-byte.
 # ------------------------------------------------------------------------------
-_TRACKER_KIND_CACHE=""
-tracker_kind() {
-  local repo="${1:-}"
+_tracker_axis_kind() {
+  local axis="$1" repo="${2:-}" key="${1}_kind" legacy="kind" pv="" k=""
+  case "$axis" in issue|review) : ;; *) return 1 ;; esac
   if [ -n "$repo" ]; then
-    local pv
-    if pv=$(_tracker_project_value "$repo" kind) && [ -n "$pv" ]; then
+    if pv=$(_tracker_project_value "$repo" "$key") && [ -n "$pv" ]; then
+      echo "$pv"
+      return 0
+    fi
+    if pv=$(_tracker_project_value "$repo" "$legacy") && [ -n "$pv" ]; then
       echo "$pv"
       return 0
     fi
   fi
-  if [ -z "$repo" ] && [ -n "$_TRACKER_KIND_CACHE" ]; then
-    echo "$_TRACKER_KIND_CACHE"
+  if [ "$axis" = "issue" ]; then
+    k="${_TRACKER_ISSUE_KIND_CACHE:-}"
+  else
+    k="${_TRACKER_REVIEW_KIND_CACHE:-}"
+  fi
+  if [ -z "$repo" ] && [ -n "$k" ]; then
+    echo "$k"
     return 0
   fi
   _tracker_load_config_lib
-  local k
-  k=$(config_get_or '.tracker.kind' 'gh' 2>/dev/null)
+  k=$(config_get_or ".tracker.$key" '' 2>/dev/null)
+  if [ -z "$k" ] || [ "$k" = "null" ]; then
+    k=$(config_get_or '.tracker.kind' 'gh' 2>/dev/null)
+  fi
   if [ -z "$k" ] || [ "$k" = "null" ]; then
     k="gh"
   fi
   if [ -z "$repo" ]; then
-    _TRACKER_KIND_CACHE="$k"
+    if [ "$axis" = "issue" ]; then
+      _TRACKER_ISSUE_KIND_CACHE="$k"
+    else
+      _TRACKER_REVIEW_KIND_CACHE="$k"
+    fi
   fi
   echo "$k"
+}
+
+_TRACKER_ISSUE_KIND_CACHE=""
+_TRACKER_REVIEW_KIND_CACHE=""
+tracker_issue_kind() { _tracker_axis_kind issue "${1:-}"; }
+tracker_review_kind() { _tracker_axis_kind review "${1:-}"; }
+_TRACKER_KIND_CACHE=""
+tracker_kind() {
+  local repo="${1:-}" value
+  # Preserve the historical cache variable because existing consumers and
+  # tests may set it directly when stubbing the legacy resolver.
+  if [ -z "$repo" ] && [ -n "$_TRACKER_KIND_CACHE" ]; then
+    echo "$_TRACKER_KIND_CACHE"
+    return 0
+  fi
+  value=$(tracker_issue_kind "$repo") || return $?
+  [ -z "$repo" ] && _TRACKER_KIND_CACHE="$value"
+  echo "$value"
 }
 
 # ------------------------------------------------------------------------------
@@ -580,7 +614,7 @@ tracker_view() {
   # and view_command come from that project's registry override (if any),
   # falling back to the global config block. See AgDR-0072 / #670.
   local kind
-  kind=$(tracker_kind "$owner_repo")
+  kind=$(tracker_issue_kind "$owner_repo")
 
   case "$kind" in
     none)
@@ -797,7 +831,7 @@ tracker_create() {
   fi
 
   local kind
-  kind=$(tracker_kind "$repo")
+  kind=$(tracker_issue_kind "$repo")
   case "$kind" in
     none)
       # Shape-only mode (tracker.kind=none): no tracker CLI to call. Emit the
@@ -1066,7 +1100,7 @@ tracker_list() {
   # Per-project resolution: the target repo selects the project's tracker
   # override, else the global block (never cwd, never a session marker).
   local kind
-  kind=$(tracker_kind "$repo")
+  kind=$(tracker_issue_kind "$repo")
   case "$kind" in
     none)
       printf '[]\n'
@@ -1170,7 +1204,7 @@ tracker_label_ensure() {
     return 0
   fi
   local kind
-  kind=$(tracker_kind "$repo")
+  kind=$(tracker_issue_kind "$repo")
   case "$kind" in
     gh)   _tracker_label_ensure_gh   "$repo" "$name" "$color" "$desc" ;;
     glab) _tracker_label_ensure_glab "$repo" "$name" "$color" "$desc" ;;
@@ -1291,13 +1325,10 @@ _tracker_review_custom() {
 
 # Public: tracker_review_submit <owner/repo> <pr> <verdict> [<body_file>]
 #
-# NOTE on the tracker.kind axis: kind describes the ISSUE tracker, but a review
-# targets the PR/MR HOST (the git remote). For gh+github and glab+gitlab they
-# coincide, which is exactly the pair this ticket (#758) covers. The wildcard
-# default below assumes a non-gh/glab issue tracker (jira/linear/asana) is paired
-# with a GitHub code host — correct for the common jira-issues+github-code setup,
-# but a jira-issues+gitlab-code adopter would need `tracker.kind=custom` with a
-# review_command (or a future dedicated review-host config).
+# Review operations resolve `tracker.review_kind`. For backward compatibility,
+# that axis falls back to `tracker.kind` when `review_kind` is absent. This lets
+# Jira/Linear/Asana issue adopters select `glab` for code reviews without a
+# custom review command.
 tracker_review_submit() {
   local repo="$1" pr="$2" verdict="${3:-comment}" body_file="${4:-}"
   if [ -z "$repo" ] || [ -z "$pr" ]; then
@@ -1315,7 +1346,7 @@ tracker_review_submit() {
   esac
 
   local kind
-  kind=$(tracker_kind "$repo")
+  kind=$(tracker_review_kind "$repo")
   [ "$kind" = "none" ] || _tracker_check_private_refs "$repo" "" "$body_file" || return $?
   case "$kind" in
     none)
@@ -1395,7 +1426,7 @@ tracker_review_at_sha() {
   esac
 
   local kind
-  kind=$(tracker_kind "$repo")
+  kind=$(tracker_review_kind "$repo")
   case "$kind" in
     gh) : ;;
     *)  return 3 ;;   # not verifiable on this forge — see FORGE SUPPORT above
@@ -1610,10 +1641,8 @@ _tracker_merge_resolve_sha() {
 
 # Public: tracker_pr_merge <owner/repo> <pr> <strategy> [<delete_branch>]
 #
-# NOTE on the tracker.kind axis: same caveat as tracker_review_submit — kind
-# describes the ISSUE tracker, but a merge targets the PR/MR HOST. For gh+github
-# and glab+gitlab they coincide (this ticket's covered pair). A jira-issues+
-# gitlab-code adopter needs `tracker.kind=custom` with a merge_command.
+# Merge operations resolve `tracker.review_kind`, with the legacy `tracker.kind`
+# value as the fallback for existing projects.
 tracker_pr_merge() {
   local repo="$1" pr="$2" strategy delete_branch subject body_file
   if [ -z "$repo" ] || [ -z "$pr" ]; then
@@ -1656,7 +1685,7 @@ tracker_pr_merge() {
   fi
 
   local kind
-  kind=$(tracker_kind "$repo")
+  kind=$(tracker_review_kind "$repo")
   [ "$kind" = "none" ] || _tracker_check_private_refs "$repo" "$subject" "$body_file" || return $?
   case "$kind" in
     none)
@@ -1758,6 +1787,8 @@ tracker_check_issues() {
 # ------------------------------------------------------------------------------
 tracker_clear_cache() {
   _TRACKER_KIND_CACHE=""
+  _TRACKER_ISSUE_KIND_CACHE=""
+  _TRACKER_REVIEW_KIND_CACHE=""
   _TRACKER_ID_PATTERN_CACHE=""
   _TRACKER_VIEW_TPL_CACHE=""
 }

--- a/.claude/hooks/tests/test_split_tracker_hosts.sh
+++ b/.claude/hooks/tests/test_split_tracker_hosts.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Split issue/review tracker axes (#1225). No real tracker calls are made.
+set -u
+
+HOOK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SB=$(mktemp -d)
+mkdir -p "$SB/.claude/hooks" "$SB/bin"
+cleanup() { rm -rf "$SB"; }
+trap cleanup EXIT
+cp "$HOOK_DIR/_lib-tracker.sh" "$HOOK_DIR/_lib-read-config.sh" "$HOOK_DIR/_lib-portfolio-paths.sh" "$HOOK_DIR/check-private-refs-runtime.sh" "$SB/.claude/hooks/"
+chmod +x "$SB/.claude/hooks/check-private-refs-runtime.sh"
+touch "$SB/.apexyard-fork" "$SB/onboarding.yaml"
+cat > "$SB/.claude/project-config.defaults.json" <<'JSON'
+{"tracker":{"kind":"gh","issue_kind":"jira","review_kind":"glab"}}
+JSON
+printf 'version: 1\nprojects: []\n' > "$SB/apexyard.projects.yaml"
+git -C "$SB" init -q
+cat > "$SB/bin/glab" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$@" > "${GLAB_CAPTURE:?}"
+exit 0
+EOF
+chmod +x "$SB/bin/glab"
+cd "$SB" || exit 1
+. "$SB/.claude/hooks/_lib-tracker.sh"
+
+fail=0
+assert_eq() {
+  if [ "$2" = "$3" ]; then printf 'PASS: %s\n' "$1"; else printf 'FAIL: %s (expected %s, got %s)\n' "$1" "$2" "$3"; fail=1; fi
+}
+
+tracker_clear_cache
+assert_eq 'legacy tracker_kind remains issue axis' jira "$(tracker_kind o/r)"
+assert_eq 'issue axis resolves explicit issue_kind' jira "$(tracker_issue_kind o/r)"
+assert_eq 'review axis resolves explicit review_kind' glab "$(tracker_review_kind o/r)"
+printf 'review body\n' > "$SB/body"
+GLAB_CAPTURE="$SB/review" PATH="$SB/bin:$PATH" tracker_review_submit o/r 42 comment "$SB/body"
+assert_eq 'review submission dispatches to glab' mr "$(sed -n '1p' "$SB/review")"
+assert_eq 'review submission uses note create' create "$(sed -n '3p' "$SB/review")"
+
+cat > "$SB/apexyard.projects.yaml" <<'YAML'
+version: 1
+projects:
+  - name: split
+    repo: o/r
+    tracker:
+      issue_kind: linear
+      review_kind: gh
+YAML
+tracker_clear_cache
+assert_eq 'per-project issue_kind overrides global axis' linear "$(tracker_issue_kind o/r)"
+assert_eq 'per-project review_kind overrides global axis' gh "$(tracker_review_kind o/r)"
+
+if [ "$fail" -ne 0 ]; then exit 1; fi
+echo 'PASS: split tracker host cases'

--- a/docs/agdr/AgDR-0146-split-tracker-hosts.md
+++ b/docs/agdr/AgDR-0146-split-tracker-hosts.md
@@ -1,0 +1,30 @@
+# Split issue and review tracker hosts
+
+> In the context of projects that track issues and code reviews in different systems, facing a single tracker adapter axis, I decided to resolve issue and review adapters independently to support mixed-host projects without breaking existing configurations, accepting a small compatibility layer in the tracker library and configuration docs.
+
+## Context
+
+`tracker.kind` currently selects both issue operations and code-review operations. This forces a Jira-issues and GitLab-reviews project into an inaccurate or custom configuration. The change crosses the shared tracker library and every review-host resolver, so it is a framework-level integration decision.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| Keep one `tracker.kind` and require custom commands | No code change | Mixed-host projects remain second-class and easy to misconfigure |
+| Add `tracker.issue_kind` and `tracker.review_kind`, with legacy fallback | Independent routing, backward compatible, incremental adapter support | Adds two resolution paths and documentation burden |
+| Add a separate top-level review-host object | Clear long-term model | Larger schema migration and more compatibility work than this issue requires |
+
+## Decision
+
+Chosen: **two tracker kind fields with legacy fallback**. Issue reads and writes resolve `issue_kind`; review submission, merge, SHA checks, and forge detection resolve `review_kind`. When either new field is absent, `tracker.kind` supplies the value for that axis.
+
+## Consequences
+
+- Existing projects retain their current behavior without configuration changes.
+- A project can declare Jira or Linear issues with GitHub or GitLab reviews.
+- Adapter-specific commands remain unchanged; this change only routes each operation to the correct existing adapter.
+- A later change can add richer per-axis command templates without changing the basic resolution contract.
+
+## Artifacts
+
+- Issue: https://github.com/me2resh/apexyard/issues/1225

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -1041,6 +1041,21 @@ For Jira, point at the [ankitpokhrel/jira-cli](https://github.com/ankitpokhrel/j
 }
 ```
 
+When issues and code reviews live on different systems, set the two axes
+independently. Each omitted axis falls back to the legacy `tracker.kind` value;
+the example below uses Jira for issues and GitLab for reviews:
+
+```json
+{
+  "tracker": {
+    "issue_kind": "jira",
+    "review_kind": "glab",
+    "view_command": "jira issue view {id} --raw",
+    "id_pattern": "^[A-Z]+-[0-9]+$"
+  }
+}
+```
+
 For Asana (per-task lookup by GID):
 
 ```json


### PR DESCRIPTION
## Summary
- Add independent `tracker.issue_kind` and `tracker.review_kind` configuration axes.
- Route issue operations through the issue adapter and reviews, merges, SHA checks, and forge detection through the review adapter.
- Preserve existing `tracker.kind` configurations through fallback resolution.

## Why this matters
Projects that manage issues in Jira or Linear and code reviews in GitHub or GitLab can now configure both systems directly. Existing single-host projects retain their current behavior.

## Testing
- `bash .claude/hooks/tests/test_split_tracker_hosts.sh`
- `bash .claude/hooks/tests/test_tracker_aware_hooks.sh`
- `bash .claude/hooks/tests/test_tracker_create.sh`
- `bash .claude/hooks/tests/test_tracker_issues_detection.sh`
- `bash .claude/hooks/tests/test_tracker_list.sh`
- `bash .claude/hooks/tests/test_tracker_pr_merge.sh`
- `bash .claude/hooks/tests/test_tracker_review_submit.sh`
- `bash .claude/hooks/tests/test_tracker_zsh_self_location.sh`
- `bash .claude/hooks/tests/test_forge_aware_extract_pr.sh`
- `git diff --check`

## Glossary
| Term | Definition |
|---|---|
| Issue host | The system that stores and queries work items. |
| Review host | The system that stores and reviews pull requests or merge requests. |
| `tracker.kind` | The legacy single adapter setting, used as fallback for both axes. |
| `tracker.issue_kind` | The adapter kind used for issue operations. |
| `tracker.review_kind` | The adapter kind used for review and merge operations. |

Refs #1225
