### PR TITLE
docs(#1164): clarify quality and adapter guides

### DIFF
--- a/docs/cursor-adapter.md
+++ b/docs/cursor-adapter.md
@@ -1,9 +1,9 @@
 # Cursor Adapter
 
-ApexYard's canonical runtime still lives in `.claude/`: skills, agents, hooks,
-rules, and hook wiring are authored there first. Cursor support is generated
-from that source of truth so the two agent surfaces do not drift by hand —
-the same declarative-generate pattern as the [Codex adapter](codex-adapter.md).
+ApexYard's canonical runtime lives in `.claude/`: skills, agents, hooks, rules,
+and hook wiring are authored there first. Cursor support is generated from
+that source, so the two agent surfaces do not drift by hand. This follows the
+same generate-from-source pattern as the [Codex adapter](codex-adapter.md).
 
 Decision record: [`AgDR-0091`](agdr/AgDR-0091-cursor-adapter-generation.md).
 Precedent: [`AgDR-0088`](agdr/AgDR-0088-codex-adapter-generation.md) (Codex),
@@ -22,13 +22,11 @@ Precedent: [`AgDR-0088`](agdr/AgDR-0088-codex-adapter-generation.md) (Codex),
 > own.
 
 **Where Cursor stands among the four third-party adapters.** opencode and pi
-are both live-proven — their CLIs genuinely execute the delegated extension
-code. Codex carried the same "live conformance unverified" caveat as Cursor
-when its own AgDR (AgDR-0088) was written, but live testing has since closed
-that gap (it turned out to be a trust-prompt issue, resolved via
-`--dangerously-bypass-hook-trust` / a user-level trust grant) — Codex is now
-live-proven too. **Cursor is the sole remaining outlier**: see "Known
-Limitations" below for exactly what "enforced" means on Cursor today.
+are live-proven: their CLIs execute the delegated extension code. Codex had
+the same unverified-conformance caveat when its AgDR was written, but live
+testing closed that gap through the trust prompt; Codex is now live-proven.
+**Cursor is the remaining outlier.** See "Known Limitations" for what
+"enforced" means on Cursor today.
 
 ## Install (the path that actually loads in Cursor 3.x)
 
@@ -72,7 +70,7 @@ CLI-targeting adapter (translating apexyard's gates into
 future work. Only the Cursor IDE agent (Cursor.app / Composer) is addressed
 by `hooks.json`.
 
-## Generate The Project-Level Adapter (kept available, not the load-bearing path)
+## Generate the project-level adapter (available, but not the load-bearing path)
 
 ```bash
 bin/sync-cursor-adapter.sh

--- a/docs/quality-regression/README.md
+++ b/docs/quality-regression/README.md
@@ -1,6 +1,6 @@
 # Quality regression — grounding, proportionality, readability
 
-**Outcome.** The framework keeps a small, permanent corpus of real failure cases and a runner that replays them through every supported harness. **Reason.** The three behavioral rules shipped in me2resh/apexyard#1162, #1163, and #1164 are prose, not hooks; the only way to know they work across harnesses is to run the same tasks everywhere and look. **Decision.** Scoring is human-adjudicated against observable pass / fail conditions, helped by mechanical checks, and never by an LLM judge rating prose ([AgDR-0089](../agdr/AgDR-0089-eval-agents-methodology.md) found that shape at chance). **Next action.** Run the corpus before a release; a high-severity failure on any supported harness stops the release until it is fixed.
+The framework keeps a small, permanent corpus of real failure cases and a runner that replays them through every supported harness. The three behavioral rules shipped in #1162, #1163, and #1164 are prose rather than hooks, so the same tasks must run on each harness to show that the behavior holds. A person scores each run against observable pass/fail conditions; mechanical checks provide evidence, but no model grades the prose ([AgDR-0089](../agdr/AgDR-0089-eval-agents-methodology.md)). Run the corpus before a release. A high-severity failure on any supported harness stops the release until it is fixed.
 
 ## The corpus
 
@@ -12,7 +12,7 @@ The cases are the three fixture files the rules already ship. They are the singl
 | `.claude/rules/tests/fixtures/proportionate-work-cases.md` | `PW` | proportionality — smallest change, reuse, undemonstrated abstraction, advice stays conversational, Lean planning, Heavy rails | 7 |
 | .claude/rules/tests/fixtures/human-friendly-cases.md | HF | controlled technical writing profile for artifacts, clear machine text, evidence retention, and review rejection | 10 |
 
-Each case states a **Given** (the situation), a **Prompt** (what the operator says), a **Fail if**, and a **Pass if**. Both conditions are observable in the transcript or in the files the agent wrote. See [`corpus.md`](corpus.md) for every case with its dimension, severity, representative flag, and mechanical check.
+Each case states a **Given** (the situation), a **Prompt** (what the operator says), a **Fail if**, and a **Pass if**. The result must be observable in the transcript or in files the agent wrote. See [`corpus.md`](corpus.md) for each case's dimension, severity, representative flag, and mechanical check.
 
 **Representative set** (runs on every harness): EG-01, EG-03, EG-05, PW-01, PW-04, PW-06, HF-01, HF-06 — one clear case per failure family, and both rails.
 
@@ -29,7 +29,7 @@ Four scores per run, all read from transcripts:
 
 **Severity.** A failure is **high** when it reduces safety, technical precision, or task completion: EG-02, EG-03, EG-06, PW-06, PW-07, HF-06. Every other failure is **medium**. The release gate is: no high-severity failure on any supported harness that ran.
 
-**Mechanical checks** are heuristics on observable text and on written files (for example, "output contains `#N`" or "worktree has a modified file"). They are printed per case and pre-fill the scorecard. **The adjudicated column is final** and is filled by a person from the transcript. A mechanical PASS with an adjudicated FAIL is expected sometimes; the reverse should be rare and is worth a note.
+**Mechanical checks** are heuristics over observable text and written files, such as "output contains `#N`" or "worktree has a modified file." They print per case and pre-fill the scorecard. **The adjudicated column is final** and is completed by a person from the transcript. A mechanical PASS with an adjudicated FAIL is sometimes expected; the reverse should be rare and deserves a note.
 
 ## Running it
 
@@ -60,7 +60,7 @@ Each case runs in its own detached worktree of `--ref` under `.claude/worktrees/
 ## What this is not
 
 - Not an LLM-judge benchmark. No model rates prose here.
-- Not proof of behavior. Twenty cases on a handful of harnesses is a smoke test that catches regressions in the defaults, not a measurement of the model.
+- Not proof of all behavior. Twenty cases on a handful of harnesses is a smoke test for regressions in the defaults, not a measurement of the model.
 - Not a hook. Nothing here blocks a merge. The release process reads the latest run.
 
 Decision record: [AgDR-0127](../agdr/AgDR-0127-cross-harness-quality-regression.md). Ticket: me2resh/apexyard#1165.


### PR DESCRIPTION
## Summary
- Clarify the quality-regression guide's purpose, evidence model, and limits.
- Simplify the Cursor adapter introduction and support-status explanation.
- Preserve issue references, commands, support claims, caveats, and release-gate behavior.

## Why it matters
These pages explain how operators validate behavior across harnesses and how Cursor differs from the native runtime. Clearer framing helps readers choose the right test and understand the adapter's limits.

## Testing
- `git diff --check`
- `bash .claude/rules/tests/test_writing_standard.sh` (144 passed)
- `npx --yes markdownlint-cli2 docs/quality-regression/README.md docs/cursor-adapter.md`

## Glossary
| Term | Definition |
|------|------------|
| Quality regression | A repeatable run that checks governed behavior across supported harnesses. |
| Corpus | The fixed set of cases used by the regression runner. |
| Adjudication | A person's final PASS or FAIL decision based on transcript evidence. |
| Adapter | The generated transport that connects a harness to the canonical hooks. |
| Fail closed | Block the action when a security-critical check cannot evaluate safely. |

Refs #1164
