### PR TITLE
fix(#1261): support large PR file lists in merge gates

### DIFF
--- a/.claude/hooks/require-architecture-review.sh
+++ b/.claude/hooks/require-architecture-review.sh
@@ -122,15 +122,6 @@ fi
 PR_NUMBER=$(extract_pr_number "$COMMAND")
 CMD_REPO=$(resolve_merge_repo "$COMMAND")
 
-# Derive REPO_FLAG from the FULLY-resolved CMD_REPO (#687) so the `gh pr diff`
-# below targets the PR's real repo. If this were set before the cd-target /
-# fallback steps, the no---repo split-portfolio case would diff the ops fork,
-# find no design artifact, and silently bypass the gate.
-REPO_FLAG=""
-if [ -n "$CMD_REPO" ]; then
-  REPO_FLAG="--repo $CMD_REPO"
-fi
-
 if [ -z "$PR_NUMBER" ]; then
   # Let block-unreviewed-merge.sh handle the "no PR number" error — we skip
   exit 0
@@ -166,10 +157,19 @@ if [ -n "$REPO_ROOT" ] && [ -f "${REPO_ROOT}/.claude/project-config.json" ]; the
   fi
 fi
 
-# Get the PR's changed files
-CHANGED=$(gh pr diff "$PR_NUMBER" $REPO_FLAG --name-only 2>/dev/null)
-CHANGED_RC=$?
-if [ "$CHANGED_RC" -ne 0 ] || [ -z "$CHANGED" ]; then
+# Get the PR's changed files. The diff endpoint rejects responses over 300
+# files; the files API is paginated and supports larger PRs. It caps at 3,000
+# files, so refuse to evaluate a truncated result rather than fail open.
+CHANGED_FILE_LIST=$(mktemp "${TMPDIR:-/tmp}/apexyard-pr-files.XXXXXX") || exit 2
+CHANGED_RC=0
+if [ -z "$CMD_REPO" ] || ! gh api --paginate "repos/${CMD_REPO}/pulls/${PR_NUMBER}/files?per_page=100" --jq '.[].filename' >"$CHANGED_FILE_LIST" 2>/dev/null; then
+  CHANGED_RC=1
+fi
+CHANGED_COUNT=$(wc -l <"$CHANGED_FILE_LIST" 2>/dev/null | tr -d ' ')
+CHANGED_COUNT=${CHANGED_COUNT:-0}
+CHANGED=$(cat "$CHANGED_FILE_LIST" 2>/dev/null)
+rm -f "$CHANGED_FILE_LIST"
+if [ "$CHANGED_RC" -ne 0 ] || [ -z "$CHANGED" ] || [ "$CHANGED_COUNT" -gt 3000 ]; then
   echo "BLOCKED: architecture-review gate could not determine the PR's changed files. Refusing to merge until the diff can be verified." >&2
   exit 2
 fi

--- a/.claude/hooks/require-architecture-review.sh
+++ b/.claude/hooks/require-architecture-review.sh
@@ -162,14 +162,15 @@ fi
 # files, so refuse to evaluate a truncated result rather than fail open.
 CHANGED_FILE_LIST=$(mktemp "${TMPDIR:-/tmp}/apexyard-pr-files.XXXXXX") || exit 2
 CHANGED_RC=0
-if [ -z "$CMD_REPO" ] || ! gh api --paginate "repos/${CMD_REPO}/pulls/${PR_NUMBER}/files?per_page=100" --jq '.[].filename' >"$CHANGED_FILE_LIST" 2>/dev/null; then
+TOTAL_FILES=""
+if [ -z "$CMD_REPO" ] || ! TOTAL_FILES=$(gh api "repos/${CMD_REPO}/pulls/${PR_NUMBER}" --jq '.changed_files' 2>/dev/null) || ! printf '%s' "$TOTAL_FILES" | grep -qE '^[0-9]+$' || [ "$TOTAL_FILES" -gt 3000 ] || ! gh api --paginate "repos/${CMD_REPO}/pulls/${PR_NUMBER}/files?per_page=100" --jq '.[].filename' >"$CHANGED_FILE_LIST" 2>/dev/null; then
   CHANGED_RC=1
 fi
 CHANGED_COUNT=$(wc -l <"$CHANGED_FILE_LIST" 2>/dev/null | tr -d ' ')
 CHANGED_COUNT=${CHANGED_COUNT:-0}
 CHANGED=$(cat "$CHANGED_FILE_LIST" 2>/dev/null)
 rm -f "$CHANGED_FILE_LIST"
-if [ "$CHANGED_RC" -ne 0 ] || [ -z "$CHANGED" ] || [ "$CHANGED_COUNT" -gt 3000 ]; then
+if [ "$CHANGED_RC" -ne 0 ] || [ -z "$CHANGED" ] || [ "$TOTAL_FILES" -gt 3000 ]; then
   echo "BLOCKED: architecture-review gate could not determine the PR's changed files. Refusing to merge until the diff can be verified." >&2
   exit 2
 fi

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -130,15 +130,6 @@ fi
 PR_NUMBER=$(extract_pr_number "$COMMAND")
 CMD_REPO=$(resolve_merge_repo "$COMMAND")
 
-# Derive REPO_FLAG from the FULLY-resolved CMD_REPO (#687) so the `gh pr diff`
-# below targets the PR's real repo. If this were set before the cd-target /
-# fallback steps, the no---repo split-portfolio case would diff the ops fork,
-# find no UI files, and silently bypass the gate.
-REPO_FLAG=""
-if [ -n "$CMD_REPO" ]; then
-  REPO_FLAG="--repo $CMD_REPO"
-fi
-
 if [ -z "$PR_NUMBER" ]; then
   # Let block-unreviewed-merge.sh handle the "no PR number" error — we skip
   exit 0
@@ -178,10 +169,19 @@ if [ -n "$REPO_ROOT" ] && [ -f "${REPO_ROOT}/.claude/project-config.json" ]; the
   fi
 fi
 
-# Get the PR's changed files
-CHANGED=$(gh pr diff "$PR_NUMBER" $REPO_FLAG --name-only 2>/dev/null)
-CHANGED_RC=$?
-if [ "$CHANGED_RC" -ne 0 ] || [ -z "$CHANGED" ]; then
+# Get the PR's changed files. The diff endpoint rejects responses over 300
+# files; the files API is paginated and supports larger PRs. It caps at 3,000
+# files, so refuse to evaluate a truncated result rather than fail open.
+CHANGED_FILE_LIST=$(mktemp "${TMPDIR:-/tmp}/apexyard-pr-files.XXXXXX") || exit 2
+CHANGED_RC=0
+if [ -z "$CMD_REPO" ] || ! gh api --paginate "repos/${CMD_REPO}/pulls/${PR_NUMBER}/files?per_page=100" --jq '.[].filename' >"$CHANGED_FILE_LIST" 2>/dev/null; then
+  CHANGED_RC=1
+fi
+CHANGED_COUNT=$(wc -l <"$CHANGED_FILE_LIST" 2>/dev/null | tr -d ' ')
+CHANGED_COUNT=${CHANGED_COUNT:-0}
+CHANGED=$(cat "$CHANGED_FILE_LIST" 2>/dev/null)
+rm -f "$CHANGED_FILE_LIST"
+if [ "$CHANGED_RC" -ne 0 ] || [ -z "$CHANGED" ] || [ "$CHANGED_COUNT" -gt 3000 ]; then
   echo "BLOCKED: design-review gate could not determine the PR's changed files. Refusing to merge until the diff can be verified." >&2
   exit 2
 fi

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -174,14 +174,15 @@ fi
 # files, so refuse to evaluate a truncated result rather than fail open.
 CHANGED_FILE_LIST=$(mktemp "${TMPDIR:-/tmp}/apexyard-pr-files.XXXXXX") || exit 2
 CHANGED_RC=0
-if [ -z "$CMD_REPO" ] || ! gh api --paginate "repos/${CMD_REPO}/pulls/${PR_NUMBER}/files?per_page=100" --jq '.[].filename' >"$CHANGED_FILE_LIST" 2>/dev/null; then
+TOTAL_FILES=""
+if [ -z "$CMD_REPO" ] || ! TOTAL_FILES=$(gh api "repos/${CMD_REPO}/pulls/${PR_NUMBER}" --jq '.changed_files' 2>/dev/null) || ! printf '%s' "$TOTAL_FILES" | grep -qE '^[0-9]+$' || [ "$TOTAL_FILES" -gt 3000 ] || ! gh api --paginate "repos/${CMD_REPO}/pulls/${PR_NUMBER}/files?per_page=100" --jq '.[].filename' >"$CHANGED_FILE_LIST" 2>/dev/null; then
   CHANGED_RC=1
 fi
 CHANGED_COUNT=$(wc -l <"$CHANGED_FILE_LIST" 2>/dev/null | tr -d ' ')
 CHANGED_COUNT=${CHANGED_COUNT:-0}
 CHANGED=$(cat "$CHANGED_FILE_LIST" 2>/dev/null)
 rm -f "$CHANGED_FILE_LIST"
-if [ "$CHANGED_RC" -ne 0 ] || [ -z "$CHANGED" ] || [ "$CHANGED_COUNT" -gt 3000 ]; then
+if [ "$CHANGED_RC" -ne 0 ] || [ -z "$CHANGED" ] || [ "$TOTAL_FILES" -gt 3000 ]; then
   echo "BLOCKED: design-review gate could not determine the PR's changed files. Refusing to merge until the diff can be verified." >&2
   exit 2
 fi

--- a/.claude/hooks/tests/test_require_architecture_review.sh
+++ b/.claude/hooks/tests/test_require_architecture_review.sh
@@ -117,6 +117,9 @@ install_mock_gh() {
 #!/bin/bash
 args="\$*"
 case "\$args" in
+  *"api"*"pulls/77"*"changed_files"*)
+    if [ "\${MOCK_LARGE:-0}" = 1 ]; then printf '%s\n' 3001; else printf '%s\n' 1; fi
+    ;;
   *"api"*"pulls/"*"/files"*)
     if [ "\${MOCK_LARGE:-0}" = 1 ]; then
       seq 1 3001 | sed 's|^|src/file-|; s|$|.ts|'
