### PR TITLE
fix(#1272): allow orchestrator review worktree setup

### DIFF
--- a/.claude/hooks/block-reviewer-repo-mutation.sh
+++ b/.claude/hooks/block-reviewer-repo-mutation.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # CLASS: CONTROL — blocks repository-mutating git commands while a sanctioned
-# review-class agent is active (me2resh/apexyard#1233, AgDR-0145).
+# review-class agent is active (me2resh/apexyard#1233, AgDR-0145). Worktree
+# creation remains available so the orchestrator can provision an isolated
+# review checkout after the active-reviewer marker is set (AgDR-0147).
 #
 # The active-reviewer marker is written by the review skill immediately before
 # Rex, Hakim, or Tariq is spawned. It is a narrow session signal: when present,
@@ -81,7 +83,14 @@ if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]
   echo "BLOCKED: review-class agent cannot alter Git notes during an active review." >&2
   exit 2
 fi
-if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?worktree([[:space:]]|$)([^;&|]*[[:space:]])?(add|lock|move|prune|remove|repair|unlock)([[:space:];|&]|$)"; then
+# `git worktree add` creates the isolated checkout that the orchestrator gives
+# to the reviewer. It does not alter the reviewed worktree or its index, so it
+# stays available during the review window. Lock, move, prune, remove, repair,
+# and unlock remain blocked because they alter existing worktree state.
+if printf '%s' "$COMMAND" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^;&|]+[[:space:]]+&&[[:space:]]*)?git[[:space:]]+([^;&|]*[[:space:]])?worktree[[:space:]]+add([[:space:]][^;&|]*)?[[:space:]]*$'; then
+  exit 0
+fi
+if printf '%s' "$COMMAND" | grep -qE "(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+([^;&|]*[[:space:]])?worktree([[:space:]]|$)([^;&|]*[[:space:]])?(lock|move|prune|remove|repair|unlock)([[:space:];|&]|$)"; then
   echo "BLOCKED: review-class agent cannot alter worktrees during an active review." >&2
   exit 2
 fi

--- a/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
+++ b/.claude/hooks/tests/test_block_reviewer_repo_mutation.sh
@@ -43,7 +43,9 @@ run_case 'git fetch is blocked' 'git fetch origin' blocked
 run_case 'git checkout-index is blocked' 'git checkout-index --all' blocked
 run_case 'git apply is blocked' 'git apply fix.patch' blocked
 run_case 'git submodule update is blocked' 'git submodule update --init' blocked
-run_case 'git worktree add is blocked' 'git worktree add ../review-copy HEAD' blocked
+run_case 'git worktree add remains available for orchestration' 'git worktree add ../review-copy HEAD' allowed
+run_case 'git worktree add with branch remains available' 'git worktree add -b reviewer-copy ../review-copy HEAD' allowed
+run_case 'git worktree lock is blocked' 'git worktree lock ../review-copy' blocked
 run_case 'git notes is blocked' 'git notes add -m note HEAD' blocked
 run_case 'git revert is blocked' 'git revert HEAD' blocked
 run_case 'git am is blocked' 'git am review.patch' blocked

--- a/docs/agdr/AgDR-0147-review-worktree-provisioning.md
+++ b/docs/agdr/AgDR-0147-review-worktree-provisioning.md
@@ -1,0 +1,34 @@
+# Allow orchestration to provision review worktrees
+
+> In the context of an active review window, facing the read-only control blocking the only actor that can create the reviewer's isolated checkout, I decided to allow `git worktree add` while continuing to block changes to existing worktrees, to preserve reviewer isolation without deadlocking review setup.
+
+## Context
+
+AgDR-0145 made repository mutation unavailable while the active-reviewer marker exists. The control correctly prevents a reviewer from changing the reviewed checkout, but it also blocks the orchestrator from running `git worktree add`. The documented review flow writes the marker before it starts the reviewer, so no actor can provision a fresh isolated checkout after that point.
+
+`git worktree add` creates a separate checkout. It does not alter the reviewed worktree or its index. Operations that alter or remove an existing worktree remain blocked.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| Require provisioning before the marker | No hook change | The ordering constraint is easy to miss and leaves no recovery path when a reviewer needs a new checkout. |
+| Add an orchestrator identity signal | Could distinguish the intended actor | No reliable actor signal is available to this hook at command time. |
+| Allow `git worktree add`; keep existing-worktree changes blocked | Restores isolated-review setup and preserves the author/reviewer boundary | Worktree creation can create a branch reference, so the operation remains a controlled exception. |
+
+## Decision
+
+Chosen: **allow `git worktree add` while blocking existing-worktree operations**, because the command provisions the isolated review surface and does not change the builder's checkout. The hook continues to block `lock`, `move`, `prune`, `remove`, `repair`, and `unlock` while a review is active.
+
+## Consequences
+
+- The orchestrator can provision a reviewer worktree after setting the active-reviewer marker.
+- A reviewer cannot alter or remove an existing worktree during the review.
+- Branch creation through `git worktree add -b` is an accepted, visible exception needed to provision an isolated branch.
+- The focused hook test records the allowed and blocked worktree subcommands.
+
+## Artifacts
+
+- `.claude/hooks/block-reviewer-repo-mutation.sh`
+- `.claude/hooks/tests/test_block_reviewer_repo_mutation.sh`
+- Issue #1272


### PR DESCRIPTION
## Summary

- Allow the orchestrator to run `git worktree add` after the active reviewer marker is set.
- Keep operations that change or remove existing worktrees blocked during review.
- Add regression coverage and document the controlled exception in AgDR-0147.

## Why it matters

The review flow sets the active reviewer marker before it provisions the reviewer checkout. The mutation hook then blocked the provisioning command, so review setup could deadlock before the reviewer started. This change restores isolated checkout provisioning without giving the reviewer access to the builder's worktree or index.

## Validation

- `bash .claude/hooks/tests/test_block_reviewer_repo_mutation.sh`
- `git diff --check`
- `shellcheck .claude/hooks/block-reviewer-repo-mutation.sh .claude/hooks/tests/test_block_reviewer_repo_mutation.sh`

## Glossary

| Term | Meaning |
| --- | --- |
| Active reviewer marker | Session file that indicates a sanctioned review is in progress. |
| Worktree | A separate Git checkout attached to the same repository. |
| Orchestrator | The process that prepares and coordinates a review. |

Closes #1272
