### PR TITLE
fix(#1270): find nested ops fork under enclosing repo

### DIFF
--- a/.claude/hooks/_lib-ops-root.sh
+++ b/.claude/hooks/_lib-ops-root.sh
@@ -122,6 +122,25 @@ resolve_ops_root_walk() {
   # normalize the starting point before looking for ops-root anchors.
   start=$(_ops_root_main_worktree "$start")
 
+  # A caller can start one level above the fork when that enclosing directory
+  # is itself a Git repository. The upward walk cannot descend into the fork,
+  # so inspect immediate child directories for a single anchored fork before
+  # walking toward /. Do not guess when several children look like forks.
+  local child child_candidate="" child_matches=0
+  for child in "$start"/*; do
+    [ -d "$child" ] || continue
+    if [ -f "$child/.apexyard-fork" ] || {
+      [ -f "$child/onboarding.yaml" ] && [ -f "$child/apexyard.projects.yaml" ]
+    }; then
+      child_matches=$((child_matches + 1))
+      child_candidate="$child"
+    fi
+  done
+  if [ "$child_matches" -eq 1 ]; then
+    printf '%s' "$child_candidate"
+    return 0
+  fi
+
   local r="$start"
   while [ -n "$r" ] && [ "$r" != "/" ]; do
     # v2 anchor (preferred): the explicit .apexyard-fork marker file.

--- a/.claude/hooks/tests/test_ops_root.sh
+++ b/.claude/hooks/tests/test_ops_root.sh
@@ -224,8 +224,29 @@ case_8() {
   )
 }
 
+# ---------------------------------------------------------------------------
+# Case 9: the fork is one level below an unrelated enclosing git repository
+# ---------------------------------------------------------------------------
+case_9() {
+  local case_name="resolve_ops_root from enclosing git repo → nested fork"
+  local outer sb
+  outer=$(mktemp -d)
+  sb="$outer/apexyard-fork"
+  git init -q "$outer"
+  build_sandbox "$sb"
+  local expected
+  expected=$(cd "$sb" && pwd -P)
+  (
+    # shellcheck source=/dev/null
+    . "$LIB"
+    out=$(cd "$outer" && resolve_ops_root)
+    [ "$out" = "$expected" ] || { mark_fail "$case_name" "expected '$expected', got '$out'"; return; }
+    mark_pass "$case_name"
+  )
+}
+
 echo "Running ops-root lib tests..."
-for fn in case_1 case_2 case_3 case_4 case_5 case_6 case_7 case_8; do
+for fn in case_1 case_2 case_3 case_4 case_5 case_6 case_7 case_8 case_9; do
   run_case "$fn"
 done
 

--- a/docs/agdr/AgDR-0148-nested-ops-root-discovery.md
+++ b/docs/agdr/AgDR-0148-nested-ops-root-discovery.md
@@ -1,0 +1,32 @@
+# Discover a single nested ops fork from an enclosing repository
+
+> In the context of ops-root discovery, facing a fork nested inside an unrelated enclosing Git repository, I decided to inspect immediate child directories for one anchored fork before the existing upward walk, to avoid silently resolving against the enclosing repository.
+
+## Context
+
+The resolver walks upward from the Git toplevel. If an unrelated parent directory is itself a Git repository, that toplevel can be one level above the ops fork. An upward-only walk cannot descend into the fork and can therefore select the wrong root or report misleading missing configuration.
+
+## Options Considered
+
+| Option | Pros | Cons |
+| --- | --- | --- |
+| Keep the upward-only walk | No code change | The nested fork remains undiscoverable and path state can split silently. |
+| Search all descendants | Finds more layouts | It can cross project boundaries and select a distant or unrelated fork. |
+| Inspect immediate children and require one match | Covers the reported layout and avoids guessing | Deeper nesting remains unsupported; multiple matching children remain unresolved. |
+
+## Decision
+
+Chosen: **inspect immediate child directories for exactly one ops-root anchor** (`.apexyard-fork` or the legacy configuration pair) before walking upward. Return that child when there is one match. If there are zero or multiple matches, retain the existing upward walk and its fail-soft miss behavior.
+
+## Consequences
+
+- A fork nested one level below an enclosing Git repository resolves to the fork.
+- Multiple candidate forks do not cause an arbitrary selection.
+- Existing direct and workspace-clone resolution remains unchanged.
+- Deeper nesting still requires an explicit start directory or a future scoped change.
+
+## Artifacts
+
+- `.claude/hooks/_lib-ops-root.sh`
+- `.claude/hooks/tests/test_ops_root.sh`
+- Issue #1270


### PR DESCRIPTION
## Summary

- Detect a single anchored ops fork directly below an enclosing Git repository.
- Preserve the existing upward walk and avoid selecting an arbitrary fork when multiple candidates exist.
- Add regression coverage for the nested-fork layout and document the decision in AgDR-0148.

## Why it matters

When an unrelated parent directory is itself a Git repository, the resolver starts at that parent and can never descend into the actual ops fork. Downstream path helpers then use the wrong root and can create or read state in the wrong location. The focused child probe resolves the reported layout without broad descendant searching.

## Validation

- `bash .claude/hooks/tests/test_ops_root.sh`
- `bash .claude/hooks/tests/test_resolve_ops_root_pin.sh`
- `bash .claude/hooks/tests/test_split_portfolio_v2_migration.sh`
- `git diff --check`
- `shellcheck .claude/hooks/_lib-ops-root.sh .claude/hooks/tests/test_ops_root.sh`

## Glossary

| Term | Meaning |
| --- | --- |
| Ops fork | An adopter's ApexYard repository marked by `.apexyard-fork` or the legacy configuration pair. |
| Ops-root resolver | The shared helper that locates the ops fork from a working directory. |
| Enclosing repository | An unrelated Git repository containing the ops fork as a child directory. |

Closes #1270
