### PR TITLE
fix(#1268): require explicit tracker repo across projects

### DIFF
--- a/.claude/hooks/block-ambient-tracker-repo.sh
+++ b/.claude/hooks/block-ambient-tracker-repo.sh
@@ -27,8 +27,11 @@ fi
 unqualified=0
 while IFS= read -r segment; do
   segment="${segment%%#*}"
+  # A standalone `--` ends GitHub CLI option parsing. Ignore any repo-like
+  # token after it; only flags before that boundary can authorize the call.
+  options="$(printf '%s' "$segment" | sed -E 's/[[:space:]]--([[:space:]].*)?$//')"
   if printf '%s' "$segment" | grep -qE '(^|[^[:alnum:]_])gh[[:space:]]+(issue|pr)[[:space:]]+' \
-    && ! printf '%s' "$segment" | grep -qE '(^|[[:space:]])(--repo|-R)(=|[[:space:]])'; then
+    && ! printf '%s' "$options" | grep -qE '(^|[[:space:]])(--repo|-R)(=|[[:space:]])'; then
     unqualified=1
     break
   fi

--- a/.claude/hooks/block-ambient-tracker-repo.sh
+++ b/.claude/hooks/block-ambient-tracker-repo.sh
@@ -10,7 +10,12 @@ COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/nul
 # This guard covers raw GitHub issue and pull-request commands. Commands that
 # already name --repo/-R are explicit by definition and may intentionally cross
 # repository boundaries.
-if ! printf '%s' "$COMMAND" | grep -qE '(^|[;&|])[[:space:]]*gh[[:space:]]+(issue|pr)[[:space:]]+'; then
+# A shell command can prefix, group, or conditionally execute the tracker
+# invocation. Match `gh issue` / `gh pr` after any non-word shell delimiter so
+# wrappers such as `timeout`, `command`, subshells, and `if` cannot bypass the
+# repository check. Fail closed on quoted or commented matches because this is
+# a trust-chain control and false negatives are worse than extra checks.
+if ! printf '%s' "$COMMAND" | grep -qE '(^|[^[:alnum:]_])gh[[:space:]]+(issue|pr)[[:space:]]+'; then
   exit 0
 fi
 if printf '%s' "$COMMAND" | grep -qE '(^|[[:space:]])(--repo|-R)(=|[[:space:]])'; then

--- a/.claude/hooks/block-ambient-tracker-repo.sh
+++ b/.claude/hooks/block-ambient-tracker-repo.sh
@@ -18,9 +18,22 @@ COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/nul
 if ! printf '%s' "$COMMAND" | grep -qE '(^|[^[:alnum:]_])gh[[:space:]]+(issue|pr)[[:space:]]+'; then
   exit 0
 fi
-if printf '%s' "$COMMAND" | grep -qE '(^|[[:space:]])(--repo|-R)(=|[[:space:]])'; then
-  exit 0
-fi
+# Check each shell command segment independently. A repository flag in a
+# comment or a separate command must not authorize an unqualified tracker
+# invocation. Splitting on shell control characters is intentionally
+# conservative. A segment that cannot be classified remains blocked.
+# A segment with an explicit repository is safe. If every tracker segment had
+# one, no unqualified segment remains to check.
+unqualified=0
+while IFS= read -r segment; do
+  segment="${segment%%#*}"
+  if printf '%s' "$segment" | grep -qE '(^|[^[:alnum:]_])gh[[:space:]]+(issue|pr)[[:space:]]+' \
+    && ! printf '%s' "$segment" | grep -qE '(^|[[:space:]])(--repo|-R)(=|[[:space:]])'; then
+    unqualified=1
+    break
+  fi
+done < <(printf '%s\n' "$COMMAND" | tr ';|&()' '\n')
+[ "$unqualified" -eq 1 ] || exit 0
 
 HOOK_DIR=$(cd "$(dirname "$0")" 2>/dev/null && pwd) || exit 0
 if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then

--- a/.claude/hooks/block-ambient-tracker-repo.sh
+++ b/.claude/hooks/block-ambient-tracker-repo.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# CLASS: CONTROL — require an explicit repository for tracker commands when
+# the active ticket belongs to a different repository than the current
+# checkout (me2resh/apexyard#1268).
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -n "$COMMAND" ] || exit 0
+
+# This guard covers raw GitHub issue and pull-request commands. Commands that
+# already name --repo/-R are explicit by definition and may intentionally cross
+# repository boundaries.
+if ! printf '%s' "$COMMAND" | grep -qE '(^|[;&|])[[:space:]]*gh[[:space:]]+(issue|pr)[[:space:]]+'; then
+  exit 0
+fi
+if printf '%s' "$COMMAND" | grep -qE '(^|[[:space:]])(--repo|-R)(=|[[:space:]])'; then
+  exit 0
+fi
+
+HOOK_DIR=$(cd "$(dirname "$0")" 2>/dev/null && pwd) || exit 0
+if [ -f "$HOOK_DIR/_lib-ops-root.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOOK_DIR/_lib-ops-root.sh"
+else
+  exit 0
+fi
+
+OPS_ROOT=$(resolve_ops_root "$PWD")
+[ -n "$OPS_ROOT" ] || exit 0
+
+# Read the repo pins from active ticket markers. A marker without repo= is the
+# legacy/framework fallback and cannot establish a managed-project target.
+MARKER_DIR="$OPS_ROOT/.claude/session"
+REPOS=""
+for marker in "$MARKER_DIR/current-ticket" "$MARKER_DIR/tickets"/* "$MARKER_DIR/tickets"/*/*; do
+  [ -f "$marker" ] || continue
+  repo=$(sed -n 's/^repo=//p' "$marker" | head -1)
+  [ -n "$repo" ] && REPOS="${REPOS}${repo}\n"
+done
+[ -n "$REPOS" ] || exit 0
+
+UNIQUE_REPOS=$(printf '%b' "$REPOS" | sed '/^$/d' | sort -u)
+COUNT=$(printf '%s\n' "$UNIQUE_REPOS" | sed '/^$/d' | wc -l | tr -d ' ')
+
+# If exactly one active target matches the checkout's origin, ambient gh is
+# safe. Otherwise require the caller to state the repository explicitly.
+ORIGIN_URL=$(git remote get-url origin 2>/dev/null || true)
+ORIGIN_REPO=$(printf '%s' "$ORIGIN_URL" | sed -nE 's|.*[:/]([^/:]+/[^/]+)\.git$|\1|p; s|.*[:/]([^/:]+/[^/]+)$|\1|p' | head -1)
+if [ "$COUNT" -eq 1 ] && [ "$(printf '%s' "$UNIQUE_REPOS" | tr '[:upper:]' '[:lower:]')" = "$(printf '%s' "$ORIGIN_REPO" | tr '[:upper:]' '[:lower:]')" ]; then
+  exit 0
+fi
+
+if [ "$COUNT" -eq 1 ]; then
+  TARGET=$(printf '%s' "$UNIQUE_REPOS" | head -1)
+  echo "BLOCKED: tracker command has no explicit repository, but the active ticket targets $TARGET while this checkout resolves to ${ORIGIN_REPO:-no origin}. Add --repo $TARGET (or -R $TARGET)." >&2
+else
+  echo "BLOCKED: tracker command has no explicit repository, and active tickets target multiple repositories. Add --repo <owner/repo> (or -R <owner/repo>)." >&2
+fi
+exit 2

--- a/.claude/hooks/tests/test_block_ambient_tracker_repo.sh
+++ b/.claude/hooks/tests/test_block_ambient_tracker_repo.sh
@@ -33,6 +33,12 @@ root=$(mktemp -d)
 make_repo "$root" "git@github.com:owner/framework.git"
 printf '%s\n' 'repo=owner/project' > "$root/.claude/session/tickets/demo"
 run_case 'unqualified issue lookup is blocked for a different active repo' 2 'gh issue view 42' "$root"
+run_case 'environment-prefixed issue lookup is blocked' 2 'FOO=bar gh issue view 42' "$root"
+run_case 'timeout-prefixed issue lookup is blocked' 2 'timeout 5 gh issue view 42' "$root"
+run_case 'command-prefixed issue lookup is blocked' 2 'command gh issue view 42' "$root"
+run_case 'subshell issue lookup is blocked' 2 '( gh issue view 42 )' "$root"
+run_case 'conditional issue lookup is blocked' 2 'if true; then gh issue view 42; fi' "$root"
+run_case 'pipeline issue lookup is blocked' 2 'printf x | gh issue view 42' "$root"
 run_case 'explicit issue repo is allowed' 0 'gh issue view 42 --repo owner/project' "$root"
 run_case 'explicit short repo flag is allowed' 0 'gh pr list -R owner/project' "$root"
 

--- a/.claude/hooks/tests/test_block_ambient_tracker_repo.sh
+++ b/.claude/hooks/tests/test_block_ambient_tracker_repo.sh
@@ -42,6 +42,7 @@ run_case 'pipeline issue lookup is blocked' 2 'printf x | gh issue view 42' "$ro
 run_case 'repository flag in a comment does not authorize issue lookup' 2 'gh issue view 42 # --repo owner/project' "$root"
 run_case 'repository flag in a separate command does not authorize issue lookup' 2 'echo --repo owner/project; gh issue view 42' "$root"
 run_case 'short repository flag in a separate command does not authorize PR lookup' 2 'echo -R owner/project; gh pr list' "$root"
+run_case 'repository flag after option terminator does not authorize issue lookup' 2 'gh issue view 42 -- --repo owner/project' "$root"
 run_case 'explicit issue repo is allowed' 0 'gh issue view 42 --repo owner/project' "$root"
 run_case 'explicit short repo flag is allowed' 0 'gh pr list -R owner/project' "$root"
 

--- a/.claude/hooks/tests/test_block_ambient_tracker_repo.sh
+++ b/.claude/hooks/tests/test_block_ambient_tracker_repo.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Regression tests for the explicit tracker-repository guard (#1268).
+
+set -u
+SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK="$SRC_ROOT/.claude/hooks/block-ambient-tracker-repo.sh"
+PASS=0
+FAIL=0
+
+run_case() {
+  local name="$1" expected="$2" command="$3" root="$4" rc
+  rc=0
+  (cd "$root" && printf '%s' "{\"tool_input\":{\"command\":$(printf '%s' "$command" | jq -Rs .)}}" | "$HOOK" >/tmp/ambient-tracker.out 2>&1) || rc=$?
+  if [ "$rc" -eq "$expected" ]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (expected $expected, got $rc)" >&2
+    cat /tmp/ambient-tracker.out >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+make_repo() {
+  local root="$1" origin="$2"
+  mkdir -p "$root/.claude/session/tickets"
+  : > "$root/.apexyard-fork"
+  git init -q "$root"
+  git -C "$root" remote add origin "$origin"
+}
+
+root=$(mktemp -d)
+make_repo "$root" "git@github.com:owner/framework.git"
+printf '%s\n' 'repo=owner/project' > "$root/.claude/session/tickets/demo"
+run_case 'unqualified issue lookup is blocked for a different active repo' 2 'gh issue view 42' "$root"
+run_case 'explicit issue repo is allowed' 0 'gh issue view 42 --repo owner/project' "$root"
+run_case 'explicit short repo flag is allowed' 0 'gh pr list -R owner/project' "$root"
+
+matching=$(mktemp -d)
+make_repo "$matching" "git@github.com:owner/project.git"
+printf '%s\n' 'repo=owner/project' > "$matching/.claude/session/tickets/demo"
+run_case 'matching checkout origin keeps ambient lookup available' 0 'gh issue view 42' "$matching"
+
+empty=$(mktemp -d)
+make_repo "$empty" "git@github.com:owner/framework.git"
+run_case 'no active repo marker leaves unrelated commands unchanged' 0 'gh issue view 42' "$empty"
+
+multiple=$(mktemp -d)
+make_repo "$multiple" "git@github.com:owner/framework.git"
+printf '%s\n' 'repo=owner/project-a' > "$multiple/.claude/session/tickets/a"
+printf '%s\n' 'repo=owner/project-b' > "$multiple/.claude/session/tickets/b"
+run_case 'multiple active repos require an explicit target' 2 'gh pr list' "$multiple"
+
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/tests/test_block_ambient_tracker_repo.sh
+++ b/.claude/hooks/tests/test_block_ambient_tracker_repo.sh
@@ -39,6 +39,9 @@ run_case 'command-prefixed issue lookup is blocked' 2 'command gh issue view 42'
 run_case 'subshell issue lookup is blocked' 2 '( gh issue view 42 )' "$root"
 run_case 'conditional issue lookup is blocked' 2 'if true; then gh issue view 42; fi' "$root"
 run_case 'pipeline issue lookup is blocked' 2 'printf x | gh issue view 42' "$root"
+run_case 'repository flag in a comment does not authorize issue lookup' 2 'gh issue view 42 # --repo owner/project' "$root"
+run_case 'repository flag in a separate command does not authorize issue lookup' 2 'echo --repo owner/project; gh issue view 42' "$root"
+run_case 'short repository flag in a separate command does not authorize PR lookup' 2 'echo -R owner/project; gh pr list' "$root"
 run_case 'explicit issue repo is allowed' 0 'gh issue view 42 --repo owner/project' "$root"
 run_case 'explicit short repo flag is allowed' 0 'gh pr list -R owner/project' "$root"
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -120,6 +120,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-ambient-tracker-repo.sh\"'"
+          },
+          {
+            "type": "command",
             "command": "bash -c 'r=\"\";if [ -n \"${CLAUDE_CODE_SESSION_ID:-}\" ];then p=\"${APEXYARD_OPS_PIN_DIR:-$HOME/.claude/apexyard}/ops-root-${CLAUDE_CODE_SESSION_ID}\";[ -f \"$p\" ] && IFS= read -r r < \"$p\" && [ -d \"$r/.claude/hooks\" ] || r=\"\";fi;if [ -z \"$r\" ];then r=$PWD;while [ -n \"$r\" ] && [ \"$r\" != / ];do { [ -f \"$r/.apexyard-fork\" ] || [ -f \"$r/onboarding.yaml\" ]; } && [ -d \"$r/.claude/hooks\" ] && break;r=${r%/*};done;fi;[ -d \"$r/.claude/hooks\" ] || exit 0;exec \"$r/.claude/hooks/block-privileged-escalation.sh\"'"
           },
           {

--- a/docs/agdr/AgDR-0149-explicit-tracker-repository-guard.md
+++ b/docs/agdr/AgDR-0149-explicit-tracker-repository-guard.md
@@ -1,0 +1,33 @@
+# Require an explicit tracker repository across project boundaries
+
+> In the context of raw GitHub tracker commands from an ApexYard session, facing ambient repository selection that can return or mutate a different project's issues, I decided to require `--repo` or `-R` when the active ticket repository differs from the current checkout or when active tickets are ambiguous.
+
+## Context
+
+Framework helpers already pass resolved repositories to their tracker calls. Raw `gh issue` and `gh pr` commands remain able to use GitHub's ambient repository selection. When an operator runs from the ops fork with a managed-project ticket active, that ambient selection can resolve to the framework repository and return authoritative-looking state for the wrong project.
+
+## Options Considered
+
+| Option | Pros | Cons |
+| --- | --- | --- |
+| Rely on command conventions | No hook changes | A missed flag can read or write the wrong repository. |
+| Block every unqualified tracker command | Strong mechanical boundary | It also blocks safe commands when the checkout origin already matches the active ticket. |
+| Require explicit targeting only across a detected boundary | Blocks the dangerous ambiguity and preserves same-repo ergonomics | Marker discovery is limited to active ticket files and cannot identify an unstarted project. |
+
+## Decision
+
+Chosen: **add a Bash PreToolUse control for raw `gh issue` and `gh pr` commands**. If active ticket markers identify one repository and it matches the checkout origin, ambient use remains available. If the target differs, or multiple active repositories exist, the command is blocked until it includes `--repo` or `-R`. Sessions without a repo-bearing active marker retain existing behavior.
+
+## Consequences
+
+- Managed-project tracker operations cannot silently fall back to the ops-fork repository.
+- Explicit cross-repository framework maintenance remains possible.
+- Same-repository commands do not need a redundant repository flag.
+- Commands that use other GitHub API shapes, such as raw `gh api`, remain governed by their existing controls and are outside this narrow guard.
+
+## Artifacts
+
+- `.claude/hooks/block-ambient-tracker-repo.sh`
+- `.claude/settings.json`
+- `.claude/hooks/tests/test_block_ambient_tracker_repo.sh`
+- Issue #1268


### PR DESCRIPTION
## Summary

- Add a PreToolUse guard for raw `gh issue` and `gh pr` commands.
- Require `--repo` or `-R` when an active ticket targets a different repository or active tickets are ambiguous.
- Preserve same-origin commands, explicit cross-repository commands, and sessions without repo-bearing markers.
- Add regression coverage and AgDR-0149.

## Why it matters

GitHub's ambient repository selection can return or mutate a different project's tracker when an operator runs from the ops fork. The guard makes the repository boundary explicit at the point of the raw tracker command, while keeping framework maintenance and same-repository workflows usable.

## Validation

- `bash .claude/hooks/tests/test_block_ambient_tracker_repo.sh`
- `bash .claude/hooks/tests/test_settings_wrappers_silent_noop.sh`
- `bash .claude/hooks/tests/test_fail_closed_json.sh`
- `git diff --check`
- `jq empty .claude/settings.json`
- `shellcheck .claude/hooks/block-ambient-tracker-repo.sh .claude/hooks/tests/test_block_ambient_tracker_repo.sh`

## Glossary

| Term | Meaning |
| --- | --- |
| Active ticket marker | Session file containing the current ticket and its tracker repository. |
| Ambient repository | The repository GitHub CLI infers when no repository flag is supplied. |
| Explicit repository | A repository supplied with `--repo` or `-R`. |

Closes #1268