@@ -252,6 +255,7 @@ args="\$*"
 case "\$args" in
   *"--repo $portfolio"*|*"repos/$portfolio/"*)
     case "\$args" in
+      *"pulls/77"*"changed_files"*) printf '%s\n' 1 ;;
       *"pulls/77/files"*) printf '%s\n' $diff_files ;;
       *"pr view"*headRefOid*)    printf '%s\n' "$head_sha" ;;
       *"pr view"*headRepository*) printf '%s\n' "$portfolio" ;;

--- a/.claude/hooks/tests/test_require_architecture_review.sh
+++ b/.claude/hooks/tests/test_require_architecture_review.sh
@@ -117,8 +117,12 @@ install_mock_gh() {
 #!/bin/bash
 args="\$*"
 case "\$args" in
-  *"pr diff"*"--name-only"*)
-    printf '%s\n' $diff_files
+  *"api"*"pulls/"*"/files"*)
+    if [ "\${MOCK_LARGE:-0}" = 1 ]; then
+      seq 1 3001 | sed 's|^|src/file-|; s|$|.ts|'
+    else
+      printf '%s\n' $diff_files
+    fi
     ;;
   *"pr view"*headRefOid*)
     printf '%s\n' "$head_sha"
@@ -248,13 +252,13 @@ args="\$*"
 case "\$args" in
   *"--repo $portfolio"*|*"repos/$portfolio/"*)
     case "\$args" in
