### PR TITLE
fix(#1278): restore structured Rex review reports

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -65,6 +65,8 @@ The GitHub review is a durable artifact. Read .claude/rules/writing-standard.md.
 Use the controlled technical writing profile. Request changes when the artifact fails the profile.
 State the verdict and next action first. State the reason in short sentences.
 Put evidence after the opening. Keep TBD values, hedges, numbers, and modality.
+Use the required Output Format below for first reviews, re-reviews, and reduced-scope reviews.
+Short sentences must preserve the review sections and supporting evidence.
 Do not write a process transcript. Do not present an author self-check as Rex review.
 
 ## Input
@@ -853,7 +855,25 @@ Report the failure in plain text with the exact command the caller needs to run.
 
 ## Output Format
 
+Use this structure for every posted review, including re-reviews and reduced-scope reviews.
+Keep the title, Commit, Scope, Summary, Checklist Results, Issues Found, Validation, Verdict, and reviewer footer.
+Start with the verdict and next action, then provide the structured report below.
+Do not replace the report with a prose-only approval or a list of fixed issues.
+
+Give each checklist result a brief reason or an evidence reference.
+Use N/A with a reason for checks outside the review scope.
+Use Unverified with the limitation when an applicable check could not run.
+Do not mark an unperformed check as Pass.
+Report validation commands, their results, and any remaining verification limits.
+For re-reviews, identify resolved findings and reassess the current commit without claiming checks that were not repeated.
+For reduced-scope reviews, preserve the sections and explain skipped checks without expanding the review depth.
+Retain relevant factual checks and rationale under descriptive headings when they help the reader assess the verdict.
+Omit Handbook Findings, Fallow Findings, and Suggestions when they have no applicable content.
+If no issues remain, write "None" under Issues Found.
+
 ```markdown
+[Verdict and next action in short, complete sentences.]
+
 ## Code Review: PR #{number}
 
 **Commit**: `{headRefOid}`  ← REQUIRED — always include this.
@@ -863,16 +883,18 @@ Report the failure in plain text with the exact command the caller needs to run.
 [Brief summary of what the PR does]
 
 ### Checklist Results
-- ✅ Architecture & Design:    [Pass / Fail]
-- ✅ Code Quality:              [Pass / Fail]
-- ✅ Testing:                   [Pass / Fail]
-- ✅ Security:                  [Pass / Fail]
-- ✅ Performance:               [Pass / Fail]
-- ✅ PR Description & Glossary: [Pass / Fail]
-- ⚠ Summary Bullet Narrative:  [Pass / Advisory]   ← advisory only, never blocks
-- ✅ Technical Decisions (AgDR):[Pass / Fail / N/A]
-- ✅ Adopter Handbooks:         [Pass / Fail / N/A]   ← N/A if no handbooks loaded
-- ⚠ Fallow Static Analysis (JS/TS): [Pass / Advisory / N/A]   ← advisory only, never blocks; N/A if not JS/TS or CLI absent
+- Architecture & Design: [Result — reason or evidence]
+- Code Quality: [Result — reason or evidence]
+- Testing: [Result — reason or evidence]
+- Security: [Result — reason or evidence]
+- Performance: [Result — reason or evidence]
+- PR Description & Glossary: [Result — reason or evidence]
+- Summary Bullet Narrative: [Pass / Advisory — reason (advisory only)]
+- Technical Decisions (AgDR): [Result — decision record or reason]
+- Adopter Handbooks: [Result — applicable standards or reason]
+- Fallow Static Analysis (JS/TS): [Pass / Advisory / N/A — reason (advisory only)]
+
+[Use ✅ for Pass, ❌ for Fail, and ⚠ for Advisory or Unverified. Explain N/A without a success icon.]
 
 ### Issues Found
 [List any issues, or "None"]
@@ -886,8 +908,12 @@ Report the failure in plain text with the exact command the caller needs to run.
 ### Suggestions
 [Optional improvements, not blocking]
 
+### Validation
+[Commands and results, inspected evidence, and verification limits. Distinguish current checks from earlier reported results.]
+
 ### Verdict
 **[APPROVED / CHANGES REQUESTED / COMMENT]**
+[Explain why the findings support this verdict.]
 
 ---
 🤖 Reviewed by Rex (Code Reviewer Agent)

--- a/.claude/rules/tests/fixtures/human-friendly-cases.md
+++ b/.claude/rules/tests/fixtures/human-friendly-cases.md
@@ -55,10 +55,10 @@ rule.
 
 ## HF-08 — PR and review use the profile
 
-- **Given**: A framework fix needs a PR body and a review.
-- **Prompt**: Draft both artifacts.
-- **Fail if**: A sentence has more than 25 words or uses a semicolon.
-- **Pass if**: Both artifacts use short sentences, active voice, and clear terms.
+- **Given**: A framework fix needs a PR body and a structured Rex review under the controlled technical writing profile.
+- **Prompt**: Draft both artifacts using Rex's Output Format. Then show a shorter re-review after one finding is fixed. Finally show a reduced-scope variant for an eligible docs-only change. Preserve required sections, checklist reasons, validation results, and verification limits in each version. Mark unavailable evidence as unverified.
+- **Fail if**: A sentence has more than 25 words or uses a semicolon. Any review omits required sections, checklist reasons, validation results, or verification limits. The review marks an unperformed check as Pass or invents evidence.
+- **Pass if**: Both artifacts use short sentences, active voice, and clear terms while retaining required sections and supporting evidence.
 
 ## HF-09 — Producers load the profile
 

--- a/.claude/rules/tests/test_writing_standard.sh
+++ b/.claude/rules/tests/test_writing_standard.sh
@@ -7,6 +7,7 @@ SRC_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 RULE_FILE="$SRC_ROOT/.claude/rules/writing-standard.md"
 CASES_FILE="$SRC_ROOT/.claude/rules/tests/fixtures/human-friendly-cases.md"
 AGDR_FILE="$SRC_ROOT/docs/agdr/AgDR-0134-controlled-technical-writing-profile.md"
+REX_FILE="$SRC_ROOT/.claude/agents/code-reviewer.md"
 
 PASS=0
 FAIL=0
@@ -34,6 +35,8 @@ assert "rule:one-term" grep -qF 'Use one term for one item or action' "$RULE_FIL
 assert "rule:one-instruction" grep -qF 'Give one instruction in each sentence' "$RULE_FILE"
 assert "rule:no-semicolon" grep -qF 'Do not use a semicolon' "$RULE_FILE"
 assert "rule:preserve-evidence" grep -qF 'must not change the evidence' "$RULE_FILE"
+assert "rule:preserve-required-sections" grep -qF 'Required artifact sections remain required' "$RULE_FILE"
+assert "rule:no-review-length-cap" grep -qF 'do not impose a total review length limit' "$RULE_FILE"
 assert "rule:no-retroactive-rewrite" grep -qF 'does not rewrite existing artifacts' "$RULE_FILE"
 assert "rule:review-rejection" grep -qF 'must request changes' "$RULE_FILE"
 assert "rule:no-certification-claim" grep -qF 'does not implement or claim' "$RULE_FILE"
@@ -72,12 +75,31 @@ assert "consumer:code-reviewer:profile" grep -qF 'controlled technical writing p
 assert "reviewer:code-review" grep -qF 'you must request changes' "$SRC_ROOT/.claude/skills/code-review/SKILL.md"
 assert "reviewer:design-review" grep -qF 'you must request changes' "$SRC_ROOT/.claude/skills/design-review/SKILL.md"
 assert "reviewer:rex" grep -qF 'Request changes when the artifact fails the profile' "$SRC_ROOT/.claude/agents/code-reviewer.md"
+assert "reviewer:skill-output-format" grep -qF "agent's required Output Format" "$SRC_ROOT/.claude/skills/code-review/SKILL.md"
+assert "reviewer:all-review-scopes" grep -qF 'first reviews, re-reviews, and reduced-scope reviews' "$REX_FILE"
+assert "reviewer:checklist-evidence" grep -qF 'Give each checklist result a brief reason or an evidence reference.' "$REX_FILE"
+assert "reviewer:unperformed-checks" grep -qF 'Do not mark an unperformed check as Pass.' "$REX_FILE"
+# Check the actual output template, not headings in the review instructions.
+rex_template_has() {
+  awk '/^## Output Format$/{section=1; next}
+       section && /^```markdown$/{template=1; next}
+       template && /^```$/{exit}
+       template {print}' "$REX_FILE" | grep -qF -- "$1"
+}
+for heading in '## Code Review: PR' '**Commit**:' '**Scope**:' '### Summary' \
+  '### Checklist Results' '### Issues Found' '### Validation' '### Verdict' \
+  'Reviewed by Rex' 'Reviewed commit:'; do
+  assert "reviewer:template:$heading" rex_template_has "$heading"
+done
 assert "pr-quality:profile" grep -qF 'controlled technical writing profile' "$SRC_ROOT/.claude/rules/pr-quality.md"
 assert "consumer:tech-lead:profile" grep -qF 'controlled technical writing profile' "$SRC_ROOT/roles/engineering/tech-lead.md"
 
 assert "cases:file-exists" test -f "$CASES_FILE"
 assert "cases:ten-cases" awk '/^## HF-[0-9][0-9] /{count++} END{exit count != 10}' "$CASES_FILE"
 assert "cases:pr-review" grep -qF 'PR and review use the profile' "$CASES_FILE"
+assert "cases:review-structure" grep -qF 'Any review omits required sections, checklist reasons, validation results, or verification limits.' "$CASES_FILE"
+assert "cases:review-variants" grep -qF 'Then show a shorter re-review' "$CASES_FILE"
+assert "cases:reduced-scope" grep -qF 'reduced-scope variant' "$CASES_FILE"
 assert "cases:rejection" grep -qF 'Reviewer rejects a profile fault' "$CASES_FILE"
 
 assert "agdr:file-exists" test -f "$AGDR_FILE"

--- a/.claude/rules/writing-standard.md
+++ b/.claude/rules/writing-standard.md
@@ -36,6 +36,13 @@ the project's approved technical terms.
 12. Delete empty conditional sections. Remove placeholders before you file an
     artifact.
 
+Required artifact sections remain required under this profile.
+Short sentences must preserve structure, evidence, rationale, and verification limits.
+For Rex reviews, follow the Output Format in `.claude/agents/code-reviewer.md`.
+Keep required sections even when their result is None, N/A, or Unverified.
+Explain why a check does not apply or could not run.
+The sentence limits do not impose a total review length limit.
+
 Use the project's approved terms for product names, API names, code identifiers,
 and other technical names. Add a short glossary when a reader can misunderstand
 a technical term.
@@ -50,6 +57,7 @@ Before you file an artifact, check each item:
     [ ] Does the artifact use active voice where the actor matters?
     [ ] Does the opening state the outcome and next action?
     [ ] Did the rewrite retain all evidence and uncertainty?
+    [ ] Did the rewrite retain the artifact's required sections and supporting rationale?
     [ ] Did you remove empty sections and placeholders?
 
 A reviewer must request changes when an artifact does not meet this profile.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -40,6 +40,9 @@ Before you draft or post a review, read .claude/rules/writing-standard.md.
 Use the controlled technical writing profile. The review is a durable artifact.
 If the artifact fails the profile, you must request changes.
 State the verdict and next action first. State the reason and evidence after it.
+Use the Code Reviewer agent's required Output Format for first reviews, re-reviews, and reduced-scope reviews.
+Retain its required sections and give each checklist result a reason or evidence reference.
+Before submission, check the report against that format and repair omissions.
 Do not write a process transcript.
 
 ### 0. Write the active-reviewer marker (REQUIRED — me2resh/apexyard#843)


### PR DESCRIPTION
## Summary

Rex reviews can collapse into short prose when agents overapply sentence-length guidance. This change makes the existing structured report mandatory across review scopes.

- Require scope, summary, checklist results, findings, validation, and verdict so reviewers preserve the evidence behind each decision.
- Require reasons for checklist outcomes so skipped or unverified checks cannot appear as unsupported passes.
- Clarify the writing profile and code-review skill so short sentences preserve required report sections.
- Extend the existing regression case and static checks to cover first reviews, re-reviews, and reduced-scope reviews.

Closes #1278

The [review on PR 1124](https://github.com/me2resh/apexyard/pull/1124#pullrequestreview-4834618525) provides the format reference.

## Testing

- Writing-standard suite: 163 checks passed.
- Quality-regression suite: 47 checks passed.
- Codex adapter suite: 59 checks passed.
- Changed Markdown files passed markdownlint.
- Shell syntax and ShellCheck at warning severity passed.
- The new assertions reject the previous Rex instructions and a copy with the checklist section removed.

These checks validate instructions, template structure, and fixture parsing. They do not establish consistent model behavior across harnesses.

## Technical decisions

This change reinforces the existing review contract. It adds no dependency, service, enforcement hook, or approval gate.

## Glossary

| Term | Meaning |
| --- | --- |
| Rex | ApexYard's independent code-review agent. |
| Reduced-scope review | A focused review for eligible small changes that retains mandatory outputs. |
| Static check | A test that inspects instruction or template content without running a model. |
| Unverified | A check whose required evidence was unavailable. |
