### PR TITLE
fix(#1255): ground reviewer behavior claims in real usage

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -86,6 +86,18 @@ It also lowers review token cost (targeted semantic excerpts vs. broad `grep` + 
 
 When citing a file as evidence — prior art, precedent, a counterexample, or a claim about how another part of the framework behaves — read the cited region in full before asserting what it does. A section header, scope line, table heading, or gate lead-in is not the mechanism. Verify the applicable criterion, including its conditions and exceptions, and cite the line where that criterion lives. Do not assert that a condition is absent until you have read the region where it could be defined.
 
+## Evidence-backed behavior claims
+
+Before stating that code, configuration, or a workflow **does** something, verify the claim against the repository's real usage. Inspect relevant call sites, build scripts, CI references, and tests. When the claim depends on runtime behavior, run the smallest available command or reproduction that exercises it. A diff can show intent, but it does not prove that a path is reachable or that a commented section is active.
+
+Classify the basis of each load-bearing behavior finding:
+
+- **Observed** — reproduced by a command, test, or direct repository evidence.
+- **Inferred** — supported by code evidence but not exercised; state the inference and its basis.
+- **Unverified** — the required usage or runtime check was unavailable; report the gap and keep the finding conditional.
+
+Do not present an inference or an unverified hypothesis as a confirmed defect. If no suitable reproduction exists, say what was checked and what remains unknown. Keep examples and commands generic; do not copy private repository paths, credentials, or adopter identifiers into framework artifacts.
+
 ## Reduced-Scope Review — Lean-tier diffs (Option 4, AgDR-0116)
 
 Per `.claude/rules/right-size-ceremony.md`, a **Lean-tier** diff still requires a Rex pass — the merge gate (`block-unreviewed-merge.sh`) requires the `*-rex.approved` marker on EVERY PR, regardless of tier, unconditionally, because it is a CONTROL that reads structured state (a marker vs. the forge-reported HEAD) and structurally cannot itself inspect a diff's content to decide a tier. What changes for a Lean diff is the **depth** of your pass, never whether one happens.

--- a/.claude/rules/tests/test_evidence_grounding.sh
+++ b/.claude/rules/tests/test_evidence_grounding.sh
@@ -8,6 +8,7 @@ set -u
 
 SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 RULE_FILE="$SRC_ROOT/.claude/rules/evidence-grounding.md"
+REVIEWER_FILE="$SRC_ROOT/.claude/agents/code-reviewer.md"
 CASES_FILE="$SRC_ROOT/.claude/rules/tests/fixtures/evidence-grounding-cases.md"
 AGDR_FILE="$SRC_ROOT/docs/agdr/AgDR-0124-universal-evidence-grounding-contract.md"
 
@@ -39,6 +40,10 @@ assert "rule:mutable-state" grep -qF 'Re-check mutable state immediately before 
 assert "rule:preserve-uncertainty" grep -qF 'Preserve uncertainty' "$RULE_FILE"
 assert "rule:no-false-success" grep -qF 'without a success result' "$RULE_FILE"
 assert "rule:advisory-honesty" grep -qF 'A shell hook cannot determine whether prose follows from evidence' "$RULE_FILE"
+assert "reviewer:real-usage" grep -qF "verify the claim against the repository's real usage" "$REVIEWER_FILE"
+assert "reviewer:runtime-reproduction" grep -qF 'smallest available command or reproduction' "$REVIEWER_FILE"
+assert "reviewer:claim-states" grep -qF '**Unverified**' "$REVIEWER_FILE"
+assert "reviewer:no-private-identifiers" grep -qF 'do not copy private repository paths' "$REVIEWER_FILE"
 
 assert "wiring:claude" grep -qF '@.claude/rules/evidence-grounding.md' "$SRC_ROOT/CLAUDE.md"
 assert "wiring:agents" grep -qF '.claude/rules/evidence-grounding.md' "$SRC_ROOT/AGENTS.md"


### PR DESCRIPTION
## Summary
- Requires the code reviewer to verify behavior claims against real call sites, build or CI usage, and the smallest available runtime reproduction so findings are based on reachable behavior.
- Requires reviewers to label findings as observed, inferred, or unverified and preserve uncertainty when verification is incomplete, which prevents hypotheses from being presented as confirmed defects.
- Adds regression assertions to keep the reviewer guidance and privacy boundary present.

Closes #1255

## Validation
- `bash .claude/rules/tests/test_evidence_grounding.sh` (33 passed)
- `git diff --check`

## Glossary
| Term | Meaning |
| --- | --- |
| Behavior claim | A statement about what code, configuration, or a workflow does. |
| Call site | A location that invokes or references the code under review. |
| Minimal reproduction | The smallest command or test that demonstrates the claimed behavior. |
| Unverified | A claim for which the required usage or runtime check was not available. |