-      *"pr diff"*"--name-only"*) printf '%s\n' $diff_files ;;
+      *"pulls/77/files"*) printf '%s\n' $diff_files ;;
       *"pr view"*headRefOid*)    printf '%s\n' "$head_sha" ;;
       *"pr view"*headRepository*) printf '%s\n' "$portfolio" ;;
       *) exit 0 ;;
     esac
     ;;
-  *"pr diff"*"--name-only"*) ;;    # bare → no files (ops-fork resolution)
+  *"pulls/77/files"*) ;;    # bare → no files (ops-fork resolution)
   *"pr view"*headRefOid*) ;;        # bare → empty
   *) exit 0 ;;
 esac
@@ -323,8 +327,12 @@ install_mock_gh_headrefoid_fails() {
 #!/bin/bash
 args="\$*"
 case "\$args" in
-  *"pr diff"*"--name-only"*)
-    printf '%s\n' $diff_files
+  *"pulls/"*"/files"*)
+    if [ "${MOCK_LARGE:-0}" = 1 ]; then
+      seq 1 3001 | sed 's|^|src/file-|; s|$|.ts|'
+    else
+      printf '%s\n' $diff_files
+    fi
     ;;
   *"pr view"*headRefOid*)
     exit 1
@@ -350,6 +358,14 @@ local_head=$(cd "$sb" && git rev-parse HEAD 2>/dev/null)
 printf '%s\n' "$local_head" > "$(review_marker_path "o/r" 77 architecture "$sb")"
 code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
 assert_eq "#1091: forge HEAD unresolvable + marker matching LOCAL head -> BLOCKED" "2" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "B) PR over the files API ceiling -> BLOCK (exit 2)"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"src/handlers/user.ts"' "$SHA"
