### PR TITLE
chore(#1266): sync dev after v5.5.1 release

### DIFF
--- a/.claude/migrations/v5.5.0-to-v5.5.1.sh
+++ b/.claude/migrations/v5.5.0-to-v5.5.1.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# v5.5.0 → v5.5.1 migration: PLACEHOLDER (no-op)
+#
+# v5.5.1 ships no per-adopter file or configuration migration. This script
+# keeps the migration chain continuous for adopters upgrading from v5.5.0.
+
+set -u
+
+QUIET="${APEXYARD_MIGRATION_QUIET:-0}"
+info() { [ "$QUIET" = "1" ] || echo "$@"; }
+
+info "migration v5.5.0→v5.5.1: placeholder (no adopter-facing migration for this release)."
+exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [v5.5.1] — 2026-09-11
+
+Patch release — 1 improvement.
+
+### Changed (refactor / chore / docs)
+
+- (#1260) credit issue contributors across repository history — 3c50de0
+
+### Closes
+
+- Closes #1259
+
 ## [v5.5.0] — 2026-09-10
 
 Minor release — 8 features, 48 fixes, 21 improvements.

--- a/README.md
+++ b/README.md
@@ -244,20 +244,72 @@ For larger changes (new skills, rule changes, workflow redesigns), open a discus
 
 ## Contributors
 
-Thanks to everyone who has helped forge ApexYard:
+Thanks to everyone who contributes code, documentation, bug reports, ideas, and feedback.
 
-<table>
-  <tr>
-    <td align="center"><a href="https://github.com/me2resh"><img src="https://github.com/me2resh.png?size=100" width="64" alt="me2resh"><br><sub><b>me2resh</b></sub></a></td>
-    <td align="center"><a href="https://github.com/AbdElrahmaN31"><img src="https://github.com/AbdElrahmaN31.png?size=100" width="64" alt="AbdElrahmaN31"><br><sub>AbdElrahmaN31</sub></a></td>
-    <td align="center"><a href="https://github.com/HishamM1"><img src="https://github.com/HishamM1.png?size=100" width="64" alt="HishamM1"><br><sub>HishamM1</sub></a></td>
-    <td align="center"><a href="https://github.com/tifa64"><img src="https://github.com/tifa64.png?size=100" width="64" alt="tifa64"><br><sub>tifa64</sub></a></td>
-    <td align="center"><a href="https://github.com/hossam-96"><img src="https://github.com/hossam-96.png?size=100" width="64" alt="hossam-96"><br><sub>hossam-96</sub></a></td>
-    <td align="center"><a href="https://github.com/aniketshukla1"><img src="https://github.com/aniketshukla1.png?size=100" width="64" alt="aniketshukla1"><br><sub>aniketshukla1</sub></a></td>
-  </tr>
-</table>
+<p>
+<a href="https://github.com/me2resh" title="me2resh"><img src="https://github.com/me2resh.png?size=100" width="64" height="64" alt="me2resh"></a>
+<a href="https://github.com/AbdElrahmaN31" title="AbdElrahmaN31"><img src="https://github.com/AbdElrahmaN31.png?size=100" width="64" height="64" alt="AbdElrahmaN31"></a>
+<a href="https://github.com/HishamM1" title="HishamM1"><img src="https://github.com/HishamM1.png?size=100" width="64" height="64" alt="HishamM1"></a>
+<a href="https://github.com/tifa64" title="tifa64"><img src="https://github.com/tifa64.png?size=100" width="64" height="64" alt="tifa64"></a>
+<a href="https://github.com/hossam-96" title="hossam-96"><img src="https://github.com/hossam-96.png?size=100" width="64" height="64" alt="hossam-96"></a>
+<a href="https://github.com/aniketshukla1" title="aniketshukla1"><img src="https://github.com/aniketshukla1.png?size=100" width="64" height="64" alt="aniketshukla1"></a>
+</p>
 
-<sub>This list credits every human directly, since squash-merges hide them from GitHub's contributor graph. New contributor? Open a PR and you'll be added.</sub>
+### Issue contributors
+
+Thank you to everyone who opened issues, including bug reports, feature requests, questions, and documentation feedback.
+
+<p>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aa-abdellatif98" title="a-abdellatif98"><img src="https://github.com/a-abdellatif98.png?size=100" width="64" height="64" alt="a-abdellatif98"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aa-elnemr" title="a-elnemr"><img src="https://github.com/a-elnemr.png?size=100" width="64" height="64" alt="a-elnemr"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAbdelrahman-Shahda" title="Abdelrahman-Shahda"><img src="https://github.com/Abdelrahman-Shahda.png?size=100" width="64" height="64" alt="Abdelrahman-Shahda"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aaelnemr" title="aelnemr"><img src="https://github.com/aelnemr.png?size=100" width="64" height="64" alt="aelnemr"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedashraffcih" title="ahmedashraffcih"><img src="https://github.com/ahmedashraffcih.png?size=100" width="64" height="64" alt="ahmedashraffcih"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedgemi" title="ahmedgemi"><img src="https://github.com/ahmedgemi.png?size=100" width="64" height="64" alt="ahmedgemi"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AAhmedTheGeek" title="AhmedTheGeek"><img src="https://github.com/AhmedTheGeek.png?size=100" width="64" height="64" alt="AhmedTheGeek"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aahmedwael216" title="ahmedwael216"><img src="https://github.com/ahmedwael216.png?size=100" width="64" height="64" alt="ahmedwael216"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aalalm3i" title="alalm3i"><img src="https://github.com/alalm3i.png?size=100" width="64" height="64" alt="alalm3i"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aasami-me" title="asami-me"><img src="https://github.com/asami-me.png?size=100" width="64" height="64" alt="asami-me"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aatlas-apex" title="atlas-apex"><img src="https://github.com/atlas-apex.png?size=100" width="64" height="64" alt="atlas-apex"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aaureyia" title="aureyia"><img src="https://github.com/aureyia.png?size=100" width="64" height="64" alt="aureyia"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Abatout" title="batout"><img src="https://github.com/batout.png?size=100" width="64" height="64" alt="batout"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Abitwhispererrr" title="bitwhispererrr"><img src="https://github.com/bitwhispererrr.png?size=100" width="64" height="64" alt="bitwhispererrr"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aborzoj" title="borzoj"><img src="https://github.com/borzoj.png?size=100" width="64" height="64" alt="borzoj"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3ADr-kersho" title="Dr-kersho"><img src="https://github.com/Dr-kersho.png?size=100" width="64" height="64" alt="Dr-kersho"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Adrmas" title="drmas"><img src="https://github.com/drmas.png?size=100" width="64" height="64" alt="drmas"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aengnaruto" title="engnaruto"><img src="https://github.com/engnaruto.png?size=100" width="64" height="64" alt="engnaruto"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahamoda-dev" title="hamoda-dev"><img src="https://github.com/hamoda-dev.png?size=100" width="64" height="64" alt="hamoda-dev"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ahazemahmedx0" title="hazemahmedx0"><img src="https://github.com/hazemahmedx0.png?size=100" width="64" height="64" alt="hazemahmedx0"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AHC12026" title="HC12026"><img src="https://github.com/HC12026.png?size=100" width="64" height="64" alt="HC12026"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aibrahim-gad" title="ibrahim-gad"><img src="https://github.com/ibrahim-gad.png?size=100" width="64" height="64" alt="ibrahim-gad"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AKarimEbrahemAbdelaziz" title="KarimEbrahemAbdelaziz"><img src="https://github.com/KarimEbrahemAbdelaziz.png?size=100" width="64" height="64" alt="KarimEbrahemAbdelaziz"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Akhaledmedra" title="khaledmedra"><img src="https://github.com/khaledmedra.png?size=100" width="64" height="64" alt="khaledmedra"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amabdelaziz77" title="mabdelaziz77"><img src="https://github.com/mabdelaziz77.png?size=100" width="64" height="64" alt="mabdelaziz77"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AManito2z" title="Manito2z"><img src="https://github.com/Manito2z.png?size=100" width="64" height="64" alt="Manito2z"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMedNewton" title="MedNewton"><img src="https://github.com/MedNewton.png?size=100" width="64" height="64" alt="MedNewton"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMeDoTarek73" title="MeDoTarek73"><img src="https://github.com/MeDoTarek73.png?size=100" width="64" height="64" alt="MeDoTarek73"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AMina4lfy" title="Mina4lfy"><img src="https://github.com/Mina4lfy.png?size=100" width="64" height="64" alt="Mina4lfy"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AmohamedELamine" title="mohamedELamine"><img src="https://github.com/mohamedELamine.png?size=100" width="64" height="64" alt="mohamedELamine"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amosta7il" title="mosta7il"><img src="https://github.com/mosta7il.png?size=100" width="64" height="64" alt="mosta7il"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amostiwheelietravel" title="mostiwheelietravel"><img src="https://github.com/mostiwheelietravel.png?size=100" width="64" height="64" alt="mostiwheelietravel"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amoussaws" title="moussaws"><img src="https://github.com/moussaws.png?size=100" width="64" height="64" alt="moussaws"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Amuhammadattia95" title="muhammadattia95"><img src="https://github.com/muhammadattia95.png?size=100" width="64" height="64" alt="muhammadattia95"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Anickyreinert" title="nickyreinert"><img src="https://github.com/nickyreinert.png?size=100" width="64" height="64" alt="nickyreinert"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AnLoops" title="nLoops"><img src="https://github.com/nLoops.png?size=100" width="64" height="64" alt="nLoops"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOmar-Elhorbity" title="Omar-Elhorbity"><img src="https://github.com/Omar-Elhorbity.png?size=100" width="64" height="64" alt="Omar-Elhorbity"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOmarEhab007" title="OmarEhab007"><img src="https://github.com/OmarEhab007.png?size=100" width="64" height="64" alt="OmarEhab007"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOmarElaraby26" title="OmarElaraby26"><img src="https://github.com/OmarElaraby26.png?size=100" width="64" height="64" alt="OmarElaraby26"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Aosama-abu-baker" title="osama-abu-baker"><img src="https://github.com/osama-abu-baker.png?size=100" width="64" height="64" alt="osama-abu-baker"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3AOsamaAlSabry" title="OsamaAlSabry"><img src="https://github.com/OsamaAlSabry.png?size=100" width="64" height="64" alt="OsamaAlSabry"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Arafik-wahid-cubeish" title="rafik-wahid-cubeish"><img src="https://github.com/rafik-wahid-cubeish.png?size=100" width="64" height="64" alt="rafik-wahid-cubeish"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3ARef34t" title="Ref34t"><img src="https://github.com/Ref34t.png?size=100" width="64" height="64" alt="Ref34t"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Asudanese" title="sudanese"><img src="https://github.com/sudanese.png?size=100" width="64" height="64" alt="sudanese"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Ayehiagamalx" title="yehiagamalx"><img src="https://github.com/yehiagamalx.png?size=100" width="64" height="64" alt="yehiagamalx"></a>
+<a href="https://github.com/me2resh/apexyard/issues?q=is%3Aissue%20author%3Azeyadsleem" title="zeyadsleem"><img src="https://github.com/zeyadsleem.png?size=100" width="64" height="64" alt="zeyadsleem"></a>
+</p>
+
+When updating these credits, include new issue authors as well as pull-request contributors.
+Use public GitHub handles and links, and describe each contribution accurately.
 
 ## License
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -70,6 +70,7 @@ The override applies once. After a successful sync, the anchor is rewritten from
 | `v5.2.0-to-v5.3.0.sh` | No-op placeholder. Backfilled by #1105. | Nobody (no-op); exists so the chain walks past this hop. |
 | `v5.3.0-to-v5.4.0.sh` | **Real migration.** Untracks `.claude/project-config.json` (`git rm --cached`, working-tree file and its content preserved, untrack staged not committed) so the long-inert `.gitignore` entry finally applies. Closes the #1065 data-loss window: while the file was tracked, a plain `git checkout` could silently overwrite it and destroy a split-portfolio adopter's private `portfolio` block (never in git to restore from). Idempotent — no-op if the file is already untracked; defers to the operator (exit 1) rather than force past an unexpected staged state. | Every adopter whose fork still tracks `.claude/project-config.json` (anyone upgrading from ≤ v5.3.0). No-op once untracked. |
 | `v5.4.0-to-v5.5.0.sh` | No-op placeholder — v5.5.0 has no per-adopter file or configuration migration. | Nobody (no-op); exists so the chain walks past this hop. |
+| `v5.5.0-to-v5.5.1.sh` | No-op placeholder — v5.5.1 has no per-adopter file or configuration migration. | Nobody (no-op); exists so the chain walks past this hop. |
 
 When a future release adds a migration, this table is the source of truth — the release PR template requires a row to be added here.
 


### PR DESCRIPTION
<!-- multi-close: approved -->

## Summary

- Merges the released `v5.5.1` `main` state into `dev`.
- Preserves the release tag and the `Released-From` trailer.
- Keeps future development and release ranges complete.

## Verification

- `main` is an ancestor of `dev` after this merge.
- The merge commit has both the previous `dev` head and released `main` head as parents.
- Tag `v5.5.1` remains reachable from `dev`.

## Testing

- `git merge-base --is-ancestor upstream/main HEAD` passes.
- The merge is a true two-parent merge.

Refs #1266

## Glossary

| Term | Definition |
| --- | --- |
| Release sync | A merge that brings the released `main` state into `dev`. |
| True merge | A commit with both `main` and `dev` as parents. |
