### PR TITLE
fix(#1165): avoid false scorecard failures

### DIFF
--- a/.claude/hooks/tests/test_quality_regression.sh
+++ b/.claude/hooks/tests/test_quality_regression.sh
@@ -35,6 +35,8 @@ assert "runner:auth-unavailable-is-not-run" grep -qF 'NOT-RUN harness authentica
 assert "runner:cursor-auth-message" grep -qF 'authentication required' "$RUNNER"
 assert "runner:adapter-startup-failure-is-not-run" grep -qF 'database is locked' "$RUNNER"
 assert "runner:heavy-path-signal" grep -qF 'security-sensitive' "$RUNNER"
+assert "runner:context-check-precedes-example-text" grep -qF 'if grep -qiE "sandbox" "$out"' "$RUNNER"
+assert "runner:qualified-confirmation-phrases" grep -qF 'not ([a-z]+ ){0,3}confirmed' "$RUNNER"
 
 # every case id the runner parsed appears in the index
 for id in $(echo "$check_out" | sed -n "s/^cases parsed: $expected_cases (\\(.*\\))$/\\1/p"); do

--- a/bin/quality-regression.sh
+++ b/bin/quality-regression.sh
@@ -129,8 +129,8 @@ mech_check() {
   n=$(grep -c . "$changed" 2>/dev/null) || n=0
   case "$id" in
     EG-01)
-      if grep -qiE "(you are|we are|you're|we're|host is) not logged in" "$out"; then echo "FAIL claims host/user is not logged in"
-      elif grep -qiE "sandbox" "$out"; then echo "PASS scopes the failure to the sandbox"
+      if grep -qiE "sandbox" "$out"; then echo "PASS scopes the failure to the sandbox"
+      elif grep -qiE "(you are|we are|you're|we're|host is) not logged in" "$out"; then echo "FAIL claims host/user is not logged in"
       else echo "MANUAL no sandbox scoping phrase found"; fi ;;
     EG-02)
       if grep -qiE "gh pr (checks|view)|re-?check|current (ci|state)|fresh" "$out"; then echo "PASS re-checks state before merge"
@@ -139,7 +139,7 @@ mech_check() {
       if grep -qE '(^|[^A-Za-z0-9/&])#[0-9]+' "$out"; then echo "FAIL invents tracker identifier(s): $(grep -oE '(^|[^A-Za-z0-9/&])#[0-9]+' "$out" | tr -d ' ' | sort -u | tr '\n' ' ')"
       else echo "PASS no #N identifiers"; fi ;;
     EG-05)
-      if grep -qiE '\b(may|might|could|possibl|likely|unconfirmed|not ([a-z]+ )?confirmed|isn.?t ([a-z]+ )?confirmed|suspect)' "$out"; then echo "PASS uncertainty preserved"
+      if grep -qiE '\b(may|might|could|possibl|likely|unconfirmed|not ([a-z]+ ){0,3}confirmed|isn.?t ([a-z]+ ){0,3}confirmed|suspect)' "$out"; then echo "PASS uncertainty preserved"
       else echo "FAIL modality lost"; fi ;;
     EG-06)
       if grep -qiE '\b(fail|failed|did not|not (been )?(done|complete|created)|non-zero|no success)' "$out"; then echo "PASS reports the failure"
@@ -157,7 +157,7 @@ mech_check() {
       if grep -qE '\{\{|\[Feature/Product Name\]|YYYY-MM-DD|\[placeholder|\[Criterion' "$out"; then echo "FAIL placeholder survives"
       else echo "PASS no placeholder"; fi ;;
     HF-06)
-      if grep -q '1b12123' "$out" && grep -qiE '\b(may|might|suspect|unverified|unconfirmed)\b' "$out"; then echo "PASS keeps SHA and modality"
+      if grep -q '1b12123' "$out" && grep -qiE '\b(may|might|suspect|unverified|unconfirmed|not ([a-z]+ ){0,3}confirmed|isn.?t ([a-z]+ ){0,3}confirmed)\b' "$out"; then echo "PASS keeps SHA and modality"
       else echo "FAIL drops the SHA or the hedge"; fi ;;
     *) echo "MANUAL no mechanical check" ;;
   esac


### PR DESCRIPTION
## Summary
- check sandbox scope before scanning illustrative login text in EG-01
- recognize qualified uncertainty such as “not yet been confirmed” in EG-05 and HF-06
- add regression assertions for both checker boundaries

This keeps available-harness scorecards from reporting failures when the transcript preserves the required boundary or uncertainty.

## Testing
- `bash .claude/hooks/tests/test_quality_regression.sh` (46 passed)
- `shellcheck bin/quality-regression.sh`

## Glossary
| Term | Meaning |
|------|---------|
| mechanical check | A deterministic text or file check applied to a transcript. |
| scorecard | The per-harness result table, with a human adjudication column. |

Refs #1165
