### PR TITLE
docs(#1164): clarify onboarding language

### DIFF
--- a/docs/onboarding/capability-tour.md
+++ b/docs/onboarding/capability-tour.md
@@ -1,52 +1,48 @@
 # ApexYard Capability Tour
 
-A 60-second orientation to the three ideas that make ApexYard different from
-"just a folder of prompts": **roles**, **skills**, and **gates**. This is the
-shared tour content rendered by both `/onboard` (first-run) and `/tutorial`
-(re-entry, any time) — one asset, read by both, never duplicated. See
+A 60-second introduction to the three ideas that organize ApexYard:
+**roles**, **skills**, and **gates**. `/onboard` shows this content during
+first use, and `/tutorial` shows it again whenever someone needs a refresher.
+Both commands read this one shared file. See
 `docs/technical-designs/onboarding-increment-1.md` § D3.
 
-Skippable in one word — say "skip" at any point and move on.
+You can skip the tour at any time by saying "skip".
 
 ---
 
 ## What's a role?
 
-A role is a named persona with its own responsibilities and CAN/CANNOT
-boundaries — think of it as a teammate, not a mode. When work matches a
-role's trigger (a PR touches `**/auth/**`, a technical design needs review),
-that role activates and drives the task.
+A role names a type of teammate, its responsibilities, and its CAN/CANNOT
+boundaries. When work matches a role's trigger, the role activates and guides
+the task. For example, a PR that touches `**/auth/**` activates the Security
+Auditor.
 
-**Example**: open a PR that touches authentication code, and Hakim (the
-Security Auditor) activates automatically to review it — you didn't have to
-ask.
+**Example**: Hakim reviews that authentication PR automatically. You do not
+need to ask for the review.
 
 ## What's a skill?
 
-A skill is a slash command that packages a whole workflow — questions to
-ask, a template to fill in, a place to file the result — so you don't have
-to reconstruct the process by hand each time.
+A skill is a slash command that packages a workflow: the questions to ask, the
+template to use, and where to save the result. It gives each run the same
+starting point.
 
-**Example**: `/feature` asks you for a user story and acceptance criteria,
-shows you the formatted ticket, and files it as a real GitHub issue once you
-confirm.
+**Example**: `/feature` asks for a user story and acceptance criteria, shows
+the formatted ticket, and files a GitHub issue after you confirm it.
 
 ## What's a gate?
 
-A gate is a checkpoint the work can't pass until a specific condition is
-met — tests green, a reviewer's sign-off, your explicit approval. Gates are
-mechanically enforced, not just written down: a hook blocks the action until
-the gate is satisfied.
+A gate is a checkpoint. Work cannot pass it until a required condition is
+met, such as passing tests, a reviewer sign-off, or your explicit approval.
+Hooks enforce these conditions, so the gate is an action the system checks,
+not only a rule in a document.
 
-**Example**: `gh pr merge` is blocked until both Rex (the automated code
-reviewer) and you, the human, have each approved that exact commit — no
-merge slips through on a plan-level "go".
+**Example**: `gh pr merge` stays blocked until Rex and you have approved the
+same commit. A plan-level "go" does not replace those approvals.
 
 ## How the loop works
 
-Idea → ticket → PR → review → merge. Every feature moves through this loop;
-roles drive each stage, skills do the mechanical work, gates make sure
-nothing skips a step.
+Idea → ticket → PR → review → merge. Roles guide each stage, skills carry out
+repeatable steps, and gates stop work from skipping a required check.
 
 ---
 

--- a/docs/onboarding/glossary.md
+++ b/docs/onboarding/glossary.md
@@ -1,28 +1,24 @@
 # ApexYard Plain-Language Glossary
 
-Five core SDLC terms explained in one to three plain-language sentences
-each — no jargon used to define another piece of jargon. This is the
-**single shared asset** three surfaces read from, never duplicated: the
-just-in-time asides in `/onboard` (guided mode, one term at a time), the
-full re-entry render in `/tutorial`, and the any-session on-demand lookup
-(`.claude/rules/glossary-lookup.md`). See
+Five common SDLC terms explained in one to three plain-language sentences
+each. This is the **single shared asset** used by three surfaces: `/onboard`
+shows one term at a time, `/tutorial` renders the full glossary, and
+`.claude/rules/glossary-lookup.md` provides on-demand lookup. See
 `docs/technical-designs/onboarding-increment-2.md` § D1 (AgDR-0100).
 
-**Read contract** — every consumer of this file relies on this exact
-shape, so keep it if you edit an entry:
+**Read contract** — consumers rely on this exact shape. Keep it when you edit
+an entry:
 
 - One term per stable `###` heading.
 - The heading's very first line is a greppable key comment
   `<!-- term: <key>[,<key>...] -->` — comma-separated surface spellings
   that all resolve to the same entry (e.g. "issue" and "ticket" both map
   to the first section below).
-- Body: 1–3 plain-language sentences. No word inside a definition may be
-  jargon unless it is inlined right there or is itself one of these five
-  terms (D6 — Consistency).
-- `/tutorial` renders the whole file, top to bottom, unchanged. The
-  just-in-time asides and the on-demand lookup slice exactly one section
-  by its `term:` key. No consumer ever re-types or paraphrases this prose
-  elsewhere.
+- Body: 1–3 plain-language sentences. Define any necessary technical term
+  in the same entry, unless it is one of these five terms (D6 — Consistency).
+- `/tutorial` renders the whole file, top to bottom, unchanged. The other
+  consumers select one section by its `term:` key. They do not copy or
+  paraphrase this text elsewhere.
 
 ---
 
@@ -32,64 +28,55 @@ shape, so keep it if you edit an entry:
 
 <!-- term: issue,ticket -->
 
-A ticket (GitHub calls it an "issue") is a tracked to-do item with its own
-number, like `#42`. It's where the team writes down what needs to happen,
-follows the discussion, and links the pull request that eventually does
-the work — so anyone can look up "what was #42 about?" months later.
+A ticket (GitHub calls it an "issue") is a tracked piece of work with its own
+number, such as `#42`. The ticket holds the request, its discussion, and the
+PR that delivers the change, so the team can find the context later.
 
-**Example**: when `/feature` files a ticket for you, it's a real page on
-GitHub you can open, comment on, and refer back to by that number.
+**Example**: `/feature` files a ticket as a GitHub page that you can open,
+comment on, and reference by number.
 
 ### PR (pull request)
 
 <!-- term: pr -->
 
-A PR is a proposed change to the code, packaged up for review before it
-becomes part of the project. It shows exactly what would change (line by
-line) alongside a description of what and why, so a reviewer can decide
-whether it's safe to bring in.
+A PR is a proposed code change packaged for review before it becomes part of
+the project. It shows the line-by-line changes and explains what they do and
+why they are needed.
 
-**Example**: finishing a ticket's work opens a PR; nothing from it reaches
-the main codebase until that PR is reviewed and merged.
+**Example**: finishing a ticket opens a PR. Its changes do not reach the main
+codebase until the PR is reviewed and merged.
 
 ### merge
 
 <!-- term: merge -->
 
-Merging is the moment a PR's changes are actually folded into the main
-codebase — the point of no casual return. Because of that, a merge only
-happens after both an automated reviewer and a human have explicitly
-approved that exact version of the change; nothing merges on a vague
-"looks good, go ahead."
+Merging folds a PR's changes into the main codebase. It happens only after an
+automated reviewer and a human have approved the exact version being merged.
 
-**Example**: `gh pr merge` is blocked until the two approvals above both
-match the PR's current state — a fresh commit after approval means
-approving again first.
+**Example**: `gh pr merge` is blocked until both approvals match the PR's
+current commit. A new commit requires fresh approval.
 
 ### branch
 
 <!-- term: branch -->
 
-A branch is a parallel, separate copy of the code where a change can be
-built and tested without touching the version everyone else is using. Once
-the work on a branch is ready, it becomes a PR asking to bring those
-changes back into the main line.
+A branch is a separate line of the code where a change can be built and
+tested without changing the shared version. When the work is ready, a PR
+asks to bring it back into the main line.
 
-**Example**: starting a ticket creates a branch named after it (like
-`feature/#42-add-login`), so the in-progress work stays isolated until
-it's reviewed.
+**Example**: a ticket may use a branch such as `feature/#42-add-login`, which
+keeps the in-progress work isolated until review.
 
 ### CI (continuous integration)
 
 <!-- term: ci -->
 
-CI is an automated check that runs every time a PR is opened or updated —
-it builds the code, runs the tests, and reports back pass or fail before
-any human review even starts. A PR with a failing CI check ("red CI")
-never gets merged, regardless of how small the change looks.
+CI is an automated check that runs when a PR is opened or updated. It builds
+the code, runs tests, and reports pass or fail. A PR with a failing CI check
+("red CI") cannot be merged.
 
-**Example**: pushing a new commit to an open PR re-runs CI automatically,
-so a fix you just made gets verified before anyone re-reviews it.
+**Example**: pushing a new commit to an open PR starts CI again, so the fix
+is checked before the next review.
 
 ---
 

--- a/docs/onboarding/glossary.md
+++ b/docs/onboarding/glossary.md
@@ -14,8 +14,9 @@ an entry:
   `<!-- term: <key>[,<key>...] -->` — comma-separated surface spellings
   that all resolve to the same entry (e.g. "issue" and "ticket" both map
   to the first section below).
-- Body: 1–3 plain-language sentences. Define any necessary technical term
-  in the same entry, unless it is one of these five terms (D6 — Consistency).
+- Body: 1–3 plain-language sentences. Do not use jargon to define another
+  term. If a technical term is necessary, define it in the same entry unless
+  it is one of these five terms (D6 — Consistency).
 - `/tutorial` renders the whole file, top to bottom, unchanged. The other
   consumers select one section by its `term:` key. They do not copy or
   paraphrase this text elsewhere.


### PR DESCRIPTION
## Summary
- Rewrite the capability tour so roles, skills, and gates are explained in direct language.
- Simplify the shared glossary while preserving its stable headings, lookup keys, and rendering contract.
- Keep the onboarding behavior and all gate requirements unchanged.

## Why it matters
These files are shown to people who are learning or re-entering ApexYard. Clear definitions make the workflow easier to understand without changing what the commands or gates do.

## Testing
- `git diff --check`
- `bash .claude/rules/tests/test_writing_standard.sh` (144 passed)
- `npx --yes markdownlint-cli2 docs/onboarding/capability-tour.md docs/onboarding/glossary.md`

## Glossary
| Term | Definition |
|------|------------|
| Role | A named teammate type with defined responsibilities and boundaries. |
| Skill | A slash command that packages a repeatable workflow. |
| Gate | A checkpoint that blocks work until its required condition is met. |
| PR | A proposed change submitted for review before merge. |
| CI | Automated checks that run when a PR is opened or updated. |

Refs #1164
