### PR TITLE
docs(#1164): clarify hook comments

### DIFF
--- a/.claude/hooks/_lib-migration-chain.sh
+++ b/.claude/hooks/_lib-migration-chain.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-# _lib-migration-chain.sh — detect the current framework version anchor,
-# discover the chain of intermediate-release migrations needed to reach
-# a target version, and shell out to each per-pair migration script.
+# _lib-migration-chain.sh — read the current framework version, build the
+# ordered migration path to a target release, and run each migration script.
 #
 # Source this library from /update (and from the smoke test).
 #
@@ -18,7 +17,7 @@
 # Single-line "vMAJOR.MINOR.PATCH". Written by /update on every successful
 # sync. See AgDR-0032.
 #
-# Design notes (kept here so the rationale travels with the code):
+# Design notes (kept here so the rationale stays next to the code):
 #   - The anchor is a separate file (not a git-derived signal) because
 #     adopters routinely rewrite history (squash-merge, rebase) and an
 #     anchor that depends on tag presence would silently drift.

--- a/.claude/hooks/_lib-ops-root.sh
+++ b/.claude/hooks/_lib-ops-root.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# _lib-ops-root.sh — shared OPS_ROOT discovery for hooks and skills.
+# _lib-ops-root.sh — shared OPS_ROOT lookup for hooks and skills.
 #
 # An "ops root" is the directory containing one of:
 #
@@ -7,14 +7,10 @@
 #   2. BOTH `onboarding.yaml` AND `apexyard.projects.yaml` (legacy v1
 #      layout — pre-v2 single-fork OR pre-v2 split-portfolio adopters).
 #
-# Hooks that write or read framework session state (`.claude/session/*`)
-# need this to resolve consistently regardless of cwd. The failure mode
-# is real: when the operator works inside a managed-project workspace
-# clone at `workspace/<project>/`, `git rev-parse --show-toplevel`
-# returns the project clone, NOT the ops fork. Hooks that wrote markers
-# under the ops fork (e.g. via `require-active-ticket.sh`'s OPS_ROOT
-# walk) ended up invisible to merge-gate hooks that resolved REPO_ROOT
-# via plain `git rev-parse`.
+# Hooks that read or write `.claude/session/*` must resolve the same root from
+# every cwd. From `workspace/<project>/`, `git rev-parse --show-toplevel`
+# returns the managed project clone, not the ops fork. Without this lookup,
+# one hook can write a marker in the ops fork while another searches the clone.
 #
 # Why a marker file: split-portfolio v2 (#242) moves both `onboarding.yaml`
 # AND `apexyard.projects.yaml` to the private sibling repo. The legacy

--- a/.claude/hooks/_lib-portfolio-paths.sh
+++ b/.claude/hooks/_lib-portfolio-paths.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-# _lib-portfolio-paths.sh — resolve portfolio paths from project-config.
+# _lib-portfolio-paths.sh — resolve configured portfolio paths.
 #
-# Source this library from any hook or skill that reads/writes the
-# portfolio registry, per-project docs dir, ideas backlog, the
-# onboarding config, or the workspace dir. Reads the `portfolio` block
+# Source this library from hooks or skills that read or write the portfolio
+# registry, project docs, ideas backlog, onboarding config, or workspace. It reads the `portfolio` block
 # from .claude/project-config.{defaults,}.json (via _lib-read-config.sh's
 # `config_get_or`).
 #

--- a/.claude/hooks/auto-code-review.sh
+++ b/.claude/hooks/auto-code-review.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# PostToolUse hook: after `gh pr create` succeeds, tell Claude to invoke the
-# code-reviewer agent (Rex) on the new PR automatically.
+# PostToolUse hook: after `gh pr create` succeeds, tell Claude to run the
+# code-reviewer agent (Rex) on the new PR.
 #
 # Mechanism: the hook writes a pending-review marker and exits with code 2
 # so the stderr message is surfaced back to Claude as an "error", which in

--- a/.claude/hooks/require-active-ticket.sh
+++ b/.claude/hooks/require-active-ticket.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Blocks Edit/Write/MultiEdit on code paths when no active ticket is set.
-# Enforces the ticket-first rule mechanically instead of relying on prose
-# in CLAUDE.md, workflows/sdlc.md, or .claude/rules/workflow-gates.md.
+# This enforces the ticket-first rule instead of relying on prose in
+# CLAUDE.md, workflows/sdlc.md, or .claude/rules/workflow-gates.md.
 #
 # Active tickets are declared by the /start-ticket skill. The marker
 # layout is three-tier (apexyard#41 + #513):


### PR DESCRIPTION
## Summary
- Clarify comments in the migration-chain, ops-root, and portfolio-path libraries.
- Make the ticket gate and automatic review hook comments easier to scan.
- Preserve all security rationale, compatibility boundaries, and runtime behavior.

## Why it matters
These libraries sit in the framework's trust chain. Clear comments help maintainers understand why the code exists without changing the checks themselves.

## Testing
- `git diff --check`
- `bash .claude/rules/tests/test_writing_standard.sh` (144 passed)
- `bash .claude/hooks/tests/test_ops_root.sh`
- `bash .claude/hooks/tests/test_portfolio_paths.sh` (45 passed)
- `bash .claude/hooks/tests/test_require_active_ticket_bash.sh` (81 passed)
- `npx --yes markdownlint-cli2` was not applicable because these are shell files.

## Glossary
| Term | Definition |
|------|------------|
| Ops root | The ApexYard fork root used for shared session state. |
| Migration chain | Ordered scripts that move a fork between releases. |
| Portfolio path | A configured location for registry, project, onboarding, or workspace data. |
| Ticket gate | The check that requires an active ticket before governed edits. |
| Trust chain | The set of checks that protects review, merge, and sensitive operations. |

Refs #1164