+code=$(MOCK_LARGE=1 run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
+assert_eq "blocks when changed-file count exceeds 3000" "2" "$code"
 rm -rf "$sb"
 
 echo ""

--- a/.claude/hooks/tests/test_require_design_review_for_ui.sh
+++ b/.claude/hooks/tests/test_require_design_review_for_ui.sh
@@ -114,8 +114,12 @@ install_mock_gh() {
 #!/bin/bash
 args="\$*"
 case "\$args" in
-  *"pr diff"*"--name-only"*)
-    printf '%s\n' $diff_files
+  *"api"*"pulls/"*"/files"*)
+    if [ "\${MOCK_LARGE:-0}" = 1 ]; then
+      seq 1 3001 | sed 's|^|src/file-|; s|$|.ts|'
+    else
+      printf '%s\n' $diff_files
+    fi
     ;;
   *"pr view"*headRefOid*)
     printf '%s\n' "$head_sha"
@@ -239,13 +243,13 @@ args="\$*"
 case "\$args" in
   *"--repo $portfolio"*|*"repos/$portfolio/"*)
     case "\$args" in
-      *"pr diff"*"--name-only"*) printf '%s\n' $diff_files ;;
+      *"pulls/77/files"*) printf '%s\n' $diff_files ;;
       *"pr view"*headRefOid*)    printf '%s\n' "$head_sha" ;;
       *"pr view"*headRepository*) printf '%s\n' "$portfolio" ;;
       *) exit 0 ;;
     esac
     ;;
-  *"pr diff"*"--name-only"*) ;;    # bare → no files (ops-fork resolution)
+  *"pulls/77/files"*) ;;    # bare → no files (ops-fork resolution)
   *"pr view"*headRefOid*) ;;        # bare → empty
   *) exit 0 ;;
 esac
@@ -312,8 +316,12 @@ install_mock_gh_headrefoid_fails() {
 #!/bin/bash
 args="\$*"
 case "\$args" in
-  *"pr diff"*"--name-only"*)
-    printf '%s\n' $diff_files
+  *"pulls/"*"/files"*)
+    if [ "${MOCK_LARGE:-0}" = 1 ]; then
+      seq 1 3001 | sed 's|^|src/file-|; s|$|.ts|'
+    else
+      printf '%s\n' $diff_files
+    fi
     ;;
   *"pr view"*headRefOid*)
     exit 1
