### PR TITLE
test(#1261): isolate search config fixtures

### DIFF
--- a/.claude/hooks/tests/test_validate_search_config.sh
+++ b/.claude/hooks/tests/test_validate_search_config.sh
@@ -45,12 +45,16 @@ build_sandbox() {
   mkdir -p "$1"
   : > "$1/onboarding.yaml"
   : > "$1/apexyard.projects.yaml"
+  mkdir -p "$1/.claude"
+  printf '%s\n' '{"portfolio":{"registry":"./apexyard.projects.yaml"}}' > "$1/.claude/project-config.json"
 }
 
 run_hook_in() {
   # run_hook_in <dir> [env assignments...]
   local dir="$1"; shift
-  ( cd "$dir" && env "$@" bash "$HOOK" ) 2>&1
+  # Clear operator-level root overrides so each fixture is isolated from the
+  # surrounding split-portfolio session.
+  ( cd "$dir" && env -u APEXYARD_OPS_ROOT -u APEXYARD_PORTFOLIO_ROOT "$@" bash "$HOOK" ) 2>&1
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Clear inherited ApexYard root overrides when running search-config fixtures.
- Prevent live split-portfolio configuration from contaminating the no-intent case.

## Why it matters

The regression suite must produce the same result in a live operator session and in CI. This keeps fixture reads inside their temporary sandbox.

## Validation

- `test_validate_search_config.sh`: 7 passed.
- Full hook suite from latest `dev`: 152 passed, 0 failed, 4 expected environment skips.

## Glossary

| Term | Definition |
| --- | --- |
| Fixture isolation | Preventing tests from reading live operator configuration. |
| Root override | An `APEXYARD_OPS_ROOT` or `APEXYARD_PORTFOLIO_ROOT` environment variable. |

Refs #1261