### PR TITLE
docs(#1164): clarify workflow guides

### DIFF
--- a/workflows/code-review.md
+++ b/workflows/code-review.md
@@ -1,6 +1,6 @@
 # Code Review Process
 
-Ensure code quality, share knowledge, and catch issues before they reach production.
+Code review checks that a change is correct, safe, and understandable before it reaches production. It also records the reasoning that future maintainers need.
 
 ---
 
@@ -23,9 +23,9 @@ Code review is a **role-activated** workflow. The roles below activate automatic
 
 ### Before Requesting Review
 
-1. **Self-review your diff** -- Read every line you changed
-2. **Ensure CI passes** -- Lint, type check, tests
-3. **Write a good PR description**
+1. **Read your diff** — inspect every changed line.
+2. **Run the checks** — lint, type checks, and tests must pass.
+3. **Write a useful PR description** — explain what changed, why it matters, and how to verify it.
 
 ### PR Description Format
 
@@ -48,7 +48,7 @@ Fixes #[ticket-id]
 
 **Summary bullets must be narrative, not label-only.** Every bullet should answer *what changed* AND *why it matters to the person reading this*. Label-only bullets ("State fix", "CI pipeline changes") force reviewers into diff archaeology and waste their judgment time. See [`.claude/rules/pr-quality.md`](../.claude/rules/pr-quality.md) § "Summary bullets — narrative quality" for the rule, a worked bad/good pair, and the legitimate-exceptions list. Rex flags label-only bullets as an advisory finding (`nit:` / `suggestion:`, non-blocking).
 
-**Why a Glossary?** Every PR is a learning opportunity. Explaining concepts helps:
+**Why a Glossary?** A glossary makes a PR useful to more than the people who wrote it. Clear definitions help:
 
 - Junior devs learn from senior work
 - Seniors articulate their thinking
@@ -69,11 +69,11 @@ Fixes #[ticket-id]
 
 ### How to Review
 
-1. **Understand context first** -- Read PR description, check linked ticket
-2. **Review for correctness** -- Does it do what it's supposed to? Edge cases?
-3. **Review for quality** -- Architecture, conventions, readability, maintainability
-4. **Review for security** -- Input validation, auth, sensitive data
-5. **Review tests** -- Meaningful tests, edge cases, regression protection
+1. **Understand the context** — read the PR description and linked ticket.
+2. **Check correctness** — confirm the requested behavior and test the important edge cases.
+3. **Check quality** — review architecture, conventions, readability, and maintenance cost.
+4. **Check security** — look for validation gaps, authorization errors, and leaked sensitive data.
+5. **Check tests** — confirm that tests cover the behavior and protect against regressions.
 
 ### Giving Feedback
 

--- a/workflows/deployment.md
+++ b/workflows/deployment.md
@@ -1,6 +1,6 @@
 # Deployment Process
 
-How code moves from development to production.
+This guide explains how a tested change moves from development to production and how the team watches it after release.
 
 ## Roles
 
@@ -26,10 +26,10 @@ Push to main
 CI/CD triggers
     |
     v
-Authenticate with cloud provider
+Authenticate with the cloud provider
     |
     v
-Apply infrastructure changes (IaC)
+Apply infrastructure changes (infrastructure as code)
     |
     v
 Build application
@@ -95,7 +95,7 @@ Verify and monitor
 
 ## Pre-Deploy Checklist
 
-Before deploying to production:
+Before production deployment:
 
 - [ ] All tests passing
 - [ ] QA sign-off received
@@ -110,7 +110,7 @@ Before deploying to production:
 
 ## Infrastructure as Code
 
-All infrastructure changes must be:
+Treat every infrastructure change as code. It must be:
 
 1. **Defined in code** -- No manual console changes
 2. **Version controlled** -- In the same repo as application code
@@ -148,7 +148,7 @@ git push origin main
 # Use your IaC tool's rollback mechanism
 ```
 
-### When to Rollback
+### When to Roll Back
 
 - Error rate spikes above threshold
 - P1 incident caused by deployment
@@ -178,7 +178,7 @@ Is the issue affecting users?
 
 ### Production Deploy Approval
 
-Before promoting to production:
+Before promoting a staging build to production:
 
 1. Staging has been tested
 2. QA has signed off

--- a/workflows/sdlc.md
+++ b/workflows/sdlc.md
@@ -1,6 +1,6 @@
 # Software Development Lifecycle (SDLC)
 
-How features move from idea to production.
+This guide explains how work moves from an idea to a monitored production release.
 
 ---
 
@@ -40,9 +40,9 @@ Planning --> Design --> Build --> Review --> QA --> Deploy --> Monitor
 - Tickets created and prioritized
 - Work scheduled in sprint/cycle
 
-> **Sidebar — when to file a `/spike` instead of a `/feature`.** If you can answer the technical question through reasoning alone (will library X work, does this approach scale, does this UX make sense), feel free to draft the feature directly. If you genuinely don't know, file a `[Spike]` first via `/spike` — a 1-3 day, hypothesis-driven, throw-away-by-default ticket. The spike's output is the answer, not shippable code; once the answer is in, run `/spike-close --promote` (file a fresh `[Feature]` for production-shaped delivery) or `/spike-close --discard` (write a memo to `docs/spike-memos/<slug>.md` so future-us doesn't re-explore the same ground). Spike PRs are exempt from the AgDR + 80% coverage gates; code review (Rex) and the security auditor still apply. See `.claude/rules/workflow-gates.md` § Spike work and `templates/tickets/spike.md`.
+> **Sidebar — when to file a `/spike` instead of a `/feature`.** If reasoning can answer the technical question (for example, whether a library works or an approach scales), write the feature directly. If the answer is unknown, file a `[Spike]` with `/spike`. A spike is a 1–3 day, hypothesis-driven ticket whose default output is disposable learning, not production code. When the question is answered, run `/spike-close --promote` to file a fresh `[Feature]`, or `/spike-close --discard` to save a memo in `docs/spike-memos/<slug>.md`. Spike PRs do not require an AgDR or 80% coverage; Rex and the security auditor still review them. See `.claude/rules/workflow-gates.md` § Spike work and `templates/tickets/spike.md`.
 >
-> **Sidebar — the early-work taxonomy: `/spike` vs `/prototype` vs `/walking-skeleton`.** Three early-phase scaffolds across two axes (throwaway-vs-kept, technical-vs-UX):
+> **Sidebar — the early-work taxonomy: `/spike` vs `/prototype` vs `/walking-skeleton`.** These three tools answer different questions and have different lifecycles:
 >
 > | Skill | Question | Lifecycle |
 > |-------|----------|-----------|
@@ -99,7 +99,7 @@ Skill reference: `.claude/skills/journey/SKILL.md`. Rendering decision rationale
 | Break into tasks | Tech Lead | Task list with estimates |
 | Identify risks | Tech Lead | Risk register |
 
-> **"Have we decided this before?"** Before drafting a design, run `/agdr search <term>` (or `/agdr browse --category architecture`) to scan the portfolio's existing Agent Decision Records. The skill walks every managed project and the apexyard fork itself, so prior calls on auth, data layers, or vendor choices surface in seconds rather than getting silently re-litigated.
+> **"Have we decided this before?"** Before drafting a design, run `/agdr search <term>` or `/agdr browse --category architecture`. This searches the managed projects and the ApexYard fork, so prior decisions about authentication, data layers, or vendors are easy to find and do not get reconsidered by accident.
 
 ### Exit Criteria
 
@@ -131,7 +131,7 @@ Skill reference: `.claude/skills/journey/SKILL.md`. Rendering decision rationale
 
 ### Pre-Build Gate (MANDATORY)
 
-DO NOT START CODING until these exist in your ticket tracker:
+Do not start coding until the ticket tracker contains all of the following:
 
 | Requirement | How to Verify |
 |-------------|---------------|
@@ -142,7 +142,7 @@ DO NOT START CODING until these exist in your ticket tracker:
 
 ### One Ticket at a Time (MANDATORY)
 
-Work on ONE ticket at a time. Complete it fully before starting the next.
+Complete one ticket before starting the next. The ticket is not complete until its PR, review, and QA work are complete.
 
 ```
 WRONG:
@@ -157,23 +157,23 @@ RIGHT:
 ### Development Flow
 
 ```
-1. Create branch from main
+1. Create a branch from `main`.
    git checkout -b feature/TICKET-ID-description
 
-2. Implement in small commits
+2. Implement in small commits.
    - Follow architecture principles
    - Follow coding conventions
    - Write tests as you go
 
-3. Keep branch updated
+3. Keep the branch updated.
    git rebase main regularly
 
-4. Self-review before PR
+4. Review your own work before opening the PR.
    - Run lint/format
    - Run tests locally
    - Review own diff
 
-5. Create PR with description
+5. Create the PR with a description that answers:
    - What: Summary of changes
    - Why: Link to ticket
    - How: Technical approach


### PR DESCRIPTION
## Summary
- Clarify the SDLC guide so phase gates, spike choices, and the one-ticket rule are easier to follow.
- Rewrite code-review guidance as direct actions for authors and reviewers.
- Explain deployment and rollback steps with simpler wording while preserving the existing controls and thresholds.

## Why it matters
These workflow pages are used as operating instructions. Clearer sentences reduce interpretation time while keeping the roles, commands, gates, and release checks unchanged.

## Testing
- `git diff --check`
- `bash .claude/rules/tests/test_writing_standard.sh` (144 passed)
- `npx --yes markdownlint-cli2 workflows/sdlc.md workflows/code-review.md workflows/deployment.md`

## Glossary
| Term | Definition |
|------|------------|
| SDLC | The sequence of planning, design, build, review, QA, deployment, and monitoring steps. |
| CI | Automated checks that run when a change is proposed or updated. |
| QA | Verification that the merged change meets its acceptance criteria. |
| IaC | Infrastructure managed as versioned code. |
| PR | A proposed change submitted for review before merge. |

Refs #1164