@@ -339,6 +347,14 @@ local_head=$(cd "$sb" && git rev-parse HEAD 2>/dev/null)
 printf '%s\n' "$local_head" > "$(review_marker_path "o/r" 77 design "$sb")"
 code=$(run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
 assert_eq "#1091: forge HEAD unresolvable + marker matching LOCAL head -> BLOCKED" "2" "$code"
+rm -rf "$sb"
+
+echo ""
+echo "B) PR over the files API ceiling -> BLOCK (exit 2)"
+sb=$(make_sandbox)
+install_mock_gh "$sb" '"src/handlers/user.ts"' "$SHA"
+code=$(MOCK_LARGE=1 run_gate "$sb" "gh pr merge 77 --repo o/r --squash")
+assert_eq "blocks when changed-file count exceeds 3000" "2" "$code"
 rm -rf "$sb"
 
 echo ""

--- a/.claude/hooks/tests/test_require_design_review_for_ui.sh
+++ b/.claude/hooks/tests/test_require_design_review_for_ui.sh
@@ -114,6 +114,9 @@ install_mock_gh() {
 #!/bin/bash
 args="\$*"
 case "\$args" in
+  *"api"*"pulls/77"*"changed_files"*)
+    if [ "\${MOCK_LARGE:-0}" = 1 ]; then printf '%s\n' 3001; else printf '%s\n' 1; fi
+    ;;
   *"api"*"pulls/"*"/files"*)
     if [ "\${MOCK_LARGE:-0}" = 1 ]; then
       seq 1 3001 | sed 's|^|src/file-|; s|$|.ts|'
@@ -243,6 +246,7 @@ args="\$*"
 case "\$args" in
   *"--repo $portfolio"*|*"repos/$portfolio/"*)
     case "\$args" in
+      *"pulls/77"*"changed_files"*) printf '%s\n' 1 ;;
       *"pulls/77/files"*) printf '%s\n' $diff_files ;;
       *"pr view"*headRefOid*)    printf '%s\n' "$head_sha" ;;
       *"pr view"*headRepository*) printf '%s\n' "$portfolio" ;;

--- a/docs/agdr/AgDR-0150-large-pr-files-api.md
+++ b/docs/agdr/AgDR-0150-large-pr-files-api.md
@@ -1,0 +1,38 @@
+---
+id: AgDR-0150
+timestamp: 2026-09-13T06:00:00Z
+agent: Codex
+model: GPT-6
+session: GH-1261
+trigger: user-prompt
+status: executed
+category: security
+---
+
+# Use the paginated pull-files API for large PR merge gates
+
+> In the context of merge gates evaluating large pull requests, facing GitHub's 300-file diff limit, I decided to use the paginated pull-files API with an authoritative file-count check to preserve fail-closed review behavior.
+
+## Context
+
+The `gh pr diff --name-only` endpoint fails above 300 changed files. The pull-files API supports larger responses but returns at most 3,000 files. A gate must not scan a truncated result.
+
+## Options Considered
+
+| Option | Pros | Cons |
+| --- | --- | --- |
+| Use the pull-files API with `changed_files` validation | Handles large supported PRs and detects the API ceiling | Adds one metadata request and pagination |
+| Keep the diff endpoint | Minimal code change | Blocks valid large PRs above 300 files |
+
+## Decision
+
+Chosen: **the pull-files API with an authoritative count**, because it removes the 300-file failure while blocking PRs above the 3,000-file API ceiling.
+
+## Consequences
+
+- Large PRs through `/update` can be evaluated when their total is within the supported limit.
+- PRs above 3,000 files remain blocked until the framework supports a complete file-set source.
+
+## Artifacts
+
+- [Issue #1261](https://github.com/me2resh/apexyard/issues/1261)


### PR DESCRIPTION
## Summary

- Replace the 300-file-limited diff endpoint in both merge gates with the paginated pull-files API.
- Read the authoritative `changed_files` total and fail closed above 3,000 files.
- Add regression coverage for the large-file ceiling and preserve existing gate scenarios.

## Why it matters

Large `/update` sync PRs can exceed GitHub's diff endpoint limit. The merge gates can now inspect supported large PRs without silently treating an unavailable or truncated file list as complete.

## Validation

- Architecture gate tests: 28 passed.
- Design gate tests: 28 passed.
- ShellCheck and shell syntax checks passed.
- `git diff --check` passed.

## Technical decision

See [AgDR-0150](https://github.com/me2resh/apexyard/blob/fix/GH-1261-large-pr-diff/docs/agdr/AgDR-0150-large-pr-files-api.md) for the Files API and ceiling decision.

## Glossary

| Term | Definition |
| --- | --- |
| Files API | GitHub endpoint that returns changed files in paginated responses. |
| Diff ceiling | The 300-file limit on GitHub's pull-request diff endpoint. |
| Fail closed | Block the merge when the changed-file set cannot be verified. |

Refs #1261
