### PR TITLE
docs(#1164): clarify framework prose

### DIFF
--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -1,54 +1,27 @@
 #!/bin/bash
-# Shared PR-number and repo extraction for the merge-gate hooks:
-#   - block-unreviewed-merge.sh
-#   - require-design-review-for-ui.sh
-#   - require-architecture-review.sh
-#   - block-merge-on-red-ci.sh
+# Shared PR and repo extraction for merge-gate hooks. The hooks are:
+# block-unreviewed-merge.sh, require-design-review-for-ui.sh,
+# require-architecture-review.sh, and block-merge-on-red-ci.sh.
 #
-# Not a hook itself (prefixed with `_lib-` so it's never wired as one). Sourced
-# by the hooks above via `. "$(dirname "$0")/_lib-extract-pr.sh"`.
+# This file is a library, not a hook. The merge gates source it and share the
+# same tested parser. Keep parsing here instead of duplicating it in a hook.
+# The shared parser prevents API merge forms from bypassing the gates, as the
+# original GitHub API incident showed (#47).
 #
-# WHY THIS EXISTS
-# ---------------
-# The merge gates originally only matched `gh pr merge <N>`. Incident (#47):
-# merges via `gh api repos/<owner>/<repo>/pulls/<N>/merge -X PUT` silently
-# bypassed all three gates because neither the matcher nor the PR-number
-# extraction knew about the API shape. This helper gives every gate a single,
-# tested way to recognise both shapes:
+# The parser covers GitHub and GitLab CLI and API merge forms. Examples:
+#   gh pr merge 42 --squash
+#   gh api repos/owner/repo/pulls/42/merge -X PUT
+#   glab mr merge 42 -R owner/repo
+#   glab api projects/owner%2Frepo/merge_requests/42/merge
 #
-#   1. `gh pr merge 42 --squash`                                  → PR is 42
-#   2. `gh api repos/owner/repo/pulls/42/merge -X PUT`            → PR is 42
-#
-# Any tool that edits one of the three merge hooks MUST keep calling this
-# helper, not re-implement the parsing inline. That's the whole point.
-#
-# USAGE
-# -----
+# Usage:
 #   . "$(dirname "$0")/_lib-extract-pr.sh"
 #   if ! is_merge_command "$COMMAND"; then exit 0; fi
 #   PR_NUMBER=$(extract_pr_number "$COMMAND")
 #
-# FORGE-AWARENESS (#764)
-# ----------------------
-# The gates originally spoke only GitHub. A GitLab-forge project (`tracker.kind:
-# glab`) merges via `glab mr merge <iid>` — a shape neither the matcher nor this
-# helper recognised, so the gates silently did not fire (an ungated-merge hole,
-# the forge analog of the #47 `gh api` bypass). This helper now recognises both
-# forges' merge shapes and resolves MR/PR state via the matching CLI:
-#
-#   3. `glab mr merge 42 -R owner/repo`                           → MR is 42
-#   4. `glab api projects/owner%2Frepo/merge_requests/42/merge`   → MR is 42
-#
-# Shape 4 (#767) is the GitLab raw-API merge — the exact forge analog of the #47
-# `gh api …/pulls/<N>/merge` bypass. Gating only `glab mr merge` (shape 3) while
-# leaving the API passthrough open would re-create #47 on GitLab, so both glab
-# shapes are recognised (matched with `Bash(glab api *)` in settings.json, the
-# same way the gh CLI shape is paired with `Bash(gh api *)`).
-#
-# The gh path is unchanged byte-for-byte; glab is additive. Forge selection for
-# the CLI-calling resolvers goes through `tracker_review_kind` from `_lib-tracker.sh`
-# (gh + glab coincide with github + gitlab per #762); the shape detectors read
-# the command text directly.
+# GitLab support is additive. Forge selection uses tracker_review_kind. Shape
+# detection reads the command text directly. CLI state resolution uses the
+# matching forge adapter.
 #
 # CI-STATUS RESOLUTION (#790)
 # ----------------------------

--- a/.claude/hooks/_lib-read-config.sh
+++ b/.claude/hooks/_lib-read-config.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
-# _lib-read-config.sh — shared reader for .claude/project-config.*.json
+# _lib-read-config.sh — read .claude/project-config.*.json
 #
-# Source this library from any hook or skill that needs to read project config.
-# Defaults ship at .claude/project-config.defaults.json (committed, upstream-
-# maintained). User overrides live at .claude/project-config.json (optional;
-# each fork decides whether to commit or gitignore it).
+# Source this library from a hook or skill that reads project configuration.
+# Defaults live in .claude/project-config.defaults.json. A fork can add the
+# optional .claude/project-config.json override.
 #
-# Merge strategy: `jq`'s `*` recursively merges objects, with the override's
-# scalar values winning conflicts, and replaces arrays wholesale. An override
-# can therefore name one object member without dropping its siblings, while an
-# array override replaces the inherited array. This is the behavior of the
-# implementation below; callers should state explicitly which shape they rely
-# on rather than calling the whole merge shallow.
+# Merge behavior: jq recursively merges objects. The override wins scalar
+# conflicts. An override array replaces the inherited array.
 #
 # Usage:
 #   source "$(git rev-parse --show-toplevel)/.claude/hooks/_lib-read-config.sh"
@@ -19,10 +14,9 @@
 #   config_get '.branch.type_whitelist[]'
 #   config_get '.ticket.label_priority_scheme'
 #
-# Silent fallback behaviour:
-#   - No defaults file present: emit '{}' and an error on stderr. Callers should
-#     treat config_get as "unknown" and apply their own safety.
-#   - jq not installed: emit '{}' and a one-time warning on stderr.
+# Fallback behavior:
+#   - Missing defaults: emit '{}' and an error. Callers must apply their safety.
+#   - Missing jq: emit '{}' and one warning per process.
 
 # ------------------------------------------------------------------------------
 # Session-scoped, CROSS-PROCESS cache (me2resh/apexyard#1013 / AgDR-0120).

--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
-# _lib-tracker.sh — tracker-agnostic existence verification + ID-shape regex.
+# _lib-tracker.sh — tracker-agnostic issue and review operations.
 #
-# Source this library from any hook or skill that needs to verify a ticket
-# exists in the adopter's tracker (GitHub Issues, Linear, Jira, Asana, custom).
-# It dispatches based on the `tracker` block of .claude/project-config.{defaults,}.json.
+# Source this library from a hook or skill that needs tracker access. The
+# library dispatches through the `tracker` block in
+# .claude/project-config.{defaults,}.json.
 #
-# Resolved at config time:
-#   tracker.kind         — "gh" | "linear" | "jira" | "asana" | "custom" | "none"
-#   tracker.view_command — template string with {id} and {owner_repo} placeholders
-#   tracker.id_pattern   — regex for valid ticket-ID shape (no-existence-check fallback)
+# Main settings:
+#   tracker.kind         — legacy adapter for both axes
+#   tracker.issue_kind   — adapter for issue operations
+#   tracker.review_kind  — adapter for pull or merge request operations
+#   tracker.view_command — template with {id} and {owner_repo} placeholders
+#   tracker.id_pattern   — ticket-ID shape used by shape-only checks
 #
 # Public functions:
 #   tracker_issue_kind [<owner/repo>]  echoes the issue-system adapter kind
@@ -58,25 +60,18 @@
 #                                      blocked / body_file unreadable; 3 = shape-only (kind=none,
 #                                      nothing to call).
 #
-# Per-project resolution (#670 / AgDR-0072): tracker_issue_kind / tracker_review_kind /
-# tracker_kind / tracker_id_pattern /
-# tracker_view take an OPTIONAL owner/repo. When supplied, a `tracker:` block on
-# that project's apexyard.projects.yaml entry overrides the global config block
-# (per key); when omitted, the global block is used — byte-for-byte the original
-# behaviour. The project is chosen by the OPERATION'S TARGET REPO the caller
-# already holds — never by cwd or a session-global marker.
+# Per-project resolution (#670 / AgDR-0072) accepts an optional owner/repo.
+# That repo selects the registry entry and its tracker overrides. Without a
+# repo, the library uses the global config. It never uses cwd or session state.
 #
-# Normalisation: each adapter parses the underlying CLI's JSON (gh / linear /
-# jira / asana / custom) into the common shape above. Consumers should only
-# touch the normalised fields — never reach for adapter-specific shapes.
+# Each adapter maps CLI output to one common JSON shape. Consumers must use the
+# common fields and must not depend on adapter-specific output.
 #
 # `tracker.kind = none` makes `tracker_view` a no-op that exits 1 (no
 # existence check possible). Consumers should fall back to shape-only
 # verification using `tracker_id_pattern`.
 #
-# Caching: results cached per-process in shell vars. Same pattern as
-# _CONFIG_CACHE in _lib-read-config.sh and _PORTFOLIO_*_CACHE in
-# _lib-portfolio-paths.sh.
+# Results use per-process shell caches, like the config and portfolio helpers.
 
 # ------------------------------------------------------------------------------
 # Internal: ensure _lib-read-config.sh is loaded so config_get_or works.

--- a/README.md
+++ b/README.md
@@ -16,36 +16,45 @@
   <a href="https://github.com/me2resh/apexyard/stargazers"><img src="https://img.shields.io/github/stars/me2resh/apexyard?style=social" alt="Stars"></a>
 </p>
 
-## You built something real with AI. Then it fell apart.
+## AI can build quickly. Shipping safely needs a system.
 
-The first 80% flew — a working prototype in a weekend, features landing faster than you could test them. Then the context slipped. The codebase turned into a pile nobody could review, decisions vanished into chat history, and the thing you were *so close* to shipping never actually made it to production.
+AI can produce a working prototype in a weekend. Teams still need a way to
+track decisions, review changes, run checks, and approve a release.
 
-**ApexYard is the machinery that takes agent-built code the last mile.** It wraps your AI coding agent in the discipline a real engineering team runs on: every change moves through a ticket, gets an independent review, and hits a merge gate that stays shut until a *named human* says "ship it." So the code your agent writes is actually safe to put in front of users.
+**ApexYard provides that system.** Every change starts with a ticket. An
+independent reviewer checks the change. A merge gate stays closed until a
+named human approves the exact commit.
 
-Concretely, it's a multi-project **ops repo**: you fork it, register your projects, and govern them all as one organisation — shared memory across the portfolio, a strict SDLC, and dozens of shell hooks that enforce the rules mechanically instead of hoping everyone remembers them. Built for founders who ship alone, and for teams standing up AI-enabled squads.
+ApexYard is a multi-project **ops repo**. You fork it, register your projects,
+and manage the portfolio from one place. Shared rules, project records, and
+shell hooks keep the workflow consistent.
 
-Claude Code is the default driver, but the rules, hooks, and templates are plain markdown and shell. Swap the AI. Keep the forge. No SaaS. No lock-in.
+Claude Code is the default driver. The rules, hooks, and templates are plain
+Markdown and shell, so you can use another coding tool through an adapter.
+There is no service to run and no hosted lock-in.
 
-**Proven shipping** TypeScript + AWS Lambda backends, Next.js web apps, Chrome extensions, and native **Swift** macOS desktop apps. The stack is process and guardrails — not a language or framework lock-in.
+The workflow has been used with TypeScript and AWS Lambda backends, Next.js
+apps, Chrome extensions, and native Swift macOS apps.
 
 ## What makes it different
 
-| Feature | Without ApexYard | With ApexYard |
-|---------|-------------------|----------------|
-| Code reviews | Ad-hoc prompts | Rex agent on every PR, SHA-bound approval marker |
-| Technical decisions | Lost in chat history | Documented as Agent Decision Records |
-| Quality gates | Hope and pray | Shell hooks block bad commits, forged markers, unreviewed merges |
-| Merge approval | Informal "LGTM" | Two-marker gate — Rex (code) + a named human (per-PR explicit) |
-| Database migrations | Drop-column-on-Friday | Dedicated gate: labelled ticket + migration AgDR (rollback, downtime, consumers) required before schema edits |
-| Architecture docs | Nobody draws them | C4 L1 + L2 Mermaid templates + `/c4` skill generates stubs from a codebase |
-| Portfolio visibility | Tab through 5 GitHubs | `/inbox`, `/status`, `/tasks` aggregate across a single registry file |
-| Upstream sync | Forget for 6 months | Session-start drift banner + `/update` skill |
-| Role consistency | Re-explain every session | Persistent role definitions, activation-triggered |
-| Onboarding | Days of context-setting | `/setup` three-exchange config |
+| Area | Without ApexYard | With ApexYard |
+|---|---|---|
+| Code review | Ad-hoc prompts | Rex reviews every pull request. |
+| Technical decisions | Lost in chat | Agent Decision Records preserve them. |
+| Quality gates | Manual memory | Shell hooks block unsafe actions. |
+| Merge approval | Informal “LGTM” | Rex and a named human approve the exact commit. |
+| Database migrations | High-risk edits | A migration ticket and rollback plan are required. |
+| Architecture | Scattered notes | C4 templates and the `/c4` skill create a shared model. |
+| Portfolio view | Several GitHub tabs | `/inbox`, `/status`, and `/tasks` read one registry. |
+| Upstream updates | Easy to forget | `/update` reports drift and guides the sync. |
+| Roles | Repeated context | Role files activate from clear triggers. |
+| Onboarding | Manual setup | `/setup` collects the required configuration. |
 
 ## What's inside
 
-ApexYard is a set of plain-text primitives Claude Code reads automatically — no runtime, no service:
+ApexYard is a set of plain-text files. Claude Code reads them from the repo
+root. No runtime or service is required.
 
 - **20 roles** across 6 departments (engineering, product, design, security, data, architecture) that activate on triggers
 - **49 shell hooks** that mechanically enforce the SDLC — ticket-first edits, a two-marker merge gate, migration gates, secrets scanning, and more
@@ -53,23 +62,29 @@ ApexYard is a set of plain-text primitives Claude Code reads automatically — n
 - **23 sub-agents** — Rex (code review), Hakim (security), Tariq (design review), plus the department personas
 - **18 rule files**, workflow docs, and document templates (PRD, tech design, ADR, AgDR, C4 diagrams)
 
-**Full directory tree and the complete role / hook / skill / agent breakdown → [`docs/whats-inside.md`](docs/whats-inside.md).**
+**See [`docs/whats-inside.md`](docs/whats-inside.md) for the full directory and component list.**
 
 > **Marketing site:** the site that was previously bundled here has moved to its own repo ([me2resh/apexyard-site](https://github.com/me2resh/apexyard-site)) and is deployed independently at [apexyard.ai](https://apexyard.ai).
 >
-> **Built for Claude Code first**, but opencode, pi, and Codex run the same enforcement through a small adapter (Cursor partially) — see [Using another AI coding tool?](#using-another-ai-coding-tool) below.
+> **Built for Claude Code first.** opencode, pi, and Codex use the same rules through small adapters. Cursor has partial support. See [Using another AI coding tool?](#using-another-ai-coding-tool).
 >
-> **For AI coding agents:** the repo root carries `AGENTS.md` — a universal entry doc for Cursor / Claude Code / Aider / Cline / pi, for harnesses that don't auto-load `CLAUDE.md`. Details: [`docs/harnesses/pi.md`](docs/harnesses/pi.md).
+> **For AI coding agents:** `AGENTS.md` is the universal entry document for tools that do not load `CLAUDE.md`. See [`docs/harnesses/pi.md`](docs/harnesses/pi.md).
 
 ## Quick Start — fork and go
 
-ApexYard governs a **portfolio of repos** as one organisation. You fork apexyard, clone the fork, treat it as your "ops repo", and register every project you want under management. No `.apexyard/` symlinks, no nested installs — the fork IS the ops repo.
+ApexYard governs a **portfolio of repos** as one organisation. Fork and clone
+the repository. Use that fork as your ops repo. Register each project you want
+to manage. The fork is the ops repo, so no nested installation is needed.
 
-> **On opencode, pi, or Codex?** Steps 1–3 below are plain `git` / `gh` and work as-is. Install your tool's adapter (one command — see [Using another AI coding tool?](#using-another-ai-coding-tool)) before steps 4–6; each of those steps also shows the manual-file equivalent for when there's no `/skill` to run. The rules that get enforced are identical either way.
+> **Using opencode, pi, or Codex?** Steps 1–3 use plain `git` and `gh`. Install
+> your tool's adapter before steps 4–6. Each step also gives a manual file
+> option. The enforced rules are the same in both paths.
 
 ### 1. Star + Fork on GitHub
 
-Visit [`github.com/me2resh/apexyard`](https://github.com/me2resh/apexyard), **Star** it, then **Fork** it into your org. You can keep the fork named `apexyard` or rename to something that fits your naming convention (`your-org/ops`, `your-org/apex`, etc.).
+Visit [`github.com/me2resh/apexyard`](https://github.com/me2resh/apexyard).
+Star it, then fork it into your organisation. Keep the name `apexyard`, or use
+a name such as `your-org/ops`.
 
 ### 2. Clone your fork locally
 
@@ -91,29 +106,38 @@ cd apexyard
 git remote add upstream https://github.com/me2resh/apexyard.git
 ```
 
-Later, run **`/update`** to pull the latest apexyard improvements into your fork — it previews the upstream diff, merges on a sync branch, and walks you through any per-version migrations (don't hand-merge `main`).
+Later, run **`/update`** to bring upstream changes into your fork. The skill
+previews the diff, uses a sync branch, and guides any version migrations.
 
 ### 4. Configure the framework — run `/setup`
 
-Run **`/setup`** in Claude Code. In three exchanges (describe your stack → review the proposed defaults → accept or tweak) it captures your company, team, tech stack, and quality bar and writes your config.
+Run **`/setup`** in Claude Code. The skill asks about your company, team,
+technology, and quality bar. It shows the proposed defaults before it writes
+the configuration.
 
 ```text
 /setup
 ```
 
-Your real config lives in `onboarding.yaml`, which is **gitignored** — it stays local and is never published. `/setup` copies it from the tracked `onboarding.example.yaml` placeholder and fills it in, so nothing private is committed. (A commit-time guard blocks a filled-in `onboarding.yaml` if you ever try to add it.)
+Your real config lives in the **gitignored** `onboarding.yaml`. It stays local.
+`/setup` copies the tracked `onboarding.example.yaml` placeholder and fills it
+in. A commit-time guard blocks the real file if you try to add it.
 
-No `/setup` on your tool? `cp onboarding.example.yaml onboarding.yaml` and fill in your company, stack, and quality bar by hand — the gates read the file, not the skill.
+No `/setup` on your tool? Copy the example and fill it in by hand:
+`cp onboarding.example.yaml onboarding.yaml`. The gates read the file, not the
+skill.
 
 ### 5. Register your projects — run `/handover`
 
-Projects join the portfolio through a skill, not hand-edited YAML. For each repo you want under management:
+Projects join the portfolio through a skill. For each repo you want to manage:
 
 ```text
 /handover <repo-url-or-local-path>
 ```
 
-**`/handover`** clones the repo, scores its "harnessability" across five dimensions, seeds its per-project docs, and **registers it in `apexyard.projects.yaml`** (creating the registry on first use). `/setup` also offered to register your first project back in step 4.
+**`/handover`** clones the repo, scores five harnessability dimensions, seeds
+the project docs, and **registers the repo in `apexyard.projects.yaml`**. It
+creates the registry on first use. `/setup` can register your first project.
 
 The registry it maintains looks like this — you rarely touch it by hand:
 
@@ -126,18 +150,21 @@ projects:
     status: active
 ```
 
-Register even a single repo — the portfolio skills (`/projects`, `/inbox`, `/status`) work off the registry. No `/handover` on your tool? `cp apexyard.projects.yaml.example apexyard.projects.yaml` and add your repos by hand — same registry, no skill required.
+Register a single repo too. The portfolio skills (`/projects`, `/inbox`, and
+`/status`) read the same registry. No `/handover` on your tool? Copy
+`apexyard.projects.yaml.example` and add the repos by hand.
 
 ### 6. Start working
 
 ```
-/projects          # list every managed project + status
-/inbox             # PRs, issues, comments needing your attention
-/status            # git + CI snapshot per project
-/decide            # make a technical decision (creates an AgDR)
+/projects          # list managed projects and status
+/inbox             # show PRs, issues, and comments that need attention
+/status            # show the git and CI state for each project
+/decide            # record a technical decision
 ```
 
-The hooks fire on every `git` / `gh` command, the portfolio skills aggregate across the registry, and the Code Reviewer agent can be invoked with `/code-review <pr>`.
+Hooks run on `git` and `gh` commands. Portfolio skills read the registry. Run
+`/code-review <pr>` to invoke the Code Reviewer agent.
 
 Full setup guide with directory layout, daily workflow, and FAQ: [`docs/multi-project.md`](docs/multi-project.md).
 
@@ -145,7 +172,14 @@ Keeping a fork current — upgrade in place, when to re-fork instead, and how to
 
 ## Using another AI coding tool?
 
-**ApexYard was built for Claude Code** — that's where everything is native: the `/setup`, `/handover`, and other `/…` commands are Claude Code skills, a convenience layer on top of the real enforcement. But the part that actually *enforces* your rules is plain bash, not tied to Claude Code, so other AI coding tools can run the **exact same rules** through a small adapter. We only claim what we've watched work: as of **2026-07-09**, three tools — **opencode, pi, and Codex** — are proven, meaning a real agent turn on each was stopped by the same unmodified rule. Each needs one small setting so the agent's command actually reaches the rule. Cursor is the honest exception. On any of these tools, the manual fallback is always the same plain-text config files shown in the Quick Start steps above — no skill required, just done by hand.
+**ApexYard was built for Claude Code.** Its slash commands are native Claude
+Code skills. The enforcement layer is plain Bash, so other tools can use the
+same rules through an adapter.
+
+As of **2026-07-09**, opencode, pi, and Codex have passed real enforcement
+checks. Each tool needs one setting so its commands reach the rules. Cursor has
+partial support and is not included in that claim. You can always use the
+manual configuration files from Quick Start when a skill is unavailable.
 
 | Tool | Enforces your rules? | Setup | Good to know |
 |------|----------------------|-------|--------------|

--- a/docs/codex-adapter.md
+++ b/docs/codex-adapter.md
@@ -1,8 +1,8 @@
 # Codex Adapter
 
-ApexYard's canonical runtime still lives in `.claude/`: skills, agents, hooks,
-rules, and hook wiring are authored there first. Codex support is generated from
-that source of truth so the two agent surfaces do not drift by hand.
+ApexYard's source of truth remains `.claude/`. It contains the skills, agents,
+hooks, rules, and hook wiring. The Codex adapter is generated from those files.
+This keeps the two agent surfaces aligned.
 
 Decision record: [`AgDR-0088`](agdr/AgDR-0088-codex-adapter-generation.md). For where Codex sits among all supported harnesses (and the shared-core architecture behind every adapter), see the [harness support index](harnesses/README.md).
 
@@ -12,25 +12,23 @@ Decision record: [`AgDR-0088`](agdr/AgDR-0088-codex-adapter-generation.md). For 
 bin/sync-codex-adapter.sh
 ```
 
-The command emits:
+The command generates:
 
 - `.claude/skills/` to `.agents/skills/`
 - `.claude/agents/*.md` to `.codex/agents/*.toml`
 - `.claude/settings.json` to `.codex/hooks.json`
 - adapter ownership metadata to `.codex/apexyard-adapter.json`
 
-It does **not** copy `.claude/hooks/` into `.codex/hooks/`. The generated
-`hooks.json` keeps the existing commands that exec the unmodified
-`.claude/hooks/*.sh` scripts. That keeps gate decisions, session markers,
-review markers, and trust-chain path checks in the same audited bash files that
-Claude Code uses today.
+The command does **not** copy `.claude/hooks/` into `.codex/hooks/`. The
+generated `hooks.json` runs the original `.claude/hooks/*.sh` scripts. Gate
+decisions, session markers, review markers, and trust-chain checks stay in the
+same audited Bash files that Claude Code uses.
 
-Codex documents repo-local hook loading from `.codex/hooks.json`; trusted
-project hooks run from the session working directory, and `PreToolUse` hooks can
-block by exiting `2` ([Codex hooks docs](https://developers.openai.com/codex/hooks)).
-The adapter test therefore proves the generated command path preserves the hook
-stdin and exit-code contract. Live Codex coverage still depends on Codex's hook
-runtime and trust settings.
+Codex loads project hooks from `.codex/hooks.json`. Trusted hooks run from the
+session working directory. A `PreToolUse` hook can block by exiting `2`
+([Codex hooks docs](https://developers.openai.com/codex/hooks)). The adapter
+test checks the generated command, input, and exit-code contract. Live coverage
+still depends on Codex hook loading and trust settings.
 
 Claude Code's handler-level `if` predicates are not part of Codex's documented
 hook handler shape. During generation, those predicates are compiled into the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,7 @@
 # Getting Started with ApexYard
 
-Short version of the setup flow. For the full walkthrough (directory layout, daily workflow, upgrade path, FAQ) see [`multi-project.md`](multi-project.md).
+This page gives the short setup flow. See [`multi-project.md`](multi-project.md)
+for the directory layout, daily workflow, upgrade path, and FAQ.
 
 ---
 
@@ -8,18 +9,23 @@ Short version of the setup flow. For the full walkthrough (directory layout, dai
 
 - A GitHub account and an org you can fork into
 - [Claude Code](https://claude.com/claude-code) installed
-- [GitHub CLI (`gh`)](https://cli.github.com) installed (optional but recommended)
+- [GitHub CLI (`gh`)](https://cli.github.com) installed (recommended, but optional)
 - [`jq`](https://jqlang.org/download/) installed — required. Framework hooks use jq to read `.claude/project-config.json` overrides; without it your overrides silently no-op. `brew install jq` / `apt-get install jq` / `dnf install jq` depending on platform. `/setup` refuses to run without it, and a SessionStart banner surfaces the gap if jq disappears later. See [AgDR-0038](agdr/AgDR-0038-jq-as-hard-dependency.md) for the rationale.
-- **Windows**: [Git for Windows](https://gitforwindows.org) (which bundles Git Bash) or WSL — required. `.claude/hooks/*.sh` are bash scripts; native `cmd.exe`/PowerShell can't run them. This already works today (the ancestor-directory-walk hang some Windows users hit on `C:`-drive paths was fixed in [#691](https://github.com/me2resh/apexyard/issues/691)) — this is just making the requirement explicit, same shape as the `jq` line above.
+- **Windows**: Use [Git for Windows](https://gitforwindows.org) or WSL. The
+  `.claude/hooks/*.sh` files use Bash. Native `cmd.exe` and PowerShell cannot
+  run them. The `C:`-drive path issue reported in [#691](https://github.com/me2resh/apexyard/issues/691)
+  is fixed.
 - Basic familiarity with Claude Code's `CLAUDE.md` system
 
 ---
 
 ## Step 1: Fork apexyard on GitHub
 
-Your ops repo **is** a fork of apexyard. One repo, no nested installs.
+Your ops repo is a fork of ApexYard. It is one repository with no nested install.
 
-Visit [`github.com/me2resh/apexyard`](https://github.com/me2resh/apexyard), **Star** it, then **Fork** it into your org. Rename the fork if you want (`your-org/ops`, `your-org/apex`, or keep it as `apexyard` — GitHub handles the rename cleanly).
+Visit [`github.com/me2resh/apexyard`](https://github.com/me2resh/apexyard).
+Star it, then fork it into your organisation. Keep `apexyard`, or rename the
+fork to a name such as `your-org/ops`.
 
 Then clone your fork locally:
 
@@ -35,13 +41,18 @@ git clone https://github.com/your-org/apexyard.git
 cd apexyard
 ```
 
-Add the upstream remote so you can pull future updates:
+Add the upstream remote so you can pull updates later:
 
 ```bash
 git remote add upstream https://github.com/me2resh/apexyard.git
 ```
 
-Later, `git fetch upstream && git merge upstream/main` pulls the latest apexyard improvements into your fork.
+Later, fetch and merge from `upstream/dev` to update your fork:
+
+```bash
+git fetch upstream
+git merge upstream/dev
+```
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,11 +47,11 @@ Add the upstream remote so you can pull updates later:
 git remote add upstream https://github.com/me2resh/apexyard.git
 ```
 
-Later, fetch and merge from `upstream/dev` to update your fork:
+Later, fetch and merge from `upstream/main` to update your fork:
 
 ```bash
 git fetch upstream
-git merge upstream/dev
+git merge upstream/main
 ```
 
 ---

--- a/docs/harnesses/README.md
+++ b/docs/harnesses/README.md
@@ -1,12 +1,24 @@
 # Harness support
 
-An **agent harness** is the CLI/IDE runtime that actually drives an ApexYard session — Claude Code, Codex, pi, opencode, Cursor. ApexYard was built for Claude Code first, and Claude Code is still the only harness where the whole experience is native. But the framework's mechanical enforcement layer — the merge gate, ticket-first edits, secrets scanning, red-CI blocking — is **portable bash**, not Claude-Code-specific, so it can be reached from other harnesses through thin adapters. This directory is the honest, per-harness "what works where, today" breakdown.
+An **agent harness** is the CLI or IDE that runs an ApexYard session. Examples
+include Claude Code, Codex, pi, opencode, and Cursor.
 
-> **Not a rebrand.** The primary tagline is still **"for Claude Code."** These pages document the engineering reality — and as of 2026-07-09 that reality includes **three live-proven adapters (opencode, pi, and Codex)**: a real model turn under each was actually blocked by a delegated bash gate. That clears the rebrand trigger's ≥2-live-proven condition, but the headline flip is a **separate, coordinated decision** and hasn't been made — the tagline stays "for Claude Code" until it is. See [Rebrand trigger](#rebrand-trigger) below.
+ApexYard was built for Claude Code first. Claude Code still provides the full
+native experience. The enforcement layer uses portable Bash. Other harnesses
+can reach the same gates through thin adapters.
+
+This directory records what each harness supports today.
+
+> **Positioning:** The primary tagline remains **"for Claude Code."** These
+> pages document the current adapter support. A separate product decision is
+> required before the headline changes. See [Rebrand trigger](#rebrand-trigger).
 
 ## Support matrix
 
-The one question this answers: **"I use tool X — does ApexYard enforce my rules on it, and what do I do?"** A tool is only marked **proven** when a real, credentialed agent turn on it was actually stopped by the same unmodified bash rule — not a mock, not a by-construction test.
+This page answers one question: **does ApexYard enforce my rules on this tool,
+and how do I set it up?** A tool is **proven** only after a real,
+credentialed agent turn is stopped by the same unmodified Bash rule. Mocks do
+not qualify.
 
 | Tool | Enforces your rules? | Setup | Good to know |
 |------|----------------------|-------|--------------|

--- a/docs/project-config.md
+++ b/docs/project-config.md
@@ -1,6 +1,9 @@
 # Project Config
 
-`.claude/project-config.defaults.json` ships the framework defaults. Each fork optionally creates `.claude/project-config.json` to override specific top-level keys. Both files live inside `.claude/`, so edits are exempt from the ticket-first hook (per `.claude/rules/workflow-gates.md`).
+`.claude/project-config.defaults.json` contains the framework defaults. A fork
+can create `.claude/project-config.json` to override selected keys. Both files
+live in `.claude/`, so the ticket-first hook does not block these edits. See
+`.claude/rules/workflow-gates.md` for the exemption.
 
 Related: apexyard#109 introduced this scheme; apexyard#107, #111, #112, #113, #114, #115 all read from it.
 
@@ -14,9 +17,14 @@ Related: apexyard#109 introduced this scheme; apexyard#107, #111, #112, #113, #1
 
 ### Why the real file is untracked (apexyard#1031)
 
-This mirrors the `onboarding.example.yaml` / `onboarding.yaml` pair: the example is tracked so upstream can improve it, and the real file stays purely local.
+This follows the `onboarding.example.yaml` and `onboarding.yaml` pattern. The
+example is tracked so upstream can improve it. The real file stays local.
 
-Until #1031 the framework tracked `project-config.json` *and* listed it in `.gitignore`. Git ignores `.gitignore` for already-tracked files, so the entry was inert for every adopter — and the consequence was worse than the drift it appeared to be. Because the file was tracked, a plain `git checkout <branch>` wrote the indexed version over the working copy. For a split-portfolio adopter that silently destroyed the `portfolio` block, which is load-bearing (path resolution is config-only; there is no convention-based sibling discovery). The destroyed content had never been in git — correctly, it is private — so there was nothing to restore from.
+Before #1031, the framework tracked `project-config.json` and listed it in
+`.gitignore`. Git does not ignore a file that is already tracked. A checkout
+could therefore overwrite a fork's local configuration. For a split portfolio,
+that could remove the `portfolio` block and break path resolution. The private
+content was not in git, so the file could not be restored from history.
 
 **If you have an existing fork that committed this file**, run `git rm --cached .claude/project-config.json` once. It leaves the file on disk and lets the ignore entry finally apply. Back the file up first if it holds a `portfolio` block: it is not recoverable from git.
 
@@ -44,7 +52,11 @@ The defaults file would be the obvious home, and it is the wrong one. `_lib-read
 
 ## Merge semantics
 
-Objects merge recursively, with override values winning scalar conflicts. Arrays replace the inherited array wholesale. For example, an override containing only `"portfolio": {"registry": "custom"}` keeps other inherited object members such as `portfolio.stale_days`, while an override of `ticket.bootstrap_skills` replaces that array. This is the behavior of `jq -s '.[0] * .[1]'` used by the shared config reader.
+Objects merge recursively. Override values win scalar conflicts. Arrays replace
+the inherited array as a whole. An override containing only
+`"portfolio": {"registry": "custom"}` keeps other object members such as
+`portfolio.stale_days`. An override of `ticket.bootstrap_skills` replaces that
+array. The shared config reader gets this behavior from `jq -s '.[0] * .[1]'`.
 
 ## Schema (v1)
 

--- a/docs/whats-inside.md
+++ b/docs/whats-inside.md
@@ -1,8 +1,11 @@
 # What's Inside ApexYard
 
-The full component breakdown — directory layout, every role, the workflow docs, the templates, and the runnable `.claude/` layer (hooks, rules, agents, skills). The [README](../README.md) keeps a lean summary; this is the exhaustive reference.
+This page lists the ApexYard components. It covers the directory layout, roles,
+workflow documents, templates, and the runnable `.claude/` layer.
 
-All of it is plain markdown and shell. There is no runtime and no service — Claude Code reads these files directly, and the hooks fire on your `git` / `gh` commands.
+The [README](../README.md) gives the short version. This page is the detailed
+reference. The files use plain Markdown and shell. Claude Code reads them from
+the repository root. Hooks run when you use `git` or `gh`.
 
 ## Directory layout
 
@@ -54,7 +57,11 @@ apexyard/
 
 ## Roles
 
-ApexYard includes 20 software-development roles across 6 departments. Roles are not passive docs — they **activate on triggers** (a PR touching `**/auth/**` fires the Security Auditor; a ticket labelled `qa` fires the QA Engineer). See [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md) for the full activation table.
+ApexYard includes 20 software-development roles across 6 departments. A role
+activates when its trigger matches the work. For example, a pull request that
+touches `**/auth/**` activates the Security Auditor. A ticket labelled `qa`
+activates the QA Engineer. See [`.claude/rules/role-triggers.md`](../.claude/rules/role-triggers.md)
+for the full trigger table.
 
 ### Engineering (7 roles)
 
@@ -102,17 +109,19 @@ ApexYard includes 20 software-development roles across 6 departments. Roles are 
 Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 ```
 
-Each phase has entry criteria, activities, exit criteria, and quality gates. See [`workflows/sdlc.md`](../workflows/sdlc.md) for the full flow.
+Each phase has entry criteria, activities, exit criteria, and quality gates.
+See [`workflows/sdlc.md`](../workflows/sdlc.md) for the full flow.
 
 ### Code Review Process
 
-Structured review with:
+The review process defines:
 
 - Author responsibilities and PR description format
 - Reviewer checklist (architecture, security, testing, performance)
 - Feedback severity levels (blocking, suggestion, question)
 - Response time targets
-- Rex (code-reviewer agent) auto-runs on every PR; human reviewer activates per role triggers
+- Rex, the Code Reviewer agent, runs on every pull request. A human reviewer
+  joins when a role trigger requires one.
 
 See [`workflows/code-review.md`](../workflows/code-review.md).
 
@@ -127,7 +136,8 @@ See [`workflows/deployment.md`](../workflows/deployment.md) for the full flow.
 
 ### Database Migration Sub-Workflow
 
-Migrations are high-blast-radius work and get their own gate (workflow gate 3a). Any edit to `migrate-*.{ts,js,py,sql}`, `**/migrations/**`, `prisma/schema.prisma`, `alembic/versions/*`, or similar requires:
+Migrations can affect many users and services. They have their own gate
+(workflow gate 3a). An edit to a migration path requires:
 
 1. A labelled `migration` ticket
 2. A matching migration AgDR that documents rollback, estimated downtime, cross-service consumers, data volume, testing plan, observability
@@ -148,7 +158,8 @@ The `/migration` skill creates both artefacts in one guided flow; the `require-m
 
 ## The `.claude/` layer — the runnable primitives
 
-This is what turns the markdown above into an enforced workflow. Claude Code picks it up automatically when the `.claude/` directory lives at the repo root.
+The `.claude/` directory turns the documents into an enforced workflow. Claude
+Code loads it when it is at the repository root.
 
 | Layer | Path | What it is |
 |-------|------|------------|


### PR DESCRIPTION
## Summary
- Rewrite the public README and core setup/configuration guides in shorter, clearer prose.
- Clarify harness and Codex adapter documentation without changing support claims or behavior.
- Simplify shared hook library headers while retaining security rationale, parser scope, and configuration semantics.

## Why this matters
The framework documentation has grown dense as features accumulated. This pass makes the outcome, action, and limits easier to find without changing the workflow or removing technical context.

## Scope
This is the first reviewable batch for the broader documentation pass. It covers public entry points and high-traffic shared-library comments. Historical decision records and machine-facing instructions remain unchanged.

## Testing
- `bash .claude/rules/tests/test_writing_standard.sh` — 144 passed.
- `npx --yes markdownlint-cli2 README.md docs/whats-inside.md docs/project-config.md docs/getting-started.md docs/harnesses/README.md docs/codex-adapter.md`
- `git diff --check`

## Glossary
| Term | Definition |
|---|---|
| Ops repo | The ApexYard fork that stores portfolio configuration and governance files. |
| Harness | The CLI or IDE that runs an ApexYard session. |
| Gate | A check that blocks an action until its condition is satisfied. |
| Adapter | A bridge that lets another harness invoke the shared Bash hooks. |

Refs #1164
