### PR TITLE
docs(#1259): credit issue contributors across repository history

### DIFF
--- a/.claude/migrations/v5.4.0-to-v5.5.0.sh
+++ b/.claude/migrations/v5.4.0-to-v5.5.0.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# v5.4.0 → v5.5.0 migration: PLACEHOLDER (no-op)
+#
+# v5.5.0 ships no per-adopter file or configuration migration. This script
+# keeps the migration chain continuous for adopters upgrading from v5.4.0.
+
+set -u
+
+QUIET="${APEXYARD_MIGRATION_QUIET:-0}"
+info() { [ "$QUIET" = "1" ] || echo "$@"; }
+
+info "migration v5.4.0→v5.5.0: placeholder (no adopter-facing migration for this release)."
+exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,124 @@
+## [v5.5.0] — 2026-09-10
+
+Minor release — 8 features, 48 fixes, 21 improvements.
+
+### Added (feat)
+
+- (#1239) split issue and review tracker hosts — 1796a60
+- enforce controlled technical writing for new artifacts — f468a0e
+- (#1191) require browser evidence in QA and design-review records — 5408ddd
+- (#1179) add build-time handbook discovery — 012d586
+- (#1170) add cross-harness quality regression — ba05168
+- (#1168) add writing standard with Strict and Flavored modes — 97e8479
+- (#1167) extend right-size tiers to planning, implementation, and artifacts — 11e7e14
+- (#1166) add universal evidence-grounding contract — 5327d74
+
+### Fixed (fix)
+
+- (#1257) block agent privilege escalation — 8be2866
+- (#1255) ground reviewer behavior claims in real usage — afb20eb
+- recognize security approval safeguards — 205a967
+- avoid false quality-regression failures — ff08420
+- recognize likely and unconfirmed findings — e34fb5a
+- recognize qualified uncertainty in regression checks — 6e52f45
+- classify harness startup failures as not run — 0881cf8
+- (#1248) make regression fixtures actionable — 8b441dc
+- (#1238) keep review agents read-only — 8a1ec98
+- (#1234) prevent doubled leading slash in path resolver — 951715f
+- (#1232) scope protected-branch backstop to target repo — 0c3e610
+- (#1227) accept v-prefixed changelog headings — fcfccc5
+- (#1224) require browser evidence for Head of Design — 98b378d
+- (#1223) keep release PR variables in one shell block — aa96a5a
+- (#1222) restore fixture heading — 10ba602
+- (#1221) require Rex to verify cited criteria — b5bf397
+- (#1220) scan staged private references — 16450aa
+- (#1219) block heredoc compound commands — 31317de
+- complete AgDR renumbering audit — 6605342
+- reserve AgDR identifiers across branches — ccfad7a
+- coordinate AgDR allocation across worktrees — 453a98c
+- guard AgDR identifier allocation — 57d9796
+- normalize pinned worktree roots — 98cc377
+- normalize linked worktree ops roots — 648a5c7
+- report skipped suites as failures — 9a65a41
+- fail when hook suites skip cases — 15e6414
+- surface skipped hook tests — 943b430
+- fail closed on unresolved PR base — db1c1a2
+- document wrapper scan limits — 9c54059
+- block compound shell substitutions — ba12f90
+- reject nested commit commands — 51e3701
+- cover the wrapper shapes and fix two review-attribution bugs — 2e8b787
+- reject newline compound commit commands — e3cc705
+- reject compound commit commands — 98bc8ef
+- parse first commit message argument — b9b52f3
+- scan gh pr review and gh pr merge for leaked private references — 2d72f33
+- (#1198) compose _resolve_real_path after lexical collapse in migration gate — 7359a5d
+- (#1192) preserve Released-From trailer on release-PR squash — 4bbacfd
+- (#1190) correct same-account review verdict guidance — a300c98
+- (#1180) refuse unresolvable migration write targets instead of falling back — 65a304b
+- (#1156) preserve workspace README in split setup — 62b65f7
+- (#1155) resolve merge repo before cd heuristic — a4878dd
+- (#1173) make the merge gate satisfiable through the sanctioned path — da0ce0a
+- (#1177) close command validation parse bypasses — 0bd7ee5
+- (#1176) fail closed on unreadable hook payloads — 47ca52a
+- (#1172) right-size handbook review triggers — 2efcf30
+- (#1157) detect review markers written to a gate-invisible path — 89209c9
+- (#1154) scope Wave 1 skills to tracked files — 6a0f5f1
+
+### Changed (refactor / chore / docs)
+
+- (#1247) clarify quality and adapter guides — fabef4a
+- (#1246) clarify hook comments — 7c14a3d
+- (#1245) clarify portfolio operations — bc1b0e8
+- (#1244) clarify release and harness guides — af69862
+- (#1243) clarify single-fork setup — 4eac600
+- (#1242) clarify onboarding language — 0e3a11c
+- (#1241) clarify workflow guides — ec197aa
+- (#1240) clarify framework prose — ace2247
+- (#1237) close multi-repo design residuals — b300ed6
+- (#1236) dismiss stale forge approvals — aa5b9a6
+- (#1235) describe jq config merge semantics accurately — fa46f8d
+- (#1231) share active-ticket marker resolver — 56aacc0
+- resolve adapter dependency advisories — f86c050
+- update AgDR inbound reference — 1b885f0
+- cover write detector false positives — ed3f45e
+- audit portfolio root worktree behavior — 81e7f43
+- quarantine documented environment skips — 471f575
+- Merge remote-tracking branch 'upstream/dev' into fix/GH-1206-leak-protection-gaps — 6fe94d2
+- (#1205) technical design for portfolio multi-repo aggregation — 6dc663a
+- (#1175) apply writing standard across artefacts — 1171f75
+- (#1148) point live site references to apexyard.ai — 173c07c
+
+### Closes
+
+- Closes #1136
+- Closes #1138
+- Closes #1146
+- Closes #1147
+- Closes #1148
+- Closes #1151
+- Closes #1152
+- Closes #1159
+- Closes #1161
+- Closes #1163
+- Closes #1164
+- Closes #1165
+- Closes #1171
+- Closes #1174
+- Closes #1181
+- Closes #1182
+- Closes #1187
+- Closes #1196
+- Closes #1197
+- Closes #1202
+- Closes #1207
+- Closes #1209
+- Closes #1218
+- Closes #1225
+- Closes #1230
+- Closes #1233
+- Closes #1255
+- Closes #1257
+
 # Changelog
 
 All notable changes to ApexYard are documented here.

--- a/README.md
+++ b/README.md
@@ -255,19 +255,14 @@ Thanks to everyone who contributes code, documentation, bug reports, ideas, and 
 <a href="https://github.com/aniketshukla1" title="aniketshukla1"><img src="https://github.com/aniketshukla1.png?size=100" width="64" height="64" alt="aniketshukla1"></a>
 </p>
 
-Squash merges can hide individual contributions from GitHub's contributor graph, so we keep these credits here.
-
 ### Issue contributors
 
 Thank you to everyone who opened issues, including bug reports, feature requests, questions, and documentation feedback.
-These credits recognize issue contributions, regardless of whether an issue is open, closed, or included in a release.
-Select an avatar below to see that account's public issues. Hover over an avatar to see the GitHub handle.
 
 <p>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aa-abdellatif98" title="a-abdellatif98"><img src="https://github.com/a-abdellatif98.png?size=100" width="64" height="64" alt="a-abdellatif98"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aa-elnemr" title="a-elnemr"><img src="https://github.com/a-elnemr.png?size=100" width="64" height="64" alt="a-elnemr"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAbdelrahman-Shahda" title="Abdelrahman-Shahda"><img src="https://github.com/Abdelrahman-Shahda.png?size=100" width="64" height="64" alt="Abdelrahman-Shahda"></a>
-<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAbdElrahmaN31" title="AbdElrahmaN31"><img src="https://github.com/AbdElrahmaN31.png?size=100" width="64" height="64" alt="AbdElrahmaN31"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aaelnemr" title="aelnemr"><img src="https://github.com/aelnemr.png?size=100" width="64" height="64" alt="aelnemr"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedashraffcih" title="ahmedashraffcih"><img src="https://github.com/ahmedashraffcih.png?size=100" width="64" height="64" alt="ahmedashraffcih"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedgemi" title="ahmedgemi"><img src="https://github.com/ahmedgemi.png?size=100" width="64" height="64" alt="ahmedgemi"></a>
@@ -286,14 +281,11 @@ Select an avatar below to see that account's public issues. Hover over an avatar
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahamoda-dev" title="hamoda-dev"><img src="https://github.com/hamoda-dev.png?size=100" width="64" height="64" alt="hamoda-dev"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahazemahmedx0" title="hazemahmedx0"><img src="https://github.com/hazemahmedx0.png?size=100" width="64" height="64" alt="hazemahmedx0"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AHC12026" title="HC12026"><img src="https://github.com/HC12026.png?size=100" width="64" height="64" alt="HC12026"></a>
-<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AHishamM1" title="HishamM1"><img src="https://github.com/HishamM1.png?size=100" width="64" height="64" alt="HishamM1"></a>
-<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahossam-96" title="hossam-96"><img src="https://github.com/hossam-96.png?size=100" width="64" height="64" alt="hossam-96"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aibrahim-gad" title="ibrahim-gad"><img src="https://github.com/ibrahim-gad.png?size=100" width="64" height="64" alt="ibrahim-gad"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AKarimEbrahemAbdelaziz" title="KarimEbrahemAbdelaziz"><img src="https://github.com/KarimEbrahemAbdelaziz.png?size=100" width="64" height="64" alt="KarimEbrahemAbdelaziz"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Akhaledmedra" title="khaledmedra"><img src="https://github.com/khaledmedra.png?size=100" width="64" height="64" alt="khaledmedra"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amabdelaziz77" title="mabdelaziz77"><img src="https://github.com/mabdelaziz77.png?size=100" width="64" height="64" alt="mabdelaziz77"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AManito2z" title="Manito2z"><img src="https://github.com/Manito2z.png?size=100" width="64" height="64" alt="Manito2z"></a>
-<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ame2resh" title="me2resh"><img src="https://github.com/me2resh.png?size=100" width="64" height="64" alt="me2resh"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMedNewton" title="MedNewton"><img src="https://github.com/MedNewton.png?size=100" width="64" height="64" alt="MedNewton"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMeDoTarek73" title="MeDoTarek73"><img src="https://github.com/MeDoTarek73.png?size=100" width="64" height="64" alt="MeDoTarek73"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMina4lfy" title="Mina4lfy"><img src="https://github.com/Mina4lfy.png?size=100" width="64" height="64" alt="Mina4lfy"></a>
@@ -312,12 +304,9 @@ Select an avatar below to see that account's public issues. Hover over an avatar
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Arafik-wahid-cubeish" title="rafik-wahid-cubeish"><img src="https://github.com/rafik-wahid-cubeish.png?size=100" width="64" height="64" alt="rafik-wahid-cubeish"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3ARef34t" title="Ref34t"><img src="https://github.com/Ref34t.png?size=100" width="64" height="64" alt="Ref34t"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Asudanese" title="sudanese"><img src="https://github.com/sudanese.png?size=100" width="64" height="64" alt="sudanese"></a>
-<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Atifa64" title="tifa64"><img src="https://github.com/tifa64.png?size=100" width="64" height="64" alt="tifa64"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ayehiagamalx" title="yehiagamalx"><img src="https://github.com/yehiagamalx.png?size=100" width="64" height="64" alt="yehiagamalx"></a>
 <a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Azeyadsleem" title="zeyadsleem"><img src="https://github.com/zeyadsleem.png?size=100" width="64" height="64" alt="zeyadsleem"></a>
 </p>
-
-This list covers available issue-author accounts through September 10, 2026. GitHub bot accounts are excluded.
 
 When updating these credits, include new issue authors as well as pull-request contributors.
 Use public GitHub handles and links, and describe each contribution accurately.

--- a/README.md
+++ b/README.md
@@ -246,16 +246,14 @@ For larger changes (new skills, rule changes, workflow redesigns), open a discus
 
 Thanks to everyone who contributes code, documentation, bug reports, ideas, and feedback.
 
-<table>
-  <tr>
-    <td align="center"><a href="https://github.com/me2resh"><img src="https://github.com/me2resh.png?size=100" width="64" alt="me2resh"><br><sub><b>me2resh</b></sub></a></td>
-    <td align="center"><a href="https://github.com/AbdElrahmaN31"><img src="https://github.com/AbdElrahmaN31.png?size=100" width="64" alt="AbdElrahmaN31"><br><sub>AbdElrahmaN31</sub></a></td>
-    <td align="center"><a href="https://github.com/HishamM1"><img src="https://github.com/HishamM1.png?size=100" width="64" alt="HishamM1"><br><sub>HishamM1</sub></a></td>
-    <td align="center"><a href="https://github.com/tifa64"><img src="https://github.com/tifa64.png?size=100" width="64" alt="tifa64"><br><sub>tifa64</sub></a></td>
-    <td align="center"><a href="https://github.com/hossam-96"><img src="https://github.com/hossam-96.png?size=100" width="64" alt="hossam-96"><br><sub>hossam-96</sub></a></td>
-    <td align="center"><a href="https://github.com/aniketshukla1"><img src="https://github.com/aniketshukla1.png?size=100" width="64" alt="aniketshukla1"><br><sub>aniketshukla1</sub></a></td>
-  </tr>
-</table>
+<p>
+<a href="https://github.com/me2resh" title="me2resh"><img src="https://github.com/me2resh.png?size=100" width="64" height="64" alt="me2resh"></a>
+<a href="https://github.com/AbdElrahmaN31" title="AbdElrahmaN31"><img src="https://github.com/AbdElrahmaN31.png?size=100" width="64" height="64" alt="AbdElrahmaN31"></a>
+<a href="https://github.com/HishamM1" title="HishamM1"><img src="https://github.com/HishamM1.png?size=100" width="64" height="64" alt="HishamM1"></a>
+<a href="https://github.com/tifa64" title="tifa64"><img src="https://github.com/tifa64.png?size=100" width="64" height="64" alt="tifa64"></a>
+<a href="https://github.com/hossam-96" title="hossam-96"><img src="https://github.com/hossam-96.png?size=100" width="64" height="64" alt="hossam-96"></a>
+<a href="https://github.com/aniketshukla1" title="aniketshukla1"><img src="https://github.com/aniketshukla1.png?size=100" width="64" height="64" alt="aniketshukla1"></a>
+</p>
 
 Squash merges can hide individual contributions from GitHub's contributor graph, so we keep these credits here.
 
@@ -263,27 +261,61 @@ Squash merges can hide individual contributions from GitHub's contributor graph,
 
 Thank you to everyone who opened issues, including bug reports, feature requests, questions, and documentation feedback.
 These credits recognize issue contributions, regardless of whether an issue is open, closed, or included in a release.
-Each link shows the account's public issues in this repository.
+Select an avatar below to see that account's public issues. Hover over an avatar to see the GitHub handle.
 
-| Contributor | Contributor | Contributor |
-| --- | --- | --- |
-| [a-abdellatif98](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aa-abdellatif98) | [a-elnemr](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aa-elnemr) | [Abdelrahman-Shahda](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAbdelrahman-Shahda) |
-| [AbdElrahmaN31](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAbdElrahmaN31) | [aelnemr](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aaelnemr) | [ahmedashraffcih](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedashraffcih) |
-| [ahmedgemi](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedgemi) | [AhmedTheGeek](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAhmedTheGeek) | [ahmedwael216](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedwael216) |
-| [alalm3i](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aalalm3i) | [asami-me](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aasami-me) | [atlas-apex](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aatlas-apex) |
-| [aureyia](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aaureyia) | [batout](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Abatout) | [bitwhispererrr](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Abitwhispererrr) |
-| [borzoj](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aborzoj) | [Dr-kersho](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3ADr-kersho) | [drmas](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Adrmas) |
-| [engnaruto](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aengnaruto) | [hamoda-dev](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahamoda-dev) | [hazemahmedx0](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahazemahmedx0) |
-| [HC12026](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AHC12026) | [HishamM1](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AHishamM1) | [hossam-96](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahossam-96) |
-| [ibrahim-gad](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aibrahim-gad) | [KarimEbrahemAbdelaziz](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AKarimEbrahemAbdelaziz) | [khaledmedra](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Akhaledmedra) |
-| [mabdelaziz77](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amabdelaziz77) | [Manito2z](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AManito2z) | [me2resh](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ame2resh) |
-| [MedNewton](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMedNewton) | [MeDoTarek73](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMeDoTarek73) | [Mina4lfy](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMina4lfy) |
-| [mohamedELamine](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AmohamedELamine) | [mosta7il](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amosta7il) | [mostiwheelietravel](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amostiwheelietravel) |
-| [moussaws](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amoussaws) | [muhammadattia95](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amuhammadattia95) | [nickyreinert](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Anickyreinert) |
-| [nLoops](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AnLoops) | [Omar-Elhorbity](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOmar-Elhorbity) | [OmarEhab007](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOmarEhab007) |
-| [OmarElaraby26](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOmarElaraby26) | [osama-abu-baker](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aosama-abu-baker) | [OsamaAlSabry](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOsamaAlSabry) |
-| [rafik-wahid-cubeish](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Arafik-wahid-cubeish) | [Ref34t](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3ARef34t) | [sudanese](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Asudanese) |
-| [tifa64](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Atifa64) | [yehiagamalx](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ayehiagamalx) | [zeyadsleem](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Azeyadsleem) |
+<p>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aa-abdellatif98" title="a-abdellatif98"><img src="https://github.com/a-abdellatif98.png?size=100" width="64" height="64" alt="a-abdellatif98"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aa-elnemr" title="a-elnemr"><img src="https://github.com/a-elnemr.png?size=100" width="64" height="64" alt="a-elnemr"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAbdelrahman-Shahda" title="Abdelrahman-Shahda"><img src="https://github.com/Abdelrahman-Shahda.png?size=100" width="64" height="64" alt="Abdelrahman-Shahda"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAbdElrahmaN31" title="AbdElrahmaN31"><img src="https://github.com/AbdElrahmaN31.png?size=100" width="64" height="64" alt="AbdElrahmaN31"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aaelnemr" title="aelnemr"><img src="https://github.com/aelnemr.png?size=100" width="64" height="64" alt="aelnemr"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedashraffcih" title="ahmedashraffcih"><img src="https://github.com/ahmedashraffcih.png?size=100" width="64" height="64" alt="ahmedashraffcih"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedgemi" title="ahmedgemi"><img src="https://github.com/ahmedgemi.png?size=100" width="64" height="64" alt="ahmedgemi"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAhmedTheGeek" title="AhmedTheGeek"><img src="https://github.com/AhmedTheGeek.png?size=100" width="64" height="64" alt="AhmedTheGeek"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedwael216" title="ahmedwael216"><img src="https://github.com/ahmedwael216.png?size=100" width="64" height="64" alt="ahmedwael216"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aalalm3i" title="alalm3i"><img src="https://github.com/alalm3i.png?size=100" width="64" height="64" alt="alalm3i"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aasami-me" title="asami-me"><img src="https://github.com/asami-me.png?size=100" width="64" height="64" alt="asami-me"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aatlas-apex" title="atlas-apex"><img src="https://github.com/atlas-apex.png?size=100" width="64" height="64" alt="atlas-apex"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aaureyia" title="aureyia"><img src="https://github.com/aureyia.png?size=100" width="64" height="64" alt="aureyia"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Abatout" title="batout"><img src="https://github.com/batout.png?size=100" width="64" height="64" alt="batout"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Abitwhispererrr" title="bitwhispererrr"><img src="https://github.com/bitwhispererrr.png?size=100" width="64" height="64" alt="bitwhispererrr"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aborzoj" title="borzoj"><img src="https://github.com/borzoj.png?size=100" width="64" height="64" alt="borzoj"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3ADr-kersho" title="Dr-kersho"><img src="https://github.com/Dr-kersho.png?size=100" width="64" height="64" alt="Dr-kersho"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Adrmas" title="drmas"><img src="https://github.com/drmas.png?size=100" width="64" height="64" alt="drmas"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aengnaruto" title="engnaruto"><img src="https://github.com/engnaruto.png?size=100" width="64" height="64" alt="engnaruto"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahamoda-dev" title="hamoda-dev"><img src="https://github.com/hamoda-dev.png?size=100" width="64" height="64" alt="hamoda-dev"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahazemahmedx0" title="hazemahmedx0"><img src="https://github.com/hazemahmedx0.png?size=100" width="64" height="64" alt="hazemahmedx0"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AHC12026" title="HC12026"><img src="https://github.com/HC12026.png?size=100" width="64" height="64" alt="HC12026"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AHishamM1" title="HishamM1"><img src="https://github.com/HishamM1.png?size=100" width="64" height="64" alt="HishamM1"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahossam-96" title="hossam-96"><img src="https://github.com/hossam-96.png?size=100" width="64" height="64" alt="hossam-96"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aibrahim-gad" title="ibrahim-gad"><img src="https://github.com/ibrahim-gad.png?size=100" width="64" height="64" alt="ibrahim-gad"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AKarimEbrahemAbdelaziz" title="KarimEbrahemAbdelaziz"><img src="https://github.com/KarimEbrahemAbdelaziz.png?size=100" width="64" height="64" alt="KarimEbrahemAbdelaziz"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Akhaledmedra" title="khaledmedra"><img src="https://github.com/khaledmedra.png?size=100" width="64" height="64" alt="khaledmedra"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amabdelaziz77" title="mabdelaziz77"><img src="https://github.com/mabdelaziz77.png?size=100" width="64" height="64" alt="mabdelaziz77"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AManito2z" title="Manito2z"><img src="https://github.com/Manito2z.png?size=100" width="64" height="64" alt="Manito2z"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ame2resh" title="me2resh"><img src="https://github.com/me2resh.png?size=100" width="64" height="64" alt="me2resh"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMedNewton" title="MedNewton"><img src="https://github.com/MedNewton.png?size=100" width="64" height="64" alt="MedNewton"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMeDoTarek73" title="MeDoTarek73"><img src="https://github.com/MeDoTarek73.png?size=100" width="64" height="64" alt="MeDoTarek73"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMina4lfy" title="Mina4lfy"><img src="https://github.com/Mina4lfy.png?size=100" width="64" height="64" alt="Mina4lfy"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AmohamedELamine" title="mohamedELamine"><img src="https://github.com/mohamedELamine.png?size=100" width="64" height="64" alt="mohamedELamine"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amosta7il" title="mosta7il"><img src="https://github.com/mosta7il.png?size=100" width="64" height="64" alt="mosta7il"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amostiwheelietravel" title="mostiwheelietravel"><img src="https://github.com/mostiwheelietravel.png?size=100" width="64" height="64" alt="mostiwheelietravel"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amoussaws" title="moussaws"><img src="https://github.com/moussaws.png?size=100" width="64" height="64" alt="moussaws"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amuhammadattia95" title="muhammadattia95"><img src="https://github.com/muhammadattia95.png?size=100" width="64" height="64" alt="muhammadattia95"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Anickyreinert" title="nickyreinert"><img src="https://github.com/nickyreinert.png?size=100" width="64" height="64" alt="nickyreinert"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AnLoops" title="nLoops"><img src="https://github.com/nLoops.png?size=100" width="64" height="64" alt="nLoops"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOmar-Elhorbity" title="Omar-Elhorbity"><img src="https://github.com/Omar-Elhorbity.png?size=100" width="64" height="64" alt="Omar-Elhorbity"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOmarEhab007" title="OmarEhab007"><img src="https://github.com/OmarEhab007.png?size=100" width="64" height="64" alt="OmarEhab007"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOmarElaraby26" title="OmarElaraby26"><img src="https://github.com/OmarElaraby26.png?size=100" width="64" height="64" alt="OmarElaraby26"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aosama-abu-baker" title="osama-abu-baker"><img src="https://github.com/osama-abu-baker.png?size=100" width="64" height="64" alt="osama-abu-baker"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOsamaAlSabry" title="OsamaAlSabry"><img src="https://github.com/OsamaAlSabry.png?size=100" width="64" height="64" alt="OsamaAlSabry"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Arafik-wahid-cubeish" title="rafik-wahid-cubeish"><img src="https://github.com/rafik-wahid-cubeish.png?size=100" width="64" height="64" alt="rafik-wahid-cubeish"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3ARef34t" title="Ref34t"><img src="https://github.com/Ref34t.png?size=100" width="64" height="64" alt="Ref34t"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Asudanese" title="sudanese"><img src="https://github.com/sudanese.png?size=100" width="64" height="64" alt="sudanese"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Atifa64" title="tifa64"><img src="https://github.com/tifa64.png?size=100" width="64" height="64" alt="tifa64"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ayehiagamalx" title="yehiagamalx"><img src="https://github.com/yehiagamalx.png?size=100" width="64" height="64" alt="yehiagamalx"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Azeyadsleem" title="zeyadsleem"><img src="https://github.com/zeyadsleem.png?size=100" width="64" height="64" alt="zeyadsleem"></a>
+</p>
 
 This list covers available issue-author accounts through September 10, 2026. GitHub bot accounts are excluded.
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ For larger changes (new skills, rule changes, workflow redesigns), open a discus
 
 ## Contributors
 
-Thanks to everyone who has helped forge ApexYard:
+Thanks to everyone who contributes code, documentation, bug reports, ideas, and feedback.
 
 <table>
   <tr>
@@ -257,7 +257,38 @@ Thanks to everyone who has helped forge ApexYard:
   </tr>
 </table>
 
-<sub>This list credits every human directly, since squash-merges hide them from GitHub's contributor graph. New contributor? Open a PR and you'll be added.</sub>
+Squash merges can hide individual contributions from GitHub's contributor graph, so we keep these credits here.
+
+### Issue contributors
+
+Thank you to everyone who opened issues, including bug reports, feature requests, questions, and documentation feedback.
+These credits recognize issue contributions, regardless of whether an issue is open, closed, or included in a release.
+Each link shows the account's public issues in this repository.
+
+| Contributor | Contributor | Contributor |
+| --- | --- | --- |
+| [a-abdellatif98](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aa-abdellatif98) | [a-elnemr](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aa-elnemr) | [Abdelrahman-Shahda](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAbdelrahman-Shahda) |
+| [AbdElrahmaN31](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAbdElrahmaN31) | [aelnemr](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aaelnemr) | [ahmedashraffcih](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedashraffcih) |
+| [ahmedgemi](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedgemi) | [AhmedTheGeek](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAhmedTheGeek) | [ahmedwael216](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedwael216) |
+| [alalm3i](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aalalm3i) | [asami-me](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aasami-me) | [atlas-apex](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aatlas-apex) |
+| [aureyia](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aaureyia) | [batout](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Abatout) | [bitwhispererrr](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Abitwhispererrr) |
+| [borzoj](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aborzoj) | [Dr-kersho](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3ADr-kersho) | [drmas](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Adrmas) |
+| [engnaruto](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aengnaruto) | [hamoda-dev](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahamoda-dev) | [hazemahmedx0](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahazemahmedx0) |
+| [HC12026](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AHC12026) | [HishamM1](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AHishamM1) | [hossam-96](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahossam-96) |
+| [ibrahim-gad](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aibrahim-gad) | [KarimEbrahemAbdelaziz](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AKarimEbrahemAbdelaziz) | [khaledmedra](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Akhaledmedra) |
+| [mabdelaziz77](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amabdelaziz77) | [Manito2z](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AManito2z) | [me2resh](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ame2resh) |
+| [MedNewton](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMedNewton) | [MeDoTarek73](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMeDoTarek73) | [Mina4lfy](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMina4lfy) |
+| [mohamedELamine](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AmohamedELamine) | [mosta7il](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amosta7il) | [mostiwheelietravel](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amostiwheelietravel) |
+| [moussaws](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amoussaws) | [muhammadattia95](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amuhammadattia95) | [nickyreinert](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Anickyreinert) |
+| [nLoops](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AnLoops) | [Omar-Elhorbity](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOmar-Elhorbity) | [OmarEhab007](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOmarEhab007) |
+| [OmarElaraby26](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOmarElaraby26) | [osama-abu-baker](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aosama-abu-baker) | [OsamaAlSabry](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOsamaAlSabry) |
+| [rafik-wahid-cubeish](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Arafik-wahid-cubeish) | [Ref34t](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3ARef34t) | [sudanese](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Asudanese) |
+| [tifa64](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Atifa64) | [yehiagamalx](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ayehiagamalx) | [zeyadsleem](https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Azeyadsleem) |
+
+This list covers available issue-author accounts through September 10, 2026. GitHub bot accounts are excluded.
+
+When updating these credits, include new issue authors as well as pull-request contributors.
+Use public GitHub handles and links, and describe each contribution accurately.
 
 ## License
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -69,6 +69,7 @@ The override applies once. After a successful sync, the anchor is rewritten from
 | `v5.1.0-to-v5.2.0.sh` | No-op placeholder. Backfilled by #1105. | Nobody (no-op); exists so the chain walks past this hop. |
 | `v5.2.0-to-v5.3.0.sh` | No-op placeholder. Backfilled by #1105. | Nobody (no-op); exists so the chain walks past this hop. |
 | `v5.3.0-to-v5.4.0.sh` | **Real migration.** Untracks `.claude/project-config.json` (`git rm --cached`, working-tree file and its content preserved, untrack staged not committed) so the long-inert `.gitignore` entry finally applies. Closes the #1065 data-loss window: while the file was tracked, a plain `git checkout` could silently overwrite it and destroy a split-portfolio adopter's private `portfolio` block (never in git to restore from). Idempotent — no-op if the file is already untracked; defers to the operator (exit 1) rather than force past an unexpected staged state. | Every adopter whose fork still tracks `.claude/project-config.json` (anyone upgrading from ≤ v5.3.0). No-op once untracked. |
+| `v5.4.0-to-v5.5.0.sh` | No-op placeholder — v5.5.0 has no per-adopter file or configuration migration. | Nobody (no-op); exists so the chain walks past this hop. |
 
 When a future release adds a migration, this table is the source of truth — the release PR template requires a row to be added here.
 


### PR DESCRIPTION
## Summary

The README omitted issue contributors from its credits. This change adds 46 issue-author accounts that are not already listed in the code-contributor credits.

- Adds alphabetical avatar credits with links to each account's public issues, so readers can see the contributions.
- Uses wrapping inline avatars for both contributor groups so the credits fit narrow README layouts without horizontal scrolling.
- Keeps code and issue contributions separate by excluding the existing code-contributor accounts from the issue group.
- Brings the release metadata on `dev` up to the latest `v5.5.0` tag: changelog entry, migration-chain placeholder, and upgrade-table row.
- Updates the maintenance guidance to include future issue authors alongside PR contributors.

Closes #1259

## Validation

Audited all 625 available open and closed issues through September 10, 2026 using the paginated GitHub issues API. Excluded PR records and GitHub bot accounts, then removed the five issue authors already present in the code-contributor credits.

Compared the README against the audit: all 46 remaining account handles appear once in the issue-contributor avatar grid. Verified each issue-search link and preserved the six existing code-contributor credits and unrelated README sections. Checked that the inline markup wraps without a fixed table layout.

Compared the release files byte-for-byte with tag `v5.5.0`. The migration follows the no-op chain pattern in [AgDR-0032](docs/agdr/AgDR-0032-update-chain-migrations.md). `git diff --check`, `bash -n` for the migration script, and the update-chain test passed (11/11).

Hosted Markdown lint will validate the changed README.

## Glossary

| Term | Definition |
| --- | --- |
| Issue contributor | An account that opened an issue and is not already listed in the code-contributor credits. |
