### PR TITLE
fix(#1271): resolve review scanner from ops pin

### DIFF
--- a/.claude/hooks/_lib-tracker.sh
+++ b/.claude/hooks/_lib-tracker.sh
@@ -712,7 +712,26 @@ _tracker_extract_ref_url() {
 
 _tracker_check_private_refs() {
   local repo="$1" title="${2:-}" body_file="${3:-}"
-  local tracker_lib_dir="" root
+  local tracker_lib_dir="" root pin_file pinned_root
+
+  # A review is often submitted from workspace/<project>, whose git root is
+  # the managed project clone rather than the ops fork that owns this scanner.
+  # Under zsh, BASH_SOURCE is unavailable as well, so the old git-root fallback
+  # selected the project clone and failed closed even though the scanner was
+  # present in the pinned ops fork. Prefer the explicit adapter override and
+  # the session pin before any shell-local or cwd-derived fallback.
+  if [ -n "${APEXYARD_OPS_ROOT:-}" ] && [ -d "$APEXYARD_OPS_ROOT/.claude/hooks" ]; then
+    tracker_lib_dir="$APEXYARD_OPS_ROOT/.claude/hooks"
+  fi
+  if [ -z "$tracker_lib_dir" ] && [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+    pin_file="${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}"
+    if [ -f "$pin_file" ]; then
+      IFS= read -r pinned_root < "$pin_file" || pinned_root=""
+      if [ -n "$pinned_root" ] && [ -d "$pinned_root/.claude/hooks" ]; then
+        tracker_lib_dir="$pinned_root/.claude/hooks"
+      fi
+    fi
+  fi
   if [ -n "${BASH_SOURCE[0]:-}" ]; then
     tracker_lib_dir=$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd) || tracker_lib_dir=""
   fi

--- a/.claude/hooks/tests/test_tracker_zsh_self_location.sh
+++ b/.claude/hooks/tests/test_tracker_zsh_self_location.sh
@@ -200,7 +200,43 @@ cd - >/dev/null || true
 rm -rf "$SB4"
 
 # ---------------------------------------------------------------------------
-# Case 5 — regression pin: every BASH_SOURCE[0] self-location reference in
+# Case 5 — a managed-project worktree still finds the scanner in the pinned
+# ops fork. Under zsh the tracker library has no BASH_SOURCE, and
+# git-rev-parse resolves to the project clone. Before #1271 that path failed
+# closed even when the session pin identified the real ops root.
+# ---------------------------------------------------------------------------
+SB5=$(mktemp -d); SB5=$(cd "$SB5" && pwd -P)
+OPS5="$SB5/ops"; PROJECT5="$SB5/project"; PIN5="$SB5/pins"
+mkdir -p "$OPS5/.claude/hooks" "$PROJECT5" "$PIN5" "$SB5/bin"
+touch "$OPS5/.apexyard-fork"
+( cd "$PROJECT5" && git init -q ) 2>/dev/null || true
+cp "$TRACKER_LIB" "$OPS5/.claude/hooks/_lib-tracker.sh"
+cp "$CONFIG_LIB" "$OPS5/.claude/hooks/_lib-read-config.sh"
+cp "$PORTFOLIO_LIB" "$OPS5/.claude/hooks/_lib-portfolio-paths.sh"
+cp "$RUNTIME_SCANNER" "$OPS5/.claude/hooks/check-private-refs-runtime.sh"
+chmod +x "$OPS5/.claude/hooks/check-private-refs-runtime.sh"
+cat > "$OPS5/.claude/project-config.defaults.json" <<'JSON'
+{ "tracker": { "kind": "gh" } }
+JSON
+printf '%s\n' "$OPS5" > "$PIN5/ops-root-test-1271"
+cat > "$SB5/bin/gh" <<'EOF'
+#!/bin/bash
+[ -n "${GH_CAPTURE:-}" ] && printf '%s\n' "$@" > "$GH_CAPTURE"
+exit 0
+EOF
+chmod +x "$SB5/bin/gh"
+printf 'body\n' > "$SB5/rev.md"
+cd "$PROJECT5" || { echo "FAIL: cd sandbox 5"; exit 1; }
+rc5=$(env -u APEXYARD_OPS_ROOT PATH="$SB5/bin:$PATH" GH_CAPTURE="$SB5/cap5" \
+  CLAUDE_CODE_SESSION_ID=test-1271 APEXYARD_OPS_PIN_DIR="$PIN5" \
+  zsh -c 'setopt NO_UNSET; source "$1/.claude/hooks/_lib-tracker.sh"; tracker_review_submit "o/r" 42 comment "$2"; echo $?' _ "$OPS5" "$SB5/rev.md" 2>/dev/null | tail -1)
+assert_eq "zsh: managed-project worktree uses the pinned ops scanner" "0" "$rc5"
+assert_eq "zsh: managed-project worktree reaches gh after scanner lookup" "yes" "$([ -f "$SB5/cap5" ] && echo yes || echo no)"
+cd - >/dev/null || true
+rm -rf "$SB5"
+
+# ---------------------------------------------------------------------------
+# Case 6 — regression pin: every BASH_SOURCE[0] self-location reference in
 # the tracker lib uses the `:-` safe-default form. A future revert to the
 # bare form fails loudly HERE instead of silently reintroducing #1025.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Resolve the private-reference scanner from the explicit ops-root override or the Claude session pin before checking the current git root.
- Allow review agents to submit reviews from managed-project worktrees under zsh, where the current git root is the project clone and `BASH_SOURCE` is unavailable.
- Add a regression case that runs the full review-submission path from a managed-project worktree.

## Why it matters

Review submission must use the scanner owned by the active ApexYard ops fork. The previous fallback inspected the managed project clone and blocked a valid review even when the session pin identified the correct scanner.

## Validation

- `bash .claude/hooks/tests/test_tracker_zsh_self_location.sh`
- `bash .claude/hooks/tests/test_tracker_review_submit.sh`
- `bash .claude/hooks/tests/test_tracker_create.sh`
- `bash .claude/hooks/tests/test_tracker_pr_merge.sh`
- `git diff --check`

Closes #1271

## Glossary

| Term | Meaning |
| --- | --- |
| Ops root | The ApexYard fork that owns session state and governance hooks. |
| Managed project | A project registered and worked on through the ApexYard fork. |
| Scanner | The runtime check that blocks private references from public tracker writes. |
